### PR TITLE
Pension submitted email

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1121,6 +1121,9 @@ features:
   pension_error_email_notification:
     actor_type: cookie_id
     description: Toggle sending of the Action Needed email notification
+  pension_submitted_email_notification:
+    actor_type: cookie_id
+    description: Toggle sending of the Submission in Progress email notification
   pension_received_email_notification:
     actor_type: cookie_id
     description: Toggle sending of the Received email notification

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1260,6 +1260,9 @@ vanotify:
         error:
           template_id: form527ez_error_email_template_id
           flipper_id: pension_error_email_notification
+        submitted:
+          template_id: form527ez_submitted_email_template_id
+          flipper_id: pension_submitted_email_notification
         received:
           template_id: form527ez_received_email_template_id
           flipper_id: pension_received_email_notification

--- a/modules/pensions/app/sidekiq/pensions/pension_benefit_intake_job.rb
+++ b/modules/pensions/app/sidekiq/pensions/pension_benefit_intake_job.rb
@@ -224,7 +224,7 @@ module Pensions
     end
 
     ##
-    # VANotify job to send Submission in Prorgess email to veteran
+    # VANotify job to send Submission in Progress email to veteran
     #
     def send_submitted_email
       Pensions::NotificationEmail.new(@claim.id).deliver(:submitted)

--- a/modules/pensions/app/sidekiq/pensions/pension_benefit_intake_job.rb
+++ b/modules/pensions/app/sidekiq/pensions/pension_benefit_intake_job.rb
@@ -65,7 +65,11 @@ module Pensions
 
       @pension_monitor.track_submission_success(@claim, @intake_service, @user_account_uuid)
 
-      send_confirmation_email
+      if Flipper.enabled?(:pension_submitted_email_notification)
+        send_submitted_email
+      else
+        send_confirmation_email
+      end
 
       @intake_service.uuid
     rescue => e
@@ -217,6 +221,15 @@ module Pensions
       Pensions::NotificationEmail.new(@claim.id).deliver(:confirmation)
     rescue => e
       @pension_monitor.track_send_confirmation_email_failure(@claim, @intake_service, @user_account_uuid, e)
+    end
+
+    ##
+    # VANotify job to send Submission in Prorgess email to veteran
+    #
+    def send_submitted_email
+      Pensions::NotificationEmail.new(@claim.id).deliver(:submitted)
+    rescue => e
+      @pension_monitor.track_send_submitted_email_failure(@claim, @intake_service, @user_account_uuid, e)
     end
 
     ##

--- a/modules/pensions/lib/pensions/monitor.rb
+++ b/modules/pensions/lib/pensions/monitor.rb
@@ -300,6 +300,30 @@ module Pensions
     end
 
     ##
+    # Tracks the failure to send a Submission in Progress email for a claim.
+    # @see PensionBenefitIntakeJob
+    #
+    # @param claim [Pension::SavedClaim]
+    # @param lighthouse_service [LighthouseService]
+    # @param user_account_uuid [String]
+    # @param e [Exception]
+    #
+    def track_send_submitted_email_failure(claim, lighthouse_service, user_account_uuid, e)
+      additional_context = {
+        confirmation_number: claim&.confirmation_number,
+        user_account_uuid:,
+        claim_id: claim&.id,
+        benefits_intake_uuid: lighthouse_service&.uuid,
+        message: e&.message,
+        tags:
+      }
+
+      track_request('warn', 'Lighthouse::PensionBenefitIntakeJob send_submitted_email failed',
+                    "#{SUBMISSION_STATS_KEY}.send_submitted_failed",
+                    call_location: caller_locations.first, **additional_context)
+    end
+
+    ##
     # log Sidkiq job cleanup error occurred, this can occur post success or failure
     # @see PensionBenefitIntakeJob
     #

--- a/modules/pensions/spec/lib/pensions/monitor_spec.rb
+++ b/modules/pensions/spec/lib/pensions/monitor_spec.rb
@@ -360,6 +360,30 @@ RSpec.describe Pensions::Monitor do
       end
     end
 
+    describe '#track_send_submitted_email_failure' do
+      it 'logs sidekiq job send_submitted_email error' do
+        log = 'Lighthouse::PensionBenefitIntakeJob send_submitted_email failed'
+        payload = {
+          claim_id: claim.id,
+          benefits_intake_uuid: lh_service.uuid,
+          confirmation_number: claim.confirmation_number,
+          user_account_uuid: current_user.uuid,
+          message: monitor_error.message,
+          tags: monitor.tags
+        }
+
+        expect(monitor).to receive(:track_request).with(
+          'warn',
+          log,
+          "#{submission_stats_key}.send_submitted_failed",
+          call_location: anything,
+          **payload
+        )
+
+        monitor.track_send_submitted_email_failure(claim, lh_service, current_user.uuid, monitor_error)
+      end
+    end
+
     describe '#track_file_cleanup_error' do
       it 'logs sidekiq job ensure file cleanup error' do
         log = 'Lighthouse::PensionBenefitIntakeJob cleanup failed'


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Send an email notifying applicants that their Pension application was submitted on VA.gov, replacing the current confirmation email.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/94104

## Testing done

- [ ] *New code is covered by unit tests*
- [ ] Submitted a Pension claim with flipper on and confirmed the "submitted" email appeared in the ClaimVANotification table
- [ ] Submitted a Pension claim with flipper off and confirmed the "confirmation" email appeared in the ClaimVANotification table

## What areas of the site does it impact?
Pensions

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
