### PR TITLE
Fix Rubocop/Rails 1

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -412,17 +412,6 @@ RSpecRails/HaveHttpStatus:
 RSpecRails/InferredSpecType:
   Enabled: false
 
-# Offense count: 8
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Rails/CompactBlank:
-  Exclude:
-    - 'app/models/form_profile.rb'
-    - 'app/models/user.rb'
-    - 'lib/evss/disability_compensation_form/form0781.rb'
-    - 'lib/evss/pciu/request_body.rb'
-    - 'lib/hca/enrollment_system.rb'
-    - 'modules/vba_documents/app/sidekiq/vba_documents/report_unsuccessful_submissions.rb'
-
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Severity.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -412,14 +412,6 @@ RSpecRails/HaveHttpStatus:
 RSpecRails/InferredSpecType:
   Enabled: false
 
-# Offense count: 3
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: Include.
-# Include: app/models/**/*
-Rails/AttributeDefaultBlockValue:
-  Exclude:
-    - 'modules/claims_api/app/models/claims_api/auto_established_claim.rb'
-
 # Offense count: 8
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Rails/CompactBlank:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -414,13 +414,6 @@ RSpecRails/InferredSpecType:
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
-Rails/ExpandedDateRange:
-  Exclude:
-    - 'modules/va_notify/app/services/va_notify/find_in_progress_forms.rb'
-    - 'modules/va_notify/lib/va_notify/in_progress_form_helper.rb'
-
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: slashes, arguments
 Rails/FilePath:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -412,28 +412,6 @@ RSpecRails/HaveHttpStatus:
 RSpecRails/InferredSpecType:
   Enabled: false
 
-# Offense count: 14
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: ExpectedOrder, Include.
-# ExpectedOrder: index, show, new, edit, create, update, destroy
-# Include: app/controllers/**/*.rb
-Rails/ActionOrder:
-  Exclude:
-    - 'app/controllers/claims_base_controller.rb'
-    - 'app/controllers/v0/dependents_applications_controller.rb'
-    - 'app/controllers/v0/gi_bill_feedbacks_controller.rb'
-    - 'app/controllers/v0/health_care_applications_controller.rb'
-    - 'app/controllers/v0/onsite_notifications_controller.rb'
-    - 'modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb'
-    - 'modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements_controller.rb'
-    - 'modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb'
-    - 'modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb'
-    - 'modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements_controller.rb'
-    - 'modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/supplemental_claims/evidence_submissions_controller.rb'
-    - 'modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/supplemental_claims_controller.rb'
-    - 'modules/vba_documents/app/controllers/vba_documents/v1/uploads_controller.rb'
-    - 'modules/vba_documents/app/controllers/vba_documents/v2/uploads_controller.rb'
-
 # Offense count: 3
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: Include.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -412,26 +412,6 @@ RSpecRails/HaveHttpStatus:
 RSpecRails/InferredSpecType:
   Enabled: false
 
-# Offense count: 36
-# This cop supports safe autocorrection (--autocorrect).
-Rails/DurationArithmetic:
-  Exclude:
-    - 'app/serializers/dependents_verifications_serializer.rb'
-    - 'modules/claims_api/spec/models/auto_establish_claim_spec.rb'
-    - 'modules/claims_api/spec/models/veteran/service/user_spec.rb'
-    - 'modules/vaos/spec/services/user_service_spec.rb'
-    - 'modules/vba_documents/app/sidekiq/vba_documents/upload_scanner.rb'
-    - 'modules/vba_documents/spec/lib/object_store_spec.rb'
-    - 'modules/vba_documents/spec/sidekiq/upload_scanner_spec.rb'
-    - 'modules/veteran/spec/models/veteran/user_spec.rb'
-    - 'spec/controllers/sign_in/application_controller_spec.rb'
-    - 'spec/controllers/v1/sessions_controller_spec.rb'
-    - 'spec/lib/iam_ssoe_oauth/session_manager_spec.rb'
-    - 'spec/services/login/user_verifier_spec.rb'
-    - 'spec/services/sign_in/access_token_jwt_decoder_spec.rb'
-    - 'spec/services/sign_in/session_refresher_spec.rb'
-    - 'spec/services/sign_in/session_revoker_spec.rb'
-
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
 Rails/ExpandedDateRange:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -412,13 +412,6 @@ RSpecRails/HaveHttpStatus:
 RSpecRails/InferredSpecType:
   Enabled: false
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: Severity.
-Rails/DeprecatedActiveModelErrorsMethods:
-  Exclude:
-    - 'modules/mobile/lib/mobile/v0/exceptions/validation_errors.rb'
-
 # Offense count: 36
 # This cop supports safe autocorrection (--autocorrect).
 Rails/DurationArithmetic:

--- a/app/controllers/claims_base_controller.rb
+++ b/app/controllers/claims_base_controller.rb
@@ -17,6 +17,11 @@ class ClaimsBaseController < ApplicationController
   skip_before_action(:authenticate)
   before_action :load_user, only: :create
 
+  def show
+    submission = CentralMailSubmission.joins(:central_mail_claim).find_by(saved_claims: { guid: params[:id] })
+    render json: BenefitsIntakeSubmissionSerializer.new(submission)
+  end
+
   # Creates and validates an instance of the class, removing any copies of
   # the form that had been previously saved by the user.
   def create
@@ -37,11 +42,6 @@ class ClaimsBaseController < ApplicationController
 
     clear_saved_form(claim.form_id)
     render json: SavedClaimSerializer.new(claim)
-  end
-
-  def show
-    submission = CentralMailSubmission.joins(:central_mail_claim).find_by(saved_claims: { guid: params[:id] })
-    render json: BenefitsIntakeSubmissionSerializer.new(submission)
   end
 
   private

--- a/app/controllers/v0/dependents_applications_controller.rb
+++ b/app/controllers/v0/dependents_applications_controller.rb
@@ -4,6 +4,15 @@ module V0
   class DependentsApplicationsController < ApplicationController
     service_tag 'dependent-change'
 
+    def show
+      dependents = dependent_service.get_dependents
+      dependents[:diaries] = dependency_verification_service.read_diaries
+      render json: DependentsSerializer.new(dependents)
+    rescue => e
+      log_exception_to_sentry(e)
+      raise Common::Exceptions::BackendServiceException.new(nil, detail: e.message)
+    end
+
     def create
       claim = SavedClaim::DependencyClaim.new(form: dependent_params.to_json)
 
@@ -20,15 +29,6 @@ module V0
       # clear_saved_form(claim.form_id) # We do not want to destroy the InProgressForm for this submission
 
       render json: SavedClaimSerializer.new(claim)
-    end
-
-    def show
-      dependents = dependent_service.get_dependents
-      dependents[:diaries] = dependency_verification_service.read_diaries
-      render json: DependentsSerializer.new(dependents)
-    rescue => e
-      log_exception_to_sentry(e)
-      raise Common::Exceptions::BackendServiceException.new(nil, detail: e.message)
     end
 
     def disability_rating

--- a/app/controllers/v0/gi_bill_feedbacks_controller.rb
+++ b/app/controllers/v0/gi_bill_feedbacks_controller.rb
@@ -6,6 +6,11 @@ module V0
     skip_before_action(:authenticate)
     before_action :load_user, only: :create
 
+    def show
+      gi_bill_feedback = GIBillFeedback.find(params[:id])
+      render json: GIBillFeedbackSerializer.new(gi_bill_feedback)
+    end
+
     def create
       gi_bill_feedback = GIBillFeedback.new(
         params.require(:gi_bill_feedback).permit(:form).merge(
@@ -21,11 +26,6 @@ module V0
 
       clear_saved_form(GIBillFeedback::FORM_ID)
 
-      render json: GIBillFeedbackSerializer.new(gi_bill_feedback)
-    end
-
-    def show
-      gi_bill_feedback = GIBillFeedback.find(params[:id])
       render json: GIBillFeedbackSerializer.new(gi_bill_feedback)
     end
   end

--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -32,6 +32,11 @@ module V0
       render json: HCARatingInfoSerializer.new(hca_rating_info)
     end
 
+    def show
+      application = HealthCareApplication.find(params[:id])
+      render json: HealthCareApplicationSerializer.new(application)
+    end
+
     def create
       health_care_application.async_compatible = params[:async_all]
       health_care_application.google_analytics_client_id = params[:ga_client_id]
@@ -50,11 +55,6 @@ module V0
       else
         render json: result
       end
-    end
-
-    def show
-      application = HealthCareApplication.find(params[:id])
-      render json: HealthCareApplicationSerializer.new(application)
     end
 
     def enrollment_status

--- a/app/controllers/v0/onsite_notifications_controller.rb
+++ b/app/controllers/v0/onsite_notifications_controller.rb
@@ -21,6 +21,16 @@ module V0
       render json: OnsiteNotificationSerializer.new(notifications, options)
     end
 
+    def create
+      onsite_notification = OnsiteNotification.new(
+        params.require(:onsite_notification).permit(:va_profile_id, :template_id)
+      )
+
+      raise Common::Exceptions::ValidationErrors, onsite_notification unless onsite_notification.save
+
+      render json: OnsiteNotificationSerializer.new(onsite_notification)
+    end
+
     def update
       onsite_notification = OnsiteNotification.find_by(id: params[:id], va_profile_id: current_user.vet360_id)
       raise Common::Exceptions::RecordNotFound, params[:id] if onsite_notification.nil?
@@ -28,16 +38,6 @@ module V0
       unless onsite_notification.update(params.require(:onsite_notification).permit(:dismissed))
         raise Common::Exceptions::ValidationErrors, onsite_notification
       end
-
-      render json: OnsiteNotificationSerializer.new(onsite_notification)
-    end
-
-    def create
-      onsite_notification = OnsiteNotification.new(
-        params.require(:onsite_notification).permit(:va_profile_id, :template_id)
-      )
-
-      raise Common::Exceptions::ValidationErrors, onsite_notification unless onsite_notification.save
 
       render json: OnsiteNotificationSerializer.new(onsite_notification)
     end

--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -427,7 +427,7 @@ class FormProfile
     when Hash
       clean_hash!(value)
     when Array
-      value.map { |v| clean!(v) }.delete_if(&:blank?)
+      value.map { |v| clean!(v) }.compact_blank!
     else
       value
     end
@@ -436,6 +436,6 @@ class FormProfile
   def clean_hash!(hash)
     hash.deep_transform_keys! { |k| k.to_s.camelize(:lower) }
     hash.each { |k, v| hash[k] = clean!(v) }
-    hash.delete_if { |_k, v| v.blank? }
+    hash.compact_blank!
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -442,7 +442,7 @@ class User < Common::RedisStore
       end
 
     [the_va_profile_email, email]
-      .reject(&:blank?)
+      .compact_blank
       .map(&:downcase)
       .uniq
   end

--- a/app/serializers/dependents_verifications_serializer.rb
+++ b/app/serializers/dependents_verifications_serializer.rb
@@ -22,7 +22,7 @@ class DependentsVerificationsSerializer
     diary_entries.any? do |diary_entry|
       diary_entry[:diary_lc_status_type] == 'PEND' &&
         diary_entry[:diary_reason_type] == '24' &&
-        diary_entry[:diary_due_date] < Time.zone.now + 7.years
+        diary_entry[:diary_due_date] < 7.years.from_now
     end
   end
 end

--- a/lib/evss/disability_compensation_form/form0781.rb
+++ b/lib/evss/disability_compensation_form/form0781.rb
@@ -94,7 +94,7 @@ module EVSS
           location['state'],
           location['country'],
           location['additionalDetails']
-        ].reject(&:blank?).join(', ')
+        ].compact_blank.join(', ')
       end
 
       def full_name

