### PR TITLE
Add test coverage to verify correct argument is passed to process_0781

### DIFF
--- a/spec/sidekiq/evss/disability_compensation_form/submit_form0781_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form0781_spec.rb
@@ -861,4 +861,52 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
       end
     end
   end
+  describe '#get_docs' do
+    let(:submission_id) { 1 }
+    let(:uuid) { 'some-uuid' }
+    let(:submission) { create(:form526_submission, id: submission_id) }
+    let(:parsed_forms) do
+      {
+        'form0781' => { 'content_0781' => 'value_0781' },
+        'form0781a' => { 'content_0781a' => 'value_0781a' },
+        'form0781v2' => nil
+      }
+    end
+
+    before do
+      allow(Form526Submission).to receive(:find_by).with(id: submission_id).and_return(submission)
+      allow_any_instance_of(described_class).to receive(:parsed_forms).and_return(parsed_forms)
+      allow_any_instance_of(described_class).to receive(:process_0781).and_return('file_path') # rubocop:disable Naming/VariableNumber
+    end
+
+    it 'returns the correct file type and file objects' do
+      result = subject.new.get_docs(submission_id, uuid)
+
+      expect(result).to eq([
+                             { type: described_class::FORM_ID_0781,
+                               file: 'file_path' },
+                             { type: described_class::FORM_ID_0781A,
+                               file: 'file_path' }
+                           ])
+    end
+
+    it 'does not include forms with no content' do
+      result = subject.new.get_docs(submission_id, uuid)
+
+      expect(result).not_to include({ type: described_class::FORM_ID_0781V2,
+                                      file: 'file_path' })
+    end
+
+    it 'correctly discerns whether to process a 0781 or 0781a' do
+      expect_any_instance_of(described_class).to receive(:process_0781).with(uuid, described_class::FORM_ID_0781, # rubocop:disable Naming/VariableNumber
+                                                                             parsed_forms['form0781'], upload: false)
+      expect_any_instance_of(described_class).to receive(:process_0781).with(uuid, described_class::FORM_ID_0781A, # rubocop:disable Naming/VariableNumber
+                                                                             parsed_forms['form0781a'], upload: false)
+      expect_any_instance_of(described_class).not_to receive(:process_0781).with(uuid, # rubocop:disable Naming/VariableNumber
+                                                                                 described_class::FORM_ID_0781V2,
+                                                                                 parsed_forms['form0781v2'],
+                                                                                 upload: false)
+      subject.new.get_docs(submission_id, uuid)
+    end
+  end
 end

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form0781_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form0781_spec.rb
@@ -864,7 +864,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
   describe '#get_docs' do
     let(:submission_id) { 1 }
     let(:uuid) { 'some-uuid' }
-    let(:submission) { create(:form526_submission, id: submission_id) }
+    let(:submission) { build(:form526_submission, id: submission_id) }
     let(:parsed_forms) do
       {
         'form0781' => { 'content_0781' => 'value_0781' },


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Added test coverage to ensure the `get_docs` method works as expected and correctly distinguishes between different form types `form0781` and `form0781a`

## Related issue(s)
https://github.com/department-of-veterans-affairs/vets-api/pull/19624

## Testing done

- [x] New code is covered by unit tests

## What areas of the site does it impact?

- Impacts the processing of disability compensation forms, specifically the generation of PDF documents for `form0781` and `form0781a`

## Acceptance criteria

- [x] I added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution.
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs.
- [x] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected.