### PR TITLE
93461: Add #zip_code_is_us_based to VBA214140

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,18 +140,6 @@ PATH
     vye (0.1.0)
 
 GEM
-  remote: https://enterprise.contribsys.com/
-  specs:
-    sidekiq-ent (7.2.4)
-      einhorn (~> 1.0)
-      gserver
-      sidekiq (>= 7.2.0, < 8)
-      sidekiq-pro (>= 7.2.0, < 8)
-    sidekiq-pro (7.2.1)
-      base64
-      sidekiq (>= 7.2.0, < 8)
-
-GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.1.0)
@@ -427,7 +415,6 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (>= 1.12, < 2)
       zeitwerk (~> 2.6)
-    einhorn (1.0.0)
     erubi (1.13.0)
     et-orbi (1.2.11)
       tzinfo
@@ -551,7 +538,6 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    gserver (0.0.1)
     guard (2.18.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -1314,8 +1300,6 @@ DEPENDENCIES
   shoulda-matchers
   shrine
   sidekiq (~> 7.2.0)
-  sidekiq-ent!
-  sidekiq-pro!
   sign_in_service
   simple_forms_api!
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,18 @@ PATH
     vye (0.1.0)
 
 GEM
+  remote: https://enterprise.contribsys.com/
+  specs:
+    sidekiq-ent (7.2.4)
+      einhorn (~> 1.0)
+      gserver
+      sidekiq (>= 7.2.0, < 8)
+      sidekiq-pro (>= 7.2.0, < 8)
+    sidekiq-pro (7.2.1)
+      base64
+      sidekiq (>= 7.2.0, < 8)
+
+GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.1.0)
@@ -415,6 +427,7 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (>= 1.12, < 2)
       zeitwerk (~> 2.6)
+    einhorn (1.0.0)
     erubi (1.13.0)
     et-orbi (1.2.11)
       tzinfo
