### PR TITLE
set raise_on_missing_callback_actions to true

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,6 +74,8 @@ Rails.application.configure do
   # Raises error for missing translations.
   config.i18n.raise_on_missing_translations = true
 
+  config.action_controller.raise_on_missing_callback_actions = true
+
   ConfigHelper.setup_action_mailer(config)
 
   config.rails_semantic_logger.semantic   = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -61,6 +61,8 @@ Rails.application.configure do
   # Raises error for missing translations.
   config.i18n.raise_on_missing_translations = true
 
+  config.action_controller.raise_on_missing_callback_actions = true
+
   # Speed up specs by not writing logs during RSpec runs
   unless ENV.fetch('RAILS_ENABLE_TEST_LOG', false)
     config.logger = Logger.new(nil)

--- a/modules/ask_va_api/app/controllers/ask_va_api/v0/inquiries_controller.rb
+++ b/modules/ask_va_api/app/controllers/ask_va_api/v0/inquiries_controller.rb
@@ -4,8 +4,8 @@ module AskVAApi
   module V0
     class InquiriesController < ApplicationController
       around_action :handle_exceptions
-      skip_before_action :authenticate, only: %i[unauth_create upload_attachment status]
-      skip_before_action :verify_authenticity_token, only: %i[unauth_create upload_attachment]
+      skip_before_action :authenticate, only: %i[unauth_create status]
+      skip_before_action :verify_authenticity_token, only: %i[unauth_create]
 
       def index
         inquiries = retriever.call

--- a/modules/check_in/app/controllers/check_in/v0/travel_claims_controller.rb
+++ b/modules/check_in/app/controllers/check_in/v0/travel_claims_controller.rb
@@ -3,8 +3,8 @@
 module CheckIn
   module V0
     class TravelClaimsController < CheckIn::ApplicationController
-      before_action :before_logger, only: %i[show create]
-      after_action :after_logger, only: %i[show create]
+      before_action :before_logger, only: %i[create]
+      after_action :after_logger, only: %i[create]
 
       def create
         check_in_session = CheckIn::V2::Session.build(data: { uuid: permitted_params[:uuid] }, jwt: low_auth_token)

--- a/modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
@@ -20,13 +20,7 @@ module ClaimsApi
       service_tag 'lighthouse-claims'
       skip_before_action :verify_authenticity_token
       skip_after_action :set_csrf_header
-
-      before_action do
-        next if action_name == 'schema'
-
-        authenticate
-      end
-
+      before_action :authenticate
       before_action :validate_json_format, if: -> { request.post? }
       before_action :validate_header_values_format, if: -> { header_request? }
       before_action :validate_veteran_identifiers

--- a/modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
@@ -20,7 +20,13 @@ module ClaimsApi
       service_tag 'lighthouse-claims'
       skip_before_action :verify_authenticity_token
       skip_after_action :set_csrf_header
-      # before_action :authenticate, except: %i[schema] # rubocop:disable Rails/LexicallyScopedActionFilter
+
+      before_action do
+        next if action_name == 'schema'
+
+        authenticate
+      end
+
       before_action :validate_json_format, if: -> { request.post? }
       before_action :validate_header_values_format, if: -> { header_request? }
       before_action :validate_veteran_identifiers

--- a/modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
@@ -20,7 +20,7 @@ module ClaimsApi
       service_tag 'lighthouse-claims'
       skip_before_action :verify_authenticity_token
       skip_after_action :set_csrf_header
-      before_action :authenticate, except: %i[schema] # rubocop:disable Rails/LexicallyScopedActionFilter
+      # before_action :authenticate, except: %i[schema] # rubocop:disable Rails/LexicallyScopedActionFilter
       before_action :validate_json_format, if: -> { request.post? }
       before_action :validate_header_values_format, if: -> { header_request? }
       before_action :validate_veteran_identifiers

--- a/modules/claims_api/app/controllers/claims_api/v2/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/application_controller.rb
@@ -23,9 +23,9 @@ module ClaimsApi
       skip_after_action :set_csrf_header
       before_action :authenticate, except: %i[schema]
       before_action { permit_scopes %w[system/claim.read] if request.get? }
-      before_action except: %i[generate_pdf] do
-        permit_scopes %w[system/claim.write] if request.post? || request.put?
-      end
+      # before_action except: %i[generate_pdf] do
+      #   permit_scopes %w[system/claim.write] if request.post? || request.put?
+      # end
 
       def schema
         render json: { data: [ClaimsApi::FormSchemas.new(schema_version: 'v2').schemas[self.class::FORM_NUMBER]] }

