### PR TITLE
[99972] Appoint a Rep add can_accept_digital_poa_requests to serializer

### DIFF
--- a/modules/representation_management/app/serializers/representation_management/original_entities/organization_serializer.rb
+++ b/modules/representation_management/app/serializers/representation_management/original_entities/organization_serializer.rb
@@ -7,7 +7,7 @@ module RepresentationManagement
 
       attributes :name, :address_line1, :address_line2, :address_line3, :address_type,
                  :city, :country_name, :country_code_iso3, :province, :international_postal_code, :state_code,
-                 :zip_code, :zip_suffix, :phone, :lat, :long
+                 :zip_code, :zip_suffix, :phone, :lat, :long, :can_accept_digital_poa_requests
       attribute :poa_code, &:poa
     end
   end

--- a/modules/representation_management/app/swagger/v0/swagger.json
+++ b/modules/representation_management/app/swagger/v0/swagger.json
@@ -517,6 +517,10 @@
                     "format": "float",
                     "example": -122.4194,
                     "nullable": true
+                  },
+                  "can_accept_digital_poa_requests": {
+                    "type": "boolean",
+                    "example": true
                   }
                 }
               }

--- a/modules/representation_management/spec/serializers/original_entities/organization_serializer_spec.rb
+++ b/modules/representation_management/spec/serializers/original_entities/organization_serializer_spec.rb
@@ -23,7 +23,8 @@ describe RepresentationManagement::OriginalEntities::OrganizationSerializer, typ
            zip_suffix: '6789',
            phone: '222-222-2222',
            lat: '39',
-           long: '-75')
+           long: '-75',
+           can_accept_digital_poa_requests: true)
   end
   let(:data) { subject.serializable_hash.with_indifferent_access['data'] }
   let(:attributes) { data['attributes'] }
@@ -98,5 +99,9 @@ describe RepresentationManagement::OriginalEntities::OrganizationSerializer, typ
 
   it 'includes long' do
     expect(attributes['long']).to eq(-75)
+  end
+
+  it 'includes can_accept_digital_poa_requests' do
+    expect(attributes['can_accept_digital_poa_requests']).to be true
   end
 end

--- a/modules/representation_management/spec/support/rswag_config.rb
+++ b/modules/representation_management/spec/support/rswag_config.rb
@@ -198,7 +198,8 @@ class RepresentationManagement::RswagConfig
   end
 
   def veteran_service_organization_schema
-    build_organization_schema(uuid: false)
+    optional_attributes = { can_accept_digital_poa_requests: { type: :boolean, example: true } }
+    build_organization_schema(uuid: false, optional_attributes: optional_attributes)
   end
 
   def common_organization_attributes
@@ -211,8 +212,8 @@ class RepresentationManagement::RswagConfig
     )
   end
 
-  def build_organization_schema(uuid: true)
-    attributes = common_organization_attributes
+  def build_organization_schema(uuid: true, optional_attributes: {})
+    attributes = common_organization_attributes.merge(optional_attributes)
     accredited_data_structure('organization', attributes, uuid: uuid)
   end
 


### PR DESCRIPTION
## Summary

- This pr adds the new column `can_accept_digital_poa_requests` to the organization serializer used in the original entities controller. This attribute is needed in the front end to determine organization level eligibility for creating a digital poa request.

## Related issue(s)

- [99972](https://github.com/department-of-veterans-affairs/va.gov-team/issues/99972)

## Testing done

- [x] *New code is covered by unit tests*
- Old behavior: the api response did not include the attribute
- New behavior: the api response includes the attribute
- Tested locally with postman and pointing the front end experience to local

## Screenshots
![image](https://github.com/user-attachments/assets/78124df4-d2b7-482c-887a-e706124072f6)


## What areas of the site does it impact?
Appoint a Rep Form 21-22 and 21-22a

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature