### PR TITLE
API-34449-poa-requests-mock

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -1,6 +1,14 @@
 ---
 :services:
 
+# BGS
+- :name: "BGS"
+  :base_uri: <%= "#{URI(Settings.bgs.url).host}:#{URI(Settings.bgs.url).port}" %>
+  :endpoints:
+    - :method: :post
+      :path: "/VDC/ManageRepresentativeService"
+      :file_path: "/bgs/manage_representative_service/read_poa_request/default"
+
 #CRM API GET endpoint
 - :name: "CRM API GET endpoint"
   :base_uri: <%= "#{URI(Settings.ask_va_api.crm_api.base_url).host}:#{URI(Settings.ask_va_api.crm_api.base_url).port}" %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -662,7 +662,7 @@ claims_api:
       lighthouse:
         api_key: ~
   bgs:
-    mock_responses: ~
+    mock_responses: false
 
 connected_apps_api:
   connected_apps:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -661,6 +661,8 @@ claims_api:
     services:
       lighthouse:
         api_key: ~
+  bgs:
+    mock_responses: ~
 
 connected_apps_api:
   connected_apps:

--- a/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/index.rb
+++ b/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/index.rb
@@ -30,7 +30,8 @@ module ClaimsApi
 
       def poa_list
         @poa_list ||= manage_representative_service.read_poa_request(poa_codes: @poa_codes, page_size: @page_size,
-                                                                     page_index: @page_index, filter: @filter)
+                                                                     page_index: @page_index, filter: @filter,
+                                                                     use_mocks: true)
 
         @poa_list['poaRequestRespondReturnVOList']
       end

--- a/modules/claims_api/lib/bgs_service/local_bgs.rb
+++ b/modules/claims_api/lib/bgs_service/local_bgs.rb
@@ -13,7 +13,6 @@ require 'bgs_service/find_definition'
 
 module ClaimsApi
   class LocalBGS
-    MOCKED_ACTIONS = %(readPOARequest)
     # rubocop:disable Metrics/MethodLength
     def initialize(external_uid:, external_key:)
       @client_ip =
@@ -307,11 +306,7 @@ module ClaimsApi
     end
 
     def use_mocks?(use_mocks)
-      if use_mocks && Settings.claims_api.bgs.mock_responses
-        true
-      else
-        false
-      end
+      use_mocks && Settings.claims_api.bgs.mock_responses
     end
   end
 end

--- a/modules/claims_api/lib/bgs_service/manage_representative_service.rb
+++ b/modules/claims_api/lib/bgs_service/manage_representative_service.rb
@@ -8,7 +8,7 @@ module ClaimsApi
       'VDC/ManageRepresentativeService'
     end
 
-    def read_poa_request(poa_codes: [], page_size: nil, page_index: nil, filter: {}) # rubocop:disable Metrics/MethodLength
+    def read_poa_request(poa_codes: [], page_size: nil, page_index: nil, filter: {}, use_mocks: false) # rubocop:disable Metrics/MethodLength
       # Workaround to allow multiple roots in the Nokogiri XML builder
       # https://stackoverflow.com/a/4907450
       doc = Nokogiri::XML::DocumentFragment.parse ''
@@ -55,7 +55,7 @@ module ClaimsApi
       body = builder_to_xml(doc)
 
       make_request(endpoint: bean_name, action: 'readPOARequest', body:, key: 'POARequestRespondReturnVO',
-                   namespaces: { 'data' => '/data' }, transform_response: false)
+                   namespaces: { 'data' => '/data' }, transform_response: false, use_mocks:)
     end
 
     def read_poa_request_by_ptcpnt_id(ptcpnt_id:)


### PR DESCRIPTION
## Summary
* Adds optional param to local BGS call so we can ensure to mock _**only**_ where we want to
* Adds BGS for mocking in the betamocks service config
* Adds new setting under the `claims_api` namespace for enabling mocking of these BGS calls
* Threads optional param through from `read_poa_request` which is the BGS call used in the workflow for this ticket specifically

## Related issue(s)
[API-34449](https://jira.devops.va.gov/browse/API-34449)

## Testing done

- [x] *There should be no change to current functionality

#### Testing Notes
*  **_You will need the matching PR from the mock data repo to properly test this out._**
* In the mockdata repo pull down the latest and switch to branch `API-34449-mock-poa-request-responses`
* In settings local add these settings right under claims api (can be anywhere other included to show indenting):
 ```
claims_api:
 ...
  bgs: <--- new
    mock_responses: true <------- new
  local_bgs:
    use_mocks_for_v2: true
  v2_docs:
    enabled: true
```
* Hit `http://localhost:3000/services/claims/v2/veterans/power-of-attorney-requests`
* You should see the mocked response (partial screenshot below) come back (we can always change the text I added `(mock)` to make this easy to see)

## Screenshots
<img width="748" alt="Screenshot 2025-01-17 at 2 52 32 PM" src="https://github.com/user-attachments/assets/03c77e2d-47eb-4089-b934-3fcea3bf6200" />

## What areas of the site does it impact?
- modified: config/betamocks/services_config.yml
- modified: config/settings.yml
- modified: modules/claims_api/app/services/claims_api/power_of_attorney_request_service/index.rb
- modified: modules/claims_api/lib/bgs_service/local_bgs.rb
- modified: modules/claims_api/lib/bgs_service/manage_representative_service.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
