### PR TITLE
VACMS-18444 Add new flipper for Facility Locator mobile map research

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -594,6 +594,10 @@ features:
     actor_type: user
     description: Send only lat/long values (no bounding box or address) to the API when querying for facilities.
     enable_in_development: true
+  facility_locator_mobile_map_update:
+    actor_type: user
+    description: Use new mobile map features for research
+    enable_in_development: true
   facility_locator_predictive_location_search:
     actor_type: user
     description: Use predictive location search in the Facility Locator UI


### PR DESCRIPTION
## Summary
We need a feature flipper to show new Facility Locator mobile map features for our research sessions.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18444
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20153