### PR TITLE
[VI-912] removes covid_vaccine registration submission tables

### DIFF
--- a/db/migrate/20250109172425_remove_covid_vaccine_registration_submissions.rb
+++ b/db/migrate/20250109172425_remove_covid_vaccine_registration_submissions.rb
@@ -1,0 +1,10 @@
+class RemoveCovidVaccineRegistrationSubmissions < ActiveRecord::Migration[7.2]
+  def up
+    drop_table :covid_vaccine_expanded_registration_submissions, if_exists: true
+    drop_table :covid_vaccine_registration_submissions, if_exists: true
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -541,42 +541,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_14_223139) do
     t.index ["client_id"], name: "index_client_configs_on_client_id", unique: true
   end
 
-  create_table "covid_vaccine_expanded_registration_submissions", id: :serial, force: :cascade do |t|
-    t.string "submission_uuid", null: false
-    t.string "vetext_sid"
-    t.boolean "sequestered", default: true, null: false
-    t.string "state"
-    t.string "email_confirmation_id"
-    t.string "enrollment_id"
-    t.string "batch_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.text "raw_form_data_ciphertext"
-    t.text "eligibility_info_ciphertext"
-    t.text "form_data_ciphertext"
-    t.text "encrypted_kms_key"
-    t.index ["batch_id"], name: "index_covid_vaccine_expanded_reg_submissions_on_batch_id"
-    t.index ["state"], name: "index_covid_vaccine_expanded_registration_submissions_on_state"
-    t.index ["submission_uuid"], name: "index_covid_vaccine_expanded_on_submission_id", unique: true
-    t.index ["vetext_sid"], name: "index_covid_vaccine_expanded_on_vetext_sid", unique: true
-  end
-
-  create_table "covid_vaccine_registration_submissions", id: :serial, force: :cascade do |t|
-    t.string "sid"
-    t.uuid "account_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "expanded", default: false, null: false
-    t.boolean "sequestered", default: false, null: false
-    t.string "email_confirmation_id"
-    t.string "enrollment_id"
-    t.text "form_data_ciphertext"
-    t.text "raw_form_data_ciphertext"
-    t.text "encrypted_kms_key"
-    t.index ["account_id", "created_at"], name: "index_covid_vaccine_registry_submissions_2"
-    t.index ["sid"], name: "index_covid_vaccine_registry_submissions_on_sid", unique: true
-  end
-
   create_table "decision_review_notification_audit_logs", force: :cascade do |t|
     t.text "notification_id"
     t.text "status"


### PR DESCRIPTION
## Summary

- Tech debt PR to remove deprecated `covid_vaccine` module database tables.

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-912

### Companion PRs

- https://github.com/department-of-veterans-affairs/vets-api/pull/20080
- https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/3351
- https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/3352

## Testing done
- Successful app launch & authentication following migration & re-seeding of DB.

## What areas of the site does it impact?
None, code is already deprecated.

## Acceptance criteria

- [ ]  No error nor warning in the console.
