### PR TITLE
[VI-917] MHV Correlation ID attribute only for verified users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -153,6 +153,7 @@ class User < Common::RedisStore
   end
 
   def mhv_correlation_id
+    return unless can_create_mhv_account?
     return mhv_user_account.id if mhv_user_account.present?
 
     mpi_mhv_correlation_id if active_mhv_ids&.one?
@@ -469,11 +470,11 @@ class User < Common::RedisStore
     MHV::AccountCreatorJob.perform_async(user_verification_id)
   end
 
+  private
+
   def can_create_mhv_account?
     loa3? && !needs_accepted_terms_of_use
   end
-
-  private
 
   def mpi_profile
     return nil unless identity && mpi


### PR DESCRIPTION

## Summary

- This PR makes it so the MHV Correlation ID attribute on the user model is only available if the user is verified and has properly accepted terms of use

## Related issue(s)

https://jira.devops.va.gov/browse/VI-918

## Testing done

- [ ] Confirmed for loa1 user that `User.mhv_correlation_id` returns nil, and no log about missing attributes is created in Rails console
- [ ] Confirmed for loa3 user that `User.mhv_correlation_id` returns a proper correlation id

## What areas of the site does it impact?
MHV attributes

## Acceptance criteria

- [ ]  Authenticate with an ial1 user, confirm that `user.mhv_correlation_id` returns nil, confirm that `user.mhv_correlation_id` does not create any Rails console logs
- [ ] Authenticate with an ial3 user that has MHV id, confirm that `user.mhv_correlation_id` returns an identifier
