### PR TITLE
Log form number and file size for form upload submissions

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
@@ -34,7 +34,12 @@ module SimpleFormsApi
         stamper.stamp_pdf
         metadata = validated_metadata
         status, confirmation_number = upload_pdf(file_path, metadata)
+        file_size = File.size(file_path).to_f / (2**20)
 
+        Rails.logger.info(
+          'Simple forms api - scanned form uploaded',
+          { form_number: params[:form_number], status:, confirmation_number:, file_size: }
+        )
         { confirmation_number:, status: }
       end
 


### PR DESCRIPTION
## Summary
This PR logs the form number and file size for form upload submissions. I think the ultimate goal is to maybe make a pie chart divided by form number. (Currently this only works for two form numbers)

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&filterQuery=-status%3AIcebox%2CEpic%2C%22Collab+Cycle%22&pane=issue&itemId=83134568&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1278
