### PR TITLE
fix: update argon2-kdf gem to address fiddle deprecation warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,7 +237,8 @@ GEM
       base64
       gyoku (>= 0.4.0)
       nokogiri
-    argon2-kdf (0.2.0)
+    argon2-kdf (0.3.0)
+      fiddle
     ast (2.4.2)
     attr_extras (7.1.0)
     awesome_print (1.9.2)
@@ -474,6 +475,7 @@ GEM
       date_time_precision (>= 0.8)
       mime-types (>= 3.0)
       nokogiri (>= 1.11.4)
+    fiddle (1.1.6)
     fitbit_api (1.0.0)
       oauth2 (~> 2.0)
     flipper (1.3.2)


### PR DESCRIPTION
- Bump argon2-kdf from 0.2.0 to 0.3.0 to include fiddle as a dependency.
- Resolves deprecation warning for `fiddle` not being part of default gems in Ruby 3.5+.

Warning:
```
.bundle/bundle/ruby/3.4.0/gems/argon2-kdf-0.2.0/lib/argon2/kdf.rb:2: warning:
~/.local/share/mise/installs/ruby/3.4.1/lib/ruby/3.4.0/fiddle/import.rb is found in
fiddle, which will no longer be part of the default gems starting from Ruby 3.5.0.
```
