### PR TITLE
Always use mhv_user_account cached response on User

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -160,7 +160,7 @@ class User < Common::RedisStore
   end
 
   def mhv_user_account
-    @mhv_user_account ||= MHV::UserAccount::Creator.new(user_verification:).perform
+    @mhv_user_account ||= MHV::UserAccount::Creator.new(user_verification:, from_cache_only: true).perform
   rescue => e
     log_mhv_user_account_error(e.message)
     nil

--- a/spec/controllers/v0/user/mhv_user_accounts_controller_spec.rb
+++ b/spec/controllers/v0/user/mhv_user_accounts_controller_spec.rb
@@ -50,7 +50,8 @@ describe V0::User::MHVUserAccountsController, type: :controller do
           expect(mhv_client).to have_received(:create_account).with(icn:,
                                                                     email: user_credential_email.credential_email,
                                                                     tou_occurred_at: terms_of_use_agreement.created_at,
-                                                                    break_cache: true)
+                                                                    break_cache: true,
+                                                                    from_cache_only: false)
         end
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1399,6 +1399,7 @@ RSpec.describe User, type: :model do
   describe '#mhv_user_account' do
     let(:user) { build(:user, :loa3) }
     let(:icn) { user.icn }
+    let(:expected_cache_key) { "mhv_account_creation_#{icn}" }
 
     let!(:user_verification) do
       create(:idme_user_verification, idme_uuid: user.idme_uuid, user_credential_email:, user_account:)
@@ -1423,55 +1424,65 @@ RSpec.describe User, type: :model do
     before do
       allow(Rails.logger).to receive(:info)
       allow(MHV::AccountCreation::Service).to receive(:new).and_return(mhv_client)
-      allow(mhv_client).to receive(:create_account).and_return(mhv_response)
+      allow(Rails.cache).to receive(:read).with(expected_cache_key).and_return(mhv_response)
     end
 
-    context 'when the user has all required attributes' do
-      it 'returns a MHVUserAccount with the expected attributes' do
-        mhv_user_account = user.mhv_user_account
+    context 'when the mhv response is cached' do
+      context 'when the user has all required attributes' do
+        it 'returns a MHVUserAccount with the expected attributes' do
+          mhv_user_account = user.mhv_user_account
 
