### PR TITLE
100496 Throw 500 if any files fail to make it to S3 - IVC CHAMPVA forms

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -192,6 +192,9 @@ features:
   champva_pdf_decrypt:
     actor_type: user
     description: Enables unlocking password protected file submissions in IVC CHAMPVA forms.
+  champva_require_all_s3_success:
+    actor_type: user
+    description: Enables raising a StandardError if any supporting documents fail to upload to S3 in IVC CHAMPVA forms.
   check_in_experience_enabled:
     actor_type: user
     description: Enables the health care check-in experiences

--- a/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
@@ -33,6 +33,7 @@ module IvcChampva
     # If any uploads yield non-200 statuses when submitted to S3, it raise a StandardError.
     #
     # @return [Array<Integer, String>] An array with a status code and an optional error message string.
+    # rubocop:disable Metrics/MethodLength
     def handle_uploads
       results = @metadata['attachment_ids'].zip(@file_paths).map do |attachment_id, file_path|
         next if file_path.blank?
@@ -52,12 +53,16 @@ module IvcChampva
 
       if all_success
         generate_and_upload_meta_json
-      else
+      elsif Flipper.enabled?(:champva_require_all_s3_success, @current_user)
         # Stop this submission in its tracks - entries will still be added to database
         # for these files, but user will see error on the FE saying submission failed.
         raise StandardError, "IVC ChampVa Forms - failed to upload all documents for submission: #{s3_err}"
+      else
+        # array of arrays, e.g.: [[200], [400, 'S3 error']]
+        results
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
@@ -54,6 +54,7 @@ module IvcChampva
       if all_success
         generate_and_upload_meta_json
       elsif Flipper.enabled?(:champva_require_all_s3_success, @current_user)
+        monitor.track_s3_upload_error(@metadata['uuid'], s3_err)
         # Stop this submission in its tracks - entries will still be added to database
         # for these files, but user will see error on the FE saying submission failed.
         raise StandardError, "IVC ChampVa Forms - failed to upload all documents for submission: #{s3_err}"

--- a/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
@@ -33,7 +33,6 @@ module IvcChampva
     # If any uploads yield non-200 statuses when submitted to S3, it raise a StandardError.
     #
     # @return [Array<Integer, String>] An array with a status code and an optional error message string.
-    # rubocop:disable Metrics/MethodLength
     def handle_uploads
       results = @metadata['attachment_ids'].zip(@file_paths).map do |attachment_id, file_path|
         next if file_path.blank?
@@ -63,7 +62,6 @@ module IvcChampva
         results
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
@@ -27,18 +27,12 @@ module IvcChampva
     #
     # The return value reflects whether or not all files were successfully uploaded.
     #
-    # If successful, it will return:
-    # - An array containing a single HTTP status code and an optional error message,
-    #   e.g. [200] | [400, 'No such file']
+    # If successful, it will return an array containing a single HTTP status code and an
+    # optional error message, e.g. [200] | [400, 'No such file']
     #
-    # If any uploads yield non-200 statuses when submitted to S3, it will return:
-    # - An array of arrays of statuses and optional error messages corresponding to the individual
-    #   uploads.
-    #   E.g., for two documents uploaded, one successful and one failed, it returns:
-    #   [[200], [400, 'No such file or directory']]
+    # If any uploads yield non-200 statuses when submitted to S3, it raise a StandardError.
     #
-    # @return [Array<Integer, String>, Array<Array<Integer, String>>] Either an array of arrays, or
-    # an array with a status code and an optional error message string.
+    # @return [Array<Integer, String>] An array with a status code and an optional error message string.
     def handle_uploads
       results = @metadata['attachment_ids'].zip(@file_paths).map do |attachment_id, file_path|
         next if file_path.blank?

--- a/modules/ivc_champva/lib/ivc_champva/monitor.rb
+++ b/modules/ivc_champva/lib/ivc_champva/monitor.rb
@@ -62,5 +62,17 @@ module IvcChampva
                     "#{STATS_KEY}.failed_send_zsf_notification_to_pega",
                     call_location: caller_locations.first, **additional_context)
     end
+
+    ##
+    # Logs UUID and S3 error message when supporting docs fail to reach S3.
+    #
+    # @param [String] form_uuid UUID of the form submission with failed uploads
+    # @param [String] s3_err Error message received from a failed upload to S3
+    def track_s3_upload_error(form_uuid, s3_err)
+      additional_context = { form_uuid:, s3_err: }
+      track_request('warn', "IVC ChampVa Forms - failed to upload all documents for submission: #{form_uuid}",
+                    "#{STATS_KEY}.s3_upload_error",
+                    call_location: caller_locations.first, **additional_context)
+    end
   end
 end

--- a/modules/ivc_champva/spec/services/file_uploader_spec.rb
+++ b/modules/ivc_champva/spec/services/file_uploader_spec.rb
@@ -24,9 +24,10 @@ describe IvcChampva::FileUploader do
       end
     end
 
-    context 'when at least one PDF upload fails' do
+    context 'when at least one PDF upload fails and champva_require_all_s3_success flipper is enabled:' do
       before do
         allow(uploader).to receive(:upload).and_return([400, 'Upload failed'])
+        allow(Flipper).to receive(:enabled?).with(:champva_require_all_s3_success, @current_user).and_return(true)
       end
 
       it 'raises an error' do
@@ -34,6 +35,17 @@ describe IvcChampva::FileUploader do
         # from completing if any files fail to make it to S3. Formerly, the expectation was:
         # `expect(uploader.handle_uploads).to eq([[400, 'Upload failed'], [400, 'Upload failed']])`
         expect { uploader.handle_uploads }.to raise_error(StandardError, /Upload failed/)
+      end
+    end
+
+    context 'when at least one PDF upload fails and champva_require_all_s3_success flipper is disabled:' do
+      before do
+        allow(uploader).to receive(:upload).and_return([400, 'Upload failed'])
+        allow(Flipper).to receive(:enabled?).with(:champva_require_all_s3_success, @current_user).and_return(false)
+      end
+
+      it 'returns an array of upload results' do
+        expect(uploader.handle_uploads).to eq([[400, 'Upload failed'], [400, 'Upload failed']])
       end
     end
   end

--- a/modules/ivc_champva/spec/services/file_uploader_spec.rb
+++ b/modules/ivc_champva/spec/services/file_uploader_spec.rb
@@ -29,8 +29,11 @@ describe IvcChampva::FileUploader do
         allow(uploader).to receive(:upload).and_return([400, 'Upload failed'])
       end
 
-      it 'returns an array of upload results' do
-        expect(uploader.handle_uploads).to eq([[400, 'Upload failed'], [400, 'Upload failed']])
+      it 'raises an error' do
+        # Updated this test to account for new error being raised. This is so submissions are blocked
+        # from completing if any files fail to make it to S3. Formerly, the expectation was:
+        # `expect(uploader.handle_uploads).to eq([[400, 'Upload failed'], [400, 'Upload failed']])`
+        expect { uploader.handle_uploads }.to raise_error(StandardError, /Upload failed/)
       end
     end
   end


### PR DESCRIPTION
## Summary

This PR updates the way the IVC CHAMPVA module handles missing uploads when some fail to make it to S3. Previously, the user's submission was allowed to continue if some files failed to make it through. Then steps were taken to manually interpret the submission and determine if enough information made it through. 

This created a lot of manual work and room for error. This PR updates the backend so that rather than letting incomplete submissions through, we fail the submission and throw an error that bubbles up to the user. This will prevent users from having a false impression that their submission was acceptable and provides breathing room until the file transmission issue can be worked out.

For more background and context, see this [explanation](https://github.com/department-of-veterans-affairs/va.gov-team/issues/100496#issuecomment-2596989025).

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/100496

## Testing done

- [X] *New code is covered by unit tests*
- Previously, if some supporting documents didn't make it to S3 a user's submission was allowed to continue
- See this [description](https://github.com/department-of-veterans-affairs/va.gov-team/issues/100496#issuecomment-2596989025) for steps on testing
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots

NA

## What areas of the site does it impact?

IVC CHAMPVA forms

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA