### PR TITLE
101426 update AppointmentsController#fetch_drive_times

### DIFF
--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -380,12 +380,9 @@ module VAOS
       end
 
       def fetch_drive_times(provider)
-        user_contact_info = current_user.vet360_contact_info
-        user_address = user_contact_info && user_contact_info.residential_address
+        user_address = current_user.vet360_contact_info&.residential_address
 
-        if user_address.nil? || user_address.latitude.nil? || user_address.longitude.nil?
-          return ''
-        end
+        return '' unless user_address&.latitude && user_address.longitude
 
         eps_provider_service.get_drive_times(
           destinations: {

--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -380,10 +380,11 @@ module VAOS
       end
 
       def fetch_drive_times(provider)
-        user_address = current_user.vet360_contact_info&.residential_address
+        user_contact_info = current_user.vet360_contact_info
+        user_address = user_contact_info && user_contact_info.residential_address
 
-        unless user_address&.latitude && user_address&.longitude
-          return ""
+        if user_address.nil? || user_address.latitude.nil? || user_address.longitude.nil?
+          return ''
         end
 
         eps_provider_service.get_drive_times(

--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -383,7 +383,7 @@ module VAOS
         user_address = current_user.vet360_contact_info&.residential_address
 
         unless user_address&.latitude && user_address&.longitude
-          return "Drive time could not be calculated: user location unavailable"
+          return ""
         end
 
         eps_provider_service.get_drive_times(

--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -382,7 +382,7 @@ module VAOS
       def fetch_drive_times(provider)
         user_address = current_user.vet360_contact_info&.residential_address
 
-        return '' unless user_address&.latitude && user_address.longitude
+        return nil unless user_address&.latitude && user_address.longitude
 
         eps_provider_service.get_drive_times(
           destinations: {

--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -380,6 +380,12 @@ module VAOS
       end
 
       def fetch_drive_times(provider)
+        user_address = current_user.vet360_contact_info&.residential_address
+
+        unless user_address&.latitude && user_address&.longitude
+          return "Drive time could not be calculated: user location unavailable"
+        end
+
         eps_provider_service.get_drive_times(
           destinations: {
             provider.id => {
@@ -388,8 +394,8 @@ module VAOS
             }
           },
           origin: {
-            latitude: current_user.address['latitude'],
-            longitude: current_user.address['longitude']
+            latitude: user_address.latitude,
+            longitude: user_address.longitude
           }
         )
       end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- updates AppointmentsController#fetch_drive_times method to utilize lat/long from user's vet360 data
- previous implementation assumed the user's residential lat/long would be available from their `address` attribute, but that data is obtained from the MPI service and does not include lat/long. Instead we can obtain the lat/long from the user's `vet360_contact_info` data if available.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/101426

## Testing done

- [ ] *New code is covered by unit tests*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

As per John W, return an empty string if the user's lat/long are not available.
