### PR TITLE
This must merge after part I so the tests will pass. Fixes definition…

### DIFF
--- a/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
+++ b/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
@@ -61,11 +61,11 @@ module ClaimsApi
           )
       end
 
-      module ClaimantService
+      module ClaimantWebService
         DEFINITION =
           Service.new(
             bean: ClaimantServiceBean::DEFINITION,
-            path: 'ClaimantService'
+            path: 'ClaimantWebService'
           )
       end
 

--- a/modules/claims_api/lib/bgs_service/claimant_web_service.rb
+++ b/modules/claims_api/lib/bgs_service/claimant_web_service.rb
@@ -25,5 +25,18 @@ module ClaimsApi
       response = make_request(endpoint: bean_name, action: 'addFlash', body:)
       response&.dig(:body, :add_flash_response) || response
     end
+
+    def find_poa_by_participant_id(id)
+      body = Nokogiri::XML::DocumentFragment.parse <<~EOXML
+        <ptcpntId />
+      EOXML
+
+      { ptcpntId: id }.each do |k, v|
+        body.xpath("./*[local-name()='#{k}']")[0].content = v
+      end
+
+      make_request(endpoint: 'ClaimantServiceBean/ClaimantWebService', action: 'findPOAByPtcpntId', body:,
+                   key: 'return')
+    end
   end
 end

--- a/modules/claims_api/lib/bgs_service/local_bgs.rb
+++ b/modules/claims_api/lib/bgs_service/local_bgs.rb
@@ -76,19 +76,6 @@ module ClaimsApi
       wsdl.status
     end
 
-    def find_poa_by_participant_id(id)
-      body = Nokogiri::XML::DocumentFragment.parse <<~EOXML
-        <ptcpntId />
-      EOXML
-
-      { ptcpntId: id }.each do |k, v|
-        body.xpath("./*[local-name()='#{k}']")[0].content = v
-      end
-
-      make_request(endpoint: 'ClaimantServiceBean/ClaimantWebService', action: 'findPOAByPtcpntId', body:,
-                   key: 'return')
-    end
-
     def header # rubocop:disable Metrics/MethodLength
       # Stock XML structure {{{
       header = Nokogiri::XML::DocumentFragment.parse <<~EOXML


### PR DESCRIPTION
# This must merge after part I so the tests will pass. 

## Summary

- Fixes definition file. Moves method from local_bgs to claimant_web_service. 
- Creates test file for new service.

## Related issue(s)

- [API-42911](https://jira.devops.va.gov/browse/API-42911)

## Testing done

- [x] * new test.
- Moves find_by_poa_by_participant_id from local_bgs to claimant_web_service. 
- [ ] in the rail C:
```
if Settings.bgs.ssl_verify_mode == 'none'
OpenSSL::SSL::VERIFY_NONE
else
OpenSSL::SSL::VERIFY_PEER
end
ClaimsApi::LocalBGS.new(external_uid:'a', external_key:'b').fetch_namespace(Faraday::Connection.new(ssl: { verify_mode: @ssl_verify_mode }), 'ClaimantServiceBean/ClaimantWebService')
```


## What areas of the site does it impact?
	modified:   modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
	modified:   modules/claims_api/lib/bgs_service/claimant_web_service.rb
	modified:   modules/claims_api/lib/bgs_service/local_bgs.rb
	new file:   modules/claims_api/spec/lib/claims_api/claimant_web_service_spec.rb
	modified:   modules/claims_api/spec/lib/claims_api/local_bgs_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature