### PR TITLE
replace Rails logging with StatsD metrics for diagnostic codes 

### DIFF
--- a/app/services/claim_fast_tracking/max_rating_annotator.rb
+++ b/app/services/claim_fast_tracking/max_rating_annotator.rb
@@ -30,10 +30,12 @@ module ClaimFastTracking
 
     def self.log_hyphenated_diagnostic_codes(rated_disabilities)
       rated_disabilities.each do |dis|
-        Rails.logger.info('Max CFI rated disability',
-                          diagnostic_code: dis&.diagnostic_code,
-                          diagnostic_code_type: diagnostic_code_type(dis),
-                          hyphenated_diagnostic_code: dis&.hyphenated_diagnostic_code)
+        StatsD.increment('api.max_cfi.rated_disability',
+                         tags: [
+                           "diagnostic_code:#{dis&.diagnostic_code}",
+                           "diagnostic_code_type:#{diagnostic_code_type(dis)}",
+                           "hyphenated_diagnostic_code:#{dis&.hyphenated_diagnostic_code}"
+                         ])
       end
     end
 

--- a/spec/services/claim_fast_tracking/max_rating_annotator_spec.rb
+++ b/spec/services/claim_fast_tracking/max_rating_annotator_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe ClaimFastTracking::MaxRatingAnnotator do
   describe 'log_hyphenated_diagnostic_codes' do
     subject { described_class.log_hyphenated_diagnostic_codes(rated_disabilities) }
 
-    before { allow(Rails.logger).to receive(:info) }
+    before { allow(StatsD).to receive(:increment) }
 
     let(:rated_disabilities) do
       disabilities_data.map { |dis| DisabilityCompensation::ApiProvider::RatedDisability.new(**dis) }
@@ -129,19 +129,34 @@ RSpec.describe ClaimFastTracking::MaxRatingAnnotator do
       ]
     end
 
-    it 'sends the correct output to Rails log' do
+    it 'increments StatsD metrics for each rated disability' do
       subject
-      expect(Rails.logger).to have_received(:info).with(
-        'Max CFI rated disability',
-        { diagnostic_code: 6260, diagnostic_code_type: :primary_max_rating, hyphenated_diagnostic_code: nil }
+
+      expect(StatsD).to have_received(:increment).with(
+        'api.max_cfi.rated_disability',
+        tags: [
+          'diagnostic_code:6260',
+          'diagnostic_code_type:primary_max_rating',
+          'hyphenated_diagnostic_code:'
+        ]
       )
-      expect(Rails.logger).to have_received(:info).with(
-        'Max CFI rated disability',
-        { diagnostic_code: 7347, diagnostic_code_type: :digestive_system, hyphenated_diagnostic_code: nil }
+
+      expect(StatsD).to have_received(:increment).with(
+        'api.max_cfi.rated_disability',
+        tags: [
+          'diagnostic_code:7347',
+          'diagnostic_code_type:digestive_system',
+          'hyphenated_diagnostic_code:'
+        ]
       )
-      expect(Rails.logger).to have_received(:info).with(
-        'Max CFI rated disability',
-        { diagnostic_code: 6516, diagnostic_code_type: :analogous_code, hyphenated_diagnostic_code: 6599 }
+
+      expect(StatsD).to have_received(:increment).with(
+        'api.max_cfi.rated_disability',
+        tags: [
+          'diagnostic_code:6516',
+          'diagnostic_code_type:analogous_code',
+          'hyphenated_diagnostic_code:6599'
+        ]
       )
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Replaced `Rails.logger.info` calls in `log_hyphenated_diagnostic_codes` with `StatsD.increment` to avoid logging sensitive diagnostic codes. The new metrics include diagnostic code, diagnostic code type, and hyphenated diagnostic code as tags.
- This change improves privacy by preventing potential de-anonymization of veterans based on logged diagnostic codes.

## Related issue(s)

- [#3941](https://github.com/department-of-veterans-affairs/abd-vro/issues/3941)

## Testing done

- [x] New code is covered by unit tests.
- Previously, diagnostic codes were logged using `Rails.logger.info`.
- Verified that `StatsD.increment` is now used to record metrics, and updated tests to ensure that the correct metrics and tags are being sent.

## What areas of the site does it impact?

- This change impacts the `log_hyphenated_diagnostic_codes` method in the `MaxRatingAnnotator` class, which handles processing diagnostic codes for rated disabilities.

## Acceptance criteria

- [x] I updated unit tests to verify the new `StatsD.increment` calls.
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution (StatsD).
- [ ] Documentation has been updated (link to documentation, if any).
- [x] No sensitive information (i.e., PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs.
