### PR TITLE
[ARP][PR stack #2] Add accredited individuals allow-list syncing system

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2097,6 +2097,7 @@ spec/support/uploader_helpers.rb @department-of-veterans-affairs/va-api-engineer
 spec/support/url_service_helpers.rb @department-of-veterans-affairs/octo-identity
 spec/support/validation_helpers.rb @department-of-veterans-affairs/octo-identity
 spec/support/va_profile @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/support/vcr_cassettes/accredited_representative_portal @department-of-veterans-affairs/benefits-accredited-rep-facing-engineers @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/apps @department-of-veterans-affairs/lighthouse-pivot
 spec/support/vcr_cassettes/ask_va_api/dynamics @department-of-veterans-affairs/ask-va-team @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 spec/support/vcr_cassettes/avs @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/after-visit-summary

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1746,9 +1746,9 @@ ogc:
 accredited_representative_portal:
   allow_list:
     github:
-      access_token: some_fake_token
-      repo: faked/fakeness
-      path: not_real.csv
+      access_token: ~
+      repo: ~
+      path: ~
 
 banners:
   drupal_username: banners_api

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1744,7 +1744,11 @@ ogc:
     api_key: fake_key
 
 accredited_representative_portal:
-  pilot_users_email_poa_codes: ~
+  allow_list:
+    github:
+      access_token: some_fake_token
+      repo: faked/fakeness
+      path: not_real.csv
 
 banners:
   drupal_username: banners_api

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -448,4 +448,8 @@ va_notify:
     bearer_token: 'va_notify_bearer_token'
 
 accredited_representative_portal:
-  pilot_user_email_poa_codes:
+  allow_list:
+    github:
+      access_token: some_fake_token
+      repo: faked/fakeness
+      path: not_real.csv

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/user_account_accredited_individual.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/user_account_accredited_individual.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# rubocop:disable Rails/I18nLocaleTexts
+module AccreditedRepresentativePortal
+  class UserAccountAccreditedIndividual < ApplicationRecord
+    enum power_of_attorney_holder_type: {
+      veteran_service_organization: 'veteran_service_organization'
+      # Future supported types (commented for documentation):
+      # attorney: 'attorney',
+      # claims_agent: 'claims_agent',
+    }
+
+    validates :accredited_individual_registration_number, presence: true
+    validates :power_of_attorney_holder_type, presence: true, inclusion: {
+      in: power_of_attorney_holder_types.keys,
+      message: 'must be: veteran_service_organization'
+    }
+    validates :user_account_email, presence: true,
+                                   format: { with: /\A[^@\s]+@[^@\s]+\z/, message: 'invalid email format' }
+  end
+end
+# rubocop:enable Rails/I18nLocaleTexts

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/user_account_accredited_individual.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/user_account_accredited_individual.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-# rubocop:disable Rails/I18nLocaleTexts
 module AccreditedRepresentativePortal
   class UserAccountAccreditedIndividual < ApplicationRecord
-    enum power_of_attorney_holder_type: {
-      veteran_service_organization: 'veteran_service_organization'
-      # Future supported types (commented for documentation):
+    enum :power_of_attorney_holder_type, {
+      ##
+      # Future supported types:
       # attorney: 'attorney',
       # claims_agent: 'claims_agent',
-    }
+      #
+      veteran_service_organization: 'veteran_service_organization'
+    }, validate: true
 
     validates :accredited_individual_registration_number, presence: true
     validates :user_account_email, presence: true,
-                                   format: { with: URI::MailTo::EMAIL_REGEXP, message: 'invalid email format' }
+                                   format: { with: URI::MailTo::EMAIL_REGEXP }
   end
 end
-# rubocop:enable Rails/I18nLocaleTexts

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/user_account_accredited_individual.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/user_account_accredited_individual.rb
@@ -11,12 +11,8 @@ module AccreditedRepresentativePortal
     }
 
     validates :accredited_individual_registration_number, presence: true
-    validates :power_of_attorney_holder_type, presence: true, inclusion: {
-      in: power_of_attorney_holder_types.keys,
-      message: 'must be: veteran_service_organization'
-    }
     validates :user_account_email, presence: true,
-                                   format: { with: /\A[^@\s]+@[^@\s]+\z/, message: 'invalid email format' }
+                                   format: { with: URI::MailTo::EMAIL_REGEXP, message: 'invalid email format' }
   end
 end
 # rubocop:enable Rails/I18nLocaleTexts

--- a/modules/accredited_representative_portal/app/sidekiq/accredited_representative_portal/allow_list_sync_job.rb
+++ b/modules/accredited_representative_portal/app/sidekiq/accredited_representative_portal/allow_list_sync_job.rb
@@ -3,105 +3,70 @@
 module AccreditedRepresentativePortal
   class AllowListSyncJob
     include Sidekiq::Job
+    sidekiq_options retry: false
 
-    MODEL = UserAccountAccreditedIndividual
-    MAX_CSV_ROWS = 500
+    # To not overload the DB.
+    MAX_RECORD_COUNT = 500
 
-    SYNC_FIELDS = %w[
-      accredited_individual_registration_number
-      power_of_attorney_holder_type
-      user_account_email
-    ].freeze
+    Error = Class.new(RuntimeError)
 
-    class InvalidRowCount < StandardError; end
+    class RecordCountError < Error
+      def initialize(record_count)
+        super("record_count: #{record_count}")
+      end
+    end
 
     def perform
-      csv_data = fetch_csv
-      raise InvalidRowCount, 'Empty CSV data received' if csv_data.blank?
+      SemanticLogger.tagged do
+        csv = extract
+        csv.size.between?(1, MAX_RECORD_COUNT) or
+          raise RecordCountError, csv.size
 
-      stats = sync_from_csv!(csv_data)
+        attributes = transform!(csv)
+        result = load(attributes)
 
-      Rails.logger.info(
-        'Successfully synced accredited individuals. ' \
-        "Replaced #{stats[:deleted_count]} records with #{stats[:inserted_count]} records."
-      )
-    rescue => e
-      Rails.logger.error(
-        "Error syncing accredited individuals: #{e.message}\n" \
-        "Backtrace: #{e.backtrace.first(5).join("\n")}"
-      )
-      raise
+        logger.info(result)
+      rescue => e
+        logger.error(e)
+        raise
+      end
     end
 
     private
 
-    # rubocop:disable Rails/SkipsModelValidations, Metrics/MethodLength
-    def sync_from_csv!(csv_data)
-      if csv_data.size > MAX_CSV_ROWS
-        raise InvalidRowCount, "CSV file exceeds maximum allowed rows of (#{MAX_CSV_ROWS})"
+    def extract
+      config = Settings.accredited_representative_portal.allow_list.github
+      Octokit::Client
+        .new(access_token: config.access_token)
+        .then { |client| client.contents(config.repo, path: config.path) }
+        .then { |contents| Base64.decode64(contents[:content]) }
+        .then { |content| CSV.parse(content, headers: true) }
+    end
+
+    def transform!(csv)
+      csv.map do |row|
+        row.to_h.tap do |attrs|
+          UserAccountAccreditedIndividual.new(attrs).validate!
+        end
       end
+    end
 
-      stats = { deleted_count: 0, inserted_count: 0, errored: 0, errors: [] }
+    def load(attributes)
+      {}.tap do |result|
+        unique_by = attributes.first.keys
 
-      # Build and validate all records before insert
-      new_records = csv_data.map do |row|
-        MODEL.new(row.to_h.slice(*SYNC_FIELDS)).tap(&:validate!)
-      rescue => e
-        stats[:errored] += 1
-        stats[:errors] << e.message
-        next # Skip this record
-      end.compact
+        UserAccountAccreditedIndividual.transaction do
+          result[:deleted_count] =
+            UserAccountAccreditedIndividual
+            .where.not(unique_by => attributes.map(&:values))
+            .delete_all
 
-      return stats if new_records.empty?
-
-      MODEL.transaction do
-        # Get incoming rows and convert them to hashes using sync fields
-        incoming_data_hashes = csv_data.map { |row| row.to_h.slice(*SYNC_FIELDS) }
-
-        # Prepare the where.not conditions dynamically
-        delete_rel = MODEL.where.not(
-          incoming_data_hashes.map(&:symbolize_keys)
-        )
-
-        # Execute the deletion
-        deleted_count = delete_rel.delete_all
-
-        # Insert with conflict handling
-        inserted = MODEL.insert_all(
-          new_records.map { |r| r.attributes.slice(*SYNC_FIELDS) },
-          returning: SYNC_FIELDS,
-          unique_by: SYNC_FIELDS
-        )
-
-        stats[:deleted_count] = deleted_count
-        stats[:inserted_count] = inserted.count
+          result[:inserted_count] =
+            UserAccountAccreditedIndividual
+            .insert_all(attributes, unique_by:) # rubocop:disable Rails/SkipsModelValidations
+            .count
+        end
       end
-
-      stats
-    end
-    # rubocop:enable Rails/SkipsModelValidations, Metrics/MethodLength
-
-    def fetch_csv
-      Rails.logger.info "Fetching CSV from GitHub: #{repo} path: #{path}"
-
-      content = github_client.contents(repo, path: path).content
-      decoded_content = Base64.decode64(content)
-
-      CSV.parse(decoded_content, headers: true)
-    end
-
-    def github_client
-      @github_client ||= Octokit::Client.new(
-        access_token: Settings.accredited_representative_portal&.allow_list&.github&.access_token
-      )
-    end
-
-    def repo
-      Settings.accredited_representative_portal&.allow_list&.github&.repo
-    end
-
-    def path
-      Settings.accredited_representative_portal&.allow_list&.github&.path
     end
   end
 end

--- a/modules/accredited_representative_portal/app/sidekiq/accredited_representative_portal/allow_list_sync_job.rb
+++ b/modules/accredited_representative_portal/app/sidekiq/accredited_representative_portal/allow_list_sync_job.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class AllowListSyncJob
+    include Sidekiq::Job
+
+    MODEL = UserAccountAccreditedIndividual
+    MAX_CSV_ROWS = 500
+
+    SYNC_FIELDS = %w[
+      accredited_individual_registration_number
+      power_of_attorney_holder_type
+      user_account_email
+    ].freeze
+
+    class InvalidRowCount < StandardError; end
+
+    def perform
+      csv_data = fetch_csv
+      raise InvalidRowCount, 'Empty CSV data received' if csv_data.blank?
+
+      stats = sync_from_csv!(csv_data)
+
+      Rails.logger.info(
+        'Successfully synced accredited individuals. ' \
+        "Replaced #{stats[:deleted_count]} records with #{stats[:inserted_count]} records."
+      )
+    rescue => e
+      Rails.logger.error(
+        "Error syncing accredited individuals: #{e.message}\n" \
+        "Backtrace: #{e.backtrace.first(5).join("\n")}"
+      )
+      raise
+    end
+
+    private
+
+    # rubocop:disable Rails/SkipsModelValidations, Metrics/MethodLength
+    def sync_from_csv!(csv_data)
+      if csv_data.size > MAX_CSV_ROWS
+        raise InvalidRowCount, "CSV file exceeds maximum allowed rows of (#{MAX_CSV_ROWS})"
+      end
+
+      MODEL.transaction do
+        # Get incoming registration numbers
+        incoming_registration_numbers = csv_data.map { |row| row['accredited_individual_registration_number'] }
+
+        # Delete records not in the incoming data
+        deleted_count = MODEL.where.not(
+          accredited_individual_registration_number: incoming_registration_numbers
+        ).delete_all
+
+        # Build and validate all records before insert
+        new_records = csv_data.map do |row|
+          MODEL.new(row.to_h.slice(*SYNC_FIELDS)).tap(&:validate!)
+        end
+
+        # Insert with conflict handling
+        inserted = MODEL.insert_all(
+          new_records.map { |r| r.attributes.slice(*SYNC_FIELDS) },
+          returning: SYNC_FIELDS,
+          unique_by: SYNC_FIELDS
+        )
+
+        {
+          deleted_count: deleted_count,
+          inserted_count: inserted.rows.length
+        }
+      end
+    end
+    # rubocop:enable Rails/SkipsModelValidations, Metrics/MethodLength
+
+    def fetch_csv
+      Rails.logger.info "Fetching CSV from GitHub: #{repo} path: #{path}"
+
+      content = github_client.contents(repo, path: path).content
+      decoded_content = Base64.decode64(content)
+
+      CSV.parse(decoded_content, headers: true)
+    end
+
+    def github_client
+      @github_client ||= Octokit::Client.new(
+        access_token: Settings.accredited_representative_portal&.allow_list&.github&.access_token
+      )
+    end
+
+    def repo
+      Settings.accredited_representative_portal&.allow_list&.github&.repo
+    end
+
+    def path
+      Settings.accredited_representative_portal&.allow_list&.github&.path
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/models/accredited_representative_portal/user_account_accredited_individual_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representative_portal/user_account_accredited_individual_spec.rb
@@ -42,12 +42,12 @@ RSpec.describe AccreditedRepresentativePortal::UserAccountAccreditedIndividual, 
     end
 
     it 'raises ArgumentError for invalid type' do
-      expect {
+      expect do
         described_class.new(
           power_of_attorney_holder_type: 'invalid_type',
-          accredited_individual_registration_number: 'REG001',
+          accredited_individual_registration_number: 'REG001'
         ).validate!
-      }.to raise_error(ActiveRecord::RecordInvalid, /Power of attorney holder type is not included in the list/)
+      end.to raise_error(ActiveRecord::RecordInvalid, /Power of attorney holder type is not included in the list/)
     end
 
     it 'provides helper methods for checking type' do

--- a/modules/accredited_representative_portal/spec/models/accredited_representative_portal/user_account_accredited_individual_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representative_portal/user_account_accredited_individual_spec.rb
@@ -22,11 +22,6 @@ RSpec.describe AccreditedRepresentativePortal::UserAccountAccreditedIndividual, 
       expect(model.errors[:accredited_individual_registration_number]).to include("can't be blank")
     end
 
-    it 'requires valid POA type' do
-      expect { model.power_of_attorney_holder_type = 'invalid_type' }
-        .to raise_error(ArgumentError, "'invalid_type' is not a valid power_of_attorney_holder_type")
-    end
-
     it 'requires email' do
       model.user_account_email = nil
       expect(model).not_to be_valid
@@ -36,7 +31,7 @@ RSpec.describe AccreditedRepresentativePortal::UserAccountAccreditedIndividual, 
     it 'validates email format' do
       model.user_account_email = 'not-an-email'
       expect(model).not_to be_valid
-      expect(model.errors[:user_account_email]).to include('invalid email format')
+      expect(model.errors[:user_account_email]).to include('is invalid')
     end
   end
 