--- a/lib/evss/pciu/request_body.rb
+++ b/lib/evss/pciu/request_body.rb
@@ -38,7 +38,7 @@ module EVSS
       end
 
       def remove_empty_attrs
-        @request_attrs = request_attrs.as_json.delete_if { |_k, v| v.blank? }
+        @request_attrs = request_attrs.as_json.compact_blank!
       end
 
       def convert_to_json

--- a/lib/hca/enrollment_system.rb
+++ b/lib/hca/enrollment_system.rb
@@ -773,7 +773,7 @@ module HCA
         result = value.map do |item|
           convert_value!(item)
         end
-        result.delete_if(&:blank?)
+        result.compact_blank!
       elsif value.in?([true, false]) || value.is_a?(Numeric)
         value.to_s
       else
@@ -785,7 +785,7 @@ module HCA
       hash.each do |k, v|
         hash[k] = convert_value!(v)
       end
-      hash.delete_if { |_k, v| v.blank? }
+      hash.compact_blank!
     end
 
     def get_user_variables(user_identifier)

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
@@ -18,6 +18,17 @@ module AppealsApi::V1
         skip_before_action :authenticate
         before_action :nod_uuid_present?, only: :create
 
+        def show
+          submission = AppealsApi::EvidenceSubmission.find_by(guid: params[:id])
+          raise Common::Exceptions::RecordNotFound, params[:id] unless submission
+
+          submission = with_status_simulation(submission) if status_requested_and_allowed?
+
+          render json: AppealsApi::EvidenceSubmissionSerializer.new(
+            submission, { params: { render_location: false } }
+          ).serializable_hash
+        end
+
         def create
           status, error = AppealsApi::EvidenceSubmissionRequestValidator.new(params[:nod_uuid],
                                                                              request.headers['X-VA-SSN'],
@@ -35,17 +46,6 @@ module AppealsApi::V1
             log_error(error)
             render json: { errors: [error] }, status: error[:title].to_sym
           end
-        end
-
-        def show
-          submission = AppealsApi::EvidenceSubmission.find_by(guid: params[:id])
-          raise Common::Exceptions::RecordNotFound, params[:id] unless submission
-
-          submission = with_status_simulation(submission) if status_requested_and_allowed?
-
-          render json: AppealsApi::EvidenceSubmissionSerializer.new(
-            submission, { params: { render_location: false } }
-          ).serializable_hash
         end
 
         private

--- a/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v1/decision_reviews/notice_of_disagreements_controller.rb
@@ -21,6 +21,13 @@ class AppealsApi::V1::DecisionReviews::NoticeOfDisagreementsController < Appeals
   FORM_NUMBER = '10182'
   MODEL_ERROR_STATUS = 422
 
+  def show
+    deprecate_headers
+
+    @notice_of_disagreement = with_status_simulation(@notice_of_disagreement) if status_requested_and_allowed?
+    render_notice_of_disagreement
+  end
+
   def create
     deprecate_headers
 
@@ -29,13 +36,6 @@ class AppealsApi::V1::DecisionReviews::NoticeOfDisagreementsController < Appeals
     # PDF and API versioning are not 1:1, but are closely coupled and in this case are the same
     pdf_version = api_version
     AppealsApi::PdfSubmitJob.perform_async(@notice_of_disagreement.id, 'AppealsApi::NoticeOfDisagreement', pdf_version)
-    render_notice_of_disagreement
-  end
-
-  def show
-    deprecate_headers
-
-    @notice_of_disagreement = with_status_simulation(@notice_of_disagreement) if status_requested_and_allowed?
     render_notice_of_disagreement
   end
 

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/higher_level_reviews_controller.rb
@@ -34,6 +34,11 @@ class AppealsApi::V2::DecisionReviews::HigherLevelReviewsController < AppealsApi
     render json: AppealsApi::HigherLevelReviewSerializer.new(veteran_hlrs).serializable_hash
   end
 
+  def show
+    @higher_level_review = with_status_simulation(@higher_level_review) if status_requested_and_allowed?
+    render_higher_level_review
+  end
+
   def create
     @higher_level_review.save
 
@@ -58,11 +63,6 @@ class AppealsApi::V2::DecisionReviews::HigherLevelReviewsController < AppealsApi
 
   def schema
     render json: AppealsApi::JsonSchemaToSwaggerConverter.remove_comments(form_schema)
-  end
-
-  def show
-    @higher_level_review = with_status_simulation(@higher_level_review) if status_requested_and_allowed?
-    render_higher_level_review
   end
 
   def download

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements/evidence_submissions_controller.rb
@@ -18,6 +18,17 @@ module AppealsApi::V2
         skip_before_action :authenticate
         before_action :nod_uuid_present?, only: :create
 
+        def show
+          submission = AppealsApi::EvidenceSubmission.find_by(guid: params[:id])
+          raise Common::Exceptions::RecordNotFound, params[:id] unless submission
+
+          submission = with_status_simulation(submission) if status_requested_and_allowed?
+
+          render json: AppealsApi::EvidenceSubmissionSerializer.new(
+            submission, { params: { render_location: false } }
+          ).serializable_hash
+        end
+
         def create
           status, error = AppealsApi::EvidenceSubmissionRequestValidator.new(params[:nod_uuid],
                                                                              request.headers['X-VA-File-Number'],
@@ -35,17 +46,6 @@ module AppealsApi::V2
             log_error(error)
             render json: { errors: [error] }, status: error[:title].to_sym
           end
-        end
-
-        def show
-          submission = AppealsApi::EvidenceSubmission.find_by(guid: params[:id])
-          raise Common::Exceptions::RecordNotFound, params[:id] unless submission
-
-          submission = with_status_simulation(submission) if status_requested_and_allowed?
-
-          render json: AppealsApi::EvidenceSubmissionSerializer.new(
-            submission, { params: { render_location: false } }
-          ).serializable_hash
         end
 
         private

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/notice_of_disagreements_controller.rb
@@ -33,6 +33,11 @@ class AppealsApi::V2::DecisionReviews::NoticeOfDisagreementsController < Appeals
     render json: AppealsApi::NoticeOfDisagreementSerializer.new(veteran_nods).serializable_hash
   end
 
+  def show
+    @notice_of_disagreement = with_status_simulation(@notice_of_disagreement) if status_requested_and_allowed?
+    render_notice_of_disagreement
+  end
+
   def create
     @notice_of_disagreement.save
     AppealsApi::PdfSubmitJob.perform_async(
@@ -40,11 +45,6 @@ class AppealsApi::V2::DecisionReviews::NoticeOfDisagreementsController < Appeals
       'AppealsApi::NoticeOfDisagreement',
       'v3'
     )
-    render_notice_of_disagreement
-  end
-
-  def show
-    @notice_of_disagreement = with_status_simulation(@notice_of_disagreement) if status_requested_and_allowed?
     render_notice_of_disagreement
   end
 

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/supplemental_claims/evidence_submissions_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/supplemental_claims/evidence_submissions_controller.rb
@@ -18,6 +18,17 @@ module AppealsApi::V2
         skip_before_action :authenticate
         before_action :supplemental_claim_uuid?, only: :create
 
+        def show
+          submission = AppealsApi::EvidenceSubmission.find_by(guid: params[:id])
+          raise Common::Exceptions::RecordNotFound, params[:id] unless submission
+
+          submission = with_status_simulation(submission) if status_requested_and_allowed?
+
+          render json: AppealsApi::EvidenceSubmissionSerializer.new(
+            submission, { params: { render_location: false } }
+          ).serializable_hash
+        end
+
         def create
           status, error = AppealsApi::EvidenceSubmissionRequestValidator.new(params[:sc_uuid],
                                                                              request.headers['X-VA-SSN'],
@@ -35,17 +46,6 @@ module AppealsApi::V2
             log_error(error)
             render json: { errors: [error] }, status: error[:title].to_sym
           end
-        end
-
-        def show
-          submission = AppealsApi::EvidenceSubmission.find_by(guid: params[:id])
-          raise Common::Exceptions::RecordNotFound, params[:id] unless submission
-
-          submission = with_status_simulation(submission) if status_requested_and_allowed?
-
-          render json: AppealsApi::EvidenceSubmissionSerializer.new(
-            submission, { params: { render_location: false } }
-          ).serializable_hash
         end
 
         private

--- a/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/supplemental_claims_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v2/decision_reviews/supplemental_claims_controller.rb
@@ -31,6 +31,16 @@ class AppealsApi::V2::DecisionReviews::SupplementalClaimsController < AppealsApi
     render json: AppealsApi::SupplementalClaimSerializer.new(veteran_scs).serializable_hash
   end
 
+  def show
+    id = params[:id]
+    sc = AppealsApi::SupplementalClaim.select(ALLOWED_COLUMNS).find(id)
+    sc = with_status_simulation(sc) if status_requested_and_allowed?
+
+    render json: AppealsApi::SupplementalClaimSerializer.new(sc).serializable_hash
+  rescue ActiveRecord::RecordNotFound
+    render_supplemental_claim_not_found(id)
+  end
+
   def create
     sc = AppealsApi::SupplementalClaim.new(
       auth_headers: request_headers,
@@ -63,16 +73,6 @@ class AppealsApi::V2::DecisionReviews::SupplementalClaimsController < AppealsApi
   def schema
     response = AppealsApi::JsonSchemaToSwaggerConverter.remove_comments(form_schema)
     render json: response
-  end
-
-  def show
-    id = params[:id]
-    sc = AppealsApi::SupplementalClaim.select(ALLOWED_COLUMNS).find(id)
-    sc = with_status_simulation(sc) if status_requested_and_allowed?
-
-    render json: AppealsApi::SupplementalClaimSerializer.new(sc).serializable_hash
-  rescue ActiveRecord::RecordNotFound
-    render_supplemental_claim_not_found(id)
   end
 
   def download

--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -52,10 +52,10 @@ module ClaimsApi
     end
 
     # EVSS Claims attributes with defaults
-    attribute :data, default: {}
+    attribute :data, default: -> { {} }
     attribute :claim_type, default: 'Compensation'
-    attribute :contention_list, default: []
-    attribute :events_timeline, default: []
+    attribute :contention_list, default: -> { [] }
+    attribute :events_timeline, default: -> { [] }
     attribute :validation_method
 
     alias token id

--- a/modules/claims_api/spec/models/veteran/service/user_spec.rb
+++ b/modules/claims_api/spec/models/veteran/service/user_spec.rb
@@ -44,9 +44,9 @@ describe Veteran::User do
           .and_return({
                         person_poa_history: {
                           person_poa: [
-                            { begin_dt: Time.zone.now - 2.years, legacy_poa_cd: '233' },
-                            { begin_dt: Time.zone.now - 1.year, legacy_poa_cd: '133' },
-                            { begin_dt: Time.zone.now - 3.years, legacy_poa_cd: '333' }
+                            { begin_dt: 2.years.ago, legacy_poa_cd: '233' },
+                            { begin_dt: 1.year.ago, legacy_poa_cd: '133' },
+                            { begin_dt: 3.years.ago, legacy_poa_cd: '333' }
                           ]
                         }
                       })

--- a/modules/mobile/lib/mobile/v0/exceptions/validation_errors.rb
+++ b/modules/mobile/lib/mobile/v0/exceptions/validation_errors.rb
@@ -5,10 +5,10 @@ module Mobile
     module Exceptions
       class ValidationErrors < Common::Exceptions::ValidationErrors
         def errors
-          @resource.errors.details.map do |k, v|
+          @resource.errors.map do |message|
             Common::Exceptions::SerializableError.new(
               i18n_data.merge(
-                detail: "#{k} #{v.first}"
+                detail: "#{message.path.first} #{message.text}"
               )
             )
           end

--- a/modules/mobile/lib/mobile/v0/exceptions/validation_errors.rb
+++ b/modules/mobile/lib/mobile/v0/exceptions/validation_errors.rb
@@ -5,7 +5,7 @@ module Mobile
     module Exceptions
       class ValidationErrors < Common::Exceptions::ValidationErrors
         def errors
-          @resource.errors.to_h.map do |k, v|
+          @resource.errors.details.map do |k, v|
             Common::Exceptions::SerializableError.new(
               i18n_data.merge(
                 detail: "#{k} #{v.first}"

--- a/modules/va_notify/app/services/va_notify/find_in_progress_forms.rb
+++ b/modules/va_notify/app/services/va_notify/find_in_progress_forms.rb
@@ -10,7 +10,7 @@ module VANotify
 
     def to_notify
       date_range = [
-        7.days.ago.beginning_of_day..7.days.ago.end_of_day
+        7.days.ago.all_day
       ]
 
       InProgressForm.where(form_id: RELEVANT_FORMS).where(updated_at: date_range)

--- a/modules/va_notify/lib/va_notify/in_progress_form_helper.rb
+++ b/modules/va_notify/lib/va_notify/in_progress_form_helper.rb
@@ -23,7 +23,7 @@ module VANotify
 
     def self.form_age(in_progress_form)
       case in_progress_form.updated_at
-      when 7.days.ago.beginning_of_day..7.days.ago.end_of_day
+      when 7.days.ago.all_day
         '&7_days'
       else
         ''

--- a/modules/vaos/spec/services/user_service_spec.rb
+++ b/modules/vaos/spec/services/user_service_spec.rb
@@ -63,7 +63,7 @@ describe VAOS::UserService do
       'SsYaPmZQ_bghzI1W1MXtUJWVOOTgJIAcESsfquXGj7-0QXxTT4rHSaL8oBRVt6UqfI9exEPmfjM58ibJY2ECVTUdaScJaT1BXShiwTDEqC5bn' \
       'ApUvAMUzEHi8dx48EIMbqNLYgUZT3GCtMs0xIP9wGjt6JK0l-UDOn0aK3b-fJUF-ZcerYdY2opUJuu5oQrDaOocbRqrwBlCFqa1oUTCxLYLV6' \
       '9cuaSOQfXqTIoWuvbj-7FSFhF1nc2lhgjOWckJ740vzINYZ_uQNA',
-      expiration: Time.zone.now + 15.minutes
+      expiration: 15.minutes.from_now
     }
   end
 
@@ -158,7 +158,7 @@ describe VAOS::UserService do
         context 'with one call outside the lock (> 60s)' do
           it 'triggers the extend session job' do
             VCR.use_cassette('vaos/users/get_user_jwts') do
-              Timecop.travel(Time.zone.now + 2.minutes)
+              Timecop.travel(2.minutes.from_now)
               expect(VAOS::ExtendSessionJob).to receive(:perform_async).with(user.account_uuid).once
               subject.extend_session(user.account_uuid)
             end
@@ -168,7 +168,7 @@ describe VAOS::UserService do
         context 'with multiple calls outside the original lock (> 60s)' do
           it 'triggers the extend session job only once' do
             VCR.use_cassette('vaos/users/get_user_jwts') do
-              Timecop.travel(Time.zone.now + 2.minutes)
+              Timecop.travel(2.minutes.from_now)
               expect(VAOS::ExtendSessionJob).to receive(:perform_async).with(user.account_uuid).once
               subject.extend_session(user.account_uuid)
               subject.extend_session(user.account_uuid)

--- a/modules/vba_documents/app/controllers/vba_documents/v1/uploads_controller.rb
+++ b/modules/vba_documents/app/controllers/vba_documents/v1/uploads_controller.rb
@@ -11,17 +11,6 @@ module VBADocuments
       before_action :verify_download_enabled, only: [:download]
       before_action :verify_validate_enabled, only: [:validate_document]
 
-      def create
-        submission = VBADocuments::UploadSubmission.create(
-          consumer_name: request.headers['X-Consumer-Username'],
-          consumer_id: request.headers['X-Consumer-ID']
-        )
-        submission.metadata['version'] = 1
-        submission.save!
-        options = { params: { render_location: true } }
-        render json: VBADocuments::V1::UploadSerializer.new(submission, options), status: :accepted
-      end
-
       def show
         submission = VBADocuments::UploadSubmission.find_by(guid: params[:id])
 
@@ -42,6 +31,17 @@ module VBADocuments
 
         options = { params: { render_location: false } }
         render json: VBADocuments::V1::UploadSerializer.new(submission, options)
+      end
+
+      def create
+        submission = VBADocuments::UploadSubmission.create(
+          consumer_name: request.headers['X-Consumer-Username'],
+          consumer_id: request.headers['X-Consumer-ID']
+        )
+        submission.metadata['version'] = 1
+        submission.save!
+        options = { params: { render_location: true } }
+        render json: VBADocuments::V1::UploadSerializer.new(submission, options), status: :accepted
       end
 
       def download

--- a/modules/vba_documents/app/sidekiq/vba_documents/report_unsuccessful_submissions.rb
+++ b/modules/vba_documents/app/sidekiq/vba_documents/report_unsuccessful_submissions.rb
@@ -16,7 +16,7 @@ module VBADocuments
       if Settings.vba_documents.report_enabled
         @to = Time.zone.now
         @from = @to.monday? ? 7.days.ago : 1.day.ago
-        @consumers = UploadSubmission.where(created_at: @from..@to).pluck(:consumer_name).uniq.reject(&:blank?)
+        @consumers = UploadSubmission.where(created_at: @from..@to).pluck(:consumer_name).uniq.compact_blank
         UnsuccessfulReportMailer.build(totals, stuck, errored, @from, @to).deliver_now
       end
     end

--- a/modules/vba_documents/app/sidekiq/vba_documents/upload_scanner.rb
+++ b/modules/vba_documents/app/sidekiq/vba_documents/upload_scanner.rb
@@ -46,7 +46,7 @@ module VBADocuments
     end
 
     def expire(upload)
-      upload.update(status: 'expired') if upload.created_at < Time.zone.now - 20.minutes
+      upload.update(status: 'expired') if upload.created_at < 20.minutes.ago
     end
 
     def bucket

--- a/modules/vba_documents/spec/lib/object_store_spec.rb
+++ b/modules/vba_documents/spec/lib/object_store_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe VBADocuments::ObjectStore do
     it 'returns the earliest available version' do
       v1 = instance_double(Aws::S3::ObjectVersion)
       v2 = instance_double(Aws::S3::ObjectVersion)
-      t1 = Time.zone.now - 1.minute
-      t2 = Time.zone.now - 2.minutes
+      t1 = 1.minute.ago
+      t2 = 2.minutes.ago
       expect(v1).to receive(:last_modified).and_return(t1)
       expect(v2).to receive(:last_modified).and_return(t2)
       expect(@resource).to receive(:bucket).and_return(@bucket)

--- a/modules/vba_documents/spec/sidekiq/upload_scanner_spec.rb
+++ b/modules/vba_documents/spec/sidekiq/upload_scanner_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe VBADocuments::UploadScanner, type: :job do
           processor = class_double(VBADocuments::UploadProcessor).as_stubbed_const
           expect(processor).to receive(:perform_async).with(upload.guid, caller: described_class.name)
 
-          Timecop.travel(Time.zone.now + 25.minutes) do
+          Timecop.travel(25.minutes.from_now) do
             described_class.new.perform
 
             expect(upload.reload.status).to eq('uploaded')
@@ -91,7 +91,7 @@ RSpec.describe VBADocuments::UploadScanner, type: :job do
           processor = class_double(VBADocuments::UploadProcessor).as_stubbed_const
           expect(processor).not_to receive(:perform_async).with(upload.guid)
 
-          Timecop.travel(Time.zone.now + 25.minutes) do
+          Timecop.travel(25.minutes.from_now) do
             described_class.new.perform
 
             expect(upload.reload.status).to eq('expired')

--- a/modules/veteran/spec/models/veteran/user_spec.rb
+++ b/modules/veteran/spec/models/veteran/user_spec.rb
@@ -35,9 +35,9 @@ describe Veteran::User do
           .and_return({
                         person_poa_history: {
                           person_poa: [
-                            { begin_dt: Time.zone.now - 2.years, legacy_poa_cd: '233' },
-                            { begin_dt: Time.zone.now - 1.year, legacy_poa_cd: '133' },
-                            { begin_dt: Time.zone.now - 3.years, legacy_poa_cd: '333' }
+                            { begin_dt: 2.years.ago, legacy_poa_cd: '233' },
+                            { begin_dt: 1.year.ago, legacy_poa_cd: '133' },
+                            { begin_dt: 3.years.ago, legacy_poa_cd: '333' }
                           ]
                         }
                       })

--- a/spec/controllers/sign_in/application_controller_spec.rb
+++ b/spec/controllers/sign_in/application_controller_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
         context 'and access_token is an expired JWT' do
           let(:access_token_object) { create(:access_token, expiration_time:) }
           let(:access_token_cookie) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token_object).perform }
-          let(:expiration_time) { Time.zone.now - 1.day }
+          let(:expiration_time) { 1.day.ago }
           let(:expected_error) { 'Access token has expired' }
           let(:expected_error_json) { { 'errors' => expected_error } }
 
@@ -231,7 +231,7 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
       context 'and access_token is an expired JWT' do
         let(:access_token_object) { create(:access_token, expiration_time:) }
         let(:access_token) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token_object).perform }
-        let(:expiration_time) { Time.zone.now - 1.day }
+        let(:expiration_time) { 1.day.ago }
         let(:expected_error) { 'Access token has expired' }
         let(:expected_error_json) { { 'errors' => expected_error } }
 
@@ -357,7 +357,7 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
         context 'and access_token is an expired JWT' do
           let(:access_token_object) { create(:access_token, expiration_time:) }
           let(:access_token_cookie) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token_object).perform }
