### PR TITLE
Fix RSpec/PendingWithoutReason

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -285,23 +285,6 @@ RSpec/NoExpectationExample:
     - 'spec/sidekiq/pager_duty/poll_maintenance_windows_spec.rb'
     - 'spec/sidekiq/vre/create_ch31_submissions_report_job_spec.rb'
 
-# Offense count: 17
-RSpec/PendingWithoutReason:
-  Exclude:
-    - 'modules/appeals_api/spec/controllers/application_controller_spec.rb'
-    - 'modules/appeals_api/spec/services/appeals_api/pdf_construction/generator_spec.rb'
-    - 'modules/appeals_api/spec/sidekiq/appeals_api/add_icn_updater_spec.rb'
-    - 'modules/claims_api/spec/lib/claims_api/evidence_waiver_pdf_constructor/pdf_spec.rb'
-    - 'modules/claims_api/spec/lib/claims_api/v1/poa_pdf_constructor/individual_spec.rb'
-    - 'modules/vaos/spec/services/v1/fhir_service_spec.rb'
-    - 'modules/vba_documents/spec/sidekiq/report_unsuccessful_submissions_spec.rb'
-    - 'spec/lib/bb/generate_report_request_form_spec.rb'
-    - 'spec/lib/bgs/vnp_relationships_spec.rb'
-    - 'spec/lib/saml/ssoe_user_spec.rb'
-    - 'spec/requests/authentication/standard_authentication_spec.rb'
-    - 'spec/requests/breakers_integration_spec.rb'
-    - 'spec/sidekiq/facilities/mental_health_reload_job_spec.rb'
-
 # Offense count: 715
 RSpec/StubbedMock:
   Enabled: false

--- a/modules/appeals_api/spec/controllers/application_controller_spec.rb
+++ b/modules/appeals_api/spec/controllers/application_controller_spec.rb
@@ -67,7 +67,7 @@ describe AppealsApi::ApplicationController, type: :controller do
       expect(error['meta']).to eq({ 'extra' => 'metadata' })
     end
 
-    xit 'allows overriding error.attribute source with custom hash' do
+    it 'allows overriding error.attribute source with custom hash', skip: 'Failing Test, per commit history' do
       error = errors[1]
       expect(error['source']).to eq({ 'header' => 'abc123' })
     end

--- a/modules/appeals_api/spec/services/appeals_api/pdf_construction/generator_spec.rb
+++ b/modules/appeals_api/spec/services/appeals_api/pdf_construction/generator_spec.rb
@@ -99,7 +99,7 @@ describe AppealsApi::PdfConstruction::Generator do
           # TODO: Try to figure out why the CI runner interprets our expected pdf differently than locally, despite
           #       being visually identical.
           # e.g. on CI, some text is interpreted in a slightly different order or W's are added in odd places.
-          xit 'generates the expected pdf' do
+          it 'generates the expected pdf', skip: 'See TODO' do
             expect(generated_pdf).to match_pdf(expected_pdf)
           end
         end

--- a/modules/appeals_api/spec/sidekiq/appeals_api/add_icn_updater_spec.rb
+++ b/modules/appeals_api/spec/sidekiq/appeals_api/add_icn_updater_spec.rb
@@ -22,12 +22,12 @@ describe AppealsApi::AddIcnUpdater, type: :job do
       expect(hlr.reload.veteran_icn).to be_present
     end
 
-    xit 'does not update ICN if flipper is disabled' do
+    it 'does not update ICN if flipper is disabled', skip: 'TODO' do
       Flipper.disable(:decision_review_icn_updater_enabled)
       # ...
     end
 
-    xit 'it logs error & does not update INC if PII has been removed from the record' do
+    it 'logs error & does not update INC if PII has been removed from the record', skip: 'TODO' do
       hlr.update(auth_headers: nil, form_data: nil)
       # ...
     end

--- a/modules/claims_api/spec/lib/claims_api/evidence_waiver_pdf_constructor/pdf_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/evidence_waiver_pdf_constructor/pdf_spec.rb
@@ -31,7 +31,7 @@ describe ClaimsApi::EvidenceWaiver do
   end
 
   context 'long name' do
-    xit 'construct truncated pdf' do
+    it 'construct truncated pdf', skip: 'Unknown reason for skip' do
       ews.auth_headers['va_eauth_lastName'] = 'Ellis-really-long-truncated-name-here'
       constructor = ClaimsApi::EvidenceWaiver.new(auth_headers: ews.auth_headers)
       expected_pdf = Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans', '5103',

--- a/modules/vba_documents/spec/sidekiq/report_unsuccessful_submissions_spec.rb
+++ b/modules/vba_documents/spec/sidekiq/report_unsuccessful_submissions_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe VBADocuments::ReportUnsuccessfulSubmissions, type: :job do
   let(:upload) { create(:upload_submission, :status_uploaded, consumer_name: 'test consumer') }
 
   describe '#perform' do
-    xit 'sends mail' do
+    it 'sends mail', skip: 'Unknown reason for skip' do
       with_settings(Settings.vba_documents,
                     report_enabled: true) do
         Timecop.freeze
@@ -39,7 +39,7 @@ RSpec.describe VBADocuments::ReportUnsuccessfulSubmissions, type: :job do
       end
     end
 
-    xit 'calculate totals' do
+    it 'calculate totals', skip: 'Unknown reason for skip' do
       with_settings(Settings.vba_documents,
                     report_enabled: true) do
         error_upload

--- a/spec/lib/bb/generate_report_request_form_spec.rb
+++ b/spec/lib/bb/generate_report_request_form_spec.rb
@@ -54,7 +54,7 @@ describe BB::GenerateReportRequestForm do
     end
 
     # This spec can be added again in the future if desired, but for now leave as MHV error
-    xit 'returns valid false with errors' do
+    it 'returns valid false with errors', skip: 'MHV error' do
       expect(subject).not_to be_valid
       expect(subject.errors.full_messages)
         .to eq(['From date must be before to date'])

--- a/spec/lib/bgs/vnp_relationships_spec.rb
+++ b/spec/lib/bgs/vnp_relationships_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe BGS::VnpRelationships do
       end
     end
 
-    xcontext 'reporting a divorce' do
+    context 'reporting a divorce', skip: 'Unknown reason for skip' do
       it 'returns a relationship hash with correct :ptcpnt_rlnshp_type_nm and :family_rlnshp_type_nm' do
         VCR.use_cassette('bgs/vnp_relationships/create/divorce') do
           divorce = {

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -866,7 +866,7 @@ RSpec.describe SAML::User do
       let(:service_name) { 'dslogon' }
       let(:account_type) { '1' }
 
-      xit 'has various important attributes' do
+      it 'has various important attributes', skip: 'Unknown reason for skip' do
         expect(subject.to_hash).to eq(
           birth_date: nil,
           authn_context:,

--- a/spec/requests/authentication/standard_authentication_spec.rb
+++ b/spec/requests/authentication/standard_authentication_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'authenticating loa3 user', order: :defined, type: :request do
     end
   end
 
-  xit 'does the tests', :aggregate_failures, :skip_mvi do
+  it 'does the tests', :aggregate_failures, :skip_mvi, skip: 'Unknown reason for skip' do
     EPISODES.each_with_index do |episode, _index|
       Timecop.freeze(episode.recorded_at) do
         VCR.use_cassette(OUTBOUND_CASSETTE) do

--- a/spec/requests/breakers_integration_spec.rb
+++ b/spec/requests/breakers_integration_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe 'Breakers Integration', type: :request do
     end
   end
 
-  xit 'includes correct tags in background jobs' do
+  it 'includes correct tags in background jobs', skip: 'Flaky test noted in commit history' do
     RequestStore.store['additional_request_attributes'] = { 'source' => 'auth' }
     PagerDuty::PollMaintenanceWindows.perform_async
     RequestStore.clear!


### PR DESCRIPTION
## Summary

- Fixes the following Rubocop offenses:
  - `RSpec/PendingWithoutReason`
    - replaced `xit` with `skip: "some reason (if known)"`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/100982