### PR TITLE
Add logging to non-module Decision Review controllers

### DIFF
--- a/app/controllers/appeals_base_controller_v1.rb
+++ b/app/controllers/appeals_base_controller_v1.rb
@@ -9,6 +9,14 @@ class AppealsBaseControllerV1 < ApplicationController
 
   private
 
+  def log_non_module_controller(action:, form_id:)
+    Rails.logger.warn({
+                        message: 'Calling decision reviews controller outside module',
+                        action:,
+                        form_id:
+                      })
+  end
+
   def decision_review_service
     DecisionReviewV1::Service.new
   end

--- a/app/controllers/v1/decision_review_evidences_controller.rb
+++ b/app/controllers/v1/decision_review_evidences_controller.rb
@@ -9,10 +9,19 @@ module V1
     include FormAttachmentCreate
     include DecisionReviewV1::Appeals::LoggingUtils
     service_tag 'evidence-upload'
+    before_action { log_non_module_controller }
 
     FORM_ATTACHMENT_MODEL = DecisionReviewEvidenceAttachment
 
     private
+
+    def log_non_module_controller
+      Rails.logger.warn({
+                          message: 'Calling decision reviews controller outside module',
+                          action: 'Decision review evidences create',
+                          form_id: get_form_id_from_request_headers
+                        })
+    end
 
     def serializer_klass
       DecisionReviewEvidenceAttachmentSerializer
@@ -69,23 +78,25 @@ module V1
       # - vets-website/src/platform/startup/setup.js (setUpCommonFunctionality)
       # - vets-website/src/platform/startup/index.js (startApp)
       # - vets-api/lib/source_app_middleware.rb
-      source_app_name = request.env['SOURCE_APP']
-      # The higher-level review form (996) is not included in this list because it does not permit evidence uploads.
-      form_id = {
-        '10182-board-appeal' => '10182',
-        '995-supplemental-claim' => '995'
-      }[source_app_name]
+      @form_id ||= begin
+        source_app_name = request.env['SOURCE_APP']
+        # The higher-level review form (996) is not included in this list because it does not permit evidence uploads.
+        form_id = {
+          '10182-board-appeal' => '10182',
+          '995-supplemental-claim' => '995'
+        }[source_app_name]
 
-      if form_id.present?
-        form_id
-      else
-        # If, for some odd reason, the `entryName`s are changed in these manifest.json files (or if the HLR form begins
-        # accepting additional evidence), we will trigger a DataDog alert hinging on the StatsD metric below. Upon
-        # receiving this alert, we can update the form_id hash above.
-        StatsD.increment('decision_review.evidence_upload_to_s3.unexpected_form_id')
-        # In this situation, there is no good reason to block the Veteran from uploading their evidence to S3,
-        # so we return the unexpected `source_app_name` to be logged by `log_formatted` above.
-        source_app_name
+        if form_id.present?
+          form_id
+        else
+          # If, for some odd reason, the `entryName`s are changed in these manifest.json files (or if the HLR
+          # form begins accepting additional evidence), we will trigger a DataDog alert hinging on the StatsD
+          # metric below. Upon receiving this alert, we can update the form_id hash above.
+          StatsD.increment('decision_review.evidence_upload_to_s3.unexpected_form_id')
+          # In this situation, there is no good reason to block the Veteran from uploading their evidence to S3,
+          # so we return the unexpected `source_app_name` to be logged by `log_formatted` above.
+          source_app_name
+        end
       end
     end
   end

--- a/app/controllers/v1/decision_review_notification_callbacks_controller.rb
+++ b/app/controllers/v1/decision_review_notification_callbacks_controller.rb
@@ -13,6 +13,7 @@ module V1
     skip_before_action :authenticate, only: [:create]
     skip_after_action :set_csrf_header, only: [:create]
     before_action :authenticate_header, only: [:create]
+    before_action :log_non_module_controller
 
     STATSD_KEY_PREFIX = 'api.decision_review.notification_callback'
 
@@ -46,6 +47,13 @@ module V1
     end
 
     private
