### PR TITLE
2122a PDF generation missing rep phone fix

### DIFF
--- a/modules/representation_management/lib/representation_management/v0/pdf_constructor/form_2122a.rb
+++ b/modules/representation_management/lib/representation_management/v0/pdf_constructor/form_2122a.rb
@@ -166,6 +166,7 @@ module RepresentationManagement
         end
 
         def representative_contact_details(data)
+          rep_phone_number = unformat_phone_number(data.representative_phone) || ''
           {
             # Representative Mailing Address
             "#{PAGE2_KEY}.MailingAddress_NumberAndStreet[2]": data.representative_field_truncated(:address_line1),
@@ -178,9 +179,9 @@ module RepresentationManagement
             "#{PAGE2_KEY}.MailingAddress_ZIPOrPostalCode_FirstFiveNumbers[2]": data.representative_zip_code_expanded[0],
             "#{PAGE2_KEY}.MailingAddress_ZIPOrPostalCode_LastFourNumbers[2]": data.representative_zip_code_expanded[1],
             # Representative Phone Number
-            "#{PAGE2_KEY}.Telephone_Number_Area_Code[2]": unformat_phone_number(data.representative_phone)[0..2],
-            "#{PAGE2_KEY}.Telephone_Middle_Three_Numbers[1]": unformat_phone_number(data.representative_phone)[3..5],
-            "#{PAGE2_KEY}.Telephone_Last_Four_Numbers[2]": unformat_phone_number(data.representative_phone)[6..9],
+            "#{PAGE2_KEY}.Telephone_Number_Area_Code[2]": rep_phone_number[0..2],
+            "#{PAGE2_KEY}.Telephone_Middle_Three_Numbers[1]": rep_phone_number[3..5],
+            "#{PAGE2_KEY}.Telephone_Last_Four_Numbers[2]": rep_phone_number[6..9],
             # Representative Email
             "#{PAGE2_KEY}.E_Mail_Address_Of_Individual_Appointed_As_Claimants_Representative_Optional[0]": \
             data.representative_field_truncated(:email)

--- a/modules/representation_management/spec/lib/representation_management/v0/pdf_constructor/form_2122a_spec.rb
+++ b/modules/representation_management/spec/lib/representation_management/v0/pdf_constructor/form_2122a_spec.rb
@@ -150,4 +150,17 @@ describe RepresentationManagement::V0::PdfConstructor::Form2122a do
     end
     # The Tempfile is automatically deleted after the block ends
   end
+
+  it 'constructs the pdf if the representative has no phone number' do
+    representative.update!(phone: nil)
+    form = RepresentationManagement::Form2122aData.new(data)
+    Tempfile.create do |tempfile|
+      tempfile.binmode
+      RepresentationManagement::V0::PdfConstructor::Form2122a.new(tempfile).construct(form)
+      reader = PDF::Reader.new(tempfile.path)
+      # Here we're just testing that the PDF is valid and has a version
+      expect(reader.pdf_version).not_to be_nil
+    end
+    # The Tempfile is automatically deleted after the block ends
+  end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- *(Summarize the changes that have been made to the platform):* A missing representative phone number will no longer crash the 2122a PDF generation.
- *(If bug, how to reproduce):* 
- *(What is the solution, why is this the solution?):* This ensures the PDF generation won't crash due to data inconsistencies we don't have control over.
- *(Which team do you work for, does your team own the maintenance of this component?):* FAR/ARM, yes we own the maintenance.
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101149
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change:* The 2122a PDF generation would crash when a rep didn't have a phone number.
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing:* Submit a request where the rep has no phone number and it won't crash.
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas):* The 2122a PDF generation within the `representation_management` module.

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
