### PR TITLE
[VI-947] Cleaning up Terms of Use implementation to remove unnecessary convoluted logic

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -86,7 +86,6 @@ sign_in:
 
 terms_of_use:
   current_version: v1
-  enabled_clients: vaweb, mhv, myvahealth
 
 lockbox:
   master_key: "0d78eaf0e90d4e7b8910c9112e16e66d8b00ec4054a89aa426e32712a13371e9"

--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -63,12 +63,8 @@ module SAML
     end
 
     def terms_of_use_redirect_url
-      if terms_of_use_enabled_application
-        Rails.logger.info('Redirecting to /terms-of-use', type: :ssoe)
-        add_query(terms_of_use_url, { redirect_url: login_redirect_url })
-      else
-        login_redirect_url
-      end
+      Rails.logger.info('Redirecting to /terms-of-use', type: :ssoe)
+      add_query(terms_of_use_url, { redirect_url: login_redirect_url })
     end
 
     # logout URL for SSOe
@@ -77,32 +73,6 @@ module SAML
     end
 
     private
-
-    def terms_of_use_enabled_application
-      cache_key = "terms_of_use_redirect_user_#{user.uuid}"
-      cached_application = retrieve_and_delete_terms_of_use_redirect_user(cache_key)
-      current_application = @tracker&.payload_attr(:application)
-      write_terms_of_use_redirect_user(cache_key, current_application) if should_cache_application?(current_application)
-      terms_of_use_redirect_enabled?(cached_application, current_application)
-    end
-
-    def terms_of_use_redirect_enabled?(cached_application, current_application)
-      enabled_tou_clients.include?(cached_application || current_application || 'vaweb')
-    end
-
-    def should_cache_application?(application)
-      enabled_tou_clients.include?(application)
-    end
-
-    def retrieve_and_delete_terms_of_use_redirect_user(cache_key)
-      application = Rails.cache.read(cache_key)
-      Rails.cache.delete(cache_key)
-      application
-    end
-
-    def write_terms_of_use_redirect_user(cache_key, application)
-      Rails.cache.write(cache_key, application, expires_in: 5.minutes)
-    end
 
     def terms_of_use_url
       current_application = @tracker&.payload_attr(:application)
@@ -144,10 +114,6 @@ module SAML
       post_params = saml_auth_request.create_params(new_url_settings, 'RelayState' => relay_state_params)
       login_url = new_url_settings.idp_sso_service_url
       [login_url, post_params]
-    end
-
-    def enabled_tou_clients
-      Settings.terms_of_use.enabled_clients.split(',').collect(&:strip)
     end
   end
 end

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -596,54 +596,16 @@ RSpec.describe V1::SessionsController, type: :controller do
 
     context 'when user has level of assurance 1' do
       let(:loa) { :loa1 }
+      let!(:user) { create(:user, loa, uuid:, idme_uuid: uuid, icn: nil) }
+      let(:application) { 'some-applicaton' }
 
-      before { allow(SAML::User).to receive(:new).and_return(saml_user) }
-
-      context 'when user has not accepted the current terms of use' do
-        let(:user) { build(:user, loa, uuid:, idme_uuid: uuid) }
-        let(:application) { 'some-applicaton' }
-
-        before do
-          SAMLRequestTracker.create(uuid: login_uuid, payload: { type: 'idme', application: })
-        end
-
-        context 'and authentication occurred with a application in Settings.terms_of_use.enabled_clients' do
-          before do
-            allow(Settings.terms_of_use).to receive(:enabled_clients).and_return(application)
-          end
-
-          context 'when the application is not in SKIP_MHV_ACCOUNT_CREATION_CLIENTS' do
-            it 'redirects to terms of use page' do
-              expect(call_endpoint).to redirect_to(
-                'http://127.0.0.1:3001/terms-of-use?redirect_url=http%3A%2F%2F127.0.0.1%3A3001%2Fauth%2Flogin%2Fcallback'
-              )
-            end
-          end
-
-          context 'when the application is in SKIP_MHV_ACCOUNT_CREATION_CLIENTS' do
-            let(:application) { 'mhv' }
-
-            it 'redirects to terms of use page with skip_mhv_account_creation query param' do
-              expect(call_endpoint).to redirect_to(a_string_including('skip_mhv_account_creation=true'))
-            end
-          end
-        end
-
-        context 'and authentication occurred with an application not in Settings.terms_of_use.enabled_clients' do
-          before do
-            allow(Settings.terms_of_use).to receive(:enabled_clients).and_return('')
-          end
-
-          it 'redirects to expected auth page' do
-            expect(call_endpoint).to redirect_to(expected_redirect_url)
-          end
-        end
+      before do
+        allow(SAML::User).to receive(:new).and_return(saml_user)
+        SAMLRequestTracker.create(uuid: login_uuid, payload: { type: 'idme', application: })
       end
 
