### PR TITLE
Log form id in SubmitBenefitsIntakeClaim

### DIFF
--- a/app/sidekiq/lighthouse/submit_benefits_intake_claim.rb
+++ b/app/sidekiq/lighthouse/submit_benefits_intake_claim.rb
@@ -156,7 +156,8 @@ module Lighthouse
       details = {
         claim_id: @claim&.id,
         benefits_intake_uuid: @lighthouse_service&.uuid,
-        confirmation_number: @claim&.confirmation_number
+        confirmation_number: @claim&.confirmation_number,
+        form_id: @claim&.form_id
       }
       details['error'] = e.message if e
       details


### PR DESCRIPTION
## Summary

- Adds the form_id to the logs in Lighthouse::SubmitBenefitsIntakeClaim to allow teams to limit their monitors to their own form(s). 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/100836

## Testing done

- [ ] *New code is covered by unit tests*
- [ ] Submitted a claim in locally and verified the form id was logged

## Screenshots
<img width="549" alt="Screenshot 2025-01-14 at 4 04 43 PM" src="https://github.com/user-attachments/assets/cb79cabc-ce1e-437f-bb24-d307b897c971" />

## What areas of the site does it impact?
Burials, Education Career Counseling, VRE, and users of SavedClaim. 

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

