### PR TITLE
Use engine only test helpers

### DIFF
--- a/modules/decision_reviews/spec/controllers/decision_review_evidences_controller_spec.rb
+++ b/modules/decision_reviews/spec/controllers/decision_review_evidences_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require './modules/decision_reviews/spec/dr_spec_helper'
+require './modules/decision_reviews/spec/support/vcr_helper'
 
 RSpec.describe DecisionReviews::V1::DecisionReviewEvidencesController, type: :controller do
   routes { DecisionReviews::Engine.routes }

--- a/modules/decision_reviews/spec/controllers/decision_review_notification_callbacks_controller_spec.rb
+++ b/modules/decision_reviews/spec/controllers/decision_review_notification_callbacks_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require './modules/decision_reviews/spec/dr_spec_helper'
 
 RSpec.describe DecisionReviews::V1::DecisionReviewNotificationCallbacksController, type: :controller do
   routes { DecisionReviews::Engine.routes }

--- a/modules/decision_reviews/spec/dr_spec_helper.rb
+++ b/modules/decision_reviews/spec/dr_spec_helper.rb
@@ -14,6 +14,7 @@ require 'shoulda/matchers'
 require 'support/stub_va_profile'
 require 'support/mpi/stub_mpi'
 require 'support/factory_bot'
+require 'support/authenticated_session_helper'
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
@@ -65,7 +66,15 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  ## authentication_session_helper
+  config.include AuthenticatedSessionHelper, type: :request
+  config.include AuthenticatedSessionHelper, type: :controller
+
   config.include StatsD::Instrument::Matchers
+
+  config.before :each, type: :controller do
+    request.host = Settings.hostname
+  end
 end
 
 Gem::Deprecate.skip = true

--- a/modules/decision_reviews/spec/requests/v1/higher_level_reviews/contestable_issues_spec.rb
+++ b/modules/decision_reviews/spec/requests/v1/higher_level_reviews/contestable_issues_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require 'support/controller_spec_helper'
+require './modules/decision_reviews/spec/dr_spec_helper'
+require './modules/decision_reviews/spec/support/vcr_helper'
 
 RSpec.describe 'DecisionReviews::V1::HigherLevelReviews::ContestableIssues', type: :request do
   let(:user) { build(:user, :loa3) }

--- a/modules/decision_reviews/spec/requests/v1/higher_level_reviews_spec.rb
+++ b/modules/decision_reviews/spec/requests/v1/higher_level_reviews_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require 'support/controller_spec_helper'
+require './modules/decision_reviews/spec/dr_spec_helper'
+require './modules/decision_reviews/spec/support/vcr_helper'
 
 RSpec.describe 'DecisonReviews::V1::HigherLevelReviews', type: :request do
   let(:user) { build(:user, :loa3) }

--- a/modules/decision_reviews/spec/requests/v1/notice_of_disagreements/contestable_issues_spec.rb
+++ b/modules/decision_reviews/spec/requests/v1/notice_of_disagreements/contestable_issues_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require 'support/controller_spec_helper'
+require './modules/decision_reviews/spec/dr_spec_helper'
+require './modules/decision_reviews/spec/support/vcr_helper'
 
 RSpec.describe 'DecisionReviews::V1::NoticeOfDisagreements::ContestableIssues', type: :request do
   let(:user) { build(:user, :loa3) }

--- a/modules/decision_reviews/spec/requests/v1/notice_of_disagreements_spec.rb
+++ b/modules/decision_reviews/spec/requests/v1/notice_of_disagreements_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require 'support/controller_spec_helper'
+require './modules/decision_reviews/spec/dr_spec_helper'
+require './modules/decision_reviews/spec/support/vcr_helper'
 
 RSpec.describe 'DecisionReviews::V1::NoticeOfDisagreements', type: :request do
   let(:user) do

--- a/modules/decision_reviews/spec/requests/v1/supplemental_claims/contestable_issues_spec.rb
+++ b/modules/decision_reviews/spec/requests/v1/supplemental_claims/contestable_issues_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require 'support/controller_spec_helper'
+require './modules/decision_reviews/spec/dr_spec_helper'
+require './modules/decision_reviews/spec/support/vcr_helper'
 
 RSpec.describe 'DecisionReviews::V1::SupplementalClaims::ContestableIssues', type: :request do
   let(:user) { build(:user, :loa3) }

--- a/modules/decision_reviews/spec/requests/v1/supplemental_claims_spec.rb
+++ b/modules/decision_reviews/spec/requests/v1/supplemental_claims_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require 'support/controller_spec_helper'
+require './modules/decision_reviews/spec/dr_spec_helper'
+require './modules/decision_reviews/spec/support/vcr_helper'
 
 RSpec.describe 'DecisionReviews::V1::SupplementalClaims', type: :request do
   let(:user) { build(:user, :loa3) }

--- a/modules/decision_reviews/spec/requests/v2/higher_level_reviews_spec.rb
+++ b/modules/decision_reviews/spec/requests/v2/higher_level_reviews_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require 'support/controller_spec_helper'
+require './modules/decision_reviews/spec/dr_spec_helper'
+require './modules/decision_reviews/spec/support/vcr_helper'
 
 RSpec.describe 'DecisionReviews::V2::HigherLevelReviews', type: :request do
   let(:user) { build(:user, :loa3) }


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- *(Summarize the changes that have been made to the platform)*
Use engine test helpers instead of main app test helpers. Already done for sidekiq and lib specs.
- *(Which team do you work for, does your team own the maintenance of this component?)*
Decision Reviews, yes

## Related issue(s)

No ticket

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
Was using main app `rails_helper`, now using engine specific test setup
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
Run test in isolation from main app, ensure tests still pass

## What areas of the site does it impact?
Decision Review engine specs

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature