### PR TITLE
Update key in email config for 26-4555

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -346,7 +346,7 @@ module SimpleFormsApi
           form_data: parsed_form_data,
           form_number: 'vba_26_4555',
           confirmation_number:,
-          date_submitted: Time.zone.today.strftime('%B %d, %Y')
+          date_received: Time.zone.today.strftime('%B %d, %Y')
         }
         notification_email = SimpleFormsApi::NotificationEmail.new(
           config,


### PR DESCRIPTION
## Summary
This PR corrects a key in the config hash sent to the Notification Email. I thought the key should have been `date_submitted` but the email is actually expecting `date_received`. This is for SAHSHA 26-4555.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=88758986&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1897
