### PR TITLE
Create UserActions and UserActionEvents tables with proposed columns …

### DIFF
--- a/db/migrate/20250115180318_create_user_actions.rb
+++ b/db/migrate/20250115180318_create_user_actions.rb
@@ -1,11 +1,11 @@
 class CreateUserActions < ActiveRecord::Migration[7.2]
   def change
-    create_table :user_actions do |t|
-      # From diagram
-      t.string :uuid, null: false, index: { unique: true }
+    create_table :user_actions, id: :uuid do |t|
+      # Core fields
+      t.references :user_account, type: :uuid, null: false, foreign_key: true
       t.uuid :acting_user_account_id, null: false
       t.uuid :subject_user_account_id, null: false
-      t.bigint :user_action_event_id
+      t.references :user_action_event, null: false, foreign_key: true
       t.string :status, default: 'initial' # initial, success, error
 
       # Additional columns from ticket
@@ -14,6 +14,9 @@ class CreateUserActions < ActiveRecord::Migration[7.2]
       t.jsonb :device_info
 
       t.timestamps null: false
+
+      # Add index for status queries
+      t.index :status
     end
 
     # Add check constraint for status values
@@ -28,5 +31,10 @@ class CreateUserActions < ActiveRecord::Migration[7.2]
         end
       end
     end
+
+    # Add foreign key for acting_user_account_id
+    add_foreign_key :user_actions, :user_accounts, column: :acting_user_account_id
+    # Add foreign key for subject_user_account_id
+    add_foreign_key :user_actions, :user_accounts, column: :subject_user_account_id
   end
 end 

--- a/db/migrate/20250115180318_create_user_actions.rb
+++ b/db/migrate/20250115180318_create_user_actions.rb
@@ -1,0 +1,30 @@
+class CreateUserActions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :user_actions do |t|
+      # From diagram
+      t.string :uuid, null: false, index: { unique: true }
+      t.uuid :acting_user_account_id, null: false
+      t.uuid :subject_user_account_id, null: false
+      t.bigint :user_action_event_id
+      t.string :status, default: 'initial' # initial, success, error
+
+      # Additional columns from ticket
+      t.boolean :user_verified, default: false
+      t.string :ip_address
+      t.jsonb :device_info
+
+      t.timestamps null: false
+    end
+
+    # Add check constraint for status values
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          ALTER TABLE user_actions
+            ADD CONSTRAINT check_status
+            CHECK (status IN ('initial', 'success', 'error'));
+        SQL
+      end
+    end
+  end
+end 

--- a/db/migrate/20250115180318_create_user_actions.rb
+++ b/db/migrate/20250115180318_create_user_actions.rb
@@ -19,11 +19,13 @@ class CreateUserActions < ActiveRecord::Migration[7.2]
     # Add check constraint for status values
     reversible do |dir|
       dir.up do
-        execute <<-SQL
-          ALTER TABLE user_actions
-            ADD CONSTRAINT check_status
-            CHECK (status IN ('initial', 'success', 'error'));
-        SQL
+        safety_assured do
+          execute <<-SQL
+            ALTER TABLE user_actions
+              ADD CONSTRAINT check_status
+              CHECK (status IN ('initial', 'success', 'error'));
+          SQL
+        end
       end
     end
   end

--- a/db/migrate/20250115180319_create_user_action_events.rb
+++ b/db/migrate/20250115180319_create_user_action_events.rb
@@ -1,9 +1,7 @@
 class CreateUserActionEvents < ActiveRecord::Migration[7.2]
   def change
     create_table :user_action_events do |t|
-      # From diagram
-      t.string :details
-
+      t.string :details, null: false
       t.timestamps null: false
     end
   end

--- a/db/migrate/20250115180319_create_user_action_events.rb
+++ b/db/migrate/20250115180319_create_user_action_events.rb
@@ -1,0 +1,10 @@
+class CreateUserActionEvents < ActiveRecord::Migration[7.2]
+  def change
+    create_table :user_action_events do |t|
+      # From diagram
+      t.string :details
+
+      t.timestamps null: false
+    end
+  end
+end 

--- a/db/migrate/20250115180320_create_user_actions.rb
+++ b/db/migrate/20250115180320_create_user_actions.rb
@@ -7,7 +7,7 @@ class CreateUserActions < ActiveRecord::Migration[7.2]
       # Core fields
       t.uuid :acting_user_account_id, null: false
       t.uuid :subject_user_account_id, null: false
-      t.references :user_action_event, null: false, foreign_key: true
+      t.references :user_action_event, null: false, foreign_key: { validate: false }
       t.enum :status, enum_type: :user_action_status, default: 'initial', null: false
 
       # Additional columns from ticket
