### PR TITLE
Btsss/submit claim endpoint

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -9,6 +9,11 @@
       :path: <%= "/#{Settings.ask_va_api.crm_api.veis_api_path}/ping" %>
       :file_path: "/ask_va/dynamics_api"
       :response_delay: 15
+    - :method: :post
+      :path: <%= "/#{Settings.ask_va_api.crm_api.veis_api_path}/inquiries/new" %>
+      :file_path: "/ask_va/crm_api/post_inquiries/default"
+      :response_delay: 0.3
+    ## Travel Pay
     - :method: :get
       :path: "/veis/api/btsss/travelclaim/api/v1/Sample/ping"
       :file_path: "/travel_pay/ping/default"
@@ -23,11 +28,26 @@
       :response_delay: 0.3
     - :method: :get
       :path: "/veis/api/btsss/travelclaim/api/v1/claims"
-      :file_path: "/travel_pay/claims/default"
+      :file_path: "/travel_pay/claims/index/default"
+      :response_delay: 0.3
+    - :method: :get
+      :path: "/veis/api/btsss/travelclaim/api/v1.1/appointments"
+      :file_path: "/travel_pay/appointments/default"
+      :response_delay: 0.3
+    - :method: :patch
+      :path: "/veis/api/btsss/travelclaim/api/v1.1/claims/*/submit"
+      :file_path: "/travel_pay/claims/submit"
+      :response_delay: 0.3
+      :cache_multiple_responses:
+        :uid_location: url
+        :uid_locator: '\/veis\/api\/btsss\/travelclaim\/api\/v1\.1\/claims\/(.+)\/submit'
+    - :method: :post
+      :path: "/veis/api/btsss/travelclaim/api/v1.1/claims"
+      :file_path: "/travel_pay/claims/create/default"
       :response_delay: 0.3
     - :method: :post
-      :path: <%= "/#{Settings.ask_va_api.crm_api.veis_api_path}/inquiries/new" %>
-      :file_path: "/ask_va/crm_api/post_inquiries/default"
+      :path: "/veis/api/btsss/travelclaim/api/v1.1/expenses/mileage"
+      :file_path: "/travel_pay/expenses/default"
       :response_delay: 0.3
 
 #CRM Token post

--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -14,39 +14,31 @@
       :file_path: "/ask_va/crm_api/post_inquiries/default"
       :response_delay: 0.3
     ## Travel Pay
-    - :method: :get
-      :path: "/veis/api/btsss/travelclaim/api/v1/Sample/ping"
-      :file_path: "/travel_pay/ping/default"
-      :response_delay: 0.3
-    - :method: :get
-      :path: "/veis/api/btsss/travelclaim/api/v1/Sample/authorized-ping"
-      :file_path: "/travel_pay/ping/default"
-      :response_delay: 0.3
     - :method: :post
-      :path: "/veis/api/btsss/travelclaim/api/v1/Auth/access-token"
+      :path: "/veis/api/btsss/travelclaim/api/v1.2/Auth/access-token"
       :file_path: "/travel_pay/btsss_token/default"
       :response_delay: 0.3
     - :method: :get
-      :path: "/veis/api/btsss/travelclaim/api/v1/claims"
+      :path: "/veis/api/btsss/travelclaim/api/v1.2/claims"
       :file_path: "/travel_pay/claims/index/default"
       :response_delay: 0.3
     - :method: :get
-      :path: "/veis/api/btsss/travelclaim/api/v1.1/appointments"
+      :path: "/veis/api/btsss/travelclaim/api/v1.2/appointments"
       :file_path: "/travel_pay/appointments/default"
       :response_delay: 0.3
     - :method: :patch
-      :path: "/veis/api/btsss/travelclaim/api/v1.1/claims/*/submit"
+      :path: "/veis/api/btsss/travelclaim/api/v1.2/claims/*/submit"
       :file_path: "/travel_pay/claims/submit"
       :response_delay: 0.3
       :cache_multiple_responses:
         :uid_location: url
-        :uid_locator: '\/veis\/api\/btsss\/travelclaim\/api\/v1\.1\/claims\/(.+)\/submit'
+        :uid_locator: '\/veis\/api\/btsss\/travelclaim\/api\/v1\.2\/claims\/(.+)\/submit'
     - :method: :post
-      :path: "/veis/api/btsss/travelclaim/api/v1.1/claims"
+      :path: "/veis/api/btsss/travelclaim/api/v1.2/claims"
       :file_path: "/travel_pay/claims/create/default"
       :response_delay: 0.3
     - :method: :post
-      :path: "/veis/api/btsss/travelclaim/api/v1.1/expenses/mileage"
+      :path: "/veis/api/btsss/travelclaim/api/v1.2/expenses/mileage"
       :file_path: "/travel_pay/expenses/default"
       :response_delay: 0.3
 

--- a/modules/travel_pay/app/controllers/travel_pay/application_controller.rb
+++ b/modules/travel_pay/app/controllers/travel_pay/application_controller.rb
@@ -3,10 +3,10 @@
 module TravelPay
   class ApplicationController < ::ApplicationController
     include ActionController::Cookies
-    include ActionController::RequestForgeryProtection
+    #include ActionController::RequestForgeryProtection
     service_tag 'travel-pay'
 
-    protect_from_forgery with: :exception
+    #protect_from_forgery with: :exception
 
     before_action :authenticate
     after_action :scrub_logs

--- a/modules/travel_pay/app/controllers/travel_pay/application_controller.rb
+++ b/modules/travel_pay/app/controllers/travel_pay/application_controller.rb
@@ -3,10 +3,7 @@
 module TravelPay
   class ApplicationController < ::ApplicationController
     include ActionController::Cookies
-    #include ActionController::RequestForgeryProtection
     service_tag 'travel-pay'
-
-    #protect_from_forgery with: :exception
 
     before_action :authenticate
     after_action :scrub_logs

--- a/modules/travel_pay/app/controllers/travel_pay/v0/claims_controller.rb
+++ b/modules/travel_pay/app/controllers/travel_pay/v0/claims_controller.rb
@@ -3,6 +3,15 @@
 module TravelPay
   module V0
     class ClaimsController < ApplicationController
+      ### HEY
+      #### KEVIN
+      ##### REMOVE THIS!!!
+      skip_before_action :verify_authenticity_token, only: [:create]
+      ##### REMOVE THIS!!!
+      #### KEVIN
+      ### HEY
+
+
       def index
         begin
           claims = claims_service.get_claims(params)
@@ -40,19 +49,41 @@ module TravelPay
           raise Common::Exceptions::ServiceUnavailable, message:
         end
         
+
         # tp api requests
         #  get appt
+        appt = appts_service.get_appointment_by_date_time({'appt_datetime' => params['appointmentDatetime']})
+          
         #  make new claim
+        claim = claims_service.create_new_claim({ 'btsss_appt_id' => appt[:data]['id'] })
+
+        claim_id = claim['data']['claimId']
+
         #  attach expense
+        expense_service.add_expense({ 'claim_id' => claim_id, 'appt_date' => params['appointmentDatetime'] })
+
         #  submit claim
-        render json: {}, status: :ok
+        submitted_claim = claims_service.submit_claim(claim_id)
+
+        render json: submitted_claim['data'], status: :accepted
       end
 
       private
 
+      def auth_manager
+        @auth_manager ||= TravelPay::AuthManager.new(Settings.travel_pay.client_number, @current_user)
+      end
+
       def claims_service
-        auth_manager = TravelPay::AuthManager.new(Settings.travel_pay.client_number, @current_user)
         @claims_service ||= TravelPay::ClaimsService.new(auth_manager)
+      end
+
+      def appts_service
+        @appts_service ||= TravelPay::AppointmentsService.new(auth_manager)
+      end
+
+      def expense_service
+        @expense_service ||= TravelPay::ExpensesService.new(auth_manager)
       end
     end
   end

--- a/modules/travel_pay/app/controllers/travel_pay/v0/claims_controller.rb
+++ b/modules/travel_pay/app/controllers/travel_pay/v0/claims_controller.rb
@@ -34,6 +34,20 @@ module TravelPay
         render json: claim, status: :ok
       end
 
+      def create
+        unless Flipper.enabled?(:travel_pay_submit_mileage_expense, @current_user)
+          message = 'Travel Pay mileage expense submission unavailable per feature toggle'
+          raise Common::Exceptions::ServiceUnavailable, message:
+        end
+        
+        # tp api requests
+        #  get appt
+        #  make new claim
+        #  attach expense
+        #  submit claim
+        render json: {}, status: :ok
+      end
+
       private
 
       def claims_service

