### PR TITLE
BE | Ask VA Api: Fix bug in inquiry details when who_is_your_question_about is nil

### DIFF
--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/inquiry_details.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/inquiry_details.rb
@@ -19,12 +19,13 @@ module AskVAApi
             return general_inquiry(inquiry_params, inquiry_details)
           end
 
-          if inquiry_params[:who_is_your_question_about] == 'Myself'
-            return handle_self_inquiry(inquiry_params, inquiry_details)
+          if inquiry_params[:who_is_your_question_about] == 'Someone else' || inquiry_params[:your_role]
+            return handle_others_inquiry(inquiry_params, inquiry_details)
           end
 
-          if inquiry_params[:who_is_your_question_about] == 'Someone else'
-            handle_others_inquiry(inquiry_params, inquiry_details)
+          if inquiry_params[:who_is_your_question_about] == 'Myself' ||
+             inquiry_params[:who_is_your_question_about].nil?
+            handle_self_inquiry(inquiry_params, inquiry_details)
           end
         end
 

--- a/modules/ask_va_api/config/locales/en.yml
+++ b/modules/ask_va_api/config/locales/en.yml
@@ -127,6 +127,11 @@ en:
               - :service_number
               - :ssn
             - :suffix
+            - :branch_of_service
+            - :preferred_name
+            - :service_date_range:
+              - :from
+              - :to
           about_the_veteran:
             - :date_of_birth
             - :first

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/inquiry_details_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/inquiry_details_spec.rb
@@ -61,6 +61,20 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::InquiryDetails do
                      level_of_authentication: 'Personal'
                    })
         end
+
+        context 'when who_is_your_question_about is nil' do
+          let(:who_is_your_question_about) { nil }
+
+          it 'returns a payload structure to CRM API' do
+            expect(builder.call)
+              .to eq({
+                       inquiry_about: 'About Me, the Veteran',
+                       dependent_relationship: nil,
+                       veteran_relationship: nil,
+                       level_of_authentication: 'Personal'
+                     })
+          end
+        end
       end
 
       context 'when the dependent is the submitter' do


### PR DESCRIPTION
## Summary

- Fixed a bug in the InquiryDetails component where the who_is_your_question_about field was nil, causing an error that prevented the creation of an inquiry.

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected