### PR TITLE
[VI-1032] Adding special case for Sign in Service STS on review instances to allow for special exception in audience validation

### DIFF
--- a/app/services/sign_in/assertion_validator.rb
+++ b/app/services/sign_in/assertion_validator.rb
@@ -90,6 +90,7 @@ module SignIn
 
     def hostname
       return localhost_hostname if Settings.vsp_environment == 'localhost'
+      return staging_hostname if Settings.review_instance_slug.present?
 
       "https://#{Settings.hostname}"
     end
@@ -163,6 +164,10 @@ module SignIn
       port = URI.parse("http://#{Settings.hostname}").port
 
       "http://localhost:#{port}"
+    end
+
+    def staging_hostname
+      'https://staging-api.va.gov'
     end
   end
 end


### PR DESCRIPTION
## Summary

- This PR changes the validations in Sign in Service STS so that the 'staging' hostname is compared against the STS token instead of the randomly generated review instance hostname

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-1032

## Testing done

- [ ] Confirmed Sign in Service STS validates the audience against `https://staging-api.va.gov` when `Settings.review_instance_slug` is set

## What areas of the site does it impact?
Sign in Service STS

## Acceptance criteria

- [ ] Set `Settings.review_instance_slug` to any value in `settings.yml`
- [ ] Validate a Sign in Service STS token, confirm that token Assertion is validated as if the hostname was `https://staging-api.va.gov`
