### PR TITLE
[VI-957] Add MHVUserAccountPolicy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -362,6 +362,7 @@ app/policies/mhv_health_records_policy.rb @department-of-veterans-affairs/vfs-he
 app/policies/mhv_medical_records_policy.rb @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/policies/mhv_messaging_policy.rb @department-of-veterans-affairs/vfs-health-modernization-initiative @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/policies/mhv_prescriptions_policy.rb @department-of-veterans-affairs/vfs-health-modernization-initiative @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/policies/mhv_user_account_policy.rb @department-of-veterans-affairs/octo-identity
 app/policies/mpi_policy.rb @department-of-veterans-affairs/octo-identity
 app/policies/ppiu_policy.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/policies/vet360_policy.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1661,6 +1662,7 @@ spec/policies/hca_disability_rating_policy_spec.rb @department-of-veterans-affai
 spec/policies/lighthouse_policy_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/policies/meb_policy_spec.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/policies/medical_copays_policy_spec.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
+spec/policies/mhv_user_account_policy_spec.rb @department-of-veterans-affairs/octo-identity
 spec/policies/mpi_policy_spec.rb @department-of-veterans-affairs/octo-identity
 spec/policies/ppiu_policy_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/policies/vet360_policy_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -481,11 +481,11 @@ class User < Common::RedisStore
     MHV::AccountCreatorJob.perform_async(user_verification_id)
   end
 
-  private
-
   def can_create_mhv_account?
     loa3? && !needs_accepted_terms_of_use
   end
+
+  private
 
   def mpi_profile
     return nil unless identity && mpi

--- a/app/policies/mhv_user_account_policy.rb
+++ b/app/policies/mhv_user_account_policy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class MHVUserAccountPolicy
+  attr_reader :user
+
+  def initialize(user, _record)
+    @user = user
+  end
+
+  def show?
+    user.present? && user.can_create_mhv_account?
+  end
+end

--- a/spec/controllers/v0/user/mhv_user_accounts_controller_spec.rb
+++ b/spec/controllers/v0/user/mhv_user_accounts_controller_spec.rb
@@ -36,100 +36,112 @@ describe V0::User::MHVUserAccountsController, type: :controller do
   end
 
   describe '#show' do
-    context 'when the user has an MHV account and the call is successful' do
-      before do
-        allow(mhv_client).to receive(:create_account).and_return(mhv_response)
+    context 'when the user is authorized' do
+      context 'when the user has an MHV account and the call is successful' do
+        before do
+          allow(mhv_client).to receive(:create_account).and_return(mhv_response)
+        end
+
+        it 'breaks the cache and returns the MHV account' do
+          get :show
+
+          expect(response).to have_http_status(:ok)
+          expect(JSON.parse(response.body)['data']['attributes']).to eq(mhv_response.with_indifferent_access)
+          expect(mhv_client).to have_received(:create_account).with(icn:,
+                                                                    email: user_credential_email.credential_email,
+                                                                    tou_occurred_at: terms_of_use_agreement.created_at,
+                                                                    break_cache: true)
+        end
       end
 
-      it 'breaks the cache and returns the MHV account' do
-        get :show
+      context 'when there is an error retrieving the MHV account' do
+        shared_examples 'an unprocessable entity' do
+          let(:expected_log_payload) { { errors: expected_errors } }
+          let(:expected_log_message) { '[User][MHVUserAccountsController] show error' }
+          let(:expected_response_body) { { errors: expected_errors }.as_json }
 
-        expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)['data']['attributes']).to eq(mhv_response.with_indifferent_access)
-        expect(mhv_client).to have_received(:create_account).with(icn:,
-                                                                  email: user_credential_email.credential_email,
-                                                                  tou_occurred_at: terms_of_use_agreement.created_at,
-                                                                  break_cache: true)
+          it 'returns an unprocessable entity' do
+            get :show
+
+            expect(response).to have_http_status(:unprocessable_entity)
+            expect(JSON.parse(response.body)).to eq(expected_response_body)
+          end
+
+          it 'logs the error' do
+            get :show
+
+            expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
+          end
+        end
+
+        context 'when the user does not have an ICN' do
+          let(:icn) { nil }
+          let(:expected_errors) { [{ title: 'Validation error', detail: 'ICN must be present' }] }
+
+          it_behaves_like 'an unprocessable entity'
+        end
+
+        context 'when the user does not have an email' do
+          let(:user_credential_email) { nil }
+          let(:expected_errors) { [{ title: 'Validation error', detail: 'Email must be present' }] }
+
+          it_behaves_like 'an unprocessable entity'
+        end
+
+        context 'when the user does not have a terms of use agreement' do
+          let(:terms_of_use_agreement) { nil }
+          let(:expected_errors) do
+            [{ title: 'Validation error', detail: 'Current terms of use agreement must be present' },
+             { title: 'Validation error', detail: "Current terms of use agreement must be 'accepted'" }]
+          end
+
+          it_behaves_like 'an unprocessable entity'
+        end
+
+        context 'when the user has not accepted the terms of use agreement' do
+          let(:terms_of_use_response) { 'declined' }
+          let(:expected_errors) do
+            [{ title: 'Validation error', detail: "Current terms of use agreement must be 'accepted'" }]
+          end
+
+          it_behaves_like 'an unprocessable entity'
+        end
+
+        context 'when there is an MHV client error' do
+          let(:mhv_error_body) { { 'errorCode' => mhv_error_code, 'message' => mhv_error_message } }
+          let(:mhv_error_code) { 'some-code' }
+          let(:mhv_error_message) { 'some-error-message' }
+
+          let(:client_error_message) { 'some-client-error' }
+
+          let(:expected_errors) { [{ title: client_error_message, detail: mhv_error_message, code: mhv_error_code }] }
+
+          before do
+            allow(mhv_client).to receive(:create_account)
+              .and_raise(Common::Client::Errors::ClientError.new(client_error_message, 400, mhv_error_body))
+          end
+
+          context 'when the response_body has a code and message' do
+            it_behaves_like 'an unprocessable entity'
+          end
+
+          context 'when the response_body does not have a code and message' do
+            let(:mhv_error_code) { nil }
+            let(:mhv_error_message) { nil }
+
+            it_behaves_like 'an unprocessable entity'
+          end
+        end
       end
     end
 
-    context 'when there is an error retrieving the MHV account' do
-      shared_examples 'an unprocessable entity' do
-        let(:expected_log_payload) { { errors: expected_errors } }
-        let(:expected_log_message) { '[User][MHVUserAccountsController] show error' }
-        let(:expected_response_body) { { errors: expected_errors }.as_json }
+    context 'when the user is not authorized' do
+      let(:user) { build(:user, :loa1) }
 
-        it 'returns an unprocessable entity' do
-          get :show
+      it 'returns unauthorized' do
+        get :show
 
-          expect(response).to have_http_status(:unprocessable_entity)
-          expect(JSON.parse(response.body)).to eq(expected_response_body)
-        end
-
-        it 'logs the error' do
-          get :show
-
-          expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
-        end
-      end
-
-      context 'when the user does not have an ICN' do
-        let(:icn) { nil }
-        let(:expected_errors) { [{ title: 'Validation error', detail: 'ICN must be present' }] }
-
-        it_behaves_like 'an unprocessable entity'
-      end
-
-      context 'when the user does not have an email' do
-        let(:user_credential_email) { nil }
-        let(:expected_errors) { [{ title: 'Validation error', detail: 'Email must be present' }] }
-
-        it_behaves_like 'an unprocessable entity'
-      end
-
-      context 'when the user does not have a terms of use agreement' do
-        let(:terms_of_use_agreement) { nil }
-        let(:expected_errors) do
-          [{ title: 'Validation error', detail: 'Current terms of use agreement must be present' },
-           { title: 'Validation error', detail: "Current terms of use agreement must be 'accepted'" }]
-        end
-
-        it_behaves_like 'an unprocessable entity'
-      end
-
-      context 'when the user has not accepted the terms of use agreement' do
-        let(:terms_of_use_response) { 'declined' }
-        let(:expected_errors) do
-          [{ title: 'Validation error', detail: "Current terms of use agreement must be 'accepted'" }]
-        end
-
-        it_behaves_like 'an unprocessable entity'
-      end
-
-      context 'when there is an MHV client error' do
-        let(:mhv_error_body) { { 'errorCode' => mhv_error_code, 'message' => mhv_error_message } }
-        let(:mhv_error_code) { 'some-code' }
-        let(:mhv_error_message) { 'some-error-message' }
-
-        let(:client_error_message) { 'some-client-error' }
-
-        let(:expected_errors) { [{ title: client_error_message, detail: mhv_error_message, code: mhv_error_code }] }
-
-        before do
-          allow(mhv_client).to receive(:create_account)
-            .and_raise(Common::Client::Errors::ClientError.new(client_error_message, 400, mhv_error_body))
-        end
-
-        context 'when the response_body has a code and message' do
-          it_behaves_like 'an unprocessable entity'
-        end
-
-        context 'when the response_body does not have a code and message' do
-          let(:mhv_error_code) { nil }
-          let(:mhv_error_message) { nil }
-
-          it_behaves_like 'an unprocessable entity'
-        end
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/policies/mhv_user_account_policy_spec.rb
+++ b/spec/policies/mhv_user_account_policy_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe MHVUserAccountPolicy do
+  subject { described_class }
+
+  permissions :show? do
+    context 'with a user who can create an MHV account' do
+      let(:user) { build(:user, :loa3) }
+
+      it 'grants access' do
+        expect(subject).to permit(user, :mhv_user_account)
+      end
+    end
+
+    context 'with a user who cannot create an MHV account' do
+      let(:user) { build(:user, :loa1) }
+
+      it 'denies access' do
+        expect(subject).not_to permit(user, :mhv_user_account)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add policy to check if user can create a MhvUserAccount 

## Related issue(s)
- https://jira.devops.va.gov/browse/VI-957

## Testing 
- Test`/v0/user/mhv_user_account` with loa1 user
  - You should get a 403
- Test`/v0/user/mhv_user_account` with loa3 user
  - You should get a 200

## What areas of the site does it impact?
MHV User Accounts

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