-          let(:expiration_time) { Time.zone.now - 1.day }
+          let(:expiration_time) { 1.day.ago }
           let(:expected_error) { 'Access token has expired' }
           let(:expected_error_json) { { 'errors' => expected_error } }
 
@@ -420,7 +420,7 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
       context 'and access_token is an expired JWT' do
         let(:access_token_object) { create(:access_token, expiration_time:) }
         let(:access_token) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token_object).perform }
-        let(:expiration_time) { Time.zone.now - 1.day }
+        let(:expiration_time) { 1.day.ago }
         let(:expected_error) { 'Access token has expired' }
         let(:expected_error_json) { { 'errors' => expected_error } }
 
@@ -544,7 +544,7 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
         context 'and access_token is an expired JWT' do
           let(:access_token_object) { create(:access_token, expiration_time:) }
           let(:access_token_cookie) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token_object).perform }
-          let(:expiration_time) { Time.zone.now - 1.day }
+          let(:expiration_time) { 1.day.ago }
           let(:expected_error) { 'Access token has expired' }
           let(:expected_error_json) { { 'errors' => expected_error } }
 
@@ -594,7 +594,7 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
       context 'and access_token is an expired JWT' do
         let(:access_token_object) { create(:access_token, expiration_time:) }
         let(:access_token) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token_object).perform }
-        let(:expiration_time) { Time.zone.now - 1.day }
+        let(:expiration_time) { 1.day.ago }
         let(:expected_error) { 'Access token has expired' }
         let(:expected_error_json) { { 'errors' => expected_error } }
 

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -826,7 +826,7 @@ RSpec.describe V1::SessionsController, type: :controller do
                            'client_id:vaweb',
                            'operation:authorize']
 
-          new_user_sign_in = Time.current + 30.minutes
+          new_user_sign_in = 30.minutes.from_now
           Timecop.freeze(new_user_sign_in)
           expect { call_endpoint }
             .to trigger_statsd_increment(described_class::STATSD_SSO_CALLBACK_KEY, tags: callback_tags, **once)

--- a/spec/lib/iam_ssoe_oauth/session_manager_spec.rb
+++ b/spec/lib/iam_ssoe_oauth/session_manager_spec.rb
@@ -35,7 +35,7 @@ describe 'IAMSSOeOAuth::SessionManager' do
     context 'with newly-authenticated token' do
       let(:dslogon_attrs) do
         build(:dslogon_level2_introspection_payload, fediam_authentication_instant: Time.current.utc.iso8601,
-                                                     iat: (Time.current + 5.minutes).strftime('%s').to_i)
+                                                     iat: 5.minutes.from_now.strftime('%s').to_i)
       end
 
       it 'increments the new OAuth session metric' do