@@ -538,6 +551,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
+    gserver (0.0.1)
     guard (2.18.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -1300,6 +1314,8 @@ DEPENDENCIES
   shoulda-matchers
   shrine
   sidekiq (~> 7.2.0)
+  sidekiq-ent!
+  sidekiq-pro!
   sign_in_service
   simple_forms_api!
   simplecov

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4140.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4140.rb
@@ -8,18 +8,22 @@ module SimpleFormsApi
 
     def metadata
       {
-        'veteranFirstName' => @data.dig('full_name', 'first'),
-        'veteranLastName' => @data.dig('full_name', 'last'),
-        'fileNumber' => @data['va_file_number'].presence || @data['ssn'],
-        'zipCode' => @data.dig('address', 'postal_code'),
+        'veteranFirstName' => data.dig('full_name', 'first'),
+        'veteranLastName' => data.dig('full_name', 'last'),
+        'fileNumber' => data['va_file_number'].presence || data['ssn'],
+        'zipCode' => data.dig('address', 'postal_code'),
         'source' => 'VA Platform Digital Forms',
-        'docType' => @data['form_number'],
+        'docType' => data['form_number'],
         'businessLine' => 'CMP'
       }
     end
 
     def submission_date_stamps(_timestamp)
       []
+    end
+
+    def zip_code_is_us_based
+      data.dig('address', 'country') == 'USA'
     end
   end
 end

--- a/modules/simple_forms_api/spec/models/vba_20_10207_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_20_10207_spec.rb
@@ -1,51 +1,10 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../support/shared_examples_for_base_form'
 
 RSpec.describe SimpleFormsApi::VBA2010207 do
-  describe 'zip_code_is_us_based' do
-    subject(:zip_code_is_us_based) { described_class.new(data).zip_code_is_us_based }
-
-    context 'veteran address is present and in US' do
-      let(:data) { { 'veteran_mailing_address' => { 'country' => 'USA' } } }
-
-      it 'returns true' do
-        expect(zip_code_is_us_based).to eq(true)
-      end
-    end
-
-    context 'veteran address is present and not in US' do
-      let(:data) { { 'veteran_mailing_address' => { 'country' => 'Canada' } } }
-
-      it 'returns false' do
-        expect(zip_code_is_us_based).to eq(false)
-      end
-    end
-
-    context 'non-veteran address is present and in US' do
-      let(:data) { { 'non_veteran_mailing_address' => { 'country' => 'USA' } } }
-
-      it 'returns true' do
-        expect(zip_code_is_us_based).to eq(true)
-      end
-    end
-
-    context 'non-veteran address is present and not in US' do
-      let(:data) { { 'non_veteran_mailing_address' => { 'country' => 'Canada' } } }
-
-      it 'returns false' do
-        expect(zip_code_is_us_based).to eq(false)
-      end
-    end
-
-    context 'no valid address is given' do
-      let(:data) { {} }
-
-      it 'returns false' do
-        expect(zip_code_is_us_based).to eq(false)
-      end
-    end
-  end
+  it_behaves_like 'zip_code_is_us_based', %w[veteran_mailing_address non_veteran_mailing_address]
 
   describe 'requester_signature' do
     statement_of_truth_signature = 'John Veteran'

--- a/modules/simple_forms_api/spec/models/vba_21_0845_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_21_0845_spec.rb
@@ -1,69 +1,8 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../support/shared_examples_for_base_form'
 
 RSpec.describe SimpleFormsApi::VBA210845 do
-  describe 'zip_code_is_us_based' do
-    subject(:zip_code_is_us_based) { described_class.new(data).zip_code_is_us_based }
-
-    context 'authorizer address is present and in US' do
-      let(:data) { { 'authorizer_address' => { 'country' => 'USA' } } }
-
-      it 'returns true' do
-        expect(zip_code_is_us_based).to eq(true)
-      end
-    end
-
-    context 'authorizer address is present and not in US' do
-      let(:data) { { 'authorizer_address' => { 'country' => 'Canada' } } }
-
-      it 'returns false' do
-        expect(zip_code_is_us_based).to eq(false)
-      end
-    end
-
-    context 'person is present and in US' do
-      let(:data) { { 'person_address' => { 'country' => 'USA' } } }
-
-      it 'returns true' do
-        expect(zip_code_is_us_based).to eq(true)
-      end
-    end
-
-    context 'person is present and not in US' do
-      let(:data) { { 'person_address' => { 'country' => 'Canada' } } }
-
-      it 'returns false' do
-        expect(zip_code_is_us_based).to eq(false)
-      end
-    end
-
-    context 'organization is present and in US' do
-      let(:data) do
-        { 'organization_address' => { 'country' => 'USA' } }
-      end
-
-      it 'returns true' do
-        expect(zip_code_is_us_based).to eq(true)
-      end
-    end
-
-    context 'organization is present and not in US' do
-      let(:data) do
-        { 'organization_address' => { 'country' => 'Canada' } }
-      end
-
-      it 'returns false' do
-        expect(zip_code_is_us_based).to eq(false)
-      end
-    end
-
-    context 'no valid address is given' do
-      let(:data) { {} }
-
-      it 'returns false' do
-        expect(zip_code_is_us_based).to eq(false)
-      end
-    end
-  end
+  it_behaves_like 'zip_code_is_us_based', %w[authorizer_address person_address organization_address]
 end

--- a/modules/simple_forms_api/spec/models/vba_21_0966_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_21_0966_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../support/shared_examples_for_base_form'
 
 RSpec.describe SimpleFormsApi::VBA210966 do
+  it_behaves_like 'zip_code_is_us_based', %w[veteran_mailing_address surviving_dependent_mailing_address]
+
   describe 'populate_veteran_data' do
     context 'data does not already have what it needs' do
       let(:expected_first_name) { 'Rory' }
@@ -47,50 +50,6 @@ RSpec.describe SimpleFormsApi::VBA210966 do
         expect(form.data['veteran_full_name']).to eq(expected_full_name)
         expect(form.data['veteran_mailing_address']).to eq expected_address
         expect(form.data['veteran_id']).to eq({ 'ssn' => expected_ssn })
-      end
-    end
-  end
-
-  describe 'zip_code_is_us_based' do
-    subject(:zip_code_is_us_based) { described_class.new(data).zip_code_is_us_based }
-
-    context 'veteran address is present and in US' do
-      let(:data) { { 'veteran_mailing_address' => { 'country' => 'USA' } } }
-
-      it 'returns true' do
-        expect(zip_code_is_us_based).to eq(true)
-      end
-    end
-
-    context 'veteran address is present and not in US' do
-      let(:data) { { 'veteran_mailing_address' => { 'country' => 'Canada' } } }
-
-      it 'returns false' do
-        expect(zip_code_is_us_based).to eq(false)
-      end
-    end
-
-    context 'surviving dependent is present and in US' do
-      let(:data) { { 'surviving_dependent_mailing_address' => { 'country' => 'USA' } } }
-
-      it 'returns true' do
-        expect(zip_code_is_us_based).to eq(true)
-      end
-    end
-
-    context 'surviving dependent is present and not in US' do
-      let(:data) { { 'surviving_dependent_mailing_address' => { 'country' => 'Canada' } } }
-
-      it 'returns false' do
-        expect(zip_code_is_us_based).to eq(false)
-      end
-    end
-
-    context 'no valid address is given' do
-      let(:data) { {} }
-
-      it 'returns false' do
-        expect(zip_code_is_us_based).to eq(false)
       end
     end
   end

--- a/modules/simple_forms_api/spec/models/vba_21_4140_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_21_4140_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../support/shared_examples_for_base_form'
 
 RSpec.describe SimpleFormsApi::VBA214140 do
   subject(:form) { described_class.new(data) }
@@ -9,6 +10,8 @@ RSpec.describe SimpleFormsApi::VBA214140 do
     Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_4140.json')
   end
   let(:data) { JSON.parse(fixture_path.read) }
+
+  it_behaves_like 'zip_code_is_us_based', %w[address]
 
   describe '#data' do
     subject { form.data }

--- a/modules/simple_forms_api/spec/models/vba_40_0247_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_40_0247_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../support/shared_examples_for_base_form'
 
-RSpec.describe 'SimpleFormsApi::VBA400247' do
+RSpec.describe SimpleFormsApi::VBA400247 do
+  it_behaves_like 'zip_code_is_us_based', %w[applicant_address]
+
   describe 'handle_attachments' do
     it 'saves the combined pdf' do
       original_pdf = double('HexaPDF::Document')

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -117,13 +117,13 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
 
       describe 'unauthenticated forms' do
         unauthenticated_forms.each do |form|
-          include_examples 'form submission', form, false
+          it_behaves_like 'form submission', form, false
         end
       end
 
       describe 'authenticated forms' do
         authenticated_forms.each do |form|
-          include_examples 'form submission', form, true
+          it_behaves_like 'form submission', form, true
         end
       end
 

--- a/modules/simple_forms_api/spec/support/shared_examples_for_base_form.rb
+++ b/modules/simple_forms_api/spec/support/shared_examples_for_base_form.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'zip_code_is_us_based' do |address_keys|
+  subject(:zip_code_is_us_based) { described_class.new(data).zip_code_is_us_based }
+
+  address_keys.each do |address_key|
+    context 'address is present and in US' do
+      let(:data) { { address_key => { 'country' => 'USA' } } }
+
+      it 'returns true' do
+        expect(zip_code_is_us_based).to eq(true)
+      end
+    end
+
+    context 'address is present and not in US' do
+      let(:data) { { address_key => { 'country' => 'Canada' } } }
+
+      it 'returns false' do
+        expect(zip_code_is_us_based).to eq(false)
+      end
+    end
+  end
+
+  context 'no valid address is given' do
+    let(:data) { {} }
+
+    it 'returns false' do
+      expect(zip_code_is_us_based).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Adds `#zip_code_is_us_based` to the `VBA214140` model.
- Refactors model specs to use a shared spec that takes in the address keys as params.
- Fixes a bug with the simple forms specs where only the last called form was being used to run the shared examples.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93461

## Testing done

- [x] *New code is covered by unit tests*
- Added new shared example spec that tests this method on every applicable simple form.
- Fixed bug with existing spec.

## What areas of the site does it impact?
At the moment, none. It will ultimately impact the Simple Forms API, adding support for the 21-4140 form.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

This was originally part of a larger PR but had to be broken out because too many lines of code were being altered. Let me know if there is a better way to deal with the LOC limit moving forward.