-      context 'when user has accepted the current terms of use' do
-        it 'redirects to expected auth page' do
-          expect(call_endpoint).to redirect_to(expected_redirect_url)
-        end
+      it 'redirects to expected auth page' do
+        expect(call_endpoint).to redirect_to(expected_redirect_url)
       end
     end
 
@@ -660,35 +622,19 @@ RSpec.describe V1::SessionsController, type: :controller do
           SAMLRequestTracker.create(uuid: login_uuid, payload: { type: 'idme', application: })
         end
 
-        context 'and authentication occurred with a application in Settings.terms_of_use.enabled_clients' do
-          before do
-            allow(Settings.terms_of_use).to receive(:enabled_clients).and_return(application)
-          end
-
-          context 'when the application is not in SKIP_MHV_ACCOUNT_CREATION_CLIENTS' do
-            it 'redirects to terms of use page' do
-              expect(call_endpoint).to redirect_to(
-                'http://127.0.0.1:3001/terms-of-use?redirect_url=http%3A%2F%2F127.0.0.1%3A3001%2Fauth%2Flogin%2Fcallback'
-              )
-            end
-          end
-
-          context 'when the application is in SKIP_MHV_ACCOUNT_CREATION_CLIENTS' do
-            let(:application) { 'mhv' }
-
-            it 'redirects to terms of use page with skip_mhv_account_creation query param' do
-              expect(call_endpoint).to redirect_to(a_string_including('skip_mhv_account_creation=true'))
-            end
+        context 'when the application is not in SKIP_MHV_ACCOUNT_CREATION_CLIENTS' do
+          it 'redirects to terms of use page' do
+            expect(call_endpoint).to redirect_to(
+              'http://127.0.0.1:3001/terms-of-use?redirect_url=http%3A%2F%2F127.0.0.1%3A3001%2Fauth%2Flogin%2Fcallback'
+            )
           end
         end
 
-        context 'and authentication occurred with an application not in Settings.terms_of_use.enabled_clients' do
-          before do
-            allow(Settings.terms_of_use).to receive(:enabled_clients).and_return('')
-          end
+        context 'when the application is in SKIP_MHV_ACCOUNT_CREATION_CLIENTS' do
+          let(:application) { 'mhv' }
 
-          it 'redirects to expected auth page' do
-            expect(call_endpoint).to redirect_to(expected_redirect_url)
+          it 'redirects to terms of use page with skip_mhv_account_creation query param' do
+            expect(call_endpoint).to redirect_to(a_string_including('skip_mhv_account_creation=true'))
           end
         end
       end

--- a/spec/lib/saml/post_url_service_spec.rb
+++ b/spec/lib/saml/post_url_service_spec.rb
@@ -635,88 +635,19 @@ RSpec.describe SAML::PostURLService do
               end
             end
 
-            context 'when associated terms of use redirect user cache object exists' do
-              let(:cache_key) { "terms_of_use_redirect_user_#{user.uuid}" }
-              let(:enabled_clients) { application }
-              let(:cache_expiration) { 5.minutes }
+            context 'and authentication is occuring on a review instance' do
+              let(:review_instance_slug) { 'some-review-instance-slug' }
+              let(:base_url) { "http://#{review_instance_slug}.review.vetsgov-internal" }
 
-              before do
-                allow(Settings.terms_of_use).to receive(:enabled_clients).and_return(enabled_clients)
-                allow(Rails.cache).to receive(:read).with(cache_key).and_return(application)
-              end
+              before { allow(Settings).to receive(:review_instance_slug).and_return(review_instance_slug) }
 
-              context 'and application is within Settings.terms_of_use.enabled_clients' do
-                let(:enabled_clients) { application }
-
-                context 'and authentication is occuring on a review instance' do
-                  let(:review_instance_slug) { 'some-review-instance-slug' }
-                  let(:base_url) { "http://#{review_instance_slug}.review.vetsgov-internal" }
-
-                  before { allow(Settings).to receive(:review_instance_slug).and_return(review_instance_slug) }
-
-                  it_behaves_like 'terms of use redirected url'
-                end
-
-                context 'and authentication is not occurring on a review instance' do
-                  let(:base_url) { values[:base_redirect] }
-
-                  it_behaves_like 'terms of use redirected url'
-                end
-              end
-
-              context 'and stored application is not within Settings.terms_of_use.enabled_clients' do
-                let(:enabled_clients) { '' }
-
-                it 'has a login redirect url with success not embedded in a terms of use page' do
-                  expect(subject.terms_of_use_redirect_url).to eq(expected_login_redirect_url)
-                end
-              end
-
-              it 'deletes the cached terms of use redirect user object' do
-                expect(Rails.cache).to receive(:delete).with(cache_key)
-                subject.terms_of_use_redirect_url
-              end
+              it_behaves_like 'terms of use redirected url'
             end
 
-            context 'when associated terms of use redirect user cache object does not exist' do
-              context 'when tracker application is within Settings.terms_of_use.enabled_clients' do
-                before do
-                  allow(Settings.terms_of_use).to receive(:enabled_clients).and_return(application)
-                end
+            context 'and authentication is not occurring on a review instance' do
+              let(:base_url) { values[:base_redirect] }
 
-                context 'and authentication is occuring on a review instance' do
-                  let(:review_instance_slug) { 'some-review-instance-slug' }
-                  let(:base_url) { "http://#{review_instance_slug}.review.vetsgov-internal" }
-
-                  before { allow(Settings).to receive(:review_instance_slug).and_return(review_instance_slug) }
-
-                  it_behaves_like 'terms of use redirected url'
-                end
-
-                context 'and authentication is not occurring on a review instance' do
-                  let(:base_url) { values[:base_redirect] }
-
-                  it_behaves_like 'terms of use redirected url'
-                end
-              end
-
-              context 'when tracker application is nil' do
-                let(:application) { nil }
-                let(:base_url) { values[:base_redirect] }
-
-                it_behaves_like 'terms of use redirected url'
-              end
-
-              context 'when tracker application is not within Settings.terms_of_use.enabled_clients' do
-                before do
-                  allow(Settings.terms_of_use).to receive(:enabled_clients).and_return('')
-                end
-
-                it 'has a login redirect url with success not embedded in a terms of use page' do
-                  expect(subject.terms_of_use_redirect_url)
-                    .to eq(expected_login_redirect_url)
-                end
-              end
+              it_behaves_like 'terms of use redirected url'
             end
           end
         end


### PR DESCRIPTION
## Summary

- This PR removes logic in the terms of use implementation that is no longer necessary now that this feature is fully rolled out

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-947

## Testing done

- [ ] Authenticated with SSOe with a user that needs to accept terms of use, and confirmed redirect to terms of use page

## What areas of the site does it impact?
Terms of Use

## Acceptance criteria

- [ ] This is difficult to test locally since SSOe verified auth is not working well on localhost right now
- [ ] Test by authenticating with a new verified user and setting `oauth=false` on sign in page to force an SSOe auth
- [ ] If you are redirected to Terms of Use page, you should be good
