### PR TITLE
Added feature toggle for appoint a rep v2 features

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -716,6 +716,10 @@ features:
     actor_type: cookie_id
     description: Enables Appoint a Representative frontend
     enable_in_development: true
+  appoint_a_representative_enable_2.0_features:
+    actor_type: user
+    description: Enables Appoint a Representative 2.0 features for frontend and backend
+    enable_in_development: true  
   appoint_a_representative_enable_pdf:
     actor_type: user
     description: Enables Appoint a Representative PDF generation endpoint


### PR DESCRIPTION
## Summary

- Added new feature toggle to features.yml called `appoint_a_representative_enable_2.0_features`

## Related issue(s)

- https://github.com/orgs/department-of-veterans-affairs/projects/1180/views/5?pane=issue&itemId=92511144&issue=department-of-veterans-affairs%7Cva.gov-team%7C99977


