### PR TITLE
[96901] Add Individual Type to current rep API response

### DIFF
--- a/modules/representation_management/app/serializers/representation_management/power_of_attorney/representative_serializer.rb
+++ b/modules/representation_management/app/serializers/representation_management/power_of_attorney/representative_serializer.rb
@@ -9,6 +9,10 @@ module RepresentationManagement
         'representative'
       end
 
+      attribute :individual_type do |object|
+        object.user_types.first
+      end
+
       attribute :email
       attribute :name, &:full_name
       attribute :phone, &:phone_number

--- a/modules/representation_management/app/swagger/v0/swagger.json
+++ b/modules/representation_management/app/swagger/v0/swagger.json
@@ -321,25 +321,36 @@
                 "type": "string",
                 "description": "Specifies the category of Power of Attorney (POA) representation.",
                 "enum": [
-                  "veteran_service_representatives",
-                  "veteran_service_organizations"
-                ]
+                  "representative",
+                  "organization"
+                ],
+                "example": "representative"
               },
               "attributes": {
                 "type": "object",
                 "properties": {
                   "type": {
                     "type": "string",
-                    "example": "organization",
+                    "example": "representative",
                     "description": "Type of Power of Attorney representation",
                     "enum": [
                       "organization",
                       "representative"
                     ]
                   },
+                  "individual_type": {
+                    "type": "string",
+                    "description": "The type of individual appointed",
+                    "enum": [
+                      "attorney",
+                      "claim_agents",
+                      "veteran_service_officer"
+                    ],
+                    "example": "attorney"
+                  },
                   "name": {
                     "type": "string",
-                    "example": "Veterans Association"
+                    "example": "Bob Law"
                   },
                   "address_line1": {
                     "type": "string",
@@ -725,9 +736,7 @@
           "PDF Generation"
         ],
         "operationId": "createPdfForm2122",
-        "parameters": [
-
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "PDF generated successfully"
@@ -958,9 +967,7 @@
           "PDF Generation"
         ],
         "operationId": "createPdfForm2122a",
-        "parameters": [
-
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "PDF generated successfully"
@@ -1218,8 +1225,7 @@
                     {
                       "type": "object",
                       "description": "An empty JSON object indicating no Power of Attorney exists.",
-                      "example": {
-                      }
+                      "example": {}
                     }
                   ]
                 }
@@ -1256,9 +1262,7 @@
           "Next Steps Email"
         ],
         "operationId": "nextStepsEmail",
-        "parameters": [
-
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "Email enqueued",

--- a/modules/representation_management/spec/requests/representation_management/v0/power_of_attorney_swagger_spec.rb
+++ b/modules/representation_management/spec/requests/representation_management/v0/power_of_attorney_swagger_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Power of Attorney API', openapi_spec: 'modules/representation_ma
         before do
           lh_response = {
             'data' => {
-              'type' => 'organization',
+              'type' => 'individual',
               'attributes' => {
                 'code' => 'abc'
               }

--- a/modules/representation_management/spec/serializers/power_of_attorney/representative_serializer_spec.rb
+++ b/modules/representation_management/spec/serializers/power_of_attorney/representative_serializer_spec.rb
@@ -27,4 +27,8 @@ describe RepresentationManagement::PowerOfAttorney::RepresentativeSerializer, ty
   it 'includes :phone' do
     expect(attributes['phone']).to eq object.phone_number
   end
+
+  it 'includes :individual_type' do
+    expect(attributes['individual_type']).to eq 'attorney'
+  end
 end

--- a/modules/representation_management/spec/support/rswag_config.rb
+++ b/modules/representation_management/spec/support/rswag_config.rb
@@ -121,7 +121,8 @@ class RepresentationManagement::RswagConfig
             type: {
               type: :string,
               description: 'Specifies the category of Power of Attorney (POA) representation.',
-              enum: %w[veteran_service_representatives veteran_service_organizations]
+              enum: %w[representative organization],
+              example: 'representative'
             },
             attributes: power_of_attorney_attributes
           }
@@ -136,9 +137,15 @@ class RepresentationManagement::RswagConfig
       properties: {
         type: {
           type: :string,
-          example: 'organization',
+          example: 'representative',
           description: 'Type of Power of Attorney representation',
           enum: %w[organization representative]
+        },
+        individual_type: {
+          type: :string,
+          description: 'The type of individual appointed',
+          enum: %w[attorney claim_agents veteran_service_officer],
+          example: 'attorney'
         }
       }.merge(power_of_attorney_detailed_attributes),
       required: %w[type name address_line1 city state_code zip_code]
@@ -249,7 +256,7 @@ class RepresentationManagement::RswagConfig
 
   def power_of_attorney_detailed_attributes
     {
-      name: { type: :string, example: 'Veterans Association' },
+      name: { type: :string, example: 'Bob Law' },
       address_line1: { type: :string, example: '1234 Freedom Blvd' },
       address_line2: { type: :string, example: 'Suite 200' },
       address_line3: { type: :string, example: 'Building 3' },

--- a/modules/representation_management/spec/support/rswag_config.rb
+++ b/modules/representation_management/spec/support/rswag_config.rb
@@ -121,8 +121,7 @@ class RepresentationManagement::RswagConfig
             type: {
               type: :string,
               description: 'Specifies the category of Power of Attorney (POA) representation.',
-              enum: %w[representative organization],
-              example: 'representative'
+              enum: %w[representative organization]
             },
             attributes: power_of_attorney_attributes
           }


### PR DESCRIPTION
## Summary

- This pr adds the individual type attribute to the current power of attorney API response so that the front end can distinguish between attorneys and claims agents.

## Related issue(s)

- [96901](https://github.com/department-of-veterans-affairs/va.gov-team/issues/96901)

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
- Appoint a Rep Form 21-22 and 21-22a

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature