### PR TITLE
[API-44247] update poa request attributes

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/blueprints/power_of_attorney_request_blueprint.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/blueprints/power_of_attorney_request_blueprint.rb
@@ -38,8 +38,8 @@ module ClaimsApi
               actioned_date: request['dateRequestActioned'],
               status: request['secondaryStatus'],
               declined_reason: request['declinedReason'],
-              change_address_authorization: request['changeAddressAuth'],
-              health_info_authorization: request['healthInfoAuth']
+              consent_address_change: request['changeAddressAuth'] == 'Y',
+              record_consent: request['healthInfoAuth'] == 'Y'
             }
           end
 

--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -10681,8 +10681,8 @@
                         "actionedDate": "2024-05-25T13:45:00-05:00",
                         "status": "New",
                         "declinedReason": null,
-                        "changeAddressAuthorization": "Y",
-                        "healthInfoAuthorization": "Y"
+                        "consentAddressChange": true,
+                        "recordConsent": true
                       }
                     },
                     {
@@ -10712,8 +10712,8 @@
                         "actionedDate": "2013-01-14T08:50:17-06:00",
                         "status": "New",
                         "declinedReason": null,
-                        "changeAddressAuthorization": "Y",
-                        "healthInfoAuthorization": "Y"
+                        "consentAddressChange": true,
+                        "recordConsent": true
                       }
                     },
                     {
@@ -10743,8 +10743,8 @@
                         "actionedDate": "2013-01-14T08:51:25-06:00",
                         "status": "New",
                         "declinedReason": null,
-                        "changeAddressAuthorization": "Y",
-                        "healthInfoAuthorization": "Y"
+                        "consentAddressChange": true,
+                        "recordConsent": true
                       }
                     }
                   ]
@@ -10850,18 +10850,18 @@
                               "declinedReason": {
                                 "type": "string"
                               },
-                              "changeAddressAuthorization": {
-                                "type": "string",
+                              "consentAddressChange": {
+                                "type": "boolean",
                                 "enum": [
-                                  "Y",
-                                  "N"
+                                  true,
+                                  false
                                 ]
                               },
-                              "healthInfoAuthorization": {
-                                "type": "string",
+                              "recordConsent": {
+                                "type": "boolean",
                                 "enum": [
-                                  "Y",
-                                  "N"
+                                  true,
+                                  false
                                 ]
                               }
                             }
@@ -11152,8 +11152,8 @@
                       "actionedDate": "2025-01-09T10:19:26-06:00",
                       "status": "Accepted",
                       "declinedReason": null,
-                      "changeAddressAuthorization": "Y",
-                      "healthInfoAuthorization": "Y"
+                      "consentAddressChange": true,
+                      "recordConsent": true
                     }
                   }
                 },
@@ -11256,18 +11256,18 @@
                             "declinedReason": {
                               "type": "string"
                             },
-                            "changeAddressAuthorization": {
-                              "type": "string",
+                            "consentAddressChange": {
+                              "type": "boolean",
                               "enum": [
-                                "Y",
-                                "N"
+                                true,
+                                false
                               ]
                             },
-                            "healthInfoAuthorization": {
-                              "type": "string",
+                            "recordConsent": {
+                              "type": "boolean",
                               "enum": [
-                                "Y",
-                                "N"
+                                true,
+                                false
                               ]
                             }
                           }

--- a/modules/claims_api/spec/requests/v2/veterans/rswag/index/200.json
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag/index/200.json
@@ -88,13 +88,13 @@
               "declinedReason": {
                 "type": ["string", "null"]
               },
-              "changeAddressAuthorization": {
-                "type": ["string", "null"],
-                "enum": ["Y", "N", null]
+              "consentAddressChange": {
+                "type": ["boolean", "null"],
+                "enum": [true, false, null]
               },
-              "healthInfoAuthorization": {
-                "type": ["string", "null"],
-                "enum": ["Y", "N", null]
+              "recordConsent": {
+                "type": ["boolean", "null"],
+                "enum": [true, false, null]
               }
             }
           }

--- a/modules/claims_api/spec/requests/v2/veterans/rswag/show/200.json
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag/show/200.json
@@ -86,13 +86,13 @@
             "declinedReason": {
               "type": ["string", "null"]
             },
-            "changeAddressAuthorization": {
-              "type": ["string", "null"],
-              "enum": ["Y", "N", null]
+            "consentAddressChange": {
+              "type": ["boolean", "null"],
+              "enum": [true, false, null]
             },
-            "healthInfoAuthorization": {
-              "type": ["string", "null"],
-              "enum": ["Y", "N", null]
+            "recordConsent": {
+              "type": ["boolean", "null"],
+              "enum": [true, false, null]
             }
           }
         }


### PR DESCRIPTION
## Summary

In the power-of-attorney-request index and show endpoints, update:
- changeAddressAuthorization → consentAddressChange
- healthInfoAuthorization → recordConsent
- 'Y' / 'N' → true / false

Update v2 docs (staging only).

## Related issue(s)

[API-44247](https://jira.devops.va.gov/browse/API-44247)

## Testing done

- [x] *New code is covered by unit tests*

Send a request to GET `/veterans/power-of-attorney-requests/:id` or POST `/veterans/power-of-attorney-requests` and observe correct response.

## Screenshots
**Index**
<img width="1320" alt="index_example" src="https://github.com/user-attachments/assets/f62e3628-15b2-4f3e-bc7e-42b7c14cb615" />
<img width="791" alt="index_schema" src="https://github.com/user-attachments/assets/4ee14c33-3f31-4870-9a4e-c721bb9cfe76" />

**Show**
<img width="1319" alt="show_example" src="https://github.com/user-attachments/assets/9810852c-f411-438d-84d3-30c4401ed192" />
<img width="801" alt="show_schema" src="https://github.com/user-attachments/assets/4e5ad267-0c9a-47f1-98e0-581eb0e986c2" />

## What areas of the site does it impact?

Power of attorney request index and show. v2 staging docs.
## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

N/A