### PR TITLE
Use the new Facilities V2 Client for EZ Lighthouse queries

### DIFF
--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -3,7 +3,6 @@
 require 'hca/service'
 require 'bgs/service'
 require 'pdf_fill/filler'
-require 'lighthouse/facilities/v1/client'
 
 module V0
   class HealthCareApplicationsController < ApplicationController
@@ -110,7 +109,7 @@ module V0
     end
 
     def lighthouse_facilities_service
-      @lighthouse_facilities_service ||= Lighthouse::Facilities::V1::Client.new
+      @lighthouse_facilities_service ||= FacilitiesApi::V2::Lighthouse::Client.new
     end
 
     def lighthouse_facilities_params

--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -3,6 +3,7 @@
 require 'hca/service'
 require 'bgs/service'
 require 'pdf_fill/filler'
+require 'lighthouse/facilities/v1/client'
 
 module V0
   class HealthCareApplicationsController < ApplicationController
@@ -109,7 +110,11 @@ module V0
     end
 
     def lighthouse_facilities_service
-      @lighthouse_facilities_service ||= FacilitiesApi::V2::Lighthouse::Client.new
+      if Flipper.enabled?(:hca_ez_use_facilities_v2)
+        @lighthouse_facilities_service ||= FacilitiesApi::V2::Lighthouse::Client.new
+      end
+
+      @lighthouse_facilities_service ||= Lighthouse::Facilities::V1::Client.new
     end
 
     def lighthouse_facilities_params

--- a/config/features.yml
+++ b/config/features.yml
@@ -103,6 +103,9 @@ features:
   hca_enrollment_status_override_enabled:
     actor_type: user
     description: Enables override of enrollment status for a user, to allow multiple submissions with same user.
+  hca_ez_use_facilities_v2:
+    actor_type: user
+    description: Use Lighthouse Facilities API V2 for EZ queries
   hca_insurance_v2_enabled:
     actor_type: user
     description: Enables the the upgraded insurance section of the Health Care Application

--- a/spec/controllers/v0/health_care_applications_controller_spec.rb
+++ b/spec/controllers/v0/health_care_applications_controller_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe V0::HealthCareApplicationsController, type: :controller do
   end
 
   describe '#facilities' do
-    let(:lighthouse_service) { instance_double(Lighthouse::Facilities::V1::Client) }
+    let(:lighthouse_service) { instance_double(FacilitiesApi::V2::Lighthouse::Client) }
     let(:unrelated_facility) { Lighthouse::Facilities::Facility.new('id' => 'vha_123', 'attributes' => {}) }
     let(:target_facility) { Lighthouse::Facilities::Facility.new('id' => 'vha_456ab', 'attributes' => {}) }
     let(:deactivated_facility) { Lighthouse::Facilities::Facility.new('id' => 'vha_789', 'attributes' => {}) }
     let(:facilities) { [unrelated_facility, target_facility] }
 
     before do
-      allow(Lighthouse::Facilities::V1::Client).to receive(:new) { lighthouse_service }
+      allow(FacilitiesApi::V2::Lighthouse::Client).to receive(:new) { lighthouse_service }
       allow(lighthouse_service).to receive(:get_facilities) { facilities }
     end
 

--- a/spec/controllers/v0/health_care_applications_controller_spec.rb
+++ b/spec/controllers/v0/health_care_applications_controller_spec.rb
@@ -15,65 +15,136 @@ RSpec.describe V0::HealthCareApplicationsController, type: :controller do
     end
   end
 
-  describe '#facilities' do
-    let(:lighthouse_service) { instance_double(FacilitiesApi::V2::Lighthouse::Client) }
-    let(:unrelated_facility) { Lighthouse::Facilities::Facility.new('id' => 'vha_123', 'attributes' => {}) }
-    let(:target_facility) { Lighthouse::Facilities::Facility.new('id' => 'vha_456ab', 'attributes' => {}) }
-    let(:deactivated_facility) { Lighthouse::Facilities::Facility.new('id' => 'vha_789', 'attributes' => {}) }
-    let(:facilities) { [unrelated_facility, target_facility] }
+  context 'with the v2 feature flag disabled' do
+    before { expect(Flipper).to receive(:enabled?).with(:hca_ez_use_facilities_v2).and_return(false) }
 
-    before do
-      allow(FacilitiesApi::V2::Lighthouse::Client).to receive(:new) { lighthouse_service }
-      allow(lighthouse_service).to receive(:get_facilities) { facilities }
-    end
+    describe '#facilities' do
+      let(:lighthouse_service) { instance_double(Lighthouse::Facilities::V1::Client) }
+      let(:unrelated_facility) { Lighthouse::Facilities::Facility.new('id' => 'vha_123', 'attributes' => {}) }
+      let(:target_facility) { Lighthouse::Facilities::Facility.new('id' => 'vha_456ab', 'attributes' => {}) }
+      let(:deactivated_facility) { Lighthouse::Facilities::Facility.new('id' => 'vha_789', 'attributes' => {}) }
+      let(:facilities) { [unrelated_facility, target_facility] }
 
-    it 'only returns facilities in VES' do
-      params = { state: 'AK' }
+      before do
+        allow(Lighthouse::Facilities::V1::Client).to receive(:new) { lighthouse_service }
+        allow(lighthouse_service).to receive(:get_facilities) { facilities }
+      end
 
-      StdInstitutionFacility.create(station_number: target_facility.unique_id)
-
-      get(:facilities, params:)
-
-      expect(response.body).to eq([target_facility].to_json)
-    end
-
-    it 'filters out deactivated facilities' do
-      params = { state: 'AK' }
-
-      StdInstitutionFacility.create(station_number: target_facility.unique_id, deactivation_date: nil)
-      StdInstitutionFacility.create(station_number: deactivated_facility.unique_id, deactivation_date: Time.current)
-
-      get(:facilities, params:)
-
-      expect(response.body).to eq([target_facility].to_json)
-    end
-
-    context 'with hca_retrieve_facilities_without_repopulating disabled' do
-      it 'invokes VES import job if query results are empty' do
-        allow(Flipper).to receive(:enabled?).with(:hca_retrieve_facilities_without_repopulating).and_return(false)
-
+      it 'only returns facilities in VES' do
         params = { state: 'AK' }
 
-        expect(StdInstitutionFacility.all).to eq([])
-
-        import_job = instance_double(HCA::StdInstitutionImportJob)
-        expect(HCA::StdInstitutionImportJob).to receive(:new).and_return(import_job)
-        expect(import_job).to receive(:perform)
+        StdInstitutionFacility.create(station_number: target_facility.unique_id)
 
         get(:facilities, params:)
+
+        expect(response.body).to eq([target_facility].to_json)
+      end
+
+      it 'filters out deactivated facilities' do
+        params = { state: 'AK' }
+
+        StdInstitutionFacility.create(station_number: target_facility.unique_id, deactivation_date: nil)
+        StdInstitutionFacility.create(station_number: deactivated_facility.unique_id, deactivation_date: Time.current)
+
+        get(:facilities, params:)
+
+        expect(response.body).to eq([target_facility].to_json)
+      end
+
+      context 'with hca_retrieve_facilities_without_repopulating disabled' do
+        it 'invokes VES import job if query results are empty' do
+          allow(Flipper).to receive(:enabled?).with(:hca_retrieve_facilities_without_repopulating).and_return(false)
+
+          params = { state: 'AK' }
+
+          expect(StdInstitutionFacility.all).to eq([])
+
+          import_job = instance_double(HCA::StdInstitutionImportJob)
+          expect(HCA::StdInstitutionImportJob).to receive(:new).and_return(import_job)
+          expect(import_job).to receive(:perform)
+
+          get(:facilities, params:)
+        end
+      end
+
+      context 'with hca_retrieve_facilities_without_repopulating enabled' do
+        it 'does not invoke VES import job even if query results are empty' do
+          allow(Flipper).to receive(:enabled?).with(:hca_retrieve_facilities_without_repopulating).and_return(true)
+          params = { state: 'AK' }
+
+          expect(StdInstitutionFacility.all).to eq([])
+
+          expect(HCA::StdInstitutionImportJob).not_to receive(:new)
+
+          get(:facilities, params:)
+        end
       end
     end
+  end
 
