### PR TITLE
fix: update caller location handling for Ruby 3.4 compatibility

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -24,7 +24,7 @@ class ApplicationRecord < ActiveRecord::Base
 
   def timestamp_attributes_for_update_in_model
     kms_key_changed = changed? && changed.include?('encrypted_kms_key')
-    called_from_kms_encrypted = caller_locations(1, 1)[0].label == 'encrypt_kms_keys'
+    called_from_kms_encrypted = caller_locations(1, 1)[0].base_label == 'encrypt_kms_keys'
 
     # If update is due to kms key, don't update updated_at
     kms_key_changed || called_from_kms_encrypted ? [] : super

--- a/lib/common/client/concerns/monitoring.rb
+++ b/lib/common/client/concerns/monitoring.rb
@@ -7,7 +7,7 @@ module Common
         extend ActiveSupport::Concern
 
         def with_monitoring(trace_location = 1)
-          caller = caller_locations(trace_location, 1)[0].label
+          caller = caller_locations(trace_location, 1)[0].base_label
           yield
         rescue => e
           increment_failure(caller, e)

--- a/modules/accredited_representative_portal/app/policies/accredited_representative_portal/application_policy.rb
+++ b/modules/accredited_representative_portal/app/policies/accredited_representative_portal/application_policy.rb
@@ -46,7 +46,7 @@ module AccreditedRepresentativePortal
 
     def override_warning
       Rails.logger.warn(
-        "#{self.class} is using the default ##{caller_locations(1, 1)[0].label} implementation. \
+        "#{self.class} is using the default ##{caller_locations(1, 1)[0].base_label} implementation. \
  Consider overriding it."
       )
     end

--- a/modules/va_notify/lib/va_notify/service.rb
+++ b/modules/va_notify/lib/va_notify/service.rb
@@ -164,7 +164,7 @@ module VaNotify
       caller_locations.each do |location|
         next if ignored_files.any? { |path| location.path.include?(path) }
 
-        return "#{location.path}:#{location.lineno} in #{location.label}"
+        return "#{location.path}:#{location.lineno} in #{location.base_label}"
       end
     end
   end


### PR DESCRIPTION
Updated instances of `caller_locations` to use `base_label` instead of `label`, reflecting changes in Ruby 3.4 where `label` includes the class name and `base_label` includes only the method name. This ensures correct behavior as we are expecting only the method name.

https://stackoverflow.com/questions/5100299/how-to-get-the-name-of-the-calling-method#comment139868411_15098459