@@ -21,9 +21,8 @@ class CreateUserActions < ActiveRecord::Migration[7.2]
       t.index :status
     end
 
-    # Add foreign key for acting_user_account_id
-    add_foreign_key :user_actions, :user_accounts, column: :acting_user_account_id
-    # Add foreign key for subject_user_account_id
-    add_foreign_key :user_actions, :user_accounts, column: :subject_user_account_id
+    # Add foreign keys without validation
+    add_foreign_key :user_actions, :user_accounts, column: :acting_user_account_id, validate: false
+    add_foreign_key :user_actions, :user_accounts, column: :subject_user_account_id, validate: false
   end
 end 

--- a/db/migrate/20250115180321_validate_user_actions_foreign_keys.rb
+++ b/db/migrate/20250115180321_validate_user_actions_foreign_keys.rb
@@ -1,0 +1,7 @@
+class ValidateUserActionsForeignKeys < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :user_actions, :user_accounts, column: :acting_user_account_id
+    validate_foreign_key :user_actions, :user_accounts, column: :subject_user_account_id
+    validate_foreign_key :user_actions, :user_action_events
+  end
+end 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_15_180319) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_01_213062) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -271,14 +271,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_15_180319) do
 
   create_table "ar_power_of_attorney_forms", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "power_of_attorney_request_id", null: false
-    t.text "encrypted_kms_key", null: false
+    t.text "encrypted_kms_key"
     t.text "data_ciphertext", null: false
-    t.string "city_bidx", null: false
-    t.string "state_bidx", null: false
-    t.string "zipcode_bidx", null: false
-    t.index ["city_bidx", "state_bidx", "zipcode_bidx"], name: "idx_on_city_bidx_state_bidx_zipcode_bidx_a85b76f9bc"
+    t.string "claimant_city_ciphertext", null: false
+    t.string "claimant_city_bidx", null: false
+    t.string "claimant_state_code_ciphertext", null: false
+    t.string "claimant_state_code_bidx", null: false
+    t.string "claimant_zip_code_ciphertext", null: false
+    t.string "claimant_zip_code_bidx", null: false
+    t.index ["claimant_city_bidx", "claimant_state_code_bidx", "claimant_zip_code_bidx"], name: "idx_on_claimant_city_bidx_claimant_state_code_bidx__11e9adbe25"
     t.index ["power_of_attorney_request_id"], name: "idx_on_power_of_attorney_request_id_fc59a0dabc", unique: true
-    t.index ["zipcode_bidx"], name: "index_ar_power_of_attorney_forms_on_zipcode_bidx"
   end
 
   create_table "ar_power_of_attorney_request_decisions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -295,7 +297,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_15_180319) do
     t.string "resolving_type", null: false
     t.uuid "resolving_id", null: false
     t.text "reason_ciphertext"
-    t.text "encrypted_kms_key", null: false
+    t.text "encrypted_kms_key"
     t.datetime "created_at", null: false
     t.index ["power_of_attorney_request_id"], name: "idx_on_power_of_attorney_request_id_fd7d2d11b1", unique: true
     t.index ["resolving_type", "resolving_id"], name: "unique_resolving_type_and_id", unique: true
@@ -304,7 +306,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_15_180319) do
   create_table "ar_power_of_attorney_requests", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "claimant_id", null: false
     t.datetime "created_at", null: false
+    t.string "claimant_type", null: false
+    t.string "power_of_attorney_holder_type", null: false
+    t.uuid "power_of_attorney_holder_id", null: false
+    t.uuid "accredited_individual_id", null: false
+    t.index ["accredited_individual_id"], name: "idx_on_accredited_individual_id_a0a1fab1e0"
     t.index ["claimant_id"], name: "index_ar_power_of_attorney_requests_on_claimant_id"
+    t.index ["power_of_attorney_holder_type", "power_of_attorney_holder_id"], name: "index_ar_power_of_attorney_requests_on_power_of_attorney_holder"
   end
 
   create_table "async_transactions", id: :serial, force: :cascade do |t|
@@ -466,6 +474,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_15_180319) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["power_of_attorney_id"], name: "idx_on_power_of_attorney_id_9fc9134311"
+    t.index ["proc_id"], name: "index_claims_api_power_of_attorney_requests_on_proc_id"
   end
 
   create_table "claims_api_power_of_attorneys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -691,6 +700,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_15_180319) do
     t.index ["updated_at"], name: "index_evss_claims_on_updated_at"
     t.index ["user_account_id"], name: "index_evss_claims_on_user_account_id"
     t.index ["user_uuid"], name: "index_evss_claims_on_user_uuid"
+  end
+
+  create_table "excel_file_events", force: :cascade do |t|
+    t.integer "number_of_submissions"
+    t.string "filename"
+    t.datetime "successful_at", precision: nil
+    t.integer "retry_attempt", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["filename"], name: "index_excel_file_events_uniqueness", unique: true
   end
 
   create_table "feature_toggle_events", force: :cascade do |t|
@@ -994,33 +1013,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_15_180319) do
     t.index ["form526_submission_id"], name: "index_lighthouse526_document_uploads_on_form526_submission_id"
     t.index ["form_attachment_id"], name: "index_lighthouse526_document_uploads_on_form_attachment_id"
     t.index ["status_last_polled_at"], name: "index_lighthouse526_document_uploads_on_status_last_polled_at"
-  end
-
-  create_table "load_testing_test_sessions", force: :cascade do |t|
-    t.string "status", null: false
-    t.integer "concurrent_users", null: false
-    t.jsonb "configuration"
-    t.datetime "started_at"
-    t.datetime "completed_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.text "error_message"
-    t.string "csrf_token"
-    t.index ["status"], name: "index_load_testing_test_sessions_on_status"
-  end
-
-  create_table "load_testing_test_tokens", force: :cascade do |t|
-    t.bigint "test_session_id", null: false
-    t.string "access_token", null: false
-    t.string "refresh_token", null: false
-    t.string "device_secret"
-    t.datetime "expires_at", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "status", default: "available"
-    t.index ["expires_at"], name: "index_load_testing_test_tokens_on_expires_at"
-    t.index ["status"], name: "index_load_testing_test_tokens_on_status"
-    t.index ["test_session_id"], name: "index_load_testing_test_tokens_on_test_session_id"
   end
 
   create_table "maintenance_windows", id: :serial, force: :cascade do |t|
@@ -1386,27 +1378,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_15_180319) do
     t.index ["icn"], name: "index_user_accounts_on_icn", unique: true
   end
 
-  create_table "user_action_events", force: :cascade do |t|
-    t.string "details"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "user_actions", force: :cascade do |t|
-    t.string "uuid", null: false
-    t.uuid "acting_user_account_id", null: false
-    t.uuid "subject_user_account_id", null: false
-    t.bigint "user_action_event_id"
-    t.string "status", default: "initial"
-    t.boolean "user_verified", default: false
-    t.string "ip_address"
-    t.jsonb "device_info"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["uuid"], name: "index_user_actions_on_uuid", unique: true
-    t.check_constraint "status::text = ANY (ARRAY['initial'::character varying::text, 'success'::character varying::text, 'error'::character varying::text])", name: "check_status"
-  end
-
   create_table "user_credential_emails", force: :cascade do |t|
     t.bigint "user_verification_id"
     t.text "credential_email_ciphertext"
@@ -1434,35 +1405,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_15_180319) do
     t.index ["mhv_uuid"], name: "index_user_verifications_on_mhv_uuid", unique: true
     t.index ["user_account_id"], name: "index_user_verifications_on_user_account_id"
     t.index ["verified_at"], name: "index_user_verifications_on_verified_at"
-  end
-
-  create_table "va_forms_forms", force: :cascade do |t|
-    t.string "form_name"
-    t.string "url"
-    t.string "title"
-    t.date "first_issued_on"
-    t.date "last_revision_on"
-    t.integer "pages"
-    t.string "sha256"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "valid_pdf", default: false
-    t.text "form_usage"
-    t.text "form_tool_intro"
-    t.string "form_tool_url"
-    t.string "form_type"
-    t.string "language"
-    t.datetime "deleted_at"
-    t.string "related_forms", array: true
-    t.jsonb "benefit_categories"
-    t.string "form_details_url"
-    t.jsonb "va_form_administration"
-    t.integer "row_id"
-    t.float "ranking"
-    t.string "tags"
-    t.date "last_sha256_change"
-    t.jsonb "change_history"
-    t.index ["valid_pdf"], name: "index_va_forms_forms_on_valid_pdf"
   end
 
   create_table "va_notify_in_progress_reminders_sent", force: :cascade do |t|
@@ -1807,6 +1749,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_15_180319) do
   add_foreign_key "ar_power_of_attorney_forms", "ar_power_of_attorney_requests", column: "power_of_attorney_request_id"
   add_foreign_key "ar_power_of_attorney_request_decisions", "user_accounts", column: "creator_id"
   add_foreign_key "ar_power_of_attorney_request_resolutions", "ar_power_of_attorney_requests", column: "power_of_attorney_request_id"
+  add_foreign_key "ar_power_of_attorney_requests", "accredited_individuals"
   add_foreign_key "ar_power_of_attorney_requests", "user_accounts", column: "claimant_id"
   add_foreign_key "async_transactions", "user_accounts"
   add_foreign_key "claim_va_notifications", "saved_claims"
@@ -1825,7 +1768,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_15_180319) do
   add_foreign_key "in_progress_forms", "user_accounts"
   add_foreign_key "lighthouse526_document_uploads", "form526_submissions"
   add_foreign_key "lighthouse526_document_uploads", "form_attachments"
-  add_foreign_key "load_testing_test_tokens", "load_testing_test_sessions", column: "test_session_id"
   add_foreign_key "mhv_opt_in_flags", "user_accounts"
   add_foreign_key "oauth_sessions", "user_accounts"
   add_foreign_key "oauth_sessions", "user_verifications"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_01_213062) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_15_180321) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -24,6 +24,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_01_213062) do
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
   create_enum "itf_remediation_status", ["unprocessed"]
+  create_enum "user_action_status", ["initial", "success", "error"]
 
   create_table "account_login_stats", force: :cascade do |t|
     t.bigint "account_id", null: false
@@ -1378,6 +1379,26 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_01_213062) do
     t.index ["icn"], name: "index_user_accounts_on_icn", unique: true
   end
 
+  create_table "user_action_events", force: :cascade do |t|
+    t.string "details", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "user_actions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "acting_user_account_id", null: false
+    t.uuid "subject_user_account_id", null: false
+    t.bigint "user_action_event_id", null: false
+    t.enum "status", default: "initial", null: false, enum_type: "user_action_status"
+    t.boolean "user_verified", default: false
+    t.string "ip_address"
+    t.jsonb "device_info"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["status"], name: "index_user_actions_on_status"
+    t.index ["user_action_event_id"], name: "index_user_actions_on_user_action_event_id"
+  end
+
   create_table "user_credential_emails", force: :cascade do |t|
     t.bigint "user_verification_id"
     t.text "credential_email_ciphertext"
@@ -1773,6 +1794,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_01_213062) do
   add_foreign_key "oauth_sessions", "user_verifications"
   add_foreign_key "terms_of_use_agreements", "user_accounts"
   add_foreign_key "user_acceptable_verified_credentials", "user_accounts"
+  add_foreign_key "user_actions", "user_accounts", column: "acting_user_account_id"
+  add_foreign_key "user_actions", "user_accounts", column: "subject_user_account_id"
+  add_foreign_key "user_actions", "user_action_events"
   add_foreign_key "user_credential_emails", "user_verifications"
   add_foreign_key "user_verifications", "user_accounts"
   add_foreign_key "va_notify_in_progress_reminders_sent", "user_accounts"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1404,7 +1404,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_15_180319) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["uuid"], name: "index_user_actions_on_uuid", unique: true
-    t.check_constraint "status::text = ANY (ARRAY['initial'::character varying, 'success'::character varying, 'error'::character varying]::text[])", name: "check_status"
+    t.check_constraint "status::text = ANY (ARRAY['initial'::character varying::text, 'success'::character varying::text, 'error'::character varying::text])", name: "check_status"
   end
 
   create_table "user_credential_emails", force: :cascade do |t|


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Creating two new database tables (`user_actions` and `user_action_events`) to support user action auditing
- Identity team owns and will maintain these components
- This is foundational database work for the user action auditing feature

## Related issue(s)

- [VI-863](https://jira.devops.va.gov/browse/VI-863)

## Testing done

- [ ] New code is covered by unit tests
- This is a new feature, adding database tables for user action auditing
- Steps to verify:
  1. Run migrations locally: `bin/rails db:drop db:create db:schema:load db:migrate`
  2. Verify table structure in database matches requirements
  3. Test enum type constraints work for status values
  4. Verify foreign key relationships between tables

## What areas of the site does it impact?

- Database schema changes only
- No direct user-facing impact yet
- Foundation for future user action auditing features

## Acceptance criteria

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable)
- [ ] No error nor warning in the console
- [ ] No sensitive information is captured in logging, hardcoded, or specs
- [ ] Documentation has been updated (migrations are self-documenting with comments)

## Database Changes
- Created `user_actions` table with:
  - Core fields: uuid (as primary key), acting_user_account_id, subject_user_account_id, user_action_event_id
  - Status using PostgreSQL native enum type (initial, success, error)
  - Additional columns: user_verified, ip_address, device_info
  - Timestamps (created_at, updated_at)
- Created `user_action_events` table with:
  - Fields: id (auto-generated), details
  - Timestamps (created_at, updated_at)
- Added proper foreign key relationships:
  - user_actions.acting_user_account_id -> user_accounts.id
  - user_actions.subject_user_account_id -> user_accounts.id
  - user_actions.user_action_event_id -> user_action_events.id

## Requested Feedback

Please review:
1. Table structure alignment with diagram
2. Additional columns implementation
3. PostgreSQL native enum implementation for status
4. Any missing indexes or constraints needed