### PR TITLE
[VI-918] Updating UserVerifier to take distinct attributes, and to properly propagate mhv uuid

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -154,12 +154,12 @@ module V1
       user_session_form = UserSessionForm.new(saml_response)
       raise_saml_error(user_session_form) unless user_session_form.valid?
       mhv_unverified_validation(user_session_form.user)
-      create_user_verification(user_session_form.user)
+      user_verification = create_user_verification(user_session_form.user_identity)
       @current_user, @session_object = user_session_form.persist
       set_cookies
       after_login_actions
 
-      if @current_user.needs_accepted_terms_of_use
+      if user_verification.user_account.needs_accepted_terms_of_use?
         redirect_to url_service.terms_of_use_redirect_url
       else
         redirect_to url_service.login_redirect_url
@@ -167,14 +167,14 @@ module V1
       login_stats(:success)
     end
 
-    def create_user_verification(user)
-      user_verifier_object = OpenStruct.new({ sign_in: user.identity.sign_in,
-                                              mhv_correlation_id: user.mhv_correlation_id,
-                                              idme_uuid: user.idme_uuid,
-                                              edipi: user.identity.edipi,
-                                              logingov_uuid: user.logingov_uuid,
-                                              icn: user.icn })
-      Login::UserVerifier.new(user_verifier_object).perform
+    def create_user_verification(user_identity)
+      Login::UserVerifier.new(login_type: user_identity.sign_in&.dig(:service_name),
+                              auth_broker: user_identity.sign_in&.dig(:auth_broker),
+                              mhv_uuid: user_identity.mhv_credential_uuid,
+                              idme_uuid: user_identity.idme_uuid,
+                              dslogon_uuid: user_identity.edipi,
+                              logingov_uuid: user_identity.logingov_uuid,
+                              icn: user_identity.icn).perform
     end
 
     def mhv_unverified_validation(user)

--- a/app/services/login/user_verifier.rb
+++ b/app/services/login/user_verifier.rb
@@ -2,14 +2,20 @@
 
 module Login
   class UserVerifier
-    def initialize(user)
-      @login_type = user.sign_in&.dig(:service_name)
-      @auth_broker = user.sign_in&.dig(:auth_broker)
-      @mhv_uuid = user.mhv_credential_uuid
-      @idme_uuid = user.idme_uuid
-      @dslogon_uuid = user.edipi
-      @logingov_uuid = user.logingov_uuid
-      @icn = user.icn.presence
+    def initialize(login_type:, # rubocop:disable Metrics/ParameterLists
+                   auth_broker:,
+                   mhv_uuid:,
+                   idme_uuid:,
+                   dslogon_uuid:,
+                   logingov_uuid:,
+                   icn:)
+      @login_type = login_type
+      @auth_broker = auth_broker
+      @mhv_uuid = mhv_uuid
+      @idme_uuid = idme_uuid
+      @dslogon_uuid = dslogon_uuid
+      @logingov_uuid = logingov_uuid
+      @icn = icn.presence
       @deprecated_log = nil
       @user_account_mismatch_log = nil
     end

--- a/app/services/sign_in/user_code_map_creator.rb
+++ b/app/services/sign_in/user_code_map_creator.rb
@@ -66,15 +66,6 @@ module SignIn
       state_payload.scope == Constants::Auth::DEVICE_SSO
     end
 
-    def user_verifier_object
-      @user_verifier_object ||= OpenStruct.new({ idme_uuid:,
-                                                 logingov_uuid:,
-                                                 sign_in:,
-                                                 edipi:,
-                                                 mhv_credential_uuid:,
-                                                 icn: verified_icn })
-    end
-
     def user_code_map
       @user_code_map ||= UserCodeMap.new(login_code:,
                                          type: state_payload.type,
@@ -84,7 +75,13 @@ module SignIn
     end
 
     def user_verification
-      @user_verification ||= Login::UserVerifier.new(user_verifier_object).perform
+      @user_verification ||= Login::UserVerifier.new(login_type: sign_in[:service_name],
+                                                     auth_broker: sign_in[:auth_broker],
+                                                     mhv_uuid: mhv_credential_uuid,
+                                                     idme_uuid:,
+                                                     dslogon_uuid: edipi,
+                                                     logingov_uuid:,
+                                                     icn: verified_icn).perform
     end
 
     def user_account

--- a/spec/controllers/v0/sign_in_controller_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_spec.rb
@@ -3036,7 +3036,8 @@ RSpec.describe V0::SignInController, type: :controller do
     context 'when successfully authenticated' do
       let(:access_token) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token_object).perform }
       let(:authorization) { "Bearer #{access_token}" }
-      let!(:user_account) { Login::UserVerifier.new(user.identity).perform.user_account }
+      let(:user_verification) { create(:idme_user_verification, idme_uuid: user.idme_uuid) }
+      let(:user_account) { user_verification.user_account }
       let(:user) { create(:user, :loa3) }
       let(:user_uuid) { user.uuid }
       let(:oauth_session) { create(:oauth_session, user_account:) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1108,16 +1108,20 @@ RSpec.describe User, type: :model do
               edipi:, mhv_credential_uuid:, authn_context:)
       )
     end
-    let(:user_verifier_object) do
-      OpenStruct.new({ idme_uuid:, logingov_uuid:, sign_in: user.identity_sign_in,
-                       edipi:, mhv_credential_uuid: })
-    end
     let(:authn_context) { LOA::IDME_LOA1_VETS }
     let(:logingov_uuid) { 'some-logingov-uuid' }
     let(:idme_uuid) { 'some-idme-uuid' }
     let(:edipi) { 'some-edipi' }
     let(:mhv_credential_uuid) { 'some-mhv-credential-uuid' }
-    let!(:user_verification) { Login::UserVerifier.new(user_verifier_object).perform }
+    let!(:user_verification) do
+      Login::UserVerifier.new(login_type: user.identity_sign_in[:service_name],
+                              auth_broker: user.identity_sign_in[:auth_broker],
+                              mhv_uuid: mhv_credential_uuid,
+                              idme_uuid:,
+                              dslogon_uuid: edipi,
+                              logingov_uuid:,
+                              icn: user.icn).perform
+    end
     let!(:user_account) { user_verification&.user_account }
 
     describe '#user_verification' do

--- a/spec/services/login/user_verifier_spec.rb
+++ b/spec/services/login/user_verifier_spec.rb
@@ -4,31 +4,25 @@ require 'rails_helper'
 
 RSpec.describe Login::UserVerifier do
   describe '#perform' do
-    subject { described_class.new(user_identity).perform }
-
-    let(:user_identity) do
-      OpenStruct.new(
-        {
-          edipi: edipi_identifier,
-          sign_in: { service_name: login_value, auth_broker: },
-          mhv_credential_uuid: mhv_credential_uuid_identifier,
-          idme_uuid: idme_uuid_identifier,
-          logingov_uuid: logingov_uuid_identifier,
-          icn:,
-          user_verification_id: nil,
-          user_account_uuid: nil
-        }
-      )
+    subject do
+      described_class.new(login_type:,
+                          auth_broker:,
+                          mhv_uuid:,
+                          idme_uuid:,
+                          dslogon_uuid:,
+                          logingov_uuid:,
+                          icn:).perform
     end
+
     let(:auth_broker) { 'some-auth-broker' }
-    let(:edipi_identifier) { 'some-edipi' }
-    let(:mhv_credential_uuid_identifier) { 'some-credential=uuid' }
-    let(:idme_uuid_identifier) { 'some-idme-uuid' }
-    let(:logingov_uuid_identifier) { 'some-logingov-uuid' }
+    let(:dslogon_uuid) { 'some-edipi' }
+    let(:mhv_uuid) { 'some-credential-uuid' }
+    let(:idme_uuid) { 'some-idme-uuid' }
+    let(:logingov_uuid) { 'some-logingov-uuid' }
     let(:locked) { false }
 
     let(:icn) { nil }
-    let(:login_value) { nil }
+    let(:login_type) { nil }
     let(:time_freeze_time) { '10-10-2021' }
 
     before do
@@ -41,10 +35,10 @@ RSpec.describe Login::UserVerifier do
 
     shared_examples 'user_verification with nil credential identifier' do
       let(:authn_identifier) { nil }
