### PR TITLE
98666 hca schema validation

### DIFF
--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -315,8 +315,16 @@ class HealthCareApplication < ApplicationRecord
 
   def form_matches_schema
     if form.present?
-      JSON::Validator.fully_validate(VetsJsonSchema::SCHEMAS[self.class::FORM_ID], parsed_form).each do |v|
-        errors.add(:form, v.to_s)
+      begin
+        JSON::Validator.fully_validate(VetsJsonSchema::SCHEMAS[self.class::FORM_ID], parsed_form).each do |v|
+          errors.add(:form, v.to_s)
+        end
+      rescue => e
+        Rails.logger.error("[#{FORM_ID}] Error during schema validation!",
+                           { error: e.message,
+                             backtrace: e.backtrace,
+                             schema: VetsJsonSchema::SCHEMAS[self.class::FORM_ID] })
+        raise
       end
     end
   end

--- a/spec/models/health_care_application_spec.rb
+++ b/spec/models/health_care_application_spec.rb
@@ -363,6 +363,25 @@ RSpec.describe HealthCareApplication, type: :model do
         expect_attr_valid(health_care_application, attr)
       end
     end
+
+    context 'schema validation raises an exception' do
+      let(:health_care_application) { build(:health_care_application) }
+      let(:exception) { StandardError.new('Some exception') }
+
+      before do
+        allow(JSON::Validator).to receive(:fully_validate).and_raise(exception)
+      end
+
+      it 'logs exception and raises exception' do
+        expect(Rails.logger).to receive(:error)
+          .with("[#{form_id}] Error during schema validation!", {
+                  error: exception.message,
+                  backtrace: anything,
+                  schema: VetsJsonSchema::SCHEMAS[form_id]
+                })
+        expect { health_care_application.valid? }.to raise_error(exception.class, exception.message)
+      end
+    end
   end
 
   describe '#process!' do

--- a/spec/models/health_care_application_spec.rb
+++ b/spec/models/health_care_application_spec.rb
@@ -369,10 +369,18 @@ RSpec.describe HealthCareApplication, type: :model do
       let(:exception) { StandardError.new('Some exception') }
 
       before do
+        allow(PersonalInformationLog).to receive(:create)
         allow(JSON::Validator).to receive(:fully_validate).and_raise(exception)
       end
 
       it 'logs exception and raises exception' do
+        expect(PersonalInformationLog).to receive(:create).with(
+          data: {
+            schema: VetsJsonSchema::SCHEMAS[form_id],
+            parsed_form: health_care_application.parsed_form
+          },
+          error_class: 'HealthCareApplication FormValidationError'
+        )
         expect(Rails.logger).to receive(:error)
           .with("[#{form_id}] Error during schema validation!", {
                   error: exception.message,


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Add exception handling to log the exception and create a PIL for when a 10-10EZ form fails a schema validation. These are very rare, but they do happen. We want to have more information available to determine why these fail schema validations. There is also currently work underway to add a new json schema validation gem, and this will allow us to have some more insight for when we move over to the other gem. 
- 1010 Health Apps
- No flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98666

## Testing done

- [x] *New code is covered by unit tests*
- Previously it just raised an exception. Now we log that exception. 
- Check that a log occurs if the json schema validation method raises an exception.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
10-10EZ

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