-    context 'with hca_retrieve_facilities_without_repopulating enabled' do
-      it 'does not invoke VES import job even if query results are empty' do
-        allow(Flipper).to receive(:enabled?).with(:hca_retrieve_facilities_without_repopulating).and_return(true)
+  context 'with the v2 feature flag enabled' do
+    before { expect(Flipper).to receive(:enabled?).with(:hca_ez_use_facilities_v2).and_return(true) }
+
+    describe '#facilities' do
+      let(:lighthouse_service) { instance_double(FacilitiesApi::V2::Lighthouse::Client) }
+      let(:unrelated_facility) { Lighthouse::Facilities::Facility.new('id' => 'vha_123', 'attributes' => {}) }
+      let(:target_facility) { Lighthouse::Facilities::Facility.new('id' => 'vha_456ab', 'attributes' => {}) }
+      let(:deactivated_facility) { Lighthouse::Facilities::Facility.new('id' => 'vha_789', 'attributes' => {}) }
+      let(:facilities) { [unrelated_facility, target_facility] }
+
+      before do
+        allow(FacilitiesApi::V2::Lighthouse::Client).to receive(:new) { lighthouse_service }
+        allow(lighthouse_service).to receive(:get_facilities) { facilities }
+      end
+
+      it 'only returns facilities in VES' do
         params = { state: 'AK' }
 
-        expect(StdInstitutionFacility.all).to eq([])
-
-        expect(HCA::StdInstitutionImportJob).not_to receive(:new)
+        StdInstitutionFacility.create(station_number: target_facility.unique_id)
 
         get(:facilities, params:)
+
+        expect(response.body).to eq([target_facility].to_json)
+      end
+
+      it 'filters out deactivated facilities' do
+        params = { state: 'AK' }
+
+        StdInstitutionFacility.create(station_number: target_facility.unique_id, deactivation_date: nil)
+        StdInstitutionFacility.create(station_number: deactivated_facility.unique_id, deactivation_date: Time.current)
+
+        get(:facilities, params:)
+
+        expect(response.body).to eq([target_facility].to_json)
+      end
+
+      context 'with hca_retrieve_facilities_without_repopulating disabled' do
+        it 'invokes VES import job if query results are empty' do
+          allow(Flipper).to receive(:enabled?).with(:hca_retrieve_facilities_without_repopulating).and_return(false)
+
+          params = { state: 'AK' }
+
+          expect(StdInstitutionFacility.all).to eq([])
+
+          import_job = instance_double(HCA::StdInstitutionImportJob)
+          expect(HCA::StdInstitutionImportJob).to receive(:new).and_return(import_job)
+          expect(import_job).to receive(:perform)
+
+          get(:facilities, params:)
+        end
+      end
+
+      context 'with hca_retrieve_facilities_without_repopulating enabled' do
+        it 'does not invoke VES import job even if query results are empty' do
+          allow(Flipper).to receive(:enabled?).with(:hca_retrieve_facilities_without_repopulating).and_return(true)
+          params = { state: 'AK' }
+
+          expect(StdInstitutionFacility.all).to eq([])
+
+          expect(HCA::StdInstitutionImportJob).not_to receive(:new)
+
+          get(:facilities, params:)
+        end
       end
     end
   end

--- a/spec/requests/v0/health_care_applications_spec.rb
+++ b/spec/requests/v0/health_care_applications_spec.rb
@@ -234,7 +234,6 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
       end
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body[0]).to eq({ 'access' => nil,
-                                              'active_status' => nil,
                                               'address' => {
                                                 'mailing' => { 'zip' => '66713', 'city' => 'Leavenworth',
                                                                'state' => 'KS', 'address1' => '150 Muncie Rd' },
@@ -243,7 +242,6 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
                                                                 'address1' => 'Baxter Springs City Cemetery' }
                                               },
                                               'classification' => 'Soldiers Lot',
-                                              'detailed_services' => nil,
                                               'distance' => nil,
                                               'facility_type' => 'va_cemetery',
                                               'facility_type_prefix' => 'nca',
@@ -266,10 +264,12 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
                                               'parent' => nil,
                                               'phone' => { 'fax' => '9137584136', 'main' => '9137584105' },
                                               'services' => nil,
+                                              'time_zone' => 'America/Chicago',
                                               'type' => 'va_facilities',
                                               'unique_id' => '042',
                                               'visn' => nil,
-                                              'website' => 'https://www.cem.va.gov/cems/lots/BaxterSprings.asp' })
+                                              'website' => 'https://www.cem.va.gov/cems/lots/BaxterSprings.asp',
+                                              'tmp_covid_online_scheduling' => nil })
     end
 
     context 'with hca_retrieve_facilities_without_repopulating disabled' do

--- a/spec/requests/v0/health_care_applications_spec.rb
+++ b/spec/requests/v0/health_care_applications_spec.rb
@@ -226,75 +226,155 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
   end
 
   describe 'GET facilities' do
-    it 'responds with facilities data for supported facilities' do
-      StdInstitutionFacility.create(station_number: '042')
+    context 'with the v2 feature flag enabled' do
+      before { allow(Flipper).to receive(:enabled?).with(:hca_ez_use_facilities_v2).and_return(true) }
 
-      VCR.use_cassette('lighthouse/facilities/v1/200_facilities_facility_ids', match_requests_on: %i[method uri]) do
-        get(facilities_v0_health_care_applications_path(facilityIds: %w[vha_757 vha_358]))
-      end
-      expect(response).to have_http_status(:ok)
-      expect(response.parsed_body[0]).to eq({ 'access' => nil,
-                                              'address' => {
-                                                'mailing' => { 'zip' => '66713', 'city' => 'Leavenworth',
-                                                               'state' => 'KS', 'address1' => '150 Muncie Rd' },
-                                                'physical' => { 'zip' => '66713', 'city' => 'Baxter Springs',
-                                                                'state' => 'KS',
-                                                                'address1' => 'Baxter Springs City Cemetery' }
-                                              },
-                                              'classification' => 'Soldiers Lot',
-                                              'distance' => nil,
-                                              'facility_type' => 'va_cemetery',
-                                              'facility_type_prefix' => 'nca',
-                                              'feedback' => nil,
-                                              'hours' =>
-                                               { 'monday' => 'Sunrise - Sundown',
-                                                 'tuesday' => 'Sunrise - Sundown',
-                                                 'wednesday' => 'Sunrise - Sundown',
-                                                 'thursday' => 'Sunrise - Sundown',
-                                                 'friday' => 'Sunrise - Sundown',
-                                                 'saturday' => 'Sunrise - Sundown',
-                                                 'sunday' => 'Sunrise - Sundown' },
-                                              'id' => 'nca_042',
-                                              'lat' => 37.0320575,
-                                              'long' => -94.7706605,
-                                              'mobile' => nil,
-                                              'name' => "Baxter Springs City Soldiers' Lot",
-                                              'operating_status' => { 'code' => 'NORMAL' },
-                                              'operational_hours_special_instructions' => nil,
-                                              'parent' => nil,
-                                              'phone' => { 'fax' => '9137584136', 'main' => '9137584105' },
-                                              'services' => nil,
-                                              'time_zone' => 'America/Chicago',
-                                              'type' => 'va_facilities',
-                                              'unique_id' => '042',
-                                              'visn' => nil,
-                                              'website' => 'https://www.cem.va.gov/cems/lots/BaxterSprings.asp',
-                                              'tmp_covid_online_scheduling' => nil })
-    end
+      it 'responds with facilities data for supported facilities' do
+        StdInstitutionFacility.create(station_number: '042')
 
-    context 'with hca_retrieve_facilities_without_repopulating disabled' do
-      it 'populates VES facilities cache if it returns no results' do
-        allow(Flipper).to receive(:enabled?).with(:hca_retrieve_facilities_without_repopulating).and_return(false)
-        expect(StdInstitutionFacility.count).to eq(0)
         VCR.use_cassette('lighthouse/facilities/v1/200_facilities_facility_ids', match_requests_on: %i[method uri]) do
           get(facilities_v0_health_care_applications_path(facilityIds: %w[vha_757 vha_358]))
         end
