### PR TITLE
Fix production error, parse va appointment requests as va appointments in mobile module

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1537,6 +1537,10 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle to remove Podiatry from the type of care list when scheduling an online appointment.
+  va_online_scheduling_appointment_type_consolidation:
+    actor_type: user
+    enable_in_development: true
+    description: Toggle to enable appointment type consolidation logic.
   va_v2_person_service:
     actor_type: user
     description: When enabled, the VAProfile::V2::Person::Service will be enabled

--- a/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointment.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointment.rb
@@ -80,7 +80,8 @@ module Mobile
 
         attr_reader :appointment
 
-        def initialize(appointment)
+        def initialize(user, appointment)
+          @user = user
           @appointment = appointment
         end
 
@@ -277,6 +278,12 @@ module Mobile
             APPOINTMENT_TYPES[:cc]
           when VAOS::V2::AppointmentsService::APPOINTMENT_TYPES[:va]
             convert_va_appointment_type
+          when VAOS::V2::AppointmentsService::APPOINTMENT_TYPES[:request]
+            if Flipper.enabled?(:va_online_scheduling_appointment_type_consolidation, @user)
+              APPOINTMENT_TYPES[:va]
+            else
+              appointment[:type]
+            end
           else
             appointment[:type]
           end

--- a/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointments.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointments.rb
@@ -11,6 +11,10 @@ module Mobile
       #   Mobile::V0::Adapters::VAOSV2Appointments.new.parse(appointments)
       #
       class VAOSV2Appointments
+        def initialize(user)
+          @user = user
+        end
+
         # Takes a result set of VAOS v2 appointments from the appointments web service
         # and returns the set adapted to a common schema.
         #
@@ -22,7 +26,7 @@ module Mobile
           return [] if appointments.nil?
 
           appointments.map do |appointment_hash|
-            appointment_adapter = VAOSV2Appointment.new(appointment_hash)
+            appointment_adapter = VAOSV2Appointment.new(@user, appointment_hash)
             appointment_adapter.build_appointment_model
           end.compact
         end

--- a/modules/mobile/app/services/mobile/v2/appointments/proxy.rb
+++ b/modules/mobile/app/services/mobile/v2/appointments/proxy.rb
@@ -50,7 +50,7 @@ module Mobile
         end
 
         def vaos_v2_to_v0_appointment_adapter
-          Mobile::V0::Adapters::VAOSV2Appointments.new
+          Mobile::V0::Adapters::VAOSV2Appointments.new(@user)
         end
       end
     end

--- a/modules/mobile/spec/models/adapters/appointments_vaos_v2_adapter_spec.rb
+++ b/modules/mobile/spec/models/adapters/appointments_vaos_v2_adapter_spec.rb
@@ -135,7 +135,10 @@ describe Mobile::V0::Adapters::VAOSV2Appointments, :aggregate_failures do
 
   describe 'appointment_type' do
     context 'with appointment_type_consolidation flag on' do
-      before { Flipper.enable(:va_online_scheduling_appointment_type_consolidation) }
+      before do
+        allow(Flipper).to receive(:enabled?).with(:va_online_scheduling_appointment_type_consolidation,
+                                                  instance_of(User)).and_return(true)
+      end
 
       it 'sets va requests to VA' do
         appt = appointment_by_id(proposed_va_id)

--- a/modules/mobile/spec/models/adapters/appointments_vaos_v2_adapter_spec.rb
+++ b/modules/mobile/spec/models/adapters/appointments_vaos_v2_adapter_spec.rb
@@ -3,24 +3,6 @@
 require 'rails_helper'
 
 describe Mobile::V0::Adapters::VAOSV2Appointments, :aggregate_failures do
-  def appointment_data(index = nil)
-    appts = index ? raw_data[index] : raw_data
-    Array.wrap(appts).map { |appt| OpenStruct.new(appt) }
-  end
-
-  def appointment_by_id(id, overrides: {}, without: [])
-    appointment = raw_data.find { |appt| appt[:id] == id }
-    appointment.merge!(overrides) if overrides.any?
-    without.each do |property|
-      if property.is_a?(Hash)
-        appointment.dig(*property[:at]).delete(property[:key])
-      else
-        appointment.delete(property)
-      end
-    end
-    subject.parse(Array.wrap(appointment)).first
-  end
-
   let(:appointment_fixtures) do
     Rails.root.join('modules', 'mobile', 'spec', 'support', 'fixtures', 'VAOS_v2_appointments.json').read
   end
