### PR TITLE
Revert "Skip user authentication for address validation"

### DIFF
--- a/app/controllers/v0/profile/address_validation_controller.rb
+++ b/app/controllers/v0/profile/address_validation_controller.rb
@@ -11,7 +11,6 @@ module V0
       service_tag 'profile'
 
       skip_before_action :authenticate, only: [:create]
-      skip_before_action :verify_authenticity_token
 
       def create
         address = if Flipper.enabled?(:va_v3_contact_information_service)


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#20448

Per Identity Team: 

We shouldn't be skipping CSRF for POST routes that are exposed to the [VA.gov](http://va.gov/) frontend