### PR TITLE
93461: Add #employment_history to VBA214140

### DIFF
--- a/modules/simple_forms_api/app/form_mappings/vba_21_4140.json.erb
+++ b/modules/simple_forms_api/app/form_mappings/vba_21_4140.json.erb
@@ -8,7 +8,7 @@
   <%# Date Mailed %>
   "F[0].Page_1[0].Date_Mailed[0]": "<%= %>",
 
-  <%# Section I: Veteran's Identification Information %>
+  <%# Section I - Veteran's Identification Information %>
 
   <%# 1. Name of Veteran %>
   "F[0].Page_1[0].VeteranFirstName[0]": "<%= form.first_name %>",
@@ -52,12 +52,24 @@
   <%# 10. Were you employed by VA, others or self employed at any time during the past 12 months? %>
   "F[0].Page_1[0].RadioButtonList[0]": "<%= form.data.dig('RadioButtonList') %>",
 
-  "F[0].Page_1[0].Type_Of_Work[0]": "<%= form.data.dig('Type_Of_Work') %>",
-  "F[0].Page_1[0].Time_Lost_From_Illness[0]": "<%= form.data.dig('Time_Lost_From_Illness') %>",
+  <%# Section II - Employment Certification %>
+  <%# 11A. Name and Address of Employer %>
   "F[0].Page_1[0].Name_And_Address_Of_Employer[0]": "<%= form.data.dig('Name_And_Address_Of_Employer') %>",
+
+  <%# 11B. Type of Work %>
+  "F[0].Page_1[0].Type_Of_Work[0]": "<%= form.data.dig('Type_Of_Work') %>",
+
+  <%# 11C. Hours Per Week %>
   "F[0].Page_1[0].Hours_Per_Week[0]": "<%= form.data.dig('Hours_Per_Week') %>",
+
+  <%# 11D. Dates of Employment or Self-Employment %>
   "F[0].Page_1[0].Date_Of_Employment_From[0]": "<%= form.data.dig('Date_Of_Employment_From') %>",
   "F[0].Page_1[0].Date_Of_Employment_To[0]": "<%= form.data.dig('Date_Of_Employment_To') %>",
+
+  <%# 11E. Time Lost From Illness %>
+  "F[0].Page_1[0].Time_Lost_From_Illness[0]": "<%= form.data.dig('Time_Lost_From_Illness') %>",
+
+  <%# 11F. Highest Gross Earnings Per Month %>
   "F[0].Page_1[0].Gross_Earnings_Per_Month[0]": "<%= form.data.dig('Gross_Earnings_Per_Month') %>",
 
   <%# Page 2 %>
@@ -66,29 +78,42 @@
   "F[0].#subform[1].Veterans_Social_SecurityNumber_SecondTwoNumbers[0]": "<%= form.ssn[1] %>",
   "F[0].#subform[1].Veterans_Social_SecurityNumber_LastFourNumbers[0]": "<%= form.ssn[2] %>",
 
-  "F[0].#subform[1].DateSigned[0]": "<%= form.data.dig('DateSigned') %>",
-  "F[0].#subform[1].SignatureField1[0]": "<%= form.data.dig('SignatureField1') %>",
-  "F[0].#subform[1].Gross_Earnings_Per_Month[0]": "<%= form.data.dig('Gross_Earnings_Per_Month') %>",
-  "F[0].#subform[1].Type_Of_Work[0]": "<%= form.data.dig('Type_Of_Work') %>",
-  "F[0].#subform[1].Time_Lost_From_Illness[0]": "<%= form.data.dig('Time_Lost_From_Illness') %>",
+  <%# Section II - Employment Certification (Continued) %>
+  <%# 11A. Name and Address of Employer %>
   "F[0].#subform[1].Name_And_Address_Of_Employer[0]": "<%= form.data.dig('Name_And_Address_Of_Employer') %>",
-  "F[0].#subform[1].Hours_Per_Week[0]": "<%= form.data.dig('Hours_Per_Week') %>",
-  "F[0].#subform[1].Date_Of_Employment_From[0]": "<%= form.data.dig('Date_Of_Employment_From') %>",
-  "F[0].#subform[1].Date_Of_Employment_To[0]": "<%= form.data.dig('Date_Of_Employment_To') %>",
-  "F[0].#subform[1].Gross_Earnings_Per_Month[1]": "<%= form.data.dig('Gross_Earnings_Per_Month') %>",
-  "F[0].#subform[1].Date_Of_Employment_To[1]": "<%= form.data.dig('Date_Of_Employment_To') %>",
-  "F[0].#subform[1].Date_Of_Employment_From[1]": "<%= form.data.dig('Date_Of_Employment_From') %>",
-  "F[0].#subform[1].Hours_Per_Week[1]": "<%= form.data.dig('Hours_Per_Week') %>",
   "F[0].#subform[1].Name_And_Address_Of_Employer[1]": "<%= form.data.dig('Name_And_Address_Of_Employer') %>",
-  "F[0].#subform[1].Time_Lost_From_Illness[1]": "<%= form.data.dig('Time_Lost_From_Illness') %>",
+  "F[0].#subform[1].Name_And_Address_Of_Employer[2]": "<%= form.data.dig('Name_And_Address_Of_Employer') %>",
+
+  <%# 11B. Type of Work %>
+  "F[0].#subform[1].Type_Of_Work[0]": "<%= form.data.dig('Type_Of_Work') %>",
   "F[0].#subform[1].Type_Of_Work[1]": "<%= form.data.dig('Type_Of_Work') %>",
   "F[0].#subform[1].Type_Of_Work[2]": "<%= form.data.dig('Type_Of_Work') %>",
-  "F[0].#subform[1].Time_Lost_From_Illness[2]": "<%= form.data.dig('Time_Lost_From_Illness') %>",
-  "F[0].#subform[1].Name_And_Address_Of_Employer[2]": "<%= form.data.dig('Name_And_Address_Of_Employer') %>",
+
+  <%# 11C. Hours Per Week %>
+  "F[0].#subform[1].Hours_Per_Week[0]": "<%= form.data.dig('Hours_Per_Week') %>",
+  "F[0].#subform[1].Hours_Per_Week[1]": "<%= form.data.dig('Hours_Per_Week') %>",
   "F[0].#subform[1].Hours_Per_Week[2]": "<%= form.data.dig('Hours_Per_Week') %>",
+
+  <%# 11D. Dates of Employment or Self-Employment %>
+  "F[0].#subform[1].Date_Of_Employment_From[0]": "<%= form.data.dig('Date_Of_Employment_From') %>",
+  "F[0].#subform[1].Date_Of_Employment_To[0]": "<%= form.data.dig('Date_Of_Employment_To') %>",
+  "F[0].#subform[1].Date_Of_Employment_From[1]": "<%= form.data.dig('Date_Of_Employment_From') %>",
   "F[0].#subform[1].Date_Of_Employment_From[2]": "<%= form.data.dig('Date_Of_Employment_From') %>",
   "F[0].#subform[1].Date_Of_Employment_To[2]": "<%= form.data.dig('Date_Of_Employment_To') %>",
+  "F[0].#subform[1].Date_Of_Employment_To[1]": "<%= form.data.dig('Date_Of_Employment_To') %>",
+
+  <%# 11E. Time Lost From Illness %>
+  "F[0].#subform[1].Time_Lost_From_Illness[0]": "<%= form.data.dig('Time_Lost_From_Illness') %>",
+  "F[0].#subform[1].Time_Lost_From_Illness[1]": "<%= form.data.dig('Time_Lost_From_Illness') %>",
+  "F[0].#subform[1].Time_Lost_From_Illness[2]": "<%= form.data.dig('Time_Lost_From_Illness') %>",
+
+  <%# 11F. Highest Gross Earnings Per Month %>
+  "F[0].#subform[1].Gross_Earnings_Per_Month[0]": "<%= form.data.dig('Gross_Earnings_Per_Month') %>",
+  "F[0].#subform[1].Gross_Earnings_Per_Month[1]": "<%= form.data.dig('Gross_Earnings_Per_Month') %>",
   "F[0].#subform[1].Gross_Earnings_Per_Month[2]": "<%= form.data.dig('Gross_Earnings_Per_Month') %>",
+
+  "F[0].#subform[1].DateSigned[0]": "<%= form.data.dig('DateSigned') %>",
+  "F[0].#subform[1].SignatureField1[0]": "<%= form.data.dig('SignatureField1') %>",
   "F[0].#subform[1].SignatureField1[1]": "<%= form.data.dig('SignatureField1') %>",
   "F[0].#subform[1].DateSigned[1]": "<%= form.data.dig('DateSigned') %>"
 }

--- a/modules/simple_forms_api/app/form_mappings/vba_21_4140.json.erb
+++ b/modules/simple_forms_api/app/form_mappings/vba_21_4140.json.erb
@@ -67,7 +67,7 @@
   "F[0].Page_1[0].Date_Of_Employment_To[0]": "<%= form.employment_history[0].date_ended %>",
 
   <%# 11E. Time Lost From Illness %>
-  "F[0].Page_1[0].Time_Lost_From_Illness[0]": "<%= form.employment_history[0].time_lost %>",
+  "F[0].Page_1[0].Time_Lost_From_Illness[0]": "<%= form.employment_history[0].lost_time %>",
 
   <%# 11F. Highest Gross Earnings Per Month %>
   "F[0].Page_1[0].Gross_Earnings_Per_Month[0]": "<%= form.employment_history[0].highest_income %>",
@@ -80,37 +80,37 @@
 
   <%# Section II - Employment Certification (Continued) %>
   <%# 11A. Name and Address of Employer %>
-  "F[0].#subform[1].Name_And_Address_Of_Employer[0]": "<%= form.employment_history[1].name_and_address %>",
+  "F[0].#subform[1].Name_And_Address_Of_Employer[0]": "<%= form.employment_history[3].name_and_address %>",
   "F[0].#subform[1].Name_And_Address_Of_Employer[1]": "<%= form.employment_history[2].name_and_address %>",
-  "F[0].#subform[1].Name_And_Address_Of_Employer[2]": "<%= form.employment_history[3].name_and_address %>",
+  "F[0].#subform[1].Name_And_Address_Of_Employer[2]": "<%= form.employment_history[1].name_and_address %>",
 
   <%# 11B. Type of Work %>
-  "F[0].#subform[1].Type_Of_Work[0]": "<%= form.employment_history[1].type_of_work %>",
+  "F[0].#subform[1].Type_Of_Work[0]": "<%= form.employment_history[3].type_of_work %>",
   "F[0].#subform[1].Type_Of_Work[1]": "<%= form.employment_history[2].type_of_work %>",
-  "F[0].#subform[1].Type_Of_Work[2]": "<%= form.employment_history[3].type_of_work %>",
+  "F[0].#subform[1].Type_Of_Work[2]": "<%= form.employment_history[1].type_of_work %>",
 
   <%# 11C. Hours Per Week %>
-  "F[0].#subform[1].Hours_Per_Week[0]": "<%= form.employment_history[1].hours_per_week %>",
+  "F[0].#subform[1].Hours_Per_Week[0]": "<%= form.employment_history[3].hours_per_week %>",
   "F[0].#subform[1].Hours_Per_Week[1]": "<%= form.employment_history[2].hours_per_week %>",
-  "F[0].#subform[1].Hours_Per_Week[2]": "<%= form.employment_history[3].hours_per_week %>",
+  "F[0].#subform[1].Hours_Per_Week[2]": "<%= form.employment_history[1].hours_per_week %>",
 
   <%# 11D. Dates of Employment or Self-Employment %>
-  "F[0].#subform[1].Date_Of_Employment_From[0]": "<%= form.employment_history[1].date_started %>",
-  "F[0].#subform[1].Date_Of_Employment_To[0]": "<%= form.employment_history[1].date_ended %>",
+  "F[0].#subform[1].Date_Of_Employment_From[0]": "<%= form.employment_history[3].date_started %>",
+  "F[0].#subform[1].Date_Of_Employment_To[0]": "<%= form.employment_history[3].date_ended %>",
   "F[0].#subform[1].Date_Of_Employment_From[1]": "<%= form.employment_history[2].date_started %>",
   "F[0].#subform[1].Date_Of_Employment_To[1]": "<%= form.employment_history[2].date_ended %>",
-  "F[0].#subform[1].Date_Of_Employment_From[2]": "<%= form.employment_history[3].date_started %>",
-  "F[0].#subform[1].Date_Of_Employment_To[2]": "<%= form.employment_history[3].date_ended %>",
+  "F[0].#subform[1].Date_Of_Employment_From[2]": "<%= form.employment_history[1].date_started %>",
+  "F[0].#subform[1].Date_Of_Employment_To[2]": "<%= form.employment_history[1].date_ended %>",
 
   <%# 11E. Time Lost From Illness %>
-  "F[0].#subform[1].Time_Lost_From_Illness[0]": "<%= form.employment_history[1].time_lost %>",
-  "F[0].#subform[1].Time_Lost_From_Illness[1]": "<%= form.employment_history[2].time_lost %>",
-  "F[0].#subform[1].Time_Lost_From_Illness[2]": "<%= form.employment_history[3].time_lost %>",
+  "F[0].#subform[1].Time_Lost_From_Illness[0]": "<%= form.employment_history[3].lost_time %>",
+  "F[0].#subform[1].Time_Lost_From_Illness[1]": "<%= form.employment_history[2].lost_time %>",
+  "F[0].#subform[1].Time_Lost_From_Illness[2]": "<%= form.employment_history[1].lost_time %>",
 
   <%# 11F. Highest Gross Earnings Per Month %>
-  "F[0].#subform[1].Gross_Earnings_Per_Month[0]": "<%= form.employment_history[1].highest_income %>",
-  "F[0].#subform[1].Gross_Earnings_Per_Month[1]": "<%= form.employment_history[2].highest_income %>",
-  "F[0].#subform[1].Gross_Earnings_Per_Month[2]": "<%= form.employment_history[3].highest_income %>",
+  "F[0].#subform[1].Gross_Earnings_Per_Month[0]": "<%= form.employment_history[2].highest_income %>",
+  "F[0].#subform[1].Gross_Earnings_Per_Month[1]": "<%= form.employment_history[3].highest_income %>",
+  "F[0].#subform[1].Gross_Earnings_Per_Month[2]": "<%= form.employment_history[1].highest_income %>",
 
   "F[0].#subform[1].DateSigned[0]": "<%= form.data.dig('DateSigned') %>",
   "F[0].#subform[1].SignatureField1[0]": "<%= form.data.dig('SignatureField1') %>",

--- a/modules/simple_forms_api/app/form_mappings/vba_21_4140.json.erb
+++ b/modules/simple_forms_api/app/form_mappings/vba_21_4140.json.erb
@@ -54,23 +54,23 @@
 
   <%# Section II - Employment Certification %>
   <%# 11A. Name and Address of Employer %>
-  "F[0].Page_1[0].Name_And_Address_Of_Employer[0]": "<%= form.data.dig('Name_And_Address_Of_Employer') %>",
+  "F[0].Page_1[0].Name_And_Address_Of_Employer[0]": "<%= form.employment_history[0].name_and_address %>",
 
   <%# 11B. Type of Work %>
-  "F[0].Page_1[0].Type_Of_Work[0]": "<%= form.data.dig('Type_Of_Work') %>",
+  "F[0].Page_1[0].Type_Of_Work[0]": "<%= form.employment_history[0].type_of_work %>",
 
   <%# 11C. Hours Per Week %>
-  "F[0].Page_1[0].Hours_Per_Week[0]": "<%= form.data.dig('Hours_Per_Week') %>",
+  "F[0].Page_1[0].Hours_Per_Week[0]": "<%= form.employment_history[0].hours_per_week %>",
 
   <%# 11D. Dates of Employment or Self-Employment %>
-  "F[0].Page_1[0].Date_Of_Employment_From[0]": "<%= form.data.dig('Date_Of_Employment_From') %>",
-  "F[0].Page_1[0].Date_Of_Employment_To[0]": "<%= form.data.dig('Date_Of_Employment_To') %>",
+  "F[0].Page_1[0].Date_Of_Employment_From[0]": "<%= form.employment_history[0].date_started %>",
+  "F[0].Page_1[0].Date_Of_Employment_To[0]": "<%= form.employment_history[0].date_ended %>",
 
   <%# 11E. Time Lost From Illness %>
-  "F[0].Page_1[0].Time_Lost_From_Illness[0]": "<%= form.data.dig('Time_Lost_From_Illness') %>",
+  "F[0].Page_1[0].Time_Lost_From_Illness[0]": "<%= form.employment_history[0].time_lost %>",
 
   <%# 11F. Highest Gross Earnings Per Month %>
-  "F[0].Page_1[0].Gross_Earnings_Per_Month[0]": "<%= form.data.dig('Gross_Earnings_Per_Month') %>",
+  "F[0].Page_1[0].Gross_Earnings_Per_Month[0]": "<%= form.employment_history[0].highest_income %>",
 
   <%# Page 2 %>
   <%# Veteran's Social Security No. %>
@@ -80,37 +80,37 @@
 
   <%# Section II - Employment Certification (Continued) %>
   <%# 11A. Name and Address of Employer %>
-  "F[0].#subform[1].Name_And_Address_Of_Employer[0]": "<%= form.data.dig('Name_And_Address_Of_Employer') %>",
-  "F[0].#subform[1].Name_And_Address_Of_Employer[1]": "<%= form.data.dig('Name_And_Address_Of_Employer') %>",
-  "F[0].#subform[1].Name_And_Address_Of_Employer[2]": "<%= form.data.dig('Name_And_Address_Of_Employer') %>",
+  "F[0].#subform[1].Name_And_Address_Of_Employer[0]": "<%= form.employment_history[1].name_and_address %>",
+  "F[0].#subform[1].Name_And_Address_Of_Employer[1]": "<%= form.employment_history[2].name_and_address %>",
+  "F[0].#subform[1].Name_And_Address_Of_Employer[2]": "<%= form.employment_history[3].name_and_address %>",
 
   <%# 11B. Type of Work %>
-  "F[0].#subform[1].Type_Of_Work[0]": "<%= form.data.dig('Type_Of_Work') %>",
-  "F[0].#subform[1].Type_Of_Work[1]": "<%= form.data.dig('Type_Of_Work') %>",
-  "F[0].#subform[1].Type_Of_Work[2]": "<%= form.data.dig('Type_Of_Work') %>",
+  "F[0].#subform[1].Type_Of_Work[0]": "<%= form.employment_history[1].type_of_work %>",
+  "F[0].#subform[1].Type_Of_Work[1]": "<%= form.employment_history[2].type_of_work %>",
+  "F[0].#subform[1].Type_Of_Work[2]": "<%= form.employment_history[3].type_of_work %>",
 
   <%# 11C. Hours Per Week %>
-  "F[0].#subform[1].Hours_Per_Week[0]": "<%= form.data.dig('Hours_Per_Week') %>",
-  "F[0].#subform[1].Hours_Per_Week[1]": "<%= form.data.dig('Hours_Per_Week') %>",
-  "F[0].#subform[1].Hours_Per_Week[2]": "<%= form.data.dig('Hours_Per_Week') %>",
+  "F[0].#subform[1].Hours_Per_Week[0]": "<%= form.employment_history[1].hours_per_week %>",
+  "F[0].#subform[1].Hours_Per_Week[1]": "<%= form.employment_history[2].hours_per_week %>",
+  "F[0].#subform[1].Hours_Per_Week[2]": "<%= form.employment_history[3].hours_per_week %>",
 
   <%# 11D. Dates of Employment or Self-Employment %>
-  "F[0].#subform[1].Date_Of_Employment_From[0]": "<%= form.data.dig('Date_Of_Employment_From') %>",
-  "F[0].#subform[1].Date_Of_Employment_To[0]": "<%= form.data.dig('Date_Of_Employment_To') %>",
-  "F[0].#subform[1].Date_Of_Employment_From[1]": "<%= form.data.dig('Date_Of_Employment_From') %>",
-  "F[0].#subform[1].Date_Of_Employment_From[2]": "<%= form.data.dig('Date_Of_Employment_From') %>",
-  "F[0].#subform[1].Date_Of_Employment_To[2]": "<%= form.data.dig('Date_Of_Employment_To') %>",
-  "F[0].#subform[1].Date_Of_Employment_To[1]": "<%= form.data.dig('Date_Of_Employment_To') %>",
+  "F[0].#subform[1].Date_Of_Employment_From[0]": "<%= form.employment_history[1].date_started %>",
+  "F[0].#subform[1].Date_Of_Employment_To[0]": "<%= form.employment_history[1].date_ended %>",
+  "F[0].#subform[1].Date_Of_Employment_From[1]": "<%= form.employment_history[2].date_started %>",
+  "F[0].#subform[1].Date_Of_Employment_To[1]": "<%= form.employment_history[2].date_ended %>",
+  "F[0].#subform[1].Date_Of_Employment_From[2]": "<%= form.employment_history[3].date_started %>",
+  "F[0].#subform[1].Date_Of_Employment_To[2]": "<%= form.employment_history[3].date_ended %>",
 
   <%# 11E. Time Lost From Illness %>
-  "F[0].#subform[1].Time_Lost_From_Illness[0]": "<%= form.data.dig('Time_Lost_From_Illness') %>",
-  "F[0].#subform[1].Time_Lost_From_Illness[1]": "<%= form.data.dig('Time_Lost_From_Illness') %>",
-  "F[0].#subform[1].Time_Lost_From_Illness[2]": "<%= form.data.dig('Time_Lost_From_Illness') %>",
+  "F[0].#subform[1].Time_Lost_From_Illness[0]": "<%= form.employment_history[1].time_lost %>",
+  "F[0].#subform[1].Time_Lost_From_Illness[1]": "<%= form.employment_history[2].time_lost %>",
+  "F[0].#subform[1].Time_Lost_From_Illness[2]": "<%= form.employment_history[3].time_lost %>",
 
   <%# 11F. Highest Gross Earnings Per Month %>
-  "F[0].#subform[1].Gross_Earnings_Per_Month[0]": "<%= form.data.dig('Gross_Earnings_Per_Month') %>",
-  "F[0].#subform[1].Gross_Earnings_Per_Month[1]": "<%= form.data.dig('Gross_Earnings_Per_Month') %>",
-  "F[0].#subform[1].Gross_Earnings_Per_Month[2]": "<%= form.data.dig('Gross_Earnings_Per_Month') %>",
+  "F[0].#subform[1].Gross_Earnings_Per_Month[0]": "<%= form.employment_history[1].highest_income %>",
+  "F[0].#subform[1].Gross_Earnings_Per_Month[1]": "<%= form.employment_history[2].highest_income %>",
+  "F[0].#subform[1].Gross_Earnings_Per_Month[2]": "<%= form.employment_history[3].highest_income %>",
 
   "F[0].#subform[1].DateSigned[0]": "<%= form.data.dig('DateSigned') %>",
   "F[0].#subform[1].SignatureField1[0]": "<%= form.data.dig('SignatureField1') %>",

--- a/modules/simple_forms_api/app/models/form_engine/employment_history.rb
+++ b/modules/simple_forms_api/app/models/form_engine/employment_history.rb
@@ -6,16 +6,33 @@ module SimpleFormsApi
       attr_reader :date_ended, :date_started, :hours_per_week, :lost_time, :type_of_work
 
       def initialize(data)
+        @city = data.dig('address', 'city')
+        @country = data.dig('address', 'country')
         @data = data
         @date_ended = data.dig('date_range', 'to')
         @date_started = data.dig('date_range', 'from')
         @hours_per_week = data['hours_per_week']
         @lost_time = data['lost_time']
+        @name = data['name']
+        @postal_code = data.dig('address', 'postal_code')
+        @state = data.dig('address', 'state')
+        @street = data.dig('address', 'street')
         @type_of_work = data['type_of_work']
       end
 
       def highest_income
         ActiveSupport::NumberHelper.number_to_currency(@data['highest_income'])
+      end
+
+      def name_and_address
+        output = []
+
+        output << @name
+        output << @street
+        output << "#{@city}, #{@state} #{@postal_code}"
+        output << IsoCountryCodes.find(@country).name
+
+        output.join("\n")
       end
     end
   end

--- a/modules/simple_forms_api/app/models/form_engine/employment_history.rb
+++ b/modules/simple_forms_api/app/models/form_engine/employment_history.rb
@@ -1,59 +1,57 @@
 # frozen_string_literal: true
 
-module SimpleFormsApi
-  module FormEngine
-    class EmploymentHistory
-      attr_reader :date_ended,
-                  :date_started,
-                  :highest_income,
-                  :hours_per_week,
-                  :lost_time,
-                  :name_and_address,
-                  :type_of_work
+module FormEngine
+  class EmploymentHistory
+    attr_reader :date_ended,
+                :date_started,
+                :highest_income,
+                :hours_per_week,
+                :lost_time,
+                :name_and_address,
+                :type_of_work
 
-      def initialize(data)
-        @data = data
+    def initialize(data)
+      @data = data
 
-        set_ivars if data.present?
-      end
+      set_ivars if data.present?
+    end
 
-      private
+    private
 
-      attr_reader :city, :country, :data, :name, :postal_code, :state, :street
+    attr_reader :city, :country, :data, :name, :postal_code, :state, :street
 
-      def format_date(date)
-        date_arr = date.split('-')
+    def format_date(date)
+      date_arr = date.split('-')
 
-        "#{date_arr[1]}/#{date_arr[2]}/#{date_arr[0]}"
-      end
+      "#{date_arr[1]}/#{date_arr[2]}/#{date_arr[0]}"
+    end
 
-      def format_name_and_address
-        output = []
+    def format_name_and_address
+      output = []
 
-        output << name
-        output << street
-        output << "#{city}, #{state} #{postal_code}"
-        output << IsoCountryCodes.find(country).name
+      output << name
+      output << street
+      output << "#{city}, #{state} #{postal_code}"
+      output << IsoCountryCodes.find(country).name
 
-        output.join('\n')
-      end
+      output.join('\n')
+    end
 
-      def set_ivars
-        @city = data.dig('address', 'city')
-        @country = data.dig('address', 'country')
-        @date_ended = format_date(data.dig('date_range', 'to'))
-        @date_started = format_date(data.dig('date_range', 'from'))
-        @highest_income = ActiveSupport::NumberHelper.number_to_currency(data['highest_income'])
-        @hours_per_week = data['hours_per_week']
-        @lost_time = data['lost_time']
-        @name = data['name']
-        @postal_code = data.dig('address', 'postal_code')
-        @state = data.dig('address', 'state')
-        @street = data.dig('address', 'street')
-        @type_of_work = data['type_of_work']
+    def set_ivars
+      @city = data.dig('address', 'city')
+      @country = data.dig('address', 'country')
+      @date_ended = format_date(data.dig('date_range', 'to'))
+      @date_started = format_date(data.dig('date_range', 'from'))
+      @highest_income = ActiveSupport::NumberHelper.number_to_currency(data['highest_income'])
+      @hours_per_week = data['hours_per_week']
+      @lost_time = data['lost_time']
+      @name = data['name']
+      @postal_code = data.dig('address', 'postal_code')
+      @state = data.dig('address', 'state')
+      @street = data.dig('address', 'street')
+      @type_of_work = data['type_of_work']
 
-        @name_and_address = format_name_and_address
-      end
+      @name_and_address = format_name_and_address
     end
   end
 end

--- a/modules/simple_forms_api/app/models/form_engine/employment_history.rb
+++ b/modules/simple_forms_api/app/models/form_engine/employment_history.rb
@@ -29,7 +29,7 @@ module SimpleFormsApi
         output << "#{city}, #{state} #{postal_code}"
         output << IsoCountryCodes.find(country).name
 
-        output.join("\n")
+        output.join('\n')
       end
 
       def set_ivars

--- a/modules/simple_forms_api/app/models/form_engine/employment_history.rb
+++ b/modules/simple_forms_api/app/models/form_engine/employment_history.rb
@@ -3,14 +3,41 @@
 module SimpleFormsApi
   module FormEngine
     class EmploymentHistory
-      attr_reader :date_ended, :date_started, :hours_per_week, :lost_time, :type_of_work
+      attr_reader :date_ended,
+                  :date_started,
+                  :highest_income,
+                  :hours_per_week,
+                  :lost_time,
+                  :name_and_address,
+                  :type_of_work
 
       def initialize(data)
+        @data = data
+
+        set_ivars if data.present?
+      end
+
+      private
+
+      attr_reader :city, :country, :data, :name, :postal_code, :state, :street
+
+      def format_name_and_address
+        output = []
+
+        output << name
+        output << street
+        output << "#{city}, #{state} #{postal_code}"
+        output << IsoCountryCodes.find(country).name
+
+        output.join("\n")
+      end
+
+      def set_ivars
         @city = data.dig('address', 'city')
         @country = data.dig('address', 'country')
-        @data = data
         @date_ended = data.dig('date_range', 'to')
         @date_started = data.dig('date_range', 'from')
+        @highest_income = ActiveSupport::NumberHelper.number_to_currency(data['highest_income'])
         @hours_per_week = data['hours_per_week']
         @lost_time = data['lost_time']
         @name = data['name']
@@ -18,21 +45,8 @@ module SimpleFormsApi
         @state = data.dig('address', 'state')
         @street = data.dig('address', 'street')
         @type_of_work = data['type_of_work']
-      end
 
-      def highest_income
-        ActiveSupport::NumberHelper.number_to_currency(@data['highest_income'])
-      end
-
-      def name_and_address
-        output = []
-
-        output << @name
-        output << @street
-        output << "#{@city}, #{@state} #{@postal_code}"
-        output << IsoCountryCodes.find(@country).name
-
-        output.join("\n")
+        @name_and_address = format_name_and_address
       end
     end
   end

--- a/modules/simple_forms_api/app/models/form_engine/employment_history.rb
+++ b/modules/simple_forms_api/app/models/form_engine/employment_history.rb
@@ -6,11 +6,16 @@ module SimpleFormsApi
       attr_reader :date_ended, :date_started, :hours_per_week, :lost_time, :type_of_work
 
       def initialize(data)
+        @data = data
         @date_ended = data.dig('date_range', 'to')
         @date_started = data.dig('date_range', 'from')
         @hours_per_week = data['hours_per_week']
         @lost_time = data['lost_time']
         @type_of_work = data['type_of_work']
+      end
+
+      def highest_income
+        ActiveSupport::NumberHelper.number_to_currency(@data['highest_income'])
       end
     end
   end

--- a/modules/simple_forms_api/app/models/form_engine/employment_history.rb
+++ b/modules/simple_forms_api/app/models/form_engine/employment_history.rb
@@ -21,6 +21,12 @@ module SimpleFormsApi
 
       attr_reader :city, :country, :data, :name, :postal_code, :state, :street
 
+      def format_date(date)
+        date_arr = date.split('-')
+
+        "#{date_arr[1]}/#{date_arr[2]}/#{date_arr[0]}"
+      end
+
       def format_name_and_address
         output = []
 
@@ -35,8 +41,8 @@ module SimpleFormsApi
       def set_ivars
         @city = data.dig('address', 'city')
         @country = data.dig('address', 'country')
-        @date_ended = data.dig('date_range', 'to')
-        @date_started = data.dig('date_range', 'from')
+        @date_ended = format_date(data.dig('date_range', 'to'))
+        @date_started = format_date(data.dig('date_range', 'from'))
         @highest_income = ActiveSupport::NumberHelper.number_to_currency(data['highest_income'])
         @hours_per_week = data['hours_per_week']
         @lost_time = data['lost_time']

--- a/modules/simple_forms_api/app/models/form_engine/employment_history.rb
+++ b/modules/simple_forms_api/app/models/form_engine/employment_history.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SimpleFormsApi
+  module FormEngine
+    class EmploymentHistory
+      attr_reader :date_ended, :date_started, :hours_per_week, :lost_time, :type_of_work
+
+      def initialize(data)
+        @date_ended = data.dig('date_range', 'to')
+        @date_started = data.dig('date_range', 'from')
+        @hours_per_week = data['hours_per_week']
+        @lost_time = data['lost_time']
+        @type_of_work = data['type_of_work']
+      end
+    end
+  end
+end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4140.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4140.rb
@@ -35,7 +35,7 @@ module SimpleFormsApi
     end
 
     def employment_history
-      [*0..3].map { |_i| SimpleFormsApi::FormEngine::EmploymentHistory.new }
+      [*0..3].map { |i| SimpleFormsApi::FormEngine::EmploymentHistory.new(data['employers'][i]) }
     end
 
     def first_name

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4140.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4140.rb
@@ -31,11 +31,11 @@ module SimpleFormsApi
     end
 
     def employed?
