### PR TITLE
[VI-976] Removing email requirement to call MHV Account Creator API

### DIFF
--- a/app/services/mhv/user_account/creator.rb
+++ b/app/services/mhv/user_account/creator.rb
@@ -71,7 +71,6 @@ module MHV
       def validate!
         errors = [
           ('ICN must be present' if icn.blank?),
-          ('Email must be present' if email.blank?),
           ('Current terms of use agreement must be present' if current_tou_agreement.blank?),
           ("Current terms of use agreement must be 'accepted'" unless current_tou_agreement&.accepted?)
         ].compact

--- a/spec/controllers/v0/user/mhv_user_accounts_controller_spec.rb
+++ b/spec/controllers/v0/user/mhv_user_accounts_controller_spec.rb
@@ -82,13 +82,6 @@ describe V0::User::MHVUserAccountsController, type: :controller do
           it_behaves_like 'an unprocessable entity'
         end
 
-        context 'when the user does not have an email' do
-          let(:user_credential_email) { nil }
-          let(:expected_errors) { [{ title: 'Validation error', detail: 'Email must be present' }] }
-
-          it_behaves_like 'an unprocessable entity'
-        end
-
         context 'when the user does not have a terms of use agreement' do
           let(:terms_of_use_agreement) { nil }
           let(:expected_errors) do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1462,13 +1462,6 @@ RSpec.describe User, type: :model do
           it_behaves_like 'mhv_user_account error'
         end
 
-        context 'when the user does not have a user_credential_email' do
-          let(:user_credential_email) { nil }
-          let(:expected_error_message) { 'Email must be present' }
-
-          it_behaves_like 'mhv_user_account error'
-        end
-
         context 'when the user does not have an icn' do
           let(:icn) { nil }
           let(:expected_error_message) { 'ICN must be present' }

--- a/spec/services/mhv/user_account/creator_spec.rb
+++ b/spec/services/mhv/user_account/creator_spec.rb
@@ -54,13 +54,6 @@ RSpec.describe MHV::UserAccount::Creator do
 
         it_behaves_like 'an invalid creator'
       end
-
-      context 'when email is not present' do
-        let(:user_credential_email) { nil }
-        let(:expected_error_message) { 'Email must be present' }
-
-        it_behaves_like 'an invalid creator'
-      end
     end
 
     context 'when tou_occurred_at is not present' do


### PR DESCRIPTION
## Summary

- This PR removes the email requirement to call the MHV Account Creator API. Some MHV Users don't have an email, so this allows them to successfully call the MHV Account Creation API

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-976

## Testing done
- Logged in locally and confirmed a user with a 'nil' value for `UserVerification.user_credential_email` was able to call the MHV Account creation API


## What areas of the site does it impact?
MHV Account Creation API

## Acceptance criteria

- [ ] Log in with a user
- [ ] In rails console, delete the `UserCredentialEmail` for the user: `user.user_verification.user_credential_email.destroy`
- [ ] Navigate to `localhost:3000/my-health` and confirm `MHVUserAccountsController` was called, and that the MHV Account Creation API was called without a validation error