--- a/modules/travel_pay/app/controllers/travel_pay/v0/claims_controller.rb
+++ b/modules/travel_pay/app/controllers/travel_pay/v0/claims_controller.rb
@@ -62,7 +62,6 @@ module TravelPay
         rescue ArgumentError => e
           raise Common::Exceptions::BadRequest, detail: e.message
         rescue Faraday::ClientError, Faraday::ServerError => e
-          byebug
           raise Common::Exceptions::InternalServerError.new(e)
         end
 

--- a/modules/travel_pay/app/controllers/travel_pay/v0/claims_controller.rb
+++ b/modules/travel_pay/app/controllers/travel_pay/v0/claims_controller.rb
@@ -3,15 +3,6 @@
 module TravelPay
   module V0
     class ClaimsController < ApplicationController
-      ### HEY
-      #### KEVIN
-      ##### REMOVE THIS!!!
-      skip_before_action :verify_authenticity_token, only: [:create]
-      ##### REMOVE THIS!!!
-      #### KEVIN
-      ### HEY
-
-
       def index
         begin
           claims = claims_service.get_claims(params)
@@ -48,9 +39,9 @@ module TravelPay
           message = 'Travel Pay mileage expense submission unavailable per feature toggle'
           raise Common::Exceptions::ServiceUnavailable, message:
         end
-        
+
         begin
-          appt = appts_service.get_appointment_by_date_time({'appt_datetime' => params['appointmentDatetime']})
+          appt = appts_service.get_appointment_by_date_time({ 'appt_datetime' => params['appointmentDatetime'] })
 
           claim = claims_service.create_new_claim({ 'btsss_appt_id' => appt[:data]['id'] })
 
@@ -62,7 +53,7 @@ module TravelPay
         rescue ArgumentError => e
           raise Common::Exceptions::BadRequest, detail: e.message
         rescue Faraday::ClientError, Faraday::ServerError => e
-          raise Common::Exceptions::InternalServerError.new(e)
+          raise Common::Exceptions::InternalServerError, exception: e
         end
 
         render json: submitted_claim, status: :created

--- a/modules/travel_pay/app/services/travel_pay/appointments_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/appointments_client.rb
@@ -24,9 +24,9 @@ module TravelPay
       Rails.logger.debug(message: 'Correlation ID', correlation_id:)
 
       query_path = if params.empty?
-                     'api/v1.1/appointments'
+                     'api/v1.2/appointments'
                    else
-                     "api/v1.1/appointments?#{params.to_query}"
+                     "api/v1.2/appointments?#{params.to_query}"
                    end
 
       connection(server_url: btsss_url).get(query_path) do |req|

--- a/modules/travel_pay/app/services/travel_pay/appointments_service.rb
+++ b/modules/travel_pay/app/services/travel_pay/appointments_service.rb
@@ -54,7 +54,7 @@ module TravelPay
       end
     rescue DateTime::Error => e
       Rails.logger.error(message: "#{e} Invalid appointment time provided (given: #{date_string}).")
-      raise ArgumentError, message: "#{e} Invalid appointment time provided (given: #{date_string})."
+      raise ArgumentError, "#{e} Invalid appointment time provided (given: #{date_string})."
     end
 
     def client

--- a/modules/travel_pay/app/services/travel_pay/claims_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/claims_client.rb
@@ -84,5 +84,28 @@ module TravelPay
         }.to_json
       end
     end
+
+    ##
+    # HTTP POST call to the BTSSS 'claims/:id/submit' endpoint
+    # API responds with confirmation of claim submission
+    #
+    # @params {
+    #  "claimId": "string",
+    # }
+    #
+    # @return Faraday::Response claim submission payload
+    #
+    def submit_claim(veis_token, btsss_token, claim_id)
+      btsss_url = Settings.travel_pay.base_url
+      correlation_id = SecureRandom.uuid
+      Rails.logger.debug(message: 'Correlation ID', correlation_id:)
+
+      connection(server_url: btsss_url).patch("api/v1.1/claims/#{claim_id}/submit") do |req|
+        req.headers['Authorization'] = "Bearer #{veis_token}"
+        req.headers['BTSSS-Access-Token'] = btsss_token
+        req.headers['X-Correlation-ID'] = correlation_id
+        req.headers.merge!(claim_headers)
+      end
+    end
   end
 end

--- a/modules/travel_pay/app/services/travel_pay/claims_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/claims_client.rb
@@ -16,7 +16,7 @@ module TravelPay
       correlation_id = SecureRandom.uuid
       Rails.logger.debug(message: 'Correlation ID', correlation_id:)
 