+
+    def log_non_module_controller
+      Rails.logger.warn({
+                          message: 'Calling decision reviews controller outside module',
+                          action: 'Notification callbacks controller'
+                        })
+    end
 
     def log_params(payload, is_success)
       {

--- a/app/controllers/v1/higher_level_reviews/contestable_issues_controller.rb
+++ b/app/controllers/v1/higher_level_reviews/contestable_issues_controller.rb
@@ -4,6 +4,7 @@ module V1
   module HigherLevelReviews
     class ContestableIssuesController < AppealsBaseControllerV1
       service_tag 'higher-level-review'
+      before_action { log_non_module_controller(action: "HLR contestable issues #{action_name}", form_id: '996') }
 
       def index
         ci = decision_review_service

--- a/app/controllers/v1/higher_level_reviews_controller.rb
+++ b/app/controllers/v1/higher_level_reviews_controller.rb
@@ -6,6 +6,7 @@ module V1
   class HigherLevelReviewsController < AppealsBaseControllerV1
     include DecisionReview::SavedClaim::Service
     service_tag 'higher-level-review'
+    before_action { log_non_module_controller(action: "HLR #{action_name}", form_id: '996') }
 
     def show
       render json: decision_review_service.get_higher_level_review(params[:id]).body

--- a/app/controllers/v1/notice_of_disagreements/contestable_issues_controller.rb
+++ b/app/controllers/v1/notice_of_disagreements/contestable_issues_controller.rb
@@ -4,6 +4,7 @@ module V1
   module NoticeOfDisagreements
     class ContestableIssuesController < AppealsBaseControllerV1
       service_tag 'board-appeal'
+      before_action { log_non_module_controller(action: "NOD contestable issues #{action_name}", form_id: '10182') }
 
       def index
         render json: decision_review_service

--- a/app/controllers/v1/notice_of_disagreements_controller.rb
+++ b/app/controllers/v1/notice_of_disagreements_controller.rb
@@ -3,6 +3,7 @@
 module V1
   class NoticeOfDisagreementsController < AppealsBaseControllerV1
     service_tag 'board-appeal'
+    before_action { log_non_module_controller(action: "NOD #{action_name}", form_id: '10182') }
 
     def show
       render json: decision_review_service.get_notice_of_disagreement(params[:id]).body

--- a/app/controllers/v1/supplemental_claims/contestable_issues_controller.rb
+++ b/app/controllers/v1/supplemental_claims/contestable_issues_controller.rb
@@ -4,6 +4,7 @@ module V1
   module SupplementalClaims
     class ContestableIssuesController < AppealsBaseControllerV1
       service_tag 'appeal-application'
+      before_action { log_non_module_controller(action: "SC contestable issues #{action_name}", form_id: '995') }
 
       def index
         ci = decision_review_service

--- a/app/controllers/v1/supplemental_claims_controller.rb
+++ b/app/controllers/v1/supplemental_claims_controller.rb
@@ -9,6 +9,7 @@ module V1
     include DecisionReviewV1::Appeals::Helpers
     include DecisionReview::SavedClaim::Service
     service_tag 'appeal-application'
+    before_action { log_non_module_controller(action: "SC #{action_name}", form_id: '995') }
 
     def show
       render json: decision_review_service.get_supplemental_claim(params[:id]).body

--- a/app/controllers/v2/higher_level_reviews_controller.rb
+++ b/app/controllers/v2/higher_level_reviews_controller.rb
@@ -6,6 +6,7 @@ module V2
   class HigherLevelReviewsController < AppealsBaseControllerV1
     include DecisionReview::SavedClaim::Service
     service_tag 'higher-level-review'
+    before_action { log_non_module_controller(action: "HLR V2 #{action_name}", form_id: '996') }
 
     def show
       render json: decision_review_service.get_higher_level_review(params[:id]).body

--- a/spec/controllers/v1/decision_review_evidences_controller_spec.rb
+++ b/spec/controllers/v1/decision_review_evidences_controller_spec.rb
@@ -25,6 +25,19 @@ RSpec.describe V1::DecisionReviewEvidencesController, type: :controller do
       sign_in_as(user)
     end
 
+    it 'logs use of the old controller' do
+      request.env['SOURCE_APP'] = '10182-board-appeal'
+      params = { param_namespace => { file_data: pdf_file } }
+      warn_old_controller_args = {
+        message: 'Calling decision reviews controller outside module',
+        action: 'Decision review evidences create',
+        form_id: anything
+      }
+      allow(Rails.logger).to receive(:warn)
+      expect(Rails.logger).to receive(:warn).with(warn_old_controller_args)
+      post(:create, params:)
+    end
+
     it 'requires params.`param_namespace`' do
       empty_req_params = [nil, {}]
       empty_req_params << { param_namespace => {} }

--- a/spec/controllers/v1/decision_review_notification_callbacks_controller_spec.rb
+++ b/spec/controllers/v1/decision_review_notification_callbacks_controller_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe V1::DecisionReviewNotificationCallbacksController, type: :control
       allow(DecisionReviewNotificationAuditLog).to receive(:create!)
     end
 
+    it 'logs use of the old controller' do
+      warn_old_controller_args = {
+        message: 'Calling decision reviews controller outside module',
+        action: 'Notification callbacks controller'
+      }
+      allow(Rails.logger).to receive(:warn)
+      expect(Rails.logger).to receive(:warn).with(warn_old_controller_args)
+      post(:create, params:, as: :json)
+    end
+
     context 'the record saved without an issue' do
       it 'returns success' do
         expect(DecisionReviewNotificationAuditLog).to receive(:create!)

--- a/spec/requests/v1/higher_level_reviews/contestable_issues_spec.rb
+++ b/spec/requests/v1/higher_level_reviews/contestable_issues_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe 'V1::HigherLevelReviews::ContestableIssues', type: :request do
 
     subject { get '/v1/higher_level_reviews/contestable_issues/compensation' }
 
+    it 'logs use of the old controller' do
+      warn_old_controller_args = {
+        message: 'Calling decision reviews controller outside module',
+        action: 'HLR contestable issues index',
+        form_id: '996'
+      }
+      allow(Rails.logger).to receive(:warn)
+      expect(Rails.logger).to receive(:warn).with(warn_old_controller_args)
+      subject
+    end
+
     it 'fetches issues that the Veteran could contest via a higher-level review' do
       VCR.use_cassette('decision_review/HLR-GET-CONTESTABLE-ISSUES-RESPONSE-200_V1') do
         VCR.use_cassette('decision_review/HLR-GET-LEGACY_APPEALS-RESPONSE-200_V1') do

--- a/spec/requests/v1/higher_level_reviews_spec.rb
+++ b/spec/requests/v1/higher_level_reviews_spec.rb
@@ -68,6 +68,17 @@ RSpec.describe 'V1::HigherLevelReviews', type: :request do
            headers:
     end
 
+    it 'logs use of the old controller' do
+      warn_old_controller_args = {
+        message: 'Calling decision reviews controller outside module',
+        action: 'HLR create',
+        form_id: '996'
+      }
+      allow(Rails.logger).to receive(:warn)
+      expect(Rails.logger).to receive(:warn).with(warn_old_controller_args)
+      subject
+    end
+
     it 'creates an HLR' do
       VCR.use_cassette('decision_review/HLR-CREATE-RESPONSE-200_V1') do
         # Create an InProgressForm

--- a/spec/requests/v1/notice_of_disagreements/contestable_issues_spec.rb
+++ b/spec/requests/v1/notice_of_disagreements/contestable_issues_spec.rb
@@ -16,6 +16,17 @@ RSpec.describe 'V1::NoticeOfDisagreements::ContestableIssues', type: :request do
 
     subject { get '/v1/notice_of_disagreements/contestable_issues' }
 
+    it 'logs use of the old controller' do
+      warn_old_controller_args = {
+        message: 'Calling decision reviews controller outside module',
+        action: 'NOD contestable issues index',
+        form_id: '10182'
+      }
+      allow(Rails.logger).to receive(:warn)
+      expect(Rails.logger).to receive(:warn).with(warn_old_controller_args)
+      subject
+    end
+
     it 'fetches issues that the Veteran could contest via a notice of disagreement' do
       VCR.use_cassette('decision_review/NOD-GET-CONTESTABLE-ISSUES-RESPONSE-200_V1') do
         subject

--- a/spec/requests/v1/notice_of_disagreements_spec.rb
+++ b/spec/requests/v1/notice_of_disagreements_spec.rb
@@ -65,6 +65,17 @@ RSpec.describe 'V1::NoticeOfDisagreements', type: :request do
                                  'valid_NOD_create_request.json').read
     end
 
+    it 'logs use of the old controller' do
+      warn_old_controller_args = {
+        message: 'Calling decision reviews controller outside module',
+        action: 'NOD create',
+        form_id: '10182'
+      }
+      allow(Rails.logger).to receive(:warn)
+      expect(Rails.logger).to receive(:warn).with(warn_old_controller_args)
+      subject
+    end
+
     it 'creates an NOD and logs to StatsD and logger' do
       VCR.use_cassette('decision_review/NOD-CREATE-RESPONSE-200_V1') do
         allow(Rails.logger).to receive(:info)

--- a/spec/requests/v1/supplemental_claims/contestable_issues_spec.rb
+++ b/spec/requests/v1/supplemental_claims/contestable_issues_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe 'V1::SupplementalClaims::ContestableIssues', type: :request do
 
     subject { get '/v1/supplemental_claims/contestable_issues/compensation' }
 
+    it 'logs use of the old controller' do
+      warn_old_controller_args = {
+        message: 'Calling decision reviews controller outside module',
+        action: 'SC contestable issues index',
+        form_id: '995'
+      }
+      allow(Rails.logger).to receive(:warn)
+      expect(Rails.logger).to receive(:warn).with(warn_old_controller_args)
+      subject
+    end
+
     it 'fetches issues that the Veteran could contest via a supplemental claim' do
       VCR.use_cassette('decision_review/SC-GET-CONTESTABLE-ISSUES-RESPONSE-200_V1') do
         allow(Rails.logger).to receive(:info)

