### PR TITLE
MHV-65985 Added a check to block BBInternal client init threads if ICN is not set

### DIFF
--- a/lib/medical_records/bb_internal/client.rb
+++ b/lib/medical_records/bb_internal/client.rb
@@ -323,10 +323,10 @@ module BBInternal
     end
 
     ##
-    # Overriding MHVSessionBasedClient's method to ensure the thread blocks if patient ID is not yet set.
+    # Overriding MHVSessionBasedClient's method to ensure the thread blocks if ICN or patient ID are not yet set.
     #
     def invalid?(session)
-      super(session) || session.patient_id.blank?
+      super(session) || session.icn.blank? || session.patient_id.blank?
     end
 
     ##

--- a/modules/my_health/spec/requests/my_health/v1/medical_records/imaging_spec.rb
+++ b/modules/my_health/spec/requests/my_health/v1/medical_records/imaging_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'MyHealth::V1::MedicalRecords::ImagingController', type: :request
     bb_internal_client = BBInternal::Client.new(
       session: {
         user_id: 11_375_034,
+        icn: '1000000000V000000',
         patient_id: '11382904',
         expires_at: 1.hour.from_now,
         token: 'SESSION_TOKEN'

--- a/modules/my_health/spec/requests/my_health/v1/medical_records/radiology_spec.rb
+++ b/modules/my_health/spec/requests/my_health/v1/medical_records/radiology_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'MyHealth::V1::MedicalRecords::Radiology', type: :request do
     bb_internal_client = BBInternal::Client.new(
       session: {
         user_id: 11_375_034,
+        icn: '1000000000V000000',
         patient_id: '11382904',
         expires_at: 1.hour.from_now,
         token: 'SESSION_TOKEN'

--- a/spec/lib/medical_records/bb_internal/client_spec.rb
+++ b/spec/lib/medical_records/bb_internal/client_spec.rb
@@ -439,10 +439,21 @@ describe BBInternal::Client do
   end
 
   describe '#invalid?' do
-    let(:session_data) { OpenStruct.new(patient_id: patient_id, expired?: session_expired) }
+    let(:session_data) { OpenStruct.new(icn: icn, patient_id: patient_id, expired?: session_expired) }
 
     context 'when session is expired' do
       let(:session_expired) { true }
+      let(:icn) { '1000000000V000000' }
+      let(:patient_id) { '12345' }
+
+      it 'returns true' do
+        expect(client.send(:invalid?, session_data)).to be true
+      end
+    end
+
+    context 'when session has no icn' do
+      let(:session_expired) { false }
+      let(:icn) { nil }
       let(:patient_id) { '12345' }
 
       it 'returns true' do
@@ -452,6 +463,7 @@ describe BBInternal::Client do
 
     context 'when session has no patient_id' do
       let(:session_expired) { false }
+      let(:icn) { '1000000000V000000' }
       let(:patient_id) { nil }
 
       it 'returns true' do
@@ -461,6 +473,7 @@ describe BBInternal::Client do
 
     context 'when session is valid' do
       let(:session_expired) { false }
+      let(:icn) { '1000000000V000000' }
       let(:patient_id) { '12345' }
 
       it 'returns false' do


### PR DESCRIPTION
## Summary

- There is currently a very small window during which requests can be made while the ICN is not set in session (`session.ICN` is briefly deleted while calling a super method and then restored).
- This is a small fix to ensure that ICN is present when making requests.

## Related issue(s)

### [MHV-65985](https://jira.devops.va.gov/browse/MHV-65985) - About 1% of requests to fetch CVIX reports fail with HTTP 404 ###

> The request_download action is failing just about 1% of the time with a 404. This appears to be because the ICN is not being included in the backend request. You can see a list of these errors [here](https://vagov.ddog-gov.com/logs?query=bluebutton%20studyjob%20icn%20studyid%20status%3Awarn&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1736271128595&to_ts=1736443928595&live=true).


## Testing done

- As this is only an occasional issue during a race condition, this cannot be automatically tested.
- If this works, we will see the number of this error decrease.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
MHV Medical Records

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
