### PR TITLE
[10-10CG] Refactor facilityIds param formatting

### DIFF
--- a/app/controllers/v0/caregivers_assistance_claims_controller.rb
+++ b/app/controllers/v0/caregivers_assistance_claims_controller.rb
@@ -90,9 +90,7 @@ module V0
       )
 
       # The Lighthouse Facilities api expects the facility ids param as `facilityIds`
-      permitted_params.to_h.tap do |hash|
-        hash['facilityIds'] = hash.delete('facility_ids') if hash.key?('facility_ids')
-      end
+      permitted_params.to_h.transform_keys { |key| key == 'facility_ids' ? 'facilityIds' : key }
     end
 
     def record_submission_attempt


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO, but the  `vets-website` code that calls this endpoint currently is
- Small refactor to improve readability and efficiency when reformatting the `facility_ids` to `facilityIds` param for the Lighthouse API call per @stevenjcumming's suggestion. 
- 1010 Health Apps 
- `vets-website` call is `caregiver_use_facilities_API`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101907

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
