### PR TITLE
1387 update 1095b

### DIFF
--- a/app/controllers/v0/form1095_bs_controller.rb
+++ b/app/controllers/v0/form1095_bs_controller.rb
@@ -2,6 +2,7 @@
 
 module V0
   class Form1095BsController < ApplicationController
+    service_tag 'deprecated'
     before_action { authorize :form1095, :access? }
     before_action :set_form, only: %i[download_pdf download_txt]
     before_action :set_available_forms, only: :available_forms

--- a/app/models/form1095_b.rb
+++ b/app/models/form1095_b.rb
@@ -63,13 +63,13 @@ class Form1095B < ApplicationRecord
     data[:middle_name] ? data[:middle_name][0] : ''
   end
 
-  def ssn_or_birthdate
+  def birthdate_unless_ssn
     data[:last_4_ssn].present? ? '' : data[:birth_date]
   end
 
   def txt_form_data
     text_data = {
-      birth_date_field: data[:last_4_ssn].present? ? '' : data[:birth_date],
+      birth_date_field: birthdate_unless_ssn,
       state_or_province: data[:state] || data[:province],
       country_and_zip:,
       middle_init: middle_initial,
@@ -95,7 +95,7 @@ class Form1095B < ApplicationRecord
         'topmostSubform[0].Page1[0].Part1Contents[0].Line1[0].f1_02[0]': data[:middle_name],
         'topmostSubform[0].Page1[0].Part1Contents[0].Line1[0].f1_03[0]': data[:last_name],
         'topmostSubform[0].Page1[0].Part1Contents[0].f1_04[0]': data[:last_4_ssn] || '',
-        'topmostSubform[0].Page1[0].Part1Contents[0].f1_05[0]': ssn_or_birthdate,
+        'topmostSubform[0].Page1[0].Part1Contents[0].f1_05[0]': birthdate_unless_ssn,
         'topmostSubform[0].Page1[0].Part1Contents[0].f1_06[0]': data[:address],
         'topmostSubform[0].Page1[0].Part1Contents[0].f1_07[0]': data[:city],
         'topmostSubform[0].Page1[0].Part1Contents[0].f1_08[0]': data[:state] || data[:province],
@@ -112,7 +112,7 @@ class Form1095B < ApplicationRecord
         'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_26[0]': middle_initial,
         'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_27[0]': data[:last_name],
         'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_28[0]': data[:last_4_ssn] || '',
-        'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_29[0]': ssn_or_birthdate,
+        'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_29[0]': birthdate_unless_ssn,
         'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_01[0]': data[:coverage_months][0] && 1,
         'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_02[0]': data[:coverage_months][1] && 1,
         'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_03[0]': data[:coverage_months][2] && 1,

--- a/app/models/form1095_b.rb
+++ b/app/models/form1095_b.rb
@@ -61,9 +61,13 @@ class Form1095B < ApplicationRecord
     data[:middle_name] ? data[:middle_name][0] : ''
   end
 
+  def ssn_or_birthdate
+     data[:last_4_ssn].present? ? '' : data[:birth_date]
+  end
+
   def txt_form_data
     text_data = {
-      birth_date_field: data[:last_4_ssn] ? '' : data[:birth_date],
+      birth_date_field: data[:last_4_ssn].present? ? '' : data[:birth_date],
       state_or_province: data[:state] || data[:province],
       country_and_zip:,
       middle_init: middle_initial,
@@ -89,16 +93,24 @@ class Form1095B < ApplicationRecord
         'topmostSubform[0].Page1[0].Part1Contents[0].Line1[0].f1_02[0]': data[:middle_name],
         'topmostSubform[0].Page1[0].Part1Contents[0].Line1[0].f1_03[0]': data[:last_name],
         'topmostSubform[0].Page1[0].Part1Contents[0].f1_04[0]': data[:last_4_ssn] || '',
-        'topmostSubform[0].Page1[0].Part1Contents[0].f1_05[0]': data[:last_4_ssn] ? '' : data[:birth_date],
+        'topmostSubform[0].Page1[0].Part1Contents[0].f1_05[0]': ssn_or_birthdate,
         'topmostSubform[0].Page1[0].Part1Contents[0].f1_06[0]': data[:address],
         'topmostSubform[0].Page1[0].Part1Contents[0].f1_07[0]': data[:city],
         'topmostSubform[0].Page1[0].Part1Contents[0].f1_08[0]': data[:state] || data[:province],
         'topmostSubform[0].Page1[0].Part1Contents[0].f1_09[0]': country_and_zip,
+        "topmostSubform[0].Page1[0].Part1Contents[0].f1_10[0]": 'C',
+        "topmostSubform[0].Page1[0].f1_18[0]": 'US Department of Veterans Affairs',
+        "topmostSubform[0].Page1[0].f1_19[0]": '74-1612229',
+        "topmostSubform[0].Page1[0].f1_20[0]": '877-222-8387',
+        "topmostSubform[0].Page1[0].f1_21[0]": 'P.O. BOX 149975',
+        "topmostSubform[0].Page1[0].f1_22[0]": 'Austin',
+        "topmostSubform[0].Page1[0].f1_23[0]": 'TX',
+        "topmostSubform[0].Page1[0].f1_24[0]": '78714-8957',
         'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_25[0]': data[:first_name],
         'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_26[0]': middle_initial,
         'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_27[0]': data[:last_name],
         'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_28[0]': data[:last_4_ssn] || '',
-        'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_29[0]': data[:last_4_ssn] ? '' : data[:birth_date],
+        'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_29[0]': ssn_or_birthdate,
         'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_01[0]': data[:coverage_months][0] && 1,
         'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_02[0]': data[:coverage_months][1] && 1,
         'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_03[0]': data[:coverage_months][2] && 1,

--- a/app/models/form1095_b.rb
+++ b/app/models/form1095_b.rb
@@ -10,7 +10,7 @@ class Form1095B < ApplicationRecord
   validate :proper_form_data_schema
 
   # scopes
-  scope :available_forms, lambda { |icn| where(veteran_icn: icn).order(tax_year: :desc) }
+  scope :available_forms, ->(icn) { where(veteran_icn: icn).order(tax_year: :desc) }
 
   # methods
   def txt_file
@@ -64,7 +64,7 @@ class Form1095B < ApplicationRecord
   end
 
   def ssn_or_birthdate
-     data[:last_4_ssn].present? ? '' : data[:birth_date]
+    data[:last_4_ssn].present? ? '' : data[:birth_date]
   end
 
   def txt_form_data
@@ -100,14 +100,14 @@ class Form1095B < ApplicationRecord
         'topmostSubform[0].Page1[0].Part1Contents[0].f1_07[0]': data[:city],
         'topmostSubform[0].Page1[0].Part1Contents[0].f1_08[0]': data[:state] || data[:province],
         'topmostSubform[0].Page1[0].Part1Contents[0].f1_09[0]': country_and_zip,
-        "topmostSubform[0].Page1[0].Part1Contents[0].f1_10[0]": 'C',
-        "topmostSubform[0].Page1[0].f1_18[0]": 'US Department of Veterans Affairs',
-        "topmostSubform[0].Page1[0].f1_19[0]": '74-1612229',
-        "topmostSubform[0].Page1[0].f1_20[0]": '877-222-8387',
-        "topmostSubform[0].Page1[0].f1_21[0]": 'P.O. BOX 149975',
-        "topmostSubform[0].Page1[0].f1_22[0]": 'Austin',
-        "topmostSubform[0].Page1[0].f1_23[0]": 'TX',
-        "topmostSubform[0].Page1[0].f1_24[0]": '78714-8957',
+        'topmostSubform[0].Page1[0].Part1Contents[0].f1_10[0]': 'C',
+        'topmostSubform[0].Page1[0].f1_18[0]': 'US Department of Veterans Affairs',
+        'topmostSubform[0].Page1[0].f1_19[0]': '74-1612229',
+        'topmostSubform[0].Page1[0].f1_20[0]': '877-222-8387',
+        'topmostSubform[0].Page1[0].f1_21[0]': 'P.O. BOX 149975',
+        'topmostSubform[0].Page1[0].f1_22[0]': 'Austin',
+        'topmostSubform[0].Page1[0].f1_23[0]': 'TX',
+        'topmostSubform[0].Page1[0].f1_24[0]': '78714-8957',
         'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_25[0]': data[:first_name],
         'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_26[0]': middle_initial,
         'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_27[0]': data[:last_name],

--- a/app/models/form1095_b.rb
+++ b/app/models/form1095_b.rb
@@ -16,7 +16,9 @@ class Form1095B < ApplicationRecord
   def txt_file
     unless File.exist?(txt_template_path)
       Rails.logger.error "1095-B template for year #{tax_year} does not exist."
-      raise "1095-B for tax year #{tax_year} not supported"
+      raise Common::Exceptions::UnprocessableEntity.new(
+        detail: "1095-B for tax year #{tax_year} not supported", source: self.class.name
+      )
     end
 
     template_file = File.open(txt_template_path, 'r')
@@ -35,7 +37,9 @@ class Form1095B < ApplicationRecord
 
     unless File.exist?(pdf_template_path)
       Rails.logger.error "1095-B template for year #{tax_year} does not exist."
-      raise "1095-B for tax year #{tax_year} not supported"
+      raise Common::Exceptions::UnprocessableEntity.new(
+        detail: "1095-B for tax year #{tax_year} not supported", source: self.class.name
+      )
     end
 
     generate_pdf(pdftk, tmp_file)

--- a/app/models/form1095_b.rb
+++ b/app/models/form1095_b.rb
@@ -10,9 +10,7 @@ class Form1095B < ApplicationRecord
   validate :proper_form_data_schema
 
   # scopes
-  scope :available_forms, lambda { |icn|
-    where(veteran_icn: icn).order(tax_year: :desc).pluck(:tax_year, :updated_at)
-  }
+  scope :available_forms, lambda { |icn| where(veteran_icn: icn).order(tax_year: :desc) }
 
   # methods
   def txt_file

--- a/lib/form1095_b/templates/txts/1095b-2024.txt
+++ b/lib/form1095_b/templates/txts/1095b-2024.txt
@@ -1,0 +1,789 @@
+<Page 1>
+
+Department of the Treasury
+Internal Revenue Service
+OMB No. 1545-2252
+560118
+
+Form 1095-B
+2024
+Health Coverage
+
+-- VOID
+%{corrected} CORRECTED
+
+ Do not attach to your tax return. Keep for your records.
+ Go to www.irs.gov/Form1095B for instructions and the latest information.
+
+Part I Responsible Individual
+
+1 Name of responsible individual-First name, middle name, last name ---- %{first_name} %{middle_name} %{last_name}
+2 Social security number (SSN) or other TIN ---- %{last_4_ssn}
+3 Date of birth (if SSN or other TIN is not available) ---- %{birth_date_field}
+4 Street address (including apartment no.) ---- %{address}
+5 City or town ---- %{city}
+6 State or province ---- %{state_or_province}
+7 Country and ZIP or foreign postal code ---- %{country_and_zip}
+8 Enter letter identifying Origin of the Health Coverage (see instructions for codes): ---- C
+9 Reserved shaded
+
+Part II Information About Certain Employer-Sponsored Coverage (see instructions)
+
+10 Employer name ----
+11 Employer identification number (EIN) ----
+12 Street address (including room or suite no.) ----
+13 City or town ----
+14 State or province ----
+15 Country and ZIP or foreign postal code ----
+
+Part III Issuer or Other Coverage Provider (see instructions)
+
+16 Name ---- US Department of Veterans Affairs
+17 Employer identification number (EIN) ---- 74-1612229
+18 Contact telephone number ---- 877-222-8387
+19 Street address (including room or suite no.) ---- P.O. BOX 149975
+20 City or town ---- AUSTIN
+21 State or province ---- TX
+22 Country and ZIP or foreign postal code ---- 78714-8957
+
+Part IV Covered Individuals (Enter the information for each covered individual.)
+
+23
+(a) Name of covered individual(s) First name, middle initial, last name ---- %{first_name} %{middle_init} %{last_name}
+(b) SSN or other TIN ---- %{last_4_ssn}
+(c) DOB (if SSN or other TIN is not available) ---- %{birth_date_field}
+(d) Covered all 12 months %{coverage_month_0}
+(e) Months of coverage
+%{coverage_month_1} Jan
+%{coverage_month_2} Feb
+%{coverage_month_3} Mar
+%{coverage_month_4} Apr
+%{coverage_month_5} May
+%{coverage_month_6} Jun
+%{coverage_month_7} Jul
+%{coverage_month_8} Aug
+%{coverage_month_9} Sep
+%{coverage_month_10} Oct
+%{coverage_month_11} Nov
+%{coverage_month_12} Dec
+24
+(a) Name of covered individual(s) First name, middle initial, last name ----
+(b) SSN or other TIN ----
+(c) DOB (if SSN or other TIN is not available) ----
+(d) Covered all 12 months --
+(e) Months of coverage
+-- Jan
+-- Feb
+-- Mar
+-- Apr
+-- May
+-- Jun
+-- Jul
+-- Aug
+-- Sep
+-- Oct
+-- Nov
+-- Dec
+25
+(a) Name of covered individual(s) First name, middle initial, last name ----
+(b) SSN or other TIN ----
+(c) DOB (if SSN or other TIN is not available) ----
+(d) Covered all 12 months --
+(e) Months of coverage
+-- Jan
+-- Feb
+-- Mar
+-- Apr
+-- May
+-- Jun
+-- Jul
+-- Aug
+-- Sep
+-- Oct
+-- Nov
+-- Dec
+26
+(a) Name of covered individual(s) First name, middle initial, last name ----
+(b) SSN or other TIN ----
+(c) DOB (if SSN or other TIN is not available) ----
+(d) Covered all 12 months --
+(e) Months of coverage
+-- Jan
+-- Feb
+-- Mar
+-- Apr
+-- May
+-- Jun
+-- Jul
+-- Aug
+-- Sep
+-- Oct
+-- Nov
+-- Dec
+27
+(a) Name of covered individual(s) First name, middle initial, last name ----
+(b) SSN or other TIN ----
+(c) DOB (if SSN or other TIN is not available) ----
+(d) Covered all 12 months --
+(e) Months of coverage
+-- Jan
+-- Feb
+-- Mar
+-- Apr
+-- May
+-- Jun
+-- Jul
+-- Aug
+-- Sep
+-- Oct
+-- Nov
+-- Dec
+28
+(a) Name of covered individual(s) First name, middle initial, last name ----
+(b) SSN or other TIN ----
+(c) DOB (if SSN or other TIN is not available) ----
+(d) Covered all 12 months --
+(e) Months of coverage
+-- Jan
+-- Feb
+-- Mar
+-- Apr
+-- May
+-- Jun
+-- Jul
+-- Aug
+-- Sep
+-- Oct
+-- Nov
+-- Dec
+
+For Privacy Act and Paperwork Reduction Act Notice, see separate instructions.
+Cat. No. 60704B
+Form 1095-B (2024)
+
+<Page 2>
+
+560220
+Form 1095-B (2024)
+Page 2
+
+Instructions for Recipient
+
+This Form 1095-B provides information about the individuals in your tax family (yourself, spouse, and dependents) who had certain health coverage (referred to as "minimum essential coverage") for some or all months during the year. Minimum essential coverage includes government-sponsored programs, eligible employer-sponsored plans, individual market plans, and other coverage the Department of Health and Human Services designates as minimum essential coverage.
+
+Before 2019, individuals who did not have minimum essential coverage and did not qualify for an exemption from this requirement could be liable for the individual shared responsibility payment. Beginning in 2019, individuals will not be responsible for the individual shared responsibility payment because the payment amount is reduced to $0. However, if individuals in your tax family are eligible for certain types of minimum essential coverage, you may not be eligible for the premium tax credit. For more information on the premium tax credit, see Pub. 974, Premium Tax Credit (PTC).
+
+TIP Providers of minimum essential coverage are required to furnish only one Form 1095-B for all individuals whose coverage is reported on that form. As the recipient of this Form 1095-B, you should provide a copy to other individuals covered under the policy if they request it for their records.
+
+Additional information. For additional information about the tax provisions of the Affordable Care Act (ACA), including the individual shared responsibility provisions, and the premium tax credit, see www.irs.gov/ACA or call the IRS Healthcare Hotline for ACA questions (800-919-0452).
+
+Part I. Responsible Individual, lines 1-9. Part I reports information about you and the coverage.
+
+Lines 2 and 3. Line 2 reports your social security number (SSN) or other taxpayer identification number (TIN), if applicable. For your protection, this form may show only the last four digits. However, the coverage provider is required to report your complete SSN or other TIN, if applicable, to the IRS. Your date of birth will be entered on line 3 only if line 2 is blank.
+
+Line 8. This is the code for the type of coverage in which you or other covered individuals were enrolled. Only one letter will be entered on this line.
+
+A. Small Business Health Options Program (SHOP)
+B. Employer-sponsored coverage
+C. Government-sponsored program
+D. Individual market insurance
+E. Multiemployer plan
+F. Other designated minimum essential coverage
+G. Individual coverage health reimbursement arrangement (HRA)
+
+TIP If you or another family member received health insurance coverage through a Health Insurance Marketplace (also known as an Exchange), that coverage will generally be reported on a Form 1095-A rather than a Form 1095-B. If you or another family member received employer-sponsored coverage, that coverage may be reported on a Form 1095-C (Part III) rather than a Form 1095-B. For more information, see www.irs.gov/Affordable-Care-Act/Questions-and-Answers-About-Health-Care-Information-Forms-for-Individuals.
+
+Line 9. Reserved.
+
+Part II. Information About Certain Employer-Sponsored Coverage, lines 10-15. If you had employer-sponsored health coverage, this part may provide information about the employer sponsoring the coverage. This part may show only the last four digits of the employer's EIN. This part may also be left blank, even if you had employer-sponsored health coverage. If this part is blank, you do not need to fill in the information or return it to your employer or other coverage provider.
+
+Part III. Issuer or Other Coverage Provider, lines 16-22. This part reports information about the coverage provider (insurance company, employer providing self-insured coverage, government agency sponsoring coverage under a government program such as Medicaid or Medicare, or other coverage sponsor). Line 18 reports a telephone number for the coverage provider that you can call if you have questions about the information reported on the form.
+
+Part IV. Covered Individuals, lines 23-28. This part reports the name, SSN or other TIN, and coverage information for each covered individual. A date of birth will be entered in column (c) only if the SSN or other TIN is not entered in column (b). Column (d) will be checked if the individual was covered for at least 1 day in every month of the year. For individuals who were covered for some but not all months, information will be entered in column (e) indicating the months for which these individuals were covered. If there are more than six covered individuals, see Part IV, Continuation Sheet(s), for information about the additional covered individuals.
+
+<Page 3>
+
+560318
+Form 1095-B (2024)
+Page 3
+
+Name of responsible individual-First name, middle name, last name ----
+Social security number (SSN) or other TIN ----
+Date of birth (if SSN or other TIN is not available) ----
+
+Part IV Covered Individuals � Continuation Sheet
+
+29
+(a) Name of covered individual(s) First name, middle initial, last name ----
+(b) SSN or other TIN ----
+(c) DOB (if SSN or other TIN is not available) ----
+(d) Covered all 12 months --
+(e) Months of coverage
+-- Jan
+-- Feb
+-- Mar
+-- Apr
+-- May
+-- Jun
+-- Jul
+-- Aug
+-- Sep
+-- Oct
+-- Nov
+-- Dec
+30
+(a) Name of covered individual(s) First name, middle initial, last name ----
+(b) SSN or other TIN ----
+(c) DOB (if SSN or other TIN is not available) ----
+(d) Covered all 12 months --
+(e) Months of coverage
+-- Jan
+-- Feb
+-- Mar
+-- Apr
+-- May
+-- Jun
+-- Jul
+-- Aug
+-- Sep
+-- Oct
+-- Nov
+-- Dec
+31
+(a) Name of covered individual(s) First name, middle initial, last name ----
+(b) SSN or other TIN ----
+(c) DOB (if SSN or other TIN is not available) ----
+(d) Covered all 12 months --
+(e) Months of coverage
+-- Jan
+-- Feb
+-- Mar
+-- Apr
+-- May
+-- Jun
+-- Jul
+-- Aug
+-- Sep
+-- Oct
+-- Nov
+-- Dec
+32
+(a) Name of covered individual(s) First name, middle initial, last name ----
+(b) SSN or other TIN ----
+(c) DOB (if SSN or other TIN is not available) ----
+(d) Covered all 12 months --
+(e) Months of coverage
+-- Jan
+-- Feb
+-- Mar
+-- Apr
+-- May
+-- Jun
+-- Jul
+-- Aug
+-- Sep
+-- Oct
+-- Nov
+-- Dec
+33
+(a) Name of covered individual(s) First name, middle initial, last name ----
+(b) SSN or other TIN ----
+(c) DOB (if SSN or other TIN is not available) ----
+(d) Covered all 12 months --
+(e) Months of coverage
+-- Jan
+-- Feb
+-- Mar
+-- Apr
+-- May
+-- Jun
+-- Jul
+-- Aug
+-- Sep
+-- Oct
+-- Nov
+-- Dec
+34
+(a) Name of covered individual(s) First name, middle initial, last name ----
+(b) SSN or other TIN ----
+(c) DOB (if SSN or other TIN is not available) ----
+(d) Covered all 12 months --
+(e) Months of coverage
+-- Jan
+-- Feb
+-- Mar
+-- Apr
+-- May
+-- Jun
+-- Jul
+-- Aug
+-- Sep
+-- Oct
+-- Nov
+-- Dec
+35
+(a) Name of covered individual(s) First name, middle initial, last name ----
+(b) SSN or other TIN ----
+(c) DOB (if SSN or other TIN is not available) ----
+(d) Covered all 12 months --
+(e) Months of coverage
+-- Jan
+-- Feb
+-- Mar
+-- Apr
+-- May
+-- Jun
+-- Jul
+-- Aug
+-- Sep
+-- Oct
+-- Nov
+-- Dec
+36
+(a) Name of covered individual(s) First name, middle initial, last name ----
+(b) SSN or other TIN ----
+(c) DOB (if SSN or other TIN is not available) ----
+(d) Covered all 12 months --
+(e) Months of coverage
+-- Jan
+-- Feb
+-- Mar
+-- Apr
+-- May
+-- Jun
+-- Jul
+-- Aug
+-- Sep
+-- Oct
+-- Nov
+-- Dec
+37
+(a) Name of covered individual(s) First name, middle initial, last name ----
+(b) SSN or other TIN ----
+(c) DOB (if SSN or other TIN is not available) ----
+(d) Covered all 12 months --
+(e) Months of coverage
+-- Jan
+-- Feb
+-- Mar
+-- Apr
+-- May
+-- Jun
+-- Jul
+-- Aug
+-- Sep
+-- Oct
+-- Nov
+-- Dec
+38
+(a) Name of covered individual(s) First name, middle initial, last name ----
+(b) SSN or other TIN ----
+(c) DOB (if SSN or other TIN is not available) ----
+(d) Covered all 12 months --
+(e) Months of coverage
+-- Jan
+-- Feb
+-- Mar
+-- Apr
+-- May
+-- Jun
+-- Jul
+-- Aug
+-- Sep
+-- Oct
+-- Nov
+-- Dec
+39
+(a) Name of covered individual(s) First name, middle initial, last name ----
+(b) SSN or other TIN ----
+(c) DOB (if SSN or other TIN is not available) ----
+(d) Covered all 12 months --
+(e) Months of coverage
+-- Jan
+-- Feb
+-- Mar
+-- Apr
+-- May
+-- Jun
+-- Jul
+-- Aug
+-- Sep
+-- Oct
+-- Nov
+-- Dec
+40
+(a) Name of covered individual(s) First name, middle initial, last name ----
+(b) SSN or other TIN ----
+(c) DOB (if SSN or other TIN is not available) ----
+(d) Covered all 12 months --
+(e) Months of coverage
+-- Jan
+-- Feb
+-- Mar
+-- Apr
+-- May
+-- Jun
+-- Jul
+-- Aug
+-- Sep
+-- Oct
+-- Nov
+-- Dec
+
+Form 1095-B (2024)
+
+<Page 1>
+
+Department of the Treasury
+Internal Revenue Service
+Dec 09, 2024
+Cat. No. 63017B
+
+2024 Instructions for Forms
+1094-B and 1095-B
+
+Section references are to the Internal Revenue Code unless otherwise noted.
+
+Future Developments
+
+For the latest information about developments relating to Forms 1094-B, Transmittal of Health Coverage Information Returns, and 1095-B, Health Coverage, and their instructions, such as legislation enacted after they were published, go to IRS.gov/Form1094B and IRS.gov/Form1095B.
+
+What's New
+
+Extension of due date for furnishing statements. The due date for furnishing Form 1095-B to individuals is extended from January 31, 2022, to March 2, 2022. See Proposed Regulations section 1.6055-1(g) and Extension of time to furnish statement to recipients, later. A provider of minimum essential coverage will be treated as timely furnishing Form 1095-B to individuals if the form is made available through the provider's website and certain conditions are met. See Proposed Regulations section 1.6055-1(g) and Alternative manner of furnishing statements, later.
+
+Additional Information
+
+For information relating to the Affordable Care Act, visit IRS.gov/ACA.
+
+For the final regulations relating to Form 1095-B reporting, see T.D. 9660, 2014-13 I.R.B. at IRS.gov/IRB/2014-13_IRB/AR08.html.
+
+For additional guidance and proposed regulatory changes relating to Form 1095-B reporting, including clarifications regarding the reporting requirements for providers of minimum essential coverage and the requirement to solicit the TIN of each covered individual for purposes of the reporting of health coverage information, see Proposed Regulations section 1.6055-1(h) and Regulations section 301.6724-1.
+
+For additional information relating to reporting by Providers of Minimum Essential Coverage, go to IRS.gov/Affordable-Care-Act/Employers/
+Information-Reporting-by-Providers-of-
+Minimum-Essential-Coverage.
+
+For information relating to filing Forms 1094-B and 1095-B electronically, visit IRS.gov/For-Tax-Pros/
+Software-Developers/Information-
+Returns/Affordable-Care-Act-Information-
+Return-Air-Program.
+
+General Instructions for Forms
+1094-B and 1095-B
+
+Purpose of Form
+
+Form 1095-B is used to report certain information to the IRS and to taxpayers about individuals who are covered by minimum essential coverage. Eligibility for certain types of minimum essential coverage can affect a taxpayer's eligibility for the premium tax credit.
+
+Minimum essential coverage includes government-sponsored programs, eligible employer-sponsored plans, individual market plans, and other coverage the Department of Health and Human Services designates as minimum essential coverage. Minimum essential coverage is described in more detail under Who Must File, later.
+
+TIP Minimum essential coverage doesn't include coverage consisting solely of excepted benefits. Excepted benefits include vision and dental coverage not part of a comprehensive health insurance plan, workers' compensation coverage, and coverage limited to a specified disease or illness.
+
+Who Must File
+
+Every person that provides minimum essential coverage to an individual during a calendar year must file an information return reporting the coverage. Filers will use Form 1094-B (transmittal) to submit Forms 1095-B (returns).
+
+Employers (including government employers) subject to the employer shared responsibility provisions sponsoring self-insured group health plans, including individual coverage HRAs, will generally report information about the coverage in Part III of Form 1095-C instead of on Form 1095-B. However, employers that offer employer-sponsored self-insured health coverage to nonemployees who enroll in the coverage may use Form 1095-B, rather than Form 1095-C, Part III, to report coverage for those individuals and other family members. In general, employers with 50 or more full-time employees (including full-time equivalent employees) during the prior calendar year are subject to the employer shared responsibility provisions. See the Instructions for Forms 1094-C and 1095-C for more information about who must file Forms 1094-C and 1095-C and for more information about reporting coverage for nonemployees. Small employers that aren't subject to the employer shared responsibility provisions sponsoring self-insured group health plans will use Forms 1094-B and 1095-B to report information about covered individuals.
+
+Insured coverage. Health insurance issuers and carriers must file Form 1095-B for most health insurance coverage, including individual market coverage and insured coverage sponsored by employers. However, health insurance issuers and carriers don't report coverage under the Children's Health Insurance Program (CHIP), Medicaid, Medicare (including Medicare Advantage), or the Basic Health Program provided through health insurance companies. These types of coverage are reported by the government sponsors of those programs.
+
+In addition, health insurance issuers and carriers aren't required to file Form 1095-B to report coverage in individual market qualified health plans that individuals enroll in through Health Insurance Marketplaces. This coverage is generally reported by Marketplaces on Form 1095-A. However, health insurance issuers are required to file Form 1095-B to report on coverage for employees obtained through the Small Business Health Options Program (SHOP). For coverage in 2024 (filing in 2022), health insurance issuers and carriers are encouraged (but not required) to report coverage in catastrophic health plans enrolled in through the Marketplace.
+
+<Page 2>
+
+Eligible Employer-Sponsored Plans
+
+Eligible employer-sponsored plans are minimum essential coverage and include the following.
+
+1. Group health insurance coverage for employees under the following.
+a. A governmental plan, such as the Federal Employees Health Benefits program.
+b. An insured plan or coverage offered in the small or large group market within a state.
+c. A grandfathered health plan offered in a group market.
+2. A self-insured group health plan for employees. Generally, an HRA, including an individual coverage HRA, is a self-insured group health plan.
+
+As noted earlier, minimum essential coverage doesn't include coverage consisting solely of excepted benefits. Excepted benefits include vision and dental coverage not part of a comprehensive health insurance plan, workers compensation coverage, and coverage limited to a specified disease or illness.
+
+Health insurance issuers or carriers will file Form 1095-B for all insured employer coverage. Plan sponsors are responsible for reporting self-insured employer coverage. Plan sponsors that are employers subject to the employer shared responsibility provisions must generally report the coverage on Form 1095-C and other plan sponsors (such as employers not subject to the employer shared responsibility provisions and sponsors of multiemployer plans) report the coverage on Form 1095-B.
+
+Plan sponsors of self-insured employer coverage include:
+
+� Each participating employer (for its own covered individuals) in a plan or arrangement established or maintained by more than one employer;
+� The association, committee, joint board of trustees, or similar group of representatives who establish or maintain a multiemployer plan;
+� The employee organization for a plan or arrangement maintained solely by an employee organization; and
+� Each participating employer (for its own employees) for a plan or arrangement maintained by a Multiple Employer Welfare Arrangement.
+
+A government employer may designate another government entity to report coverage of its employees. Generally, a designated government entity will file Form 1095-B on behalf of a government employer that sponsors or maintains a self-insured group health plan for its employees only if that government employer isn't subject to the employer shared responsibility provisions, which would require reporting on Form 1095-C. The Instructions for Forms 1094-C and 1095-C contain further information on reporting options for government entities.
+
+Government-Sponsored Programs
+
+The following government-sponsored programs are minimum essential coverage.
+
+1. Medicare Part A.
+2. Medicaid, except for the following programs.
+a. Optional coverage of family planning services.
+b. Optional coverage of tuberculosis-related services.
+c. Coverage of pregnancy-related services.
+d. Coverage of medical emergency services.
+e. Coverage of medically needy individuals.
+f. Coverage of COVID-19 testing and diagnostic services.
+3. The Children's Health Insurance Program (CHIP).
+4. The TRICARE program, except for the following options.
+a. Coverage on a space-available basis in a military treatment facility for individuals who aren't eligible for TRICARE coverage for private sector care.
+b. Coverage for a line-of-duty-related injury, illness, or disease for individuals who have left active duty.
+5. Coverage administered by the Department of Veterans Affairs that is:
+a. Coverage consisting of the medical benefits package for eligible veterans,
+b. CHAMPVA, or
+c. Comprehensive health care for children suffering from spina bifida who are the children of Vietnam veterans and veterans of covered service in Korea.
+6. Coverage for Peace Corps volunteers.
+7. The Nonappropriated Fund Health Benefits Program of the Department of Defense.
+
+In general, the government agency sponsoring the program will file Form 1095-B. The state agency that administers a Medicaid or CHIP program will file Form 1095-B for coverage under those programs. However, Medicaid and CHIP agencies in U.S. possessions or territories (American Samoa, the Commonwealth of the Northern Mariana Islands, Guam, Puerto Rico, and the U.S. Virgin Islands) aren't required to report Medicaid or CHIP coverage on Form 1095-B.
+
+When coverage under the Nonappropriated Fund Health Benefits Program of the Department of Defense or TRICARE is reported on Form 1095-B, Part I, line 8, filers should use code C (government-sponsored program).
+
+Coverage designated as minimum essential coverage. The Department of Health and Human Services has designated the following health benefit plans or arrangements as minimum essential coverage.
+
+1. Medicare Part C (Medicare Advantage).
+2. Refugee Medical Assistance.
+3. Coverage provided to a business owner under a plan that is eligible employer-sponsored coverage with respect to at least one employee.
+4. Coverage under a group health plan provided through insurance regulated by a foreign government if:
+a. A covered individual is physically absent from the United States for at least 1 day during the month, or
+b. A covered individual is physically present in the United States for a full month and the coverage provides health benefits within the United States while the individual is outside the United States.
+5. The Basic Health Program.
+6. Coverage of pregnancy-related services that consists of full Medicaid benefits.
+7. Coverage under a section 1115 demonstration waiver program.
+8. Specific programs listed at CMS.gov/CCIIO/Programs-and-Initiatives/Health-Insurance-Market-Reforms/Minimum-Essential-Coverage.html (click on the link for "approved plans").
+
+Providers of these and later designated programs will file Form 1095-B. The sponsor for the Basic Health Program is the state government agency administering the program.
+
+<Page 3>
+
+Coverage in More Than One Minimum Essential Coverage Plan or Program
+
+If, for any month, an individual is covered by more than one minimum essential coverage plan or program that is provided by the same provider, the provider is required to report only one of the plans or programs for that month. For example, if an individual is covered by a self-insured major medical plan and a health reimbursement arrangement (HRA) provided by the same employer for a month, the employer is the provider of both types of coverage and therefore is required to report the coverage of the individual under only one of the arrangements for that month.
+
+Generally, reporting is also not required for an individual's minimum essential coverage for a month if that minimum essential coverage is offered only to individuals who are also covered by other minimum essential coverage for which reporting is required. For example, an insurance company offering a Medicare or TRICARE supplement for which only individuals enrolled in Medicare or TRICARE are eligible is not required to report coverage under the Medicare or TRICARE supplement.
+
+Under this rule, a state Medicaid agency is not required to report Medicaid coverage for which only individuals enrolled in other minimum essential coverage, such as employer-sponsored coverage or a qualified health plan, are eligible.
+
+This second rule applies to eligible employer-sponsored coverage only if both types of coverage (the supplemental coverage and the eligible employer-sponsored coverage for which section 6055 reporting is required) are offered by the same employer. For example, if an employer offers both an insured group health plan and an HRA that an employee is eligible for if the employee enrolls in the insured group health plan, and an employee enrolls in both, the employer is not required to report the employee's coverage under the HRA for the months in which the employee is enrolled in both plans. If, however, an individual is covered by an HRA sponsored by one employer, including an individual coverage HRA, and a non-HRA group health plan sponsored by another employer (such as spousal coverage) or an individual is covered by an individual coverage HRA, each employer (or the health insurance issuer or carrier, if the plan is insured) must report the coverage the employer (or issuer or carrier) provides.
+
+For more information on the reporting of supplemental coverage, including the rule on when different entities are treated as a single employer for purposes of the second rule, see Proposed Regulations section 1.6055-1(d)(2) and (3).
+
+When To File
+
+Generally, the return and transmittal form must be filed with the IRS on or before February 28 if filing on paper (March 31 if filing electronically) of the year following the calendar year of coverage.
+
+You will meet the requirement to file if the form is properly addressed and mailed on or before the due date. If the regular due date falls on a Saturday, Sunday, or legal holiday, file by the next business day. A business day is any day that isn't a Saturday, Sunday, or legal holiday.
+
+For forms filed in 2022 reporting coverage provided in calendar year 2024, Forms 1094-B and 1095-B are required to be filed by February 28, 2022, or March 31, 2022, if filing electronically.
+
+See Statements Furnished to Individuals, later, for information on when Form 1095-B must be furnished.
+
+Extension of Time To File
+
+You can get an automatic 30-day extension of time to file by completing Form 8809 and filing it with the IRS on or before the due date for the Forms 1094-B and 1095-B. Form 8809 may be submitted on paper or through the FIRE System either as a fill-in form or an electronic file. No signature or explanation is required for the extension. However, you must file Form 8809 by the due date of the returns in order to get the 30-day extension. Under certain hardship conditions, you may apply for an additional 30-day extension. See Form 8809 and its instructions for more information about extensions of time to file.
+
+How to apply. File Form 8809 as soon as you know that a 30-day extension of time to file is needed. Follow the instructions on Form 8809, which provide information on where to fax or mail your Form 8809. You can also submit the extension request online through the FIRE System. You are encouraged to submit requests using the online fill-in form. See Pub. 1220 for more information on filing online or electronically. See the instructions for Form 8809 for more information.
+
+Where To File
+
+Send all information returns filed on paper to the following.
+
+If your principal business, office or agency, or legal residence in the case of an individual, is located in: Alabama, Arizona, Arkansas, Connecticut, Delaware, Florida, Georgia, Kentucky, Louisiana, Maine, Massachusetts, Mississippi, New Hampshire, New Jersey, New Mexico, New York, North Carolina, Ohio, Pennsylvania, Rhode Island, Texas, Vermont, Virginia, West Virginia
+Use the following address:
+Department of the Treasury
+Internal Revenue Service Center
+Austin, TX 73301
+If your principal business, office or agency, or legal residence in the case of an individual, is located in: Alaska, California, Colorado, District of Columbia, Hawaii, Idaho, Illinois, Indiana, Iowa, Kansas, Maryland, Michigan, Minnesota, Missouri, Montana, Nebraska, Nevada, North Dakota, Oklahoma, Oregon, South Carolina, South Dakota, Tennessee, Utah, Washington, Wisconsin, Wyoming
+Use the following address:
+Department of the Treasury
+Internal Revenue Service Center
+P.O. Box 219256
+Kansas City, MO 64121-9256
+
+If your legal residence or principal place of business or principal office or agency is outside the United States, file with the Department of the Treasury, Internal Revenue Service Center, Austin, TX 73301.
+
+How To File
+
+Filing Paper Returns With the IRS
+
+Shipping and mailing. If you're filing on paper, send the forms to the IRS in a flat mailing (not folded) and don't staple or paperclip the forms together. If you're sending many forms, you may send them in conveniently sized packages. On each package, write your name, and number the packages consecutively. Place Form 1094-B in package number one and a copy of Form 1094-B in each additional package. Postal
+
+<Page 4>
+
+regulations require forms and packages to be sent by first-class mail. Returns filed with the IRS must be printed in landscape format.
+
+Keeping copies. Generally, keep copies of information returns you filed with the IRS or maintain the ability to reconstruct the data for at least 3 years, from the due date of the returns.
+
+IRS e-file If you're required to file 250 or more information returns, you must file electronically. The 250-or-more requirement applies separately to each type of form filed and separately for original and corrected returns. For example, if you must file 500 Forms 1095-B and 100 Forms 1095-C, you must file Forms 1095-B electronically, but you aren't required to file Forms 1095-C electronically. As another example, if you have 150 Forms 1095-B to correct, you may file the corrected returns on paper because they fall under the 250 threshold even if you originally filed 250 or more Forms 1095-B and properly filed those forms electronically. If you have 300 Forms 1095-B to correct, they must be filed electronically. The electronic filing requirement doesn't apply if you apply for and receive a hardship waiver. The IRS encourages you to file electronically even if you're filing fewer than 250 returns.
+
+Waiver. To receive a waiver from the required filing of information returns electronically, submit Form 8508. You are encouraged to file Form 8508 at least 45 days before the due date of the return but no later than the due date of the return. The IRS doesn't process waiver requests until January 1 of the calendar year the returns are due. You can't apply for a waiver for more than 1 tax year at a time. If you need a waiver for more than 1 tax year, you must reapply at the appropriate time each year. An approved waiver for original returns will cover corrections only for the same type of return. If you receive an approved waiver, don't send a copy of it to the service center where you file your paper returns. Keep the waiver for your records only.
+
+If you are required to file electronically but fail to do so, and you don't have an approved waiver, you may be subject to a penalty of up to $280 per return unless you establish reasonable cause. However, you can file up to 250 returns on paper; those returns will not be subject to a penalty for failure to file electronically. The penalty applies separately to original returns and corrected returns.
+
+Pub. 5165, Guide for Electronically Filing Affordable Care Act (ACA) Information Returns for Software Developers and Transmitters, specifies the communication procedures, transmission formats, business rules, and validation procedures, and explains when a return will be accepted, accepted with errors, or rejected for returns filed electronically for calendar year 2024 through the ACA Information Return (AIR) system. To develop software for use with the AIR system, software developers, transmitters, and issuers, including employers filing their own Forms 1094-B and 1095-B, should use the guidelines provided in Pub. 5165, along with the Extensible Markup Language (XML) Schemas published on IRS.gov.
+
+Reminder. The formatting directions in these instructions are for the preparation of paper returns. When filing forms electronically, the formatting set forth in the XML Schemas and Business Rules published on IRS.gov must be followed rather than the formatting directions in these instructions. For more information regarding electronic filing, see Pubs. 5164 and 5165.
+
+Substitute Returns Filed With the IRS
+
+See Pub. 5223, General Rules and Specifications for Affordable Care Act Substitute Forms 1095-A, 1094-B, 1095-B, 1094-C, and 1095-C, for specifications for private printing of substitute information returns. You may not request special consideration.
+
+Only forms that conform to the official form and the specifications in Pub. 5223 are acceptable for filing with the IRS. Substitute returns filed with the IRS must be printed in landscape format.
+
+Void Box
+
+Don't use this box on Form 1095-B.
+
+Corrected Form 1095-B
+
+For information about filing corrections for electronically filed forms, see section 7.1 of Pub. 5165. A corrected return should be filed as soon as possible after an error is discovered. File corrected returns as follows.
+
+� Form 1095-B: Fully complete Form 1095-B and enter an "X" in the CORRECTED checkbox. File a Form 1094-B Transmittal with the corrected Forms 1095-B. (Do not file a corrected Form 1094-B.)
+� Recipient's statement: A copy of the corrected Form 1095-B must be furnished to the individual who received the original Form 1095-B.
+
+Note. Enter an "X" in the CORRECTED checkbox only when correcting a Form 1095-B previously filed with the IRS. If you are correcting a Form 1095-B that was previously furnished to a recipient, but not filed with the IRS, write, print, or type "CORRECTED" on the new Form 1095-B furnished to the recipient.
+
+TIP See the next chart for examples of errors and step-by-step instructions for filing corrected returns.
+
+Original Form 1095-B Filed With the IRS and Furnished to the Recipient
+
+IF any of the following are incorrect ...
+Name of responsible individual (Part I)
+Origin of the Health Coverage (Part I)
+Social security number (SSN) or taxpayer identification number (TIN) (Part I)
+Information About Certain Employer-Sponsored Coverage (Part II)
+Issuer or Other Coverage Provider (Part III)
+Covered Individuals (Part IV)
+THEN ...
+1. Fully complete a new Form 1095-B and enter an "X" in the CORRECTED checkbox.
+2. File a Form 1094-B Transmittal with the corrected Form 1095-B.
+3. Furnish a copy of the corrected Form 1095-B to the person identified as the responsible individual.
+
+CAUTION! You must file a corrected return to report retroactive changes in coverage.
+
+Example 1. Tim enrolls in health insurance with Ace Insurance Company in January 2024. Tim fails to pay his premiums for November and December 2024 and January 2022. Ace sends Tim a Form 1095-B on January 31, 2022, reporting coverage for every month in 2024. On February 1, 2022, Ace cancels Tim's coverage effective November 1, 2024. Ace must
+
+<Page 5>
+
+send Tim a corrected Form 1095-B reporting that Tim was covered only for January through October 2024. If Ace filed the Form 1095-B with the IRS, it must file a corrected Form 1095-B with the IRS reporting coverage only for January through October 2024.
+
+Example 2. Sharon is enrolled in Medicaid for January through September 2024. The Medicaid agency files a Form 1095-B and furnishes a statement to Sharon reporting coverage for January through September 2024. In April 2022, Sharon is approved for Medicaid coverage beginning on November 1, 2024. The Medicaid agency must file a corrected Form 1095-B with the IRS and furnish Sharon a corrected statement reporting coverage for January through September and November through December 2024.
+
+Statements Furnished to Individuals
+
+Filers of Form 1095-B must furnish a copy by March 2, 2022, to the person identified as the "responsible individual" on the form for coverage in 2024. However, a provider of minimum essential coverage will be treated as timely furnishing Form 1095-B to individuals if the form is made available through the provider's website and certain conditions are met. See Proposed Regulations section 1.6055-1(g) and Alternative manner of furnishing statements, later.
+
+The "responsible individual" is the person who, based on a relationship to the covered individuals, the primary name on the coverage, or some other circumstances, should receive the statement. Generally, the statement recipient should be the taxpayer (tax filer) who would be liable for the individual shared responsibility payment for the covered individuals, if that person is known. A statement recipient may be a parent if only minor children are covered individuals, a primary subscriber for insured coverage, an employee or former employee in the case of employer-sponsored coverage, a uniformed services sponsor for TRICARE, or another individual who should receive the statement. Filers may, but aren't required to, furnish a statement to more than one recipient.
+
+Copies of Form 1095-B furnished to recipients may include a truncated SSN or other TIN, if applicable, of the statement recipient and covered individuals by showing only the last four digits of the SSN or other TIN and replacing the first five digits with asterisks (*) or Xs. Copies of Form 1095-B furnished to recipients may also truncate the EIN of an employer reported in Part II, if any. The filer's EIN may not be truncated on the statement furnished to recipients. Truncation of TINs, including EINs, is not allowed on returns filed with the IRS.
+
+In general, statements must be furnished on paper by mail (or hand delivered), unless the recipient affirmatively consents to receive the statement in an electronic format. If mailed, the statement must be sent to the recipient's last known permanent address, or, if no permanent address is known, to the recipient's temporary address.
+
+Alternative manner of furnishing statements. A provider of minimum essential coverage will be treated as timely furnishing Form 1095-B to individuals if the provider uses the alternative manner of furnishing statements described in Proposed Regulations section 1.6055-1(g). If the provider is an applicable large employer (as defined under Treasury Regulations section 54.4980H-1(a)(4)) that offers employer-sponsored self-insured health coverage, the employer may use the alternative manner of furnishing for statements to non-full-time employees and nonemployees who are enrolled in the self-insured health coverage. See Who Must File, earlier. To use the alternative manner of furnishing statements, the following conditions must be met.
+
+� The provider must provide clear and conspicuous notice, in a location on its website that is reasonably accessible to all responsible individuals, stating that responsible individuals may receive a copy of their statement upon request. The notice must include an email address, a physical address to which a request for a statement may be sent, and a telephone number that responsible individuals may use to contact the provider with any questions. A notice posted on a provider's website must be written in plain, non-technical terms and with letters of a font size large enough, including any visual clues or graphical figures, to call to a viewer's attention that the information pertains to tax statements reporting that individuals had health coverage. For example, a provider's website provides a clear and conspicuous notice if it (1) includes a statement on the main page�or a link on the main page, reading "Tax Information," to a secondary page that includes a statement�in capital letters, "IMPORTANT HEALTH COVERAGE TAX DOCUMENTS"; (2) explains how responsible individuals may request a copy of Form 1095-B, Health Coverage, (or, for an applicable large employer member that sponsors a self-insured group health plan and makes a return in accordance with Regulations section 1.6055-1(f)(2)(i), explains how non-full-time employees and nonemployees who are enrolled in the plan may request a copy of Form 1095-C, Employer-Provided Health Insurance Offer and Coverage); and (3) includes the provider's email address, mailing address, and telephone number.
+� The provider must retain the notice in the same location on its website through October 17, 2022.
+� The provider must furnish the statement to a requesting responsible individual within 30 days of the date the request is received. To satisfy this requirement, the provider may furnish the statement electronically if the recipient affirmatively consents.
+
+Consent to furnish statement electronically. Except as provided below, a filer is required to obtain affirmative consent to furnish a statement electronically. The requirement to obtain affirmative consent to furnish a statement electronically ensures that statements are sent electronically only to individuals who are able to access them. The consent must relate specifically to receiving Form 1095-B electronically. A recipient may consent on paper or electronically, such as by email. If consent is on paper, the recipient must confirm the consent electronically. A statement may be furnished electronically by email or by informing the recipient how to access the statement on the filer's website. Statements reporting coverage under an expatriate health plan, however, may be furnished electronically unless the recipient has explicitly refused to consent to receive the statement in an electronic format.
+
+Extension of time to furnish statement to recipients. The due date for furnishing Form 1095-B is automatically extended from January 31, 2022, to March 2, 2022. Thus, no additional extensions will be granted.
+
+Substitute Statements to Recipients
+
+If you aren't using the official IRS form to furnish statements to recipients, see Pub. 5223, which explains the requirements for format and content of substitute statements to recipients. You may develop them yourself or buy them from a private printer.
+
+Information Reporting Penalties
+
+A provider of minimum essential coverage that fails to comply with the information reporting requirements may be subject to the general information reporting penalty provisions for failure to file correct information returns and failure to furnish correct payee statements. For returns required to be made and
+
+<Page 6>
+
+statements required to be furnished for 2024 tax year returns, the following apply.
+
+� The penalty for failure to file a correct information return is $280 for each return for which the failure occurs, with the total penalty for a calendar year not to exceed $3,426,000.
+� The penalty for failure to provide a correct payee statement is $280 for each statement for which the failure occurs, with the total penalty for a calendar year not to exceed $3,426,000.
+� Special rules apply that increase the per-return and per-statement and total penalties with no maximum limitations if there is intentional disregard of the requirement to file the returns and furnish recipient statements.
+
+Waiver of Penalties
+
+The penalties may be waived if the failure was due to reasonable cause and not willful neglect. See section 6724, Regulations section 301.6724-1, and Proposed Regulations section 1.6055-1(h). For additional information, see Pub. 1586.
+
+Specific Instructions for Form 1094-B
+
+Line 1. Enter the filer's complete name.
+
+Line 2. Enter the filer's nine-digit employer identification number (EIN). If you don't have an EIN, you may apply for one online at IRS.gov/EIN. You may also apply by faxing or mailing Form SS-4, Application for Employer Identification Number, to the IRS. See the Instructions for Form SS-4 and Pub. 1635 for more information.
+
+Lines 3 and 4. Enter the name and telephone number, including area code, of the person to contact who is responsible for answering any questions from the IRS regarding the filing of or information reported on Form 1094-B or 1095-B.
+
+Lines 5-8. Enter the filer's complete address where all correspondence will be sent. If mail is delivered to a P.O. box and not a street address, enter the box number instead of the street address.
+
+Line 9. Enter the total number of Forms 1095-B that are transmitted with Form 1094-B.
+
+Specific Instructions for Form 1095-B
+
+Part I�Responsible Individual
+
+Line 1. Enter the name of the responsible individual (statement recipient). See the description of who is a "responsible individual" in Statements Furnished to Individuals, earlier.
+
+Line 2. Enter the nine-digit social security number (SSN) of the responsible individual (111-11-1111). If the responsible individual doesn't have an SSN, enter the responsible individual's other TIN. No SSN or other TIN is required if the responsible individual isn't a covered individual identified in Part IV. See Statements Furnished to Individuals, earlier, for information on truncating the SSN or other TIN.
+
+Line 3. Enter the responsible individual's date of birth (YYYY/MM/DD) only if line 2 is blank.
+
+Lines 4-7. Enter the complete mailing address of the responsible individual. If mail isn't delivered to the street address and the responsible individual has a P.O. box, enter the box number instead of the street address.
+
+Line 8. Enter the letter identifying the Origin of the Health Coverage. See Who Must File, earlier, to determine which types of coverage fall under each category listed below.
+
+A. Small Business Health Options Program (SHOP).
+B. Employer-sponsored coverage, except for an individual coverage HRA.
+C. Government-sponsored program.
+D. Individual market insurance.
+E. Multiemployer plan.
+F. Other designated minimum essential coverage.
+G. Employer-sponsored coverage that is an individual coverage HRA.
+
+Line 9. For 2024, leave this line blank.
+
+Part II�Information About Certain Employer-Sponsored Coverage
+
+This part is completed only by issuers or carriers of insured group health plans, including coverage purchased through the SHOP.
+
+TIP Insurance companies entering code A or B on line 8 will complete Part II. Employers reporting self-insured group health plan coverage on Form 1095-B, except for an individual coverage HRA, enter code B on line 8, but don't complete Part II. If you entered code B for self-insured coverage, skip Part II and go to Part III.
+
+Lines 10-15. Enter the name, EIN, and complete mailing address for the employer sponsoring the coverage. If mail isn't delivered to the street address and the employer has a P.O. box, enter the box number instead of the street address. See Statements Furnished to Individuals, earlier, for information on truncating the employer's EIN. If the employer is a member of a controlled group, enter information for the specific controlled group member that is the covered employee's employer. If the coverage is provided through an association or a Multiple Employer Welfare Arrangement, enter information for the participating employer of the covered employee. Don't complete Part II if the coverage is provided through a multiemployer plan.
+
+Part III�Issuer or Other Coverage Provider
+
+Lines 16-22. Enter your name, EIN, and complete mailing address. The provider of the coverage is the issuer or carrier of insured coverage, sponsor of a self-insured employer plan, government agency providing government-sponsored coverage, or other coverage sponsor. Enter on line 18 the telephone number that an individual seeking additional information may call to speak to a person.
+
+Part IV�Covered Individuals
+
+Column (a). Enter the name of each covered individual.
+
+Column (b). Enter the nine-digit SSN or other TIN for each covered individual (111-11-1111). The field may be left blank if the covered individual doesn't have a TIN. See Statements Furnished to Individuals, earlier, for information on truncating the SSN or other TIN.
+
+Column (c). Enter a date of birth (YYYY/MM/DD) for the covered individual only if an SSN or other TIN isn't entered in column (b).
+
+Column (d). Check this box if the individual was covered for at least 1 day per month for all 12 months of the calendar year.
+
+Column (e). If the individual wasn't covered for all 12 months, check the applicable box(es) for the months in which the individual was covered for at least 1 day.
+
+If there are more than six covered individuals, complete this information for the additional covered individuals on Part IV, Continuation Sheet(s). Do not count the continuation sheet(s) as additional Forms 1095-B in the count of forms submitted with the accompanying Form 1094-B.
+
+<Page 7>
+
+Privacy Act and Paperwork Reduction Act Notice. We ask for the information on these forms to carry out the Internal Revenue laws of the United States and the Patient Protection and Affordable Care Act. Our legal right to ask for the information on this form is Internal Revenue Code section 6055 and its regulations. Providing false or fraudulent information may subject you to penalties. We may disclose this information to the Department of Justice for civil or criminal investigation, and to cities, states, and the District of Columbia for use in administering their tax laws. We may also disclose this information to other countries under a tax treaty, to federal and state agencies to enforce federal nontax criminal laws, or to federal law enforcement and intelligence agencies to combat terrorism.
+
+You aren't required to provide the information requested on a form that is subject to the Paperwork Reduction Act unless the form displays a valid OMB control number. Books or records relating to a form or its instructions must be retained as long as their contents may become material in the administration of any Internal Revenue law. Generally, tax returns and return information are confidential, as required by section 6103.
+
+The time needed to complete the following forms will vary depending on individual circumstances. The estimated average time is:
+
+Form 1094-B 10 min.
+
+Form 1095-B 1 min.
+
+If you have comments concerning the accuracy of these time estimates or suggestions for making this form simpler, we would be happy to hear from you. You can send us comments from IRS.gov/FormComments. Or you can write to the Internal Revenue Service, Tax Forms and Publications Division, 1111 Constitution Ave. NW, IR-6526, Washington, DC 20224. Don't send the form to this office.

--- a/spec/models/form1095_b_spec.rb
+++ b/spec/models/form1095_b_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Form1095B, type: :model do
       let(:inv_year_form) { create(:form1095_b, veteran_icn: '654678976543678', tax_year: 2008) }
 
       it 'fails if no template PDF for the tax_year' do
-        expect { inv_year_form.pdf_file }.to raise_error(RuntimeError, /1095-B for tax year 2008 not supported/)
+        expect { inv_year_form.pdf_file }.to raise_error(Common::Exceptions::UnprocessableEntity)
       end
     end
   end
@@ -63,7 +63,7 @@ RSpec.describe Form1095B, type: :model do
       let(:inv_year_form) { create(:form1095_b, veteran_icn: '654678976543678', tax_year: 2008) }
 
       it 'fails if no template txt file for the tax_year' do
-        expect { inv_year_form.txt_file }.to raise_error(RuntimeError, /1095-B for tax year 2008 not supported/)
+        expect { inv_year_form.txt_file }.to raise_error(Common::Exceptions::UnprocessableEntity)
       end
     end
   end

--- a/spec/models/form1095_b_spec.rb
+++ b/spec/models/form1095_b_spec.rb
@@ -78,7 +78,9 @@ RSpec.describe Form1095B, type: :model do
     end
 
     it 'returns available forms in descending order by tax year' do
-      expect(Form1095B.available_forms(multi_search_form_1.veteran_icn)).to eq([multi_search_form_1, multi_search_form_2, multi_search_form_3])
+      expect(Form1095B.available_forms(multi_search_form_1.veteran_icn)).to eq(
+        [multi_search_form_1, multi_search_form_2, multi_search_form_3]
+      )
     end
 
     it 'expects empty array if no available forms exist' do

--- a/spec/models/form1095_b_spec.rb
+++ b/spec/models/form1095_b_spec.rb
@@ -73,21 +73,12 @@ RSpec.describe Form1095B, type: :model do
     let!(:multi_search_form_1) { create(:form1095_b, veteran_icn: '123456787654321') }
     let!(:multi_search_form_3) { create(:form1095_b, veteran_icn: '123456787654321', tax_year: 2019) }
 
-    let(:expected_val_1) { [[subject.tax_year, subject.updated_at]] }
-    let(:expected_val_2) do
-      [
-        [multi_search_form_1.tax_year, multi_search_form_1.updated_at],
-        [multi_search_form_2.tax_year, multi_search_form_2.updated_at],
-        [multi_search_form_3.tax_year, multi_search_form_3.updated_at]
-      ]
-    end
-
     it 'returns individual available form' do
-      expect(Form1095B.available_forms(subject.veteran_icn)).to eq(expected_val_1)
+      expect(Form1095B.available_forms(subject.veteran_icn)).to eq([subject])
     end
 
     it 'returns available forms in descending order by tax year' do
-      expect(Form1095B.available_forms(multi_search_form_1.veteran_icn)).to eq(expected_val_2)
+      expect(Form1095B.available_forms(multi_search_form_1.veteran_icn)).to eq([multi_search_form_1, multi_search_form_2, multi_search_form_3])
     end
 
     it 'expects empty array if no available forms exist' do

--- a/spec/requests/v0/form1095_bs_spec.rb
+++ b/spec/requests/v0/form1095_bs_spec.rb
@@ -99,7 +99,8 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
       last_tax_year_form = create(:form1095_b, tax_year: last_year)
       get '/v0/form1095_bs/available_forms'
       expect(response.body).to eq(
-        { available_forms: [{ year: last_tax_year_form.tax_year, last_updated: last_tax_year_form.updated_at }] }.to_json
+        { available_forms: [{ year: last_tax_year_form.tax_year,
+                              last_updated: last_tax_year_form.updated_at }] }.to_json
       )
     end
   end

--- a/spec/requests/v0/form1095_bs_spec.rb
+++ b/spec/requests/v0/form1095_bs_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
 
   let(:user) { build(:user, :loa3, icn: subject.veteran_icn) }
   let(:invalid_user) { build(:user, :loa1, icn: subject.veteran_icn) }
-  let(:user_without_form) { build(:user, :loa3, icn: '7832473474389') }
-  # let(:past_form) { create(:form1095_b, tax_year: 2010) }
 
   describe 'GET /download_pdf for valid user' do
     before do
@@ -28,6 +26,12 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
     it 'throws 404 when form not found' do
       get '/v0/form1095_bs/download_pdf/2018'
       expect(response).to have_http_status(:not_found)
+    end
+
+    it 'throws 422 when no template exists for requested year' do
+      create(:form1095_b, tax_year: 2018)
+      get '/v0/form1095_bs/download_pdf/2018'
+      expect(response).to have_http_status(:unprocessable_entity)
     end
   end
 
@@ -60,6 +64,12 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
     it 'throws 404 when form not found' do
       get '/v0/form1095_bs/download_txt/2018'
       expect(response).to have_http_status(:not_found)
+    end
+
+    it 'throws 422 when no template exists for requested year' do
+      create(:form1095_b, tax_year: 2018)
+      get '/v0/form1095_bs/download_txt/2018'
+      expect(response).to have_http_status(:unprocessable_entity)
     end
   end
 

--- a/spec/requests/v0/form1095_bs_spec.rb
+++ b/spec/requests/v0/form1095_bs_spec.rb
@@ -85,7 +85,8 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
     end
 
     it 'returns only the most recent tax year' do
-      last_tax_year_form = create(:form1095_b, tax_year: 2024)
+      last_year = Date.current.year - 1
+      last_tax_year_form = create(:form1095_b, tax_year: last_year)
       get '/v0/form1095_bs/available_forms'
       expect(response.body).to eq(
         { available_forms: [{ year: last_tax_year_form.tax_year, last_updated: last_tax_year_form.updated_at }] }.to_json

--- a/spec/requests/v0/form1095_bs_spec.rb
+++ b/spec/requests/v0/form1095_bs_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
   let(:user) { build(:user, :loa3, icn: subject.veteran_icn) }
   let(:invalid_user) { build(:user, :loa1, icn: subject.veteran_icn) }
   let(:user_without_form) { build(:user, :loa3, icn: '7832473474389') }
-  let(:past_form) { create(:form1095_b, tax_year: 2010) }
+  # let(:past_form) { create(:form1095_b, tax_year: 2010) }
 
   describe 'GET /download_pdf for valid user' do
     before do
@@ -84,10 +84,11 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
       expect(response).to have_http_status(:success)
     end
 
-    it 'returns last updated object' do
+    it 'returns only the most recent tax year' do
+      last_tax_year_form = create(:form1095_b, tax_year: 2024)
       get '/v0/form1095_bs/available_forms'
       expect(response.body).to eq(
-        { available_forms: [{ year: subject.tax_year, last_updated: subject.updated_at }] }.to_json
+        { available_forms: [{ year: last_tax_year_form.tax_year, last_updated: last_tax_year_form.updated_at }] }.to_json
       )
     end
   end


### PR DESCRIPTION

## Summary

- This work is behind a feature toggle (flipper): It is feature flagged on the front end. The endpoint is not currently in use.
- Adds new 2024 1095b text file
- Programmatically adds VA contact info to 1095b form
- limits available forms endpoint to only return most recent tax year

## Related issue(s)
https://github.com/department-of-veterans-affairs/va-iir/issues/1387

## Testing done

Specs.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Only impacts 1095b endpoints, which are not currently in use.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

