### PR TITLE
updated expected form id for burial applications

### DIFF
--- a/app/controllers/v0/claim_documents_controller.rb
+++ b/app/controllers/v0/claim_documents_controller.rb
@@ -19,7 +19,7 @@ module V0
       # add the file after so that we have a form_id and guid for the uploader to use
       @attachment.file = unlock_file(params['file'], params['password'])
 
-      if %w[21P-527EZ 21P-530 21P-530V2].include?(form_id) &&
+      if %w[21P-527EZ 21P-530EZ 21P-530V2].include?(form_id) &&
          Flipper.enabled?(:document_upload_validation_enabled) && !stamped_pdf_valid?
 
         raise Common::Exceptions::ValidationErrors, @attachment


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- The conditional that checks for pension and burial applications for the updated validation process for document uploads was checking for the incorrect burials form_id. It should've been `21P-530EZ` but was instead checking for `21P-530`. This PR rectifies this issue.
- Go to burial application and attempt to upload invalid documents on the "Additional Information" page. The validations should block uploads of invalid files, but uploads succeed due to the incorrect form_id being checked.
- Pension & Burial Program (PBP) team to own this work.

## Related issue(s)

- [*Link to ticket created in va.gov-team repo*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/101121)
- [*Link to previous change of the code/bug*](https://github.com/department-of-veterans-affairs/vets-api/pull/19532)

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
