### PR TITLE
Implement simple forms notification_email_address

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/base_form.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/base_form.rb
@@ -16,5 +16,9 @@ module SimpleFormsApi
     def notification_first_name
       data.dig('veteran_full_name', 'first')
     end
+
+    def notification_email_address
+      data.dig('veteran', 'email')
+    end
   end
 end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10206.rb
@@ -29,6 +29,10 @@ module SimpleFormsApi
       data.dig('full_name', 'first')
     end
 
+    def notification_email_address
+      data['email_address']
+    end
+
     def zip_code_is_us_based
       @data.dig('address', 'country') == 'USA'
     end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_20_10207.rb
@@ -73,6 +73,14 @@ module SimpleFormsApi
       end
     end
 
+    def notification_email_address
+      if %w[veteran third-party-veteran].include? data['preparer_type']
+        data['veteran_email_address']
+      else
+        data['non_veteran_email_address']
+      end
+    end
+
     def zip_code_is_us_based
       @data.dig('veteran_mailing_address', 'country') == 'USA' ||
         @data.dig('non_veteran_mailing_address', 'country') == 'USA'

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0845.rb
@@ -26,6 +26,14 @@ module SimpleFormsApi
       end
     end
 
+    def notification_email_address
+      if data['authorizer_type'] == 'veteran'
+        data['veteran_email']
+      elsif data['authorizer_type'] == 'nonVeteran'
+        data['authorizer_email']
+      end
+    end
+
     def zip_code_is_us_based
       @data.dig('authorizer_address',
                 'country') == 'USA' || @data.dig('person_address',

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0966.rb
@@ -47,6 +47,14 @@ module SimpleFormsApi
       end
     end
 
+    def notification_email_address
+      if data['preparer_identification'] == 'SURVIVING_DEPENDENT'
+        data['surviving_dependent_email']
+      else
+        data['veteran_email']
+      end
+    end
+
     def zip_code_is_us_based
       @data.dig('veteran_mailing_address',
                 'country') == 'USA' || @data.dig('surviving_dependent_mailing_address', 'country') == 'USA'

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
@@ -20,6 +20,10 @@ module SimpleFormsApi
       data.dig('preparer_full_name', 'first')
     end
 
+    def notification_email_address
+      data['preparer_email']
+    end
+
     def zip_code_is_us_based
       @data.dig('preparer_address', 'country') == 'USA'
     end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_10210.rb
@@ -26,6 +26,16 @@ module SimpleFormsApi
       end
     end
 
+    def notification_email_address
+      if data['claim_ownership'] == 'self' && @data['claimant_type'] == 'veteran'
+        data['veteran_email']
+      elsif data['claim_ownership'] == 'self' && @data['claimant_type'] == 'non-veteran'
+        data['claimant_email']
+      elsif data['claim_ownership'] == 'third-party'
+        data['witness_email']
+      end
+    end
+
     def zip_code_is_us_based
       @data.dig('veteran_mailing_address', 'country') == 'USA'
     end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4142.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4142.rb
@@ -25,6 +25,10 @@ module SimpleFormsApi
       data.dig('veteran', 'full_name', 'first')
     end
 
+    def notification_email_address
+      data.dig('veteran', 'email')
+    end
+
     def zip_code_is_us_based
       @data.dig('veteran', 'address', 'country') == 'USA'
     end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
@@ -24,6 +24,10 @@ module SimpleFormsApi
       data.dig('preparer_name', 'first')
     end
 
+    def notification_email_address
+      data['preparer_email']
+    end
+
     def zip_code_is_us_based
       @data.dig('preparer_address', 'country') == 'USA'
     end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_26_4555.rb
@@ -37,6 +37,10 @@ module SimpleFormsApi
       data.dig('veteran', 'full_name', 'first')
     end
 
+    def notification_email_address
+      data.dig('veteran', 'email')
+    end
+
     def zip_code_is_us_based
       @data.dig('veteran', 'address', 'country') == 'USA'
     end

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_40_0247.rb
@@ -18,6 +18,10 @@ module SimpleFormsApi
       data.dig('applicant_full_name', 'first')
     end
 
+    def notification_email_address
+      data['applicant_email']
+    end
+
     def veteran_name
       first_name = data.dig('veteran_full_name', 'first') || ''
       middle_name = data.dig('veteran_full_name', 'middle') || ''

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_40_10007.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_40_10007.rb
@@ -49,6 +49,10 @@ module SimpleFormsApi
       end
     end
 
+    def notification_email_address
+      data.dig('application', 'claimant', 'email')
+    end
+
     def zip_code_is_us_based
       # TODO: Implement this
       true

--- a/modules/simple_forms_api/spec/models/base_form_spec.rb
+++ b/modules/simple_forms_api/spec/models/base_form_spec.rb
@@ -15,4 +15,12 @@ RSpec.describe SimpleFormsApi::BaseForm do
       expect(described_class.new(data).notification_first_name).to eq 'Veteran'
     end
   end
+
+  describe '#notification_email_address' do
+    it 'returns the email address to be used in notifications' do
+      data = { 'veteran' => { 'email' => 'a@b.com' } }
+
+      expect(described_class.new(data).notification_email_address).to eq 'a@b.com'
+    end
+  end
 end

--- a/modules/simple_forms_api/spec/models/vba_20_10206_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_20_10206_spec.rb
@@ -20,4 +20,14 @@ RSpec.describe SimpleFormsApi::VBA2010206 do
       expect(described_class.new(data).notification_first_name).to eq 'Veteran'
     end
   end
+
+  describe '#notification_email_address' do
+    let(:data) do
+      { 'email_address' => 'a@b.com' }
+    end
+
+    it 'returns the email address to be used in notifications' do
+      expect(described_class.new(data).notification_email_address).to eq 'a@b.com'
+    end
+  end
 end

--- a/modules/simple_forms_api/spec/models/vba_20_10207_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_20_10207_spec.rb
@@ -140,4 +140,45 @@ RSpec.describe SimpleFormsApi::VBA2010207 do
       end
     end
   end
+
+  describe '#notification_email_address' do
+    context 'preparer is veteran' do
+      let(:data) do
+        {
+          'preparer_type' => 'veteran',
+          'veteran_email_address' => 'a@b.com'
+        }
+      end
+
+      it 'returns the veteran email address' do
+        expect(described_class.new(data).notification_email_address).to eq 'a@b.com'
+      end
+    end
+
+    context 'preparer is third party veteran' do
+      let(:data) do
+        {
+          'preparer_type' => 'third-party-veteran',
+          'veteran_email_address' => 'a@b.com'
+        }
+      end
+
+      it 'returns the veteran email address' do
+        expect(described_class.new(data).notification_email_address).to eq 'a@b.com'
+      end
+    end
+
+    context 'preparer is anything else' do
+      let(:data) do
+        {
+          'preparer_type' => 'space-alien',
+          'non_veteran_email_address' => 'a@b.com'
+        }
+      end
+
+      it 'returns the non-veteran email address' do
+        expect(described_class.new(data).notification_email_address).to eq 'a@b.com'
+      end
+    end
+  end
 end

--- a/modules/simple_forms_api/spec/models/vba_21_0845_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_21_0845_spec.rb
@@ -39,4 +39,32 @@ RSpec.describe SimpleFormsApi::VBA210845 do
       end
     end
   end
+
+  describe '#notification_email_address' do
+    context 'preparer is veteran' do
+      let(:data) do
+        {
+          'authorizer_type' => 'veteran',
+          'veteran_email' => 'a@b.com'
+        }
+      end
+
+      it 'returns the veteran email address' do
+        expect(described_class.new(data).notification_email_address).to eq 'a@b.com'
+      end
+    end
+
+    context 'preparer is nonVeteran' do
+      let(:data) do
+        {
+          'authorizer_type' => 'nonVeteran',
+          'authorizer_email' => 'a@b.com'
+        }
+      end
+
+      it 'returns the authorizer email address' do
+        expect(described_class.new(data).notification_email_address).to eq 'a@b.com'
+      end
+    end
+  end
 end

--- a/modules/simple_forms_api/spec/models/vba_21_0966_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_21_0966_spec.rb
@@ -87,4 +87,32 @@ RSpec.describe SimpleFormsApi::VBA210966 do
       end
     end
   end
+
+  describe '#notification_email_address' do
+    context 'preparer is surviving dependent' do
+      let(:data) do
+        {
+          'preparer_identification' => 'SURVIVING_DEPENDENT',
+          'surviving_dependent_email' => 'a@b.com'
+        }
+      end
+
+      it 'returns the surviving dependent email address' do
+        expect(described_class.new(data).notification_email_address).to eq 'a@b.com'
+      end
+    end
+
+    context 'preparer is anyone else' do
+      let(:data) do
+        {
+          'preparer_identification' => 'space-alien',
+          'veteran_email' => 'a@b.com'
+        }
+      end
+
+      it 'returns the veteran email address' do
+        expect(described_class.new(data).notification_email_address).to eq 'a@b.com'
+      end
+    end
+  end
 end

--- a/modules/simple_forms_api/spec/models/vba_21_0972_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_21_0972_spec.rb
@@ -20,4 +20,14 @@ RSpec.describe SimpleFormsApi::VBA210972 do
       expect(described_class.new(data).notification_first_name).to eq 'Veteran'
     end
   end
+
+  describe '#notification_email_address' do
+    let(:data) do
+      { 'preparer_email' => 'a@b.com' }
+    end
+
+    it 'returns the email address to be used in notifications' do
+      expect(described_class.new(data).notification_email_address).to eq 'a@b.com'
+    end
+  end
 end

--- a/modules/simple_forms_api/spec/models/vba_21_10210_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_21_10210_spec.rb
@@ -59,4 +59,49 @@ RSpec.describe SimpleFormsApi::VBA2110210 do
       end
     end
   end
+
+  describe '#notification_email_address' do
+    context "preparer's own claim" do
+      context 'preparer is veteran' do
+        let(:data) do
+          {
+            'claim_ownership' => 'self',
+            'claimant_type' => 'veteran',
+            'veteran_email' => 'a@b.com'
+          }
+        end
+
+        it 'returns the veteran email address' do
+          expect(described_class.new(data).notification_email_address).to eq 'a@b.com'
+        end
+      end
+
+      context 'preparer is not veteran' do
+        let(:data) do
+          {
+            'claim_ownership' => 'self',
+            'claimant_type' => 'non-veteran',
+            'claimant_email' => 'a@b.com'
+          }
+        end
+
+        it 'returns the claimant email address' do
+          expect(described_class.new(data).notification_email_address).to eq 'a@b.com'
+        end
+      end
+    end
+
+    context 'third party claim' do
+      let(:data) do
+        {
+          'claim_ownership' => 'third-party',
+          'witness_email' => 'a@b.com'
+        }
+      end
+
+      it 'returns the witness email address' do
+        expect(described_class.new(data).notification_email_address).to eq 'a@b.com'
+      end
+    end
+  end
 end

--- a/modules/simple_forms_api/spec/models/vba_21_4142_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_21_4142_spec.rb
@@ -20,4 +20,14 @@ RSpec.describe SimpleFormsApi::VBA214142 do
       expect(described_class.new(data).notification_first_name).to eq 'Veteran'
     end
   end
+
+  describe '#notification_email_address' do
+    let(:data) do
+      { 'veteran' => { 'email' => 'a@b.com' } }
+    end
+
+    it 'returns the email address to be used in notifications' do
+      expect(described_class.new(data).notification_email_address).to eq 'a@b.com'
+    end
+  end
 end

--- a/modules/simple_forms_api/spec/models/vba_21p_0847_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_21p_0847_spec.rb
@@ -20,4 +20,14 @@ RSpec.describe SimpleFormsApi::VBA21p0847 do
       expect(described_class.new(data).notification_first_name).to eq 'Veteran'
     end
   end
+
+  describe '#notification_email_address' do
+    let(:data) do
+      { 'preparer_email' => 'a@b.com' }
+    end
+
+    it 'returns the email address to be used in notifications' do
+      expect(described_class.new(data).notification_email_address).to eq 'a@b.com'
+    end
+  end
 end

--- a/modules/simple_forms_api/spec/models/vba_26_4555_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_26_4555_spec.rb
@@ -66,4 +66,14 @@ RSpec.describe SimpleFormsApi::VBA264555 do
       expect(described_class.new(data).notification_first_name).to eq 'Veteran'
     end
   end
+
+  describe '#notification_email_address' do
+    let(:data) do
+      { 'veteran' => { 'email' => 'a@b.com' } }
+    end
+
+    it 'returns the email address to be used in notifications' do
+      expect(described_class.new(data).notification_email_address).to eq 'a@b.com'
+    end
+  end
 end

--- a/modules/simple_forms_api/spec/models/vba_40_0247_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_40_0247_spec.rb
@@ -61,4 +61,14 @@ RSpec.describe SimpleFormsApi::VBA400247 do
       expect(described_class.new(data).notification_first_name).to eq 'Applicant'
     end
   end
+
+  describe '#notification_email_address' do
+    let(:data) do
+      { 'applicant_email' => 'a@b.com' }
+    end
+
+    it 'returns the email address to be used in notifications' do
+      expect(described_class.new(data).notification_email_address).to eq 'a@b.com'
+    end
+  end
 end

--- a/modules/simple_forms_api/spec/models/vba_40_10007_spec.rb
+++ b/modules/simple_forms_api/spec/models/vba_40_10007_spec.rb
@@ -74,4 +74,20 @@ RSpec.describe SimpleFormsApi::VBA4010007 do
       end
     end
   end
+
+  describe '#notification_email_address' do
+    let(:data) do
+      {
+        'application' => {
+          'claimant' => {
+            'email' => 'a@b.com'
+          }
+        }
+      }
+    end
+
+    it 'returns the claimant email address' do
+      expect(described_class.new(data).notification_email_address).to eq 'a@b.com'
+    end
+  end
 end


### PR DESCRIPTION
## Summary
This is the second part, beginning with [this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/20376) of a big refactor of Simple Forms emails. This one implements a method across all our forms, `notification_email_address`, so we can remove that logic from the `NotificationEmail` service later on.