@@ -50,7 +50,7 @@ describe 'IAMSSOeOAuth::SessionManager' do
     context 'with refreshed token' do
       let(:idme_attrs) do
         build(:idme_loa3_introspection_payload, fediam_authentication_instant: Time.current.utc.iso8601,
-                                                iat: (Time.current + 1.hour).strftime('%s').to_i)
+                                                iat: 1.hour.from_now.strftime('%s').to_i)
       end
 
       it 'increments the new OAuth session metric' do

--- a/spec/services/login/user_verifier_spec.rb
+++ b/spec/services/login/user_verifier_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Login::UserVerifier do
                                      verified_at:,
                                      locked:)
           end
-          let(:verified_at) { Time.zone.now - 1.day }
+          let(:verified_at) { 1.day.ago }
 
           it 'does not make new user log to rails logger' do
             expect(Rails.logger).not_to receive(:info).with(expected_log, { icn: })
@@ -188,7 +188,7 @@ RSpec.describe Login::UserVerifier do
 
               context 'and the current user_verification is verified' do
                 let(:user_account) { UserAccount.new(icn: 'some-other-icn') }
-                let(:verified_at) { Time.zone.now - 1.day }
+                let(:verified_at) { 1.day.ago }
                 let(:expected_message) do
                   "[Login::UserVerifier] User Account Mismatch for UserVerification id=#{user_verification.id}, " \
                     "UserAccount id=#{user_account.id}, icn=#{user_account.icn}, " \

--- a/spec/services/sign_in/access_token_jwt_decoder_spec.rb
+++ b/spec/services/sign_in/access_token_jwt_decoder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SignIn::AccessTokenJwtDecoder do
 
     context 'when access token jwt is expired' do
       let(:access_token_jwt) { SignIn::AccessTokenJwtEncoder.new(access_token:).perform }
-      let(:access_token) { create(:access_token, expiration_time: Time.zone.now - 1.day) }
+      let(:access_token) { create(:access_token, expiration_time: 1.day.ago) }
 
       context 'and jwt validation is enabled' do
         let(:expected_error) { SignIn::Errors::AccessTokenExpiredError }

--- a/spec/services/sign_in/session_refresher_spec.rb
+++ b/spec/services/sign_in/session_refresher_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe SignIn::SessionRefresher do
                user_verification:,
                client_id:)
       end
-      let(:session_expiration) { (Time.zone.now + 5.minutes).round(3) }
+      let(:session_expiration) { 5.minutes.from_now.round(3) }
       let(:client_id) { client_config.client_id }
       let(:client_config) do
         create(:client_config, anti_csrf:, refresh_token_duration:, access_token_attributes:, enforced_terms:)
@@ -270,7 +270,7 @@ RSpec.describe SignIn::SessionRefresher do
         end
 
         context 'and session is expired' do
-          let(:session_expiration) { Time.zone.now - 30.minutes }
+          let(:session_expiration) { 30.minutes.ago }
           let(:expected_error) { SignIn::Errors::SessionNotAuthorizedError }
           let(:expected_error_message) { 'No valid Session found' }
 

--- a/spec/services/sign_in/session_revoker_spec.rb
+++ b/spec/services/sign_in/session_revoker_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe SignIn::SessionRevoker do
       let(:client_id) { client_config.client_id }
       let(:client_config) { create(:client_config, anti_csrf:) }
       let(:anti_csrf) { false }
-      let(:session_expiration) { Time.zone.now + 5.minutes }
+      let(:session_expiration) { 5.minutes.from_now }
 
       before do
         Timecop.freeze(Time.zone.now.floor)
@@ -145,7 +145,7 @@ RSpec.describe SignIn::SessionRevoker do
         end
 
         context 'and session is expired' do
-          let(:session_expiration) { Time.zone.now - 30.minutes }
+          let(:session_expiration) { 30.minutes.ago }
           let(:expected_error) { SignIn::Errors::SessionNotAuthorizedError }
           let(:expected_error_message) { 'No valid Session found' }
 
@@ -194,7 +194,7 @@ RSpec.describe SignIn::SessionRevoker do
       let(:client_id) { client_config.client_id }
       let(:client_config) { create(:client_config, anti_csrf:) }
       let(:anti_csrf) { false }
-      let(:session_expiration) { Time.zone.now + 5.minutes }
+      let(:session_expiration) { 5.minutes.from_now }
 
       before do
         Timecop.freeze(Time.zone.now.floor)
@@ -241,7 +241,7 @@ RSpec.describe SignIn::SessionRevoker do
         end
 
         context 'and session is expired' do
-          let(:session_expiration) { Time.zone.now - 30.minutes }
+          let(:session_expiration) { 30.minutes.ago }
           let(:expected_error) { SignIn::Errors::SessionNotAuthorizedError }
           let(:expected_error_message) { 'No valid Session found' }
 


### PR DESCRIPTION
## Summary

- Fixes the following Rubocop offenses:
  - `Rails/ActionOrder`
    - Action show should appear before create.
  - `Rails/AttributeDefaultBlockValue`
    - Pass method in a block to :default option.
  - `Rails/CompactBlank`
    - Use compact_blank! instead.
  - `Rails/DeprecatedActiveModelErrorsMethods`
    - Avoid manipulating ActiveModel errors as hash directly
  - `Rails/DurationArithmetic`
    - Do not add or subtract duration
  - `Rails/ExpandedDateRange`
    - Use 7.days.ago.all_day instead

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/100982