@@ -39,6 +21,25 @@ describe Mobile::V0::Adapters::VAOSV2Appointments, :aggregate_failures do
   let(:past_request_date_appt_id) { '53360' }
   let(:future_request_date_appt_id) { '53359' }
   let(:telehealth_onsite_id) { '50097' }
+  let(:user) { build(:user) }
+
+  def appointment_data(index = nil)
+    appts = index ? raw_data[index] : raw_data
+    Array.wrap(appts).map { |appt| OpenStruct.new(appt) }
+  end
+
+  def appointment_by_id(id, overrides: {}, without: [])
+    appointment = raw_data.find { |appt| appt[:id] == id }
+    appointment.merge!(overrides) if overrides.any?
+    without.each do |property|
+      if property.is_a?(Hash)
+        appointment.dig(*property[:at]).delete(property[:key])
+      else
+        appointment.delete(property)
+      end
+    end
+    Mobile::V0::Adapters::VAOSV2Appointments.new(user).parse(Array.wrap(appointment)).first
+  end
 
   before do
     Timecop.freeze(Time.zone.parse('2022-08-25T19:25:00Z'))
@@ -49,11 +50,11 @@ describe Mobile::V0::Adapters::VAOSV2Appointments, :aggregate_failures do
   end
 
   it 'returns an empty array when provided nil' do
-    expect(subject.parse(nil)).to eq([])
+    expect(Mobile::V0::Adapters::VAOSV2Appointments.new(user).parse(nil)).to eq([])
   end
 
   it 'returns a list of Mobile::V0::Appointments at the expected size' do
-    adapted_appointments = subject.parse(appointment_data)
+    adapted_appointments = Mobile::V0::Adapters::VAOSV2Appointments.new(user).parse(appointment_data)
     expect(adapted_appointments.size).to eq(13)
     expect(adapted_appointments.map(&:class).uniq).to match_array(Mobile::V0::Appointment)
   end
@@ -133,6 +134,15 @@ describe Mobile::V0::Adapters::VAOSV2Appointments, :aggregate_failures do
   end
 
   describe 'appointment_type' do
+    context 'with appointment_type_consolidation flag on' do
+      before { Flipper.enable(:va_online_scheduling_appointment_type_consolidation) }
+
+      it 'sets va requests to VA' do
+        appt = appointment_by_id(proposed_va_id)
+        expect(appt.appointment_type).to eq('VA')
+      end
+    end
+
     it 'sets phone appointments to VA' do
       appt = appointment_by_id(phone_va_id)
       expect(appt.appointment_type).to eq('VA')

--- a/modules/mobile/spec/requests/mobile/v0/facilities_info_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/facilities_info_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Mobile::V0::FacilitiesInfo', type: :request do
     va_path = Rails.root.join('modules', 'mobile', 'spec', 'support', 'fixtures',
                               'VAOS_v2_appointments_facilities.json')
     va_json = File.read(va_path)
-    va_appointments = Mobile::V0::Adapters::VAOSV2Appointments.new.parse(
+    va_appointments = Mobile::V0::Adapters::VAOSV2Appointments.new(user).parse(
       JSON.parse(va_json, symbolize_names: true)
     )
 

--- a/modules/mobile/spec/support/fixtures/VAOS_v2_appointments.json
+++ b/modules/mobile/spec/support/fixtures/VAOS_v2_appointments.json
@@ -305,7 +305,7 @@
       "code": null
     },
     "kind": "clinic",
-    "type": "VA",
+    "type": "REQUEST",
     "status": "proposed",
     "service_type": "socialWork",
     "patient_icn": "1012845331V153043",


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES - `va_online_scheduling_appointment_type_consolidation`
- We noticed a issue that causes 502 errors in production for mobile appointments and we are fixing it in this PR.
- The bug was introduced in https://github.com/department-of-veterans-affairs/vets-api/pull/18879 where `REQUEST` appointment types were not handled correctly via the model adapters. 
- The fix is to update the appointment type resolution logic for `REQUEST` appointment types returned by the vets-api appointments service which should be resolved to `VA` for mobile appointments.
- Appointments (VAOS) Team
- We'll remove the toggle once the issue has been validated to be fixed in production.

## Related issue(s)

- The discussion for this production issue is tracked in Slack [here](https://dsva.slack.com/archives/C018V2JCWRJ/p1737655190350189)

## Testing done

- [x] *New code is covered by unit tests*
- Tested locally and added unit tests to ensure the updated behavior

## Screenshots
N/A

## What areas of the site does it impact?
Appointments-Mobile

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