-        expect(StdInstitutionFacility.all.any?).to be(true)
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body[0]).to be_nil
+        expect(response.parsed_body[0]).to eq({ 'access' => nil,
+                                                'address' => {
+                                                  'mailing' => { 'zip' => '66713', 'city' => 'Leavenworth',
+                                                                 'state' => 'KS', 'address1' => '150 Muncie Rd' },
+                                                  'physical' => { 'zip' => '66713', 'city' => 'Baxter Springs',
+                                                                  'state' => 'KS',
+                                                                  'address1' => 'Baxter Springs City Cemetery' }
+                                                },
+                                                'classification' => 'Soldiers Lot',
+                                                'distance' => nil,
+                                                'facility_type' => 'va_cemetery',
+                                                'facility_type_prefix' => 'nca',
+                                                'feedback' => nil,
+                                                'hours' =>
+                                                  { 'monday' => 'Sunrise - Sundown',
+                                                    'tuesday' => 'Sunrise - Sundown',
+                                                    'wednesday' => 'Sunrise - Sundown',
+                                                    'thursday' => 'Sunrise - Sundown',
+                                                    'friday' => 'Sunrise - Sundown',
+                                                    'saturday' => 'Sunrise - Sundown',
+                                                    'sunday' => 'Sunrise - Sundown' },
+                                                'id' => 'nca_042',
+                                                'lat' => 37.0320575,
+                                                'long' => -94.7706605,
+                                                'mobile' => nil,
+                                                'name' => "Baxter Springs City Soldiers' Lot",
+                                                'operating_status' => { 'code' => 'NORMAL' },
+                                                'operational_hours_special_instructions' => nil,
+                                                'parent' => nil,
+                                                'phone' => { 'fax' => '9137584136', 'main' => '9137584105' },
+                                                'services' => nil,
+                                                'time_zone' => 'America/Chicago',
+                                                'type' => 'va_facilities',
+                                                'unique_id' => '042',
+                                                'visn' => nil,
+                                                'website' => 'https://www.cem.va.gov/cems/lots/BaxterSprings.asp',
+                                                'tmp_covid_online_scheduling' => nil })
+      end
+
+      context 'with hca_retrieve_facilities_without_repopulating disabled' do
+        it 'populates VES facilities cache if it returns no results' do
+          allow(Flipper).to receive(:enabled?).with(:hca_retrieve_facilities_without_repopulating).and_return(false)
+          expect(StdInstitutionFacility.count).to eq(0)
+          VCR.use_cassette('lighthouse/facilities/v1/200_facilities_facility_ids', match_requests_on: %i[method uri]) do
+            get(facilities_v0_health_care_applications_path(facilityIds: %w[vha_757 vha_358]))
+          end
+          expect(StdInstitutionFacility.all.any?).to be(true)
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body[0]).to be_nil
+        end
+      end
+
+      context 'with hca_retrieve_facilities_without_repopulating enabled' do
+        it 'returns no results when the cache is empty without populating it' do
+          allow(Flipper).to receive(:enabled?).with(:hca_retrieve_facilities_without_repopulating).and_return(true)
+          expect(StdInstitutionFacility.count).to eq(0)
+          VCR.use_cassette('lighthouse/facilities/v1/200_facilities_facility_ids', match_requests_on: %i[method uri]) do
+            get(facilities_v0_health_care_applications_path(facilityIds: %w[vha_757 vha_358]))
+          end
+          expect(StdInstitutionFacility.count).to eq(0)
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body[0]).to be_nil
+        end
       end
     end
 
-    context 'with hca_retrieve_facilities_without_repopulating enabled' do
-      it 'returns no results when the cache is empty without populating it' do
-        allow(Flipper).to receive(:enabled?).with(:hca_retrieve_facilities_without_repopulating).and_return(true)
-        expect(StdInstitutionFacility.count).to eq(0)
+    context 'with the v2 feature flag disabled' do
+      before { allow(Flipper).to receive(:enabled?).with(:hca_ez_use_facilities_v2).and_return(false) }
+
+      it 'responds with facilities data for supported facilities' do
+        StdInstitutionFacility.create(station_number: '042')
+
         VCR.use_cassette('lighthouse/facilities/v1/200_facilities_facility_ids', match_requests_on: %i[method uri]) do
           get(facilities_v0_health_care_applications_path(facilityIds: %w[vha_757 vha_358]))
         end
-        expect(StdInstitutionFacility.count).to eq(0)
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body[0]).to be_nil
+        expect(response.parsed_body[0]).to eq({ 'access' => nil,
+                                                'active_status' => nil,
+                                                'address' => {
+                                                  'mailing' => { 'zip' => '66713', 'city' => 'Leavenworth',
+                                                                 'state' => 'KS', 'address1' => '150 Muncie Rd' },
+                                                  'physical' => { 'zip' => '66713', 'city' => 'Baxter Springs',
+                                                                  'state' => 'KS',
+                                                                  'address1' => 'Baxter Springs City Cemetery' }
+                                                },
+                                                'classification' => 'Soldiers Lot',
+                                                'detailed_services' => nil,
+                                                'distance' => nil,
+                                                'facility_type' => 'va_cemetery',
+                                                'facility_type_prefix' => 'nca',
+                                                'feedback' => nil,
+                                                'hours' =>
+                                                  { 'monday' => 'Sunrise - Sundown',
+                                                    'tuesday' => 'Sunrise - Sundown',
+                                                    'wednesday' => 'Sunrise - Sundown',
+                                                    'thursday' => 'Sunrise - Sundown',
+                                                    'friday' => 'Sunrise - Sundown',
+                                                    'saturday' => 'Sunrise - Sundown',
+                                                    'sunday' => 'Sunrise - Sundown' },
+                                                'id' => 'nca_042',
+                                                'lat' => 37.0320575,
+                                                'long' => -94.7706605,
+                                                'mobile' => nil,
+                                                'name' => "Baxter Springs City Soldiers' Lot",
+                                                'operating_status' => { 'code' => 'NORMAL' },
+                                                'operational_hours_special_instructions' => nil,
+                                                'parent' => nil,
+                                                'phone' => { 'fax' => '9137584136', 'main' => '9137584105' },
+                                                'services' => nil,
+                                                'type' => 'va_facilities',
+                                                'unique_id' => '042',
+                                                'visn' => nil,
+                                                'website' => 'https://www.cem.va.gov/cems/lots/BaxterSprings.asp' })
+      end
+
+      context 'with hca_retrieve_facilities_without_repopulating disabled' do
+        it 'populates VES facilities cache if it returns no results' do
+          allow(Flipper).to receive(:enabled?).with(:hca_retrieve_facilities_without_repopulating).and_return(false)
+          expect(StdInstitutionFacility.count).to eq(0)
+          VCR.use_cassette('lighthouse/facilities/v1/200_facilities_facility_ids', match_requests_on: %i[method uri]) do
+            get(facilities_v0_health_care_applications_path(facilityIds: %w[vha_757 vha_358]))
+          end
+          expect(StdInstitutionFacility.all.any?).to be(true)
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body[0]).to be_nil
+        end
+      end
+
+      context 'with hca_retrieve_facilities_without_repopulating enabled' do
+        it 'returns no results when the cache is empty without populating it' do
+          allow(Flipper).to receive(:enabled?).with(:hca_retrieve_facilities_without_repopulating).and_return(true)
+          expect(StdInstitutionFacility.count).to eq(0)
+          VCR.use_cassette('lighthouse/facilities/v1/200_facilities_facility_ids', match_requests_on: %i[method uri]) do
+            get(facilities_v0_health_care_applications_path(facilityIds: %w[vha_757 vha_358]))
+          end
+          expect(StdInstitutionFacility.count).to eq(0)
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body[0]).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Update the Health Care Applications backend to use the new Lighthouse Facilities Client V2, since V1 is being deprecated.
- 10-10 Health Enrollment Team EZ/CG
- `hca_ez_use_facilities_v2` flipper toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99214

## Testing done

- [x] *New code is covered by unit tests*
- Old behavior: use the V1 Client to retrieve Facilities from Lighthouse.
- New behavior: uses V2 instead.
- To verify, start a 10-10EZ application, and proceed to the VA Facility page. Choose a `State`, and confirm that the `Center or clinic` dropdown populates with facilities.

## What areas of the site does it impact?
* 10-10EZ Health Care Application form

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
