### PR TITLE
Bump carrierwave 3.0.7 -> 3.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,7 +291,7 @@ GEM
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
     byebug (11.1.3)
-    carrierwave (3.0.7)
+    carrierwave (3.1.0)
       activemodel (>= 6.0.0)
       activesupport (>= 6.0.0)
       addressable (~> 2.6)
@@ -461,8 +461,8 @@ GEM
     faraday_curl (0.0.2)
       faraday (>= 0.9.0)
     fastimage (2.3.1)
-    ffi (1.17.0)
-    ffi (1.17.0-java)
+    ffi (1.17.1)
+    ffi (1.17.1-java)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
@@ -599,7 +599,7 @@ GEM
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    image_processing (1.12.2)
+    image_processing (1.13.0)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
     io-console (0.8.0)
@@ -982,8 +982,9 @@ GEM
     ruby-saml (1.17.0)
       nokogiri (>= 1.13.10)
       rexml
-    ruby-vips (2.2.1)
+    ruby-vips (2.2.2)
       ffi (~> 1.12)
+      logger
     rubyzip (2.3.2)
     rufus-scheduler (3.9.2)
       fugit (~> 1.1, >= 1.11.1)
@@ -1047,7 +1048,7 @@ GEM
     socksify (1.7.1)
     spoon (0.0.6)
       ffi
-    ssrf_filter (1.1.2)
+    ssrf_filter (1.2.0)
     staccato (0.5.3)
     statsd-instrument (3.9.7)
     stringio (3.1.2)


### PR DESCRIPTION
## Summary

- Bump carrierwave 3.0.7 -> 3.1.0