### PR TITLE
EP Merge feature flag removal

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -515,9 +515,6 @@ features:
     actor_type: user
     description: enables sending 526 claim id and vbms submitted claim id to Contention Classification service for linking/monitoring.
     enable_in_development: true
-  disability_526_ep_merge_api: # TODO: Remove
-    actor_type: user
-    description: enables sending 526 claims with a pending EP to VRO EP Merge API for automated merging.
   disability_526_ee_process_als_flash:
     actor_type: user
     description: enables adding applicable flashes to disability_526 prior to submission.


### PR DESCRIPTION
Follow-on to EP merge functionality removal. See description in that PR:
https://github.com/department-of-veterans-affairs/vets-api/pull/20433

Once this is merged, will need to do the below:
```bash
# Feature toggles can simply be removed by running Flipper.remove(:feature_name) in the Rails console for each environment

# Note that each env (dev/staging/sandbox/prod) has their own table to track the state of each flag, so the command must be run in each env.

# ⚠️ ⚠️ Make sure features are not removed from the DB until AFTER the commit removing the flag from features.yml has propagated to the respective deployed app (Dev/Staging happen soon after merging master, while Production/Sandbox get manually deployed ~1pm ET each day). Otherwise, if the app deploys again, it will recreate any flipper records found in features.yml

Flipper.remove(:disability_526_ep_merge_api)
```