### PR TITLE
Fix bug in credential email route with missing credential email

### DIFF
--- a/app/controllers/v0/users_controller.rb
+++ b/app/controllers/v0/users_controller.rb
@@ -18,12 +18,12 @@ module V0
     end
 
     def credential_emails
-      emails = current_user.user_account.user_verifications.each_with_object({}) do |verification, credentials|
-        credentials[verification.credential_type.to_sym] =
-          verification.user_credential_email.credential_email
+      credential_emails = UserCredentialEmail.where(user_verification: current_user.user_account.user_verifications)
+      credential_emails_hash = credential_emails.each_with_object({}) do |credential_email, email_hash|
+        email_hash[credential_email.user_verification.credential_type.to_sym] = credential_email.credential_email
       end
 
-      render json: emails
+      render json: credential_emails_hash
     end
   end
 end

--- a/spec/controllers/v0/users_controller_spec.rb
+++ b/spec/controllers/v0/users_controller_spec.rb
@@ -179,5 +179,23 @@ RSpec.describe V0::UsersController, type: :controller do
       expect(response).to be_successful
       expect(JSON.parse(response.body)).to eq(expected_response)
     end
+
+    context 'when a user verification does not have a credential email' do
+      let!(:logingov_user_verification) do
+        create(:user_verification,
+               logingov_uuid: user.logingov_uuid,
+               user_credential_email: nil,
+               user_account_id: user_account.id)
+      end
+      let(:expected_response) do
+        { idme_user_verification.credential_type => user_credential_email1.credential_email }
+      end
+
+      it 'returns the users credential emails that are not nil' do
+        get :credential_emails
+        expect(response).to be_successful
+        expect(JSON.parse(response.body)).to eq(expected_response)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- This PR fixes a bug in the credential email route that occurs when a user's `UserVerification` does not have a `UserCredentialEmail`

## What areas of the site does it impact?
Interstitial Authentication