-      connection(server_url: btsss_url).get('api/v1/claims') do |req|
+      connection(server_url: btsss_url).get('api/v1.2/claims') do |req|
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['BTSSS-Access-Token'] = btsss_token
         req.headers['X-Correlation-ID'] = correlation_id
@@ -47,7 +47,7 @@ module TravelPay
 
       connection(server_url: btsss_url)
         # URL subject to change once v1.2 is available (proposed endpoint: '/search')
-        .get("api/v1.1/claims/search-by-appointment-date?#{url_params.to_query}") do |req|
+        .get("api/v1.2/claims/search-by-appointment-date?#{url_params.to_query}") do |req|
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['BTSSS-Access-Token'] = btsss_token
         req.headers['X-Correlation-ID'] = correlation_id
@@ -72,7 +72,7 @@ module TravelPay
       correlation_id = SecureRandom.uuid
       Rails.logger.debug(message: 'Correlation ID', correlation_id:)
 
-      connection(server_url: btsss_url).post('api/v1.1/claims') do |req|
+      connection(server_url: btsss_url).post('api/v1.2/claims') do |req|
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['BTSSS-Access-Token'] = btsss_token
         req.headers['X-Correlation-ID'] = correlation_id
@@ -100,7 +100,7 @@ module TravelPay
       correlation_id = SecureRandom.uuid
       Rails.logger.debug(message: 'Correlation ID', correlation_id:)
 
-      connection(server_url: btsss_url).patch("api/v1.1/claims/#{claim_id}/submit") do |req|
+      connection(server_url: btsss_url).patch("api/v1.2/claims/#{claim_id}/submit") do |req|
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['BTSSS-Access-Token'] = btsss_token
         req.headers['X-Correlation-ID'] = correlation_id

--- a/modules/travel_pay/app/services/travel_pay/claims_service.rb
+++ b/modules/travel_pay/app/services/travel_pay/claims_service.rb
@@ -86,7 +86,7 @@ module TravelPay
       @auth_manager.authorize => { veis_token:, btsss_token: }
       new_claim_response = client.create_claim(veis_token, btsss_token, params)
 
-      new_claim_response.body
+      new_claim_response.body['data']
     end
 
     def submit_claim(claim_id)
@@ -98,7 +98,7 @@ module TravelPay
       @auth_manager.authorize => { veis_token:, btsss_token: }
       submitted_claim_response = client.submit_claim(veis_token, btsss_token, claim_id)
 
-      submitted_claim_response.body
+      submitted_claim_response.body['data']
     end
 
     private

--- a/modules/travel_pay/app/services/travel_pay/claims_service.rb
+++ b/modules/travel_pay/app/services/travel_pay/claims_service.rb
@@ -89,6 +89,18 @@ module TravelPay
       new_claim_response.body
     end
 
+    def submit_claim(claim_id)
+      unless claim_id
+        raise ArgumentError,
+              message: 'You must provide a BTSSS claim ID to submit a claim.'
+      end
+
+      @auth_manager.authorize => { veis_token:, btsss_token: }
+      submitted_claim_response = client.submit_claim(veis_token, btsss_token, claim_id)
+
+      submitted_claim_response.body
+    end
+
     private
 
     def filter_by_date(date_string, claims)

--- a/modules/travel_pay/app/services/travel_pay/claims_service.rb
+++ b/modules/travel_pay/app/services/travel_pay/claims_service.rb
@@ -99,7 +99,7 @@ module TravelPay
       uuid_all_version_format = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[89ABCD][0-9A-F]{3}-[0-9A-F]{12}$/i
       unless uuid_all_version_format.match?(claim_id)
         raise ArgumentError,
-              message: "Expected BTSSS claim id to be a valid UUID"
+              message: 'Expected BTSSS claim id to be a valid UUID'
       end
 
       @auth_manager.authorize => { veis_token:, btsss_token: }

--- a/modules/travel_pay/app/services/travel_pay/claims_service.rb
+++ b/modules/travel_pay/app/services/travel_pay/claims_service.rb
@@ -95,6 +95,13 @@ module TravelPay
               message: 'You must provide a BTSSS claim ID to submit a claim.'
       end
 
+      # ensure claim ID is the right format, allowing any version
+      uuid_all_version_format = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[89ABCD][0-9A-F]{3}-[0-9A-F]{12}$/i
+      unless uuid_all_version_format.match?(claim_id)
+        raise ArgumentError,
+              message: "Expected BTSSS claim id to be a valid UUID"
+      end
+
       @auth_manager.authorize => { veis_token:, btsss_token: }
       submitted_claim_response = client.submit_claim(veis_token, btsss_token, claim_id)
 

--- a/modules/travel_pay/app/services/travel_pay/expenses_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/expenses_client.rb
@@ -30,7 +30,7 @@ module TravelPay
       correlation_id = SecureRandom.uuid
       Rails.logger.debug(message: 'Correlation ID', correlation_id:)
 
-      connection(server_url: btsss_url).post('api/v1.1/expenses/mileage') do |req|
+      connection(server_url: btsss_url).post('api/v1.2/expenses/mileage') do |req|
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['BTSSS-Access-Token'] = btsss_token
         req.headers['X-Correlation-ID'] = correlation_id

--- a/modules/travel_pay/app/services/travel_pay/token_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/token_client.rb
@@ -38,7 +38,7 @@ module TravelPay
       correlation_id = SecureRandom.uuid
       Rails.logger.debug(message: 'Correlation ID', correlation_id:)
 
-      response = connection(server_url: btsss_url).post('api/v1/Auth/access-token') do |req|
+      response = connection(server_url: btsss_url).post('api/v1.2/Auth/access-token') do |req|
         req.headers['Authorization'] = "Bearer #{veis_token}"
         req.headers['BTSSS-API-Client-Number'] = @client_number.to_s
         req.headers['X-Correlation-ID'] = correlation_id

--- a/modules/travel_pay/spec/requests/travel_pay/claims_spec.rb
+++ b/modules/travel_pay/spec/requests/travel_pay/claims_spec.rb
@@ -114,7 +114,6 @@ RSpec.describe TravelPay::V0::ClaimsController, type: :request do
       params = {}
 
       post '/travel_pay/v0/claims', headers: headers, params: params
-      byebug
 
       expect(response).to have_http_status(:service_unavailable)
     end

--- a/modules/travel_pay/spec/requests/travel_pay/claims_spec.rb
+++ b/modules/travel_pay/spec/requests/travel_pay/claims_spec.rb
@@ -101,4 +101,22 @@ RSpec.describe TravelPay::V0::ClaimsController, type: :request do
       expect(response).to have_http_status(:service_unavailable)
     end
   end
+
+  describe '#create' do
+    before do
+      Flipper.enable(:travel_pay_submit_mileage_expense)
+    end
+    
+    it 'returns a ServiceUnavailable response if feature flag turned off' do
+      Flipper.disable(:travel_pay_submit_mileage_expense)
+
+      headers = { 'Authorization' => 'Bearer vagov_token' }
+      params = {}
+
+      post '/travel_pay/v0/claims', headers: headers, params: params
+      byebug
+
+      expect(response).to have_http_status(:service_unavailable)
+    end
+  end
 end

--- a/modules/travel_pay/spec/services/appointments_client_spec.rb
+++ b/modules/travel_pay/spec/services/appointments_client_spec.rb
@@ -89,7 +89,7 @@ describe TravelPay::AppointmentsClient do
 
   context '/appointments' do
     it 'returns a response only with appointments with no claims' do
