### PR TITLE
[API-44352] 526 v1 - Retry [417] error

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/claim_establisher.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/claim_establisher.rb
@@ -46,12 +46,21 @@ module ClaimsApi
     rescue ::ClaimsApi::Common::Exceptions::Lighthouse::BackendServiceException,
            ::Common::Exceptions::BackendServiceException => e
       handle_exception(auto_claim:, orig_form_data:, e:)
+      raise e if expectation_failed_error?(e)
     rescue => e
       handle_exception(auto_claim:, orig_form_data:, e:)
       raise e
     end
 
     private
+
+    def expectation_failed_error?(e)
+      error_messages = get_error_message(e)
+
+      return false if error_messages&.dig(:messages).nil?
+
+      error_messages[:messages].any? { |msg| msg[:text]&.include?('417') }
+    end
 
     def handle_exception(auto_claim:, orig_form_data:, e:)
       auto_claim.status = ClaimsApi::AutoEstablishedClaim::ERRORED

--- a/modules/claims_api/app/sidekiq/claims_api/claim_establisher.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/claim_establisher.rb
@@ -57,6 +57,8 @@ module ClaimsApi
     def expectation_failed_error?(e)
       error_messages = get_error_message(e)
 
+      return error_messages.include?('417') if error_messages.is_a?(String)
+
       return false if error_messages&.dig(:messages).nil?
 
       error_messages[:messages].any? { |msg| msg[:text]&.include?('417') }


### PR DESCRIPTION
## Summary

In ClaimEstablisherJob (only used in v1 526), raise an error when the EVSS Docker container fails with 417 Expectation Failed (thereby retrying the job where previously we did not).

## Related issue(s)

[API-44352](https://jira.devops.va.gov/browse/API-44352)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots

N/A

## What areas of the site does it impact?
ClaimEstablisherJob (v1 526)

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A