### PR TITLE
101553: Update DR SavedClaim queries to memoize array instead of ActiveRecord relation

### DIFF
--- a/modules/decision_reviews/app/sidekiq/decision_reviews/hlr_status_updater_job.rb
+++ b/modules/decision_reviews/app/sidekiq/decision_reviews/hlr_status_updater_job.rb
@@ -7,7 +7,7 @@ module DecisionReviews
     private
 
     def records_to_update
-      @higher_level_reviews ||= ::SavedClaim::HigherLevelReview.where(delete_date: nil).order(created_at: :asc)
+      @higher_level_reviews ||= ::SavedClaim::HigherLevelReview.where(delete_date: nil).order(created_at: :asc).to_a
     end
 
     def statsd_prefix

--- a/modules/decision_reviews/app/sidekiq/decision_reviews/nod_status_updater_job.rb
+++ b/modules/decision_reviews/app/sidekiq/decision_reviews/nod_status_updater_job.rb
@@ -7,7 +7,8 @@ module DecisionReviews
     private
 
     def records_to_update
-      @notice_of_disagreements ||= ::SavedClaim::NoticeOfDisagreement.where(delete_date: nil).order(created_at: :asc)
+      @notice_of_disagreements ||=
+        ::SavedClaim::NoticeOfDisagreement.where(delete_date: nil).order(created_at: :asc).to_a
     end
 
     def statsd_prefix

--- a/modules/decision_reviews/app/sidekiq/decision_reviews/sc_status_updater_job.rb
+++ b/modules/decision_reviews/app/sidekiq/decision_reviews/sc_status_updater_job.rb
@@ -7,7 +7,7 @@ module DecisionReviews
     private
 
     def records_to_update
-      @supplemental_claims ||= ::SavedClaim::SupplementalClaim.where(delete_date: nil).order(created_at: :asc)
+      @supplemental_claims ||= ::SavedClaim::SupplementalClaim.where(delete_date: nil).order(created_at: :asc).to_a
     end
 
     def statsd_prefix


### PR DESCRIPTION
## Summary
This fixes a memoization issue for the SavedClaim status updater jobs. This is intended to address an intermittent query timeout issue by reducing the number of DB queries to the SavedClaim table.

- *This work is behind a feature toggle (flipper): YES/NO*
No

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/101553

## Testing done
Tested locally and passes existing tests
- [x] *New code is covered by unit tests*
The previous memoized values in the status updater jobs were ActiveRecord relation objects, so the same queries would be executed multiple times. 

## What areas of the site does it impact?
Sidekiq jobs and vets-api postgres db

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
