### PR TITLE
Renaming feature toggle to remove . character

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -704,10 +704,10 @@ features:
     actor_type: cookie_id
     description: Enables Appoint a Representative frontend
     enable_in_development: true
-  appoint_a_representative_enable_2.0_features:
+  appoint_a_representative_enable_v2_features:
     actor_type: user
     description: Enables Appoint a Representative 2.0 features for frontend and backend
-    enable_in_development: true  
+    enable_in_development: true
   appoint_a_representative_enable_pdf:
     actor_type: user
     description: Enables Appoint a Representative PDF generation endpoint


### PR DESCRIPTION
## Summary

- Renamed feature toggle to avoid the `.` character

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99977

