### PR TITLE
[VI-869] Add audit_db config and connection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -808,7 +808,9 @@ config/spring.rb @department-of-veterans-affairs/va-api-engineers @department-of
 config/ssoe_idp_int_metadata_isam.xml @department-of-veterans-affairs/octo-identity
 config/storage.yml @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 datadog-service-catalog @department-of-veterans-affairs/backend-review-group
+db/audit_migrate @department-of-veterans-affairs/octo-identity
 db/migrate @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+db/audit_schema.rb @department-of-veterans-affairs/octo-identity
 db/schema.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 db/seeds @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 docs/deployment @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -63,6 +63,7 @@ jobs:
       TERM: xterm-256color
       DOCKER_BUILDKIT: 1
       COMPOSE_DOCKER_CLI_BUILD: 1
+      COMPOSE_BASH_CMD: docker compose -f docker-compose.test.yml run web bash -c
     permissions: write-all
     runs-on: ubuntu-32-cores-latest
     outputs:
@@ -116,15 +117,15 @@ jobs:
           timeout_minutes: 10
           retry_wait_seconds: 3 # Seconds
           max_attempts: 3
-          command: |
-            docker compose -f docker-compose.test.yml run web bash \
-              -c "CI=true RAILS_ENV=test DISABLE_BOOTSNAP=true bundle exec parallel_test -n 24  -e 'bin/rails db:reset'"
+          command: >
+             ${{ env.COMPOSE_BASH_CMD }}
+             "bundle exec rake parallel:setup[24]"
 
       - name: Run Specs
         timeout-minutes: 15
-        run: |
-          docker compose -f docker-compose.test.yml run web bash \
-          -c "CI=true DISABLE_BOOTSNAP=true bundle exec parallel_rspec spec/ modules/ -n 24 -o '--color --tty'"
+        run: >
+          ${{ env.COMPOSE_BASH_CMD }}
+          "bundle exec rake 'parallel:spec[24, , , modules\/]'"
 
       - name: Set Test Status
         id: test-status

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,8 +26,10 @@ AllCops:
     - '**/*.rb'
   Exclude:
     - db/schema.rb
+    - db/audit_schema.rb
     - db/seeds.rb
     - db/migrate/*.rb
+    - db/audit_migrate/*.rb
     - 'vendor/**/*'
     - modules/**/db/migrate/*.rb
     - 'tmp/**/*'

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,68 +1,30 @@
 default: &default
   adapter: postgis
   encoding: unicode
-  # For details on connection pooling, see rails configuration guide
-  # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch('RAILS_MAX_THREADS') { 5 } %>
 
 development:
-  url: <%= Settings.database_url %>
+  primary:
+    url: <%= Settings.database_url %>
+  audit:
+    url: <%= "#{Settings.audit_db.url}_development" %>
+    migrations_paths: db/audit_migrate
 
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user that initialized the database.
-  #username: postgres
-
-  # The password associated with the postgres role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
-  url: <%= Settings.test_database_url %><%= ENV['TEST_ENV_NUMBER'] %>
+  primary:
+    url: <%= Settings.test_database_url %><%= ENV['TEST_ENV_NUMBER'] %>
+  audit:
+    url: <%= "#{Settings.audit_db.url}_test#{ENV['TEST_ENV_NUMBER']}" %>
+    migrations_paths: db/audit_migrate
 
-# As with config/secrets.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password as a unix environment variable when you boot
-# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full rundown on how to provide these environment variables in a
-# production deployment.
-#
-# On Heroku and other platform providers, you may have a full connection URL
-# available as an environment variable. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# You can use this database configuration with:
-#
-#   production:
-#     url: <%= ENV['DATABASE_URL'] %>
-#
 production:
-  url: <%= Settings.database_url %>
-  connect_timeout: 5
-  variables:
-    statement_timeout: <%= ENV["STATEMENT_TIMEOUT"] || "60s" %>
-    lock_timeout: 15s
+  primary:
+    url: <%= Settings.database_url %>
+    connect_timeout: 5
+    variables:
+      statement_timeout: <%= ENV["STATEMENT_TIMEOUT"] || "60s" %>
+      lock_timeout: 15s
+  audit:
+    url: <%= "#{Settings.audit_db.url}" %>
+    migrations_paths: db/audit_migrate
+    database_tasks: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,6 +8,9 @@ virtual_hosts: ["127.0.0.1", "localhost"] # Safe host names
 web_origin: http://localhost:3000,http://localhost:3001,http://127.0.0.1:3000,http://127.0.0.1:3001,null
 web_origin_regex: \Ahttps?:\/\/www\.va\.gov\z
 
+audit_db:
+  url: postgis:///vets_api_audit
+
 logingov:
   client_id: https://sqa.eauth.va.gov/isam/sps/saml20sp/saml20
   redirect_uri: http://localhost:3000/v0/sign_in/callback

--- a/db/audit_schema.rb
+++ b/db/audit_schema.rb
@@ -1,0 +1,17 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.2].define(version: 0) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end

--- a/docker-compose.review.yml
+++ b/docker-compose.review.yml
@@ -11,6 +11,7 @@ x-app: &common
     BUNDLE_ENTERPRISE__CONTRIBSYS__COM: "${BUNDLE_ENTERPRISE__CONTRIBSYS__COM}"
     SETTINGS__DATABASE_URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_development}?pool=4"
     SETTINGS__TEST_DATABASE_URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_test}"
+    SETTINGS__AUDIT_DB__URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_audit}"
     SETTINGS__REDIS__APP_DATA__URL: "redis://redis:6379"
     SETTINGS__REDIS__SIDEKIQ__URL: "redis://redis:6379"
     SETTINGS__REDIS__RAILS_CACHE__URL: "redis://redis:6379"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -22,6 +22,7 @@ services:
     environment:
       SETTINGS__DATABASE_URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_development}?pool=4"
       SETTINGS__TEST_DATABASE_URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_test}"
+      SETTINGS__AUDIT_DB__URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_audit}"
       SETTINGS__REDIS__APP_DATA__URL: "redis://redis:6379"
       SETTINGS__REDIS__SIDEKIQ__URL: "redis://redis:6379"
       POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"
@@ -35,6 +36,7 @@ services:
       GIT_URL:             "${GIT_URL}"
       JENKINS_URL:         "${JENKINS_URL}"
       DANGER_GITHUB_API_TOKEN: "${DANGER_GITHUB_API_TOKEN}"
+      DISABLE_BOOTSNAP: "true"
     depends_on:
       - postgres
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ x-app: &common
     BUNDLE_ENTERPRISE__CONTRIBSYS__COM: "${BUNDLE_ENTERPRISE__CONTRIBSYS__COM}"
     SETTINGS__DATABASE_URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_development}?pool=4"
     SETTINGS__TEST_DATABASE_URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_test}"
+    SETTINGS__AUDIT_DB__URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_audit}"
     SETTINGS__REDIS__APP_DATA__URL: "redis://redis:6379"
     SETTINGS__REDIS__SIDEKIQ__URL: "redis://redis:6379"
     SETTINGS__REDIS__RAILS_CACHE__URL: "redis://redis:6379"


### PR DESCRIPTION
## Summary

- This adds the audit database config and connection using rails standard for multiple databases
- Updates docker compose files
- the production audit database has `database_tasks: false`. This will skip migrations in the deployed envs until the database is set up
- In development, Rails database commands with no suffix will run tasks for both databases (`rails db:migrate`) or you can add a suffix (`rails db:migrate:primary`, `rails db:migrate:audit`) to run tasks on the specified database only.
- clean up code_checks pipeline

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-869

## Testing 
- create the databases (`development`, `test`)
  - `rails db:create`
  -  or `rails db:create:audit`
- Load schema (⚠️ Only do this on the `audit` db or you will loose all your data in `primary`)
  - `rails db:load_schema:audit`
-  Make sure the server starts and there aren't any errors

- Test Docker
  - `make up`
    - make sure it starts without error and you can navigate to http://loaclhost:3000

## What areas of the site does it impact?
Audit DB, database config

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

