### PR TITLE
EZR: Add VANotify callback metadata to email notify job

### DIFF
--- a/app/sidekiq/hca/ezr_submission_job.rb
+++ b/app/sidekiq/hca/ezr_submission_job.rb
@@ -11,10 +11,10 @@ module HCA
     FORM_ID = '10-10EZR'
     VALIDATION_ERROR = HCA::SOAPParser::ValidationError
     STATSD_KEY_PREFIX = 'api.1010ezr'
-    DD_ZSF_TAGS = [
-      'service:healthcare-application',
-      'function: 10-10EZR async form submission'
-    ].freeze
+    DD_ZSF_TAGS = {
+      service: 'healthcare-application',
+      function: '10-10EZR async form submission'
+    }.freeze
 
     # retry for  2d 1h 47m 12s
     # https://github.com/sidekiq/sidekiq/wiki/Error-Handling

--- a/spec/sidekiq/hca/ezr_submission_job_spec.rb
+++ b/spec/sidekiq/hca/ezr_submission_job_spec.rb
@@ -98,7 +98,6 @@ RSpec.describe HCA::EzrSubmissionJob, type: :job do
           described_class.within_sidekiq_retries_exhausted_block(msg) do
             expect(VANotify::EmailJob).not_to receive(:perform_async)
             expect(StatsD).not_to receive(:increment).with('api.1010ezr.submission_failure_email_sent')
-            expect(StatsD).not_to receive(:increment).with('silent_failure_avoided_no_confirmation', tags:)
           end
         end
       end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
-  Adds support for VANotify callbacks when sending the failure email to the Veteran

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/94083

## Testing done

- [ ] *New code is covered by unit tests*
- We will validate the metadata is sent when QA'ing the failure email

## What areas of the site does it impact?
Form 10-10 EZR

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
