### PR TITLE
[SIMPLE-FORMS] feat: add submission api to submit return json

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -138,7 +138,7 @@ module SimpleFormsApi
           end
         end
 
-        { json: { reference_number:, status: }, status: lgy_response.status }
+        { json: { reference_number:, status:, submission_api: 'sahsha' }, status: lgy_response.status }
       end
 
       def submit_form_to_benefits_intake
@@ -275,7 +275,7 @@ module SimpleFormsApi
       end
 
       def get_json(confirmation_number, pdf_url)
-        { confirmation_number: }.tap do |json|
+        { confirmation_number:, submission_api: 'benefitsIntake' }.tap do |json|
           json[:pdf_url] = pdf_url if pdf_url.present?
           json[:expiration_date] = 1.year.from_now if form_id == 'vba_21_0966'
         end
@@ -305,7 +305,8 @@ module SimpleFormsApi
           expiration_date:,
           compensation_intent: existing_intents['compensation'],
           pension_intent: existing_intents['pension'],
-          survivor_intent: existing_intents['survivor']
+          survivor_intent: existing_intents['survivor'],
+          submission_api: 'intentToFile'
         } }
       end
 


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- This PR enhances the API responses for both synchronous and asynchronous submissions by adding a `submissionApi` field. This field indicates whether the submission originates from the benefits intake API (central mail) or the benefits claim API, allowing the frontend to differentiate between the two types of submissions.
- The previous responses did not include this field, which could lead to confusion on the frontend regarding the type of submission being processed.
- The solution involves modifying the response generation logic in the relevant API controllers to include the `submissionApi` field based on the context of the submission (intake vs. claim vs. SAHSHA). This change is necessary to improve the clarity and usability of the API responses.
- I work for the VFF development team, which owns the maintenance of this component.
- No feature toggle is introduced, as this change is intended to be deployed immediately.

## Related issue(s)

- [Ticket #21-0966](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/1928) - Add Submission Type to API Responses
- Previous changes related to API response formats are not applicable in this case.
- No epic link is provided as this change is standalone.

## Testing done

- [x] New code is covered by unit tests
- Prior to this change, the API responses did not include the `submissionApi` field, which could lead to ambiguity in handling submissions.
- To verify the changes:
  1. Send a synchronous submission request and check that the response includes the `submission_api` field with a valid value (`benefitsIntake`, 'sahsha', or `benefitsClaim`).
  2. Send an asynchronous submission request and ensure the same field is present and correctly populated.
  3. Run existing tests to confirm that no other functionality is broken by this change.

## Screenshots

*Note: Optional*

## What areas of the site does it impact?

- This change impacts the API endpoints that handle submission responses. Specifically, it modifies the response structure for both synchronous and asynchronous submissions, ensuring that the frontend can correctly interpret the type of submission.

## Acceptance criteria

- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution.
- [x] Documentation has been updated to reflect the changes in response structure.
- [x] No sensitive information (i.e., PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs.
- [ ] Feature/bug has a monitor built into Datadog (if applicable).
- [ ] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected.
- [ ] I added a screenshot of the developed feature.

## Requested Feedback

I would appreciate feedback on the clarity of the API response changes and whether the documentation accurately reflects the new structure. Additionally, any insights on potential edge cases that may not have been covered in the tests would be helpful.