### PR TITLE
99356: Reduce frequency of DR SavedClaim status updater jobs

### DIFF
--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -224,10 +224,10 @@ PERIODIC_JOBS = lambda { |mgr| # rubocop:disable Metrics/BlockLength
   # Every 15min job that sends missing Pega statuses to DataDog
   mgr.register('*/15 * * * *', 'IvcChampva::MissingFormStatusJob')
 
-  # Engine version: Hourly jobs that update DR SavedClaims with delete_date
-  mgr.register('10 * * * *', 'DecisionReviews::HlrStatusUpdaterJob')
-  mgr.register('15 * * * *', 'DecisionReviews::NodStatusUpdaterJob')
-  mgr.register('40 * * * *', 'DecisionReviews::ScStatusUpdaterJob')
+  # Engine version: Sync non-final DR SavedClaims to LH status
+  mgr.register('10 0,4,8,12,16,20 * * *', 'DecisionReviews::HlrStatusUpdaterJob')
+  mgr.register('15 1,5,9,13,17,21 * * *', 'DecisionReviews::NodStatusUpdaterJob')
+  mgr.register('30 2,6,10,14,18,22 * * *', 'DecisionReviews::ScStatusUpdaterJob')
 
   # Engine version: Clean SavedClaim records that are past delete date
   mgr.register('0 5 * * *', 'DecisionReviews::DeleteSavedClaimRecordsJob')

--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -225,9 +225,9 @@ PERIODIC_JOBS = lambda { |mgr| # rubocop:disable Metrics/BlockLength
   mgr.register('*/15 * * * *', 'IvcChampva::MissingFormStatusJob')
 
   # Engine version: Sync non-final DR SavedClaims to LH status
-  mgr.register('10 0,4,8,12,16,20 * * *', 'DecisionReviews::HlrStatusUpdaterJob')
-  mgr.register('15 1,5,9,13,17,21 * * *', 'DecisionReviews::NodStatusUpdaterJob')
-  mgr.register('30 2,6,10,14,18,22 * * *', 'DecisionReviews::ScStatusUpdaterJob')
+  mgr.register('10 */4 * * *', 'DecisionReviews::HlrStatusUpdaterJob')
+  mgr.register('15 1-21/4 * * *', 'DecisionReviews::NodStatusUpdaterJob')
+  mgr.register('30 2-22/4 * * *', 'DecisionReviews::ScStatusUpdaterJob')
 
   # Engine version: Clean SavedClaim records that are past delete date
   mgr.register('0 5 * * *', 'DecisionReviews::DeleteSavedClaimRecordsJob')


### PR DESCRIPTION
## Summary
This PR changes the frequency and offset of the SavedClaim status updater jobs to reduce the number of requests to the LH API.

- *This work is behind a feature toggle (flipper): NO*

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/99356

## Testing done
Tested locally.

- [ ] *New code is covered by unit tests* - only updates the periodic job schedule
The old behavior was to run all status updater jobs hourly - this decreases the frequency of each job to 6 times a day.

## What areas of the site does it impact?
Sidekiq jobs to update the SavedClaim table

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
