### PR TITLE
Fallback to current user's first name in 21-0966

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -377,7 +377,7 @@ module SimpleFormsApi
       if form_data['preparer_identification'] == 'SURVIVING_DEPENDENT'
         form_data.dig('surviving_dependent_full_name', 'first')
       else
-        form_data.dig('veteran_full_name', 'first')
+        form_data.dig('veteran_full_name', 'first') || user&.first_name
       end
     end
 


### PR DESCRIPTION
## Summary
This PR adds a fallback where we do not rely on form data for a veteran's first name but instead we rely on their logged-in user's first name. This is for sending emails after receipt of submissions.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=93326260&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1967
