### PR TITLE
Only log to slack in prod and convert sentry logging to datadog for Representatives sidekiq jobs in the Veteran module

### DIFF
--- a/modules/veteran/app/sidekiq/representatives/queue_updates.rb
+++ b/modules/veteran/app/sidekiq/representatives/queue_updates.rb
@@ -79,7 +79,7 @@ module Representatives
     end
 
     def log_to_slack(message)
-      return unless Rails.env.production?
+      return unless Settings.vsp_environment == 'production'
 
       client = SlackNotify::Client.new(webhook_url: Settings.edu.slack.webhook_url,
                                        channel: '#benefits-representation-management-notifications',

--- a/modules/veteran/app/sidekiq/representatives/queue_updates.rb
+++ b/modules/veteran/app/sidekiq/representatives/queue_updates.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 require 'sidekiq'
-require 'sentry_logging'
 
 module Representatives
   class QueueUpdates
     include Sidekiq::Job
-    include SentryLogging
 
     SLICE_SIZE = 30
 
@@ -76,11 +74,13 @@ module Representatives
 
     def log_error(message)
       message = "QueueUpdates error: #{message}"
-      log_message_to_sentry(message, :error)
+      Rails.logger.error(message)
       @slack_messages << "----- #{message}"
     end
 
     def log_to_slack(message)
+      return unless Rails.env.production?
+
       client = SlackNotify::Client.new(webhook_url: Settings.edu.slack.webhook_url,
                                        channel: '#benefits-representation-management-notifications',
                                        username: 'Representatives::QueueUpdates Bot')

--- a/modules/veteran/app/sidekiq/representatives/update.rb
+++ b/modules/veteran/app/sidekiq/representatives/update.rb
@@ -326,7 +326,7 @@ module Representatives
     end
 
     def log_to_slack(message)
-      return unless Rails.env.production?
+      return unless Settings.vsp_environment == 'production'
 
       client = SlackNotify::Client.new(webhook_url: Settings.edu.slack.webhook_url,
                                        channel: '#benefits-representation-management-notifications',

--- a/modules/veteran/app/sidekiq/representatives/update.rb
+++ b/modules/veteran/app/sidekiq/representatives/update.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'sidekiq'
-require 'sentry_logging'
 require 'va_profile/models/validation_address'
 require 'va_profile/address_validation/service'
 require 'va_profile/models/v3/validation_address'
@@ -14,7 +13,6 @@ module Representatives
   # address, email, or phone number is updated.
   class Update
     include Sidekiq::Job
-    include SentryLogging
 
     attr_accessor :slack_messages
 
@@ -118,7 +116,7 @@ module Representatives
     end
 
     # Updates the address record based on the rep_data and validation response.
-    # If the record cannot be found, logs an error to Sentry.
+    # If the record cannot be found, logs an error to Datadog.
     # @param rep_data [Hash] Original rep_data containing the address and other details.
     # @param api_response [Hash] The response from the address validation service.
     def update_rep_record(rep_data, api_response)
@@ -228,11 +226,11 @@ module Representatives
       }
     end
 
-    # Logs an error to Sentry.
+    # Logs an error to Datadog and adds an error to the array that will be logged to slack.
     # @param error [Exception] The error string to be logged.
     def log_error(error)
       message = "Representatives::Update: #{error}"
-      log_message_to_sentry(message, :error)
+      Rails.logger.error(message)
       @slack_messages << "----- #{message}"
     end
 
@@ -328,6 +326,8 @@ module Representatives
     end
 
     def log_to_slack(message)
+      return unless Rails.env.production?
+
       client = SlackNotify::Client.new(webhook_url: Settings.edu.slack.webhook_url,
                                        channel: '#benefits-representation-management-notifications',
                                        username: 'Representatives::Update Bot')

--- a/modules/veteran/app/sidekiq/veteran/vso_reloader.rb
+++ b/modules/veteran/app/sidekiq/veteran/vso_reloader.rb
@@ -102,7 +102,7 @@ module Veteran
     end
 
     def log_to_slack(message)
-      return unless Rails.env.production?
+      return unless Settings.vsp_environment == 'production'
 
       client = SlackNotify::Client.new(webhook_url: Settings.claims_api.slack.webhook_url,
                                        channel: '#api-benefits-claims',

--- a/modules/veteran/app/sidekiq/veteran/vso_reloader.rb
+++ b/modules/veteran/app/sidekiq/veteran/vso_reloader.rb
@@ -18,10 +18,10 @@ module Veteran
         rep.destroy!
       end
     rescue Faraday::ConnectionFailed => e
-      Rails.logger.warn("OGC connection failed: #{e.message}")
+      log_message_to_sentry("OGC connection failed: #{e.message}", :warn)
       log_to_slack('VSO Reloader failed to connect to OGC')
     rescue Common::Client::Errors::ClientError, Common::Exceptions::GatewayTimeout => e
-      Rails.logger.warn("VSO Reloading error: #{e.message}")
+      log_message_to_sentry("VSO Reloading error: #{e.message}", :warn)
       log_to_slack('VSO Reloader job has failed!')
     end
 

--- a/modules/veteran/spec/sidekiq/representatives/queue_updates_spec.rb
+++ b/modules/veteran/spec/sidekiq/representatives/queue_updates_spec.rb
@@ -9,10 +9,6 @@ RSpec.describe Representatives::QueueUpdates, type: :job do
     it 'includes Sidekiq::Job' do
       expect(described_class.included_modules).to include(Sidekiq::Job)
     end
-
-    it 'includes SentryLogging' do
-      expect(described_class.included_modules).to include(SentryLogging)
-    end
   end
 
   describe '#perform' do
@@ -31,7 +27,6 @@ RSpec.describe Representatives::QueueUpdates, type: :job do
       Veteran::Service::Representative.create(representative_id: '345', poa_codes: ['A1'])
       allow(Representatives::XlsxFileFetcher).to receive(:new).and_return(double(fetch: file_content))
       allow_any_instance_of(Representatives::XlsxFileProcessor).to receive(:process).and_return(processed_data)
-      expect_any_instance_of(SlackNotify::Client).to receive(:notify)
     end
 
     context 'when file processing is successful' do

--- a/modules/veteran/spec/sidekiq/representatives/update_spec.rb
+++ b/modules/veteran/spec/sidekiq/representatives/update_spec.rb
@@ -226,13 +226,9 @@ RSpec.describe Representatives::Update do
     context 'when JSON parsing fails' do
       let(:invalid_json_data) { 'invalid json' }
 
-      before do
-        expect_any_instance_of(SlackNotify::Client).to receive(:notify)
-      end
-
-      it 'logs an error to Sentry' do
-        expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(
-          "Representatives::Update: Error processing job: unexpected token at 'invalid json'", :error
+      it 'logs an error' do
+        expect(Rails.logger).to receive(:error).with(
+          "Representatives::Update: Error processing job: unexpected token at 'invalid json'"
         )
 
         subject.perform(invalid_json_data)
@@ -246,13 +242,9 @@ RSpec.describe Representatives::Update do
       let(:email_changed) { false }
       let(:phone_number_changed) { false }
 
-      before do
-        expect_any_instance_of(SlackNotify::Client).to receive(:notify)
-      end
-
-      it 'logs an error to Sentry' do
-        expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(
-          'Representatives::Update: Update failed for Rep id: not_found: Representative not found.', :error
+      it 'logs an error' do
+        expect(Rails.logger).to receive(:error).with(
+          'Representatives::Update: Update failed for Rep id: not_found: Representative not found.'
         )
 
         subject.perform(json_data)
@@ -745,13 +737,9 @@ RSpec.describe Representatives::Update do
       context 'when JSON parsing fails' do
         let(:invalid_json_data) { 'invalid json' }
 
-        before do
-          expect_any_instance_of(SlackNotify::Client).to receive(:notify)
-        end
-
-        it 'logs an error to Sentry' do
-          expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(
-            "Representatives::Update: Error processing job: unexpected token at 'invalid json'", :error
+        it 'logs an error' do
+          expect(Rails.logger).to receive(:error).with(
+            "Representatives::Update: Error processing job: unexpected token at 'invalid json'"
           )
 
           subject.perform(invalid_json_data)
@@ -765,13 +753,9 @@ RSpec.describe Representatives::Update do
         let(:email_changed) { false }
         let(:phone_number_changed) { false }
 
-        before do
-          expect_any_instance_of(SlackNotify::Client).to receive(:notify)
-        end
-
-        it 'logs an error to Sentry' do
-          expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(
-            'Representatives::Update: Update failed for Rep id: not_found: Representative not found.', :error
+        it 'logs an error' do
+          expect(Rails.logger).to receive(:error).with(
+            'Representatives::Update: Update failed for Rep id: not_found: Representative not found.'
           )
 
           subject.perform(json_data)

--- a/modules/veteran/spec/sidekiq/veteran/vso_reloader_spec.rb
+++ b/modules/veteran/spec/sidekiq/veteran/vso_reloader_spec.rb
@@ -117,29 +117,6 @@ RSpec.describe Veteran::VSOReloader, type: :job do
       end
     end
 
-    context 'with a failed connection' do
-      before do
-        allow_any_instance_of(Faraday::Connection).to receive(:post).and_raise(Faraday::ConnectionFailed,
-                                                                               'some message')
-      end
-
-      it 'notifies slack' do
-        expect_any_instance_of(SlackNotify::Client).to receive(:notify)
-        Veteran::VSOReloader.new.perform
-      end
-    end
-
-    context 'with an client error' do
-      before do
-        allow_any_instance_of(Faraday::Connection).to receive(:post).and_raise(Common::Client::Errors::ClientError)
-      end
-
-      it 'notifies slack' do
-        expect_any_instance_of(SlackNotify::Client).to receive(:notify)
-        subject.new.perform
-      end
-    end
-
     context 'handling names' do
       before do
         VCR.use_cassette('veteran/ogc_vso_rep_data') do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- *(Summarize the changes that have been made to the platform):* The sidekiq jobs in `modules/veteran/app/sidekiq/representatives` were logging to Sentry and Slack in all ENVs.  Now they log to Datadog instead of Sentry and only log to Slack in `production`.  This should cut down on sidekiq retries in `dev` and `sandbox` where there is no slack webhook url configured.
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?):* We made changes recently to these jobs to make logging more verbose so we could see what was happening and we went too far.
- *(Which team do you work for, does your team own the maintenance of this component?):* FAR/ARM, we own the maintenance.
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/102251
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change:* The sidekiq jobs logged to Sentry and tried to log to slack in every ENV.
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing:* After deploy check to see if sidekiq retries reduce and if Sentry errors are reduced.
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas):* Just the `Representatives` sidekiq jobs in the `Veteran` module.

## Acceptance criteria

- [x]  I fixed unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
