### PR TITLE
Adding header needed for DataDog RUM

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,7 +34,7 @@ app/controllers/concerns/authentication_and_sso_concerns.rb @department-of-veter
 app/controllers/concerns/exception_handling.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/failed_request_loggable.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/form_attachment_create.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/controllers/concerns/headers.rb @department-of-veterans-affairs/mobile-api-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/controllers/concerns/headers.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/instrumentation.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/octo-identity
 app/controllers/concerns/json_api_pagination_links.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/mhv_controller_concerns.rb @department-of-veterans-affairs/vfs-health-modernization-initiative @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/concerns/headers.rb
+++ b/app/controllers/concerns/headers.rb
@@ -8,5 +8,6 @@ module Headers
   def set_app_info_headers
     headers['X-Git-SHA'] = AppInfo::GIT_REVISION
     headers['X-GitHub-Repository'] = AppInfo::GITHUB_URL
+    headers['Timing-Allow-Origin'] = Settings.web_origin # DataDog RUM
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -72,6 +72,7 @@ module VetsAPI
                       methods: :any,
                       credentials: true,
                       expose: %w[
+                        Timing-Allow-Origin
                         X-RateLimit-Limit
                         X-RateLimit-Remaining
                         X-RateLimit-Reset


### PR DESCRIPTION
## Summary
Adding the `Timing-Allow-Origin` header to the headers sent on API responses. This is to allow DataDog Real User Monitoring to collect timing metrics on requests to vets-api made by vets-website. I set it to `Settings.web_origin` so that it will only allow timing info for vets-website. I'm not sure if I need to add `Timing-Allow-Origin` to the list of headers in rack-cors though. It seemed to work without it so I left it out.

[DataDog recommendations](https://docs.datadoghq.com/real_user_monitoring/browser/monitoring_resource_performance/#resource-timing-and-cors)
[MDN Article on Timing-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/API/Performance_API/Resource_timing#cross-origin_timing_information)

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101997

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
