### PR TITLE
[ART] lower camel responses & skip redundant olive branch transformation

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_users_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_users_controller.rb
@@ -11,18 +11,18 @@ module AccreditedRepresentativePortal
         # serialization layer.
         render json: {
           account: {
-            account_uuid: @current_user.user_account_uuid
+            accountUuid: @current_user.user_account_uuid
           },
           profile: {
-            first_name: @current_user.first_name,
-            last_name: @current_user.last_name,
+            firstName: @current_user.first_name,
+            lastName: @current_user.last_name,
             verified: @current_user.user_account.verified?,
-            sign_in: {
-              service_name: @current_user.sign_in[:service_name]
+            signIn: {
+              serviceName: @current_user.sign_in[:service_name]
             }
           },
-          prefills_available: [],
-          in_progress_forms:
+          prefillsAvailable: [],
+          inProgressForms: in_progress_forms
         }
       end
 

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_form.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_form.rb
@@ -49,8 +49,8 @@ module AccreditedRepresentativePortal
       return unless address
 
       self.claimant_city = address['city']
-      self.claimant_state_code = address['state_code']
-      self.claimant_zip_code = address['zip_code']
+      self.claimant_state_code = address['stateCode']
+      self.claimant_zip_code = address['zipCode']
     end
 
     def data_must_comply_with_schema
@@ -83,11 +83,11 @@ module AccreditedRepresentativePortal
           "authorizations": {
             "type": "object",
             "properties": {
-              "record_disclosure": {
+              "recordDisclosure": {
                 "type": "boolean",
                 "example": true
               },
-              "record_disclosure_limitations": {
+              "recordDisclosureLimitations": {
                 "type": "array",
                 "items": {
                   "type": "string",
@@ -105,15 +105,15 @@ module AccreditedRepresentativePortal
                   "SICKLE_CELL"
                 ]
               },
-              "address_change": {
+              "addressChange": {
                 "type": "boolean",
                 "example": false
               }
             },
             "required": [
-              "record_disclosure",
-              "record_disclosure_limitations",
-              "address_change"
+              "recordDisclosure",
+              "recordDisclosureLimitations",
+              "addressChange"
             ]
           },
           "dependent": {
@@ -144,11 +144,11 @@ module AccreditedRepresentativePortal
               "address": {
                 "type": "object",
                 "properties": {
-                  "address_line1": {
+                  "addressLine1": {
                     "type": "string",
                     "example": "123 Main St"
                   },
-                  "address_line2": {
+                  "addressLine2": {
                     "type": ["string", "null"],
                     "example": "Apt 1"
                   },
@@ -156,7 +156,7 @@ module AccreditedRepresentativePortal
                     "type": "string",
                     "example": "Springfield"
                   },
-                  "state_code": {
+                  "stateCode": {
                     "type": "string",
                     "example": "IL"
                   },
@@ -164,26 +164,26 @@ module AccreditedRepresentativePortal
                     "type": "string",
                     "example": "US"
                   },
-                  "zip_code": {
+                  "zipCode": {
                     "type": "string",
                     "example": "62704"
                   },
-                  "zip_code_suffix": {
+                  "zipCodeSuffix": {
                     "type": ["string", "null"],
                     "example": "6789"
                   }
                 },
                 "required": [
-                  "address_line1",
-                  "address_line2",
+                  "addressLine1",
+                  "addressLine2",
                   "city",
-                  "state_code",
+                  "stateCode",
                   "country",
-                  "zip_code",
-                  "zip_code_suffix"
+                  "zipCode",
+                  "zipCodeSuffix"
                 ]
               },
-              "date_of_birth": {
+              "dateOfBirth": {
                 "type": "string",
                 "format": "date",
                 "example": "1980-12-31"
@@ -204,7 +204,7 @@ module AccreditedRepresentativePortal
             "required": [
               "name",
               "address",
-              "date_of_birth",
+              "dateOfBirth",
               "relationship",
               "phone",
               "email"
@@ -238,11 +238,11 @@ module AccreditedRepresentativePortal
               "address": {
                 "type": "object",
                 "properties": {
-                  "address_line1": {
+                  "addressLine1": {
                     "type": "string",
                     "example": "123 Main St"
                   },
-                  "address_line2": {
+                  "addressLine2": {
                     "type": ["string", "null"],
                     "example": "Apt 1"
                   },
@@ -250,7 +250,7 @@ module AccreditedRepresentativePortal
                     "type": "string",
                     "example": "Springfield"
                   },
-                  "state_code": {
+                  "stateCode": {
                     "type": "string",
                     "example": "IL"
                   },
@@ -258,43 +258,43 @@ module AccreditedRepresentativePortal
                     "type": "string",
                     "example": "US"
                   },
-                  "zip_code": {
+                  "zipCode": {
                     "type": "string",
                     "example": "62704"
                   },
-                  "zip_code_suffix": {
+                  "zipCodeSuffix": {
                     "type": ["string", "null"],
                     "example": "6789"
                   }
                 },
                 "required": [
-                  "address_line1",
-                  "address_line2",
+                  "addressLine1",
+                  "addressLine2",
                   "city",
-                  "state_code",
+                  "stateCode",
                   "country",
-                  "zip_code",
-                  "zip_code_suffix"
+                  "zipCode",
+                  "zipCodeSuffix"
                 ]
               },
               "ssn": {
                 "type": "string",
                 "example": "123456789"
               },
-              "va_file_number": {
+              "vaFileNumber": {
                 "type": ["string", "null"],
                 "example": "123456789"
               },
-              "date_of_birth": {
+              "dateOfBirth": {
                 "type": "string",
                 "format": "date",
                 "example": "1980-12-31"
               },
-              "service_number": {
+              "serviceNumber": {
                 "type": ["string", "null"],
                 "example": "123456789"
               },
-              "service_branch": {
+              "serviceBranch": {
                 "type": ["string", "null"],
                 "enum": [
                   "ARMY",
@@ -321,10 +321,10 @@ module AccreditedRepresentativePortal
               "name",
               "address",
               "ssn",
-              "va_file_number",
-              "date_of_birth",
-              "service_number",
-              "service_branch",
+              "vaFileNumber",
+              "dateOfBirth",
+              "serviceNumber",
+              "serviceBranch",
               "phone",
               "email"
             ]

--- a/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/application_serializer.rb
+++ b/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/application_serializer.rb
@@ -4,6 +4,8 @@ module AccreditedRepresentativePortal
   class ApplicationSerializer
     include JSONAPI::Serializer
 
+    set_key_transform :camel_lower
+
     # We're not building to JSONAPI.
     def serializable_hash
       data = super[:data]

--- a/modules/accredited_representative_portal/config/initializers/exclude_olive_branch.rb
+++ b/modules/accredited_representative_portal/config/initializers/exclude_olive_branch.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  ##
+  # This excludes ARP's API endpoints from `OliveBranch`'s redundant processing.
+  # Redundant because we will have our serialization layer set our desired key
+  # casing while constructing the response payload. `OliveBranch`, on the other
+  # hand, deserializes JSON, transforms it, and serializes it again, which is
+  # inefficient and redundant.
+  #
+  module ExcludeOliveBranch
+    ARP_PATH_REGEX = %r{^/accredited_representative_portal/}
+
+    private
+
+    def exclude?(env, ...)
+      env['REQUEST_PATH'] =~ ARP_PATH_REGEX || super
+    end
+  end
+end
+
+module OliveBranch
+  class Middleware
+    prepend AccreditedRepresentativePortal::ExcludeOliveBranch
+  end
+end

--- a/modules/accredited_representative_portal/spec/factories/power_of_attorney_form.rb
+++ b/modules/accredited_representative_portal/spec/factories/power_of_attorney_form.rb
@@ -2,9 +2,9 @@
 
 dependent_claimant_data_hash = {
   authorizations: {
-    record_disclosure: true,
-    record_disclosure_limitations: [],
-    address_change: true
+    recordDisclosure: true,
+    recordDisclosureLimitations: [],
+    addressChange: true
   },
   dependent: {
     name: {
@@ -13,15 +13,15 @@ dependent_claimant_data_hash = {
       last: 'Doe'
     },
     address: {
-      address_line1: '123 Main St',
-      address_line2: 'Apt 1',
+      addressLine1: '123 Main St',
+      addressLine2: 'Apt 1',
       city: 'Springfield',
-      state_code: 'IL',
+      stateCode: 'IL',
       country: 'US',
-      zip_code: '62704',
-      zip_code_suffix: '6789'
+      zipCode: '62704',
+      zipCodeSuffix: '6789'
     },
-    date_of_birth: '1980-12-31',
+    dateOfBirth: '1980-12-31',
     relationship: 'Spouse',
     phone: '1234567890',
     email: 'veteran@example.com'
@@ -33,19 +33,19 @@ dependent_claimant_data_hash = {
       last: 'Doe'
     },
     address: {
-      address_line1: '123 Main St',
-      address_line2: 'Apt 1',
+      addressLine1: '123 Main St',
+      addressLine2: 'Apt 1',
       city: 'Springfield',
-      state_code: 'IL',
+      stateCode: 'IL',
       country: 'US',
-      zip_code: '62704',
-      zip_code_suffix: '6789'
+      zipCode: '62704',
+      zipCodeSuffix: '6789'
     },
     ssn: '123456789',
-    va_file_number: '123456789',
-    date_of_birth: '1980-12-31',
-    service_number: '123456789',
-    service_branch: 'ARMY',
+    vaFileNumber: '123456789',
+    dateOfBirth: '1980-12-31',
+    serviceNumber: '123456789',
+    serviceBranch: 'ARMY',
     phone: '1234567890',
     email: 'veteran@example.com'
   }
@@ -53,12 +53,12 @@ dependent_claimant_data_hash = {
 
 veteran_claimant_data_hash = {
   authorizations: {
-    record_disclosure: true,
-    record_disclosure_limitations: %w[
+    recordDisclosure: true,
+    recordDisclosureLimitations: %w[
       HIV
       DRUG_ABUSE
     ],
-    address_change: true
+    addressChange: true
   },
   dependent: nil,
   veteran: {
@@ -68,19 +68,19 @@ veteran_claimant_data_hash = {
       last: 'Doe'
     },
     address: {
-      address_line1: '123 Main St',
-      address_line2: 'Apt 1',
+      addressLine1: '123 Main St',
+      addressLine2: 'Apt 1',
       city: 'Springfield',
-      state_code: 'IL',
+      stateCode: 'IL',
       country: 'US',
-      zip_code: '62704',
-      zip_code_suffix: '6789'
+      zipCode: '62704',
+      zipCodeSuffix: '6789'
     },
     ssn: '123456789',
-    va_file_number: '123456789',
-    date_of_birth: '1980-12-31',
-    service_number: '123456789',
-    service_branch: 'ARMY',
+    vaFileNumber: '123456789',
+    dateOfBirth: '1980-12-31',
+    serviceNumber: '123456789',
+    serviceBranch: 'ARMY',
     phone: '1234567890',
     email: 'veteran@example.com'
   }
@@ -94,14 +94,14 @@ FactoryBot.define do
       data_hash do
         {
           authorizations: {
-            record_disclosure: Faker::Boolean.boolean,
-            record_disclosure_limitations: %w[
+            recordDisclosure: Faker::Boolean.boolean,
+            recordDisclosureLimitations: %w[
               ALCOHOLISM
               DRUG_ABUSE
               HIV
               SICKLE_CELL
             ].select { rand < 0.5 },
-            address_change: Faker::Boolean.boolean
+            addressChange: Faker::Boolean.boolean
           },
           dependent: nil,
           veteran: {
@@ -111,19 +111,19 @@ FactoryBot.define do
               last: Faker::Name.first_name
             },
             address: {
-              address_line1: Faker::Address.street_address,
-              address_line2: nil,
+              addressLine1: Faker::Address.street_address,
+              addressLine2: nil,
               city: Faker::Address.city,
-              state_code: Faker::Address.state_abbr,
+              stateCode: Faker::Address.state_abbr,
               country: 'US',
-              zip_code: Faker::Address.zip_code,
-              zip_code_suffix: nil
+              zipCode: Faker::Address.zip_code,
+              zipCodeSuffix: nil
             },
             ssn: Faker::Number.number(digits: 9).to_s,
-            va_file_number: Faker::Number.number(digits: 9).to_s,
-            date_of_birth: Faker::Date.birthday(min_age: 21, max_age: 100).to_s,
-            service_number: Faker::Number.number(digits: 9).to_s,
-            service_branch: %w[
+            vaFileNumber: Faker::Number.number(digits: 9).to_s,
+            dateOfBirth: Faker::Date.birthday(min_age: 21, max_age: 100).to_s,
+            serviceNumber: Faker::Number.number(digits: 9).to_s,
+            serviceBranch: %w[
               ARMY
               NAVY
               AIR_FORCE

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
     resolution.power_of_attorney_request
   end
   let(:time) { '2024-12-21T04:45:37.000Z' }
-  let(:time_plus_one_day) { '2024-12-22T04:45:37.000Z' }
   let(:expires_at) { '2025-02-19T04:45:37.000Z' }
 
   let(:poa_requests) do
@@ -83,18 +82,18 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
         [
           {
             'id' => poa_requests[0].id,
-            'claimant_id' => poa_requests[0].claimant_id,
-            'created_at' => time,
-            'expires_at' => (Time.zone.parse(time) + 60.days).iso8601(3),
-            'power_of_attorney_form' => veteran_claimant_power_of_attorney_form,
-            'power_of_attorney_holder' => {
+            'claimantId' => poa_requests[0].claimant_id,
+            'createdAt' => time,
+            'expiresAt' => (Time.zone.parse(time) + 60.days).iso8601(3),
+            'powerOfAttorneyForm' => veteran_claimant_power_of_attorney_form,
+            'powerOfAttorneyHolder' => {
               'id' => poa_requests[0].power_of_attorney_holder.id,
               'type' => 'veteran_service_organization',
               'name' => poa_requests[0].power_of_attorney_holder.name
             },
-            'accredited_individual' => {
+            'accreditedIndividual' => {
               'id' => poa_requests[0].accredited_individual.id,
-              'full_name' => [
+              'fullName' => [
                 poa_requests[0].accredited_individual.first_name,
                 poa_requests[0].accredited_individual.last_name
               ].join(' ')
@@ -103,18 +102,18 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
           },
           {
             'id' => poa_requests[1].id,
-            'claimant_id' => poa_requests[1].claimant_id,
-            'created_at' => time,
-            'expires_at' => nil,
-            'power_of_attorney_form' => dependent_claimant_power_of_attorney_form,
-            'power_of_attorney_holder' => {
+            'claimantId' => poa_requests[1].claimant_id,
+            'createdAt' => time,
+            'expiresAt' => nil,
+            'powerOfAttorneyForm' => dependent_claimant_power_of_attorney_form,
+            'powerOfAttorneyHolder' => {
               'id' => poa_requests[1].power_of_attorney_holder.id,
               'type' => 'veteran_service_organization',
               'name' => poa_requests[1].power_of_attorney_holder.name
             },
-            'accredited_individual' => {
+            'accreditedIndividual' => {
               'id' => poa_requests[1].accredited_individual.id,
-              'full_name' => [
+              'fullName' => [
                 poa_requests[1].accredited_individual.first_name,
                 poa_requests[1].accredited_individual.last_name
               ].join(' ')
@@ -122,25 +121,25 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
             'resolution' => {
               'id' => poa_requests[1].resolution.id,
               'type' => 'decision',
-              'created_at' => time,
-              'creator_id' => poa_requests[1].resolution.resolving.creator_id,
-              'decision_type' => 'acceptance'
+              'createdAt' => time,
+              'creatorId' => poa_requests[1].resolution.resolving.creator_id,
+              'decisionType' => 'acceptance'
             }
           },
           {
             'id' => poa_requests[2].id,
-            'claimant_id' => poa_requests[2].claimant_id,
-            'created_at' => time,
-            'expires_at' => nil,
-            'power_of_attorney_form' => dependent_claimant_power_of_attorney_form,
-            'power_of_attorney_holder' => {
+            'claimantId' => poa_requests[2].claimant_id,
+            'createdAt' => time,
+            'expiresAt' => nil,
+            'powerOfAttorneyForm' => dependent_claimant_power_of_attorney_form,
+            'powerOfAttorneyHolder' => {
               'id' => poa_requests[2].power_of_attorney_holder.id,
               'type' => 'veteran_service_organization',
               'name' => poa_requests[2].power_of_attorney_holder.name
             },
-            'accredited_individual' => {
+            'accreditedIndividual' => {
               'id' => poa_requests[2].accredited_individual.id,
-              'full_name' => [
+              'fullName' => [
                 poa_requests[2].accredited_individual.first_name,
                 poa_requests[2].accredited_individual.last_name
               ].join(' ')
@@ -148,26 +147,26 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
             'resolution' => {
               'id' => poa_requests[2].resolution.id,
               'type' => 'decision',
-              'created_at' => time,
-              'creator_id' => poa_requests[2].resolution.resolving.creator_id,
+              'createdAt' => time,
+              'creatorId' => poa_requests[2].resolution.resolving.creator_id,
               'reason' => 'Didn\'t authorize treatment record disclosure',
-              'decision_type' => 'declination'
+              'decisionType' => 'declination'
             }
           },
           {
             'id' => poa_requests[3].id,
-            'claimant_id' => poa_requests[3].claimant_id,
-            'created_at' => time,
-            'expires_at' => nil,
-            'power_of_attorney_form' => dependent_claimant_power_of_attorney_form,
-            'power_of_attorney_holder' => {
+            'claimantId' => poa_requests[3].claimant_id,
+            'createdAt' => time,
+            'expiresAt' => nil,
+            'powerOfAttorneyForm' => dependent_claimant_power_of_attorney_form,
+            'powerOfAttorneyHolder' => {
               'id' => poa_requests[3].power_of_attorney_holder.id,
               'type' => 'veteran_service_organization',
               'name' => poa_requests[3].power_of_attorney_holder.name
             },
-            'accredited_individual' => {
+            'accreditedIndividual' => {
               'id' => poa_requests[3].accredited_individual.id,
-              'full_name' => [
+              'fullName' => [
                 poa_requests[3].accredited_individual.first_name,
                 poa_requests[3].accredited_individual.last_name
               ].join(' ')
@@ -175,7 +174,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
             'resolution' => {
               'id' => poa_requests[3].resolution.id,
               'type' => 'expiration',
-              'created_at' => time
+              'createdAt' => time
             }
           }
         ]
@@ -226,26 +225,26 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
       expect(parsed_response).to eq(
         {
           'id' => poa_request.id,
-          'claimant_id' => poa_request.claimant_id,
-          'created_at' => time,
-          'expires_at' => nil,
-          'power_of_attorney_form' => power_of_attorney_form,
+          'claimantId' => poa_request.claimant_id,
+          'createdAt' => time,
+          'expiresAt' => nil,
+          'powerOfAttorneyForm' => power_of_attorney_form,
           'resolution' => {
             'id' => poa_request.resolution.id,
             'type' => 'decision',
-            'created_at' => time,
-            'creator_id' => poa_request.resolution.resolving.creator_id,
+            'createdAt' => time,
+            'creatorId' => poa_request.resolution.resolving.creator_id,
             'reason' => 'Didn\'t authorize treatment record disclosure',
-            'decision_type' => 'declination'
+            'decisionType' => 'declination'
           },
-          'power_of_attorney_holder' => {
+          'powerOfAttorneyHolder' => {
             'id' => poa_request.power_of_attorney_holder.id,
             'type' => 'veteran_service_organization',
             'name' => poa_request.power_of_attorney_holder.name
           },
-          'accredited_individual' => {
+          'accreditedIndividual' => {
             'id' => poa_request.accredited_individual.id,
-            'full_name' => [
+            'fullName' => [
               poa_request.accredited_individual.first_name,
               poa_request.accredited_individual.last_name
             ].join(' ')

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec/responses/dependent_claimant_power_of_attorney_form.json
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec/responses/dependent_claimant_power_of_attorney_form.json
@@ -1,8 +1,8 @@
 {
   "authorizations": {
-    "record_disclosure": true,
-    "record_disclosure_limitations": [],
-    "address_change": true
+    "recordDisclosure": true,
+    "recordDisclosureLimitations": [],
+    "addressChange": true
   },
   "veteran": {
     "name": {
@@ -11,19 +11,19 @@
       "last": "Doe"
     },
     "address": {
-      "address_line1": "123 Main St",
-      "address_line2": "Apt 1",
+      "addressLine1": "123 Main St",
+      "addressLine2": "Apt 1",
       "city": "Springfield",
-      "state_code": "IL",
+      "stateCode": "IL",
       "country": "US",
-      "zip_code": "62704",
-      "zip_code_suffix": "6789"
+      "zipCode": "62704",
+      "zipCodeSuffix": "6789"
     },
     "ssn": "123456789",
-    "va_file_number": "123456789",
-    "date_of_birth": "1980-12-31",
-    "service_number": "123456789",
-    "service_branch": "ARMY",
+    "vaFileNumber": "123456789",
+    "dateOfBirth": "1980-12-31",
+    "serviceNumber": "123456789",
+    "serviceBranch": "ARMY",
     "phone": "1234567890",
     "email": "veteran@example.com"
   },
@@ -34,15 +34,15 @@
       "last": "Doe"
     },
     "address": {
-      "address_line1": "123 Main St",
-      "address_line2": "Apt 1",
+      "addressLine1": "123 Main St",
+      "addressLine2": "Apt 1",
       "city": "Springfield",
-      "state_code": "IL",
+      "stateCode": "IL",
       "country": "US",
-      "zip_code": "62704",
-      "zip_code_suffix": "6789"
+      "zipCode": "62704",
+      "zipCodeSuffix": "6789"
     },
-    "date_of_birth": "1980-12-31",
+    "dateOfBirth": "1980-12-31",
     "relationship": "Spouse",
     "phone": "1234567890",
     "email": "veteran@example.com"

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec/responses/veteran_claimant_power_of_attorney_form.json
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec/responses/veteran_claimant_power_of_attorney_form.json
@@ -1,11 +1,11 @@
 {
   "authorizations": {
-    "record_disclosure": true,
-    "record_disclosure_limitations": [
+    "recordDisclosure": true,
+    "recordDisclosureLimitations": [
       "HIV",
       "DRUG_ABUSE"
     ],
-    "address_change": true
+    "addressChange": true
   },
   "claimant": {
     "name": {
@@ -14,19 +14,19 @@
       "last": "Doe"
     },
     "address": {
-      "address_line1": "123 Main St",
-      "address_line2": "Apt 1",
+      "addressLine1": "123 Main St",
+      "addressLine2": "Apt 1",
       "city": "Springfield",
-      "state_code": "IL",
+      "stateCode": "IL",
       "country": "US",
-      "zip_code": "62704",
-      "zip_code_suffix": "6789"
+      "zipCode": "62704",
+      "zipCodeSuffix": "6789"
     },
     "ssn": "123456789",
-    "va_file_number": "123456789",
-    "date_of_birth": "1980-12-31",
-    "service_number": "123456789",
-    "service_branch": "ARMY",
+    "vaFileNumber": "123456789",
+    "dateOfBirth": "1980-12-31",
+    "serviceNumber": "123456789",
+    "serviceBranch": "ARMY",
     "phone": "1234567890",
     "email": "veteran@example.com"
   }

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/user_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/user_spec.rb
@@ -46,18 +46,18 @@ RSpec.describe 'AccreditedRepresentativePortal::V0::User', type: :request do
           expect(parsed_response).to eq(
             {
               'account' => {
-                'account_uuid' => user.user_account.id
+                'accountUuid' => user.user_account.id
               },
               'profile' => {
-                'first_name' => first_name,
-                'last_name' => last_name,
+                'firstName' => first_name,
+                'lastName' => last_name,
                 'verified' => true,
-                'sign_in' => {
-                  'service_name' => sign_in_service_name
+                'signIn' => {
+                  'serviceName' => sign_in_service_name
                 }
               },
-              'prefills_available' => [],
-              'in_progress_forms' => [
+              'prefillsAvailable' => [],
+              'inProgressForms' => [
                 {
                   'form' => in_progress_form_id,
                   'metadata' => {

--- a/modules/accredited_representative_portal/spec/serializers/accredited_representative_portal/power_of_attorney_request_serializer_spec.rb
+++ b/modules/accredited_representative_portal/spec/serializers/accredited_representative_portal/power_of_attorney_request_serializer_spec.rb
@@ -28,20 +28,20 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestSerializer,
     end
 
     it 'includes :claimant_id' do
-      expect(veteran_declined_data[:claimant_id]).to eq veteran_declined_poa_request.claimant_id
+      expect(veteran_declined_data[:claimantId]).to eq veteran_declined_poa_request.claimant_id
     end
 
     it 'includes :created_at' do
-      expect(veteran_declined_data[:created_at]).to eq veteran_declined_poa_request.created_at
+      expect(veteran_declined_data[:createdAt]).to eq veteran_declined_poa_request.created_at
     end
 
     it 'includes :expires_at' do
-      expect(veteran_declined_data[:expires_at]).to eq veteran_declined_poa_request.expires_at.as_json
+      expect(veteran_declined_data[:expiresAt]).to eq veteran_declined_poa_request.expires_at.as_json
     end
 
     describe ':power_of_attorney_form' do
       it 'modifies claimant key based on claimant type for veteran type' do
-        veteran_declined_serialized_form = veteran_declined_data[:power_of_attorney_form]
+        veteran_declined_serialized_form = veteran_declined_data[:powerOfAttorneyForm]
 
         expect(veteran_declined_serialized_form['claimant']).to be_present
         expect(veteran_declined_serialized_form).not_to be_key('dependent')
@@ -49,7 +49,7 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestSerializer,
       end
 
       it 'modifies claimant key based on claimant type for dependent type' do
-        dependent_expiration_serialized_form = dependent_expiration_data[:power_of_attorney_form]
+        dependent_expiration_serialized_form = dependent_expiration_data[:powerOfAttorneyForm]
 
         expect(dependent_expiration_serialized_form['claimant']).to be_present
         expect(dependent_expiration_serialized_form).not_to be_key('dependent')
@@ -62,10 +62,10 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestSerializer,
         it 'includes the decision resolution' do
           veteran_declined_resolution_data = veteran_declined_data[:resolution]
           expect(veteran_declined_resolution_data[:type]).to eq 'decision'
-          expect(veteran_declined_resolution_data[:decision_type]).to eq 'declination'
+          expect(veteran_declined_resolution_data[:decisionType]).to eq 'declination'
           expect(veteran_declined_resolution_data[:reason]).to eq "Didn't authorize treatment record disclosure"
           expect(veteran_declined_resolution_data[:id]).to eq veteran_declined_resolution.id
-          expect(veteran_declined_resolution_data[:creator_id]).to eq veteran_declined_resolution.resolving.creator_id
+          expect(veteran_declined_resolution_data[:creatorId]).to eq veteran_declined_resolution.resolving.creator_id
         end
       end
 
@@ -91,10 +91,10 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestSerializer,
           pending_individual_poa_request.power_of_attorney_holder = accredited_individual
           pending_individual_poa_request.save
           pending_individual_response = described_class.new(pending_individual_poa_request)
-          pending_individual_holder_data = pending_individual_response.serializable_hash[:power_of_attorney_holder]
+          pending_individual_holder_data = pending_individual_response.serializable_hash[:powerOfAttorneyHolder]
           expect(pending_individual_holder_data[:type]).to eq 'accredited_representative'
           # rubocop:disable Layout/LineLength
-          expect(pending_individual_holder_data[:full_name]).to eq "#{accredited_individual.first_name} #{accredited_individual.last_name}"
+          expect(pending_individual_holder_data[:fullName]).to eq "#{accredited_individual.first_name} #{accredited_individual.last_name}"
           # rubocop:enable Layout/LineLength
           expect(pending_individual_holder_data[:id]).to eq accredited_individual.id
         end
@@ -102,7 +102,7 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestSerializer,
 
       context 'when the holder is an AccreditedOrganization' do
         it 'serializes the accredited organization' do
-          veteran_declined_holder_data = veteran_declined_data[:power_of_attorney_holder]
+          veteran_declined_holder_data = veteran_declined_data[:powerOfAttorneyHolder]
           expect(veteran_declined_holder_data[:type]).to eq 'veteran_service_organization'
           expect(veteran_declined_holder_data[:name]).to eq veteran_declined_power_of_attorney_holder.name
           expect(veteran_declined_holder_data[:id]).to eq veteran_declined_power_of_attorney_holder.id
@@ -112,10 +112,10 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestSerializer,
 
     describe ':accredited_individual' do
       it 'serializes the accredited individual' do
-        veteran_declined_serialized_individual = veteran_declined_data[:accredited_individual]
+        veteran_declined_serialized_individual = veteran_declined_data[:accreditedIndividual]
         expect(veteran_declined_serialized_individual[:id]).to eq veteran_declined_accredited_individual.id
         # rubocop:disable Layout/LineLength
-        expect(veteran_declined_serialized_individual[:full_name]).to eq "#{veteran_declined_accredited_individual.first_name} #{veteran_declined_accredited_individual.last_name}"
+        expect(veteran_declined_serialized_individual[:fullName]).to eq "#{veteran_declined_accredited_individual.first_name} #{veteran_declined_accredited_individual.last_name}"
         # rubocop:enable Layout/LineLength
       end
     end


### PR DESCRIPTION
`AccreditedRepresentativePortal::ApplicationSerializer.set_key_transform :camel_lower`

Also bypasses `OliveBranch` with this rationale:
> This excludes ARP's API endpoints from `OliveBranch`'s redundant processing. Redundant because we will have our serialization layer set our desired key casing while constructing the response payload. `OliveBranch`, on the other hand, deserializes JSON, transforms it, and serializes it again, which is inefficient and redundant.