### PR TITLE
[10-10EZ] Remove log email diff toggle

### DIFF
--- a/app/sidekiq/hca/log_email_diff_job.rb
+++ b/app/sidekiq/hca/log_email_diff_job.rb
@@ -6,37 +6,6 @@ module HCA
     sidekiq_options retry: false
 
     def perform(in_progress_form_id, user_uuid)
-      if Flipper.enabled?(:hca_log_email_diff_in_progress_form)
-        log_email_difference(in_progress_form_id, user_uuid)
-      else
-        log_email_difference_redis(in_progress_form_id, user_uuid)
-      end
-    end
-
-    def log_email_difference_redis(in_progress_form_id, user_uuid)
-      redis_key = "HCA::LogEmailDiffJob:#{user_uuid}"
-      return if $redis.get(redis_key).present?
-
-      in_progress_form = InProgressForm.find_by(id: in_progress_form_id)
-      return if in_progress_form.nil?
-
-      parsed_form = JSON.parse(in_progress_form.form_data)
-      form_email = parsed_form['email']
-
-      return if form_email.blank?
-
-      user = User.find(user_uuid)
-      va_profile_email = user.va_profile_email
-
-      tag_text = va_profile_email&.downcase == form_email.downcase ? 'same' : 'different'
-
-      StatsD.increment(
-        "api.1010ez.in_progress_form_email.#{tag_text}"
-      )
-      $redis.set(redis_key, 't')
-    end
-
-    def log_email_difference(in_progress_form_id, user_uuid)
       return if FormEmailMatchesProfileLog.exists?(user_uuid:, in_progress_form_id:)
 
       in_progress_form = InProgressForm.find_by(id: in_progress_form_id)

--- a/config/features.yml
+++ b/config/features.yml
@@ -126,9 +126,6 @@ features:
   hca_log_form_attachment_create:
     actor_type: user
     description: Enable logging all successful-looking attachment creation calls to Sentry at info-level
-  hca_log_email_diff_in_progress_form:
-    actor_type: user
-    description: Enable using database instead of redis to log email differences between va_profile and in progress forms.
   hca_retrieve_facilities_without_repopulating:
     actor_type: user
     description: Constrain facilities endpoint to only return existing facilities values - even if the table is empty, do not rerun the Job to populate it.

--- a/spec/sidekiq/hca/log_email_diff_job_spec.rb
+++ b/spec/sidekiq/hca/log_email_diff_job_spec.rb
@@ -6,166 +6,83 @@ RSpec.describe HCA::LogEmailDiffJob, type: :job do
   let!(:in_progress_form) { create(:in_progress_1010ez_form_with_email) }
   let!(:user) { create(:user, :loa3) }
 
-  describe 'hca_log_email_diff_in_progress_form enabled' do
-    before do
-      allow(Flipper).to receive(:enabled?).with(:hca_log_email_diff_in_progress_form).and_return(true)
-      allow(Flipper).to receive(:enabled?).with(:remove_pciu, instance_of(User)).and_return(false)
-      in_progress_form.update!(user_uuid: user.uuid)
-      allow(User).to receive(:find).with(user.uuid).and_return(user)
-    end
+  before do
+    allow(Flipper).to receive(:enabled?).with(:remove_pciu, instance_of(User)).and_return(false)
+    in_progress_form.update!(user_uuid: user.uuid)
+    allow(User).to receive(:find).with(user.uuid).and_return(user)
+  end
 
-    def self.expect_does_nothing
-      it 'does nothing' do
-        expect(StatsD).not_to receive(:increment)
+  def self.expect_does_nothing
+    it 'does nothing' do
+      expect(StatsD).not_to receive(:increment)
 
-        subject
+      subject
 
-        expect(FormEmailMatchesProfileLog).not_to receive(:create).with(
-          user_uuid: user.uuid, in_progress_form_id: in_progress_form.id
-        )
-      end
-    end
-
-    def self.expect_email_tag(tag)
-      it "logs that email is #{tag}" do
-        expect do
-          subject
-        end.to trigger_statsd_increment("api.1010ez.in_progress_form_email.#{tag}")
-
-        expect(InProgressForm.where(user_uuid: user.uuid, id: in_progress_form.id)).to exist
-      end
-    end
-
-    describe '#perform' do
-      subject { described_class.new.perform(in_progress_form.id, user.uuid) }
-
-      context 'when the form has been deleted' do
-        before do
-          in_progress_form.destroy!
-        end
-
-        expect_does_nothing
-      end
-
-      context 'when form email is present' do
-        context 'when va profile email is different' do
-          expect_email_tag('different')
-        end
-
-        context 'when va profile is the same' do
-          before do
-            allow(user).to receive(:va_profile_email).and_return('Email@email.com')
-          end
-
-          expect_email_tag('same')
-
-          context 'when FormEmailMatchesProfileLog already exists' do
-            before do
-              FormEmailMatchesProfileLog.create(user_uuid: user.uuid, in_progress_form_id: in_progress_form.id)
-            end
-
-            expect_does_nothing
-          end
-        end
-
-        context 'when va profile email is blank' do
-          before do
-            expect(user).to receive(:va_profile_email).and_return(nil)
-          end
-
-          expect_email_tag('different')
-        end
-      end
-
-      context 'when form email is blank' do
-        before do
-          in_progress_form.update!(
-            form_data: JSON.parse(in_progress_form.form_data).except('email').to_json
-          )
-        end
-
-        expect_does_nothing
-      end
+      expect(FormEmailMatchesProfileLog).not_to receive(:create).with(
+        user_uuid: user.uuid, in_progress_form_id: in_progress_form.id
+      )
     end
   end
 