-      data['employers'].size.positive?
+      data['employers'] ? data['employers'].size.positive? : false
     end
 
     def employment_history
-      [*0..3].map { |i| SimpleFormsApi::FormEngine::EmploymentHistory.new(data['employers'][i]) }
+      [*0..3].map { |i| FormEngine::EmploymentHistory.new(data['employers'][i]) }
     end
 
     def first_name

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4140.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4140.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../form_engine/address'
+require_rel '../form_engine'
 
 module SimpleFormsApi
   class VBA214140 < BaseForm
@@ -28,6 +28,14 @@ module SimpleFormsApi
       trimmed_dob = data['date_of_birth']&.tr('-', '')
 
       [trimmed_dob&.[](0..3), trimmed_dob&.[](4..5), trimmed_dob&.[](6..7)]
+    end
+
+    def employed?
+      data['employers'].size.positive?
+    end
+
+    def employment_history
+      [*0..3].map { |_i| SimpleFormsApi::FormEngine::EmploymentHistory.new }
     end
 
     def first_name

--- a/modules/simple_forms_api/spec/fixtures/form_json/vba_21_4140-min.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/vba_21_4140-min.json
@@ -20,44 +20,6 @@
       "middle": "Test",
       "last": "Mephistopheles-Reinhardt"
    },
-   "employers": [
-      {
-         "type_of_work": "Full-time",
-         "hours_per_week": "40",
-         "lost_time": "13",
-         "highest_income": "2300",
-         "date_range": {
-            "from": "2018-03-15",
-            "to": "2020-06-30"
-         },
-         "name": "Test Employer",
-         "address": {
-            "country": "USA",
-            "street": "1234 Executive Ave",
-            "city": "Metropolis",
-            "state": "CA",
-            "postal_code": "90210"
-         }
-      },
-      {
-         "type_of_work": "Freelance",
-         "hours_per_week": "20",
-         "lost_time": "30",
-         "highest_income": "1300",
-         "date_range": {
-            "from": "2020-07-01",
-            "to": "2022-09-13"
-         },
-         "name": "Freelancer",
-         "address": {
-            "country": "USA",
-            "street": "123 Test St",
-            "city": "Test City",
-            "state": "CA",
-            "postal_code": "90210"
-         }
-      }
-   ],
    "statement_of_truth_signature": "Example Test User",
    "statement_of_truth_certified": true,
    "form_number": "21-4140"

--- a/modules/simple_forms_api/spec/fixtures/form_json/vba_21_4140.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/vba_21_4140.json
@@ -58,7 +58,26 @@
             "state": "CA",
             "postal_code": "90210"
          }
-      }
+      },
+      {
+         "type_of_work": "Sub-contractor",
+         "hours_per_week": "60",
+         "lost_time": "56",
+         "highest_income": "600",
+         "date_range": {
+            "from": "2022-10-11",
+            "to": "2024-04-07"
+         },
+         "name": "Example Construction Company",
+         "address": {
+            "country": "CAN",
+            "street": "4321 Example Ave",
+            "city": "Test City",
+            "state": "NS",
+            "postal_code": "M4B 1G5"
+         }
+      },
+      {}
    ],
    "statement_of_truth_signature": "Example Test User",
    "statement_of_truth_certified": true,

--- a/modules/simple_forms_api/spec/models/form_engine/employment_history_spec.rb
+++ b/modules/simple_forms_api/spec/models/form_engine/employment_history_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe SimpleFormsApi::FormEngine::EmploymentHistory do
   end
 
   describe '#name_and_address' do
-    it 'returns a multi-line string'
+    subject(:name_and_address) { employment_history.name_and_address }
+
+    it 'returns a multi-line string' do
+      expect(name_and_address).to(
+        eq(
+          "#{data['name']}\n" \
+          "#{data.dig('address', 'street')}\n" \
+          "#{data.dig('address', 'city')}, " \
+          "#{data.dig('address', 'state')} #{data.dig('address', 'postal_code')}\n" \
+          'United States of America'
+        )
+      )
+    end
   end
 end

--- a/modules/simple_forms_api/spec/models/form_engine/employment_history_spec.rb
+++ b/modules/simple_forms_api/spec/models/form_engine/employment_history_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require_relative '../../../app/models/form_engine/employment_history'
 
-RSpec.describe SimpleFormsApi::FormEngine::EmploymentHistory do
+RSpec.describe FormEngine::EmploymentHistory do
   subject(:employment_history) { described_class.new(data) }
 
   let(:fixture_file) { 'vba_21_4140.json' }

--- a/modules/simple_forms_api/spec/models/form_engine/employment_history_spec.rb
+++ b/modules/simple_forms_api/spec/models/form_engine/employment_history_spec.rb
@@ -12,12 +12,26 @@ RSpec.describe SimpleFormsApi::FormEngine::EmploymentHistory do
   end
   let(:data) { JSON.parse(fixture_path.read)['employers'][0] }
 
+  shared_examples 'properly formatted date' do
+    it { is_expected.to match(%r{\d{2}/\d{2}/\d{4}}) }
+  end
+
   it 'sets the correct attributes' do
-    expect(employment_history.date_ended).to eq data.dig('date_range', 'to')
-    expect(employment_history.date_started).to eq data.dig('date_range', 'from')
     expect(employment_history.hours_per_week).to eq data['hours_per_week']
     expect(employment_history.lost_time).to eq data['lost_time']
     expect(employment_history.type_of_work).to eq data['type_of_work']
