### PR TITLE
Handle uninitialized constant

### DIFF
--- a/lib/sidekiq/retry_monitoring.rb
+++ b/lib/sidekiq/retry_monitoring.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'sidekiq/retry_monitoring'
+
 module Sidekiq
   class RetryMonitoring
     def call(worker, params, _queue)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- A message, `NameError: uninitialized constant Sidekiq::MonitoredWorker`, occasionally appears in the logs when a Sidekiq job fails/retries. It appears that this comes from a missing import in `lib/sidekiq/retry_monitoring.rb`, and that requiring 'sidekiq/retry_monitoring' should fix it. 

## Related issue(s)

## Testing done

- [ ] *New code is covered by unit tests*
- Ran code which triggered a Sidekiq retry and no longer saw the error message locally 

## Screenshots
<img width="1560" alt="Screenshot 2025-01-21 at 1 34 09 PM" src="https://github.com/user-attachments/assets/10b7c6f7-ecbe-45f1-b4b0-af2946bb3c32" />

## What areas of the site does it impact?
Sidekiq monitored workers

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature