### PR TITLE
vebt-830 code tims fix and tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,7 +280,7 @@ GEM
     blueprinter (1.1.2)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (6.2.2)
+    brakeman (7.0.0)
       racc
     breakers (0.7.1)
       faraday (>= 1.2.0, < 3.0)

--- a/modules/vye/app/models/vye/user_profile.rb
+++ b/modules/vye/app/models/vye/user_profile.rb
@@ -111,14 +111,6 @@ class Vye::UserProfile < ApplicationRecord
     nil
   end
 
-  def check_for_match
-    user_profile = self
-    attribute_name = %w[ssn_digest file_number_digest icn].find { |a| attribute_changed? a }
-    conflict = attribute_name.present?
-
-    { user_profile:, conflict:, attribute_name: }
-  end
-
   def self.produce(attributes)
     ssn, file_number, icn = attributes.values_at(:ssn, :file_number, :icn).map(&:presence)
     ssn_digest, file_number_digest = [ssn, file_number].map { |value| gen_digest(value) }
@@ -126,7 +118,8 @@ class Vye::UserProfile < ApplicationRecord
 
     user_profile = find_or_build(ssn_digest:, file_number_digest:)
     user_profile&.assign_attributes(**assignment)
-    user_profile&.check_for_match
+
+    user_profile
   end
 
   def self.find_or_build(ssn_digest:, file_number_digest:)

--- a/modules/vye/lib/vye/load_data.rb
+++ b/modules/vye/lib/vye/load_data.rb
@@ -112,7 +112,6 @@ module Vye
         @user_profile = user_profile
         return true
       end
-    
 
       if user_profile.changed?
         # this shouldn't be happening

--- a/modules/vye/lib/vye/load_data.rb
+++ b/modules/vye/lib/vye/load_data.rb
@@ -1,11 +1,27 @@
 # frozen_string_literal: true
 
 module Vye
-  class UserProfileConflict < RuntimeError; end
-  class UserProfileNotFound < RuntimeError; end
-
   class LoadData
+    STATSD_PREFIX = name.gsub('::', '.').underscore
+    STATSD_NAMES = {
+      failure: "#{STATSD_PREFIX}.failure.no_source",
+      team_sensitive_failure: "#{STATSD_PREFIX}.failure.team_sensitive",
+      tims_feed_failure: "#{STATSD_PREFIX}.failure.tims_feed",
+      bdn_feed_failure: "#{STATSD_PREFIX}.failure.bdn_feed",
+      user_profile_created: "#{STATSD_PREFIX}.user_profile.created",
+      user_profile_updated: "#{STATSD_PREFIX}.user_profile.updated",
+      user_profile_creation_skipped: "#{STATSD_PREFIX}.user_profile.creation_skipped",
+      user_profile_update_skipped: "#{STATSD_PREFIX}.user_profile.update_skipped"
+    }.freeze
+
     SOURCES = %i[team_sensitive tims_feed bdn_feed].freeze
+
+    FAILURE_TEMPLATE = <<~FAILURE_TEMPLATE_HEREDOC.gsub(/\n/, ' ').freeze
+      Loading data failed:
+      source: %<source>s,
+      locator: %<locator>s,
+      error message: %<error_message>s
+    FAILURE_TEMPLATE_HEREDOC
 
     private_constant :SOURCES
 
@@ -15,7 +31,7 @@ module Vye
 
     def initialize(source:, locator:, bdn_clone: nil, records: {})
       raise ArgumentError, format('Invalid source: %<source>s', source:) unless sources.include?(source)
-      raise ArgumentError, 'Missing profile' if records[:profile].blank?
+      raise ArgumentError, 'Missing locater' if locator.blank?
       raise ArgumentError, 'Missing bdn_clone' unless source == :tims_feed || bdn_clone.present?
 
       @bdn_clone = bdn_clone
@@ -23,68 +39,106 @@ module Vye
       @source = source
 
       UserProfile.transaction do
-        send(source, **records)
+        @valid_flag = send(source, **records)
+      end
+    rescue => e
+      format(FAILURE_TEMPLATE, source:, locator:, error_message: e.message).tap do |msg|
+        Rails.logger.error(msg)
       end
 
-      @valid_flag = true
-    rescue => e
-      @error_message =
-        format(
-          'Loading data failed: source: %<source>s, locator: %<locator>s, error message: %<message>s',
-          source:, locator:, message: e.message
-        )
-      Rails.logger.error @error_message
+      (sources.include?(source) ? :"#{source}_failure" : :failure).tap do |key|
+        StatsD.increment(STATSD_NAMES[key])
+      end
+
+      Sentry.capture_exception(e)
       @valid_flag = false
     end
 
     def sources = SOURCES
 
     def team_sensitive(profile:, info:, address:, awards: [], pending_documents: [])
-      load_profile(profile)
+      return false unless load_profile(profile)
+
       load_info(info)
       load_address(address)
       load_awards(awards)
       load_pending_documents(pending_documents)
+      true
     end
 
     def tims_feed(profile:, pending_document:)
-      load_profile(profile)
+      return false unless load_profile(profile)
+
       load_pending_document(pending_document)
+      true
     end
 
     def bdn_feed(profile:, info:, address:, awards: [])
-      bdn_clone_line = locator
-      load_profile(profile)
-      load_info(info.merge(bdn_clone_line:))
+      return false unless load_profile(profile)
+
+      load_info(info)
       load_address(address)
       load_awards(awards)
+      true
     end
 
     def load_profile(attributes)
-      user_profile, conflict, attribute_name =
-        UserProfile
-        .produce(attributes)
-        .values_at(:user_profile, :conflict, :attribute_name)
+      attributes || {} => {ssn:, file_number:} # this shouldn't throw NoMatchingPatternKeyError
+      user_profile = UserProfile.produce(attributes)
 
-      if user_profile.new_record? && source == :tims_feed
-        raise UserProfileNotFound
-      elsif conflict == true && source == :tims_feed
-        raise UserProfileConflict
-      elsif conflict == true
-        message =
-          format(
-            'Updated conflict for %<attribute_name>s from BDN feed line: %<locator>s',
-            attribute_name:, locator:
-          )
-        Rails.logger.info message
+      unless user_profile.new_record? || user_profile.changed?
+        # as time goes on this should be whats mostly happening
+        @user_profile = user_profile
+        return true
       end
 
-      user_profile.save!
-      @user_profile = user_profile
+      if source == :tims_feed && user_profile.new_record?
+        # we are not going to create a new record based of off the TIMS feed
+        StatsD.increment(STATSD_NAMES[:user_profile_creation_skipped])
+        return false
+      end
+
+      if source == :tims_feed && user_profile.changed?
+        # we are not updating a record conflict from TIMS
+        StatsD.increment(STATSD_NAMES[:user_profile_update_skipped])
+        return false
+      end
+
+      if user_profile.new_record?
+        # we are going to count the number of records created
+        # this should be decreasing over time
+        StatsD.increment(STATSD_NAMES[:user_profile_created])
+        user_profile.save!
+        @user_profile = user_profile
+        return true
+      end
+    
+
+      if user_profile.changed?
+        # this shouldn't be happening
+        # we will update a record conflict from BDN (or TeamSensitive),
+        # but need to investigate why this is happening
+        user_profile_id = user_profile.id
+        changed_attributes = user_profile.changed_attributes
+
+        format(
+          'UserProfile(%<user_profile_id>u) updated %<changed_attributes>p from BDN feed line: %<locator>s',
+          user_profile_id:, changed_attributes:, locator:
+        ).tap do |msg|
+          Rails.logger.warn msg
+        end
+
+        StatsD.increment(STATSD_NAMES[:user_profile_updated])
+        user_profile.save!
+        @user_profile = user_profile
+        true
+      end
     end
 
     def load_info(attributes)
-      @user_info = user_profile.user_infos.create!(attributes.merge(bdn_clone:))
+      bdn_clone_line = locator
+      attributes_final = attributes.merge(bdn_clone:, bdn_clone_line:)
+      @user_info = user_profile.user_infos.create!(attributes_final)
     end
 
     def load_address(attributes)
@@ -108,8 +162,6 @@ module Vye
     end
 
     public
-
-    attr_reader :error_message
 
     def valid?
       @valid_flag

--- a/modules/vye/spec/lib/vye/load_data_spec.rb
+++ b/modules/vye/spec/lib/vye/load_data_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Vye::Engine.root / 'spec/rails_helper'
+
+RSpec.describe Vye::LoadData do
+  let(:source) { :bdn_feed }
+  let(:locator) { 'test' }
+  let(:bdn_clone) { FactoryBot.create(:vye_bdn_clone_base) }
+  let(:records) do
+    {
+      profile: {
+        ssn: '123456789',
+        file_number: ''
+      },
+      info: {
+        file_number: '',
+        dob: '19800101',
+        mr_status: 'E',
+        rem_ent: '3600000',
+        cert_issue_date: '19860328',
+        del_date: '19960205',
+        date_last_certified: '19860328',
+        stub_nm: 'JAPPLES',
+        rpo_code: '316',
+        fac_code: '11907111',
+        payment_amt: '0011550',
+        indicator: 'A'
+      },
+      address: {
+        veteran_name: 'JOHN APPLESEED',
+        address1: '1 Mockingbird Ln',
+        address2: 'APT 1',
+        address3: 'Houston TX',
+        address4: '',
+        address5: '',
+        zip_code: '77401',
+        origin: 'backend'
+      },
+      awards: [
+        {
+          award_begin_date: '00000000',
+          award_end_date: '19860328',
+          training_time: '1',
+          payment_date: '19860328',
+          monthly_rate: 35.0,
+          begin_rsn: '',
+          end_rsn: '66',
+          type_training: '',
+          number_hours: '00',
+          type_hours: '',
+          cur_award_ind: 'C'
+        }
+      ]
+    }
+  end
+
+  describe '::new' do
+    it 'can be instantiated' do
+      r = described_class.new(source:, locator:, bdn_clone:, records:)
+
+      expect(r).to be_a described_class
+      expect(r.valid?).to be(true)
+    end
+
+    it 'reports the exception if source is invalid' do
+      expect(Rails.logger).to receive(:error).with(/Loading data failed:/)
+      expect(StatsD).to receive(:increment).with('vye.load_data.failure.no_source')
+      expect(Sentry).to receive(:capture_exception).with(an_instance_of(ArgumentError))
+
+      r = described_class.new(source: :something_else, locator:, bdn_clone:, records:)
+
+      expect(r.valid?).to be(false)
+    end
+
+    it 'reports the exception if locator is blank' do
+      expect(Rails.logger).to receive(:error).with(/Loading data failed:/)
+      expect(StatsD).to receive(:increment).with('vye.load_data.failure.bdn_feed')
+      expect(Sentry).to receive(:capture_exception).with(an_instance_of(ArgumentError))
+
+      r = described_class.new(source:, locator: nil, bdn_clone:, records:)
+
+      expect(r.valid?).to be(false)
+    end
+
+    it 'reports the exception if bdn_clone is blank' do
+      expect(Rails.logger).to receive(:error).with(/Loading data failed:/)
+      expect(StatsD).to receive(:increment).with('vye.load_data.failure.bdn_feed')
+      expect(Sentry).to receive(:capture_exception).with(an_instance_of(ArgumentError))
+
+      r = described_class.new(source:, locator:, bdn_clone: nil, records:)
+
+      expect(r.valid?).to be(false)
+    end
+
+    it 'reports the exception if profile attributes hash is incorrect' do
+      expect(Rails.logger).to receive(:error).with(/Loading data failed:/)
+      expect(StatsD).to receive(:increment).with('vye.load_data.failure.bdn_feed')
+      expect(Sentry).to receive(:capture_exception).with(an_instance_of(NoMatchingPatternKeyError))
+
+      r = described_class.new(source:, locator:, bdn_clone:, records: records.merge(profile: { invalid: 'data' }))
+
+      expect(r.valid?).to be(false)
+    end
+  end
+
+  describe '#load_profile' do
+    let(:described_instance) { described_class.allocate }
+    let(:user_profile) { instance_double(Vye::UserProfile) }
+
+    before do
+      allow(described_instance).to receive(:load_info)
+      allow(described_instance).to receive(:load_address)
+      allow(described_instance).to receive(:load_awards)
+
+      allow(Vye::UserProfile).to receive(:produce).and_return(user_profile)
+    end
+
+    context 'when UserProfile gets loaded unchanged' do
+      before do
+        allow(user_profile).to receive_messages(
+          new_record?: false,
+          changed?: false
+        )
+      end
+
+      it "doesn't report an exception" do
+        described_instance.send(:initialize, source:, locator:, bdn_clone:, records:)
+
+        expect(described_instance.valid?).to be(true)
+      end
+    end
+
+    context 'when UserProfile gets loaded from BDN feed as a new record' do
+      before do
+        allow(user_profile).to receive(:new_record?).and_return(true)
+      end
+
+      it "doesn't report an exception" do
+        expect(StatsD).to receive(:increment).with('vye.load_data.user_profile.created')
+        expect(user_profile).to receive(:save!).and_return(true)
+
+        described_instance.send(:initialize, source:, locator:, bdn_clone:, records:)
+
+        expect(described_instance.valid?).to be(true)
+      end
+    end
+
+    context 'when UserProfile gets loaded from BDN feed with changed' do
+      before do
+        allow(user_profile).to(
+          receive_messages(
+            new_record?: false,
+            changed?: true,
+            id: 1,
+            changed_attributes: {
+              'ssn_digest' => 'old_ssn_digest',
+              'file_number' => 'old_file_number'
+            }
+          )
+        )
+      end
+
+      it "doesn't report an exception" do
+        expect(StatsD).to receive(:increment).with('vye.load_data.user_profile.updated')
+        expect(user_profile).to receive(:save!).and_return(true)
+
+        described_instance.send(:initialize, source:, locator:, bdn_clone:, records:)
+
+        expect(described_instance.valid?).to be(true)
+      end
+    end
+
+    # context 'when UserProfile gets loaded from TIMS feed as a new record' do
+    # end
+
+    # context 'when UserProfile gets loaded from TIMS feed with changed' do
+    # end
+  end
+end

--- a/modules/vye/spec/models/vye/user_profile_spec.rb
+++ b/modules/vye/spec/models/vye/user_profile_spec.rb
@@ -311,7 +311,6 @@ RSpec.describe Vye::UserProfile, type: :model do
 
         user_profile = described_class.produce(ssn: ssn_clear_req, file_number: file_number_clear_req)
 
-
         expect(user_profile.attributes['ssn_digest']).to eq(ssn_digest_req)
         expect(user_profile.attributes['file_number_digest']).to eq(file_number_digest_req)
       end

--- a/modules/vye/spec/models/vye/user_profile_spec.rb
+++ b/modules/vye/spec/models/vye/user_profile_spec.rb
@@ -233,45 +233,6 @@ RSpec.describe Vye::UserProfile, type: :model do
     end
   end
 
-  describe '#check_for_match' do
-    let!(:user_profile) do
-      create(:vye_user_profile_fresh_import)
-    end
-
-    it 'reports if nothings changed' do
-      ssn_digest, = user_profile.attributes.values_at('ssn_digest')
-      user_profile.assign_attributes(ssn_digest:)
-
-      conflict, attribute_name = user_profile.check_for_match.values_at(:conflict, :attribute_name)
-      expect(conflict).to be(false)
-      expect(attribute_name).to be_nil
-    end
-
-    it 'reports if ssn_digest has changed' do
-      user_profile.assign_attributes(ssn_digest: 'ssn_digest_x')
-
-      conflict, attribute_name = user_profile.check_for_match.values_at(:conflict, :attribute_name)
-      expect(conflict).to be(true)
-      expect(attribute_name).to eq('ssn_digest')
-    end
-
-    it 'reports if file_number_digest has changed' do
-      user_profile.assign_attributes(file_number_digest: 'file_number_digest_x')
-
-      conflict, attribute_name = user_profile.check_for_match.values_at(:conflict, :attribute_name)
-      expect(conflict).to be(true)
-      expect(attribute_name).to eq('file_number_digest')
-    end
-
-    it 'reports if icn is changed' do
-      user_profile.assign_attributes(icn: 'icn_x')
-
-      conflict, attribute_name = user_profile.check_for_match.values_at(:conflict, :attribute_name)
-      expect(conflict).to be(true)
-      expect(attribute_name).to eq('icn')
-    end
-  end
-
   describe '::produce' do
     let(:ssn_clear_db) { 'ssn_clear_db' }
     let(:ssn_digest_db) { 'ssn_digest_db' }
@@ -317,14 +278,9 @@ RSpec.describe Vye::UserProfile, type: :model do
         expect(described_class).to receive(:gen_digest).with(ssn_clear_req).and_return(ssn_digest_req)
         expect(described_class).to receive(:gen_digest).with(file_number_clear_req).and_return(file_number_digest_req)
 
-        found, conflict, attribute_name =
-          described_class
-          .produce(ssn: ssn_clear_req, file_number: file_number_clear_req)
-          .values_at(:user_profile, :conflict, :attribute_name)
+        found = described_class.produce(ssn: ssn_clear_req, file_number: file_number_clear_req)
 
         expect(found).to eq(user_profile)
-        expect(conflict).to be(false)
-        expect(attribute_name).to be_nil
       end
     end
 
@@ -337,15 +293,10 @@ RSpec.describe Vye::UserProfile, type: :model do
         expect(described_class).to receive(:gen_digest).with(ssn_clear_req).and_return(ssn_digest_req)
         expect(described_class).to receive(:gen_digest).with(file_number_clear_req).and_return(file_number_digest_req)
 
-        user_profile, conflict, attribute_name =
-          described_class
-          .produce(ssn: ssn_clear_req, file_number: file_number_clear_req)
-          .values_at(:user_profile, :conflict, :attribute_name)
+        user_profile = described_class.produce(ssn: ssn_clear_req, file_number: file_number_clear_req)
 
         expect(user_profile.attributes['ssn_digest']).to eq(ssn_digest_req)
         expect(user_profile.attributes['file_number_digest']).to eq(file_number_digest_req)
-        expect(conflict).to be(true)
-        expect(attribute_name).to eq('ssn_digest')
       end
     end
 
@@ -358,15 +309,11 @@ RSpec.describe Vye::UserProfile, type: :model do
         expect(described_class).to receive(:gen_digest).with(ssn_clear_req).and_return(ssn_digest_req)
         expect(described_class).to receive(:gen_digest).with(file_number_clear_req).and_return(file_number_digest_req)
 
-        user_profile, conflict, attribute_name =
-          described_class
-          .produce(ssn: ssn_clear_req, file_number: file_number_clear_req)
-          .values_at(:user_profile, :conflict, :attribute_name)
+        user_profile = described_class.produce(ssn: ssn_clear_req, file_number: file_number_clear_req)
+
 
         expect(user_profile.attributes['ssn_digest']).to eq(ssn_digest_req)
         expect(user_profile.attributes['file_number_digest']).to eq(file_number_digest_req)
-        expect(conflict).to be(true)
-        expect(attribute_name).to eq('file_number_digest')
       end
     end
 
@@ -384,16 +331,11 @@ RSpec.describe Vye::UserProfile, type: :model do
         expect(described_class).to receive(:gen_digest).with(ssn_clear_req).and_return(ssn_digest_req)
         expect(described_class).to receive(:gen_digest).with(file_number_clear_req).and_return(file_number_digest_req)
 
-        user_profile, conflict, attribute_name =
-          described_class
-          .produce(ssn: ssn_clear_req, file_number: file_number_clear_req, icn: icn_req)
-          .values_at(:user_profile, :conflict, :attribute_name)
+        user_profile = described_class.produce(ssn: ssn_clear_req, file_number: file_number_clear_req, icn: icn_req)
 
         expect(user_profile.attributes['ssn_digest']).to eq(ssn_digest_req)
         expect(user_profile.attributes['file_number_digest']).to eq(file_number_digest_req)
         expect(user_profile.attributes['icn']).to eq(icn_req)
-        expect(conflict).to be(true)
-        expect(attribute_name).to eq('icn')
       end
     end
   end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Refined criteria for processing TIMS ingest errors
- Not sure if this would be classified as a bug so much as incorrect criteria?
- Removed logic that incorrectly checked for a conflict and changed logic for loading user profile
- vebt
- N/A

## Related issue(s)

- Jira ticket attached in word document

## Testing done

- [x ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
  TIMS ingest records were incorrectly being identified as having errors when they should not have.
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
  Run a TIMS ingest job (LoadData rake task) and confirm errors are not being flagged that shouldn't be. These will be logged.
  Run RSpec tests

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)

[VEBT-830.docx](https://github.com/user-attachments/files/18280780/VEBT-830.docx)