+  end
+
+  describe '.date_ended' do
+    subject { employment_history.date_ended }
+
+    it_behaves_like 'properly formatted date'
+  end
+
+  describe '.date_started' do
+    subject { employment_history.date_started }
+
+    it_behaves_like 'properly formatted date'
   end
 
   describe '#highest_income' do

--- a/modules/simple_forms_api/spec/models/form_engine/employment_history_spec.rb
+++ b/modules/simple_forms_api/spec/models/form_engine/employment_history_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe SimpleFormsApi::FormEngine::EmploymentHistory do
   end
 
   describe '#highest_income' do
-    it 'returns a currency string'
+    subject { employment_history.highest_income }
+
+    it { is_expected.to eq '$2,300.00' }
   end
 
   describe '#name_and_address' do

--- a/modules/simple_forms_api/spec/models/form_engine/employment_history_spec.rb
+++ b/modules/simple_forms_api/spec/models/form_engine/employment_history_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../../app/models/form_engine/employment_history'
+
+RSpec.describe SimpleFormsApi::FormEngine::EmploymentHistory do
+  subject(:employment_history) { described_class.new(data) }
+
+  let(:fixture_file) { 'vba_21_4140.json' }
+  let(:fixture_path) do
+    Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', fixture_file)
+  end
+  let(:data) { JSON.parse(fixture_path.read)['employers'][0] }
+
+  it 'sets the correct attributes' do
+    expect(employment_history.date_ended).to eq data.dig('date_range', 'to')
+    expect(employment_history.date_started).to eq data.dig('date_range', 'from')
+    expect(employment_history.hours_per_week).to eq data['hours_per_week']
+    expect(employment_history.lost_time).to eq data['lost_time']
+    expect(employment_history.type_of_work).to eq data['type_of_work']
+  end
+
+  describe '#highest_income' do
+    it 'returns a currency string'
+  end
+
+  describe '#name_and_address' do
+    it 'returns a multi-line string'
+  end
+end

--- a/modules/simple_forms_api/spec/models/form_engine/employment_history_spec.rb
+++ b/modules/simple_forms_api/spec/models/form_engine/employment_history_spec.rb
@@ -32,11 +32,7 @@ RSpec.describe SimpleFormsApi::FormEngine::EmploymentHistory do
     it 'returns a multi-line string' do
       expect(name_and_address).to(
         eq(
-          "#{data['name']}\n" \
-          "#{data.dig('address', 'street')}\n" \
-          "#{data.dig('address', 'city')}, " \
-          "#{data.dig('address', 'state')} #{data.dig('address', 'postal_code')}\n" \
-          'United States of America'
+          'Test Employer\\n1234 Executive Ave\\nMetropolis, CA 90210\\nUnited States of America'
         )
       )
     end

--- a/modules/simple_forms_api/spec/models/vba_21_4140_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_21_4140_spec.rb
@@ -85,9 +85,9 @@ RSpec.describe SimpleFormsApi::VBA214140 do
 
     it 'returns an array of four EmploymentHistory instances' do
       expect(employment_history.length).to eq 4
-      expect(employment_history[0]).to be_a SimpleFormsApi::FormEngine::EmploymentHistory
+      expect(employment_history[0]).to be_a FormEngine::EmploymentHistory
       expect(employment_history[0].lost_time).to eq data['employers'][0]['lost_time']
-      expect(employment_history[3]).to be_a SimpleFormsApi::FormEngine::EmploymentHistory
+      expect(employment_history[3]).to be_a FormEngine::EmploymentHistory
       expect(employment_history[3].lost_time).to eq nil
     end
   end

--- a/modules/simple_forms_api/spec/models/vba_21_4140_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_21_4140_spec.rb
@@ -2,7 +2,6 @@
 
 require 'rails_helper'
 require_relative '../support/shared_examples_for_base_form'
-require_relative '../../app/models/form_engine/address'
 
 RSpec.describe SimpleFormsApi::VBA214140 do
   subject(:form) { described_class.new(data) }
@@ -64,6 +63,32 @@ RSpec.describe SimpleFormsApi::VBA214140 do
         expect(month).to eq nil
         expect(day).to eq nil
       end
+    end
+  end
+
+  describe '#employed?' do
+    subject { form.employed? }
+
+    context 'when employers exist' do
+      it { is_expected.to eq true }
+    end
+
+    context 'when employers do not exist' do
+      let(:fixture_file) { 'vba_21_4140-min.json' }
+
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe '#employment_history' do
+    subject(:employment_history) { form.employment_history }
+
+    it 'returns an array of four EmploymentHistory instances' do
+      expect(employment_history.length).to eq 4
+      expect(employment_history[0]).to be_a SimpleFormsApi::FormEngine::EmploymentHistory
+      expect(employment_history[0].lost_time).to eq data['employers'][0]['lost_time']
+      expect(employment_history[3]).to be_a SimpleFormsApi::FormEngine::EmploymentHistory
+      expect(employment_history[3].lost_time).to eq nil
     end
   end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This should be the penultimate PR spawned from https://github.com/department-of-veterans-affairs/va.gov-team/issues/93461 due to LOC limitations. There should be one more PR after this.
- Adds `#employment_history` and `#employed?` to `VBA214140`.
- Maps employment history submission data to the 21-4140 PDF template.
- Creates a `FormEngine::EmploymentHistory` class to handle employment history data.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93461

## Testing done

- [x] *New code is covered by unit tests*
- Unit tests for the new `FormEngine::EmploymentHistory` class
- Unit tests for the `#employment_history` and `#employed?` instance methods

## What areas of the site does it impact?
At the moment, none. It will ultimately impact the Simple Forms API, adding support for the 21-4140 form.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
