### PR TITLE
API-43896-v1-poa-dependent-job-arguments

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/poa_assign_dependent_claimant_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/poa_assign_dependent_claimant_job.rb
@@ -4,7 +4,7 @@ module ClaimsApi
   class PoaAssignDependentClaimantJob < ClaimsApi::ServiceBase
     LOG_TAG = 'poa_assign_dependent_claimant_job'
 
-    def perform(poa_id, rep_id)
+    def perform(poa_id, rep_id = nil)
       poa = ClaimsApi::PowerOfAttorney.find(poa_id)
 
       service = dependent_claimant_poa_assignment_service(


### PR DESCRIPTION
## Summary
* Makes argument optional so v1 calls to `PoaAssignDependentClaimantJob` still succeed

## Related issue(s)
[API-43896](https://jira.devops.va.gov/browse/API-43896)

## Testing done
- *Describe what the old behavior was prior to the change* - No changes to existing behavior, this is jsut a fix since this job was being called from two places and only one is sending in the added argument

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
modified:   modules/claims_api/app/sidekiq/claims_api/poa_assign_dependent_claimant_job.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
