### PR TITLE
Skip user authentication for address validation

### DIFF
--- a/app/controllers/v0/profile/address_validation_controller.rb
+++ b/app/controllers/v0/profile/address_validation_controller.rb
@@ -10,7 +10,8 @@ module V0
     class AddressValidationController < ApplicationController
       service_tag 'profile'
 
-      skip_before_action :authenticate, only: [:create]
+      skip_before_action :authenticate
+      skip_before_action :verify_authenticity_token
 
       def create
         address = if Flipper.enabled?(:va_v3_contact_information_service)

--- a/app/controllers/v0/profile/address_validation_controller.rb
+++ b/app/controllers/v0/profile/address_validation_controller.rb
@@ -10,7 +10,7 @@ module V0
     class AddressValidationController < ApplicationController
       service_tag 'profile'
 
-      skip_before_action :authenticate
+      skip_before_action :authenticate, only: [:create]
       skip_before_action :verify_authenticity_token
 
       def create


### PR DESCRIPTION
## Summary

- Pre-need-integration is hitting unathorized errors when attempting to validate addresses without a user being signed in
- This change fixes that

## Related issue(s)

- Jira Link: https://jira.devops.va.gov/browse/MBMS-71996
- Front End PR 1: https://github.com/department-of-veterans-affairs/vets-website/pull/34127

## Testing done

- [x] Spec tests passing
- [x] Internal Review
- [x] QA
- [x] External Review

## Screenshots
![image](https://github.com/user-attachments/assets/1b65bb63-63a2-4707-930c-2895b5c90662)

## What areas of the site does it impact?

- Address validation controller 
    - With that being said, everyone but pre-need-integration that uses this controller requires users to sign in before attempting address validation so the only form affected by this change will be pre-need-integration
  