### PR TITLE
Update configuration.rb

### DIFF
--- a/lib/lighthouse/benefits_documents/configuration.rb
+++ b/lib/lighthouse/benefits_documents/configuration.rb
@@ -11,7 +11,7 @@ module BenefitsDocuments
   # sets the base path, the base request headers, and a service name for breakers and metrics.
   #
   class Configuration < Common::Client::Configuration::REST
-    self.read_timeout = Settings.lighthouse.benefits_documents.timeout || 20
+    self.read_timeout = Settings.lighthouse.benefits_documents.timeout || 55
 
     SYSTEM_NAME = 'VA.gov'
     API_SCOPES = %w[documents.read documents.write].freeze


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- This change bumps the default lighthouse timeout from 20s to 55s
- This code is owner by the Benefits Disability Crew

This is to increase the default lighthouse document api config timeout from 20s to 55s. This is to make it match with what EVSS previously was. We have seen timeout errors in production on some veteran evidence because this is set too low. This is causing us to keep retrying the file and failing. 

## Related issue(s)

No ticket, but related slack threads:
https://dsva.slack.com/archives/C053U7BUT27/p1734723040942789
https://dsva.slack.com/archives/C02CQP3RFFX/p1736397299103119

