### PR TITLE
add flush statement

### DIFF
--- a/modules/ivc_champva/app/services/ivc_champva/pdf_filler.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/pdf_filler.rb
@@ -38,6 +38,8 @@ module IvcChampva
       else
         raise "stamped template file does not exist: #{stamped_template_path}"
       end
+    ensure
+      tempfile&.close!
     end
 
     def create_tempfile
@@ -46,6 +48,7 @@ module IvcChampva
       template_form_path = "#{TEMPLATE_BASE}/#{form_number}.pdf"
       Tempfile.new(['', '.pdf'], Rails.root.join('tmp')).tap do |tmpfile|
         IO.copy_stream(template_form_path, tmpfile)
+        tmpfile.flush
         tmpfile.close
       end
     end

--- a/modules/ivc_champva/spec/services/pdf_filler_spec.rb
+++ b/modules/ivc_champva/spec/services/pdf_filler_spec.rb
@@ -102,9 +102,12 @@ describe IvcChampva::PdfFiller do
 
         allow(Tempfile).to receive(:new).and_return(tempfile)
         allow(IO).to receive(:copy_stream)
+        # Allow both close and flush to be called on the tempfile
         allow(tempfile).to receive(:close)
+        allow(tempfile).to receive(:flush)
 
         expect(IO).to receive(:copy_stream).with(template_path, tempfile)
+        expect(tempfile).to receive(:flush) # This is the new line for testing flush
         pdf_filler.create_tempfile
       end
     end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*

Fix: Prevent race conditions causing "No such file or directory" errors

This PR addresses a recurring issue where file processing operations (e.g., PDF generation, uploads) were failing with "No such file or directory" errors. This was caused by race conditions where operations were attempted on files before they were fully written to disk.

Key changes:

*   Modified `create_tempfile` to explicitly flush and close temporary files.
*   Added unit tests to verify file completion.

This change improves the reliability of file processing and prevents intermittent errors.

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-api/pull/19930


https://github.com/orgs/department-of-veterans-affairs/projects/1533/views/1?pane=issue&itemId=89440653&issue=department-of-veterans-affairs%7Cva.gov-team%7C98150

## Testing done

- [ x] *New code is covered by unit tests*


## What areas of the site does it impact?

1010D and 7959F1.
All IVC CHAMPVA forms