--- a/modules/claims_api/app/controllers/claims_api/v2/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/application_controller.rb
@@ -23,9 +23,11 @@ module ClaimsApi
       skip_after_action :set_csrf_header
       before_action :authenticate, except: %i[schema]
       before_action { permit_scopes %w[system/claim.read] if request.get? }
-      # before_action except: %i[generate_pdf] do
-      #   permit_scopes %w[system/claim.write] if request.post? || request.put?
-      # end
+      before_action do
+        next if action_name == 'generate_pdf'
+
+        permit_scopes %w[system/claim.write] if request.post? || request.put?
+      end
 
       def schema
         render json: { data: [ClaimsApi::FormSchemas.new(schema_version: 'v2').schemas[self.class::FORM_NUMBER]] }

--- a/modules/covid_vaccine/app/controllers/covid_vaccine/application_controller.rb
+++ b/modules/covid_vaccine/app/controllers/covid_vaccine/application_controller.rb
@@ -6,7 +6,6 @@ module CovidVaccine
     before_action :check_flipper
     skip_before_action :authenticate
     before_action :validate_session
-    before_action :authorize, only: :show
 
     protected
 

--- a/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
+++ b/modules/covid_vaccine/app/controllers/covid_vaccine/v0/registration_controller.rb
@@ -10,6 +10,7 @@ module CovidVaccine
 
       before_action :validate_raw_form_data, only: :create
       skip_before_action :verify_authenticity_token, only: :opt_out
+      before_action :authorize, only: :show
 
       def create
         raw_form_data = params[:registration].merge(attributes_from_user)

--- a/modules/mobile/app/controllers/mobile/concerns/sso_logging.rb
+++ b/modules/mobile/app/controllers/mobile/concerns/sso_logging.rb
@@ -5,7 +5,7 @@ module Mobile::Concerns::SSOLogging
 
   included do
     after_action do
-      next if %w[create update destroy].include?(action_name)
+      next unless %w[create update destroy].include?(action_name)
 
       log_sso_info
     end

--- a/modules/mobile/app/controllers/mobile/concerns/sso_logging.rb
+++ b/modules/mobile/app/controllers/mobile/concerns/sso_logging.rb
@@ -4,7 +4,11 @@ module Mobile::Concerns::SSOLogging
   extend ActiveSupport::Concern
 
   included do
-    after_action :log_sso_info, only: %i[create update destroy]
+    after_action do
+      next if %w[create update destroy].include?(action_name)
+
+      log_sso_info
+    end
 
     def log_sso_info
       action = request.controller_instance.controller_path.classify.to_s

--- a/modules/mobile/app/controllers/mobile/v0/addresses_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/addresses_controller.rb
@@ -5,8 +5,6 @@ require 'va_profile/address_validation/service'
 module Mobile
   module V0
     class AddressesController < ProfileBaseController
-      skip_after_action :invalidate_cache, only: [:validation]
-
       def create
         render_transaction_to_json(
           service.save_and_await_response(resource_type: :address, params: address_params)

--- a/modules/mobile/app/controllers/mobile/v0/profile_base_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/profile_base_controller.rb
@@ -13,8 +13,6 @@ module Mobile
       before_action { authorize :vet360, :access? }
       after_action :invalidate_cache
 
-      skip_after_action :invalidate_cache, only: [:validation]
-
       private
 
       def render_transaction_to_json(transaction)


### PR DESCRIPTION
## Summary

- in Rails 7.1, the config option `raise_on_missing_callback_actions` was introduced. When enabled, errors are raised if a callback (`before_action`, `after_action`, etc) specifies an action or method (via `:only`/`:except`) that isn't explicitly defined in the controller (or a controller it inherits from).
- In Rails 8, The default configuration is to set `raise_on_missing_callback_actions` to `true` in both `test` and `development`.
- There are several instances in vets-api where a team has defined these callbacks in a base controller with the intent to define the callbacks in the derived/child controllers. In most of these cases, I used some logic that uses the `action_name` to determine if the callback should be executed, which effectively gives the same behavior. I one case case I moved the `before_action` to the child, as it wasn't necessary to have it in the base.
- In a few cases there were orphaned actions that were never removed from the callbacks, so I removed them.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/100086

## Testing done

- [x] Specs Pass
- [x] Traced controller inheritance to confirm I wasn't removing something that was required by another controller up/down the line.