### PR TITLE
MHV-65628 Escape spaces in name for generate_ccd

### DIFF
--- a/lib/medical_records/bb_internal/client.rb
+++ b/lib/medical_records/bb_internal/client.rb
@@ -145,7 +145,8 @@ module BBInternal
     # @return JSON [{ dateGenerated, status, patientId }]
     #
     def get_generate_ccd(icn, last_name)
-      response = perform(:get, "bluebutton/healthsummary/#{icn}/#{last_name}/xml", nil, token_headers)
+      escaped_last_name = URI::DEFAULT_PARSER.escape(last_name)
+      response = perform(:get, "bluebutton/healthsummary/#{icn}/#{escaped_last_name}/xml", nil, token_headers)
       response.body
     end
 

--- a/spec/lib/medical_records/bb_internal/client_spec.rb
+++ b/spec/lib/medical_records/bb_internal/client_spec.rb
@@ -120,6 +120,10 @@ describe BBInternal::Client do
   end
 
   describe '#get_generate_ccd' do
+    let(:icn) { '1000000000V000000' }
+    let(:last_name_with_space) { 'DOE SMITH' }
+    let(:expected_escaped_last_name) { 'DOE%20SMITH' }
+
     it 'requests a CCD be generated and returns the correct structure' do
       VCR.use_cassette 'mr_client/bb_internal/generate_ccd' do
         ccd_list = client.get_generate_ccd(client.session.icn, 'DOE')
@@ -135,6 +139,20 @@ describe BBInternal::Client do
         expect(first_ccd).to have_key('status')
         expect(first_ccd['status']).to be_a(String)
       end
+    end
+
+    it 'ensures the URL contains no spaces by escaping them' do
+      # Mock the `perform` method to intercept the URL
+      allow(client).to receive(:perform).and_wrap_original do |_original_method, _method, url, _body, _headers|
+        # Verify the URL contains no spaces
+        expect(url).to include(expected_escaped_last_name)
+        expect(url).not_to include(' ')
+        # Return a mock response to satisfy the method call
+        double('Response', body: [])
+      end
+
+      # Call the method
+      client.get_generate_ccd(icn, last_name_with_space)
     end
   end
 


### PR DESCRIPTION
## Summary

- Quick fix to escape spaces in the last name to avoid `InvalidURIError`

## Related issue(s)

### [MHV-65628](https://jira.devops.va.gov/browse/MHV-65628) - InvalidURIError when generating CCD downloads ###

> We need to escape the "last name" param in the URL, as spaces in the name cause a failure with InvalidURIError.
> 
> Slack thread: https://dsva.slack.com/archives/C04ER7MHX5E/p1735843276066719
> 
> Example DD trace: https://vagov.ddog-gov.com/apm/trace/1288248410188108306?timeHint=1735840358996.1582

## Testing done

- [x] *New code is covered by unit tests*
- Previously, call to generate the CCD returned a `InvalidURIError`
- To validate, generate the CCD for a user with a space in the last name

## Screenshots

### Before ###

<img width="600" alt="image" src="https://github.com/user-attachments/assets/45e05177-4eba-4108-ba22-9b14037fff4a" />

### After ###

<img width="600" alt="image" src="https://github.com/user-attachments/assets/74ef6e3e-7c09-4f95-a884-339cb970125f" />


## What areas of the site does it impact?
MHV Medical Records

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
