### PR TITLE
[10-10CG] Display facility Id in pdf if name is not found in vets-json-schema

### DIFF
--- a/lib/pdf_fill/forms/va1010cg.rb
+++ b/lib/pdf_fill/forms/va1010cg.rb
@@ -695,9 +695,16 @@ module PdfFill
 
       def merge_planned_facility_label_helper
         target_facility_code = @form_data.dig 'veteran', 'plannedClinic'
+
         caregiver_facilities = VetsJsonSchema::CONSTANTS['caregiverProgramFacilities'].values.flatten
         selected_facility = caregiver_facilities.find { |facility| facility['code'] == target_facility_code }
-        display_value = selected_facility.nil? ? nil : "#{selected_facility['code']} - #{selected_facility['label']}"
+
+        display_value = if selected_facility.nil?
+                          target_facility_code
+                        else
+                          "#{selected_facility['code']} - #{selected_facility['label']}"
+                        end
+
         @form_data['helpers']['veteran']['plannedClinic'] = display_value
       end
 

--- a/spec/fixtures/pdf_fill/10-10CG/merge_fields.json
+++ b/spec/fixtures/pdf_fill/10-10CG/merge_fields.json
@@ -1,0 +1,157 @@
+{
+  "veteran": {
+    "fullName": {
+      "first": "Rose",
+      "last": "Jerde",
+      "middle": "A",
+      "suffix": "Sr."
+    },
+    "ssnOrTin": "789787893",
+    "dateOfBirth": "1990-07-03",
+    "gender": "M",
+    "address": {
+      "street": "111 2nd St S",
+      "street2": "#501",
+      "city": "Seattle",
+      "state": "WA",
+      "postalCode": "98101",
+      "county": "King"
+    },
+    "primaryPhoneNumber": "8887775541",
+    "alternativePhoneNumber": "8887775542",
+    "email": "veteranEmail@email.com",
+    "plannedClinic": "740",
+    "signature": "Rosamond A Jerde"
+  },
+  "primaryCaregiver": {
+    "fullName": {
+      "first": "Joan",
+      "last": "Jerde",
+      "middle": "Bednar",
+      "suffix": "Jr."
+    },
+    "ssnOrTin": "202901412",
+    "dateOfBirth": "1978-07-03",
+    "gender": "F",
+    "address": {
+      "street": "111 2nd St S",
+      "street2": "#502",
+      "city": "Seattle",
+      "state": "WA",
+      "postalCode": "98101",
+      "county": "King"
+    },
+    "mailingAddress": {
+      "street": "1 Bahringer Way",
+      "street2": "A",
+      "city": "Seattle",
+      "state": "WA",
+      "postalCode": "98101",
+      "county": "King"
+    },
+    "primaryPhoneNumber": "1112929933",
+    "alternativePhoneNumber": "9990239330",
+    "email": "primaryCaregiverEmail@email.com",
+    "vetRelationship": "Spouse",
+    "signature": "Joan Jerde"
+  },
+  "secondaryCaregiverOne": {
+    "fullName": {
+      "first": "Pauline",
+      "last": "Moen",
+      "middle": "Amber",
+      "suffix": "II"
+    },
+    "ssnOrTin": "994328445",
+    "dateOfBirth": "1981-03-29",
+    "gender": "F",
+    "address": {
+      "street": "1022 East Dedraburgh",
+      "street2": "Unit 101",
+      "city": "Seattle",
+      "state": "WA",
+      "postalCode": "98101",
+      "county": "King"
+    },
+    "mailingAddress": {
+      "street": "2 Bahringer Way",
+      "street2": "A",
+      "city": "Seattle",
+      "state": "WA",
+      "postalCode": "98101",
+      "county": "King"
+    },
+    "primaryPhoneNumber": "1118293993",
+    "alternativePhoneNumber": "0002938484",
+    "email": "secondaryOneCaregiverEmail@email.com",
+    "vetRelationship": "Daughter"
+  },
+  "secondaryCaregiverTwo": {
+    "fullName": {
+      "first": "Derrick",
+      "last": "Jaskolski",
+      "middle": "J.",
+      "suffix": "III"
+    },
+    "ssnOrTin": "091449494",
+    "dateOfBirth": "1980-09-06",
+    "gender": "F",
+    "address": {
+      "street": "1946 Bahringer Way",
+      "street2": "A",
+      "city": "Seattle",
+      "state": "WA",
+      "postalCode": "98101",
+      "county": "King"
+    },
+    "mailingAddress": {
+      "street": "3 Bahringer Way",
+      "street2": "A",
+      "city": "Seattle",
+      "state": "WA",
+      "postalCode": "98101",
+      "county": "King"
+    },
+    "primaryPhoneNumber": "8784844999",
+    "alternativePhoneNumber": "8788894300",
+    "email": "secondaryTwoCaregiverEmail@email.com",
+    "vetRelationship": "Friend/Neighbor",
+    "signature": "Derrick J. Jaskolski"
+  },
+  "helpers": {
+    "veteran": {
+      "address": {
+        "street": "111 2nd St S #501"
+      },
+      "gender": "2",
+      "plannedClinic": "740 - Harlingen VA Clinic"
+    },
+    "primaryCaregiver": {
+      "address": {
+        "street": "111 2nd St S #502"
+      },
+      "mailingAddress": {
+        "street": "1 Bahringer Way A"
+      },
+      "gender": "3"
+    },
+    "secondaryCaregiverOne": {
+      "address": {
+        "street": "1022 East Dedraburgh Unit 101"
+      },
+      "mailingAddress": {
+        "street": "2 Bahringer Way A"
+      },
+      "gender": "3"
+    },
+    "secondaryCaregiverTwo": {
+      "address": {
+        "street": "1946 Bahringer Way A"
+      },
+      "mailingAddress": {
+        "street": "3 Bahringer Way A"
+      },
+      "gender": "3"
+    }
+  }
+}

