### PR TITLE
Add filtering info to Vets::Collection

### DIFF
--- a/lib/vets/collection.rb
+++ b/lib/vets/collection.rb
@@ -45,12 +45,12 @@ module Vets
     end
 
     def where(conditions = {})
-      results = Vets::Collections::Finder.new(data: @records, conditions:).all
+      results = Vets::Collections::Finder.new(data: @records).all(conditions)
       Vets::Collection.new(results, metadata: { filter: conditions })
     end
 
     def find_by(conditions = {})
-      Vets::Collections::Finder.new(data: @records, conditions:).first
+      Vets::Collections::Finder.new(data: @records).first(conditions)
     end
 
     private

--- a/lib/vets/collection.rb
+++ b/lib/vets/collection.rb
@@ -64,8 +64,8 @@ module Vets
 
     def find_by(conditions = {})
       Vets::Collections::Finder.new(data: @records).first(conditions)
-    end 
-    
+    end
+
     def paginate(page: nil, per_page: nil)
       pagination = Vets::Collections::Pagination.new(
         page: normalize_page(page),

--- a/lib/vets/collection.rb
+++ b/lib/vets/collection.rb
@@ -7,13 +7,17 @@
 
 require 'common/models/comparable/ascending'
 require 'common/models/comparable/descending'
+require 'vets/collections/finder'
 
 # This will be a replacement for Common::Collection
 module Vets
   class Collection
-    def initialize(records)
+    attr_accessor :records, :metadata
+
+    def initialize(records, metadata: {})
       records = Array.wrap(records)
       @model_class = records.first.class
+      @metadata = metadata
 
       unless records.all? { |record| record.is_a?(@model_class) }
         raise ArgumentError, "All records must be instances of #{@model_class}"
@@ -38,6 +42,15 @@ module Vets
           direction == :asc ? Common::Ascending.new(value) : Common::Descending.new(value)
         end
       end
+    end
+
+    def where(conditions = {})
+      results = Vets::Collections::Finder.new(data: @records, conditions:).all
+      Vets::Collection.new(results, metadata: { filter: conditions })
+    end
+
+    def find_by(conditions = {})
+      Vets::Collections::Finder.new(data: @records, conditions:).first
     end
 
     private

--- a/lib/vets/collections/finder.rb
+++ b/lib/vets/collections/finder.rb
@@ -40,7 +40,7 @@ module Vets
         raise Common::Exceptions::InvalidFiltersSyntax, 'Filters must be present' if conditions.blank?
 
         # Validate attributes are filterable
-        failed_attributes = (conditions.keys - @filterable_attributes.keys).join(', ')
+        failed_attributes = (conditions.keys.map(&:to_s) - @filterable_attributes.keys.map(&:to_s)).join(', ')
         raise Common::Exceptions::FilterNotAllowed, failed_attributes unless failed_attributes.empty?
 
         # Validate the operations are valid for each attribute

--- a/lib/vets/collections/finder.rb
+++ b/lib/vets/collections/finder.rb
@@ -57,12 +57,12 @@ module Vets
       # operator means ==, <=
       def compare(object, conditions)
         conditions.to_hash.all? do |attribute, predicates|
-          predicates.all? do |operation, value|
+          predicates.all? do |operation, operand|
             object_value = object.send(attribute)
             operator = OPERATIONS_MAP.fetch(operation)
 
-            parsed_values = value.try(:split, ',') || [value]
-            results = parsed_values.map do |_item|
+            parsed_values = operand.try(:split, ',') || [operand]
+            results = parsed_values.map do |value|
               if operator == 'match'
                 object_value.downcase.include?(value.downcase)
               else

--- a/lib/vets/collections/finder.rb
+++ b/lib/vets/collections/finder.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'common/exceptions/base_error'
+require 'common/exceptions/filter_not_allowed'
+require 'common/exceptions/invalid_filters_syntax'
+
+module Vets
+  module Collections
+    class Finder
+      OPERATIONS_MAP = {
+        'eq' => '==',
+        'lteq' => '<=',
+        'gteq' => '>=',
+        'not_eq' => '!=',
+        'match' => 'match'
+      }.with_indifferent_access.freeze
+
+      attr_reader :data, :filterable_attribute
+
+      def initialize(data:)
+        @data = data
+        @model_class = data.first.class
+        @filterable_attribute = @model_class.filterable_attributes
+      end
+
+      def all(conditions)
+        validate_conditions(conditions)
+        @data.select { |item| finder(item, conditions) }
+      end
+
+      def first(conditions)
+        validate_conditions(conditions)
+        @data.detect { |item| finder(item, conditions) }
+      end
+
+      private
+
+      def validate_conditions(conditions)
+        # Validate attributes are filterable
+        failed_attributes = (conditions.keys.map(&:to_s) - @filterable_attributes.keys).join(', ')
+        raise Common::Exceptions::FilterNotAllowed, failed_attributes unless failed_attributes.empty?
+
+        # Validate the operations are valid for each attribute
+        conditions.each do |attribute, predicates|
+          predicates.each_key do |operation|
+            valid_operation = @filterable_attributes[attribute].include?(operation.to_s)
+            message = "#{operation} for #{attribute}"
+            raise Common::Exceptions::FilterNotAllowed, message unless valid_operation
+          end
+        end
+      end
+
+      # operation means eq, lteq, etc
+      # operator means ==, <=
+      def compare(object, conditions)
+        conditions.to_hash.all? do |attribute, predicates|
+          predicates.all? do |operation, value|
+            object_value = object.send(attribute)
+            operator = OPERATIONS_MAP.fetch(operation)
+
+            parsed_values = value.try(:split, ',') || [value]
+            results = parsed_values.map do |item|
+              if operator == 'match'
+                object_value.to_s.match?(value.to_s)
+                object_value.downcase.include?(item.downcase)
+              else
+                object_value.public_send(operator, value)
+              end
+            end
+            results.any?
+          end
+        end
+      rescue
+        raise Common::Exceptions::InvalidFiltersSyntax.new(nil, detail: 'The syntax for your filters is invalid')
+      end
+    end
+  end
+end

--- a/spec/lib/vets/collection_spec.rb
+++ b/spec/lib/vets/collection_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Vets::Collection do
 
       attribute :name, String
       attribute :age, Integer
-      
+
       set_pagination per_page: 21, max_per_page: 41
 
       def <=>(other)

--- a/spec/lib/vets/collection_spec.rb
+++ b/spec/lib/vets/collection_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Vets::Collection do
 
       def self.filterable_attributes
         {
-          'name' => ['match', 'eq'],
-          'age' => ['eq', 'gteq', 'lteq']
+          'name' => %w[match eq],
+          'age' => %w[eq gteq lteq]
         }.with_indifferent_access
       end
     end
@@ -82,7 +82,6 @@ RSpec.describe Vets::Collection do
   end
 
   describe '#where' do
-
     let(:records) do
       [
         dummy_class.new(name: 'Alice', age: 30),
@@ -107,7 +106,6 @@ RSpec.describe Vets::Collection do
   end
 
   describe '#find_by' do
-
     let(:records) do
       [
         dummy_class.new(name: 'Alice', age: 30),

--- a/spec/lib/vets/collection_spec.rb
+++ b/spec/lib/vets/collection_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Vets::Collection do
         pager.replace(records[0, 2])
       end
       collection = described_class.from_will_paginate(will_collection)
-      expect(collection.records.map(&:name)).to eq(%w[Bob Alice])
+      expect(collection.records.map(&:name)).to eq(%w[Alice Bob])
     end
 
     it 'raises an error if any element is not a hash' do
@@ -197,7 +197,7 @@ RSpec.describe Vets::Collection do
       it 'defaults to the first page' do
         record1 = dummy_class.new(name: 'Bob', age: 25)
         record2 = dummy_class.new(name: 'Alice', age: 30)
-        records = [record1, record2]
+        records = [record2, record1]
 
         collection = described_class.new(records)
 

--- a/spec/lib/vets/collections/finder_spec.rb
+++ b/spec/lib/vets/collections/finder_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'vets/collection/finder'
+require 'vets/model'
+
+RSpec.describe Vets::Collections::Finder do
+  let(:dummy_class) do
+    Class.new do
+      include Vets::Model
+
+      attribute :name, String
+      attribute :age, Integer
+
+      set_pagination per_page: 21, max_per_page: 41
+
+      # Simulating filterable attributes for this dummy model
+      def self.filterable_attributes
+        { name: %w[match eq], age: %w[eq lteq gteq] }
+      end
+    end
+  end
+
+  let(:data) do
+    [
+      dummy_class.new(name: 'John Doe', age: 30),
+      dummy_class.new(name: 'Jane Smith', age: 40),
+      dummy_class.new(name: 'Jim Brown', age: 50)
+    ]
+  end
+
+  let(:finder) { described_class.new(data: data) }
+
+  describe '#all' do
+    context 'when valid conditions are passed' do
+      it 'returns filtered data based on conditions' do
+        conditions = { name: { eq: 'John Doe' } }
+        result = finder.all(conditions)
+
+        expect(result.size).to eq(1)
+        expect(result.first.name).to eq('John Doe')
+      end
+
+      it 'returns filtered data using multiple conditions' do
+        conditions = { age: { lteq: 40 } }
+        result = finder.all(conditions)
+
+        expect(result.size).to eq(2)
+        expect(result.map(&:name)).to include('John Doe', 'Jane Smith')
+      end
+    end
+
+    context 'when invalid conditions are passed' do
+      it 'raises FilterNotAllowed for an invalid attribute' do
+        conditions = { invalid_attr: { eq: 'some value' } }
+        expect { finder.all(conditions) }.to raise_error(Common::Exceptions::FilterNotAllowed)
+      end
+
+      it 'raises FilterNotAllowed for an invalid operation' do
+        conditions = { name: { not_eq: 'John Doe' } }
+        expect { finder.all(conditions) }.to raise_error(Common::Exceptions::FilterNotAllowed)
+      end
+    end
+  end
+
+  describe '#first' do
+    context 'when valid conditions are passed' do
+      it 'returns the first filtered item' do
+        conditions = { name: { eq: 'Jane Smith' } }
+        result = finder.first(conditions)
+
+        expect(result.name).to eq('Jane Smith')
+      end
+    end
+
+    context 'when no match is found' do
+      it 'returns nil' do
+        conditions = { name: { eq: 'Nonexistent Name' } }
+        result = finder.first(conditions)
+
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe '#compare' do
+    context 'when valid conditions are passed' do
+      it 'compares correctly with equality operator' do
+        conditions = { name: { eq: 'John Doe' } }
+        object = dummy_class.new(name: 'John Doe', age: 30)
+        result = finder.send(:compare, object, conditions)
+
+        expect(result).to be_truthy
+      end
+
+      it 'compares correctly with match operator' do
+        conditions = { name: { match: 'John' } }
+        object = dummy_class.new(name: 'John Doe', age: 30)
+        result = finder.send(:compare, object, conditions)
+
+        expect(result).to be_truthy
+      end
+
+      it 'returns false for mismatched conditions' do
+        conditions = { name: { eq: 'Jim Brown' } }
+        object = dummy_class.new(name: 'John Doe', age: 30)
+        result = finder.send(:compare, object, conditions)
+
+        expect(result).to be_falsey
+      end
+    end
+
+    context 'when invalid syntax is passed' do
+      it 'raises InvalidFiltersSyntax for invalid filters' do
+        conditions = { name: { invalid_op: 'John Doe' } }
+        object = dummy_class.new(name: 'John Doe', age: 30)
+
+        expect { finder.send(:compare, object, conditions) }.to raise_error(Common::Exceptions::InvalidFiltersSyntax)
+      end
+    end
+  end
+
+  describe 'validations' do
+    it 'raises FilterNotAllowed for unsupported operations' do
+      conditions = { age: { not_eq: 30 } }
+      expect { finder.send(:validate_conditions, conditions) }.to raise_error(Common::Exceptions::FilterNotAllowed)
+    end
+
+    it 'raises FilterNotAllowed for unsupported attributes' do
+      conditions = { unknown_attr: { eq: 'value' } }
+      expect { finder.send(:validate_conditions, conditions) }.to raise_error(Common::Exceptions::FilterNotAllowed)
+    end
+  end
+end


### PR DESCRIPTION
**_Mergers to a feature branch_**

## Summary 

- Add new `where` and `find_by` method to collection class
- Create a new class `Finder` to handle "filtering" for records

## Related issue(s)

- main PR: https://github.com/department-of-veterans-affairs/vets-api/pull/19895
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99123

## Testing done

- [x] Manual testing
- [x] New spec for module

## Acceptance criteria

- [x] Collections of Vets::Models can be filtered
- [x] Filter functionality is the same as `Common::Collection`

## Review Feedback Request

`Common::Collection` uses `find_by` to find all "matching" records and `find_first_by` to find the first. I believe these are bad choices because `find_by` is used by ActiveRecord to get a single object. So I chose to rename the find all and find first method names to mimic the most similar query methods... `where` and `find_by` for Vets::Collection.

I'm open to other suggestions, but I think `find_by` and `find_first_by` should be renamed 