### PR TITLE
[VACMS-20093]Update real-time banners every 5 minutes instead of waiting 10

### DIFF
--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -50,8 +50,8 @@ PERIODIC_JOBS = lambda { |mgr| # rubocop:disable Metrics/BlockLength
   # Checks status of Flipper features expected to be enabled and alerts to Slack if any are not enabled
   mgr.register('0 2,9,16 * * 1-5', 'AppealsApi::FlipperStatusAlert')
 
-  # Update alternative Banners data every 10 minutes
-  mgr.register('*/10 * * * *', 'Banners::UpdateAllJob')
+  # Update alternative Banners data every 5 minutes
+  mgr.register('*/5 * * * *', 'Banners::UpdateAllJob')
 
   # Update static data cache
   mgr.register('0 0 * * *', 'Crm::TopicsDataJob')


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES* The Realtime banners are behind a feature flag as well as the job that is updating via a separate flag
- This will have real time banners update jobs running every 5 minutes instead of 10, bringing down the expected update time for Editors from 20minutes to 10.

- Sitewide team built and owned

## Related issue(s)

- Issue: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20093

## Testing done

- [ ] *New code is covered by unit tests*
- Previously this job would be run every 10minutes, with the update only adjusting to run this every 5

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Real-time banners DB updating

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
