### PR TITLE
[VACMS-19908]Swagger API docs, lower case "b" for banners keys to lineup

### DIFF
--- a/app/controllers/v0/apidocs_controller.rb
+++ b/app/controllers/v0/apidocs_controller.rb
@@ -86,7 +86,7 @@ module V0
         key :description, 'Veteran Medical Copay information for VA facilities'
       end
       tag do
-        key :name, 'Banners'
+        key :name, 'banners'
         key :description, 'VAMC Situation Update Banners'
       end
       key :host, Settings.hostname


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Updates Swagger documentation for the new Realtime Banners API to matchup keys
- Original work was recently created here https://github.com/department-of-veterans-affairs/vets-api/pull/20234
- Sitewide Team owns and maintains the Banners Controller API and its related docs

## Related issue(s)

- Issue: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19908
- Epic: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19302
- OG PR: https://github.com/department-of-veterans-affairs/vets-api/pull/20234

## Testing done

- [ ] *New code is covered by unit tests*
- AFAIK there is no way to test our Swagger documentation locally. This documentation update will need to be verified on https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/ once deployed

## Screenshots
Because of the keys mismatching, currently the API docs look like this today.

<img width="1173" alt="Screenshot 2025-01-21 at 8 47 59 AM" src="https://github.com/user-attachments/assets/fac3b92b-60ce-46c9-a9a7-084794a1a84c" />


## What areas of the site does it impact?
This will only affect Swagger documentation for Banners which should end up [here](https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/banners)

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/banners)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

Is there a way to test Swagger documentation locally? If so, please share!
