### PR TITLE
[VACMS-18736]Correct spelling for search v2 'enable_in_development'

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1967,7 +1967,7 @@ features:
   search_use_v2_gsa:
     actor_type: cookie_id
     description: Swaps the Search Service's for one with an updated api.gsa.gov address
-    enabled_in_development: true
+    enable_in_development: true
   remove_pciu:
     actor_type: user
     description: If enabled, VA Profile is used to populate contact information with PCIU backup calls


### PR DESCRIPTION
## Summary

- There is a typo for the `search_use_v2_gsa` feature flipper, this corrects `enabled_in_development` to the correct `enable_in_development`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18736
- 
## Testing done

- [ ] *New code is covered by unit tests*
- *This did not cause any bugs or direct issues before, but kept the flag from being enabled by default in local development.
- The `search_use_v2_gsa` flipper will now be enabled by default in local development environments

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Flipper flag related to v2 search which is currently on hold.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
