### PR TITLE
[VI-1014] Adding functionality to enable oauth compatibility for sign…

### DIFF
--- a/app/controllers/sign_in/client_configs_controller.rb
+++ b/app/controllers/sign_in/client_configs_controller.rb
@@ -48,8 +48,10 @@ module SignIn
       params.require(:client_config).permit(:client_id, :authentication, :redirect_uri, :refresh_token_duration,
                                             :access_token_duration, :access_token_audience, :logout_redirect_uri,
                                             :pkce, :terms_of_use_url, :enforced_terms, :shared_sessions, :anti_csrf,
-                                            :description, certificates: [], access_token_attributes: [],
-                                                          service_levels: [], credential_service_providers: [])
+                                            :description, :json_api_compatibility, certificates: [],
+                                                                                   access_token_attributes: [],
+                                                                                   service_levels: [],
+                                                                                   credential_service_providers: [])
     end
 
     def set_client_config

--- a/app/models/sign_in/client_config.rb
+++ b/app/models/sign_in/client_config.rb
@@ -27,6 +27,7 @@ module SignIn
     validates :service_levels, presence: true, inclusion: { in: Constants::Auth::ACR_VALUES, allow_nil: false }
     validates :credential_service_providers, presence: true,
                                              inclusion: { in: Constants::Auth::CSP_TYPES, allow_nil: false }
+    validates :json_api_compatibility, inclusion: [true, false]
 
     def self.valid_client_id?(client_id:)
       find_by(client_id:).present?

--- a/app/services/sign_in/token_serializer.rb
+++ b/app/services/sign_in/token_serializer.rb
@@ -65,7 +65,9 @@ module SignIn
     end
 
     def token_json_response
-      { data: token_json_payload }
+      return { data: token_json_payload } if json_api_compatibility_client?
+
+      token_json_payload
     end
 
     def token_json_payload
@@ -95,6 +97,10 @@ module SignIn
 
     def anti_csrf_enabled_client?
       client_config.anti_csrf
+    end
+
+    def json_api_compatibility_client?
+      client_config.json_api_compatibility
     end
 
     def device_secret

--- a/spec/factories/sign_in/client_configs.rb
+++ b/spec/factories/sign_in/client_configs.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     refresh_token_duration { SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES }
     description { Faker::Lorem.sentence }
     access_token_attributes { [] }
+    json_api_compatibility { true }
     enforced_terms { SignIn::Constants::Auth::VA_TERMS }
     terms_of_use_url { Faker::Internet.url }
     shared_sessions { false }

--- a/spec/models/sign_in/client_config_spec.rb
+++ b/spec/models/sign_in/client_config_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe SignIn::ClientConfig, type: :model do
            enforced_terms:,
            terms_of_use_url:,
            service_levels:,
+           json_api_compatibility:,
            credential_service_providers:)
   end
   let(:client_id) { 'some-client-id' }
@@ -26,6 +27,7 @@ RSpec.describe SignIn::ClientConfig, type: :model do
   let(:certificates) { [] }
   let(:anti_csrf) { false }
   let(:shared_sessions) { false }
+  let(:json_api_compatibility) { false }
   let(:redirect_uri) { 'some-redirect-uri' }
   let(:logout_redirect_uri) { 'some-logout-redirect-uri' }
   let(:access_token_duration) { SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES }
@@ -181,6 +183,18 @@ RSpec.describe SignIn::ClientConfig, type: :model do
       context 'when anti_csrf is nil' do
         let(:anti_csrf) { nil }
         let(:expected_error_message) { 'Validation failed: Anti csrf is not included in the list' }
+        let(:expected_error) { ActiveRecord::RecordInvalid }
+
+        it 'raises validation error' do
+          expect { subject }.to raise_error(expected_error, expected_error_message)
+        end
+      end
+    end
+
+    describe '#json_api_compatibility' do
+      context 'when json_api_compatibility is nil' do
+        let(:json_api_compatibility) { nil }
+        let(:expected_error_message) { 'Validation failed: Json api compatibility is not included in the list' }
         let(:expected_error) { ActiveRecord::RecordInvalid }
 
         it 'raises validation error' do

--- a/spec/services/sign_in/token_serializer_spec.rb
+++ b/spec/services/sign_in/token_serializer_spec.rb
@@ -22,8 +22,11 @@ RSpec.describe SignIn::TokenSerializer do
     let(:refresh_token) { create(:refresh_token) }
     let(:access_token) { create(:access_token) }
     let(:anti_csrf_token) { 'some-anti-csrf-token' }
-    let(:client_config) { create(:client_config, authentication:, anti_csrf:, shared_sessions:) }
+    let(:client_config) do
+      create(:client_config, authentication:, anti_csrf:, shared_sessions:, json_api_compatibility:)
+    end
     let(:anti_csrf) { false }
+    let(:json_api_compatibility) { true }
     let(:authentication) { SignIn::Constants::Auth::API }
     let(:device_secret) { 'some-device-secret' }
     let(:shared_sessions) { false }
@@ -180,6 +183,36 @@ RSpec.describe SignIn::TokenSerializer do
         end
 
         it 'returns expected json payload with anti csrf token' do
+          expect(subject).to eq(expected_json_payload)
+        end
+      end
+
+      context 'and client is configured to be compatible with json api' do
+        let(:json_api_compatibility) { true }
+        let(:expected_json_payload) { { data: token_payload } }
+        let(:token_payload) do
+          {
+            access_token: encoded_access_token,
+            refresh_token: encrypted_refresh_token
+          }
+        end
+
+        it 'returns expected json payload' do
+          expect(subject).to eq(expected_json_payload)
+        end
+      end
+
+      context 'and client is not configured to be compatible with json api' do
+        let(:json_api_compatibility) { false }
+        let(:expected_json_payload) { token_payload }
+        let(:token_payload) do
+          {
+            access_token: encoded_access_token,
+            refresh_token: encrypted_refresh_token
+          }
+        end
+
+        it 'returns expected json payload' do
           expect(subject).to eq(expected_json_payload)
         end
       end


### PR DESCRIPTION
## Summary

- This PR serializes the Sign in Service `/token` route slightly differently depending on whether or not a 'json_api_compatibility' field is set on the client configuration. This is for further compatibility with both existing Sign in Service clients and OAuth standard clients

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-1014

## Testing done

- [ ] Updated `vaweb` sign in service client config to set `json_api_compatibility=false`
- [ ] Confirmed `/token` returned access token at root level instead of embedded in a `data` field

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [ ] Set `SignIn::ClientConfig.json_api_compatibility` to `true`, confirm that Sign in Service client returns tokens from `/token` inside a `data` object
- [ ] Set `SignIn::ClientConfig.json_api_compatibility` to `false`, confirm that Sign in Service client returns tokens from `/token` at root level