### PR TITLE
Clarify 26-4555 email template logic around confirmation_number

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -132,7 +132,7 @@ module SimpleFormsApi
           when 'VALIDATED', 'ACCEPTED'
             send_sahsha_email(parsed_form_data, :confirmation, reference_number)
           when 'REJECTED'
-            send_sahsha_email(parsed_form_data, :rejected)
+            send_sahsha_email(parsed_form_data, :rejected, reference_number)
           when 'DUPLICATE'
             send_sahsha_email(parsed_form_data, :duplicate)
           end

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -101,7 +101,7 @@ module SimpleFormsApi
 
     def check_missing_keys(config)
       all_keys = %i[form_data form_number date_submitted]
-      all_keys << :confirmation_number if needs_confirmation_number?(config)
+      all_keys << :confirmation_number if needs_confirmation_number?
       all_keys << :expiration_date if config[:form_number] == 'vba_21_0966_intent_api'
 
       missing_keys = all_keys.select { |key| config[key].nil? || config[key].to_s.strip.empty? }
@@ -435,8 +435,10 @@ module SimpleFormsApi
       notification_type == :error
     end
 
-    def needs_confirmation_number?(config)
-      config[:form_number] != 'vba_26_4555' && %w[REJECTED DUPLICATE].exclude?(config[:notification_type])
+    def needs_confirmation_number?
+      # All email templates require confirmation_number except :duplicate for 26-4555 (SAHSHA)
+      # Only 26-4555 supports the :duplicate notification_type
+      notification_type != :duplicate
     end
   end
 end

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -1017,8 +1017,9 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
       end
 
       context 'rejected' do
+        let(:reference_number) { 'some-reference-number' }
         let(:body_status) { 'REJECTED' }
-        let(:body) { { 'status' => body_status } }
+        let(:body) { { 'reference_number' => reference_number, 'status' => body_status } }
         let(:status) { 200 }
         let(:lgy_response) { double(body:, status:) }
 
@@ -1039,7 +1040,8 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
             'form26_4555_rejected_email_template_id',
             {
               'first_name' => 'Veteran',
-              'date_submitted' => Time.zone.today.strftime('%B %d, %Y')
+              'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+              'confirmation_number' => reference_number
             }
           )
         end

--- a/modules/simple_forms_api/spec/services/notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/notification_email_spec.rb
@@ -34,18 +34,8 @@ describe SimpleFormsApi::NotificationEmail do
         end
 
         context 'notification_type is duplicate' do
-          let(:notification_type) { :duplicate }
-
           it 'does not require the confirmation_number' do
-            expect { described_class.new(config, notification_type:) }.not_to raise_error(ArgumentError)
-          end
-        end
-
-        context 'notification_type is rejeceted' do
-          let(:notification_type) { :rejected }
-
-          it 'does not require the confirmation_number' do
-            expect { described_class.new(config, notification_type:) }.not_to raise_error(ArgumentError)
+            expect { described_class.new(config, notification_type: :duplicate) }.not_to raise_error(ArgumentError)
           end
         end
       end


### PR DESCRIPTION
## Summary
This PR simplifies the logic involved in knowing whether the `confirmation_number` is required for an email template. There is only one case in which it is NOT necessary and that is a 26-4555 `:duplicate` email.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=88758986&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1897
