### PR TITLE
10: [ART] POA request resolution validates unique POA request

### DIFF
--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_resolution.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_resolution.rb
@@ -32,5 +32,7 @@ module AccreditedRepresentativePortal
     has_kms_key
 
     has_encrypted :reason, key: :kms_key, **lockbox_options
+
+    validates :power_of_attorney_request, uniqueness: true
   end
 end

--- a/modules/accredited_representative_portal/spec/models/accredited_representative_portal/power_of_attorney_request_resolution_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representative_portal/power_of_attorney_request_resolution_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestResolution, type: :model do
+  it 'must uniquely be associated to a poa request' do
+    resolution_a = create(:power_of_attorney_request_resolution, :expiration)
+
+    resolution_b = build(
+      :power_of_attorney_request_resolution, :expiration,
+      power_of_attorney_request: resolution_a.power_of_attorney_request
+    )
+
+    expect(resolution_b).not_to be_valid
+    expect(resolution_b.errors.full_messages).to eq(
+      [
+       "Power of attorney request has already been taken",
+       "Resolving is invalid"
+      ]
+    )
+  end
+end

--- a/modules/accredited_representative_portal/spec/models/accredited_representative_portal/power_of_attorney_request_resolution_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representative_portal/power_of_attorney_request_resolution_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestResolution,
     expect(resolution_b).not_to be_valid
     expect(resolution_b.errors.full_messages).to eq(
       [
-       "Power of attorney request has already been taken",
-       "Resolving is invalid"
+        'Power of attorney request has already been taken',
+        'Resolving is invalid'
       ]
     )
   end


### PR DESCRIPTION
# Add Unique Validation for POA Request Resolutions  

## Description  
This pull request introduces a uniqueness constraint for `power_of_attorney_request` in the `PowerOfAttorneyRequestResolution` model to ensure that each POA request can only be resolved once.  

### Key Changes  
- **Model Validation:**  
  - Added a `validates :power_of_attorney_request, uniqueness: true` constraint to enforce uniqueness for POA requests.  

- **Test Coverage:**  
  - Created a new RSpec test suite for `PowerOfAttorneyRequestResolution` to verify the uniqueness validation.  
  - The test ensures an appropriate error message is displayed when a duplicate POA resolution is attempted.  

