### PR TITLE
Isolated ApplicationController for DR Module

### DIFF
--- a/modules/decision_reviews/app/controllers/decision_reviews/application_controller.rb
+++ b/modules/decision_reviews/app/controllers/decision_reviews/application_controller.rb
@@ -24,13 +24,7 @@ module DecisionReviews
       response.set_header('X-CSRF-Token', token)
     end
 
-    def log_message_to_sentry(message, level, extra_context = {}, _tags_context = {})
-      level = normalize_level(level, nil)
-      formatted_message = extra_context.empty? ? message : "#{message} : #{extra_context}"
-      rails_logger(level, formatted_message)
-    end
-
-    def log_exception_to_sentry(exception, _extra_context = {}, _tags_context = {}, level = 'error')
+    def log_exception(exception, _extra_context = {}, _tags_context = {}, level = 'error')
       level = normalize_level(level, exception)
 
       if exception.is_a? Common::Exceptions::BackendServiceException
@@ -40,6 +34,8 @@ module DecisionReviews
       end
       rails_logger(level, exception.backtrace.join("\n")) unless exception.backtrace.nil?
     end
+
+    alias log_exception_to_sentry log_exception # Method call in shared ExceptionHandling is :log_exception_to_sentry
 
     def normalize_level(level, exception)
       # https://docs.sentry.io/platforms/ruby/usage/set-level/

--- a/modules/decision_reviews/app/controllers/decision_reviews/application_controller.rb
+++ b/modules/decision_reviews/app/controllers/decision_reviews/application_controller.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'feature_flipper'
+require 'aes_256_cbc_encryptor'
+
+module DecisionReviews
+  class ApplicationController < ActionController::API
+    include AuthenticationAndSSOConcerns
+    include ActionController::RequestForgeryProtection
+    include ExceptionHandling
+    include Headers
+    include Pundit::Authorization
+    include Traceable
+
+    protect_from_forgery with: :exception, if: -> { ActionController::Base.allow_forgery_protection }
+    after_action :set_csrf_header, if: -> { ActionController::Base.allow_forgery_protection }
+
+    private
+
+    attr_reader :current_user
+
+    def set_csrf_header
+      token = form_authenticity_token
+      response.set_header('X-CSRF-Token', token)
+    end
+
+    def log_message_to_sentry(message, level, extra_context = {}, _tags_context = {})
+      level = normalize_level(level, nil)
+      formatted_message = extra_context.empty? ? message : "#{message} : #{extra_context}"
+      rails_logger(level, formatted_message)
+    end
+
+    def log_exception_to_sentry(exception, _extra_context = {}, _tags_context = {}, level = 'error')
+      level = normalize_level(level, exception)
+
+      if exception.is_a? Common::Exceptions::BackendServiceException
+        rails_logger(level, exception.message, exception.errors, exception.backtrace)
+      else
+        rails_logger(level, "#{exception.message}.")
+      end
+      rails_logger(level, exception.backtrace.join("\n")) unless exception.backtrace.nil?
+    end
+
+    def normalize_level(level, exception)
+      # https://docs.sentry.io/platforms/ruby/usage/set-level/
+      # valid sentry levels: log, debug, info, warning, error, fatal
+      level = case exception
+              when Pundit::NotAuthorizedError
+                'info'
+              when Common::Exceptions::BaseError
+                exception.sentry_type.to_s
+              else
+                level.to_s
+              end
+
+      return 'warning' if level == 'warn'
+
+      level
+    end
+
+    def rails_logger(level, message, errors = nil, backtrace = nil)
+      # rails logger uses 'warn' instead of 'warning'
+      level = 'warn' if level == 'warning'
+      if errors.present?
+        error_details = errors.first.attributes.compact.reject { |_k, v| v.try(:empty?) }
+        Rails.logger.send(level, message, error_details.merge(backtrace:))
+      else
+        Rails.logger.send(level, message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- *(Summarize the changes that have been made to the platform)*
DecisionReviews module is using an isolated ApplicationController, pulling in helpers from the main app
- *(Which team do you work for, does your team own the maintenance of this component?)*
- Decision Reviews, yes


## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/101843
https://github.com/department-of-veterans-affairs/va.gov-team/issues/102061


## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- Module controllers inherited from main app ApplicationController
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- Test module endpoints in staging, ensure logging and exceptions continue to handled in the same way

## What areas of the site does it impact?
Decision Reviews module

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature