### PR TITLE
Refactor Metrics/MethodLength disable on Mobile::AppointmentsHelper

### DIFF
--- a/modules/mobile/app/helpers/mobile/appointments_helper.rb
+++ b/modules/mobile/app/helpers/mobile/appointments_helper.rb
@@ -42,30 +42,25 @@ module Mobile
     end
 
     def create_params(params)
-      params.permit(:kind,
-                    :status,
-                    :location_id,
-                    :cancellable,
-                    :clinic,
-                    :comment,
-                    :reason,
-                    :service_type,
-                    :preferred_language,
-                    :minutes_duration,
-                    :patient_instruction,
-                    :priority,
-                    reason_code: [
-                      :text, { coding: %i[system code display] }
-                    ],
-                    slot: %i[id start end],
-                    contact: [telecom: %i[type value]],
-                    practitioner_ids: %i[system value],
-                    requested_periods: %i[start end],
-                    practitioners: practitioners_params,
-                    preferred_location: %i[city state],
-                    preferred_times_for_phone_call: [],
-                    telehealth: telehealth_params,
-                    extension: %i[desired_date])
+      base_params = %i[
+        kind status location_id cancellable clinic comment reason service_type
+        preferred_language minutes_duration patient_instruction priority
+      ]
+
+      nested_params = [
+        reason_code: [:text, { coding: %i[system code display] }],
+        slot: %i[id start end],
+        contact: [telecom: %i[type value]],
+        practitioner_ids: %i[system value],
+        requested_periods: %i[start end],
+        practitioners: practitioners_params,
+        preferred_location: %i[city state],
+        preferred_times_for_phone_call: [],
+        telehealth: telehealth_params,
+        extension: %i[desired_date]
+      ]
+
+      params.permit(*base_params, *nested_params)
     end
 
     def practitioners_params

--- a/modules/mobile/app/helpers/mobile/appointments_helper.rb
+++ b/modules/mobile/app/helpers/mobile/appointments_helper.rb
@@ -41,7 +41,6 @@ module Mobile
       VAOS::V2::MobileFacilityService.new(@current_user)
     end
 
-    # rubocop:disable Metrics/MethodLength
     def create_params(params)
       params.permit(:kind,
                     :status,
@@ -62,42 +61,49 @@ module Mobile
                     contact: [telecom: %i[type value]],
                     practitioner_ids: %i[system value],
                     requested_periods: %i[start end],
-                    practitioners: [
-                      :first_name,
-                      :last_name,
-                      :practice_name,
-                      {
-                        name: %i[family given]
-                      },
-                      {
-                        identifier: %i[system value]
-                      },
-                      {
-                        address: %i[type line city state postal_code country text]
-                      }
-                    ],
+                    practitioners: practitioners_params,
                     preferred_location: %i[city state],
                     preferred_times_for_phone_call: [],
-                    telehealth: [
-                      :url,
-                      :group,
-                      :vvs_kind,
-                      {
-                        atlas: [
-                          :site_code,
-                          :confirmation_code,
-                          {
-                            address: %i[
-                              street_address city state
-                              zip country latitude longitude
-                              additional_details
-                            ]
-                          }
-                        ]
-                      }
-                    ],
+                    telehealth: telehealth_params,
                     extension: %i[desired_date])
     end
-    # rubocop:enable Metrics/MethodLength
+
+    def practitioners_params
+      [
+        :first_name,
+        :last_name,
+        :practice_name,
+        {
+          name: %i[family given]
+        },
+        {
+          identifier: %i[system value]
+        },
+        {
+          address: %i[type line city state postal_code country text]
+        }
+      ]
+    end
+
+    def telehealth_params
+      [
+        :url,
+        :group,
+        :vvs_kind,
+        {
+          atlas: [
+            :site_code,
+            :confirmation_code,
+            {
+              address: %i[
+                street_address city state
+                zip country latitude longitude
+                additional_details
+              ]
+            }
+          ]
+        }
+      ]
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Refactor `create_params` to fix  Metrics/MethodLength cop

## Related issue(s)

- n/a

## Testing done

- [ ] n/a

## Acceptance criteria

- [ ]  Rubocop disable is removed