### PR TITLE
VACMS-13484 Remove unused Facilities flipper

### DIFF
--- a/modules/ask_va_api/app/controllers/ask_va_api/v0/health_facilities_controller.rb
+++ b/modules/ask_va_api/app/controllers/ask_va_api/v0/health_facilities_controller.rb
@@ -12,12 +12,6 @@ module AskVAApi
         params[:facilityIds] = params[:ids] if params[:ids].present?
         api_results = api.get_facilities(lighthouse_params)
 
-        if Flipper.enabled?(:facilities_locator_mobile_covid_online_scheduling) && covid_mobile_params?
-          api_results.each do |api_result|
-            api_result.tmp_covid_online_scheduling = mobile_api_get_by_id(api_result.id)
-          end
-        end
-
         patsr_approved_codes = retrieve_patsr_approved_facilities[:Data].pluck(:FacilityCode)
 
         filtered_results = WillPaginate::Collection.create(

--- a/modules/ask_va_api/spec/requests/ask_va_api/v0/health_facilities_spec.rb
+++ b/modules/ask_va_api/spec/requests/ask_va_api/v0/health_facilities_spec.rb
@@ -123,54 +123,6 @@ RSpec.describe AskVAApi::V0::HealthFacilitiesController, team: :facilities, type
                       type: 'health'
                     },
                     %w[vha_648]
-
-    context 'params[:type] = health' do
-      context 'params[:services] = [\'Covid19Vaccine\']', vcr: vcr_options.merge(
-        cassette_name: 'facilities/mobile/covid'
-      ) do
-        let(:params) do
-          {
-            lat: 42.060906,
-            long: -71.051868,
-            type: 'health',
-            services: ['Covid19Vaccine']
-          }
-        end
-
-        before do
-          Flipper.enable('facilities_locator_mobile_covid_online_scheduling', flipper)
-          post '/ask_va_api/v0/health_facilities', params:
-        end
-
-        context 'facilities_locator_mobile_covid_online_scheduling enabled' do
-          let(:flipper) { true }
-
-          it { expect(response).to be_successful }
-
-          it 'is expected not to populate tmpCovidOnlineScheduling' do
-            attributes_covid = parsed_body['data'].collect { |x| x['attributes']['tmpCovidOnlineScheduling'] }
-            expect(parsed_body['data'][0]['attributes']['tmpCovidOnlineScheduling']).to be_truthy
-            expect(attributes_covid).to eql([true, false, true, false, false, true, false])
-          end
-        end
-
-        context 'facilities_locator_mobile_covid_online_scheduling disabled' do
-          let(:flipper) { false }
-
-          it { expect(response).to be_successful }
-
-          it 'is expected not to populate tmpCovidOnlineScheduling' do
-            parsed_body['data']
-
-            expect(parsed_body['data']).to all(
-              a_hash_including(
-                attributes: a_hash_including(tmpCovidOnlineScheduling: nil)
-              )
-            )
-          end
-        end
-      end
-    end
   end
 
   describe 'GET #show' do

--- a/modules/facilities_api/app/controllers/facilities_api/v2/va_controller.rb
+++ b/modules/facilities_api/app/controllers/facilities_api/v2/va_controller.rb
@@ -8,12 +8,6 @@ module FacilitiesApi
       params[:facilityIds] = params[:ids] if params[:ids].present?
       api_results = api.get_facilities(lighthouse_params)
 
-      if Flipper.enabled?(:facilities_locator_mobile_covid_online_scheduling) && covid_mobile_params?
-        api_results.each do |api_result|
-          api_result.tmp_covid_online_scheduling = mobile_api_get_by_id(api_result.id)
-        end
-      end
-
       render_json(serializer, lighthouse_params, api_results)
     end
 

--- a/modules/facilities_api/spec/requests/facilities_api/v2/va_spec.rb
+++ b/modules/facilities_api/spec/requests/facilities_api/v2/va_spec.rb
@@ -217,55 +217,6 @@ RSpec.describe 'FacilitiesApi::V2::Va', team: :facilities, type: :request, vcr: 
                         false
       end
     end
-
-    context 'params[:type] = health' do
-      context 'params[:services] = [\'Covid19Vaccine\']', vcr: vcr_options.merge(
-        cassette_name: 'facilities/mobile/covid'
-      ) do
-        let(:params) do
-          {
-            lat: 42.060906,
-            long: -71.051868,
-            type: 'health',
-            services: ['Covid19Vaccine']
-          }
-        end
-
-        before do
-          Flipper.enable('facilities_locator_mobile_covid_online_scheduling', flipper)
-          post '/facilities_api/v2/va', params:
-        end
-
-        context 'facilities_locator_mobile_covid_online_scheduling enabled' do
-          let(:flipper) { true }
-
-          it { expect(response).to be_successful }
-
-          it 'is expected not to populate tmpCovidOnlineScheduling' do
-            attributes_covid = parsed_body['data'].collect { |x| x['attributes']['tmpCovidOnlineScheduling'] }
-
-            expect(parsed_body['data'][0]['attributes']['tmpCovidOnlineScheduling']).to be_truthy
-            expect(attributes_covid).to eql([true, true, true, false, true, false, false, true, false, false])
-          end
-        end
-
-        context 'facilities_locator_mobile_covid_online_scheduling disabled' do
-          let(:flipper) { false }
-
-          it { expect(response).to be_successful }
-
-          it 'is expected not to populate tmpCovidOnlineScheduling' do
-            parsed_body['data']
-
-            expect(parsed_body['data']).to all(
-              a_hash_including(
-                attributes: a_hash_including(tmpCovidOnlineScheduling: nil)
-              )
-            )
-          end
-        end
-      end
-    end
   end
 
   describe 'GET #show' do


### PR DESCRIPTION
## Summary
Remove dead code related to the `facilities_locator_mobile_covid_online_scheduling` flipper that has already been removed from `vets-api`.

Sanity check: this flipper is only still used in `vets-api` in the files I've edited: https://github.com/search?q=org%3Adepartment-of-veterans-affairs%20facilities_locator_mobile_covid_online_scheduling&type=code

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13484

## Testing done

Checked Staging and Production Flipper Admins for this flipper; it is already gone:

### Production

<img width="920" alt="Screenshot 2025-01-29 at 7 06 13 AM" src="https://github.com/user-attachments/assets/bb53fd66-2fa8-481d-a0f6-bdc4fd093af3" />
<img width="912" alt="Screenshot 2025-01-29 at 7 06 28 AM" src="https://github.com/user-attachments/assets/b2002fa0-2802-432a-8452-d2ab7748b3f5" />

### Staging

<img width="919" alt="Screenshot 2025-01-29 at 7 06 37 AM" src="https://github.com/user-attachments/assets/e734390e-4b1c-4620-b199-553ec36acc1d" />
<img width="920" alt="Screenshot 2025-01-29 at 7 06 51 AM" src="https://github.com/user-attachments/assets/08852e5b-5cda-4b3c-a7ca-09df58b9730e" />