### PR TITLE
[API-43688] 526 - Validation for activeDutyEndDate beyond 180 days

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/disability_compensation_validations.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/disability_compensation_validations.rb
@@ -598,7 +598,7 @@ module ClaimsApi
         active_duty_end_date = sp['activeDutyEndDate']
         next if active_duty_end_date.blank?
 
-        Date.parse(active_duty_end_date) <= 180.days.from_now
+        Date.parse(active_duty_end_date) <= 180.days.from_now.end_of_day
       end
 
       unless at_least_one_active_duty_end_date_within_180_days

--- a/modules/claims_api/app/controllers/concerns/claims_api/disability_compensation_validations.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/disability_compensation_validations.rb
@@ -47,8 +47,11 @@ module ClaimsApi
       # ensure the 'treatment.endDate' is after the 'treatment.startDate'
       # ensure any provided 'treatment.treatedDisabilityNames' match a provided 'disabilities.name'
       validate_form_526_treatments!
-      validate_form_526_direct_depost!
+      validate_form_526_direct_deposit!
+      validate_form_526_at_least_one_active_duty_end_date_within_180_days!
     end
+
+    private
 
     def validate_form_526_current_mailing_address!
       validate_form_526_current_mailing_address_country!
@@ -575,7 +578,7 @@ module ClaimsApi
       end
     end
 
-    def validate_form_526_direct_depost!
+    def validate_form_526_direct_deposit!
       direct_deposit = form_attributes['directDeposit']
       return if direct_deposit.blank?
 
@@ -584,6 +587,24 @@ module ClaimsApi
         raise ::Common::Exceptions::InvalidFieldValue.new(
           'directDeposit.bankName',
           direct_deposit['bankName']
+        )
+      end
+    end
+
+    def validate_form_526_at_least_one_active_duty_end_date_within_180_days!
+      service_periods = form_attributes.dig('serviceInformation', 'servicePeriods')
+
+      at_least_one_active_duty_end_date_within_180_days = service_periods.any? do |sp|
+        active_duty_end_date = sp['activeDutyEndDate']
+        next if active_duty_end_date.blank?
+
+        Date.parse(active_duty_end_date) <= 180.days.from_now
+      end
+
+      unless at_least_one_active_duty_end_date_within_180_days
+        raise ::Common::Exceptions::InvalidFieldValue.new(
+          'serviceInformation/servicePeriods/activeDutyEndDate',
+          'At least one active duty end date must be within 180 days from now.'
         )
       end
     end

--- a/modules/claims_api/app/swagger/claims_api/v1/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v1/swagger.json
@@ -1565,7 +1565,7 @@
                                     "example": "1980-02-05"
                                   },
                                   "activeDutyEndDate": {
-                                    "description": "Date Completed Active Duty.  If in the future, 'separationLocationCode' is required.",
+                                    "description": "Date Completed Active Duty. If in the future, 'separationLocationCode' is required. Cannot be more than 180 days in the future, unless past service is also included.",
                                     "type": "string",
                                     "pattern": "^(\\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$",
                                     "example": "1990-01-02"
@@ -3429,7 +3429,7 @@
                                       "example": "1980-02-05"
                                     },
                                     "activeDutyEndDate": {
-                                      "description": "Date Completed Active Duty.  If in the future, 'separationLocationCode' is required.",
+                                      "description": "Date Completed Active Duty. If in the future, 'separationLocationCode' is required. Cannot be more than 180 days in the future, unless past service is also included.",
                                       "type": "string",
                                       "pattern": "^(\\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$",
                                       "example": "1990-01-02"
@@ -5689,7 +5689,7 @@
                                       "example": "1980-02-05"
                                     },
                                     "activeDutyEndDate": {
-                                      "description": "Date Completed Active Duty.  If in the future, 'separationLocationCode' is required.",
+                                      "description": "Date Completed Active Duty. If in the future, 'separationLocationCode' is required. Cannot be more than 180 days in the future, unless past service is also included.",
                                       "type": "string",
                                       "pattern": "^(\\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$",
                                       "example": "1990-01-02"

--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -1646,7 +1646,7 @@
                                         "example": "2018-06-06"
                                       },
                                       "activeDutyEndDate": {
-                                        "description": "Date completed active duty.",
+                                        "description": "Date Completed Active Duty. If in the future, 'separationLocationCode' is required. Cannot be more than 180 days in the future, unless past service is also included.",
                                         "type": "string",
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
@@ -3030,7 +3030,7 @@
                                       "example": "2018-06-06"
                                     },
                                     "activeDutyEndDate": {
-                                      "description": "Date completed active duty.",
+                                      "description": "Date Completed Active Duty. If in the future, 'separationLocationCode' is required. Cannot be more than 180 days in the future, unless past service is also included.",
                                       "type": "string",
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                       "example": "2018-06-06"
@@ -5184,7 +5184,7 @@
                                       "example": "2018-06-06"
                                     },
                                     "activeDutyEndDate": {
-                                      "description": "Date completed active duty.",
+                                      "description": "Date Completed Active Duty. If in the future, 'separationLocationCode' is required. Cannot be more than 180 days in the future, unless past service is also included.",
                                       "type": "string",
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                       "example": "2018-06-06"

--- a/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
@@ -1646,7 +1646,7 @@
                                         "example": "2018-06-06"
                                       },
                                       "activeDutyEndDate": {
-                                        "description": "Date completed active duty.",
+                                        "description": "Date Completed Active Duty. If in the future, 'separationLocationCode' is required. Cannot be more than 180 days in the future, unless past service is also included.",
                                         "type": "string",
                                         "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                         "example": "2018-06-06"
@@ -3030,7 +3030,7 @@
                                       "example": "2018-06-06"
                                     },
                                     "activeDutyEndDate": {
-                                      "description": "Date completed active duty.",
+                                      "description": "Date Completed Active Duty. If in the future, 'separationLocationCode' is required. Cannot be more than 180 days in the future, unless past service is also included.",
                                       "type": "string",
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                       "example": "2018-06-06"
@@ -5184,7 +5184,7 @@
                                       "example": "2018-06-06"
                                     },
                                     "activeDutyEndDate": {
-                                      "description": "Date completed active duty.",
+                                      "description": "Date Completed Active Duty. If in the future, 'separationLocationCode' is required. Cannot be more than 180 days in the future, unless past service is also included.",
                                       "type": "string",
                                       "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                                       "example": "2018-06-06"

--- a/modules/claims_api/config/schemas/v1/526.json
+++ b/modules/claims_api/config/schemas/v1/526.json
@@ -467,7 +467,7 @@
                 "example": "1980-02-05"
               },
               "activeDutyEndDate": {
-                "description": "Date Completed Active Duty.  If in the future, 'separationLocationCode' is required.",
+                "description": "Date Completed Active Duty. If in the future, 'separationLocationCode' is required. Cannot be more than 180 days in the future, unless past service is also included.",
                 "type": "string",
                 "pattern": "^(\\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$",
                 "example": "1990-01-02"

--- a/modules/claims_api/config/schemas/v2/526.json
+++ b/modules/claims_api/config/schemas/v2/526.json
@@ -779,7 +779,7 @@
                 "example": "2018-06-06"
               },
               "activeDutyEndDate": {
-                "description": "Date completed active duty.",
+                "description": "Date Completed Active Duty. If in the future, 'separationLocationCode' is required. Cannot be more than 180 days in the future, unless past service is also included.",
                 "type": "string",
                 "pattern": "^(?:[0-9]{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])$",
                 "example": "2018-06-06"


### PR DESCRIPTION
## Summary

In v1 526, validate that at least one service period activeDutyEndDate is within 180 days from the current date.

Update v1 and v2 docs to include requirement:

> Date Completed Active Duty. If in the future, 'separationLocationCode' is required. Cannot be more than 180 days in the future, unless past service is also included.

## Related issue(s)

[API-43688](https://jira.devops.va.gov/browse/API-43688)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots

**v1**
<img width="1404" alt="v1" src="https://github.com/user-attachments/assets/9b29d05a-eb4d-4480-8da7-f89bc9d3d5cc" />

**v2**
<img width="1392" alt="v2" src="https://github.com/user-attachments/assets/1191b595-aaaf-4eda-a797-2d12975d6f63" />


## What areas of the site does it impact?

526 v1 submission validation. v1 and v2 docs.

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

N/A