### PR TITLE
Delete `okta-response` keys in redis config

### DIFF
--- a/config/redis.yml
+++ b/config/redis.yml
@@ -66,9 +66,6 @@ development: &defaults
     namespace: mpi-profile-response
     each_ttl: 86400
     failure_ttl: 1800
-  okta_response:
-    namespace: okta-response
-    each_ttl: 3600
   profile:
     namespace: profile
     each_ttl: 3600
@@ -78,9 +75,6 @@ development: &defaults
   charon_response:
     namespace: charon-response
     each_ttl: 3600
-  okta_response_app:
-    namespace: okta-response
-    each_ttl: 86400
   saml_store:
     namespace: single-logout-request
     each_ttl: 43200


### PR DESCRIPTION
## Summary
While working on a ticket to find out if there were any duplicated redis namespaces in vets-api, I found `okta-response` existed twice in the redis config. Duplicated redis namespaces are bad because data can be overwritten if namespaces are created with the same keys. I did more searching in the codebase and couldn't find anywhere this namespace was being called. I even searched the entire VA org and didn’t see any references. So Lindsey and I determined these keys could be deleted. See Testing section for more investigation.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/97502

## Testing done
In a prod vets-api pod:
```
vets-api(prod)> namespace = 'okta-response'
=> "okta-response"
vets-api(prod)> redis = $redis
=> #<Redis client v5.3.0...
vets-api(prod)> count = 0
=> 0
vets-api(prod)* redis.scan_each(match: "#{namespace}:*") do |key|
vets-api(prod)*   count += 1
vets-api(prod)> end
=> nil
vets-api(prod)> puts count
0
```
No logs with `okta-response` for the last month:
<img width="680" alt="Screenshot 2024-12-31 at 1 46 20 PM" src="https://github.com/user-attachments/assets/f217c30f-7606-4f95-8e2c-23676db65235" />

## What areas of the site does it impact?
Redis namespaces. 

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
