### PR TITLE
[ARP allowlist] Create VA accredited individuals allow-list table

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_04_162258) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_04_175219) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -312,6 +312,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_04_162258) do
     t.string "accredited_individual_registration_number"
     t.string "power_of_attorney_holder_poa_code"
     t.index ["claimant_id"], name: "index_ar_power_of_attorney_requests_on_claimant_id"
+  end
+
+  create_table "ar_user_account_accredited_individuals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "accredited_individual_registration_number", null: false
+    t.string "power_of_attorney_holder_type", null: false
+    t.string "user_account_email", null: false
+    t.string "user_account_icn"
+    t.index ["accredited_individual_registration_number", "power_of_attorney_holder_type", "user_account_email"], name: "ar_user_account_accredited_individuals_hardcoding", unique: true
+    t.index ["accredited_individual_registration_number", "power_of_attorney_holder_type", "user_account_email"], name: "index_ar_user_account_accredited_individuals_unique", unique: true
+    t.index ["power_of_attorney_holder_type", "user_account_email"], name: "ar_uniq_power_of_attorney_holder_type_user_account_email", unique: true
   end
 
   create_table "async_transactions", id: :serial, force: :cascade do |t|

--- a/modules/accredited_representative_portal/db/migrate/20250204175216_create_ar_user_account_accredited_individuals.rb
+++ b/modules/accredited_representative_portal/db/migrate/20250204175216_create_ar_user_account_accredited_individuals.rb
@@ -1,0 +1,10 @@
+class CreateArUserAccountAccreditedIndividuals < ActiveRecord::Migration[7.2]
+  def change
+    create_table :ar_user_account_accredited_individuals, id: :uuid do |t|
+      t.string :accredited_individual_registration_number, null: false
+      t.string :power_of_attorney_holder_type, null: false
+      t.string :user_account_email, null: false
+      t.string :user_account_icn
+    end
+  end
+end

--- a/modules/accredited_representative_portal/db/migrate/20250204175217_add_index_to_ar_user_account_accredited_individuals.rb
+++ b/modules/accredited_representative_portal/db/migrate/20250204175217_add_index_to_ar_user_account_accredited_individuals.rb
@@ -1,0 +1,11 @@
+class AddIndexToArUserAccountAccreditedIndividuals < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :ar_user_account_accredited_individuals,
+      %i[accredited_individual_registration_number power_of_attorney_holder_type user_account_email],
+      unique: true,
+      name: 'index_ar_user_account_accredited_individuals_unique',
+      algorithm: :concurrently
+  end
+end

--- a/modules/accredited_representative_portal/db/migrate/20250204175218_add_replication_index_to_accredited_individuals.rb
+++ b/modules/accredited_representative_portal/db/migrate/20250204175218_add_replication_index_to_accredited_individuals.rb
@@ -1,0 +1,11 @@
+class AddReplicationIndexToAccreditedIndividuals < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :ar_user_account_accredited_individuals,
+      [:accredited_individual_registration_number, :power_of_attorney_holder_type, :user_account_email],
+      unique: true,
+      name: 'ar_user_account_accredited_individuals_hardcoding',
+      algorithm: :concurrently
+  end
+end

--- a/modules/accredited_representative_portal/db/migrate/20250204175219_add_power_of_attorney_holder_type_constraint.rb
+++ b/modules/accredited_representative_portal/db/migrate/20250204175219_add_power_of_attorney_holder_type_constraint.rb
@@ -1,0 +1,11 @@
+class AddPowerOfAttorneyHolderTypeConstraint < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :ar_user_account_accredited_individuals,
+      [:power_of_attorney_holder_type, :user_account_email],
+      unique: true,
+      name: 'ar_uniq_power_of_attorney_holder_type_user_account_email',
+      algorithm: :concurrently
+  end
+end


### PR DESCRIPTION
This PR sets up the database structure to maintain an allow-list of accredited VA representatives who can handle Power of Attorney requests.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/99863

## Changes
1. Creates new allow-list table `ar_user_account_accredited_individuals` to track authorized VSO representatives
   - Stores registration numbers, POA holder types, and user account info
   - Uses UUID for primary key
2. Adds indexes to support:
   - Unique registration numbers
   - CSV-based allow-list synchronization (composite unique index)
   - POA holder type constraints per email

## Why
- Maintains authoritative allow-list of accredited VSO representatives
- Supports automated synchronization with source CSV allow-list
- Ensures data integrity through uniqueness constraints
- Provides foundation for POA request authorization

## Testing
- Ran migrations in development
- Verified all uniqueness constraints
- Tested with sample representative data