-        expect(mhv_user_account).to be_a(MHVUserAccount)
-        expect(mhv_user_account.attributes).to eq(mhv_response.with_indifferent_access)
-      end
-    end
-
-    context 'when there is an error creating the account' do
-      shared_examples 'mhv_user_account error' do
-        let(:expected_log_message) { '[User] mhv_user_account error' }
-        let(:expected_log_payload) { { error_message: /#{expected_error_message}/, icn: user.icn } }
-
-        it 'logs and returns nil' do
-          expect(user.mhv_user_account).to be_nil
-          expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
+          expect(mhv_user_account).to be_a(MHVUserAccount)
+          expect(mhv_user_account.attributes).to eq(mhv_response.with_indifferent_access)
         end
       end
 
-      context 'when the user does not have a terms_of_use_agreement' do
-        let(:terms_of_use_agreement) { nil }
-        let(:expected_error_message) { 'Current terms of use agreement must be present' }
+      context 'when there is an error creating the account' do
+        shared_examples 'mhv_user_account error' do
+          let(:expected_log_message) { '[User] mhv_user_account error' }
+          let(:expected_log_payload) { { error_message: /#{expected_error_message}/, icn: user.icn } }
 
-        it_behaves_like 'mhv_user_account error'
+          it 'logs and returns nil' do
+            expect(user.mhv_user_account).to be_nil
+            expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
+          end
+        end
+
+        context 'when the user does not have a terms_of_use_agreement' do
+          let(:terms_of_use_agreement) { nil }
+          let(:expected_error_message) { 'Current terms of use agreement must be present' }
+
+          it_behaves_like 'mhv_user_account error'
+        end
+
+        context 'when the user has not accepted the terms of use' do
+          let(:terms_of_use_response) { 'declined' }
+          let(:expected_error_message) { "Current terms of use agreement must be 'accepted'" }
+
+          it_behaves_like 'mhv_user_account error'
+        end
+
+        context 'when the user does not have a user_credential_email' do
+          let(:user_credential_email) { nil }
+          let(:expected_error_message) { 'Email must be present' }
+
+          it_behaves_like 'mhv_user_account error'
+        end
+
+        context 'when the user does not have an icn' do
+          let(:icn) { nil }
+          let(:expected_error_message) { 'ICN must be present' }
+
+          it_behaves_like 'mhv_user_account error'
+        end
       end
+    end
 
-      context 'when the user has not accepted the terms of use' do
-        let(:terms_of_use_response) { 'declined' }
-        let(:expected_error_message) { "Current terms of use agreement must be 'accepted'" }
+    context 'when the mhv response is not cached' do
+      let(:mhv_response) { nil }
 
-        it_behaves_like 'mhv_user_account error'
-      end
-
-      context 'when the user does not have a user_credential_email' do
-        let(:user_credential_email) { nil }
-        let(:expected_error_message) { 'Email must be present' }
-
-        it_behaves_like 'mhv_user_account error'
-      end
-
-      context 'when the user does not have an icn' do
-        let(:icn) { nil }
-        let(:expected_error_message) { 'ICN must be present' }
-
-        it_behaves_like 'mhv_user_account error'
+      it 'returns nil' do
+        expect(user.mhv_user_account).to be_nil
       end
     end
   end

--- a/spec/services/mhv/user_account/creator_spec.rb
+++ b/spec/services/mhv/user_account/creator_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'mhv/account_creation/service'
 
 RSpec.describe MHV::UserAccount::Creator do
-  subject { described_class.new(user_verification:, break_cache:) }
+  subject { described_class.new(user_verification:, break_cache:, from_cache_only:) }
 
   let(:user_account) { create(:user_account, icn:) }
   let(:user_verification) { create(:user_verification, user_account:, user_credential_email:) }
@@ -14,6 +14,7 @@ RSpec.describe MHV::UserAccount::Creator do
   let(:email) { 'some-email@email.com' }
   let(:tou_occurred_at) { terms_of_use_agreement&.created_at }
   let(:break_cache) { false }
+  let(:from_cache_only) { false }
   let(:mhv_client) { instance_double(MHV::AccountCreation::Service) }
   let(:mhv_response_body) do
     {
@@ -30,7 +31,7 @@ RSpec.describe MHV::UserAccount::Creator do
 
     allow(MHV::AccountCreation::Service).to receive(:new).and_return(mhv_client)
     allow(mhv_client).to receive(:create_account)
-      .with(icn:, email:, tou_occurred_at:, break_cache:)
+      .with(icn:, email:, tou_occurred_at:, break_cache:, from_cache_only:)
       .and_return(mhv_response_body)
   end
 
@@ -80,7 +81,8 @@ RSpec.describe MHV::UserAccount::Creator do
       context 'when break_cache is false' do
         it 'calls MHV::AccountCreation::Service#create_account with break_cache: false' do
           subject.perform
-          expect(mhv_client).to have_received(:create_account).with(icn:, email:, tou_occurred_at:, break_cache: false)
+          expect(mhv_client).to have_received(:create_account).with(icn:, email:, tou_occurred_at:, break_cache: false,
+                                                                    from_cache_only:)
         end
       end
 
@@ -89,7 +91,39 @@ RSpec.describe MHV::UserAccount::Creator do
 
         it 'calls MHV::AccountCreation::Service#create_account with break_cache: true' do
           subject.perform
-          expect(mhv_client).to have_received(:create_account).with(icn:, email:, tou_occurred_at:, break_cache: true)
+          expect(mhv_client).to have_received(:create_account).with(icn:, email:, tou_occurred_at:, break_cache: true,
+                                                                    from_cache_only:)
+        end
+      end
+
+      context 'when from_cache_only is true' do
+        let(:from_cache_only) { true }
+        let(:expected_cache_key) { "mhv_account_creation_#{icn}" }
+
+        before do
+          allow(Rails.cache).to receive(:read).with(expected_cache_key).and_return(mhv_response_body)
+        end
+
+        it 'calls MHV::AccountCreation::Service#create_account with from_cache_only: true' do
+          subject.perform
+          expect(mhv_client).to have_received(:create_account).with(icn:, email:, tou_occurred_at:, break_cache:,
+                                                                    from_cache_only: true)
+        end
+
+        context 'when the response is cached' do
+          it 'returns the cached response' do
+            mhv_user_account = subject.perform
+            expect(mhv_user_account).to be_a(MHVUserAccount)
+            expect(mhv_user_account).to be_valid
+          end
+        end
+
+        context 'when the response is not cached' do
+          let(:mhv_response_body) { nil }
+
+          it 'returns nil' do
+            expect(subject.perform).to be_nil
+          end
         end
       end
     end


### PR DESCRIPTION
## Summary

- `User#mhv_user_account` will always use the cached version. If there is no cached version, it will return nil.

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-968

## Testing 
- make sure your local cache is enabled `rails dev:cache`
- Cache the mhv_user_account request for the user you will login with
    - start a rails server - `rails s`
    - in rails console - `rails c`:
      ```ruby
      icn = 1012667122V019349 # change to the icn of the user you will login with (they need to have accepted TOU)
      
      user_account = User.find_by(icn:)
      user_verification = user_account.user_verifications.idme.first 
      
      MHV::UserAccount::Creator.new(user_verification:).perform
      ```
  - Check to make sure the response was cached
     ```ruby
     cache_key = "mhv_account_creation_#{icn}"

    Rails.cache.read(cache_key)
    # => {:user_profile_id=>"12345678", :premium=>true, :champ_va=>true, :patient=>true, :sm_account_created=>true, :message=>"Existing MHV Account Found for ICN"} 
     ```
- Start vets-website and login
- go to http://localhost:3000/v0/user and copy uuid
- Find your user in the rails console and call mhv_user_account:
    ```ruby
    user = User.find(uuid)
    
    user.mhv_user_account
    ```
    this should return the MHVUserAccount since it is cached and not make a call to MHV
- Delete response from cache and call `user.mhv_user_account` again, this should return `nil` and not make a call to MHV
    ```ruby
    Rails.cache.delete(cache_key)

    user.mhv_user_account
    # => nil
    ```
   
## What areas of the site does it impact?
User, mhv user account

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
