### PR TITLE
Add diagnostics for VAOS modality error

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -774,7 +774,22 @@ module VAOS
           modality = 'communityCare'
         end
 
-        Rails.logger.info("VAOS appointment id #{appointment[:id]} modality cannot be determined.") if modality.nil?
+        if modality.nil?
+          Rails.logger.info("VAOS appointment id #{appointment[:id]} modality cannot be determined.")
+          if Random.new.rand(10).zero?
+            Rails.logger.info(
+              "VAOS appointment id #{appointment[:id]} modality details.",
+              {
+                service_type: appointment[:service_type],
+                service_category_text: appointment.dig(:service_category, 0, :text),
+                kind: appointment[:kind],
+                atlas: appointment.dig(:telehealth, :atlas),
+                vvs_kind: appointment.dig(:telehealth, :vvs_kind),
+                gfe: appointment.dig(:extension, :patient_has_mobile_gfe)
+              }.to_json
+            )
+          end
+        end
 
         appointment[:modality] = modality
       end

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -774,24 +774,25 @@ module VAOS
           modality = 'communityCare'
         end
 
-        if modality.nil?
-          Rails.logger.info("VAOS appointment id #{appointment[:id]} modality cannot be determined.")
-          if Random.new.rand(10).zero?
-            Rails.logger.info(
-              "VAOS appointment id #{appointment[:id]} modality details.",
-              {
-                service_type: appointment[:service_type],
-                service_category_text: appointment.dig(:service_category, 0, :text),
-                kind: appointment[:kind],
-                atlas: appointment.dig(:telehealth, :atlas),
-                vvs_kind: appointment.dig(:telehealth, :vvs_kind),
-                gfe: appointment.dig(:extension, :patient_has_mobile_gfe)
-              }.to_json
-            )
-          end
-        end
-
+        log_modality_failure(appointment) if modality.nil?
         appointment[:modality] = modality
+      end
+
+      def log_modality_failure(appointment)
+        Rails.logger.info("VAOS appointment id #{appointment[:id]} modality cannot be determined.")
+        if Random.new.rand(10).zero?
+          Rails.logger.info(
+            "VAOS appointment id #{appointment[:id]} modality details.",
+            {
+              service_type: appointment[:service_type],
+              service_category_text: appointment.dig(:service_category, 0, :text),
+              kind: appointment[:kind],
+              atlas: appointment.dig(:telehealth, :atlas),
+              vvs_kind: appointment.dig(:telehealth, :vvs_kind),
+              gfe: appointment.dig(:extension, :patient_has_mobile_gfe)
+            }.to_json
+          )
+        end
       end
 
       def telehealth_modality(appointment)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This PR adds additional diagnostic logs to help us determine the large number of modality parsing failures
- Discussion regarding this issue is in [this slack thread](https://dsva.slack.com/archives/CMNQT72LX/p1734727335423249)
- Appointments (VAOS) Team

## Related issue(s)

- N/A

## Testing done

- Tested locally but the sampling mechanism is not amenable unit testing

## Screenshots
N/A

## What areas of the site does it impact?
Appointments (VAOS)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