-      let(:edipi_identifier) { authn_identifier }
-      let(:mhv_credential_uuid_identifier) { authn_identifier }
-      let(:idme_uuid_identifier) { authn_identifier }
-      let(:logingov_uuid_identifier) { authn_identifier }
+      let(:dslogon_uuid) { authn_identifier }
+      let(:mhv_uuid) { authn_identifier }
+      let(:idme_uuid) { authn_identifier }
+      let(:logingov_uuid) { authn_identifier }
       let(:expected_log) { "[Login::UserVerifier] Nil identifier for type=#{authn_identifier_type}" }
       let(:expected_error) { Login::Errors::UserVerificationNotCreatedError }
 
@@ -58,11 +52,11 @@ RSpec.describe Login::UserVerifier do
       context 'and there is an alternate idme credential identifier' do
         let(:type) { :idme_uuid }
         let(:expected_log_idme) do
-          "[Login::UserVerifier] Attempting alternate type=#{type} identifier=#{idme_uuid_identifier}"
+          "[Login::UserVerifier] Attempting alternate type=#{type} identifier=#{idme_uuid}"
         end
-        let(:idme_uuid_identifier) { 'some-idme-uuid-identifier' }
+        let(:idme_uuid) { 'some-idme-uuid-identifier' }
         let!(:user_verification) do
