### PR TITLE
Fix flaky my health spec

### DIFF
--- a/modules/my_health/spec/requests/my_health/v1/medical_records/imaging_spec.rb
+++ b/modules/my_health/spec/requests/my_health/v1/medical_records/imaging_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe 'MyHealth::V1::MedicalRecords::ImagingController', type: :request
                         match_requests_on: %i[method sm_user_ignoring_path_param])
   end
 
+  after { VCR.eject_cassette }
+
   RSpec.shared_context 'redis setup' do
     let(:redis) { instance_double(Redis::Namespace) }
     # let(:study_id) { '453-2487450' }


### PR DESCRIPTION
## Summary

- Fixes a flaky spec. Make sure to eject VCR cassettes after specs are run or they can cause spec issues.