### PR TITLE
Pre need module for address validation, skips user authentication

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,7 @@ require 'rails/test_unit/railtie'
 Bundler.require(*Rails.groups)
 
 require_relative '../lib/olive_branch_patch'
+require_relative '../modules/preneeds/lib/preneeds'
 
 module VetsAPI
   class Application < Rails::Application

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -459,6 +459,7 @@ Rails.application.routes.draw do
   # Modules
   mount AccreditedRepresentativePortal::Engine, at: '/accredited_representative_portal'
   mount AskVAApi::Engine, at: '/ask_va_api'
+  mount Preneeds::Engine, at: '/pre_need'
   mount Avs::Engine, at: '/avs'
   mount Burials::Engine, at: '/burials'
   mount CheckIn::Engine, at: '/check_in'

--- a/modules/preneeds/app/controllers/preneeds/application_controller.rb
+++ b/modules/preneeds/app/controllers/preneeds/application_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Preneeds
+  class ApplicationController < ::ApplicationController
+    service_tag 'preneeds'
+
+    private
+
+    def handle_exceptions
+      yield
+    rescue ErrorHandler::ServiceError, Crm::ErrorHandler::ServiceError => e
+      log_and_render_error('service_error', e, :unprocessable_entity)
+    rescue => e
+      log_and_render_error('unexpected_error', e, :internal_server_error)
+    end
+
+    def log_and_render_error(action, exception, status)
+      log_error(action, exception)
+      render json: { error: exception.message }, status:
+    end
+
+    def log_error(action, exception)
+      LogService.new.call(action) do |span|
+        span.set_tag('error', true)
+        span.set_tag('error.msg', exception.message)
+      end
+      Rails.logger.error("Error during #{action}: #{exception.message}")
+    end
+  end
+end

--- a/modules/preneeds/app/controllers/preneeds/v0/address_validation_controller.rb
+++ b/modules/preneeds/app/controllers/preneeds/v0/address_validation_controller.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'va_profile/models/validation_address'
+require 'va_profile/address_validation/service'
+require 'va_profile/models/v3/validation_address'
+require 'va_profile/v3/address_validation/service'
+
+module Preneeds
+  module V0
+    class AddressValidationController < ApplicationController
+      skip_before_action :authenticate
+      skip_before_action :verify_authenticity_token
+      service_tag 'profile'
+
+      def create
+        address = if Flipper.enabled?(:va_v3_contact_information_service)
+                    VAProfile::Models::V3::ValidationAddress.new(address_params)
+                  else
+                    VAProfile::Models::ValidationAddress.new(address_params)
+                  end
+
+        raise Common::Exceptions::ValidationErrors, address unless address.valid?
+
+        Rails.logger.warn('AddressValidationController#create request completed', sso_logging_info)
+
+        render(json: service.address_suggestions(address))
+      end
+
+      private
+
+      def address_params
+        params.require(:address).permit(
+          :address_line1,
+          :address_line2,
+          :address_line3,
+          :address_pou,
+          :address_type,
+          :city,
+          :country_name,
+          :country_code_iso3,
+          :international_postal_code,
+          :province,
+          :state_code,
+          :zip_code,
+          :zip_code_suffix
+        )
+      end
+
+      def service
+        @service ||= if Flipper.enabled?(:va_v3_contact_information_service)
+                       VAProfile::V3::AddressValidation::Service.new
+                     else
+                       VAProfile::AddressValidation::Service.new
+                     end
+      end
+    end
+  end
+end

--- a/modules/preneeds/config/routes.rb
+++ b/modules/preneeds/config/routes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Preneeds::Engine.routes.draw do
+  namespace :v0 do
+    post '/address_validation', to: 'address_validation#create'
+  end
+end

--- a/modules/preneeds/lib/preneeds.rb
+++ b/modules/preneeds/lib/preneeds.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require_relative 'preneeds/engine' 
+
+module Preneeds
+end

--- a/modules/preneeds/lib/preneeds/engine.rb
+++ b/modules/preneeds/lib/preneeds/engine.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Preneeds
+  class Engine < ::Rails::Engine
+    isolate_namespace Preneeds
+  end
+end


### PR DESCRIPTION
## Summary

- This is a pre-need module to manage our own address validation. 
- This allows us to skip user authentication and validated addesses.

## Related issue(s)

- https://jira.devops.va.gov/browse/MBMS-71996

## Testing done

- [ ] Spec Tests Passing
- [ ] Internal Review
- [ ] QA
- [ ] External Review

## What areas of the site does it impact?

- _Pre-need-integration form_
