### PR TITLE
Rename COMPLETED status to PROCESSED and refactor claimant type handling

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
@@ -6,7 +6,7 @@ module AccreditedRepresentativePortal
       module Statuses
         ALL = [
           PENDING = 'pending',
-          COMPLETED = 'processed'
+          PROCESSED = 'processed'
         ].freeze
       end
 
@@ -31,7 +31,7 @@ module AccreditedRepresentativePortal
           case status
           when Statuses::PENDING
             rel.unresolved.order(created_at: :asc)
-          when Statuses::COMPLETED
+          when Statuses::PROCESSED
             rel.resolved.not_expired.order('resolution.created_at DESC')
           when NilClass
             rel

--- a/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_serializer.rb
+++ b/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/power_of_attorney_request_serializer.rb
@@ -6,16 +6,13 @@ module AccreditedRepresentativePortal
 
     attribute :power_of_attorney_form do |poa_request|
       poa_request.power_of_attorney_form.parsed_data.tap do |form|
-        claimant_key =
-          case poa_request.claimant_type
-          when PowerOfAttorneyRequest::ClaimantTypes::DEPENDENT
-            'dependent'
-          when PowerOfAttorneyRequest::ClaimantTypes::VETERAN
-            'veteran'
-          end
-
-        form['claimant'] = form.delete(claimant_key)
-        form.delete('dependent')
+        case poa_request.claimant_type
+        when PowerOfAttorneyRequest::ClaimantTypes::DEPENDENT
+          form['claimant'] = form.delete('dependent')
+        when PowerOfAttorneyRequest::ClaimantTypes::VETERAN
+          form['claimant'] = form.delete('veteran')
+          form.delete('dependent')
+        end
       end
     end
 


### PR DESCRIPTION
## Changes
- Renames the `COMPLETED` status to `PROCESSED` in the AccreditedRepresentativePortal statuses
- Updates corresponding case statement to use the new `PROCESSED` status
- Refactors the power of attorney request serializer to handle claimant type form field cleanup more consistently removing the "over-deletion" on dependent type.

## Why
This change improves code consistency by:
1. Using more accurate terminology (PROCESSED instead of COMPLETED)
2. Cleaning up redundunt logic