### PR TITLE
Update settings.yml

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -990,6 +990,7 @@ lighthouse:
         rsa_key: ~
       use_mocks: false
   benefits_documents:
+    timeout: 55
     host: https://sandbox-api.va.gov
     access_token:
       aud_claim_url: https://deptva-eval.okta.com/oauth2/ausi3ui83fLa68IJv2p7/v1/token


### PR DESCRIPTION
Related to https://github.com/department-of-veterans-affairs/vets-api/pull/20173

We should have this set here too, and should change in here going forwards. The hardcoded `|| 55` should only be a 1 time thing.