-  describe 'hca_log_email_diff_in_progress_form disabled' do
-    before do
-      allow(Flipper).to receive(:enabled?).with(:hca_log_email_diff_in_progress_form).and_return(false)
-      allow(Flipper).to receive(:enabled?).with(:remove_pciu, instance_of(User)).and_return(false)
-      in_progress_form.update!(user_uuid: user.uuid)
-      allow(User).to receive(:find).with(user.uuid).and_return(user)
-    end
-
-    def self.expect_does_nothing
-      it 'does nothing' do
-        expect(StatsD).not_to receive(:increment)
-        expect($redis).not_to receive(:set)
-
+  def self.expect_email_tag(tag)
+    it "logs that email is #{tag}" do
+      expect do
         subject
+      end.to trigger_statsd_increment("api.1010ez.in_progress_form_email.#{tag}")
+
+      expect(InProgressForm.where(user_uuid: user.uuid, id: in_progress_form.id)).to exist
+    end
+  end
+
+  describe '#perform' do
+    subject { described_class.new.perform(in_progress_form.id, user.uuid) }
+
+    context 'when the form has been deleted' do
+      before do
+        in_progress_form.destroy!
+      end
+
+      expect_does_nothing
+    end
+
+    context 'when form email is present' do
+      context 'when va profile email is different' do
+        expect_email_tag('different')
+      end
+
+      context 'when va profile is the same' do
+        before do
+          allow(user).to receive(:va_profile_email).and_return('Email@email.com')
+        end
+
+        expect_email_tag('same')
+
+        context 'when FormEmailMatchesProfileLog already exists' do
+          before do
+            FormEmailMatchesProfileLog.create(user_uuid: user.uuid, in_progress_form_id: in_progress_form.id)
+          end
+
+          expect_does_nothing
+        end
+      end
+
+      context 'when va profile email is blank' do
+        before do
+          expect(user).to receive(:va_profile_email).and_return(nil)
+        end
+
+        expect_email_tag('different')
       end
     end
 
-    def self.expect_email_tag(tag)
-      it "logs that email is #{tag}" do
-        expect do
-          subject
-        end.to trigger_statsd_increment("api.1010ez.in_progress_form_email.#{tag}")
-
-        expect($redis.get("HCA::LogEmailDiffJob:#{user.uuid}")).to eq('t')
-      end
-    end
-
-    describe '#perform' do
-      subject { described_class.new.perform(in_progress_form.id, user.uuid) }
-
-      context 'when the form has been deleted' do
-        before do
-          in_progress_form.destroy!
-        end
-
-        expect_does_nothing
+    context 'when form email is blank' do
+      before do
+        in_progress_form.update!(
+          form_data: JSON.parse(in_progress_form.form_data).except('email').to_json
+        )
       end
 
-      context 'when form email is present' do
-        context 'when va profile email is different' do
-          expect_email_tag('different')
-        end
-
-        context 'when va profile is the same' do
-          before do
-            allow(user).to receive(:va_profile_email).and_return('Email@email.com')
-          end
-
-          expect_email_tag('same')
-
-          context 'when redis key for the user is already set' do
-            before do
-              $redis.set("HCA::LogEmailDiffJob:#{user.uuid}", 't')
-            end
-
-            expect_does_nothing
-          end
-        end
-
-        context 'when va profile email is blank' do
-          before do
-            expect(user).to receive(:va_profile_email).and_return(nil)
-          end
-
-          expect_email_tag('different')
-        end
-      end
-
-      context 'when form email is blank' do
-        before do
-          in_progress_form.update!(
-            form_data: JSON.parse(in_progress_form.form_data).except('email').to_json
-          )
-        end
-
-        expect_does_nothing
-      end
+      expect_does_nothing
     end
   end
 end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Removing `hca_log_email_diff_in_progress_form` flipper toggle and corresponding usage. We have had this toggle turned on and now that logic will be the default. This PR removes the other logic flow that used a redis key and now only uses the database table.
- I will delete the toggle from all environment databases once this is merged in and deployed.
- 1010 Health Apps
- Deleting the `hca_log_email_diff_in_progress_form` toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99303

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
10-10EZ

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
