### PR TITLE
98828 Add feature toggle for RUM - form 10-10d

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -868,6 +868,9 @@ features:
   form1010d:
     actor_type: cookie_id
     description: If enabled shows the digital form experience for form 10-10d (IVC CHAMPVA)
+  form1010d_browser_monitoring_enabled:
+    actor_type: user
+    description: Datadog RUM monitoring for form 10-10d (IVC CHAMPVA)
   form107959c:
     actor_type: user
     description: If enabled shows the digital form experience for form 10-7959c (IVC CHAMPVA other health insurance)


### PR DESCRIPTION
## Summary

This PR adds a feature toggle to control the Data Dog Real User Monitoring (RUM) for form 10-10d.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98828
- https://github.com/department-of-veterans-affairs/vets-website/pull/33772

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots

NA

## What areas of the site does it impact?

IVC CHAMPVA form 10-10d only

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA
