### PR TITLE
Skip flaky form4142 spec example

### DIFF
--- a/spec/sidekiq/decision_review/form4142_submit_spec.rb
+++ b/spec/sidekiq/decision_review/form4142_submit_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe DecisionReview::Form4142Submit, type: :job do
         expect(subject.new.decrypt_form(enc_payload)).to eq(payload)
       end
 
-      it 'generates a 4142 PDF and sends it to Lighthouse API' do
+      it 'generates a 4142 PDF and sends it to Lighthouse API', skip: 'Flaky test' do
         VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
           VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
             expect do


### PR DESCRIPTION
## Summary

- This spec has been regularly failing in CI with the following PDFTK error message:
```
     PdfForms::PdftkError:
       pdftk failed with command
       /usr/bin/pdftk tmp/pdfs/21-4142_.pdf stamp tmp/5968fde7587b1bdef0d3d4ee780e3862 output tmp/b4890f926eb61dfc491dc04bf8fcdfc4.pdf
       command output was:
       Error: Invalid PDF: trailer not found.
       Error: Failed to open input PDF file: 
          tmp/pdfs/21-4142_.pdf
       Errors encountered.  No output created.
       Done.  Input errors, so no output created.
```

Here's an [example run](https://github.com/department-of-veterans-affairs/vets-api/actions/runs/13015004820/job/36306060406?pr=20308#step:10:913)