--- a/spec/requests/v1/supplemental_claims_spec.rb
+++ b/spec/requests/v1/supplemental_claims_spec.rb
@@ -66,6 +66,17 @@ RSpec.describe 'V1::SupplementalClaims', type: :request do
            headers:
     end
 
+    it 'logs use of the old controller' do
+      warn_old_controller_args = {
+        message: 'Calling decision reviews controller outside module',
+        action: 'SC create',
+        form_id: '995'
+      }
+      allow(Rails.logger).to receive(:warn)
+      expect(Rails.logger).to receive(:warn).with(warn_old_controller_args)
+      subject
+    end
+
     it 'creates a supplemental claim' do
       VCR.use_cassette('decision_review/SC-CREATE-RESPONSE-200_V1') do
         # Create an InProgressForm

--- a/spec/requests/v2/higher_level_reviews_spec.rb
+++ b/spec/requests/v2/higher_level_reviews_spec.rb
@@ -68,6 +68,17 @@ RSpec.describe 'V2::HigherLevelReviews', type: :request do
            headers:
     end
 
+    it 'logs use of the old controller' do
+      warn_old_controller_args = {
+        message: 'Calling decision reviews controller outside module',
+        action: 'HLR V2 create',
+        form_id: '996'
+      }
+      allow(Rails.logger).to receive(:warn)
+      expect(Rails.logger).to receive(:warn).with(warn_old_controller_args)
+      subject
+    end
+
     it 'creates an HLR' do
       VCR.use_cassette('decision_review/HLR-CREATE-RESPONSE-200_V1') do
         # Create an InProgressForm


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- *(Summarize the changes that have been made to the platform)*
Add logging to all non-module DR controllers, in preparation for switching to use the module versions. Intent is to be able to track any other code paths using the non-module DR controllers after we switch
- *(Which team do you work for, does your team own the maintenance of this component?)*
Decision Reviews, yes

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98907

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
No logging when old controller methods were called
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
Call the old endpoints, see logging in Datadog

## What areas of the site does it impact?
Decision Reviews controllers outside the decision_reviews module

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature