### PR TITLE
[10-10CG] Update facility_ids param in facilities endpoint

### DIFF
--- a/app/controllers/v0/caregivers_assistance_claims_controller.rb
+++ b/app/controllers/v0/caregivers_assistance_claims_controller.rb
@@ -73,7 +73,7 @@ module V0
     end
 
     def lighthouse_facilities_params
-      params.permit(
+      permitted_params = params.permit(
         :zip,
         :state,
         :lat,
@@ -84,10 +84,15 @@ module V0
         :mobile,
         :page,
         :per_page,
-        :facilityIds,
+        :facility_ids,
         services: [],
         bbox: []
       )
+
+      # The Lighthouse Facilities api expects the facility ids param as `facilityIds`
+      permitted_params.to_h.tap do |hash|
+        hash['facilityIds'] = hash.delete('facility_ids') if hash.key?('facility_ids')
+      end
     end
 
     def record_submission_attempt

--- a/spec/requests/v0/caregivers_assistance_claims_spec.rb
+++ b/spec/requests/v0/caregivers_assistance_claims_spec.rb
@@ -356,7 +356,7 @@ RSpec.describe 'V0::CaregiversAssistanceClaims', type: :request do
       }
     end
 
-    let(:params) do
+    let(:unmodified_params) do
       {
         zip: '90210',
         state: 'CA',
@@ -368,10 +368,13 @@ RSpec.describe 'V0::CaregiversAssistanceClaims', type: :request do
         mobile: true,
         page: 1,
         per_page: 10,
-        facilityIds: 'vha_123,vha_456',
         services: ['1'],
         bbox: [2]
       }
+    end
+
+    let(:params) do
+      unmodified_params.merge(facility_ids: 'vha_123,vha_456')
     end
 
     let(:mock_facility_response) do
@@ -399,7 +402,7 @@ RSpec.describe 'V0::CaregiversAssistanceClaims', type: :request do
     it 'calls the Lighthouse facilities service with the permitted params' do
       subject
 
-      expected_params = ActionController::Parameters.new(params).permit!
+      expected_params = unmodified_params.merge(facilityIds: 'vha_123,vha_456')
 
       expect(lighthouse_service).to have_received(:get_paginated_facilities)
         .with(expected_params)


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO, but the front end code that calls it is behind a toggle. 
- When looking into why invalid facility ids were being passed with 10-10CG Submissions with the new facility search functionality, we discovered that when `vets-website` was making the request to find the parent facility, the request was being made with `facilityIds` as the parameter key name. In the rails controller that was converted to snake case, which was then being passed to the Lighthouse Facilities api which expected it in camel case. Since it was being passed incorrectly, the facilities results were just returning the first 5 results.
- This PR converts the param key name to the valid camel case for the Lighthouse api
- 10-10 Health Apps
- Behind the `caregiver_use_facilities_API` on the front end

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101907

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
No UI changes

## What areas of the site does it impact?
10-10CG Facility Search

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
