### PR TITLE
Recent facilities endpoint enhancements - Filter by type of care

### DIFF
--- a/modules/vaos/app/controllers/vaos/v2/clinics_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/clinics_controller.rb
@@ -148,7 +148,7 @@ module VAOS
       end
 
       def log_no_supported_facilities(service_id)
-        Rails.logger.info('VAOS recent_facilities', "No facility that supports #{service_id} was found")
+        Rails.logger.info('VAOS recent_facilities', "No facility supporting #{service_id} service was found.")
       end
 
       def unable_to_lookup_facility?(appt)

--- a/modules/vaos/app/controllers/vaos/v2/clinics_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/clinics_controller.rb
@@ -89,7 +89,7 @@ module VAOS
 
         # Retrieve facility scheduling configurations
         facility_ids = facilities.pluck(:id).to_csv(row_sep: nil)
-        configurations = mobile_facility_service.get_scheduling_configurations(facility_ids)[:data]
+        configurations = mobile_facility_service.get_scheduling_configurations(facility_ids)&.[](:data)
         supported_facilities = []
 
         facilities.each do |facility|
@@ -100,6 +100,8 @@ module VAOS
             supported_facilities.push(facility)
           end
         end
+
+        log_no_supported_facilities(service_id) if supported_facilities.blank?
 
         supported_facilities
       end
@@ -142,7 +144,11 @@ module VAOS
       end
 
       def log_recent_facility_details(location_id, facility)
-        Rails.logger.info("VAOS recent_facilities details for location: #{location_id} - #{facility.to_json}")
+        Rails.logger.info('VAOS recent_facilities', "Details found for location: #{location_id} - #{facility.to_json}")
+      end
+
+      def log_no_supported_facilities(service_id)
+        Rails.logger.info('VAOS recent_facilities', "No facility that supports #{service_id} was found")
       end
 
       def unable_to_lookup_facility?(appt)

--- a/modules/vaos/app/docs/vaos/v2/vaos_v2.yaml
+++ b/modules/vaos/app/docs/vaos/v2/vaos_v2.yaml
@@ -438,6 +438,13 @@ paths:
         "504":
           $ref: "#/components/responses/GatewayTimeout"
   "/v2/locations/recent_facilities":
+    parameters:
+     - in: query
+       required: false
+       name: clinical_service_id
+       description: The clinical service (type of care) ID used to filter recent facilities. The currently supported/available VAOS clinical service IDs can be discovered from Mobile Facility Service v2.
+       schema:
+         type: string
     get:
       tags:
         - facilities

--- a/modules/vaos/app/docs/vaos/v2/vaos_v2.yaml
+++ b/modules/vaos/app/docs/vaos/v2/vaos_v2.yaml
@@ -63,7 +63,7 @@ paths:
         - name: _include
           in: query
           description:
-            A comma delimted list list of the desired appointment statuses to fetch/filter
+            A comma delimited list list of the desired appointment statuses to fetch/filter
             by.
           schema:
             "$ref": "#/components/schemas/AppointmentIncludes"
@@ -71,7 +71,7 @@ paths:
           explode: false
       responses:
         "200":
-          description: Retrives a list of clincs for a given facility
+          description: Retrieves a list of clinics for a given facility
           content:
             application/json:
               schema:
@@ -127,7 +127,7 @@ paths:
               $ref: "#/components/schemas/CreateAppointmentRequest"
       responses:
         "201":
-          description: Retrives a list of clincs for a given facility
+          description: Retrieves a list of clinics for a given facility
           content:
             application/json:
               schema:
@@ -521,7 +521,7 @@ paths:
             type: integer
       responses:
         "200":
-          description: Retrives a list of clincs for a given facility
+          description: Retrieves a list of clinics for a given facility
           content:
             application/json:
               schema:
@@ -623,7 +623,7 @@ paths:
             type: string
       responses:
         "200":
-          description: Retrives a list of available appointment slots for a given clinic
+          description: Retrieves a list of available appointment slots for a given clinic
           content:
             application/json:
               schema:
@@ -809,7 +809,7 @@ paths:
             type: string
       responses:
         "200":
-          description: Retrives a list of clincs for a given facility
+          description: Retrieves a list of clinics for a given facility
           content:
             application/json:
               schema:
@@ -1276,7 +1276,7 @@ components:
           type: string
         practitioners:
           type: array
-          description: The practioners participating in this appointment.
+          description: The practitioners participating in this appointment.
           items:
             "$ref": "#/components/schemas/PractitionerIds"
         requestedPeriods:
@@ -1362,7 +1362,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/CodeableConcept'
-      description: The response for a patient scheduing eligibility request.
+      description: The response for a patient scheduling eligibility request.
     PatientProviderRelationship:
       type: object
       required:

--- a/modules/vaos/spec/requests/vaos/v2/locations/clinics_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/locations/clinics_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe 'VAOS::V2::Locations::Clinics', type: :request do
             end
           end
 
-          it 'filters by facility by services' do
+          it 'filters facilities to those that supports service' do
             VCR.use_cassette('vaos/v2/systems/get_recent_facilities_200',
                              match_requests_on: %i[method path query], allow_playback_repeats: true) do
               Timecop.travel(Time.zone.local(2023, 8, 31, 13, 0, 0)) do
@@ -281,7 +281,7 @@ RSpec.describe 'VAOS::V2::Locations::Clinics', type: :request do
             end
           end
 
-          it 'logs no facilities supports service' do
+          it 'logs if no facilities supports service' do
             VCR.use_cassette('vaos/v2/systems/get_recent_facilities_200',
                              match_requests_on: %i[method path query], allow_playback_repeats: true) do
               Timecop.travel(Time.zone.local(2023, 8, 31, 13, 0, 0)) do

--- a/spec/support/vcr_cassettes/vaos/v2/systems/get_recent_facilities_200.yml
+++ b/spec/support/vcr_cassettes/vaos/v2/systems/get_recent_facilities_200.yml
@@ -382,4 +382,727 @@ http_interactions:
           "healthService" : [ "Audiology", "MentalHealthCare", "Optometry", "Podiatry", "PrimaryCare", "SpecialtyCare" ]
         }
   recorded_at: Thu, 31 Aug 2023 22:51:37 GMT
+- request:
+    method: get
+    uri: https://veteran.apps.va.gov/facilities/v2/scheduling/configurations?facilityIds=984GA,983,983GC&pageSize=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Referer:
+      - https://review-instance.va.gov
+      X-Vamf-Jwt:
+      - stubbed_token
+      X-Request-Id:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 11 Jun 2021 03:22:04 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - openresty
+      X-Vamf-Version:
+      - 2.5.2
+      B3:
+      - 9142602b7876dee6-3b8698ca83a2ff08-0
+      Access-Control-Allow-Headers:
+      - x-vamf-jwt
+      X-Vamf-Build:
+      - cc1bce1
+      X-Vamf-Timestamp:
+      - '2021-05-30T22:09:53+0000'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS
+      Access-Control-Max-Age:
+      - '3600'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "data" : [ {
+            "facilityId" : "983",
+            "services" : [ {
+              "id" : "amputation",
+              "name" : "Amputation Services",
+              "stopCodes" : [ {
+                "primary" : "211"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "submittedRequestLimit" : 2,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "covid",
+              "name" : "COVID Vaccine",
+              "stopCodes" : [ {
+                "secondary" : "710"
+              } ],
+              "char4" : "CDQC",
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : true
+              }
+            }, {
+              "id" : "CR1",
+              "name" : "Express Care",
+              "request" : {
+                "patientHistoryRequired" : false,
+                "submittedRequestLimit" : 2,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false,
+                "schedulingDays" : [ {
+                  "day" : "MONDAY",
+                  "canSchedule" : false
+                }, {
+                  "day" : "TUESDAY",
+                  "canSchedule" : false
+                }, {
+                  "day" : "WEDNESDAY",
+                  "canSchedule" : false
+                }, {
+                  "day" : "THURSDAY",
+                  "canSchedule" : false
+                }, {
+                  "day" : "FRIDAY",
+                  "canSchedule" : false
+                }, {
+                  "day" : "SATURDAY",
+                  "canSchedule" : false
+                }, {
+                  "day" : "SUNDAY",
+                  "canSchedule" : false
+                } ]
+              }
+            }, {
+              "id" : "outpatientMentalHealth",
+              "name" : "Outpatient Mental Health",
+              "stopCodes" : [ {
+                "primary" : "502",
+                "secondary" : "125"
+              }, {
+                "primary" : "502",
+                "secondary" : "179"
+              }, {
+                "primary" : "502",
+                "secondary" : "185"
+              }, {
+                "primary" : "502",
+                "secondary" : "186"
+              }, {
+                "primary" : "502",
+                "secondary" : "187"
+              }, {
+                "primary" : "502",
+                "secondary" : "509"
+              }, {
+                "primary" : "502",
+                "secondary" : "510"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "submittedRequestLimit" : 2,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "audiology",
+              "name" : "Audiology",
+              "stopCodes" : [ {
+                "primary" : "203"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "submittedRequestLimit" : 2,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "clinicalPharmacyPrimaryCare",
+              "name" : "Clinical Pharmacy-Primary Care",
+              "stopCodes" : [ {
+                "primary" : "160",
+                "secondary" : "323"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "submittedRequestLimit" : 2,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "primaryCare",
+              "name" : "Primary Care",
+              "stopCodes" : [ {
+                "primary" : "322"
+              }, {
+                "primary" : "323"
+              }, {
+                "primary" : "350"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : true
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "submittedRequestLimit" : 1,
+                "enterpriseSubmittedRequestLimit" : 1,
+                "enabled" : false
+              }
+            }, {
+              "id" : "moveProgram",
+              "name" : "MOVE! program",
+              "stopCodes" : [ {
+                "primary" : "372"
+              }, {
+                "primary" : "373"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "submittedRequestLimit" : 2,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "cpap",
+              "name" : "CPAP Clinic",
+              "stopCodes" : [ {
+                "primary" : "349",
+                "secondary" : "116"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "submittedRequestLimit" : 2,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "socialWork",
+              "name" : "Social Work",
+              "stopCodes" : [ {
+                "primary" : "125",
+                "secondary" : "323"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "submittedRequestLimit" : 2,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "411",
+              "name" : "Podiatry",
+              "stopCodes" : [ {
+                "primary" : "411"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "submittedRequestLimit" : 2,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "foodAndNutrition",
+              "name" : "Food and Nutrition",
+              "stopCodes" : [ {
+                "primary" : "123"
+              }, {
+                "primary" : "124"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "submittedRequestLimit" : 2,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "ophthalmology",
+              "name" : "Ophthalmology",
+              "stopCodes" : [ {
+                "primary" : "407"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "submittedRequestLimit" : 2,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "optometry",
+              "name" : "Optometry",
+              "stopCodes" : [ {
+                "primary" : "408"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "submittedRequestLimit" : 2,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "homeSleepTesting",
+              "name" : "Sleep Medicine – Home Sleep Testing",
+              "stopCodes" : [ {
+                "primary" : "143",
+                "secondary" : "189"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "submittedRequestLimit" : 2,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            } ],
+            "communityCare" : false
+          }, {
+            "facilityId" : "984GA",
+            "services" : [ {
+              "id" : "amputation",
+              "name" : "Amputation Services",
+              "stopCodes" : [ {
+                "primary" : "211"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 365,
+                "submittedRequestLimit" : 1,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "covid",
+              "name" : "COVID Vaccine",
+              "stopCodes" : [ {
+                "secondary" : "710"
+              } ],
+              "char4" : "CDQC",
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              }
+            }, {
+              "id" : "CR1",
+              "name" : "Express Care",
+              "request" : {
+                "patientHistoryRequired" : false,
+                "submittedRequestLimit" : 2,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false,
+                "schedulingDays" : [ {
+                  "day" : "MONDAY",
+                  "canSchedule" : false
+                }, {
+                  "day" : "TUESDAY",
+                  "canSchedule" : false
+                }, {
+                  "day" : "WEDNESDAY",
+                  "canSchedule" : false
+                }, {
+                  "day" : "THURSDAY",
+                  "canSchedule" : false
+                }, {
+                  "day" : "FRIDAY",
+                  "canSchedule" : false
+                }, {
+                  "day" : "SATURDAY",
+                  "canSchedule" : false
+                }, {
+                  "day" : "SUNDAY",
+                  "canSchedule" : false
+                } ]
+              }
+            }, {
+              "id" : "outpatientMentalHealth",
+              "name" : "Outpatient Mental Health",
+              "stopCodes" : [ {
+                "primary" : "502",
+                "secondary" : "125"
+              }, {
+                "primary" : "502",
+                "secondary" : "179"
+              }, {
+                "primary" : "502",
+                "secondary" : "185"
+              }, {
+                "primary" : "502",
+                "secondary" : "186"
+              }, {
+                "primary" : "502",
+                "secondary" : "187"
+              }, {
+                "primary" : "502",
+                "secondary" : "509"
+              }, {
+                "primary" : "502",
+                "secondary" : "510"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 365,
+                "submittedRequestLimit" : 1,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : true
+              }
+            }, {
+              "id" : "audiology",
+              "name" : "Audiology",
+              "stopCodes" : [ {
+                "primary" : "203"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 365,
+                "submittedRequestLimit" : 2,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "clinicalPharmacyPrimaryCare",
+              "name" : "Clinical Pharmacy-Primary Care",
+              "stopCodes" : [ {
+                "primary" : "160",
+                "secondary" : "323"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 365,
+                "submittedRequestLimit" : 1,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "primaryCare",
+              "name" : "Primary Care",
+              "stopCodes" : [ {
+                "primary" : "322"
+              }, {
+                "primary" : "323"
+              }, {
+                "primary" : "350"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "submittedRequestLimit" : 1,
+                "enterpriseSubmittedRequestLimit" : 1,
+                "enabled" : true
+              }
+            }, {
+              "id" : "moveProgram",
+              "name" : "MOVE! program",
+              "stopCodes" : [ {
+                "primary" : "372"
+              }, {
+                "primary" : "373"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 365,
+                "submittedRequestLimit" : 1,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "cpap",
+              "name" : "CPAP Clinic",
+              "stopCodes" : [ {
+                "primary" : "349",
+                "secondary" : "116"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 365,
+                "submittedRequestLimit" : 1,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "socialWork",
+              "name" : "Social Work",
+              "stopCodes" : [ {
+                "primary" : "125",
+                "secondary" : "323"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 365,
+                "submittedRequestLimit" : 1,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "411",
+              "name" : "Podiatry",
+              "stopCodes" : [ {
+                "primary" : "411"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 365,
+                "submittedRequestLimit" : 1,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "foodAndNutrition",
+              "name" : "Food and Nutrition",
+              "stopCodes" : [ {
+                "primary" : "123"
+              }, {
+                "primary" : "124"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 365,
+                "submittedRequestLimit" : 1,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "ophthalmology",
+              "name" : "Ophthalmology",
+              "stopCodes" : [ {
+                "primary" : "407"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 365,
+                "submittedRequestLimit" : 2,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "optometry",
+              "name" : "Optometry",
+              "stopCodes" : [ {
+                "primary" : "408"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 365,
+                "submittedRequestLimit" : 2,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            }, {
+              "id" : "homeSleepTesting",
+              "name" : "Sleep Medicine – Home Sleep Testing",
+              "stopCodes" : [ {
+                "primary" : "143",
+                "secondary" : "189"
+              } ],
+              "direct" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 0,
+                "canCancel" : true,
+                "enabled" : false
+              },
+              "request" : {
+                "patientHistoryRequired" : false,
+                "patientHistoryDuration" : 365,
+                "submittedRequestLimit" : 1,
+                "enterpriseSubmittedRequestLimit" : 2,
+                "enabled" : false
+              }
+            } ],
+            "communityCare" : true
+          } ]
+        }
+  recorded_at: Thu, 31 Aug 2023 22:51:37 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES - `va_online_scheduling_recent_locations_filter`
- This is part of ongoing development for the new recent locations feature. This PR adds an optional url param `clinical_service_id` that allows recent facilities endpoint to filter returned facilities to only those that supports the specified service.
- Appointment (VAOS) Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99311

## Testing done

- [x] *New code is covered by unit tests*
- Added new unit tests to cover the added filter capability and ensured existing tests pass


## Screenshots
N/A

## What areas of the site does it impact?
Appointments (VAOS)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

