### PR TITLE
Fix Rubocop/Lint 3

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -196,9 +196,9 @@ Lint/RedundantSafeNavigation:
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
-Lint/RedundantStringCoercion:
-  Exclude:
-    - 'rakelib/form526.rake'
+# Lint/RedundantStringCoercion:
+#   Exclude:
+#     - 'rakelib/form526.rake'
 
 # Offense count: 1
 Lint/RequireRangeParentheses:

--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -426,7 +426,7 @@ namespace :form526 do
       puts '----------------------------------------'
       puts "Jobs:\n\n"
       submission.form526_job_statuses.each do |s|
-        puts s.job_class.to_s
+        puts s.job_class
         puts "  status: #{s.status}"
         puts "  error: #{s.error_class}" if s.error_class
         puts "    message: #{s.error_message}" if s.error_message


### PR DESCRIPTION
## Summary

- Fixes the following Rubocop offenses:
  - `Lint/RedundantStringCoercion`
    - `puts` already coerces value into string

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/100982