### PR TITLE
101565_PEGA-Integration-Include-10-10d-signers-email

### DIFF
--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
@@ -23,9 +23,6 @@ module IvcChampva
         'veteranFirstName' => @data.dig('veteran', 'full_name', 'first'),
         'veteranMiddleName' => @data.dig('veteran', 'full_name', 'middle'),
         'veteranLastName' => @data.dig('veteran', 'full_name', 'last'),
-        'sponsorFirstName' => @data.fetch('applicants', [])&.first&.dig('full_name', 'first'),
-        'sponsorMiddleName' => @data.fetch('applicants', [])&.first&.dig('full_name', 'middle'),
-        'sponsorLastName' => @data.fetch('applicants', [])&.first&.dig('full_name', 'last'),
         'fileNumber' => @data.dig('veteran', 'va_claim_number').presence || @data.dig('veteran', 'ssn_or_tin'),
         'zipCode' => @data.dig('veteran', 'address', 'postal_code') || '00000',
         'country' => @data.dig('veteran', 'address', 'country') || 'USA',
@@ -35,7 +32,8 @@ module IvcChampva
         'ssn_or_tin' => @data.dig('veteran', 'ssn_or_tin'),
         'uuid' => @uuid,
         'primaryContactInfo' => @data['primary_contact_info'],
-        'hasApplicantOver65' => @data['has_applicant_over65'].to_s
+        'hasApplicantOver65' => @data['has_applicant_over65'].to_s,
+        'applicantEmailAddress' => @data['applicants']&.dig('applicantEmailAddress')
       }
     end
 

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
@@ -19,7 +19,6 @@ module IvcChampva
     end
 
     def metadata
-   #   byebug
       {
         'veteranFirstName' => @data.dig('veteran', 'full_name', 'first'),
         'veteranMiddleName' => @data.dig('veteran', 'full_name', 'middle'),

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
@@ -19,6 +19,7 @@ module IvcChampva
     end
 
     def metadata
+   #   byebug
       {
         'veteranFirstName' => @data.dig('veteran', 'full_name', 'first'),
         'veteranMiddleName' => @data.dig('veteran', 'full_name', 'middle'),
@@ -33,7 +34,7 @@ module IvcChampva
         'uuid' => @uuid,
         'primaryContactInfo' => @data['primary_contact_info'],
         'hasApplicantOver65' => @data['has_applicant_over65'].to_s,
-        'applicantEmailAddress' => @data['applicants']&.dig('applicantEmailAddress')
+        'signerEmailAddress' => @data.dig('primary_contact_info', 'email')
       }
     end
 

--- a/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe IvcChampva::VHA1010d do
           'first' => 'Veteran',
           'last' => 'Surname'
         },
-        'email' => true
+        'email' => 'certifier@email.gov'
       },
       'veteran' => {
         'full_name' => { 'first' => 'John', 'middle' => 'P', 'last' => 'Doe' },
@@ -19,9 +19,7 @@ RSpec.describe IvcChampva::VHA1010d do
       },
       'form_number' => 'VHA1010d',
       'has_applicant_over65' => false,
-      'applicants' => {
-        'applicantEmailAddress' => 'email@address.com'
-      },
+      'signerEmailAddress' => 'certifier@email.gov',
       'veteran_supporting_documents' => [
         { 'confirmation_code' => 'abc123' },
         { 'confirmation_code' => 'def456' }
@@ -59,13 +57,13 @@ RSpec.describe IvcChampva::VHA1010d do
         'docType' => 'VHA1010d',
         'businessLine' => 'CMP',
         'hasApplicantOver65' => 'false',
-        'applicantEmailAddress' => 'email@address.com',
+        'signerEmailAddress' => 'certifier@email.gov',
         'primaryContactInfo' => {
           'name' => {
             'first' => 'Veteran',
             'last' => 'Surname'
           },
-          'email' => true
+          'email' => 'certifier@email.gov'
         }
       )
     end

--- a/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe IvcChampva::VHA1010d do
           'first' => 'Veteran',
           'last' => 'Surname'
         },
-        'email' => false
+        'email' => true
       },
       'veteran' => {
         'full_name' => { 'first' => 'John', 'middle' => 'P', 'last' => 'Doe' },
@@ -19,6 +19,9 @@ RSpec.describe IvcChampva::VHA1010d do
       },
       'form_number' => 'VHA1010d',
       'has_applicant_over65' => false,
+      'applicants' => {
+        'applicantEmailAddress' => 'email@address.com'
+      },
       'veteran_supporting_documents' => [
         { 'confirmation_code' => 'abc123' },
         { 'confirmation_code' => 'def456' }
@@ -56,12 +59,13 @@ RSpec.describe IvcChampva::VHA1010d do
         'docType' => 'VHA1010d',
         'businessLine' => 'CMP',
         'hasApplicantOver65' => 'false',
+        'applicantEmailAddress' => 'email@address.com',
         'primaryContactInfo' => {
           'name' => {
             'first' => 'Veteran',
             'last' => 'Surname'
           },
-          'email' => false
+          'email' => true
         }
       )
     end


### PR DESCRIPTION
## Summary

Updated the line to directly access the applicantEmailAddress from the first element of the applicants array.
Removed unnecessary type checks and ensured the correct key is used.

## Testing done

Unit Test.

## Screenshots
<img width="977" alt="Screenshot 2025-01-29 at 6 18 32 AM" src="https://github.com/user-attachments/assets/36844f39-eb30-469e-b882-85f38221bcf1" />



## What areas of the site does it impact?
Only 1010D in IVC CHAMPVA forms
