### PR TITLE
Bumping to OVER lighthouse limit

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -990,7 +990,7 @@ lighthouse:
         rsa_key: ~
       use_mocks: false
   benefits_documents:
-    timeout: 55
+    timeout: 65
     host: https://sandbox-api.va.gov
     access_token:
       aud_claim_url: https://deptva-eval.okta.com/oauth2/ausi3ui83fLa68IJv2p7/v1/token

--- a/lib/lighthouse/benefits_documents/configuration.rb
+++ b/lib/lighthouse/benefits_documents/configuration.rb
@@ -11,7 +11,7 @@ module BenefitsDocuments
   # sets the base path, the base request headers, and a service name for breakers and metrics.
   #
   class Configuration < Common::Client::Configuration::REST
-    self.read_timeout = Settings.lighthouse.benefits_documents.timeout || 55
+    self.read_timeout = Settings.lighthouse.benefits_documents.timeout || 65
 
     SYSTEM_NAME = 'VA.gov'
     API_SCOPES = %w[documents.read documents.write].freeze


### PR DESCRIPTION
Related to previous timeout PRs

https://github.com/department-of-veterans-affairs/vets-api/pull/20174
https://github.com/department-of-veterans-affairs/vets-api/pull/20173

We need to actually make this higher than the lighthouse side timeout otherwise we are in the same situation potentially. 

Lighthouse timeout is 60s, if we set ours to 55s, any requests that complete in 55-60s still leave us in the same potential situation of not knowing if lighthouse actually got/sent the file or not. 

If we set to higher than their timeout, we rely on them to tell us if they timed out or not by their timeout and therefore eliminate uncertainty and eliminate this risk. 