### PR TITLE
[DBEX] set indicator object from submitted string value

### DIFF
--- a/lib/pdf_fill/forms/va210781v2.rb
+++ b/lib/pdf_fill/forms/va210781v2.rb
@@ -619,6 +619,7 @@ module PdfFill
 
         set_treatment_selection
         set_reports_selection
+        set_option_indicator
 
         format_other_behavior_details
         format_police_report_location
@@ -672,6 +673,16 @@ module PdfFill
         @form_data['neitherReport'] = reports['neither'] ? 2 : nil
         @form_data['policeReport'] = reports['police'] ? 3 : nil
         @form_data['otherReport'] = reports['other'] ? 4 : nil
+      end
+
+      def set_option_indicator
+        selected_option = @form_data['optionIndicator']
+        valid_options = %w[yes no revoke notEnrolled]
+
+        return if selected_option.nil? || valid_options.exclude?(selected_option)
+
+        @form_data['optionIndicator'] = valid_options.index_with { |_option| false }
+        @form_data['optionIndicator'][selected_option] = true
       end
 
       def format_other_behavior_details

--- a/spec/fixtures/pdf_fill/21-0781V2/kitchen_sink.json
+++ b/spec/fixtures/pdf_fill/21-0781V2/kitchen_sink.json
@@ -115,11 +115,6 @@
       "noDates": true
     }
   ],
-  "optionIndicator": {
-    "yes": false,
-    "no": false,
-    "revoke": false,
-    "notEnrolled": true
-  },
+  "optionIndicator": "notEnrolled",
   "signatureDate": "2016-01-31"
 }

--- a/spec/fixtures/pdf_fill/21-0781V2/overflow.json
+++ b/spec/fixtures/pdf_fill/21-0781V2/overflow.json
@@ -144,11 +144,6 @@
       "noDates": true
     }
   ],
-  "optionIndicator": {
-    "yes": false,
-    "no": false,
-    "revoke": false,
-    "notEnrolled": true
-  },
+  "optionIndicator": "notEnrolled",
   "signatureDate": "2016-01-31"
 }

--- a/spec/support/disability_compensation_form/all_claims_with_0781v2_fe_submission.json
+++ b/spec/support/disability_compensation_form/all_claims_with_0781v2_fe_submission.json
@@ -241,9 +241,7 @@
             "noDates": true
           }
         ],
-        "optionIndicator": {
-          "notEnrolled": true
-        },
+        "optionIndicator": "notEnrolled",
         "additionalInformation": "Lorem ipsum dolor sit amet."
       }
     }

--- a/spec/support/disability_compensation_form/form_0781v2.json
+++ b/spec/support/disability_compensation_form/form_0781v2.json
@@ -116,9 +116,7 @@
         "noDates": true
       }
     ],
-    "optionIndicator": {
-      "notEnrolled": true
-    },
+    "optionIndicator": "notEnrolled",
     "additionalInformation": "Lorem ipsum dolor sit amet."
   }
 }

--- a/spec/support/disability_compensation_form/submissions/with_0781v2.json
+++ b/spec/support/disability_compensation_form/submissions/with_0781v2.json
@@ -421,9 +421,7 @@
           "noDates": true
         }
       ],
-      "optionIndicator": {
-        "notEnrolled": true
-      },
+      "optionIndicator": "notEnrolled",
       "additionalInformation": "Lorem ipsum dolor sit amet."
     }
   },


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): ~YES~/NO*
  - Eventually will be gated by [disability_compensation_sync_modern_0781_flow](https://github.com/department-of-veterans-affairs/vets-api/blame/4e69360695d020fe9a3c915fc787cefc101e5cc6/config/features.yml#L570)
- *(Summarize the changes that have been made to the platform)*
  - Sets the `optionIndicator` object based on a string value being submitted, rather than a hash of attributes with true/false values
  - Expects 1 of 4 valid options
- *(If bug, how to reproduce)* **N/A**
- *(What is the solution, why is this the solution?)*
  - The current 21-0781 form generated as a result of completing the online form 21-526EZ process is outdated (expired 7/21/2020) and requires an upgrade to be in sync with the current paper form (released this summer)
- *(Which team do you work for, does your team own the maintenance of this component?)*
  - Disability Benefits Experience Team 2 (dBeX Carbs 🥖), which owns maintenance of all files in this PR
- *(If introducing a flipper, what is the success criteria being targeted?)* **N/A**

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
  - [#99849](https://github.com/department-of-veterans-affairs/va.gov-team/issues/99849) 
- *Link to previous change of the code/bug (if applicable)*
  - https://github.com/department-of-veterans-affairs/vets-api/pull/19802
  - [schema](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/teams/benefits/engineering_research/0781v2_schema.md) has been updated to reflect the structural change

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
  - Mapping of the response associated with the `optionIndicator` selection was expecting a hash of attributes with true/false values, but the [radioUI](https://github.com/department-of-veterans-affairs/vets-website/blob/df521a93d8ffab95896c4dd94c8dbfc2db892a51/src/platform/forms-system/src/js/web-component-patterns/radioPattern.jsx#L50) component submits the one selected value as a string like `"optionIndicator":"revoke"`
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
  - a `merge_fields` file confirms the expected output generated from a `kitchen_sink` data file, representing form data used to correctly fill the associated PDF
  - the test, [spec/lib/pdf_fill/forms/va210781v2_spec.rb:34](https://github.com/department-of-veterans-affairs/vets-api/blob/master/spec/lib/pdf_fill/forms/va210781v2_spec.rb#L34), verifies that a PDF's fields generated from submitted data match the expected output

## What areas of the site does it impact?

- The generation of data to fill form 21-0781 and associated PDF

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [X]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
