### PR TITLE
Fix SubmitBenefitsIntakeClaim import error

### DIFF
--- a/app/sidekiq/lighthouse/submit_benefits_intake_claim.rb
+++ b/app/sidekiq/lighthouse/submit_benefits_intake_claim.rb
@@ -7,7 +7,7 @@ require 'burials/monitor'
 require 'burials/notification_email'
 require 'pcpg/monitor'
 require 'benefits_intake_service/service'
-require 'simple_forms_api_submission/metadata_validator'
+require 'lighthouse/benefits_intake/metadata'
 require 'pdf_info'
 
 module Lighthouse
@@ -82,7 +82,7 @@ module Lighthouse
       address = form['claimantAddress'] || form['veteranAddress']
 
       # also validates/manipulates the metadata
-      BenefitsIntake::Metadata.generate(
+      ::BenefitsIntake::Metadata.generate(
         veteran_full_name['first'],
         veteran_full_name['last'],
         form['vaFileNumber'] || form['veteranSocialSecurityNumber'],

--- a/spec/sidekiq/lighthouse/submit_benefits_intake_claim_spec.rb
+++ b/spec/sidekiq/lighthouse/submit_benefits_intake_claim_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Lighthouse::SubmitBenefitsIntakeClaim, :uploader_helpers do
       allow(response).to receive(:success?).and_return(true)
 
       expect(job).to receive(:create_form_submission_attempt)
-      expect(job).to receive(:generate_metadata).once
+      expect(job).to receive(:generate_metadata).once.and_call_original
       expect(service).to receive(:upload_doc)
 
       # burials only


### PR DESCRIPTION
## Summary

- The import of BenefitsIntake::Metadata in SubmitBenefitsIntakeClaim broke after a namespace change was released last week, causing submissions to fail. This repairs the import. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/100034

## Testing done

- [ ] *New code is covered by unit tests*
     -  Confirmed that the test change caused test failure prior to fix
- [ ] Submit a Burial form and confirm that a successful Sidekiq submission is recorded in the logs

## Screenshots
Before:
<img width="553" alt="Screenshot 2025-01-06 at 1 58 56 PM" src="https://github.com/user-attachments/assets/2a31ca0b-0fe0-4dd9-86fa-7a38204c07b2" />

After:
<img width="571" alt="Screenshot 2025-01-06 at 1 55 07 PM" src="https://github.com/user-attachments/assets/4ac4e424-e810-49ad-8d2d-c8696239db4d" />

## What areas of the site does it impact?
Burials, SubmitBenefitsIntakeClaim

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