@@ -47,8 +42,12 @@ RSpec.describe AccreditedRepresentativePortal::UserAccountAccreditedIndividual, 
     end
 
     it 'raises ArgumentError for invalid type' do
-      expect { described_class.new(power_of_attorney_holder_type: 'invalid_type') }
-        .to raise_error(ArgumentError, "'invalid_type' is not a valid power_of_attorney_holder_type")
+      expect {
+        described_class.new(
+          power_of_attorney_holder_type: 'invalid_type',
+          accredited_individual_registration_number: 'REG001',
+        ).validate!
+      }.to raise_error(ActiveRecord::RecordInvalid, /Power of attorney holder type is not included in the list/)
     end
 
     it 'provides helper methods for checking type' do

--- a/modules/accredited_representative_portal/spec/models/accredited_representative_portal/user_account_accredited_individual_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representative_portal/user_account_accredited_individual_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccreditedRepresentativePortal::UserAccountAccreditedIndividual, type: :model do
+  let(:valid_attributes) do
+    {
+      accredited_individual_registration_number: 'REG001',
+      power_of_attorney_holder_type: 'veteran_service_organization',
+      user_account_email: 'rep1@vso.org'
+    }
+  end
+
+  describe 'validations' do
+    subject(:model) { described_class.new(valid_attributes) }
+
+    it { is_expected.to be_valid }
+
+    it 'requires registration number' do
+      model.accredited_individual_registration_number = nil
+      expect(model).not_to be_valid
+      expect(model.errors[:accredited_individual_registration_number]).to include("can't be blank")
+    end
+
+    it 'requires valid POA type' do
+      expect { model.power_of_attorney_holder_type = 'invalid_type' }
+        .to raise_error(ArgumentError, "'invalid_type' is not a valid power_of_attorney_holder_type")
+    end
+
+    it 'requires email' do
+      model.user_account_email = nil
+      expect(model).not_to be_valid
+      expect(model.errors[:user_account_email]).to include("can't be blank")
+    end
+
+    it 'validates email format' do
+      model.user_account_email = 'not-an-email'
+      expect(model).not_to be_valid
+      expect(model.errors[:user_account_email]).to include('invalid email format')
+    end
+  end
+
+  describe 'power_of_attorney_holder_type enum' do
+    it 'defines the correct types' do
+      expect(described_class.power_of_attorney_holder_types)
+        .to eq('veteran_service_organization' => 'veteran_service_organization')
+    end
+
+    it 'raises ArgumentError for invalid type' do
+      expect { described_class.new(power_of_attorney_holder_type: 'invalid_type') }
+        .to raise_error(ArgumentError, "'invalid_type' is not a valid power_of_attorney_holder_type")
+    end
+
+    it 'provides helper methods for checking type' do
+      model = described_class.new(power_of_attorney_holder_type: 'veteran_service_organization')
+      expect(model).to be_veteran_service_organization
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/sidekiq/accredited_representative_portal/allow_list_sync_job_spec.rb
+++ b/modules/accredited_representative_portal/spec/sidekiq/accredited_representative_portal/allow_list_sync_job_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# rubocop:disable Metrics/ModuleLength
+module AccreditedRepresentativePortal
+  RSpec.describe AllowListSyncJob, type: :job do
+    let(:csv_content) do
+      <<~CSV
+        accredited_individual_registration_number,power_of_attorney_holder_type,user_account_email
+        REG001,veteran_service_organization,rep1@vso.org
+        REG002,veteran_service_organization,rep2@vso.org
+      CSV
+    end
+
+    let(:github_client) do
+      instance_double(
+        Octokit::Client,
+        contents: double('GithubResponse', content: Base64.encode64(csv_content))
+      )
+    end
+
+    before do
+      allow(Octokit::Client).to receive(:new).and_return(github_client)
+    end
+
+    describe 'constants' do
+      it 'defines max rows limit' do
+        expect(described_class::MAX_CSV_ROWS).to eq(500)
+      end
+
+      it 'defines sync fields' do
+        expect(described_class::SYNC_FIELDS).to contain_exactly(
+          'accredited_individual_registration_number',
+          'power_of_attorney_holder_type',
+          'user_account_email'
+        )
+      end
+    end
+
+    describe '#perform' do
+      context 'with valid data' do
+        before do
+          # This record should be deleted since it's not in the incoming CSV
+          UserAccountAccreditedIndividual.create!(
+            accredited_individual_registration_number: 'OLD001',
+            power_of_attorney_holder_type: 'veteran_service_organization',
+            user_account_email: 'old@vso.org'
+          )
+        end
+
+        it 'processes CSV from GitHub and syncs records' do
+          expect(Rails.logger).to receive(:info).with(/Fetching CSV from GitHub/)
+          expect(Rails.logger).to receive(:info).with(/Successfully synced/)
+
+          described_class.new.perform
+
+          records = UserAccountAccreditedIndividual.all
+          expect(records.count).to eq(2)
+
+          expect(records.pluck(:accredited_individual_registration_number))
+            .to match_array(%w[REG001 REG002])
+
+          # Verify old record was deleted
+          expect(UserAccountAccreditedIndividual.where(
+                   accredited_individual_registration_number: 'OLD001'
+                 )).not_to exist
+        end
+      end
+
+      context 'when CSV is empty' do
+        let(:csv_content) { '' }
+
+        it 'logs error and re-raises' do
+          expect(Rails.logger).to receive(:error).with(/Empty CSV data received/)
+          expect { described_class.new.perform }
+            .to raise_error(described_class::InvalidRowCount)
+        end
+      end
+
+      context 'when CSV exceeds size limit' do
+        let(:csv_content) do
+          headers = "accredited_individual_registration_number,power_of_attorney_holder_type,user_account_email\n"
+          rows = (['REG001,veteran_service_organization,rep@vso.org'] * 501).join("\n")
+          headers + rows
+        end
+
+        it 'raises InvalidRowCount' do
+          expect { described_class.new.perform }
+            .to raise_error(described_class::InvalidRowCount)
+        end
+      end
+
+      context 'with invalid data in CSV' do
+        let(:csv_content) do
+          <<~CSV
+            accredited_individual_registration_number,power_of_attorney_holder_type,user_account_email
+            REG001,veteran_service_organization,not-an-email
+          CSV
+        end
+
+        it 'raises validation error and rolls back' do
+          expect { described_class.new.perform }
+            .to raise_error(ActiveRecord::RecordInvalid)
+
+          expect(UserAccountAccreditedIndividual.count).to eq(0)
+        end
+      end
+
+      context 'with GitHub API error' do
+        before do
+          allow(github_client).to receive(:contents).and_raise(Octokit::Error.new)
+        end
+
+        it 'logs and re-raises error' do
+          expect(Rails.logger).to receive(:error).with(/Error syncing accredited individuals/)
+          expect { described_class.new.perform }.to raise_error(Octokit::Error)
+        end
+      end
+
+      context 'with CSV parsing error' do
+        let(:csv_content) do
+          <<~CSV
+            accredited_individual_registration_number,power_of_attorney_holder_type,user_account_email
+            "
+          CSV
+        end
+
+        it 'logs and re-raises error' do
+          expect(Rails.logger).to receive(:error).with(/Error syncing accredited individuals/)
+          expect { described_class.new.perform }.to raise_error(CSV::MalformedCSVError)
+        end
+      end
+    end
+
+    # rubocop:disable RSpec/MessageChain
+    describe 'GitHub configuration' do
+      it 'uses settings for GitHub configuration' do
+        job = described_class.new
+
+        allow(Settings).to receive_message_chain(
+          'accredited_representative_portal.allow_list.github.access_token'
+        ).and_return('test-token')
+
+        expect(Octokit::Client).to receive(:new).with(access_token: 'test-token')
+
+        job.send(:github_client)
+      end
+    end
+    # rubocop:enable RSpec/MessageChain
+  end
+end
+# rubocop:enable Metrics/ModuleLength

--- a/modules/accredited_representative_portal/spec/sidekiq/accredited_representative_portal/allow_list_sync_job_spec.rb
+++ b/modules/accredited_representative_portal/spec/sidekiq/accredited_representative_portal/allow_list_sync_job_spec.rb
@@ -20,28 +20,26 @@ module AccreditedRepresentativePortal
       )
     end
 
+    # rubocop:disable RSpec/MessageChain
     before do
       allow(Octokit::Client).to receive(:new).and_return(github_client)
+      # Stub GitHub settings
+      allow(Settings).to receive_message_chain(
+        'accredited_representative_portal.allow_list.github.access_token'
+      ).and_return('test-token')
+      allow(Settings).to receive_message_chain(
+        'accredited_representative_portal.allow_list.github.repo'
+      ).and_return('test-repo')
+      allow(Settings).to receive_message_chain(
+        'accredited_representative_portal.allow_list.github.path'
+      ).and_return('test/path.csv')
     end
-
-    describe 'constants' do
-      it 'defines max rows limit' do
-        expect(described_class::MAX_CSV_ROWS).to eq(500)
-      end
-
-      it 'defines sync fields' do
-        expect(described_class::SYNC_FIELDS).to contain_exactly(
-          'accredited_individual_registration_number',
-          'power_of_attorney_holder_type',
-          'user_account_email'
-        )
-      end
-    end
+    # rubocop:enable RSpec/MessageChain
 
     describe '#perform' do
       context 'with valid data' do
         before do
-          # This record should be deleted since it's not in the incoming CSV
+          # Create an existing record that should be deleted
           UserAccountAccreditedIndividual.create!(
             accredited_individual_registration_number: 'OLD001',
             power_of_attorney_holder_type: 'veteran_service_organization',
@@ -50,60 +48,70 @@ module AccreditedRepresentativePortal
         end
 
         it 'processes CSV from GitHub and syncs records' do
-          expect(Rails.logger).to receive(:info).with(/Fetching CSV from GitHub/)
-          expect(Rails.logger).to receive(:info).with(/Successfully synced/)
+          expect(Rails.logger).to receive(:info).with('Fetching CSV from GitHub: test-repo path: test/path.csv')
+          expect(Rails.logger).to receive(:info)
+            .with('Successfully synced accredited individuals. Replaced 1 records with 2 records.')
 
           described_class.new.perform
 
           records = UserAccountAccreditedIndividual.all
           expect(records.count).to eq(2)
-
           expect(records.pluck(:accredited_individual_registration_number))
             .to match_array(%w[REG001 REG002])
+        end
+      end
 
-          # Verify old record was deleted
-          expect(UserAccountAccreditedIndividual.where(
-                   accredited_individual_registration_number: 'OLD001'
-                 )).not_to exist
+      context 'with invalid power_of_attorney_holder_type' do
+        let(:csv_content) do
+          <<~CSV
+            accredited_individual_registration_number,power_of_attorney_holder_type,user_account_email
+            REG001,attorney,rep1@vso.org
+            REG002,veteran_service_organization,rep2@vso.org
+          CSV
+        end
+
+        it 'skips invalid records and processes valid ones' do
+          expect(Rails.logger).to receive(:info).with('Fetching CSV from GitHub: test-repo path: test/path.csv')
+          expect(Rails.logger).to receive(:info)
+            .with('Successfully synced accredited individuals. Replaced 0 records with 1 records.')
+
+          described_class.new.perform
+
+          expect(UserAccountAccreditedIndividual.count).to eq(1)
+          record = UserAccountAccreditedIndividual.first
+          expect(record.power_of_attorney_holder_type).to eq('veteran_service_organization')
+          expect(record.accredited_individual_registration_number).to eq('REG002')
+        end
+      end
+
+      context 'with invalid email format' do
+        let(:csv_content) do
+          <<~CSV
+            accredited_individual_registration_number,power_of_attorney_holder_type,user_account_email
+            REG001,veteran_service_organization,not-an-email
+            REG002,veteran_service_organization,rep2@vso.org
+          CSV
+        end
+
+        it 'processes valid records and logs stats' do
+          expect(Rails.logger).to receive(:info).with('Fetching CSV from GitHub: test-repo path: test/path.csv')
+          expect(Rails.logger).to receive(:info)
+            .with('Successfully synced accredited individuals. Replaced 0 records with 1 records.')
+
+          described_class.new.perform
+
+          expect(UserAccountAccreditedIndividual.count).to eq(1)
+          expect(UserAccountAccreditedIndividual.first.user_account_email).to eq('rep2@vso.org')
         end
       end
 
       context 'when CSV is empty' do
         let(:csv_content) { '' }
 
-        it 'logs error and re-raises' do
-          expect(Rails.logger).to receive(:error).with(/Empty CSV data received/)
+        it 'logs error and raises InvalidRowCount' do
+          expect(Rails.logger).to receive(:error).with(/Error syncing accredited individuals.*Empty CSV data received/)
           expect { described_class.new.perform }
-            .to raise_error(described_class::InvalidRowCount)
-        end
-      end
-
-      context 'when CSV exceeds size limit' do
-        let(:csv_content) do
-          headers = "accredited_individual_registration_number,power_of_attorney_holder_type,user_account_email\n"
-          rows = (['REG001,veteran_service_organization,rep@vso.org'] * 501).join("\n")
-          headers + rows
-        end
-
-        it 'raises InvalidRowCount' do
-          expect { described_class.new.perform }
-            .to raise_error(described_class::InvalidRowCount)
-        end
-      end
-
-      context 'with invalid data in CSV' do
-        let(:csv_content) do
-          <<~CSV
-            accredited_individual_registration_number,power_of_attorney_holder_type,user_account_email
-            REG001,veteran_service_organization,not-an-email
-          CSV
-        end
-
-        it 'raises validation error and rolls back' do
-          expect { described_class.new.perform }
-            .to raise_error(ActiveRecord::RecordInvalid)
-
-          expect(UserAccountAccreditedIndividual.count).to eq(0)
+            .to raise_error(described_class::InvalidRowCount, /Empty CSV data received/)
         end
       end
 
@@ -117,37 +125,7 @@ module AccreditedRepresentativePortal
           expect { described_class.new.perform }.to raise_error(Octokit::Error)
         end
       end
-
-      context 'with CSV parsing error' do
-        let(:csv_content) do
-          <<~CSV
-            accredited_individual_registration_number,power_of_attorney_holder_type,user_account_email
-            "
-          CSV
-        end
-
-        it 'logs and re-raises error' do
-          expect(Rails.logger).to receive(:error).with(/Error syncing accredited individuals/)
-          expect { described_class.new.perform }.to raise_error(CSV::MalformedCSVError)
-        end
-      end
     end
-
-    # rubocop:disable RSpec/MessageChain
-    describe 'GitHub configuration' do
-      it 'uses settings for GitHub configuration' do
-        job = described_class.new
-
-        allow(Settings).to receive_message_chain(
-          'accredited_representative_portal.allow_list.github.access_token'
-        ).and_return('test-token')
-
-        expect(Octokit::Client).to receive(:new).with(access_token: 'test-token')
-
-        job.send(:github_client)
-      end
-    end
-    # rubocop:enable RSpec/MessageChain
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/modules/accredited_representative_portal/spec/sidekiq/accredited_representative_portal/allow_list_sync_job_spec.rb
+++ b/modules/accredited_representative_portal/spec/sidekiq/accredited_representative_portal/allow_list_sync_job_spec.rb
@@ -37,11 +37,9 @@ module AccreditedRepresentativePortal
         CSV.parse(data, headers: true)
       end
 
-      # rubocop:disable RSpec/MessageChain
       before do
         allow_any_instance_of(described_class).to receive(:extract).and_return(csv_content)
       end
-      # rubocop:enable RSpec/MessageChain
 
       describe '#perform' do
         context 'with valid data' do
@@ -76,9 +74,9 @@ module AccreditedRepresentativePortal
           end
 
           it 'raises an ActiveRecord::RecordInvalid error' do
-            expect {
+            expect do
               described_class.new.perform
-            }.to raise_error(ActiveRecord::RecordInvalid, /Power of attorney holder type is not included in the list/)
+            end.to raise_error(ActiveRecord::RecordInvalid, /Power of attorney holder type is not included in the list/)
           end
         end
 
@@ -94,9 +92,9 @@ module AccreditedRepresentativePortal
           end
 
           it 'raises an ActiveRecord::RecordInvalid error' do
-            expect {
+            expect do
               described_class.new.perform
-            }.to raise_error(ActiveRecord::RecordInvalid, /Validation failed: User account email is invalid/)
+            end.to raise_error(ActiveRecord::RecordInvalid, /Validation failed: User account email is invalid/)
           end
         end
 
@@ -111,7 +109,7 @@ module AccreditedRepresentativePortal
 
         context 'when CSV has too many rows' do
           let(:csv_content) do
-            headers = "accredited_individual_registration_number,power_of_attorney_holder_type,user_account_email"
+            headers = 'accredited_individual_registration_number,power_of_attorney_holder_type,user_account_email'
             rows = (1..501).map do |i|
               "REG#{i.to_s.rjust(3, '0')},veteran_service_organization,rep#{i}@vso.org"
             end

--- a/modules/accredited_representative_portal/spec/sidekiq/accredited_representative_portal/allow_list_sync_job_spec.rb
+++ b/modules/accredited_representative_portal/spec/sidekiq/accredited_representative_portal/allow_list_sync_job_spec.rb
@@ -3,147 +3,126 @@
 require 'rails_helper'
 require Rails.root / 'modules/accredited_representative_portal/spec/rails_helper'
 
-RSpec.describe AccreditedRepresentativePortal::AllowListSyncJob, type: :job do
-  context 'vcr tests' do
-    it 'makes insertions and deletions when source changes' do
-      use_cassette('insertions_and_deletions', match_requests_on: %i[method uri]) do
-        record_class = AccreditedRepresentativePortal::UserAccountAccreditedIndividual
-
-        described_class.new.perform
-        record_class.find_each { |record| record.update!(user_account_icn: SecureRandom.uuid) }
-        before = record_class.all.to_a
-
-        described_class.new.perform
-        after = record_class.all.to_a
-
-        expect((before - after).size).to be(4)
-        expect((after - before).size).to be(4)
-
-        maintained_icns = record_class.where.not(user_account_icn: nil)
-        expect(maintained_icns.count).to be(16)
-      end
-    end
-  end
-
-  context 'client mock tests' do
-    let(:csv_content) do
-      <<~CSV
-        accredited_individual_registration_number,power_of_attorney_holder_type,user_account_email
-        REG001,veteran_service_organization,rep1@vso.org
-        REG002,veteran_service_organization,rep2@vso.org
-      CSV
-    end
-
-    let(:github_client) do
-      instance_double(
-        Octokit::Client,
-        contents: double('GithubResponse', content: Base64.encode64(csv_content))
-      )
-    end
-
-    # rubocop:disable RSpec/MessageChain
-    before do
-      allow(Octokit::Client).to receive(:new).and_return(github_client)
-      # Stub GitHub settings
-      allow(Settings).to receive_message_chain(
-        'accredited_representative_portal.allow_list.github.access_token'
-      ).and_return('test-token')
-      allow(Settings).to receive_message_chain(
-        'accredited_representative_portal.allow_list.github.repo'
-      ).and_return('test-repo')
-      allow(Settings).to receive_message_chain(
-        'accredited_representative_portal.allow_list.github.path'
-      ).and_return('test/path.csv')
-    end
-    # rubocop:enable RSpec/MessageChain
-
-    describe '#perform' do
-      context 'with valid data' do
-        before do
-          # Create an existing record that should be deleted
-          UserAccountAccreditedIndividual.create!(
-            accredited_individual_registration_number: 'OLD001',
-            power_of_attorney_holder_type: 'veteran_service_organization',
-            user_account_email: 'old@vso.org'
-          )
-        end
-
-        it 'processes CSV from GitHub and syncs records' do
-          expect(Rails.logger).to receive(:info).with('Fetching CSV from GitHub: test-repo path: test/path.csv')
-          expect(Rails.logger).to receive(:info)
-            .with('Successfully synced accredited individuals. Replaced 1 records with 2 records.')
+module AccreditedRepresentativePortal
+  RSpec.describe AllowListSyncJob, type: :job do
+    context 'vcr tests' do
+      it 'makes insertions and deletions when source changes' do
+        use_cassette('insertions_and_deletions', match_requests_on: %i[method uri]) do
+          record_class = AccreditedRepresentativePortal::UserAccountAccreditedIndividual
 
           described_class.new.perform
-
-          records = UserAccountAccreditedIndividual.all
-          expect(records.count).to eq(2)
-          expect(records.pluck(:accredited_individual_registration_number))
-            .to match_array(%w[REG001 REG002])
-        end
-      end
-
-      context 'with invalid power_of_attorney_holder_type' do
-        let(:csv_content) do
-          <<~CSV
-            accredited_individual_registration_number,power_of_attorney_holder_type,user_account_email
-            REG001,attorney,rep1@vso.org
-            REG002,veteran_service_organization,rep2@vso.org
-          CSV
-        end
-
-        it 'skips invalid records and processes valid ones' do
-          expect(Rails.logger).to receive(:info).with('Fetching CSV from GitHub: test-repo path: test/path.csv')
-          expect(Rails.logger).to receive(:info)
-            .with('Successfully synced accredited individuals. Replaced 0 records with 1 records.')
+          record_class.find_each { |record| record.update!(user_account_icn: SecureRandom.uuid) }
+          before = record_class.all.to_a
 
           described_class.new.perform
+          after = record_class.all.to_a
 
-          expect(UserAccountAccreditedIndividual.count).to eq(1)
-          record = UserAccountAccreditedIndividual.first
-          expect(record.power_of_attorney_holder_type).to eq('veteran_service_organization')
-          expect(record.accredited_individual_registration_number).to eq('REG002')
+          expect((before - after).size).to be(4)
+          expect((after - before).size).to be(4)
+
+          maintained_icns = record_class.where.not(user_account_icn: nil)
+          expect(maintained_icns.count).to be(16)
         end
       end
+    end
 
-      context 'with invalid email format' do
-        let(:csv_content) do
-          <<~CSV
-            accredited_individual_registration_number,power_of_attorney_holder_type,user_account_email
-            REG001,veteran_service_organization,not-an-email
-            REG002,veteran_service_organization,rep2@vso.org
-          CSV
-        end
+    context 'client mock tests' do
+      let(:csv_content) do
+        data = <<~CSV
+          accredited_individual_registration_number,power_of_attorney_holder_type,user_account_email
+          REG001,veteran_service_organization,rep1@vso.org
+          REG002,veteran_service_organization,rep2@vso.org
+        CSV
 
-        it 'processes valid records and logs stats' do
-          expect(Rails.logger).to receive(:info).with('Fetching CSV from GitHub: test-repo path: test/path.csv')
-          expect(Rails.logger).to receive(:info)
-            .with('Successfully synced accredited individuals. Replaced 0 records with 1 records.')
-
-          described_class.new.perform
-
-          expect(UserAccountAccreditedIndividual.count).to eq(1)
-          expect(UserAccountAccreditedIndividual.first.user_account_email).to eq('rep2@vso.org')
-        end
+        CSV.parse(data, headers: true)
       end
 
-      context 'when CSV is empty' do
-        let(:csv_content) { '' }
-
-        it 'logs error and raises InvalidRowCount' do
-          expect(Rails.logger).to receive(:error).with(/Error syncing accredited individuals.*Empty CSV data received/)
-          expect { described_class.new.perform }
-            .to raise_error(described_class::InvalidRowCount, /Empty CSV data received/)
-        end
+      # rubocop:disable RSpec/MessageChain
+      before do
+        allow_any_instance_of(described_class).to receive(:extract).and_return(csv_content)
       end
+      # rubocop:enable RSpec/MessageChain
 
-      context 'with GitHub API error' do
-        before do
-          allow(github_client).to receive(:contents).and_raise(Octokit::Error.new)
+      describe '#perform' do
+        context 'with valid data' do
+          before do
+            # Create an existing record that should be deleted
+            UserAccountAccreditedIndividual.create!(
+              accredited_individual_registration_number: 'OLD001',
+              power_of_attorney_holder_type: 'veteran_service_organization',
+              user_account_email: 'old@vso.org'
+            )
+          end
+
+          it 'processes CSV from GitHub and syncs records' do
+            described_class.new.perform
+
+            records = UserAccountAccreditedIndividual.all
+            expect(records.count).to eq(2)
+            expect(records.pluck(:accredited_individual_registration_number))
+              .to match_array(%w[REG001 REG002])
+          end
         end
 
-        it 'logs and re-raises error' do
-          expect(Rails.logger).to receive(:error).with(/Error syncing accredited individuals/)
-          expect { described_class.new.perform }.to raise_error(Octokit::Error)
+        context 'with invalid power_of_attorney_holder_type' do
+          let(:csv_content) do
+            data = <<~CSV
+              accredited_individual_registration_number,power_of_attorney_holder_type,user_account_email
+              REG001,attorney,rep1@vso.org
+              REG002,veteran_service_organization,rep2@vso.org
+            CSV
+
+            CSV.parse(data, headers: true)
+          end
+
+          it 'raises an ActiveRecord::RecordInvalid error' do
+            expect {
+              described_class.new.perform
+            }.to raise_error(ActiveRecord::RecordInvalid, /Power of attorney holder type is not included in the list/)
+          end
+        end
+
+        context 'with invalid email format' do
+          let(:csv_content) do
+            data = <<~CSV
+              accredited_individual_registration_number,power_of_attorney_holder_type,user_account_email
+              REG001,veteran_service_organization,not-an-email
+              REG002,veteran_service_organization,rep2@vso.org
+            CSV
+
+            CSV.parse(data, headers: true)
+          end
+
+          it 'raises an ActiveRecord::RecordInvalid error' do
+            expect {
+              described_class.new.perform
+            }.to raise_error(ActiveRecord::RecordInvalid, /Validation failed: User account email is invalid/)
+          end
+        end
+
+        context 'when CSV is empty' do
+          let(:csv_content) { CSV.parse('', headers: true) }
+
+          it 'logs error and raises RecordCountError' do
+            expect { described_class.new.perform }
+              .to raise_error(described_class::RecordCountError, /record_count: 0/)
+          end
+        end
+
+        context 'when CSV has too many rows' do
+          let(:csv_content) do
+            headers = "accredited_individual_registration_number,power_of_attorney_holder_type,user_account_email"
+            rows = (1..501).map do |i|
+              "REG#{i.to_s.rjust(3, '0')},veteran_service_organization,rep#{i}@vso.org"
+            end
+
+            CSV.parse(([headers] + rows).join("\n"), headers: true)
+          end
+
+          it 'logs error and raises RecordCountError' do
+            expect { described_class.new.perform }
+              .to raise_error(described_class::RecordCountError, /record_count: 501/)
+          end
         end
       end
     end

--- a/modules/accredited_representative_portal/spec/spec_helper.rb
+++ b/modules/accredited_representative_portal/spec/spec_helper.rb
@@ -17,7 +17,40 @@ module Faker
   end
 end
 
+module VcrHelpers
+  VCR_OPTIONS = {
+    match_requests_on: %i[
+      method uri headers
+    ].freeze
+  }.freeze
+
+  def use_cassette(name, options = {}, &)
+    options.with_defaults!(
+      **VCR_OPTIONS,
+      use_spec_name_prefix: true
+    )
+
+    options.delete(:use_spec_name_prefix) and
+      name = spec_name_prefix / name
+
+    VCR.use_cassette(name, options, &)
+  end
+
+  def spec_name_prefix
+    caller.each do |call|
+      call = call.split(':').first
+      next unless call.end_with?('_spec.rb')
+
+      call.delete_prefix!((AccreditedRepresentativePortal::Engine.root / 'spec/').to_s)
+      call.delete_suffix!('.rb')
+      return Pathname('accredited_representative_portal') / call
+    end
+  end
+end
+
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.filter_run :focus
+
+  config.include VcrHelpers
 end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -51,7 +51,9 @@ VCR.configure do |c|
   c.filter_sensitive_data('<VRO_URL>') { Settings.virtual_regional_office.url }
   c.filter_sensitive_data('<VRO_API_KEY>') { Settings.virtual_regional_office.api_key }
   c.filter_sensitive_data('<CONTENTION_CLASSIFICATION_API_URL>') { Settings.contention_classification_api.url }
-  c.filter_sensitive_data('<ARP_ALLOW_LIST_ACCESS_TOKEN>') { Settings.accredited_representative_portal.allow_list.github.access_token }
+  c.filter_sensitive_data('<ARP_ALLOW_LIST_ACCESS_TOKEN>') do
+    Settings.accredited_representative_portal.allow_list.github.access_token
+  end
   c.filter_sensitive_data('<ARP_ALLOW_LIST_REPO>') { Settings.accredited_representative_portal.allow_list.github.repo }
   c.filter_sensitive_data('<ARP_ALLOW_LIST_PATH>') { Settings.accredited_representative_portal.allow_list.github.path }
   c.before_record do |i|

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -51,6 +51,9 @@ VCR.configure do |c|
   c.filter_sensitive_data('<VRO_URL>') { Settings.virtual_regional_office.url }
   c.filter_sensitive_data('<VRO_API_KEY>') { Settings.virtual_regional_office.api_key }
   c.filter_sensitive_data('<CONTENTION_CLASSIFICATION_API_URL>') { Settings.contention_classification_api.url }
+  c.filter_sensitive_data('<ARP_ALLOW_LIST_ACCESS_TOKEN>') { Settings.accredited_representative_portal.allow_list.github.access_token }
+  c.filter_sensitive_data('<ARP_ALLOW_LIST_REPO>') { Settings.accredited_representative_portal.allow_list.github.repo }
+  c.filter_sensitive_data('<ARP_ALLOW_LIST_PATH>') { Settings.accredited_representative_portal.allow_list.github.path }
   c.before_record do |i|
     %i[response request].each do |env|
       next unless i.send(env).headers.keys.include?('Token')

--- a/spec/support/vcr_cassettes/accredited_representative_portal/sidekiq/accredited_representative_portal/allow_list_sync_job_spec/insertions_and_deletions.yml
+++ b/spec/support/vcr_cassettes/accredited_representative_portal/sidekiq/accredited_representative_portal/allow_list_sync_job_spec/insertions_and_deletions.yml
@@ -1,0 +1,167 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/repos/<ARP_ALLOW_LIST_REPO>/contents/<ARP_ALLOW_LIST_PATH>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 9.2.0
+      Content-Type:
+      - application/json
+      Authorization: Bearer <TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 07 Feb 2025 05:50:21 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept, X-Requested-With
+      Etag:
+      - W/"6c423d527c2aeb856029427888d17ebfd65c70d5"
+      Last-Modified:
+      - Fri, 07 Feb 2025 03:23:35 GMT
+      X-Oauth-Scopes:
+      - public_repo
+      X-Accepted-Oauth-Scopes:
+      - ''
+      Github-Authentication-Token-Expiration:
+      - 2025-02-14 01:35:23 UTC
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4999'
+      X-Ratelimit-Reset:
+      - '1738911021'
+      X-Ratelimit-Used:
+      - '1'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - C710:1BAA4D:7AC31A8:F6AAB36:67A59F1D
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"<ARP_ALLOW_LIST_PATH>","path":"<ARP_ALLOW_LIST_PATH>","sha":"6c423d527c2aeb856029427888d17ebfd65c70d5","size":1123,"url":"https://api.github.com/repos/<ARP_ALLOW_LIST_REPO>/contents/<ARP_ALLOW_LIST_PATH>?ref=main","html_url":"https://github.com/<ARP_ALLOW_LIST_REPO>/blob/main/<ARP_ALLOW_LIST_PATH>","git_url":"https://api.github.com/repos/<ARP_ALLOW_LIST_REPO>/git/blobs/6c423d527c2aeb856029427888d17ebfd65c70d5","download_url":"https://raw.githubusercontent.com/<ARP_ALLOW_LIST_REPO>/main/<ARP_ALLOW_LIST_PATH>","type":"file","content":"YWNjcmVkaXRlZF9pbmRpdmlkdWFsX3JlZ2lzdHJhdGlvbl9udW1iZXIscG93\nZXJfb2ZfYXR0b3JuZXlfaG9sZGVyX3R5cGUsdXNlcl9hY2NvdW50X2VtYWls\nClZTTzEyMyx2ZXRlcmFuX3NlcnZpY2Vfb3JnYW5pemF0aW9uLHZzbzFAdmEu\nZ292ClZTTzQ1Nix2ZXRlcmFuX3NlcnZpY2Vfb3JnYW5pemF0aW9uLHZzbzJA\ndmEuZ292ClZTTzc4OSx2ZXRlcmFuX3NlcnZpY2Vfb3JnYW5pemF0aW9uLGF0\ndG9ybmV5MUBsYXdmaXJtLmNvbQpWU085ODcsdmV0ZXJhbl9zZXJ2aWNlX29y\nZ2FuaXphdGlvbixjbGFpbWFudDFAdmEuZ292ClZTTzY1NCx2ZXRlcmFuX3Nl\ncnZpY2Vfb3JnYW5pemF0aW9uLHZzbzNAdmEuZ292ClZTTzMyMSx2ZXRlcmFu\nX3NlcnZpY2Vfb3JnYW5pemF0aW9uLGF0dG9ybmV5MkBsYXdmaXJtLmNvbQpW\nU08xMTEsdmV0ZXJhbl9zZXJ2aWNlX29yZ2FuaXphdGlvbix2c280QHZhLmdv\ndgpWU08yMjIsdmV0ZXJhbl9zZXJ2aWNlX29yZ2FuaXphdGlvbixhdHRvcm5l\neTNAbGF3ZmlybS5jb20KVlNPMzMzLHZldGVyYW5fc2VydmljZV9vcmdhbml6\nYXRpb24sY2xhaW1hbnQyQHZhLmdvdgpWU080NDQsdmV0ZXJhbl9zZXJ2aWNl\nX29yZ2FuaXphdGlvbix2c281QHZhLmdvdgpWU081NTUsdmV0ZXJhbl9zZXJ2\naWNlX29yZ2FuaXphdGlvbix2c282QHZhLmdvdgpWU082NjYsdmV0ZXJhbl9z\nZXJ2aWNlX29yZ2FuaXphdGlvbix2c283QHZhLmdvdgpWU083NzcsdmV0ZXJh\nbl9zZXJ2aWNlX29yZ2FuaXphdGlvbixhdHRvcm5leTRAbGF3ZmlybS5jb20K\nVlNPODg4LHZldGVyYW5fc2VydmljZV9vcmdhbml6YXRpb24sY2xhaW1hbnQz\nQHZhLmdvdgpWU085OTksdmV0ZXJhbl9zZXJ2aWNlX29yZ2FuaXphdGlvbix2\nc284QHZhLmdvdgpWU08xMTIsdmV0ZXJhbl9zZXJ2aWNlX29yZ2FuaXphdGlv\nbix2c285QHZhLmdvdgpWU08xMTQsdmV0ZXJhbl9zZXJ2aWNlX29yZ2FuaXph\ndGlvbix2c28xMEB2YS5nb3YKVlNPMTE1LHZldGVyYW5fc2VydmljZV9vcmdh\nbml6YXRpb24sY2xhaW1hbnQ0QHZhLmdvdgpWU08xMTYsdmV0ZXJhbl9zZXJ2\naWNlX29yZ2FuaXphdGlvbix2c28xMUB2YS5nb3YKVlNPMTE3LHZldGVyYW5f\nc2VydmljZV9vcmdhbml6YXRpb24sYXR0b3JuZXk1QGxhd2Zpcm0uY29tCg==\n","encoding":"base64","_links":{"self":"https://api.github.com/repos/<ARP_ALLOW_LIST_REPO>/contents/<ARP_ALLOW_LIST_PATH>?ref=main","git":"https://api.github.com/repos/<ARP_ALLOW_LIST_REPO>/git/blobs/6c423d527c2aeb856029427888d17ebfd65c70d5","html":"https://github.com/<ARP_ALLOW_LIST_REPO>/blob/main/<ARP_ALLOW_LIST_PATH>"}}'
+  recorded_at: Fri, 07 Feb 2025 05:50:21 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/<ARP_ALLOW_LIST_REPO>/contents/<ARP_ALLOW_LIST_PATH>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 9.2.0
+      Content-Type:
+      - application/json
+      Authorization: Bearer <TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 07 Feb 2025 05:51:21 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept, X-Requested-With
+      Etag:
+      - W/"7ead51170aef2c0db3b9f4a3f485d1841dc0e393"
+      Last-Modified:
+      - Fri, 07 Feb 2025 05:51:16 GMT
+      X-Oauth-Scopes:
+      - public_repo
+      X-Accepted-Oauth-Scopes:
+      - ''
+      Github-Authentication-Token-Expiration:
+      - 2025-02-14 01:35:23 UTC
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4998'
+      X-Ratelimit-Reset:
+      - '1738911021'
+      X-Ratelimit-Used:
+      - '2'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - C744:D38BB:7D6DF96:FC0A745:67A59F59
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"<ARP_ALLOW_LIST_PATH>","path":"<ARP_ALLOW_LIST_PATH>","sha":"7ead51170aef2c0db3b9f4a3f485d1841dc0e393","size":1131,"url":"https://api.github.com/repos/<ARP_ALLOW_LIST_REPO>/contents/<ARP_ALLOW_LIST_PATH>?ref=main","html_url":"https://github.com/<ARP_ALLOW_LIST_REPO>/blob/main/<ARP_ALLOW_LIST_PATH>","git_url":"https://api.github.com/repos/<ARP_ALLOW_LIST_REPO>/git/blobs/7ead51170aef2c0db3b9f4a3f485d1841dc0e393","download_url":"https://raw.githubusercontent.com/<ARP_ALLOW_LIST_REPO>/main/<ARP_ALLOW_LIST_PATH>","type":"file","content":"YWNjcmVkaXRlZF9pbmRpdmlkdWFsX3JlZ2lzdHJhdGlvbl9udW1iZXIscG93\nZXJfb2ZfYXR0b3JuZXlfaG9sZGVyX3R5cGUsdXNlcl9hY2NvdW50X2VtYWls\nClZTTzEyMyx2ZXRlcmFuX3NlcnZpY2Vfb3JnYW5pemF0aW9uLHZzbzFAdmEu\nZ292ClZTTzQ1Nix2ZXRlcmFuX3NlcnZpY2Vfb3JnYW5pemF0aW9uLHZzbzJA\ndmEuZ292ClZTTzc4OSx2ZXRlcmFuX3NlcnZpY2Vfb3JnYW5pemF0aW9uLGF0\ndG9ybmV5MUBsYXdmaXJtLmNvbQpWU085ODcsdmV0ZXJhbl9zZXJ2aWNlX29y\nZ2FuaXphdGlvbixjbGFpbWFudDFAdmEuZ292ClZTTzY1NCx2ZXRlcmFuX3Nl\ncnZpY2Vfb3JnYW5pemF0aW9uLHZzbzNAdmEuZ292ClZTTzMyMSx2ZXRlcmFu\nX3NlcnZpY2Vfb3JnYW5pemF0aW9uLGF0dG9ybmV5MkBsYXdmaXJtLmNvbQpW\nU08xMTEsdmV0ZXJhbl9zZXJ2aWNlX29yZ2FuaXphdGlvbix2c280QHZhLmdv\ndgpWU08yMjIsdmV0ZXJhbl9zZXJ2aWNlX29yZ2FuaXphdGlvbixhdHRvcm5l\neTNAbGF3ZmlybS5jb20KVlNPMzMzMyx2ZXRlcmFuX3NlcnZpY2Vfb3JnYW5p\nemF0aW9uLGNsYWltYW50MjJAdmEuZ292ClZTTzQ0NDQsdmV0ZXJhbl9zZXJ2\naWNlX29yZ2FuaXphdGlvbix2c281NUB2YS5nb3YKVlNPNTU1NSx2ZXRlcmFu\nX3NlcnZpY2Vfb3JnYW5pemF0aW9uLHZzbzY2QHZhLmdvdgpWU082NjY2LHZl\ndGVyYW5fc2VydmljZV9vcmdhbml6YXRpb24sdnNvNzdAdmEuZ292ClZTTzc3\nNyx2ZXRlcmFuX3NlcnZpY2Vfb3JnYW5pemF0aW9uLGF0dG9ybmV5NEBsYXdm\naXJtLmNvbQpWU084ODgsdmV0ZXJhbl9zZXJ2aWNlX29yZ2FuaXphdGlvbixj\nbGFpbWFudDNAdmEuZ292ClZTTzk5OSx2ZXRlcmFuX3NlcnZpY2Vfb3JnYW5p\nemF0aW9uLHZzbzhAdmEuZ292ClZTTzExMix2ZXRlcmFuX3NlcnZpY2Vfb3Jn\nYW5pemF0aW9uLHZzbzlAdmEuZ292ClZTTzExNCx2ZXRlcmFuX3NlcnZpY2Vf\nb3JnYW5pemF0aW9uLHZzbzEwQHZhLmdvdgpWU08xMTUsdmV0ZXJhbl9zZXJ2\naWNlX29yZ2FuaXphdGlvbixjbGFpbWFudDRAdmEuZ292ClZTTzExNix2ZXRl\ncmFuX3NlcnZpY2Vfb3JnYW5pemF0aW9uLHZzbzExQHZhLmdvdgpWU08xMTcs\ndmV0ZXJhbl9zZXJ2aWNlX29yZ2FuaXphdGlvbixhdHRvcm5leTVAbGF3Zmly\nbS5jb20K\n","encoding":"base64","_links":{"self":"https://api.github.com/repos/<ARP_ALLOW_LIST_REPO>/contents/<ARP_ALLOW_LIST_PATH>?ref=main","git":"https://api.github.com/repos/<ARP_ALLOW_LIST_REPO>/git/blobs/7ead51170aef2c0db3b9f4a3f485d1841dc0e393","html":"https://github.com/<ARP_ALLOW_LIST_REPO>/blob/main/<ARP_ALLOW_LIST_PATH>"}}'
+  recorded_at: Fri, 07 Feb 2025 05:51:21 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
## Add Accredited Representative Portal Sync and Allow List Management

## Summary
This PR introduces key improvements and new features to the Accredited Representative Portal, automating allow list management via GitHub and enhancing overall system integrity and test coverage.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/99863

---

## Changes

### 1. **Code Owners Update**
- Added ownership for `spec/support/vcr_cassettes/accredited_representative_portal` to ensure proper code review for the new module.

### 2. **Configuration Updates**
- **Settings (`config/settings.yml`):** Added a new `allow_list` configuration for GitHub integration, specifying access token, repository, and CSV path.

### 3. **New Features**
- **Model (`UserAccountAccreditedIndividual`):**
  - Tracks accredited representatives with key validations:
    - Presence of registration number and email.
    - Email format validation.
  - Defined `power_of_attorney_holder_type` using an enum.

- **Background Job (`AllowListSyncJob`):**
  - Uses Sidekiq to pull and sync the allow list dynamically from GitHub.
  - Implements robust validations on record counts to ensure safe data syncing.

### 4. **Test Coverage**
- **RSpec Tests:** 
  - Model tests validate key attributes, enums, and email formats.
  - Job tests cover syncing scenarios, edge cases (e.g., invalid data, empty CSVs, and large record counts).
  - VCR integration ensures accurate testing of external API interactions.

- **VCR Helpers:** Streamlined cassette usage with reusable helper modules for consistent request matching and recording.

### 5. **Sensitive Data Protection**
- VCR filters added to mask sensitive credentials and configuration data during test recording.
