### PR TITLE
API-44208-reorder-poa-docs-1

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -1448,7 +1448,7 @@
                   "202 without a transactionId": {
                     "value": {
                       "data": {
-                        "id": "5506cc73-83c6-4c8a-8dc0-7296b628152d",
+                        "id": "0e165207-c160-41bb-8879-58254192c94a",
                         "type": "forms/526",
                         "attributes": {
                           "claimId": "600442191",
@@ -1633,7 +1633,7 @@
                             },
                             "federalActivation": {
                               "activationDate": "2023-10-01",
-                              "anticipatedSeparationDate": "2025-01-17"
+                              "anticipatedSeparationDate": "2025-01-24"
                             },
                             "confinements": [
                               {
@@ -1679,7 +1679,7 @@
                   "202 with a transactionId": {
                     "value": {
                       "data": {
-                        "id": "2ebc2bd7-66fa-4a86-afb1-3c2c3dbbb4e5",
+                        "id": "50722a9d-93fa-4b74-a6ae-7fc7f746ea13",
                         "type": "forms/526",
                         "attributes": {
                           "claimId": "600442191",
@@ -1843,7 +1843,7 @@
                                 "serviceBranch": "Public Health Service",
                                 "serviceComponent": "Active",
                                 "activeDutyBeginDate": "2008-11-14",
-                                "activeDutyEndDate": "2025-01-17",
+                                "activeDutyEndDate": "2025-01-24",
                                 "separationLocationCode": "98282"
                               }
                             ],
@@ -1864,7 +1864,7 @@
                             },
                             "federalActivation": {
                               "activationDate": "2023-10-01",
-                              "anticipatedSeparationDate": "2025-01-17"
+                              "anticipatedSeparationDate": "2025-01-24"
                             },
                             "confinements": [
                               {
@@ -5107,7 +5107,7 @@
                               "serviceBranch": "Public Health Service",
                               "serviceComponent": "Active",
                               "activeDutyBeginDate": "2008-11-14",
-                              "activeDutyEndDate": "2025-01-17",
+                              "activeDutyEndDate": "2025-01-24",
                               "separationLocationCode": "98282"
                             }
                           ],
@@ -5128,7 +5128,7 @@
                           },
                           "federalActivation": {
                             "activationDate": "2023-10-01",
-                            "anticipatedSeparationDate": "2025-01-17"
+                            "anticipatedSeparationDate": "2025-01-24"
                           },
                           "confinements": [
                             {
@@ -9650,8 +9650,8 @@
                     "id": "1",
                     "type": "intent_to_file",
                     "attributes": {
-                      "creationDate": "2025-01-15",
-                      "expirationDate": "2026-01-15",
+                      "creationDate": "2025-01-22",
+                      "expirationDate": "2026-01-22",
                       "type": "compensation",
                       "status": "active"
                     }
@@ -10497,6 +10497,898 @@
         }
       }
     },
+    "/veterans/{veteranId}/power-of-attorney-request": {
+      "post": {
+        "summary": "Create a Power of Attorney appointment request",
+        "description": "Creates a Power of Attorney appointment request.",
+        "tags": [
+          "Power of Attorney"
+        ],
+        "operationId": "postPowerOfAttorneyRequest",
+        "security": [
+          {
+            "productionOauth": [
+              "system/claim.read",
+              "system/claim.write"
+            ]
+          },
+          {
+            "sandboxOauth": [
+              "system/claim.read",
+              "system/claim.write"
+            ]
+          },
+          {
+            "bearer_token": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "veteranId",
+            "in": "path",
+            "required": true,
+            "example": "1012667145V762142",
+            "description": "ID of Veteran",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Valid request response",
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "id": "4857f836-2aad-40aa-95d6-a74b05711dad",
+                    "type": "power-of-attorney-request",
+                    "attributes": {
+                      "veteran": {
+                        "serviceNumber": "123678453",
+                        "serviceBranch": "ARMY",
+                        "address": {
+                          "addressLine1": "2719 Hyperion Ave",
+                          "addressLine2": "Apt 2",
+                          "city": "Los Angeles",
+                          "country": "USA",
+                          "stateCode": "CA",
+                          "zipCode": "92264",
+                          "zipCodeSuffix": "0200"
+                        },
+                        "phone": {
+                          "areaCode": "555",
+                          "phoneNumber": "5551234"
+                        },
+                        "email": "test@test.com",
+                        "insuranceNumber": "1234567890"
+                      },
+                      "poa": {
+                        "poaCode": "067",
+                        "registrationNumber": "999999999999",
+                        "jobTitle": "MyJob"
+                      },
+                      "recordConsent": true,
+                      "consentAddressChange": true,
+                      "consentLimits": [
+                        "DRUG_ABUSE",
+                        "SICKLE_CELL",
+                        "HIV",
+                        "ALCOHOLISM"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "id",
+                        "type",
+                        "attributes"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "The unique identifier for the power of attorney request"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "power-of-attorney-request"
+                          ],
+                          "description": "The type of the resource"
+                        },
+                        "attributes": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "required": [
+                            "veteran",
+                            "poa",
+                            "recordConsent",
+                            "consentAddressChange"
+                          ],
+                          "properties": {
+                            "veteran": {
+                              "type": "object",
+                              "additionalProperties": false,
+                              "required": [
+                                "address"
+                              ],
+                              "properties": {
+                                "serviceNumber": {
+                                  "description": "The Veteran's Service Number",
+                                  "type": "string",
+                                  "maxLength": 9
+                                },
+                                "serviceBranch": {
+                                  "description": "Service Branch for the veteran.",
+                                  "type": "string",
+                                  "enum": [
+                                    "AIR_FORCE",
+                                    "ARMY",
+                                    "COAST_GUARD",
+                                    "MARINE_CORPS",
+                                    "NAVY",
+                                    "SPACE_FORCE",
+                                    "OTHER"
+                                  ],
+                                  "example": "ARMY"
+                                },
+                                "address": {
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "addressLine1",
+                                    "city",
+                                    "stateCode",
+                                    "country",
+                                    "zipCode"
+                                  ],
+                                  "properties": {
+                                    "addressLine1": {
+                                      "description": "Street address with number and name.",
+                                      "type": "string",
+                                      "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                      "maxLength": 30
+                                    },
+                                    "addressLine2": {
+                                      "type": "string",
+                                      "maxLength": 5
+                                    },
+                                    "city": {
+                                      "description": "City for the address.",
+                                      "type": "string",
+                                      "example": "Portland",
+                                      "maxLength": 18
+                                    },
+                                    "stateCode": {
+                                      "description": "State for the address.",
+                                      "type": "string",
+                                      "pattern": "^[a-z,A-Z]{2}$",
+                                      "example": "OR"
+                                    },
+                                    "country": {
+                                      "description": "Country of the address. USA is the value to use for United States based addresses, US will not work.",
+                                      "type": "string",
+                                      "example": "USA"
+                                    },
+                                    "zipCode": {
+                                      "description": "Zipcode (First 5 digits) of the address.",
+                                      "type": "string",
+                                      "pattern": "^\\d{5}?$",
+                                      "example": "12345"
+                                    },
+                                    "zipCodeSuffix": {
+                                      "description": "Zipcode (Last 4 digits) of the address.",
+                                      "type": "string",
+                                      "pattern": "^\\d{4}?$",
+                                      "example": "6789"
+                                    }
+                                  }
+                                },
+                                "phone": {
+                                  "$comment": "the phone fields must not exceed 20 chars, when concatenated",
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "areaCode",
+                                    "phoneNumber"
+                                  ],
+                                  "properties": {
+                                    "areaCode": {
+                                      "description": "Area code of the phone number.",
+                                      "type": "string",
+                                      "pattern": "^[2-9][0-9]{2}$",
+                                      "example": "555"
+                                    },
+                                    "phoneNumber": {
+                                      "description": "Phone number.",
+                                      "type": "string",
+                                      "pattern": "^[0-9]{1,14}$",
+                                      "example": "555-5555"
+                                    }
+                                  }
+                                },
+                                "email": {
+                                  "description": "Email address of the veteran.",
+                                  "type": "string",
+                                  "pattern": ".@.",
+                                  "maxLength": 61,
+                                  "example": "veteran@example.com"
+                                },
+                                "insuranceNumber": {
+                                  "type": "string",
+                                  "maxLength": 10,
+                                  "description": "Veteran's insurance number, if applicable. Include letter prefix."
+                                }
+                              }
+                            },
+                            "claimant": {
+                              "type": "object",
+                              "additionalProperties": false,
+                              "properties": {
+                                "claimantId": {
+                                  "type": "string",
+                                  "example": "123456789",
+                                  "description": "Id of the claimant."
+                                },
+                                "address": {
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "addressLine1": {
+                                      "description": "Street address with number and name. Required if claimant information provided.",
+                                      "type": "string",
+                                      "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                      "maxLength": 30
+                                    },
+                                    "addressLine2": {
+                                      "type": "string",
+                                      "maxLength": 5
+                                    },
+                                    "city": {
+                                      "description": "City for the address. Required if claimant information provided.",
+                                      "type": "string",
+                                      "example": "Portland",
+                                      "maxLength": 18
+                                    },
+                                    "stateCode": {
+                                      "description": "State for the address. Required if claimant information provided.",
+                                      "type": "string",
+                                      "pattern": "^[a-z,A-Z]{2}$",
+                                      "example": "OR"
+                                    },
+                                    "country": {
+                                      "description": "Country of the address. Required if claimant information provided.",
+                                      "type": "string",
+                                      "example": "USA"
+                                    },
+                                    "zipCode": {
+                                      "description": "Zipcode (First 5 digits) of the address. Required if claimant information provided.",
+                                      "type": "string",
+                                      "pattern": "^\\d{5}?$",
+                                      "example": "12345"
+                                    },
+                                    "zipCodeSuffix": {
+                                      "description": "Zipcode (Last 4 digits) of the address.",
+                                      "type": "string",
+                                      "pattern": "^\\d{4}?$",
+                                      "example": "6789"
+                                    }
+                                  }
+                                },
+                                "phone": {
+                                  "$comment": "the phone fields must not exceed 20 chars, when concatenated",
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "areaCode",
+                                    "phoneNumber"
+                                  ],
+                                  "properties": {
+                                    "areaCode": {
+                                      "description": "Area code of the phone number.",
+                                      "type": "string",
+                                      "pattern": "^[2-9][0-9]{2}$",
+                                      "example": "555"
+                                    },
+                                    "phoneNumber": {
+                                      "description": "Phone number.",
+                                      "type": "string",
+                                      "pattern": "^[0-9]{1,14}$",
+                                      "example": "555-5555"
+                                    }
+                                  }
+                                },
+                                "email": {
+                                  "description": "Email address of the claimant.",
+                                  "type": "string",
+                                  "pattern": ".@.",
+                                  "maxLength": 61,
+                                  "example": "claimant@example.com"
+                                },
+                                "relationship": {
+                                  "description": "Relationship of claimant to the veteran. Required if claimant information provided.",
+                                  "type": "string",
+                                  "example": "Spouse"
+                                }
+                              }
+                            },
+                            "poa": {
+                              "description": "Details of the requested Power of Attorney representing the veteran.",
+                              "type": "object",
+                              "additionalProperties": false,
+                              "required": [
+                                "poaCode",
+                                "registrationNumber"
+                              ],
+                              "properties": {
+                                "poaCode": {
+                                  "description": "The POA code of the accredited representative or organization.",
+                                  "type": "string",
+                                  "example": "A1Q"
+                                },
+                                "registrationNumber": {
+                                  "description": "Registration Number of the accredited representative.",
+                                  "type": "string",
+                                  "example": "12345"
+                                },
+                                "jobTitle": {
+                                  "description": "Job title of the accredited representative.",
+                                  "type": "string",
+                                  "example": "Veteran Service Representative"
+                                }
+                              }
+                            },
+                            "recordConsent": {
+                              "description": "AUTHORIZATION FOR REPRESENTATIVE'S ACCESS TO RECORDS PROTECTED BY SECTION 7332, TITLE 38, U.S.C.",
+                              "type": "boolean"
+                            },
+                            "consentLimits": {
+                              "description": "Consent in Item 19 for the disclosure of records relating to treatment for drug abuse, alcoholism or alcohol abuse, infection with the human immunodeficiency virus (HIV), or sickle cell anemia is limited as follows. Will default to false if not specified.",
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "DRUG_ABUSE",
+                                  "ALCOHOLISM",
+                                  "HIV",
+                                  "SICKLE_CELL"
+                                ]
+                              },
+                              "example": "DRUG ABUSE"
+                            },
+                            "consentAddressChange": {
+                              "description": "AUTHORIZATION FOR REPRESENTATIVE TO ACT ON CLAIMANT'S BEHALF TO CHANGE CLAIMANT'S ADDRESS.",
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Not authorized",
+                      "status": "401",
+                      "detail": "Not authorized"
+                    }
+                  ]
+                },
+                "schema": {
+                  "required": [
+                    "errors"
+                  ],
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "additionalProperties": false,
+                        "required": [
+                          "title",
+                          "detail"
+                        ],
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "HTTP error title"
+                          },
+                          "detail": {
+                            "type": "string",
+                            "description": "HTTP error detail"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "HTTP error status code"
+                          },
+                          "source": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "Source of error",
+                            "properties": {
+                              "pointer": {
+                                "type": "string",
+                                "description": "Pointer to source of error"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Unprocessable entity",
+                      "detail": "The property /poa did not contain the required key poaCode",
+                      "status": "422",
+                      "source": {
+                        "pointer": "data/attributes/poa"
+                      }
+                    }
+                  ]
+                },
+                "schema": {
+                  "required": [
+                    "errors"
+                  ],
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "additionalProperties": false,
+                        "required": [
+                          "title",
+                          "detail"
+                        ],
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "HTTP error title"
+                          },
+                          "detail": {
+                            "type": "string",
+                            "description": "HTTP error detail"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "HTTP error status code"
+                          },
+                          "source": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "Source of error",
+                            "properties": {
+                              "pointer": {
+                                "type": "string",
+                                "description": "Pointer to source of error"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "errors": [
+                    {
+                      "status": "404",
+                      "title": "Resource not found",
+                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 067"
+                    }
+                  ]
+                },
+                "schema": {
+                  "required": [
+                    "errors"
+                  ],
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "additionalProperties": false,
+                        "required": [
+                          "title",
+                          "detail"
+                        ],
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "HTTP error title"
+                          },
+                          "detail": {
+                            "type": "string",
+                            "description": "HTTP error detail"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "HTTP error status code"
+                          },
+                          "source": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "Source of error",
+                            "properties": {
+                              "pointer": {
+                                "type": "string",
+                                "description": "Pointer to source of error"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "attributes",
+                      null
+                    ],
+                    "properties": {
+                      "attributes": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "description": "POA Request (21-22/a) Schema",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "veteran",
+                          "poa",
+                          "recordConsent",
+                          "consentAddressChange"
+                        ],
+                        "properties": {
+                          "veteran": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                              "address"
+                            ],
+                            "properties": {
+                              "serviceNumber": {
+                                "description": "The Veteran's Service Number",
+                                "type": "string",
+                                "maxLength": 9
+                              },
+                              "serviceBranch": {
+                                "description": "Service Branch for the veteran.",
+                                "type": "string",
+                                "enum": [
+                                  "AIR_FORCE",
+                                  "ARMY",
+                                  "COAST_GUARD",
+                                  "MARINE_CORPS",
+                                  "NAVY",
+                                  "SPACE_FORCE",
+                                  "OTHER"
+                                ],
+                                "example": "ARMY"
+                              },
+                              "address": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                  "addressLine1",
+                                  "city",
+                                  "stateCode",
+                                  "country",
+                                  "zipCode"
+                                ],
+                                "properties": {
+                                  "addressLine1": {
+                                    "description": "Street address with number and name.",
+                                    "type": "string",
+                                    "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                    "maxLength": 30
+                                  },
+                                  "addressLine2": {
+                                    "type": "string",
+                                    "maxLength": 5
+                                  },
+                                  "city": {
+                                    "description": "City for the address.",
+                                    "type": "string",
+                                    "example": "Portland",
+                                    "maxLength": 18
+                                  },
+                                  "stateCode": {
+                                    "description": "State for the address.",
+                                    "type": "string",
+                                    "pattern": "^[a-z,A-Z]{2}$",
+                                    "example": "OR"
+                                  },
+                                  "country": {
+                                    "description": "Country of the address. USA is the value to use for United States based addresses, US will not work.",
+                                    "type": "string",
+                                    "example": "USA"
+                                  },
+                                  "zipCode": {
+                                    "description": "Zipcode (First 5 digits) of the address.",
+                                    "type": "string",
+                                    "pattern": "^\\d{5}?$",
+                                    "example": "12345"
+                                  },
+                                  "zipCodeSuffix": {
+                                    "description": "Zipcode (Last 4 digits) of the address.",
+                                    "type": "string",
+                                    "pattern": "^\\d{4}?$",
+                                    "example": "6789"
+                                  }
+                                }
+                              },
+                              "phone": {
+                                "$comment": "the phone fields must not exceed 20 chars, when concatenated",
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                  "areaCode",
+                                  "phoneNumber"
+                                ],
+                                "properties": {
+                                  "areaCode": {
+                                    "description": "Area code of the phone number.",
+                                    "type": "string",
+                                    "pattern": "^[2-9][0-9]{2}$",
+                                    "example": "555"
+                                  },
+                                  "phoneNumber": {
+                                    "description": "Phone number.",
+                                    "type": "string",
+                                    "pattern": "^[0-9]{1,14}$",
+                                    "example": "555-5555"
+                                  }
+                                }
+                              },
+                              "email": {
+                                "description": "Email address of the veteran.",
+                                "type": "string",
+                                "pattern": ".@.",
+                                "maxLength": 61,
+                                "example": "veteran@example.com"
+                              },
+                              "insuranceNumber": {
+                                "type": "string",
+                                "maxLength": 10,
+                                "description": "Veteran's insurance number, if applicable. Include letter prefix."
+                              }
+                            }
+                          },
+                          "claimant": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                              "claimantId": {
+                                "type": "string",
+                                "example": "123456789",
+                                "description": "Id of the claimant."
+                              },
+                              "address": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                  "addressLine1": {
+                                    "description": "Street address with number and name. Required if claimant information provided.",
+                                    "type": "string",
+                                    "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+                                    "maxLength": 30
+                                  },
+                                  "addressLine2": {
+                                    "type": "string",
+                                    "maxLength": 5
+                                  },
+                                  "city": {
+                                    "description": "City for the address. Required if claimant information provided.",
+                                    "type": "string",
+                                    "example": "Portland",
+                                    "maxLength": 18
+                                  },
+                                  "stateCode": {
+                                    "description": "State for the address. Required if claimant information provided.",
+                                    "type": "string",
+                                    "pattern": "^[a-z,A-Z]{2}$",
+                                    "example": "OR"
+                                  },
+                                  "country": {
+                                    "description": "Country of the address. Required if claimant information provided.",
+                                    "type": "string",
+                                    "example": "USA"
+                                  },
+                                  "zipCode": {
+                                    "description": "Zipcode (First 5 digits) of the address. Required if claimant information provided.",
+                                    "type": "string",
+                                    "pattern": "^\\d{5}?$",
+                                    "example": "12345"
+                                  },
+                                  "zipCodeSuffix": {
+                                    "description": "Zipcode (Last 4 digits) of the address.",
+                                    "type": "string",
+                                    "pattern": "^\\d{4}?$",
+                                    "example": "6789"
+                                  }
+                                }
+                              },
+                              "phone": {
+                                "$comment": "the phone fields must not exceed 20 chars, when concatenated",
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                  "areaCode",
+                                  "phoneNumber"
+                                ],
+                                "properties": {
+                                  "areaCode": {
+                                    "description": "Area code of the phone number.",
+                                    "type": "string",
+                                    "pattern": "^[2-9][0-9]{2}$",
+                                    "example": "555"
+                                  },
+                                  "phoneNumber": {
+                                    "description": "Phone number.",
+                                    "type": "string",
+                                    "pattern": "^[0-9]{1,14}$",
+                                    "example": "555-5555"
+                                  }
+                                }
+                              },
+                              "email": {
+                                "description": "Email address of the claimant.",
+                                "type": "string",
+                                "pattern": ".@.",
+                                "maxLength": 61,
+                                "example": "claimant@example.com"
+                              },
+                              "relationship": {
+                                "description": "Relationship of claimant to the veteran. Required if claimant information provided.",
+                                "type": "string",
+                                "example": "Spouse"
+                              }
+                            }
+                          },
+                          "poa": {
+                            "description": "Details of the requested Power of Attorney representing the veteran.",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                              "poaCode",
+                              "registrationNumber"
+                            ],
+                            "properties": {
+                              "poaCode": {
+                                "description": "The POA code of the accredited representative or organization.",
+                                "type": "string",
+                                "example": "A1Q"
+                              },
+                              "registrationNumber": {
+                                "description": "Registration Number of the accredited representative.",
+                                "type": "string",
+                                "example": "12345"
+                              },
+                              "jobTitle": {
+                                "description": "Job title of the accredited representative.",
+                                "type": "string",
+                                "example": "Veteran Service Representative"
+                              }
+                            }
+                          },
+                          "recordConsent": {
+                            "description": "AUTHORIZATION FOR REPRESENTATIVE'S ACCESS TO RECORDS PROTECTED BY SECTION 7332, TITLE 38, U.S.C.",
+                            "type": "boolean"
+                          },
+                          "consentLimits": {
+                            "description": "Consent for the disclosure of records relating to treatment for drug abuse, alcoholism or alcohol abuse, infection with the human immunodeficiency virus (HIV), or sickle cell anemia is limited as follows. Will default to false if not specified.",
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "DRUG_ABUSE",
+                                "ALCOHOLISM",
+                                "HIV",
+                                "SICKLE_CELL"
+                              ]
+                            },
+                            "example": "DRUG ABUSE"
+                          },
+                          "consentAddressChange": {
+                            "description": "AUTHORIZATION FOR REPRESENTATIVE TO ACT ON CLAIMANT'S BEHALF TO CHANGE CLAIMANT'S ADDRESS.",
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "data": {
+                    "attributes": {
+                      "veteran": {
+                        "serviceNumber": "123678453",
+                        "serviceBranch": "ARMY",
+                        "address": {
+                          "addressLine1": "2719 Hyperion Ave",
+                          "addressLine2": "Apt 2",
+                          "city": "Los Angeles",
+                          "country": "USA",
+                          "stateCode": "CA",
+                          "zipCode": "92264",
+                          "zipCodeSuffix": "0200"
+                        },
+                        "phone": {
+                          "areaCode": "555",
+                          "phoneNumber": "5551234"
+                        },
+                        "email": "test@test.com",
+                        "insuranceNumber": "1234567890"
+                      },
+                      "poa": {
+                        "poaCode": "067",
+                        "registrationNumber": "999999999999",
+                        "jobTitle": "MyJob"
+                      },
+                      "recordConsent": true,
+                      "consentAddressChange": true,
+                      "consentLimits": [
+                        "DRUG_ABUSE",
+                        "SICKLE_CELL",
+                        "HIV",
+                        "ALCOHOLISM"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
     "/veterans/{veteranId}/2122a": {
       "post": {
         "summary": "Appoint an individual Power of Attorney for a Veteran.",
@@ -10541,7 +11433,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "e86ec7a1-e9e5-4d92-91e6-112ee437346c",
+                    "id": "72334ddd-3ca6-4cf0-b31a-24f381be7f71",
                     "type": "individual",
                     "attributes": {
                       "code": "067",
@@ -11313,7 +12205,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "91b0d284-6044-4aa2-9eb5-4876b8dda6bc",
+                    "id": "501230aa-ab2f-45b3-a41a-b2186ab2ad44",
                     "type": "organization",
                     "attributes": {
                       "code": "083",
@@ -13307,10 +14199,10 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "3395906c-c9ee-46c8-9b42-089da70dcfa4",
+                    "id": "3a60ef92-9fb0-4a9b-b1d0-eaa0d79ff74c",
                     "type": "claimsApiPowerOfAttorneys",
                     "attributes": {
-                      "dateRequestAccepted": "2025-01-15",
+                      "dateRequestAccepted": "2025-01-22",
                       "previousPoa": null,
                       "representative": {
                         "serviceOrganization": {
@@ -13520,898 +14412,6 @@
               }
             }
           }
-        }
-      }
-    },
-    "/veterans/{veteranId}/power-of-attorney-request": {
-      "post": {
-        "summary": "Create a Power of Attorney appointment request",
-        "description": "Creates a Power of Attorney appointment request.",
-        "tags": [
-          "Power of Attorney"
-        ],
-        "operationId": "postPowerOfAttorneyRequest",
-        "security": [
-          {
-            "productionOauth": [
-              "system/claim.read",
-              "system/claim.write"
-            ]
-          },
-          {
-            "sandboxOauth": [
-              "system/claim.read",
-              "system/claim.write"
-            ]
-          },
-          {
-            "bearer_token": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "veteranId",
-            "in": "path",
-            "required": true,
-            "example": "1012667145V762142",
-            "description": "ID of Veteran",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Valid request response",
-            "content": {
-              "application/json": {
-                "example": {
-                  "data": {
-                    "id": "267e1af2-bca4-45b8-9434-a04147bd3155",
-                    "type": "power-of-attorney-request",
-                    "attributes": {
-                      "veteran": {
-                        "serviceNumber": "123678453",
-                        "serviceBranch": "ARMY",
-                        "address": {
-                          "addressLine1": "2719 Hyperion Ave",
-                          "addressLine2": "Apt 2",
-                          "city": "Los Angeles",
-                          "country": "USA",
-                          "stateCode": "CA",
-                          "zipCode": "92264",
-                          "zipCodeSuffix": "0200"
-                        },
-                        "phone": {
-                          "areaCode": "555",
-                          "phoneNumber": "5551234"
-                        },
-                        "email": "test@test.com",
-                        "insuranceNumber": "1234567890"
-                      },
-                      "poa": {
-                        "poaCode": "067",
-                        "registrationNumber": "999999999999",
-                        "jobTitle": "MyJob"
-                      },
-                      "recordConsent": true,
-                      "consentAddressChange": true,
-                      "consentLimits": [
-                        "DRUG_ABUSE",
-                        "SICKLE_CELL",
-                        "HIV",
-                        "ALCOHOLISM"
-                      ]
-                    }
-                  }
-                },
-                "schema": {
-                  "$schema": "http://json-schema.org/draft-07/schema#",
-                  "type": "object",
-                  "required": [
-                    "data"
-                  ],
-                  "properties": {
-                    "data": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "required": [
-                        "id",
-                        "type",
-                        "attributes"
-                      ],
-                      "properties": {
-                        "id": {
-                          "type": "string",
-                          "description": "The unique identifier for the power of attorney request"
-                        },
-                        "type": {
-                          "type": "string",
-                          "enum": [
-                            "power-of-attorney-request"
-                          ],
-                          "description": "The type of the resource"
-                        },
-                        "attributes": {
-                          "type": "object",
-                          "additionalProperties": false,
-                          "required": [
-                            "veteran",
-                            "poa",
-                            "recordConsent",
-                            "consentAddressChange"
-                          ],
-                          "properties": {
-                            "veteran": {
-                              "type": "object",
-                              "additionalProperties": false,
-                              "required": [
-                                "address"
-                              ],
-                              "properties": {
-                                "serviceNumber": {
-                                  "description": "The Veteran's Service Number",
-                                  "type": "string",
-                                  "maxLength": 9
-                                },
-                                "serviceBranch": {
-                                  "description": "Service Branch for the veteran.",
-                                  "type": "string",
-                                  "enum": [
-                                    "AIR_FORCE",
-                                    "ARMY",
-                                    "COAST_GUARD",
-                                    "MARINE_CORPS",
-                                    "NAVY",
-                                    "SPACE_FORCE",
-                                    "OTHER"
-                                  ],
-                                  "example": "ARMY"
-                                },
-                                "address": {
-                                  "type": "object",
-                                  "additionalProperties": false,
-                                  "required": [
-                                    "addressLine1",
-                                    "city",
-                                    "stateCode",
-                                    "country",
-                                    "zipCode"
-                                  ],
-                                  "properties": {
-                                    "addressLine1": {
-                                      "description": "Street address with number and name.",
-                                      "type": "string",
-                                      "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
-                                      "maxLength": 30
-                                    },
-                                    "addressLine2": {
-                                      "type": "string",
-                                      "maxLength": 5
-                                    },
-                                    "city": {
-                                      "description": "City for the address.",
-                                      "type": "string",
-                                      "example": "Portland",
-                                      "maxLength": 18
-                                    },
-                                    "stateCode": {
-                                      "description": "State for the address.",
-                                      "type": "string",
-                                      "pattern": "^[a-z,A-Z]{2}$",
-                                      "example": "OR"
-                                    },
-                                    "country": {
-                                      "description": "Country of the address. USA is the value to use for United States based addresses, US will not work.",
-                                      "type": "string",
-                                      "example": "USA"
-                                    },
-                                    "zipCode": {
-                                      "description": "Zipcode (First 5 digits) of the address.",
-                                      "type": "string",
-                                      "pattern": "^\\d{5}?$",
-                                      "example": "12345"
-                                    },
-                                    "zipCodeSuffix": {
-                                      "description": "Zipcode (Last 4 digits) of the address.",
-                                      "type": "string",
-                                      "pattern": "^\\d{4}?$",
-                                      "example": "6789"
-                                    }
-                                  }
-                                },
-                                "phone": {
-                                  "$comment": "the phone fields must not exceed 20 chars, when concatenated",
-                                  "type": "object",
-                                  "additionalProperties": false,
-                                  "required": [
-                                    "areaCode",
-                                    "phoneNumber"
-                                  ],
-                                  "properties": {
-                                    "areaCode": {
-                                      "description": "Area code of the phone number.",
-                                      "type": "string",
-                                      "pattern": "^[2-9][0-9]{2}$",
-                                      "example": "555"
-                                    },
-                                    "phoneNumber": {
-                                      "description": "Phone number.",
-                                      "type": "string",
-                                      "pattern": "^[0-9]{1,14}$",
-                                      "example": "555-5555"
-                                    }
-                                  }
-                                },
-                                "email": {
-                                  "description": "Email address of the veteran.",
-                                  "type": "string",
-                                  "pattern": ".@.",
-                                  "maxLength": 61,
-                                  "example": "veteran@example.com"
-                                },
-                                "insuranceNumber": {
-                                  "type": "string",
-                                  "maxLength": 10,
-                                  "description": "Veteran's insurance number, if applicable. Include letter prefix."
-                                }
-                              }
-                            },
-                            "claimant": {
-                              "type": "object",
-                              "additionalProperties": false,
-                              "properties": {
-                                "claimantId": {
-                                  "type": "string",
-                                  "example": "123456789",
-                                  "description": "Id of the claimant."
-                                },
-                                "address": {
-                                  "type": "object",
-                                  "additionalProperties": false,
-                                  "properties": {
-                                    "addressLine1": {
-                                      "description": "Street address with number and name. Required if claimant information provided.",
-                                      "type": "string",
-                                      "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
-                                      "maxLength": 30
-                                    },
-                                    "addressLine2": {
-                                      "type": "string",
-                                      "maxLength": 5
-                                    },
-                                    "city": {
-                                      "description": "City for the address. Required if claimant information provided.",
-                                      "type": "string",
-                                      "example": "Portland",
-                                      "maxLength": 18
-                                    },
-                                    "stateCode": {
-                                      "description": "State for the address. Required if claimant information provided.",
-                                      "type": "string",
-                                      "pattern": "^[a-z,A-Z]{2}$",
-                                      "example": "OR"
-                                    },
-                                    "country": {
-                                      "description": "Country of the address. Required if claimant information provided.",
-                                      "type": "string",
-                                      "example": "USA"
-                                    },
-                                    "zipCode": {
-                                      "description": "Zipcode (First 5 digits) of the address. Required if claimant information provided.",
-                                      "type": "string",
-                                      "pattern": "^\\d{5}?$",
-                                      "example": "12345"
-                                    },
-                                    "zipCodeSuffix": {
-                                      "description": "Zipcode (Last 4 digits) of the address.",
-                                      "type": "string",
-                                      "pattern": "^\\d{4}?$",
-                                      "example": "6789"
-                                    }
-                                  }
-                                },
-                                "phone": {
-                                  "$comment": "the phone fields must not exceed 20 chars, when concatenated",
-                                  "type": "object",
-                                  "additionalProperties": false,
-                                  "required": [
-                                    "areaCode",
-                                    "phoneNumber"
-                                  ],
-                                  "properties": {
-                                    "areaCode": {
-                                      "description": "Area code of the phone number.",
-                                      "type": "string",
-                                      "pattern": "^[2-9][0-9]{2}$",
-                                      "example": "555"
-                                    },
-                                    "phoneNumber": {
-                                      "description": "Phone number.",
-                                      "type": "string",
-                                      "pattern": "^[0-9]{1,14}$",
-                                      "example": "555-5555"
-                                    }
-                                  }
-                                },
-                                "email": {
-                                  "description": "Email address of the claimant.",
-                                  "type": "string",
-                                  "pattern": ".@.",
-                                  "maxLength": 61,
-                                  "example": "claimant@example.com"
-                                },
-                                "relationship": {
-                                  "description": "Relationship of claimant to the veteran. Required if claimant information provided.",
-                                  "type": "string",
-                                  "example": "Spouse"
-                                }
-                              }
-                            },
-                            "poa": {
-                              "description": "Details of the requested Power of Attorney representing the veteran.",
-                              "type": "object",
-                              "additionalProperties": false,
-                              "required": [
-                                "poaCode",
-                                "registrationNumber"
-                              ],
-                              "properties": {
-                                "poaCode": {
-                                  "description": "The POA code of the accredited representative or organization.",
-                                  "type": "string",
-                                  "example": "A1Q"
-                                },
-                                "registrationNumber": {
-                                  "description": "Registration Number of the accredited representative.",
-                                  "type": "string",
-                                  "example": "12345"
-                                },
-                                "jobTitle": {
-                                  "description": "Job title of the accredited representative.",
-                                  "type": "string",
-                                  "example": "Veteran Service Representative"
-                                }
-                              }
-                            },
-                            "recordConsent": {
-                              "description": "AUTHORIZATION FOR REPRESENTATIVE'S ACCESS TO RECORDS PROTECTED BY SECTION 7332, TITLE 38, U.S.C.",
-                              "type": "boolean"
-                            },
-                            "consentLimits": {
-                              "description": "Consent in Item 19 for the disclosure of records relating to treatment for drug abuse, alcoholism or alcohol abuse, infection with the human immunodeficiency virus (HIV), or sickle cell anemia is limited as follows. Will default to false if not specified.",
-                              "type": "array",
-                              "items": {
-                                "type": "string",
-                                "enum": [
-                                  "DRUG_ABUSE",
-                                  "ALCOHOLISM",
-                                  "HIV",
-                                  "SICKLE_CELL"
-                                ]
-                              },
-                              "example": "DRUG ABUSE"
-                            },
-                            "consentAddressChange": {
-                              "description": "AUTHORIZATION FOR REPRESENTATIVE TO ACT ON CLAIMANT'S BEHALF TO CHANGE CLAIMANT'S ADDRESS.",
-                              "type": "boolean"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "example": {
-                  "errors": [
-                    {
-                      "title": "Not authorized",
-                      "status": "401",
-                      "detail": "Not authorized"
-                    }
-                  ]
-                },
-                "schema": {
-                  "required": [
-                    "errors"
-                  ],
-                  "properties": {
-                    "errors": {
-                      "type": "array",
-                      "items": {
-                        "additionalProperties": false,
-                        "required": [
-                          "title",
-                          "detail"
-                        ],
-                        "properties": {
-                          "title": {
-                            "type": "string",
-                            "description": "HTTP error title"
-                          },
-                          "detail": {
-                            "type": "string",
-                            "description": "HTTP error detail"
-                          },
-                          "status": {
-                            "type": "string",
-                            "description": "HTTP error status code"
-                          },
-                          "source": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "description": "Source of error",
-                            "properties": {
-                              "pointer": {
-                                "type": "string",
-                                "description": "Pointer to source of error"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "example": {
-                  "errors": [
-                    {
-                      "title": "Unprocessable entity",
-                      "detail": "The property /poa did not contain the required key poaCode",
-                      "status": "422",
-                      "source": {
-                        "pointer": "data/attributes/poa"
-                      }
-                    }
-                  ]
-                },
-                "schema": {
-                  "required": [
-                    "errors"
-                  ],
-                  "properties": {
-                    "errors": {
-                      "type": "array",
-                      "items": {
-                        "additionalProperties": false,
-                        "required": [
-                          "title",
-                          "detail"
-                        ],
-                        "properties": {
-                          "title": {
-                            "type": "string",
-                            "description": "HTTP error title"
-                          },
-                          "detail": {
-                            "type": "string",
-                            "description": "HTTP error detail"
-                          },
-                          "status": {
-                            "type": "string",
-                            "description": "HTTP error status code"
-                          },
-                          "source": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "description": "Source of error",
-                            "properties": {
-                              "pointer": {
-                                "type": "string",
-                                "description": "Pointer to source of error"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "example": {
-                  "errors": [
-                    {
-                      "status": "404",
-                      "title": "Resource not found",
-                      "detail": "Could not find an Accredited Representative with registration number: 999999999999 and poa code: 067"
-                    }
-                  ]
-                },
-                "schema": {
-                  "required": [
-                    "errors"
-                  ],
-                  "properties": {
-                    "errors": {
-                      "type": "array",
-                      "items": {
-                        "additionalProperties": false,
-                        "required": [
-                          "title",
-                          "detail"
-                        ],
-                        "properties": {
-                          "title": {
-                            "type": "string",
-                            "description": "HTTP error title"
-                          },
-                          "detail": {
-                            "type": "string",
-                            "description": "HTTP error detail"
-                          },
-                          "status": {
-                            "type": "string",
-                            "description": "HTTP error status code"
-                          },
-                          "source": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "description": "Source of error",
-                            "properties": {
-                              "pointer": {
-                                "type": "string",
-                                "description": "Pointer to source of error"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "data"
-                ],
-                "properties": {
-                  "data": {
-                    "type": "object",
-                    "required": [
-                      "attributes",
-                      null
-                    ],
-                    "properties": {
-                      "attributes": {
-                        "$schema": "http://json-schema.org/draft-07/schema#",
-                        "description": "POA Request (21-22/a) Schema",
-                        "type": "object",
-                        "additionalProperties": false,
-                        "required": [
-                          "veteran",
-                          "poa",
-                          "recordConsent",
-                          "consentAddressChange"
-                        ],
-                        "properties": {
-                          "veteran": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "required": [
-                              "address"
-                            ],
-                            "properties": {
-                              "serviceNumber": {
-                                "description": "The Veteran's Service Number",
-                                "type": "string",
-                                "maxLength": 9
-                              },
-                              "serviceBranch": {
-                                "description": "Service Branch for the veteran.",
-                                "type": "string",
-                                "enum": [
-                                  "AIR_FORCE",
-                                  "ARMY",
-                                  "COAST_GUARD",
-                                  "MARINE_CORPS",
-                                  "NAVY",
-                                  "SPACE_FORCE",
-                                  "OTHER"
-                                ],
-                                "example": "ARMY"
-                              },
-                              "address": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "required": [
-                                  "addressLine1",
-                                  "city",
-                                  "stateCode",
-                                  "country",
-                                  "zipCode"
-                                ],
-                                "properties": {
-                                  "addressLine1": {
-                                    "description": "Street address with number and name.",
-                                    "type": "string",
-                                    "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
-                                    "maxLength": 30
-                                  },
-                                  "addressLine2": {
-                                    "type": "string",
-                                    "maxLength": 5
-                                  },
-                                  "city": {
-                                    "description": "City for the address.",
-                                    "type": "string",
-                                    "example": "Portland",
-                                    "maxLength": 18
-                                  },
-                                  "stateCode": {
-                                    "description": "State for the address.",
-                                    "type": "string",
-                                    "pattern": "^[a-z,A-Z]{2}$",
-                                    "example": "OR"
-                                  },
-                                  "country": {
-                                    "description": "Country of the address. USA is the value to use for United States based addresses, US will not work.",
-                                    "type": "string",
-                                    "example": "USA"
-                                  },
-                                  "zipCode": {
-                                    "description": "Zipcode (First 5 digits) of the address.",
-                                    "type": "string",
-                                    "pattern": "^\\d{5}?$",
-                                    "example": "12345"
-                                  },
-                                  "zipCodeSuffix": {
-                                    "description": "Zipcode (Last 4 digits) of the address.",
-                                    "type": "string",
-                                    "pattern": "^\\d{4}?$",
-                                    "example": "6789"
-                                  }
-                                }
-                              },
-                              "phone": {
-                                "$comment": "the phone fields must not exceed 20 chars, when concatenated",
-                                "type": "object",
-                                "additionalProperties": false,
-                                "required": [
-                                  "areaCode",
-                                  "phoneNumber"
-                                ],
-                                "properties": {
-                                  "areaCode": {
-                                    "description": "Area code of the phone number.",
-                                    "type": "string",
-                                    "pattern": "^[2-9][0-9]{2}$",
-                                    "example": "555"
-                                  },
-                                  "phoneNumber": {
-                                    "description": "Phone number.",
-                                    "type": "string",
-                                    "pattern": "^[0-9]{1,14}$",
-                                    "example": "555-5555"
-                                  }
-                                }
-                              },
-                              "email": {
-                                "description": "Email address of the veteran.",
-                                "type": "string",
-                                "pattern": ".@.",
-                                "maxLength": 61,
-                                "example": "veteran@example.com"
-                              },
-                              "insuranceNumber": {
-                                "type": "string",
-                                "maxLength": 10,
-                                "description": "Veteran's insurance number, if applicable. Include letter prefix."
-                              }
-                            }
-                          },
-                          "claimant": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                              "claimantId": {
-                                "type": "string",
-                                "example": "123456789",
-                                "description": "Id of the claimant."
-                              },
-                              "address": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                  "addressLine1": {
-                                    "description": "Street address with number and name. Required if claimant information provided.",
-                                    "type": "string",
-                                    "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
-                                    "maxLength": 30
-                                  },
-                                  "addressLine2": {
-                                    "type": "string",
-                                    "maxLength": 5
-                                  },
-                                  "city": {
-                                    "description": "City for the address. Required if claimant information provided.",
-                                    "type": "string",
-                                    "example": "Portland",
-                                    "maxLength": 18
-                                  },
-                                  "stateCode": {
-                                    "description": "State for the address. Required if claimant information provided.",
-                                    "type": "string",
-                                    "pattern": "^[a-z,A-Z]{2}$",
-                                    "example": "OR"
-                                  },
-                                  "country": {
-                                    "description": "Country of the address. Required if claimant information provided.",
-                                    "type": "string",
-                                    "example": "USA"
-                                  },
-                                  "zipCode": {
-                                    "description": "Zipcode (First 5 digits) of the address. Required if claimant information provided.",
-                                    "type": "string",
-                                    "pattern": "^\\d{5}?$",
-                                    "example": "12345"
-                                  },
-                                  "zipCodeSuffix": {
-                                    "description": "Zipcode (Last 4 digits) of the address.",
-                                    "type": "string",
-                                    "pattern": "^\\d{4}?$",
-                                    "example": "6789"
-                                  }
-                                }
-                              },
-                              "phone": {
-                                "$comment": "the phone fields must not exceed 20 chars, when concatenated",
-                                "type": "object",
-                                "additionalProperties": false,
-                                "required": [
-                                  "areaCode",
-                                  "phoneNumber"
-                                ],
-                                "properties": {
-                                  "areaCode": {
-                                    "description": "Area code of the phone number.",
-                                    "type": "string",
-                                    "pattern": "^[2-9][0-9]{2}$",
-                                    "example": "555"
-                                  },
-                                  "phoneNumber": {
-                                    "description": "Phone number.",
-                                    "type": "string",
-                                    "pattern": "^[0-9]{1,14}$",
-                                    "example": "555-5555"
-                                  }
-                                }
-                              },
-                              "email": {
-                                "description": "Email address of the claimant.",
-                                "type": "string",
-                                "pattern": ".@.",
-                                "maxLength": 61,
-                                "example": "claimant@example.com"
-                              },
-                              "relationship": {
-                                "description": "Relationship of claimant to the veteran. Required if claimant information provided.",
-                                "type": "string",
-                                "example": "Spouse"
-                              }
-                            }
-                          },
-                          "poa": {
-                            "description": "Details of the requested Power of Attorney representing the veteran.",
-                            "type": "object",
-                            "additionalProperties": false,
-                            "required": [
-                              "poaCode",
-                              "registrationNumber"
-                            ],
-                            "properties": {
-                              "poaCode": {
-                                "description": "The POA code of the accredited representative or organization.",
-                                "type": "string",
-                                "example": "A1Q"
-                              },
-                              "registrationNumber": {
-                                "description": "Registration Number of the accredited representative.",
-                                "type": "string",
-                                "example": "12345"
-                              },
-                              "jobTitle": {
-                                "description": "Job title of the accredited representative.",
-                                "type": "string",
-                                "example": "Veteran Service Representative"
-                              }
-                            }
-                          },
-                          "recordConsent": {
-                            "description": "AUTHORIZATION FOR REPRESENTATIVE'S ACCESS TO RECORDS PROTECTED BY SECTION 7332, TITLE 38, U.S.C.",
-                            "type": "boolean"
-                          },
-                          "consentLimits": {
-                            "description": "Consent for the disclosure of records relating to treatment for drug abuse, alcoholism or alcohol abuse, infection with the human immunodeficiency virus (HIV), or sickle cell anemia is limited as follows. Will default to false if not specified.",
-                            "type": "array",
-                            "items": {
-                              "type": "string",
-                              "enum": [
-                                "DRUG_ABUSE",
-                                "ALCOHOLISM",
-                                "HIV",
-                                "SICKLE_CELL"
-                              ]
-                            },
-                            "example": "DRUG ABUSE"
-                          },
-                          "consentAddressChange": {
-                            "description": "AUTHORIZATION FOR REPRESENTATIVE TO ACT ON CLAIMANT'S BEHALF TO CHANGE CLAIMANT'S ADDRESS.",
-                            "type": "boolean"
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "example": {
-                  "data": {
-                    "attributes": {
-                      "veteran": {
-                        "serviceNumber": "123678453",
-                        "serviceBranch": "ARMY",
-                        "address": {
-                          "addressLine1": "2719 Hyperion Ave",
-                          "addressLine2": "Apt 2",
-                          "city": "Los Angeles",
-                          "country": "USA",
-                          "stateCode": "CA",
-                          "zipCode": "92264",
-                          "zipCodeSuffix": "0200"
-                        },
-                        "phone": {
-                          "areaCode": "555",
-                          "phoneNumber": "5551234"
-                        },
-                        "email": "test@test.com",
-                        "insuranceNumber": "1234567890"
-                      },
-                      "poa": {
-                        "poaCode": "067",
-                        "registrationNumber": "999999999999",
-                        "jobTitle": "MyJob"
-                      },
-                      "recordConsent": true,
-                      "consentAddressChange": true,
-                      "consentLimits": [
-                        "DRUG_ABUSE",
-                        "SICKLE_CELL",
-                        "HIV",
-                        "ALCOHOLISM"
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "required": true
         }
       }
     }


### PR DESCRIPTION
## Summary
* moves the /power-of-attorney-request endpoint up to be under the /power-of-attorney endpoints entry

## Related issue(s)
[API-44208](https://jira.devops.va.gov/browse/API-44208)

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots![Screenshot 2025-01-22 at 9 20 27 AM](https://github.com/user-attachments/assets/56dee5b9-eb9a-48f5-acef-4df0d9700396)

## What areas of the site does it impact?
	modified:   modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
	modified:   modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
