### PR TITLE
Add missing source app names to Vets API middleware

### DIFF
--- a/lib/source_app_middleware.rb
+++ b/lib/source_app_middleware.rb
@@ -51,8 +51,10 @@ class SourceAppMiddleware
     5490-edu-benefits
     5495-edu-benefits
     686C-674
+    686C-674-v2
     995-supplemental-claim
     appeals-testing
+    appoint-a-representative
     ask-a-question
     ask-va-too
     auth
@@ -81,6 +83,7 @@ class SourceAppMiddleware
     facilities
     feedback-tool
     find-a-representative
+    fmp-cover-sheet
     fry-dea
     gi
     hca


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

Missing source app names

Alert: https://dsva.slack.com/archives/C30LCU8S3/p1736437660505059
Triggered here: https://vagov.ddog-gov.com/monitors/200229?eval_ts=1736437869000&event_id=7921778501726393428&link_source=monitor_notif&from_ts=1736436669000&to_ts=1736437869000

Was able to identify the missing apps by [grouping the message content](https://vagov.ddog-gov.com/logs?query=%22Unrecognized%20value%20for%20HTTP_SOURCE_APP_NAME%20request%20header%22%20service%3Avets-api%20env%3Aeks-prod&agg_m=count&agg_m_source=base&agg_q=%40message_content&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=query_table&from_ts=1736115517944&to_ts=1736439604000&live=false)