--- a/spec/lib/pdf_fill/forms/va1010cg_spec.rb
+++ b/spec/lib/pdf_fill/forms/va1010cg_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'pdf_fill/forms/va1010cg'
+
+describe PdfFill::Forms::Va1010cg do
+  include SchemaMatchers
+
+  let(:form_data) do
+    get_fixture('pdf_fill/10-10CG/kitchen_sink')
+  end
+
+  let(:form_class) do
+    PdfFill::Forms::Va1010cg.new(form_data)
+  end
+
+  describe '#merge_fields' do
+    it 'merges the right fields' do
+      expect(form_class.merge_fields.to_json).to eq(
+        get_fixture('pdf_fill/10-10CG/merge_fields').to_json
+      )
+    end
+  end
+
+  describe '#merge_planned_facility_label_helper' do
+    before do
+      allow(VetsJsonSchema::CONSTANTS).to receive(:[]).with('caregiverProgramFacilities').and_return(
+        {
+          'OH' => {
+            'code' => '100',
+            'label' => 'VA Facility Name'
+          }
+        }
+      )
+    end
+
+    context 'plannedClinic is not in vets-json-schema' do
+      let(:form_data) do
+        {
+          'helpers' => {
+            'veteran' => {}
+          },
+          'veteran' => {
+            'plannedClinic' => '99'
+          }
+        }
+      end
+
+      it 'sets the plannedClinic to the facility id' do
+        form_class.send(:merge_planned_facility_label_helper)
+        expect(form_class.form_data['helpers']['veteran']['plannedClinic']).to eq '99'
+      end
+    end
+
+    context 'plannedClinic is found in vets-json-schema' do
+      let(:form_data) do
+        {
+          'helpers' => {
+            'veteran' => {}
+          },
+          'veteran' => {
+            'plannedClinic' => '100'
+          }
+        }
+      end
+
+      it 'sets the plannedClinic to facility id and facility name' do
+        form_class.send(:merge_planned_facility_label_helper)
+        expect(form_class.form_data['helpers']['veteran']['plannedClinic']).to eq '100 - VA Facility Name'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- When a 10-10CG form is submitted, a pdf version of the form is also filled out and sent with the form data payload (The same pdf is also available for the Veteran to download upon submission). In this pdf, we have a helper that fills the selected facility input with the `ID - Name of Facility` and not just the facility id like we send in the payload. Finding the name is performed by looking up the list of caregiver facilities in `vets-json-schema`, and matches the id with the object that has that id. If the id is not found, it sets the input to empty. 
- This change ensures that we at least always pass the facility id, since we know we have that because we passed the schema validation and it is required. If we find the name we set it, and if not instead of setting it to empty we simply pass the facility id we have.
- This change ensures that if the list in `vets-json-schema` is out of date, we can still have a valid 10-10CG pdf with the necessary data for submissions. 
- Future work is being considered to update how we get the name, but for now this change at least ensures we pass along the facility id.
- 1010 Health Apps

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92034

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
10-10CG

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
