### PR TITLE
Remove remove-va_online_scheduling_appointment_type_consolidation feature toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1563,10 +1563,6 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle to remove Podiatry from the type of care list when scheduling an online appointment.
-  va_online_scheduling_appointment_type_consolidation:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle to enable appointment type consolidation logic.
   va_v2_person_service:
     actor_type: user
     description: When enabled, the VAProfile::V2::Person::Service will be enabled

--- a/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointment.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointment.rb
@@ -80,8 +80,7 @@ module Mobile
 
         attr_reader :appointment
 
-        def initialize(user, appointment)
-          @user = user
+        def initialize(appointment)
           @appointment = appointment
         end
 
@@ -279,11 +278,7 @@ module Mobile
           when VAOS::V2::AppointmentsService::APPOINTMENT_TYPES[:va]
             convert_va_appointment_type
           when VAOS::V2::AppointmentsService::APPOINTMENT_TYPES[:request]
-            if Flipper.enabled?(:va_online_scheduling_appointment_type_consolidation, @user)
-              APPOINTMENT_TYPES[:va]
-            else
-              appointment[:type]
-            end
+            APPOINTMENT_TYPES[:va]
           else
             appointment[:type]
           end

--- a/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointments.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointments.rb
@@ -11,10 +11,6 @@ module Mobile
       #   Mobile::V0::Adapters::VAOSV2Appointments.new.parse(appointments)
       #
       class VAOSV2Appointments
-        def initialize(user)
-          @user = user
-        end
-
         # Takes a result set of VAOS v2 appointments from the appointments web service
         # and returns the set adapted to a common schema.
         #
@@ -26,7 +22,7 @@ module Mobile
           return [] if appointments.nil?
 
           appointments.map do |appointment_hash|
-            appointment_adapter = VAOSV2Appointment.new(@user, appointment_hash)
+            appointment_adapter = VAOSV2Appointment.new(appointment_hash)
             appointment_adapter.build_appointment_model
           end.compact
         end

--- a/modules/mobile/app/services/mobile/v2/appointments/proxy.rb
+++ b/modules/mobile/app/services/mobile/v2/appointments/proxy.rb
@@ -50,7 +50,7 @@ module Mobile
         end
 
         def vaos_v2_to_v0_appointment_adapter
-          Mobile::V0::Adapters::VAOSV2Appointments.new(@user)
+          Mobile::V0::Adapters::VAOSV2Appointments.new
         end
       end
     end

--- a/modules/mobile/spec/models/adapters/appointments_vaos_v2_adapter_spec.rb
+++ b/modules/mobile/spec/models/adapters/appointments_vaos_v2_adapter_spec.rb
@@ -21,7 +21,6 @@ describe Mobile::V0::Adapters::VAOSV2Appointments, :aggregate_failures do
   let(:past_request_date_appt_id) { '53360' }
   let(:future_request_date_appt_id) { '53359' }
   let(:telehealth_onsite_id) { '50097' }
-  let(:user) { build(:user) }
 
   def appointment_data(index = nil)
     appts = index ? raw_data[index] : raw_data
@@ -38,7 +37,7 @@ describe Mobile::V0::Adapters::VAOSV2Appointments, :aggregate_failures do
         appointment.delete(property)
       end
     end
-    Mobile::V0::Adapters::VAOSV2Appointments.new(user).parse(Array.wrap(appointment)).first
+    subject.parse(Array.wrap(appointment)).first
   end
 
   before do
@@ -50,11 +49,11 @@ describe Mobile::V0::Adapters::VAOSV2Appointments, :aggregate_failures do
   end
 
   it 'returns an empty array when provided nil' do
-    expect(Mobile::V0::Adapters::VAOSV2Appointments.new(user).parse(nil)).to eq([])
+    expect(subject.parse(nil)).to eq([])
   end
 
   it 'returns a list of Mobile::V0::Appointments at the expected size' do
-    adapted_appointments = Mobile::V0::Adapters::VAOSV2Appointments.new(user).parse(appointment_data)
+    adapted_appointments = subject.parse(appointment_data)
     expect(adapted_appointments.size).to eq(13)
     expect(adapted_appointments.map(&:class).uniq).to match_array(Mobile::V0::Appointment)
   end
@@ -134,16 +133,9 @@ describe Mobile::V0::Adapters::VAOSV2Appointments, :aggregate_failures do
   end
 
   describe 'appointment_type' do
-    context 'with appointment_type_consolidation flag on' do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:va_online_scheduling_appointment_type_consolidation,
-                                                  instance_of(User)).and_return(true)
-      end
-
-      it 'sets va requests to VA' do
-        appt = appointment_by_id(proposed_va_id)
-        expect(appt.appointment_type).to eq('VA')
-      end
+    it 'sets va requests to VA' do
+      appt = appointment_by_id(proposed_va_id)
+      expect(appt.appointment_type).to eq('VA')
     end
 
     it 'sets phone appointments to VA' do

--- a/modules/mobile/spec/requests/mobile/v0/facilities_info_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/facilities_info_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Mobile::V0::FacilitiesInfo', type: :request do
     va_path = Rails.root.join('modules', 'mobile', 'spec', 'support', 'fixtures',
                               'VAOS_v2_appointments_facilities.json')
     va_json = File.read(va_path)
-    va_appointments = Mobile::V0::Adapters::VAOSV2Appointments.new(user).parse(
+    va_appointments = Mobile::V0::Adapters::VAOSV2Appointments.new.parse(
       JSON.parse(va_json, symbolize_names: true)
     )
 


### PR DESCRIPTION
## Summary

- The production fix made in https://github.com/department-of-veterans-affairs/vets-api/pull/20427 has been fully deployed and verified in production. This PR removes the temporary feature toggle introduced for the deployment of the fix.
- Appointments (VAOS) Team is making the change but the ownership of the code is with the Mobile team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101846

## Testing done

- [x] Relevant unit tests were updated

## Screenshots
N/A

## What areas of the site does it impact?
Mobile 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
