### PR TITLE
Corrected Contact Info V2 authorization policies and added country_name to the AskVA AddressValidation Controller params

### DIFF
--- a/app/models/form_profiles/va_21686c.rb
+++ b/app/models/form_profiles/va_21686c.rb
@@ -108,7 +108,11 @@ class FormProfiles::VA21686c < FormProfile
   end
 
   def prefill
-    return {} unless user.authorize :evss, :access?
+    if Flipper.enabled?(:va_v3_contact_information_service, user)
+      return {} unless user.authorize :va_profile, :access_to_v2?
+    else
+      return {} unless user.authorize :evss, :access?
+    end
 
     @veteran_information = initialize_veteran_information
     super

--- a/app/models/form_profiles/va_526ez.rb
+++ b/app/models/form_profiles/va_526ez.rb
@@ -188,18 +188,20 @@ class FormProfiles::VA526ez < FormProfile
   end
 
   def initialize_veteran_contact_information
-    return {} unless user.authorize :evss, :access?
+    if Flipper.enabled?(:disability_compensation_remove_pciu, user)
+      return {} unless user.authorize :va_profile, :access_to_v2?
 
-    contact_info = if Flipper.enabled?(:disability_compensation_remove_pciu, user)
-                     initialize_vets360_contact_info
-                   else
-                     # fill in blank values with PCIU data
-                     initialize_vets360_contact_info.merge(
-                       mailing_address: get_common_address,
-                       email_address: extract_pciu_data(:pciu_email),
-                       primary_phone: pciu_us_phone
-                     ) { |_, old_val, new_val| old_val.presence || new_val }
-                   end
+      contact_info = initialize_vets360_contact_info
+    else
+      return {} unless user.authorize :evss, :access?
+
+      contact_info = initialize_vets360_contact_info.merge(
+        mailing_address: get_common_address,
+        email_address: extract_pciu_data(:pciu_email),
+        primary_phone: pciu_us_phone
+      ) { |_, old_val, new_val| old_val.presence || new_val }
+
+    end
     # Logging was added below to contrast/compare completeness of contact information returned
     # from VA Profile alone versus VA Profile + PCIU. This logging will be removed when the Flipper flag is.
     Rails.logger.info("disability_compensation_remove_pciu=#{Flipper.enabled?(:disability_compensation_remove_pciu,

--- a/modules/ask_va_api/app/controllers/ask_va_api/v0/address_validation_controller.rb
+++ b/modules/ask_va_api/app/controllers/ask_va_api/v0/address_validation_controller.rb
@@ -36,6 +36,7 @@ module AskVAApi
           :address_pou,
           :address_type,
           :city,
+          :country_name,
           :country_code_iso3,
           :international_postal_code,
           :province,

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -1880,6 +1880,7 @@ RSpec.describe FormProfile, type: :model do
               Flipper.enable(:disability_526_toxic_exposure, user)
               expect(user).to receive(:authorize).with(:ppiu, :access?).and_return(true).at_least(:once)
               expect(user).to receive(:authorize).with(:evss, :access?).and_return(true).at_least(:once)
+              expect(user).to receive(:authorize).with(:va_profile, :access_to_v2?).and_return(true).at_least(:once)
               VCR.use_cassette('evss/pciu_address/address_domestic') do
                 VCR.use_cassette('evss/disability_compensation_form/rated_disabilities') do
                   VCR.use_cassette('evss/ppiu/payment_information') do

--- a/spec/models/form_profile_v2_spec.rb
+++ b/spec/models/form_profile_v2_spec.rb
@@ -1557,7 +1557,7 @@ RSpec.describe FormProfile, type: :model do
 
         context 'with preenabled forms' do
           it 'returns prefilled 21-686C' do
-            expect(user).to receive(:authorize).with(:evss, :access?).and_return(true).at_least(:once)
+            expect(user).to receive(:authorize).with(:va_profile, :access_to_v2?).and_return(true).at_least(:once)
             VCR.use_cassette('evss/dependents/retrieve_user_with_max_attributes') do
               VCR.use_cassette('va_profile/military_personnel/post_read_service_histories_200',
                                allow_playback_repeats: true) do
@@ -1584,6 +1584,7 @@ RSpec.describe FormProfile, type: :model do
             Flipper.enable(:disability_526_toxic_exposure, user)
             expect(user).to receive(:authorize).with(:ppiu, :access?).and_return(true).at_least(:once)
             expect(user).to receive(:authorize).with(:evss, :access?).and_return(true).at_least(:once)
+            expect(user).to receive(:authorize).with(:va_profile, :access_to_v2?).and_return(true).at_least(:once)
             VCR.use_cassette('va_profile/v2/contact_information/get_address') do
               VCR.use_cassette('evss/disability_compensation_form/rated_disabilities') do
                 VCR.use_cassette('evss/ppiu/payment_information') do


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
The 21686c and va_526 form profiles were using the wrong policy for user authorization when initializing veteran information. The evss access policy requires a user to have an edipi, ssn.present, and participant_id. ICN is the only thing needed to initialize contact information for V2 and the va_profile access_to_v2 only requires an ICN, which is only present for verified users.

The va_526 initialize_veteran_contact_information method was reformatted due to rubocop linting errors.

The `country_name` parameter was added to the AskVAAddressValidationController, just as seen in the [V0::Profile::AddressValidationController](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/controllers/v0/profile/address_validation_controller.rb#L39).

## Related issue(s)


## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
