### PR TITLE
Allow SAHSHA emails to be sent without reference_numbers

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -129,11 +129,11 @@ module SimpleFormsApi
         if Flipper.enabled?(:simple_forms_email_confirmations)
           case status
           when 'VALIDATED', 'ACCEPTED'
-            send_sahsha_email(parsed_form_data, reference_number, :confirmation)
+            send_sahsha_email(parsed_form_data, :confirmation, reference_number)
           when 'REJECTED'
-            send_sahsha_email(parsed_form_data, reference_number, :rejected)
+            send_sahsha_email(parsed_form_data, :rejected)
           when 'DUPLICATE'
-            send_sahsha_email(parsed_form_data, reference_number, :duplicate)
+            send_sahsha_email(parsed_form_data, :duplicate)
           end
         end
 
@@ -339,7 +339,7 @@ module SimpleFormsApi
         notification_email.send
       end
 
-      def send_sahsha_email(parsed_form_data, confirmation_number, notification_type)
+      def send_sahsha_email(parsed_form_data, notification_type, confirmation_number = nil)
         config = {
           form_data: parsed_form_data,
           form_number: 'vba_26_4555',

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -435,9 +435,7 @@ module SimpleFormsApi
     end
 
     def needs_confirmation_number?(config)
-      config[:form_number] != 'vba_26_4555' &&
-        (config[:notification_type] != 'REJECTED' ||
-        config[:notification_type] != 'DUPLICATE')
+      config[:form_number] != 'vba_26_4555' && %w[REJECTED DUPLICATE].exclude(config[:notification_type])
     end
   end
 end

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -282,6 +282,7 @@ module SimpleFormsApi
                           default_personalization(first_name)
                         end
       personalization.except!('lighthouse_updated_at') unless lighthouse_updated_at
+      personalization.except!('confirmation_number') unless confirmation_number
       personalization
     end
 

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -435,7 +435,7 @@ module SimpleFormsApi
     end
 
     def needs_confirmation_number?(config)
-      config[:form_number] != 'vba_26_4555' && %w[REJECTED DUPLICATE].exclude(config[:notification_type])
+      config[:form_number] != 'vba_26_4555' && %w[REJECTED DUPLICATE].exclude?(config[:notification_type])
     end
   end
 end

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -104,7 +104,7 @@ module SimpleFormsApi
       all_keys << :confirmation_number if needs_confirmation_number?(config)
       all_keys << :expiration_date if config[:form_number] == 'vba_21_0966_intent_api'
 
-      missing_keys = all_keys.select { |key| config[key].nil? }
+      missing_keys = all_keys.select { |key| config[key].nil? || config[key].to_s.strip.empty? }
 
       if missing_keys.any?
         StatsD.increment('silent_failure', tags: statsd_tags) if error_notification?

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -1038,8 +1038,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
             'form26_4555_rejected_email_template_id',
             {
               'first_name' => 'Veteran',
-              'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-              'confirmation_number' => reference_number
+              'date_submitted' => Time.zone.today.strftime('%B %d, %Y')
             }
           )
         end
@@ -1068,8 +1067,7 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
             'form26_4555_duplicate_email_template_id',
             {
               'first_name' => 'Veteran',
-              'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-              'confirmation_number' => reference_number
+              'date_submitted' => Time.zone.today.strftime('%B %d, %Y')
             }
           )
         end

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -1016,9 +1016,8 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
       end
 
       context 'rejected' do
-        let(:reference_number) { 'some-reference-number' }
         let(:body_status) { 'REJECTED' }
-        let(:body) { { 'reference_number' => reference_number, 'status' => body_status } }
+        let(:body) { { 'status' => body_status } }
         let(:status) { 200 }
         let(:lgy_response) { double(body:, status:) }
 
@@ -1047,9 +1046,8 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
       end
 
       context 'duplicate' do
-        let(:reference_number) { 'some-reference-number' }
         let(:body_status) { 'DUPLICATE' }
-        let(:body) { { 'reference_number' => reference_number, 'status' => body_status } }
+        let(:body) { { 'status' => body_status } }
         let(:status) { 200 }
         let(:lgy_response) { double(body:, status:) }
 

--- a/modules/simple_forms_api/spec/services/notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/notification_email_spec.rb
@@ -28,6 +28,28 @@ describe SimpleFormsApi::NotificationEmail do
         end
       end
 
+      context '26-4555' do
+        let(:config) do
+          { form_data: {}, form_number: 'vba_26_4555', date_submitted: Time.zone.today.strftime('%B %d, %Y') }
+        end
+
+        context 'notification_type is duplicate' do
+          let(:notification_type) { :duplicate }
+
+          it 'does not require the confirmation_number' do
+            expect { described_class.new(config, notification_type:) }.not_to raise_error(ArgumentError)
+          end
+        end
+
+        context 'notification_type is rejeceted' do
+          let(:notification_type) { :rejected }
+
+          it 'does not require the confirmation_number' do
+            expect { described_class.new(config, notification_type:) }.not_to raise_error(ArgumentError)
+          end
+        end
+      end
+
       context 'missing form_data' do
         let(:config) do
           { form_number: 'vba_21_10210', confirmation_number: 'confirmation_number',

--- a/modules/va_notify/lib/va_notify/service.rb
+++ b/modules/va_notify/lib/va_notify/service.rb
@@ -25,7 +25,6 @@ module VaNotify
     end
 
     def send_email(args)
-      byebug
       if Flipper.enabled?(:va_notify_notification_creation)
         response = with_monitoring do
           notify_client.send_email(args)

--- a/modules/va_notify/lib/va_notify/service.rb
+++ b/modules/va_notify/lib/va_notify/service.rb
@@ -25,6 +25,7 @@ module VaNotify
     end
 
     def send_email(args)
+      byebug
       if Flipper.enabled?(:va_notify_notification_creation)
         response = with_monitoring do
           notify_client.send_email(args)


### PR DESCRIPTION
## Summary
This PR allows certain SAHSHA (26-4555) emails to be sent (REJECTED and DUPLICATE ones) without a reference_number. Currently we're seeing an error every time one of these types of emails is attempted to be sent because of this bug.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&filterQuery=-status%3AIcebox%2CEpic%2C%22Collab+Cycle%22&pane=issue&itemId=92389103&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1946
