### PR TITLE
[99972] Add org level poa submission indicator

### DIFF
--- a/db/migrate/20250116192421_add_can_accept_digital_poa_requests_to_veteran_organizations.rb
+++ b/db/migrate/20250116192421_add_can_accept_digital_poa_requests_to_veteran_organizations.rb
@@ -1,0 +1,5 @@
+class AddCanAcceptDigitalPoaRequestsToVeteranOrganizations < ActiveRecord::Migration[7.2]
+  def change
+    add_column :veteran_organizations, :can_accept_digital_poa_requests, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_14_223139) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_16_192421) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -1483,6 +1483,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_14_223139) do
     t.string "address_line1"
     t.string "address_line2"
     t.string "address_line3"
+    t.boolean "can_accept_digital_poa_requests", default: false
     t.index ["location"], name: "index_veteran_organizations_on_location", using: :gist
     t.index ["name"], name: "index_veteran_organizations_on_name"
     t.index ["poa"], name: "index_veteran_organizations_on_poa", unique: true


### PR DESCRIPTION
## Summary

- This pr adds a boolean column to `veteran_organizations` that is intended to enable/disable the ability for organizations to receive digital poa requests that can be acted upon in the accredited rep portal.
- This is the short term, low lift solution for our pilot program. The implementation and source of truth will be revisited post-pilot.

## Related issue(s)

- [99972](https://github.com/department-of-veterans-affairs/va.gov-team/issues/99972)

## Testing done

- Ran the migration locally. Unit tests are not applicable.

## What areas of the site does it impact?
This will be used in Appoint a Rep Form 21-22 and 21-22a and the Accredited Representative Portal. No immediate impact. 

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature