### PR TITLE
Fix Rubocop/Rails 3

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -460,12 +460,6 @@ Rails/SkipsModelValidations:
     - 'spec/models/form526_job_status_spec.rb'
     - 'spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb'
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Rails/StripHeredoc:
-  Exclude:
-    - 'lib/common/exceptions/backend_service_exception.rb'
-
 # Offense count: 3
 # Configuration parameters: Include.
 # Include: app/models/**/*.rb

--- a/lib/common/exceptions/backend_service_exception.rb
+++ b/lib/common/exceptions/backend_service_exception.rb
@@ -43,7 +43,7 @@ module Common
       end
 
       def va900_hint
-        <<-MESSAGE.strip_heredoc
+        <<~MESSAGE
           Add the following to exceptions.en.yml
           #{response_values[:code]}:
             code: '#{response_values[:code]}'


### PR DESCRIPTION
## Summary

- Fixes the following Rubocop offenses:
  - `Rails/StripHeredoc`
    - Use squiggly heredoc (<<~) instead of strip_heredoc

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/100982