-          UserVerification.create!(type => idme_uuid_identifier,
+          UserVerification.create!(type => idme_uuid,
                                    backing_idme_uuid:,
                                    user_account:,
                                    locked:)
@@ -86,11 +80,11 @@ RSpec.describe Login::UserVerifier do
         let(:icn) { 'some-icn' }
         let(:expected_log) do
           '[Login::UserVerifier] New VA.gov user, ' \
-            "type=#{login_value}, broker=#{auth_broker}, identifier=#{authn_identifier}, locked=#{locked}"
+            "type=#{login_type}, broker=#{auth_broker}, identifier=#{authn_identifier}, locked=#{locked}"
         end
 
         context 'and user_verification for user credential already exists' do
-          let(:user_account) { UserAccount.new(icn: user_identity.icn) }
+          let(:user_account) { UserAccount.new(icn:) }
           let!(:user_verification) do
             UserVerification.create!(authn_identifier_type => authn_identifier,
                                      user_account:,
@@ -124,7 +118,7 @@ RSpec.describe Login::UserVerifier do
           end
 
           context 'and user_account with the current user ICN exists' do
-            let(:user_account) { UserAccount.new(icn: user_identity.icn) }
+            let(:user_account) { UserAccount.new(icn:) }
 
             context 'and this user account is already associated with the user_verification' do
               it 'does not change user_verification user_account associations' do
@@ -140,7 +134,7 @@ RSpec.describe Login::UserVerifier do
             end
 
             context 'and this user account is not already associated with the user_verification' do
-              let(:other_user_account) { UserAccount.new(icn: user_identity.icn) }
+              let(:other_user_account) { UserAccount.new(icn:) }
 
               context 'and the current user_verification is not verified' do
                 let(:user_account) { UserAccount.new(icn: nil) }
@@ -229,7 +223,7 @@ RSpec.describe Login::UserVerifier do
               expect do
                 subject
                 user_account.reload
-              end.to change(user_account, :icn).from(nil).to(user_identity.icn)
+              end.to change(user_account, :icn).from(nil).to(icn)
             end
 
             it 'sets the user_verification verified_at time to now' do
@@ -249,7 +243,7 @@ RSpec.describe Login::UserVerifier do
           let(:expected_verified_at_time) { Time.zone.now }
           let(:expected_log) do
             '[Login::UserVerifier] New VA.gov user, ' \
-              "type=#{login_value}, broker=#{auth_broker}, identifier=#{authn_identifier}, locked=#{locked}"
+              "type=#{login_type}, broker=#{auth_broker}, identifier=#{authn_identifier}, locked=#{locked}"
           end
 
           it 'makes a new user log to rails logger' do
@@ -271,7 +265,7 @@ RSpec.describe Login::UserVerifier do
             it 'sets the current user ICN on the user_account record' do
               subject
               account_icn = UserVerification.where(authn_identifier_type => authn_identifier).first.user_account.icn
-              expect(account_icn).to eq user_identity.icn
+              expect(account_icn).to eq icn
             end
 
             it 'creates a user_account record attached to the user_verification record' do
@@ -330,7 +324,7 @@ RSpec.describe Login::UserVerifier do
         let(:icn) { nil }
         let(:expected_log) do
           '[Login::UserVerifier] New VA.gov user, ' \
-            "type=#{login_value}, broker=#{auth_broker}, identifier=#{authn_identifier}, locked=#{locked}"
+            "type=#{login_type}, broker=#{auth_broker}, identifier=#{authn_identifier}, locked=#{locked}"
         end
 
         context 'and user_verification for user credential already exists' do
@@ -390,10 +384,10 @@ RSpec.describe Login::UserVerifier do
     end
 
     context 'when user credential is mhv' do
-      let(:login_value) { SignIn::Constants::Auth::MHV }
-      let(:authn_identifier) { user_identity.mhv_credential_uuid }
+      let(:login_type) { SignIn::Constants::Auth::MHV }
+      let(:authn_identifier) { mhv_uuid }
       let(:authn_identifier_type) { :mhv_uuid }
-      let(:backing_idme_uuid) { idme_uuid_identifier }
+      let(:backing_idme_uuid) { idme_uuid }
       let(:linked_user_verification_type) { :mhv_user_verification }
 
       it_behaves_like 'user_verification with nil credential identifier'
@@ -401,18 +395,18 @@ RSpec.describe Login::UserVerifier do
     end
 
     context 'when user credential is idme' do
-      let(:login_value) { SignIn::Constants::Auth::IDME }
-      let(:authn_identifier) { user_identity.idme_uuid }
+      let(:login_type) { SignIn::Constants::Auth::IDME }
+      let(:authn_identifier) { idme_uuid }
       let(:authn_identifier_type) { :idme_uuid }
       let(:backing_idme_uuid) { nil }
       let(:linked_user_verification_type) { :idme_user_verification }
 
       context 'when credential identifier is nil' do
         let(:authn_identifier) { nil }
-        let(:edipi_identifier) { authn_identifier }
-        let(:mhv_credential_uuid_identifier) { authn_identifier }
-        let(:idme_uuid_identifier) { authn_identifier }
-        let(:logingov_uuid_identifier) { authn_identifier }
+        let(:dslogon_uuid) { authn_identifier }
+        let(:mhv_uuid) { authn_identifier }
+        let(:idme_uuid) { authn_identifier }
+        let(:logingov_uuid) { authn_identifier }
         let(:expected_log) { "[Login::UserVerifier] Nil identifier for type=#{authn_identifier_type}" }
         let(:expected_error) { Login::Errors::UserVerificationNotCreatedError }
 
@@ -426,10 +420,10 @@ RSpec.describe Login::UserVerifier do
     end
 
     context 'when user credential is dslogon' do
-      let(:login_value) { SignIn::Constants::Auth::DSLOGON }
-      let(:authn_identifier) { user_identity.edipi }
+      let(:login_type) { SignIn::Constants::Auth::DSLOGON }
+      let(:authn_identifier) { dslogon_uuid }
       let(:authn_identifier_type) { :dslogon_uuid }
-      let(:backing_idme_uuid) { idme_uuid_identifier }
+      let(:backing_idme_uuid) { idme_uuid }
       let(:linked_user_verification_type) { :dslogon_user_verification }
 
       it_behaves_like 'user_verification with nil credential identifier'
@@ -437,8 +431,8 @@ RSpec.describe Login::UserVerifier do
     end
 
     context 'when user credential is logingov' do
-      let(:login_value) { SignIn::Constants::Auth::LOGINGOV }
-      let(:authn_identifier) { user_identity.logingov_uuid }
+      let(:login_type) { SignIn::Constants::Auth::LOGINGOV }
+      let(:authn_identifier) { logingov_uuid }
       let(:authn_identifier_type) { :logingov_uuid }
       let(:backing_idme_uuid) { nil }
       let(:linked_user_verification_type) { :logingov_user_verification }


### PR DESCRIPTION
## Summary

- This PR updates UserVerifier functionality so that MHV accounts will properly propagate the MHV UUID when the `UserVerifier` is called during an MHV SSOe auth

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-918

## Testing done

- [ ] This refactored general UserVerifier functionality, so confirmed that SiS and SSOe authentications still create an appropriate `UserVerification` in the `UserVerifier` code
- [ ] Confirmed using Mocked Authentication that MHV authentication created a UserVerification

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [ ] Confirm authenticating with Sign in Service and SSOe still result in a UserVerification getting created or updated when appropriate
- [ ] MHV SSOe Auth is difficult to test localhost, so will have to wait until staging to test