-      @stubs.get('/api/v1.1/appointments?excludeWithClaims=true') do
+      @stubs.get('/api/v1.2/appointments?excludeWithClaims=true') do
         [
           200,
           {},
@@ -109,7 +109,7 @@ describe TravelPay::AppointmentsClient do
     end
 
     it 'returns a response with all appointments' do
-      @stubs.get('/api/v1.1/appointments') do
+      @stubs.get('/api/v1.2/appointments') do
         [
           200,
           {},

--- a/modules/travel_pay/spec/services/claims_client_spec.rb
+++ b/modules/travel_pay/spec/services/claims_client_spec.rb
@@ -37,7 +37,7 @@ describe TravelPay::ClaimsClient do
     # GET
     it 'returns response from claims endpoint' do
       allow_any_instance_of(TravelPay::ClaimsClient).to receive(:connection).and_return(@conn)
-      @stubs.get('/api/v1/claims') do
+      @stubs.get('/api/v1.2/claims') do
         [
           200,
           {},
@@ -86,7 +86,7 @@ describe TravelPay::ClaimsClient do
 
     it 'returns response from claims/search endpoint' do
       allow_any_instance_of(TravelPay::ClaimsClient).to receive(:connection).and_return(@conn)
-      @stubs.get('api/v1.1/claims/search-by-appointment-date') do
+      @stubs.get('api/v1.2/claims/search-by-appointment-date') do
         [
           200,
           {},
@@ -132,7 +132,7 @@ describe TravelPay::ClaimsClient do
       claim_id = '3fa85f64-5717-4562-b3fc-2c963f66afa6'
       body = { 'appointmentId' => 'fake_btsss_appt_id', 'claimName' => 'SMOC claim',
                'claimantType' => 'Veteran' }.to_json
-      @stubs.post('api/v1.1/claims') do
+      @stubs.post('api/v1.2/claims') do
         [
           200,
           {},
@@ -156,7 +156,7 @@ describe TravelPay::ClaimsClient do
     it 'returns a claim ID from the claims endpoint after submitting a claim' do
       claim_id = '3fa85f64-5717-4562-b3fc-2c963f66afa6'
 
-      expect_any_instance_of(Faraday::Connection).to receive(:patch).with("api/v1.1/claims/#{claim_id}/submit")
+      expect_any_instance_of(Faraday::Connection).to receive(:patch).with("api/v1.2/claims/#{claim_id}/submit")
 
       client = TravelPay::ClaimsClient.new
       client.submit_claim('veis_token', 'btsss_token', claim_id)

--- a/modules/travel_pay/spec/services/claims_client_spec.rb
+++ b/modules/travel_pay/spec/services/claims_client_spec.rb
@@ -13,7 +13,6 @@ describe TravelPay::ClaimsClient do
       c.response :json
       c.request :json
     end
-
   end
 
   context 'prod settings' do
@@ -127,7 +126,7 @@ describe TravelPay::ClaimsClient do
       expect(actual_ids).to eq(expected)
     end
 
-    # POST create_claim
+    # PATCH submit_claim
     it 'returns a claim ID from the claims endpoint' do
       allow_any_instance_of(TravelPay::ClaimsClient).to receive(:connection).and_return(@conn)
       claim_id = '3fa85f64-5717-4562-b3fc-2c963f66afa6'

--- a/modules/travel_pay/spec/services/claims_service_spec.rb
+++ b/modules/travel_pay/spec/services/claims_service_spec.rb
@@ -365,12 +365,8 @@ describe TravelPay::ClaimsService do
     let(:user) { build(:user) }
     let(:response) do
       Faraday::Response.new(
-        body: {
-            'data' => {
-              'claimId' => "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-              'status' => "InProcess"
-            }
-        }
+        body: { 'data' => { 'claimId' => '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+                            'status' => 'InProcess' } }
       )
     end
 
@@ -390,21 +386,15 @@ describe TravelPay::ClaimsService do
     end
 
     it 'raises an error if claim_id is missing' do
-      expect {
-        @service.submit_claim()
-      }.to raise_error(ArgumentError)
+      expect { @service.submit_claim }.to raise_error(ArgumentError)
     end
 
     it 'raises an error if invalid claim_id provided' do
       # present, wrong format
-      expect {
-        @service.submit_claim('claim_numero_uno')
-      }.to raise_error(ArgumentError)
+      expect { @service.submit_claim('claim_numero_uno') }.to raise_error(ArgumentError)
 
       # empty
-      expect {
-        @service.submit_claim('')
-      }.to raise_error(ArgumentError)
+      expect { @service.submit_claim('') }.to raise_error(ArgumentError)
     end
   end
 end

--- a/modules/travel_pay/spec/services/expenses_client_spec.rb
+++ b/modules/travel_pay/spec/services/expenses_client_spec.rb
@@ -21,7 +21,7 @@ describe TravelPay::ExpensesClient do
     # POST add_expense
     it 'returns an expenseId from the /expenses/mileage endpoint' do
       expense_id = '3fa85f64-5717-4562-b3fc-2c963f66afa6'
-      @stubs.post('/api/v1.1/expenses/mileage') do
+      @stubs.post('/api/v1.2/expenses/mileage') do
         [
           200,
           {},

--- a/modules/travel_pay/spec/services/token_client_spec.rb
+++ b/modules/travel_pay/spec/services/token_client_spec.rb
@@ -43,7 +43,7 @@ describe TravelPay::TokenClient do
     end
 
     it 'returns btsss token from proper endpoint' do
-      @stubs.post('api/v1/Auth/access-token') do
+      @stubs.post('api/v1.2/Auth/access-token') do
         [
           200,
           { 'Content-Type': 'application/json' },

--- a/spec/support/vcr_cassettes/travel_pay/200_claims.yml
+++ b/spec/support/vcr_cassettes/travel_pay/200_claims.yml
@@ -89,7 +89,7 @@ http_interactions:
   recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
 - request:
     method: get
-    uri: https://btsss.gov/api/v1/claims
+    uri: https://btsss.gov/api/v1.2/claims
     body:
       encoding: US-ASCII
       string: ''
@@ -287,7 +287,7 @@ http_interactions:
   recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
 - request:
     method: post
-    uri:  https://btsss.gov/api/v1/Auth/access-token
+    uri:  https://btsss.gov/api/v1.2/Auth/access-token
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/travel_pay/404_claims.yml
+++ b/spec/support/vcr_cassettes/travel_pay/404_claims.yml
@@ -89,7 +89,7 @@ http_interactions:
   recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
 - request:
     method: get
-    uri: https://btsss.gov/api/v1/claims
+    uri: https://btsss.gov/api/v1.2/claims
     body:
       encoding: US-ASCII
       string: ''
@@ -257,7 +257,7 @@ http_interactions:
   recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
 - request:
     method: post
-    uri:  https://btsss.gov/api/v1/Auth/access-token
+    uri:  https://btsss.gov/api/v1.2/Auth/access-token
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/travel_pay/show/success.yml
+++ b/spec/support/vcr_cassettes/travel_pay/show/success.yml
@@ -89,7 +89,7 @@ http_interactions:
   recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
 - request:
     method: get
-    uri: https://btsss.gov/api/v1/claims
+    uri: https://btsss.gov/api/v1.2/claims
     body:
       encoding: US-ASCII
       string: ''
@@ -287,7 +287,7 @@ http_interactions:
   recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
 - request:
     method: post
-    uri:  https://btsss.gov/api/v1/Auth/access-token
+    uri:  https://btsss.gov/api/v1.2/Auth/access-token
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/travel_pay/submit/success.yml
+++ b/spec/support/vcr_cassettes/travel_pay/submit/success.yml
@@ -1,0 +1,191 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<VEIS_AUTH_URL>/tenant_id/oauth2/token"
+    body:
+      encoding: US-ASCII
+      string: 'client_id=client_id&client_secret=client_secret&client_info=1&grant_type=client_credentials&resource=resource_id'
+  response:
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+    body:
+      encoding: ASCII-8BIT
+      string: '{
+        "data": {
+          "access_token": "string",
+          "contactId": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+        }
+      }'
+  recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
+- request:
+    method: post
+    uri: https://www.example.com/v0/sign_in/token
+    body:
+      encoding: US-ASCII
+      string: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    body:
+      encoding: ASCII-8BIT
+      string: '{
+        "data": {
+          "access_token": "sts_token"
+        }
+      }'
+  recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
+- request:
+    method: post
+    uri:  https://btsss.gov/api/v1/Auth/access-token
+    body:
+      encoding: US-ASCII
+      string: ''
+  response:
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+    body:
+      encoding: ASCII-8BIT
+      string: '{
+        "data": {
+          "accessToken": "btsss_token"
+        }
+      }'
+  recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
+- request:
+    method: get
+    uri: https://btsss.gov/api/v1.1/appointments?excludeWithClaims=true
+    body:
+      encoding: US-ASCII
+      string: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: ' 
+        { "data": [
+          {
+            "id": "aa0f63e0-5fa7-4d74-a17a-a6f510dbf69e",
+            "appointmentSource": "API",
+            "appointmentDateTime": "2024-01-01T16:45:34.465Z",
+            "appointmentName": "string",
+            "appointmentType": "EnvironmentalHealth",
+            "facilityName": "Cheyenne VA Medical Center",
+            "serviceConnectedDisability": 30,
+            "currentStatus": "string",
+            "appointmentStatus": "Completed",
+            "externalAppointmentId": "12345678-0000-0000-0000-000000000001",
+            "associatedClaimId": null,
+            "associatedClaimNumber": null,
+            "isCompleted": true
+          },
+          {
+            "id": "af8934a5-9de5-4f1c-b3de-89a2f2f2ef42",
+            "appointmentSource": "API",
+            "appointmentDateTime": "2024-03-01T16:45:34.465Z",
+            "appointmentName": "string",
+            "appointmentType": "EnvironmentalHealth",
+            "facilityName": "Cheyenne VA Medical Center",
+            "serviceConnectedDisability": 30,
+            "currentStatus": "string",
+            "appointmentStatus": "Completed",
+            "externalAppointmentId": "12345678-0000-0000-0000-000000000002",
+            "associatedClaimId": null,
+            "associatedClaimNumber": null,
+            "isCompleted": true
+          }
+        ] 
+      }'
+  recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
+- request:
+    method: post
+    uri: https://btsss.gov/api/v1.1/claims
+    body:
+      encoding: US-ASCII
+      string: '
+      { "data": {
+            "appointmentId": "aa0f63e0-5fa7-4d74-a17a-a6f510dbf69e"
+          }
+      }'
+  response:
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+    body:
+      encoding: ASCII-8BIT
+      string: '
+        { "data":
+          {
+            "claimId": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+          }
+      }'
+  recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
+- request:
+    method: post
+    uri: https://btsss.gov/api/v1.1/expenses/mileage
+    body:
+      encoding: US-ASCII
+      string: '
+      { "data": {
+        "claimId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "dateIncurred": "2024-01-01T16:45:34.465Z"
+        }
+      }'
+  response:
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+    body:
+      encoding: ASCII-8BIT
+      string: '
+        { "data": [
+          {
+            "expenseId": "12345abcd-5717-4562-b3fc-2c963f66afa6"
+          }
+        ]
+      }'
+  recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
+- request:
+    method: patch
+    uri: https://btsss.gov/api/v1.1/claims/3fa85f64-5717-4562-b3fc-2c963f66afa6/submit
+  response:
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+    body:
+      encoding: ASCII-8BIT
+      string: '
+        { "data": [
+          {
+            "expenseId": "12345abcd--5717-4562-b3fc-2c963f66afa6",
+            "claimId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "status": "InProcess",
+            "createdOn": "2024-12-10T19:53:08.446Z",
+            "modifiedOn": "2024-12-10T19:53:08.446Z"
+          }
+        ]
+      }'
+  recorded_at: Tue, 28 Feb 2023 21:02:39 GMT

--- a/spec/support/vcr_cassettes/travel_pay/submit/success.yml
+++ b/spec/support/vcr_cassettes/travel_pay/submit/success.yml
@@ -42,7 +42,7 @@ http_interactions:
   recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
 - request:
     method: post
-    uri:  https://btsss.gov/api/v1/Auth/access-token
+    uri:  https://btsss.gov/api/v1.2/Auth/access-token
     body:
       encoding: US-ASCII
       string: ''
@@ -63,7 +63,7 @@ http_interactions:
   recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
 - request:
     method: get
-    uri: https://btsss.gov/api/v1.1/appointments?excludeWithClaims=true
+    uri: https://btsss.gov/api/v1.2/appointments?excludeWithClaims=true
     body:
       encoding: US-ASCII
       string: ''
@@ -113,7 +113,7 @@ http_interactions:
   recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
 - request:
     method: post
-    uri: https://btsss.gov/api/v1.1/claims
+    uri: https://btsss.gov/api/v1.2/claims
     body:
       encoding: US-ASCII
       string: '
@@ -139,7 +139,7 @@ http_interactions:
   recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
 - request:
     method: post
-    uri: https://btsss.gov/api/v1.1/expenses/mileage
+    uri: https://btsss.gov/api/v1.2/expenses/mileage
     body:
       encoding: US-ASCII
       string: '
@@ -167,7 +167,7 @@ http_interactions:
   recorded_at: Tue, 28 Feb 2023 21:02:39 GMT
 - request:
     method: patch
-    uri: https://btsss.gov/api/v1.1/claims/3fa85f64-5717-4562-b3fc-2c963f66afa6/submit
+    uri: https://btsss.gov/api/v1.2/claims/3fa85f64-5717-4562-b3fc-2c963f66afa6/submit
   response:
     headers:
       Content-Type:


### PR DESCRIPTION
## Summary

This work is behind a feature toggle (flipper): YES

Adds the basic, synchronous flow for submitting a mileage-only travel claim.

## Related issue(s)
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/92256

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
Travel Pay (backend only)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
