### PR TITLE
[VI-1014] Schema changes to add Oauth compatibility functionality for sign in service token route

### DIFF
--- a/db/migrate/20250123220146_add_json_api_compatibility_to_client_configs.rb
+++ b/db/migrate/20250123220146_add_json_api_compatibility_to_client_configs.rb
@@ -1,0 +1,5 @@
+class AddJsonApiCompatibilityToClientConfigs < ActiveRecord::Migration[7.2]
+  def change
+    add_column :client_configs, :json_api_compatibility, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -539,6 +539,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_24_211447) do
     t.boolean "shared_sessions", default: false, null: false
     t.string "service_levels", default: ["ial1", "ial2", "loa1", "loa3", "min"], array: true
     t.string "credential_service_providers", default: ["logingov", "idme", "dslogon", "mhv"], array: true
+    t.boolean "json_api_compatibility", default: true, null: false
     t.index ["client_id"], name: "index_client_configs_on_client_id", unique: true
   end
 


### PR DESCRIPTION
## Summary

- This PR adds the schema changes necessary to separate Sign in Service clients from either JSON API compatible or OAuth RFC compatible clients

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-1014
## Testing done

- [ ] Migrated and confirmed new column was created with expected defaults

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [ ] Migrate/Rollback with expected results