### PR TITLE
HLR | Remove content toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1816,10 +1816,6 @@ features:
     actor_type: user
     description: Show updated confirmation page with form data & downloadable PDF
     enable_in_development: true
-  hlr_updateed_contnet:
-    actor_type: user
-    description: HLR show form content updates
-    enable_in_development: true
   sc_new_form:
     actor_type: user
     description: Supplemental Claim new form updates


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
  > NO - toggle removed from the frontend
- *(Summarize the changes that have been made to the platform)*
  > Removing `hlr_updateed_contnet` (typo expected) as it's no longer being used, but not yet deployed to production
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)*
  > Benefits Decision Reviews
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/100041

## Testing done

N/A

## Screenshots

N/A

## What areas of the site does it impact?

Higher-Level Review form

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
