### PR TITLE
Update telehealth appointment modality resolution logic

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -779,25 +779,25 @@ module VAOS
       end
 
       def log_modality_failure(appointment)
-        Rails.logger.warn("VAOS appointment id #{appointment[:id]} modality cannot be determined", {
+        context = {
           service_type: appointment[:service_type],
           service_category_text: appointment.dig(:service_category, 0, :text),
           kind: appointment[:kind],
           atlas: appointment.dig(:telehealth, :atlas),
           vvs_kind: appointment.dig(:telehealth, :vvs_kind),
           gfe: appointment.dig(:extension, :patient_has_mobile_gfe)
-        }.to_json)
+        }.to_json
+        Rails.logger.warn("VAOS appointment id #{appointment[:id]} modality cannot be determined", context)
       end
 
       def telehealth_modality(appointment)
+        vvs_kind = appointment.dig(:telehealth, :vvs_kind)
         if !appointment.dig(:telehealth, :atlas).nil?
           'vaVideoCareAtAnAtlasLocation'
-        elsif %w[CLINIC_BASED STORE_FORWARD].include?(appointment.dig(:telehealth, :vvs_kind))
+        elsif %w[CLINIC_BASED STORE_FORWARD].include?(vvs_kind)
           'vaVideoCareAtAVaLocation'
-        elsif appointment.dig(:extension, :patient_has_mobile_gfe)
-          'vaVideoCareOnGfe'
-        else
-          'vaVideoCareAtHome'
+        elsif vvs_kind.nil? || vvs_kind == 'MOBILE_ANY' || vvs_kind == 'ADHOC'
+          appointment.dig(:extension, :patient_has_mobile_gfe) ? 'vaVideoCareOnGfe' : 'vaVideoCareAtHome'
         end
       end
 

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -779,20 +779,14 @@ module VAOS
       end
 
       def log_modality_failure(appointment)
-        Rails.logger.info("VAOS appointment id #{appointment[:id]} modality cannot be determined.")
-        if Random.new.rand(10).zero?
-          Rails.logger.info(
-            "VAOS appointment id #{appointment[:id]} modality details.",
-            {
-              service_type: appointment[:service_type],
-              service_category_text: appointment.dig(:service_category, 0, :text),
-              kind: appointment[:kind],
-              atlas: appointment.dig(:telehealth, :atlas),
-              vvs_kind: appointment.dig(:telehealth, :vvs_kind),
-              gfe: appointment.dig(:extension, :patient_has_mobile_gfe)
-            }.to_json
-          )
-        end
+        Rails.logger.warn("VAOS appointment id #{appointment[:id]} modality cannot be determined", {
+          service_type: appointment[:service_type],
+          service_category_text: appointment.dig(:service_category, 0, :text),
+          kind: appointment[:kind],
+          atlas: appointment.dig(:telehealth, :atlas),
+          vvs_kind: appointment.dig(:telehealth, :vvs_kind),
+          gfe: appointment.dig(:extension, :patient_has_mobile_gfe)
+        }.to_json)
       end
 
       def telehealth_modality(appointment)
@@ -800,8 +794,10 @@ module VAOS
           'vaVideoCareAtAnAtlasLocation'
         elsif %w[CLINIC_BASED STORE_FORWARD].include?(appointment.dig(:telehealth, :vvs_kind))
           'vaVideoCareAtAVaLocation'
-        elsif appointment.dig(:telehealth, :vvs_kind) == 'MOBILE_ANY/ADHOC'
-          appointment.dig(:extension, :patient_has_mobile_gfe) ? 'vaVideoCareOnGfe' : 'vaVideoCareAtHome'
+        elsif appointment.dig(:extension, :patient_has_mobile_gfe)
+          'vaVideoCareOnGfe'
+        else
+          'vaVideoCareAtHome'
         end
       end
 

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -1685,25 +1685,25 @@ describe VAOS::V2::AppointmentsService do
       expect(appt[:modality]).to eq('vaVideoCareAtAVaLocation')
     end
 
-    describe 'is vaVideoCareOnGfe for' do
+    describe 'for vvsKind' do
       [nil, 'MOBILE_ANY', 'ADHOC'].each do |input|
-        it "#{input} and patient has GFE" do
-          appt = build(:appointment_form_v2, :telehealth).attributes
-          appt[:telehealth][:vvs_kind] = input
-          appt[:extension][:patient_has_mobile_gfe] = true
-          subject.send(:set_modality, appt)
-          expect(appt[:modality]).to eq('vaVideoCareOnGfe')
+        context "#{input} when patient has GFE" do
+          it 'returns vaVideoCareOnGfe' do
+            appt = build(:appointment_form_v2, :telehealth).attributes
+            appt[:telehealth][:vvs_kind] = input
+            appt[:extension][:patient_has_mobile_gfe] = true
+            subject.send(:set_modality, appt)
+            expect(appt[:modality]).to eq('vaVideoCareOnGfe')
+          end
         end
-      end
-    end
 
-    describe 'is vaVideoCareAtHome for' do
-      [nil, 'MOBILE_ANY', 'ADHOC'].each do |input|
-        it "#{input} and patient does not have GFE" do
-          appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth).attributes
-          appt[:telehealth][:vvs_kind] = input
-          subject.send(:set_modality, appt)
-          expect(appt[:modality]).to eq('vaVideoCareAtHome')
+        context "#{input} when patient does not have GFE" do
+          it 'returns vaVideoCareAtHome' do
+            appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth).attributes
+            appt[:telehealth][:vvs_kind] = input
+            subject.send(:set_modality, appt)
+            expect(appt[:modality]).to eq('vaVideoCareAtHome')
+          end
         end
       end
     end

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -1685,20 +1685,24 @@ describe VAOS::V2::AppointmentsService do
       expect(appt[:modality]).to eq('vaVideoCareAtAVaLocation')
     end
 
-    it 'is vaVideoCareOnGfe for MOBILE_ANY/ADHOC vvsKind and patient has GFE' do
+    it 'is vaVideoCareOnGfe for patient with GFE' do
       appt = build(:appointment_form_v2, :telehealth).attributes
-      appt[:telehealth][:vvs_kind] = 'MOBILE_ANY/ADHOC'
+      appt[:telehealth][:vvs_kind] = 'ADHOC'
       appt[:extension][:patient_has_mobile_gfe] = true
       subject.send(:set_modality, appt)
       expect(appt[:modality]).to eq('vaVideoCareOnGfe')
     end
 
-    it 'is vaVideoCareAtHome for MOBILE_ANY/ADHOC vvsKind and patient does not have GFE' do
-      appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth).attributes
-      appt[:telehealth][:vvs_kind] = 'MOBILE_ANY/ADHOC'
-      appt[:extension][:patient_has_mobile_gfe] = false
-      subject.send(:set_modality, appt)
-      expect(appt[:modality]).to eq('vaVideoCareAtHome')
+    describe 'is vaVideoCareAtHome for' do
+      [nil, 'MOBILE_ANY', 'ADHOC'].each do |input|
+        it "#{input} and patient does not have GFE" do
+          appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth).attributes
+          appt[:telehealth][:vvs_kind] = input
+          appt[:extension][:patient_has_mobile_gfe] = false
+          subject.send(:set_modality, appt)
+          expect(appt[:modality]).to eq('vaVideoCareAtHome')
+        end
+      end
     end
 
     it 'is vaVideoCareAtAnAtlasLocation for telehealth appointment with atlas' do
@@ -1730,12 +1734,12 @@ describe VAOS::V2::AppointmentsService do
     end
 
     it 'logs failure to determine modality' do
-      allow(Rails.logger).to receive(:info).at_least(:once)
+      allow(Rails.logger).to receive(:warn).at_least(:once)
       appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text).attributes
       appt[:kind] = 'none'
       subject.send(:set_modality, appt)
       expect(appt[:modality]).to be_nil
-      expect(Rails.logger).to have_received(:info).at_least(:once)
+      expect(Rails.logger).to have_received(:warn).at_least(:once)
     end
 
     it 'requires appointment' do

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -1685,12 +1685,16 @@ describe VAOS::V2::AppointmentsService do
       expect(appt[:modality]).to eq('vaVideoCareAtAVaLocation')
     end
 
-    it 'is vaVideoCareOnGfe for patient with GFE' do
-      appt = build(:appointment_form_v2, :telehealth).attributes
-      appt[:telehealth][:vvs_kind] = 'ADHOC'
-      appt[:extension][:patient_has_mobile_gfe] = true
-      subject.send(:set_modality, appt)
-      expect(appt[:modality]).to eq('vaVideoCareOnGfe')
+    describe 'is vaVideoCareOnGfe for' do
+      [nil, 'MOBILE_ANY', 'ADHOC'].each do |input|
+        it "#{input} and patient has GFE" do
+          appt = build(:appointment_form_v2, :telehealth).attributes
+          appt[:telehealth][:vvs_kind] = input
+          appt[:extension][:patient_has_mobile_gfe] = true
+          subject.send(:set_modality, appt)
+          expect(appt[:modality]).to eq('vaVideoCareOnGfe')
+        end
+      end
     end
 
     describe 'is vaVideoCareAtHome for' do
@@ -1698,11 +1702,17 @@ describe VAOS::V2::AppointmentsService do
         it "#{input} and patient does not have GFE" do
           appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth).attributes
           appt[:telehealth][:vvs_kind] = input
-          appt[:extension][:patient_has_mobile_gfe] = false
           subject.send(:set_modality, appt)
           expect(appt[:modality]).to eq('vaVideoCareAtHome')
         end
       end
+    end
+
+    it 'is nil for unrecognized vvsKind' do
+      appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth).attributes
+      appt[:telehealth][:vvs_kind] = 'MOBILE_GFE'
+      subject.send(:set_modality, appt)
+      expect(appt[:modality]).to be_nil
     end
 
     it 'is vaVideoCareAtAnAtlasLocation for telehealth appointment with atlas' do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- As part of the investigations into the appointments modality resolution failures, we identified three appointment variations that were unaccounted for:
1. {""kind"":""telehealth",""vvs_kind"":null}
1. {""kind"":""telehealth",""vvs_kind"":""ADHOC""}
1. {""kind"":""telehealth",""vvs_kind"":""MOBILE_ANY""}
- The appointment modality resolution logic has been updated to account for these variations
- Appointments (VAOS) Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101054

## Testing done

- [x] *New code is covered by unit tests*
- Unit tests are added to account for the appointment variations that caused failures for the previous implementation.

## Screenshots
N/A

## What areas of the site does it impact?
Appointments (VAOS)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
