### PR TITLE
MHV-66713: Review instance feature flag fix

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1056,6 +1056,7 @@ features:
   mhv_medical_records_new_eligibility_check:
     actor_type: user
     description: Enables/disables Medical Records new access policy eligibility check endpoint
+    enable_in_development: true
   mhv_medications_to_va_gov_release:
     actor_type: user
     description: Enables/disables Medications on VA.gov (intial transition from MHV to VA.gov)


### PR DESCRIPTION
## Summary
Feature flag for enabling the new eligibility check has been enabled in development which includes review instances. 

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-66713

> ### Infinite spinner for users with initial FHIR population
> Description
> We are seeing complaints from users who are waiting indefinitely for the "2 minute" spinner to finish, but it apparently never does. This is the spinner that pops up while waiting for the initial FHIR population to happen.
> 
> We need to check the logic here and see if there's an issue.
> 
> See [Slack thread](https://dsva.slack.com/archives/C03Q2UQL1AS/p1737646550870249) for more info.

## Testing done
No new tests needed

## Screenshots
No UI changes. 

## What areas of the site does it impact?
MHV medical records

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
