### PR TITLE
[CST] - Add feature flag `cst_send_evidence_submission_failure_emails`

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -414,6 +414,12 @@ features:
   claims_status_v1_lh_auto_establish_claim_enabled:
     actor_type: user
     description: With feature flag enabled, v1 /526 should use Lighthouse Form526 docker container
+  cst_send_evidence_submission_failure_emails:
+    actor_type: user
+    description: >
+      If enabled and a user submits an evidence submission upload that fails to send, an email will be sent to the user and retried.
+      When disabled and a user submits an evidence submission upload that fails to send, an email will be sent to the user and not retried.
+    enable_in_development: true
   debt_letters_show_letters_vbms:
     actor_type: user
     description: Enables debt letter download from VBMS


### PR DESCRIPTION
## Summary

- Created a feature flag `cst_send_evidence_submission_failure_emails` 

## Related issue(s)

- *Link to ticket created in va.gov-team repo https://github.com/department-of-veterans-affairs/va.gov-team/issues/100037

## Testing done

- Ran locally and I see feature flag

## Screenshots
Images of new feature flag 
![Screenshot 2025-01-06 at 2 10 37 PM](https://github.com/user-attachments/assets/54d3c08c-ab20-472f-9492-c0adfed8b6b3)
![Screenshot 2025-01-06 at 2 10 26 PM](https://github.com/user-attachments/assets/54bdf846-a0df-40b4-8a52-5735de435fa0)

## What areas of the site does it impact?
CST

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

