### PR TITLE
93461: Add #address to VBA214140

### DIFF
--- a/modules/simple_forms_api/app/form_mappings/vba_21_4140.json.erb
+++ b/modules/simple_forms_api/app/form_mappings/vba_21_4140.json.erb
@@ -1,7 +1,12 @@
 {
-  "F[0].Page_1[0].Station_Address[0]": "<%= form.data.dig('Station_Address') %>",
 
   <%# Page 1 %>
+
+  <%# Station Address %>
+  "F[0].Page_1[0].Station_Address[0]": "<%= %>",
+
+  <%# Date Mailed %>
+  "F[0].Page_1[0].Date_Mailed[0]": "<%= %>",
 
   <%# Section I: Veteran's Identification Information %>
 
@@ -44,11 +49,12 @@
   "F[0].Page_1[0].CurrentMailingAddress_ZIPOrPostalCode_FirstFiveNumbers[0]": "<%= form.address.zip_code %>",
   "F[0].Page_1[0].CurrentMailingAddress_ZIPOrPostalCode_LastFourNumbers[0]": "<%= form.address.zip_code_suffix %>",
 
+  <%# 10. Were you employed by VA, others or self employed at any time during the past 12 months? %>
+  "F[0].Page_1[0].RadioButtonList[0]": "<%= form.data.dig('RadioButtonList') %>",
+
   "F[0].Page_1[0].Type_Of_Work[0]": "<%= form.data.dig('Type_Of_Work') %>",
   "F[0].Page_1[0].Time_Lost_From_Illness[0]": "<%= form.data.dig('Time_Lost_From_Illness') %>",
   "F[0].Page_1[0].Name_And_Address_Of_Employer[0]": "<%= form.data.dig('Name_And_Address_Of_Employer') %>",
-  "F[0].Page_1[0].RadioButtonList[0]": "<%= form.data.dig('RadioButtonList') %>",
-  "F[0].Page_1[0].Date_Mailed[0]": "<%= form.data.dig('Date_Mailed') %>",
   "F[0].Page_1[0].Hours_Per_Week[0]": "<%= form.data.dig('Hours_Per_Week') %>",
   "F[0].Page_1[0].Date_Of_Employment_From[0]": "<%= form.data.dig('Date_Of_Employment_From') %>",
   "F[0].Page_1[0].Date_Of_Employment_To[0]": "<%= form.data.dig('Date_Of_Employment_To') %>",

--- a/modules/simple_forms_api/app/form_mappings/vba_21_4140.json.erb
+++ b/modules/simple_forms_api/app/form_mappings/vba_21_4140.json.erb
@@ -3,7 +3,7 @@
 
   <%# Page 1 %>
 
-  <%# Section 1: Veteran's Identification Information %>
+  <%# Section I: Veteran's Identification Information %>
 
   <%# 1. Name of Veteran %>
   "F[0].Page_1[0].VeteranFirstName[0]": "<%= form.first_name %>",
@@ -35,13 +35,15 @@
   <%# 8. Alternate Telephone Number %>
   "F[0].Page_1[0].AlternateTelephoneNumber[0]": "<%= form.phone_alternate %>",
 
-  "F[0].Page_1[0].CurrentMailingAddress_ZIPOrPostalCode_LastFourNumbers[0]": "<%= form.data.dig('CurrentMailingAddress_ZIPOrPostalCode_LastFourNumbers') %>",
-  "F[0].Page_1[0].CurrentMailingAddress_ZIPOrPostalCode_FirstFiveNumbers[0]": "<%= form.data.dig('CurrentMailingAddress_ZIPOrPostalCode_FirstFiveNumbers') %>",
-  "F[0].Page_1[0].CurrentMailingAddress_Country[0]": "<%= form.data.dig('CurrentMailingAddress_Country') %>",
-  "F[0].Page_1[0].CurrentMailingAddress_StateOrProvince[0]": "<%= form.data.dig('CurrentMailingAddress_StateOrProvince') %>",
-  "F[0].Page_1[0].CurrentMailingAddress_City[0]": "<%= form.data.dig('CurrentMailingAddress_City') %>",
-  "F[0].Page_1[0].CurrentMailingAddress_ApartmentOrUnitNumber[0]": "<%= form.data.dig('CurrentMailingAddress_ApartmentOrUnitNumber') %>",
+  <%# 9. Current Mailing Address of Veteran %>
   "F[0].Page_1[0].CurrentMailingAddress_NumberAndStreet[0]": "<%= form.data.dig('CurrentMailingAddress_NumberAndStreet') %>",
+  "F[0].Page_1[0].CurrentMailingAddress_ApartmentOrUnitNumber[0]": "<%= form.data.dig('CurrentMailingAddress_ApartmentOrUnitNumber') %>",
+  "F[0].Page_1[0].CurrentMailingAddress_City[0]": "<%= form.data.dig('CurrentMailingAddress_City') %>",
+  "F[0].Page_1[0].CurrentMailingAddress_StateOrProvince[0]": "<%= form.data.dig('CurrentMailingAddress_StateOrProvince') %>",
+  "F[0].Page_1[0].CurrentMailingAddress_Country[0]": "<%= form.data.dig('CurrentMailingAddress_Country') %>",
+  "F[0].Page_1[0].CurrentMailingAddress_ZIPOrPostalCode_FirstFiveNumbers[0]": "<%= form.data.dig('CurrentMailingAddress_ZIPOrPostalCode_FirstFiveNumbers') %>",
+  "F[0].Page_1[0].CurrentMailingAddress_ZIPOrPostalCode_LastFourNumbers[0]": "<%= form.data.dig('CurrentMailingAddress_ZIPOrPostalCode_LastFourNumbers') %>",
+
   "F[0].Page_1[0].Type_Of_Work[0]": "<%= form.data.dig('Type_Of_Work') %>",
   "F[0].Page_1[0].Time_Lost_From_Illness[0]": "<%= form.data.dig('Time_Lost_From_Illness') %>",
   "F[0].Page_1[0].Name_And_Address_Of_Employer[0]": "<%= form.data.dig('Name_And_Address_Of_Employer') %>",

--- a/modules/simple_forms_api/app/form_mappings/vba_21_4140.json.erb
+++ b/modules/simple_forms_api/app/form_mappings/vba_21_4140.json.erb
@@ -36,13 +36,13 @@
   "F[0].Page_1[0].AlternateTelephoneNumber[0]": "<%= form.phone_alternate %>",
 
   <%# 9. Current Mailing Address of Veteran %>
-  "F[0].Page_1[0].CurrentMailingAddress_NumberAndStreet[0]": "<%= form.data.dig('CurrentMailingAddress_NumberAndStreet') %>",
-  "F[0].Page_1[0].CurrentMailingAddress_ApartmentOrUnitNumber[0]": "<%= form.data.dig('CurrentMailingAddress_ApartmentOrUnitNumber') %>",
-  "F[0].Page_1[0].CurrentMailingAddress_City[0]": "<%= form.data.dig('CurrentMailingAddress_City') %>",
-  "F[0].Page_1[0].CurrentMailingAddress_StateOrProvince[0]": "<%= form.data.dig('CurrentMailingAddress_StateOrProvince') %>",
-  "F[0].Page_1[0].CurrentMailingAddress_Country[0]": "<%= form.data.dig('CurrentMailingAddress_Country') %>",
-  "F[0].Page_1[0].CurrentMailingAddress_ZIPOrPostalCode_FirstFiveNumbers[0]": "<%= form.data.dig('CurrentMailingAddress_ZIPOrPostalCode_FirstFiveNumbers') %>",
-  "F[0].Page_1[0].CurrentMailingAddress_ZIPOrPostalCode_LastFourNumbers[0]": "<%= form.data.dig('CurrentMailingAddress_ZIPOrPostalCode_LastFourNumbers') %>",
+  "F[0].Page_1[0].CurrentMailingAddress_NumberAndStreet[0]": "<%= form.address.address_line1 %>",
+  "F[0].Page_1[0].CurrentMailingAddress_ApartmentOrUnitNumber[0]": "<%= form.address.address_line2 %>",
+  "F[0].Page_1[0].CurrentMailingAddress_City[0]": "<%= form.address.city %>",
+  "F[0].Page_1[0].CurrentMailingAddress_StateOrProvince[0]": "<%= form.address.state_code %>",
+  "F[0].Page_1[0].CurrentMailingAddress_Country[0]": "<%= form.address.country_code_iso3 %>",
+  "F[0].Page_1[0].CurrentMailingAddress_ZIPOrPostalCode_FirstFiveNumbers[0]": "<%= form.address.zip_code %>",
+  "F[0].Page_1[0].CurrentMailingAddress_ZIPOrPostalCode_LastFourNumbers[0]": "<%= form.address.zip_code_suffix %>",
 
   "F[0].Page_1[0].Type_Of_Work[0]": "<%= form.data.dig('Type_Of_Work') %>",
   "F[0].Page_1[0].Time_Lost_From_Illness[0]": "<%= form.data.dig('Time_Lost_From_Illness') %>",

--- a/modules/simple_forms_api/app/form_mappings/vba_21_4140.json.erb
+++ b/modules/simple_forms_api/app/form_mappings/vba_21_4140.json.erb
@@ -45,7 +45,7 @@
   "F[0].Page_1[0].CurrentMailingAddress_ApartmentOrUnitNumber[0]": "<%= form.address.address_line2 %>",
   "F[0].Page_1[0].CurrentMailingAddress_City[0]": "<%= form.address.city %>",
   "F[0].Page_1[0].CurrentMailingAddress_StateOrProvince[0]": "<%= form.address.state_code %>",
-  "F[0].Page_1[0].CurrentMailingAddress_Country[0]": "<%= form.address.country_code_iso3 %>",
+  "F[0].Page_1[0].CurrentMailingAddress_Country[0]": "<%= form.address.country_code_iso2 %>",
   "F[0].Page_1[0].CurrentMailingAddress_ZIPOrPostalCode_FirstFiveNumbers[0]": "<%= form.address.zip_code %>",
   "F[0].Page_1[0].CurrentMailingAddress_ZIPOrPostalCode_LastFourNumbers[0]": "<%= form.address.zip_code_suffix %>",
 

--- a/modules/simple_forms_api/app/models/form_engine/address.rb
+++ b/modules/simple_forms_api/app/models/form_engine/address.rb
@@ -3,6 +3,13 @@
 module SimpleFormsApi
   module FormEngine
     class Address < VAProfile::Models::V3::Address
+      def initialize(params)
+        super(params)
+
+        if params[:country_code_iso3].present?
+          @country_code_iso2 = IsoCountryCodes.find(params[:country_code_iso3]).alpha2
+        end
+      end
     end
   end
 end

--- a/modules/simple_forms_api/app/models/form_engine/address.rb
+++ b/modules/simple_forms_api/app/models/form_engine/address.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
-module SimpleFormsApi
-  module FormEngine
-    class Address < VAProfile::Models::V3::Address
-      def initialize(params)
-        super(params)
+module FormEngine
+  class Address < VAProfile::Models::V3::Address
+    def initialize(params)
+      super(params)
 
-        if params[:country_code_iso3].present?
-          @country_code_iso2 = IsoCountryCodes.find(params[:country_code_iso3]).alpha2
-        end
+      if params[:country_code_iso3].present?
+        @country_code_iso2 = IsoCountryCodes.find(params[:country_code_iso3]).alpha2
       end
     end
   end

--- a/modules/simple_forms_api/app/models/form_engine/address.rb
+++ b/modules/simple_forms_api/app/models/form_engine/address.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module SimpleFormsApi
+  module FormEngine
+    class Address < VAProfile::Models::V3::Address
+    end
+  end
+end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4140.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4140.rb
@@ -76,7 +76,7 @@ module SimpleFormsApi
     def track_user_identity(confirmation_number); end
 
     def zip_code_is_us_based
-      data.dig('address', 'country') == 'USA'
+      address.country_code_iso3 == 'USA'
     end
   end
 end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4140.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4140.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../form_engine/address'
+
 module SimpleFormsApi
   class VBA214140 < BaseForm
     attr_reader :address

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4140.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4140.rb
@@ -2,6 +2,21 @@
 
 module SimpleFormsApi
   class VBA214140 < BaseForm
+    attr_reader :address
+
+    def initialize(data)
+      super
+
+      @address = SimpleFormsApi::FormEngine::Address.new(
+        address_line1: data.dig('address', 'street'),
+        address_line2: data.dig('address', 'street2'),
+        city: data.dig('address', 'city'),
+        country_code_iso3: data.dig('address', 'country'),
+        state_code: data.dig('address', 'state'),
+        zip_code: data.dig('address', 'postal_code')
+      )
+    end
+
     def desired_stamps
       []
     end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4140.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4140.rb
@@ -9,7 +9,7 @@ module SimpleFormsApi
     def initialize(data)
       super
 
-      @address = SimpleFormsApi::FormEngine::Address.new(
+      @address = FormEngine::Address.new(
         address_line1: data.dig('address', 'street'),
         address_line2: data.dig('address', 'street2'),
         city: data.dig('address', 'city'),

--- a/modules/simple_forms_api/spec/models/vba_21_4140_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_21_4140_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require_relative '../support/shared_examples_for_base_form'
+require_relative '../../app/models/form_engine/address'
 
 RSpec.describe SimpleFormsApi::VBA214140 do
   subject(:form) { described_class.new(data) }
@@ -16,6 +17,21 @@ RSpec.describe SimpleFormsApi::VBA214140 do
 
   shared_examples 'hyphenated_phone_number' do
     it { is_expected.to match(/\d{3}-\d{3}-\d{4}/) }
+  end
+
+  describe '#address' do
+    subject(:address) { form.address }
+
+    it { is_expected.to be_a SimpleFormsApi::FormEngine::Address }
+
+    it 'maps correctly to attributes' do
+      expect(address.address_line1).to eq data.dig('address', 'street')
+      expect(address.address_line2).to eq data.dig('address', 'street2')
+      expect(address.city).to eq data.dig('address', 'city')
+      expect(address.state_code).to eq data.dig('address', 'state')
+      expect(address.zip_code).to eq data.dig('address', 'postal_code')
+      expect(address.country_code_iso3).to eq data.dig('address', 'country')
+    end
   end
 
   describe '#data' do

--- a/modules/simple_forms_api/spec/models/vba_21_4140_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_21_4140_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe SimpleFormsApi::VBA214140 do
   describe '#address' do
     subject(:address) { form.address }
 
-    it { is_expected.to be_a SimpleFormsApi::FormEngine::Address }
+    it { is_expected.to be_a FormEngine::Address }
 
     it 'maps correctly to attributes' do
       expect(address.address_line1).to eq data.dig('address', 'street')

--- a/modules/simple_forms_api/spec/models/vba_21_4140_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_21_4140_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe SimpleFormsApi::VBA214140 do
       expect(address.state_code).to eq data.dig('address', 'state')
       expect(address.zip_code).to eq data.dig('address', 'postal_code')
       expect(address.country_code_iso3).to eq data.dig('address', 'country')
+      expect(address.country_code_iso2).to eq IsoCountryCodes.find(data.dig('address', 'country')).alpha2
     end
   end
 

--- a/modules/simple_forms_api/spec/support/shared_examples_for_base_form.rb
+++ b/modules/simple_forms_api/spec/support/shared_examples_for_base_form.rb
@@ -13,7 +13,7 @@ RSpec.shared_examples 'zip_code_is_us_based' do |address_keys|
     end
 
     context 'address is present and not in US' do
-      let(:data) { { address_key => { 'country' => 'Canada' } } }
+      let(:data) { { address_key => { 'country' => 'CAN' } } }
 
       it 'returns false' do
         expect(zip_code_is_us_based).to eq(false)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This is the 4th PR (after https://github.com/department-of-veterans-affairs/vets-api/pull/20156) sprung from https://github.com/department-of-veterans-affairs/va.gov-team/issues/93461 due to LOC limitations. There will be at least one more after this.
- Adds an `#address` instance method to `VBA214140`. Maps all relevant attributes to the associated PDF template.
- Creates a `FormEngine::Address` class to properly format Form Engine addresses.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93461

## Testing done

- [x] *New code is covered by unit tests*
- Unit tests for `#address` instance method and a spec to ensure ISO 2 conversion works.

## What areas of the site does it impact?
At the moment, none. It will ultimately impact the Simple Forms API, adding support for the 21-4140 form.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

If anyone has strong feelings about where I put the new `Address` class, now is the time to speak because there's another one coming in the next PR.
