### PR TITLE
Add logging of 'confirmed' vet status to Proof of Status

### DIFF
--- a/lib/lighthouse/veteran_verification/service.rb
+++ b/lib/lighthouse/veteran_verification/service.rb
@@ -65,7 +65,10 @@ module VeteranVerification
 
     def transform_response(response)
       attributes = response['data']['attributes']
-      return response if attributes['veteran_status'] != 'not confirmed' || attributes.exclude?('not_confirmed_reason')
+      if attributes['veteran_status'] == 'confirmed' || attributes.exclude?('not_confirmed_reason')
+        log_confirmed
+        return response
+      end
 
       reason = attributes['not_confirmed_reason']
       response['data']['message'] =
@@ -77,12 +80,16 @@ module VeteranVerification
           VeteranVerification::Constants::NOT_FOUND_MESSAGE
         end
 
-      log_reason(reason)
+      log_not_confirmed(reason)
       response
     end
 
-    def log_reason(reason)
-      ::Rails.logger.info('Vet Verification Status Success', { not_confirmed_reason: reason })
+    def log_not_confirmed(reason)
+      ::Rails.logger.info('Vet Verification Status Success: not confirmed', { not_confirmed: true, not_confirmed_reason: reason })
+    end
+
+    def log_confirmed
+      ::Rails.logger.info('Vet Verification Status Success: confirmed', { confirmed: true })
     end
   end
 end

--- a/lib/lighthouse/veteran_verification/service.rb
+++ b/lib/lighthouse/veteran_verification/service.rb
@@ -85,7 +85,8 @@ module VeteranVerification
     end
 
     def log_not_confirmed(reason)
-      ::Rails.logger.info('Vet Verification Status Success: not confirmed', { not_confirmed: true, not_confirmed_reason: reason })
+      ::Rails.logger.info('Vet Verification Status Success: not confirmed',
+                          { not_confirmed: true, not_confirmed_reason: reason })
     end
 
     def log_confirmed

--- a/spec/lib/lighthouse/veteran_verification/service_spec.rb
+++ b/spec/lib/lighthouse/veteran_verification/service_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe VeteranVerification::Service do
             expect(StatsD).to receive(:increment).with(
               VeteranVerification::Constants::STATSD_VET_VERIFICATION_TOTAL_KEY
             )
+            expect(Rails.logger).to receive(:info).with('Vet Verification Status Success: confirmed', { confirmed: true })
 
             response = @service.get_vet_verification_status(icn, '', '')
 
@@ -73,6 +74,10 @@ RSpec.describe VeteranVerification::Service do
             expect(StatsD).to receive(:increment).with(
               VeteranVerification::Constants::STATSD_VET_VERIFICATION_TOTAL_KEY
             )
+            expect(Rails.logger).to receive(:info).with(
+              'Vet Verification Status Success: not confirmed',
+              { not_confirmed: true, not_confirmed_reason: 'ERROR' }
+            )
 
             response = @service.get_vet_verification_status('1012666182V20', '', '')
 
@@ -85,6 +90,11 @@ RSpec.describe VeteranVerification::Service do
 
         it 'retrieves veteran not confirmed status from the Lighthouse API' do
           VCR.use_cassette('lighthouse/veteran_verification/status/200_not_confirmed_response') do
+            expect(Rails.logger).to receive(:info).with(
+              'Vet Verification Status Success: not confirmed',
+              { not_confirmed: true, not_confirmed_reason: 'NOT_TITLE_38' }
+            )
+
             response = @service.get_vet_verification_status('1012666182V203559', '', '')
 
             expect(response['data']['id']).to eq('1012666182V203559')
@@ -96,6 +106,11 @@ RSpec.describe VeteranVerification::Service do
 
         it 'retrieves veteran not found status from the Lighthouse API' do
           VCR.use_cassette('lighthouse/veteran_verification/status/200_person_not_found_response') do
+            expect(Rails.logger).to receive(:info).with(
+              'Vet Verification Status Success: not confirmed',
+              { not_confirmed: true, not_confirmed_reason: 'PERSON_NOT_FOUND' }
+            )
+
             response = @service.get_vet_verification_status('1012667145V762141', '', '')
 
             expect(response['data']['id']).to be_nil

--- a/spec/lib/lighthouse/veteran_verification/service_spec.rb
+++ b/spec/lib/lighthouse/veteran_verification/service_spec.rb
@@ -59,7 +59,8 @@ RSpec.describe VeteranVerification::Service do
             expect(StatsD).to receive(:increment).with(
               VeteranVerification::Constants::STATSD_VET_VERIFICATION_TOTAL_KEY
             )
-            expect(Rails.logger).to receive(:info).with('Vet Verification Status Success: confirmed', { confirmed: true })
+            expect(Rails.logger).to receive(:info).with('Vet Verification Status Success: confirmed',
+                                                        { confirmed: true })
 
             response = @service.get_vet_verification_status(icn, '', '')
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- This change adds additional logging to a Proof of Status card endpoint to capture "confirmed" veteran status in addition to "not confirmed". This will allow us to better track the ratio of confirmed to not confirmed veteran statuses and provide more detailed information for reporting.
- I work on the IIR Product team and we currently own this feature.

## Related issue(s)

- [1392](https://github.com/department-of-veterans-affairs/va-iir/issues/1392)

## Testing done

- [x] *New code is covered by unit tests*
- There is no old behavior as this just adds new logging. 

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
This only impacts the Proof of Status card endpoint and DataDog logs.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
