### PR TITLE
API-44223-consent-limit-logging

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/poa_assign_dependent_claimant_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/poa_assign_dependent_claimant_job.rb
@@ -8,7 +8,7 @@ module ClaimsApi
 
     def perform(poa_id, rep_id = nil) # rubocop:disable Metrics/MethodLength
       poa = ClaimsApi::PowerOfAttorney.find(poa_id)
-      poa_code = extract_poa_code(poa.form_data['data']['attributes'])
+      poa_code = extract_poa_code(poa.form_data)
 
       service = dependent_claimant_poa_assignment_service(
         poa.id,
@@ -60,7 +60,7 @@ module ClaimsApi
     def dependent_claimant_poa_assignment_service(poa_id, form_data, auth_headers)
       ClaimsApi::DependentClaimantPoaAssignmentService.new(
         poa_id:,
-        poa_code: extract_poa_code(form_data['data']['attributes']),
+        poa_code: extract_poa_code(form_data),
         veteran_participant_id: auth_headers['va_eauth_pid'],
         dependent_participant_id: auth_headers.dig('dependent', 'participant_id'),
         veteran_file_number: auth_headers['file_number'],

--- a/modules/claims_api/app/sidekiq/claims_api/poa_assign_dependent_claimant_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/poa_assign_dependent_claimant_job.rb
@@ -6,6 +6,7 @@ module ClaimsApi
 
     def perform(poa_id, rep_id = nil) # rubocop:disable Metrics/MethodLength
       poa = ClaimsApi::PowerOfAttorney.find(poa_id)
+      poa_code = extract_poa_code(poa.form_data['data']['attributes'])
 
       service = dependent_claimant_poa_assignment_service(
         poa.id,
@@ -13,8 +14,14 @@ module ClaimsApi
         poa.auth_headers
       )
 
-      ClaimsApi::Logger.log(LOG_TAG, poa_id: poa.id, record_consent: poa.form_data['recordConsent'],
-                                     consent_address_change: poa.form_data['consentAddressChange'])
+      ClaimsApi::Logger.log(
+        LOG_TAG,
+        poa_id: poa.id,
+        detail: form_logger_consent_detail(poa, poa_code),
+        poa_code:,
+        allow_poa_access: allow_poa_access?(poa_form_data: poa.form_data),
+        allow_poa_c_add: allow_address_change?(poa)
+      )
 
       begin
         service.assign_poa_to_dependent!
@@ -51,7 +58,7 @@ module ClaimsApi
     def dependent_claimant_poa_assignment_service(poa_id, form_data, auth_headers)
       ClaimsApi::DependentClaimantPoaAssignmentService.new(
         poa_id:,
-        poa_code: find_poa_code(form_data),
+        poa_code: extract_poa_code(form_data['data']['attributes']),
         veteran_participant_id: auth_headers['va_eauth_pid'],
         dependent_participant_id: auth_headers.dig('dependent', 'participant_id'),
         veteran_file_number: auth_headers['file_number'],
@@ -59,11 +66,6 @@ module ClaimsApi
         allow_poa_cadd: form_data['consentAddressChange'].present? ? 'Y' : nil,
         claimant_ssn: auth_headers.dig('dependent', 'ssn')
       )
-    end
-
-    def find_poa_code(data)
-      base = data.key?('serviceOrganization') ? 'serviceOrganization' : 'representative'
-      data.dig(base, 'poaCode')
     end
   end
 end

--- a/modules/claims_api/app/sidekiq/claims_api/poa_vbms_updater.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/poa_vbms_updater.rb
@@ -5,6 +5,8 @@ require 'bgs_service/corporate_update_web_service'
 
 module ClaimsApi
   class PoaVBMSUpdater < ClaimsApi::ServiceBase
+    LOG_TAG = 'poa_vbms_updater'
+
     def perform(power_of_attorney_id) # rubocop:disable Metrics/MethodLength
       poa_form = ClaimsApi::PowerOfAttorney.find(power_of_attorney_id)
       process = ClaimsApi::Process.find_or_create_by(processable: poa_form, step_type: 'POA_ACCESS_UPDATE')
@@ -14,9 +16,9 @@ module ClaimsApi
       poa_code = extract_poa_code(poa_form.form_data)
 
       ClaimsApi::Logger.log(
-        'poa_vbms_updater',
+        LOG_TAG,
         poa_id: power_of_attorney_id,
-        detail: 'Updating Access',
+        detail: form_logger_consent_detail(poa_form, poa_code),
         poa_code:,
         allow_poa_access: allow_poa_access?(poa_form_data: poa_form.form_data),
         allow_poa_c_add: allow_address_change?(poa_form)
@@ -51,10 +53,6 @@ module ClaimsApi
                       error_messages: [{ title: 'BGS Error',
                                          detail: poa_form.vbms_error_message }])
       ClaimsApi::Logger.log('poa', poa_id: poa_form.id, detail: 'BGS Error', error: e)
-    end
-
-    def allow_address_change?(poa_form)
-      poa_form.form_data['consentAddressChange']
     end
 
     def update_poa_access(poa_form:, participant_id:, poa_code:)

--- a/modules/claims_api/app/sidekiq/claims_api/service_base.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/service_base.rb
@@ -40,6 +40,12 @@ module ClaimsApi
 
     protected
 
+    def form_logger_consent_detail(poa, poa_code)
+      "Updating Access. recordConsent: #{poa.form_data['recordConsent'] || false}" \
+        "#{poa.form_data['consentLimits'] ? ', consentLimits included' : nil}" \
+        " for representative #{poa_code}"
+    end
+
     def dependent_filing?(poa)
       poa.auth_headers.key?('dependent')
     end
@@ -180,6 +186,10 @@ module ClaimsApi
             end
       # If there is a match return false because we will not retry
       NO_RETRY_ERROR_CODES.exclude?(msg)
+    end
+
+    def allow_address_change?(poa_form)
+      poa_form.form_data['consentAddressChange']
     end
 
     def will_retry_status_code?(error)

--- a/modules/claims_api/spec/sidekiq/poa_assign_dependent_claimant_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/poa_assign_dependent_claimant_job_spec.rb
@@ -57,6 +57,22 @@ RSpec.describe ClaimsApi::PoaAssignDependentClaimantJob, type: :job do
              status: ClaimsApi::PowerOfAttorney::SUBMITTED)
     end
 
+    it 'logs out the details correctly for consent information' do
+      poa_code = poa.form_data['data']['attributes']['serviceOrganization']['poaCode']
+      consent_msg = 'Updating Access. recordConsent: false ' \
+                    "for representative #{poa_code}"
+
+      allow_any_instance_of(ClaimsApi::DependentClaimantPoaAssignmentService)
+        .to receive(:assign_poa_to_dependent!).and_return(
+          true
+        )
+
+      detail_msg = ClaimsApi::ServiceBase.new.send(:form_logger_consent_detail, poa, poa_code)
+
+      expect(detail_msg).to eq(consent_msg)
+      described_class.new.perform(poa.id, 'Rep Data')
+    end
+
     it "marks the POA status as 'updated'" do
       allow_any_instance_of(ClaimsApi::DependentClaimantPoaAssignmentService)
         .to receive(:assign_poa_to_dependent!).and_return(

--- a/modules/claims_api/spec/sidekiq/poa_vbms_updater_spec.rb
+++ b/modules/claims_api/spec/sidekiq/poa_vbms_updater_spec.rb
@@ -55,6 +55,27 @@ RSpec.describe ClaimsApi::PoaVBMSUpdater, type: :job do
       end
     end
 
+    context 'consent details' do
+      let(:allow_poa_c_add) { 'Y' }
+      let(:consent_address_change) { true }
+
+      it 'logs correct with consentLimits included' do
+        poa = create_poa(allow_poa_access: true)
+        poa.form_data['consentLimits'] = ['HIV']
+        poa.save
+        create_mock_lighthouse_service_no_access
+        poa_code = poa.form_data['serviceOrganization']['poaCode']
+        consent_msg = 'Updating Access. recordConsent: true' \
+                      ', consentLimits included ' \
+                      "for representative #{poa_code}"
+
+        detail_msg = ClaimsApi::ServiceBase.new.send(:form_logger_consent_detail, poa, poa_code)
+
+        expect(detail_msg).to eq(consent_msg)
+        subject.new.perform(poa.id)
+      end
+    end
+
     context 'when address change is not present' do
       let(:allow_poa_c_add) { 'N' }
       let(:consent_address_change) { nil }
@@ -126,6 +147,18 @@ RSpec.describe ClaimsApi::PoaVBMSUpdater, type: :job do
       participant_id: user.participant_id,
       poa_code: '074',
       allow_poa_access: 'Y',
+      allow_poa_c_add:
+    ).and_return({ return_code: 'GUIE50000' })
+    service_double = instance_double(BGS::Services)
+    expect(service_double).to receive(:corporate_update).and_return(@corporate_update_stub)
+    expect(BGS::Services).to receive(:new).and_return(service_double)
+  end
+
+  def create_mock_lighthouse_service_no_access
+    expect(@corporate_update_stub).to receive(:update_poa_access).with(
+      participant_id: user.participant_id,
+      poa_code: '074',
+      allow_poa_access: 'N',
       allow_poa_c_add:
     ).and_return({ return_code: 'GUIE50000' })
     service_double = instance_double(BGS::Services)


### PR DESCRIPTION
## Summary
* Adds consent information log outs to `poa_vbms_updater` and `poa_assign_dependent_claimant_job`
* Adds tests for logger detail message
* Refactors:
    * Refactors some shared methods into the service_base file
    * removes a method that was duplicating logic

## Related issue(s)
[API-44223](https://jira.devops.va.gov/browse/API-44223)

## Testing done

- [x] *New code is covered by unit tests*

#### Testing Notes
* Manually running the jobs you should see logouts in line with images below for each scenario
* with `"recordConsent": true,` (obviously details will match your rep and all that)
```
Rails --  ClaimsApi :: poa_vbms_updater :: {... "detail":"Updating Access. recordConsent: true for representative 045","poa_code":"045","allow_poa_access":true,"allow_poa_c_add":null} :: Location:...
```
* with `      "recordConsent": false, "consentLimits": ["HIV"],`
```
Rails -- ClaimsApi :: poa_vbms_updater :: {... "detail":"Updating Access. recordConsent: false, consentLimits included for representative 045","poa_code":"045","allow_poa_access":false,"allow_poa_c_add":null} :: Location:...
```
* with `"recordConsent": false,` and no consent limits
```
Rails -- ClaimsApi :: poa_vbms_updater :: {..."detail":"Updating Access. recordConsent: false for representative 045","poa_code":"045","allow_poa_access":false,"allow_poa_c_add":null} :: Location:...
```
* for a dependent claimant filing
```
 Rails -- ClaimsApi :: poa_assign_dependent_claimant_job :: {..."detail":"Updating Access. recordConsent: true for representative 045","poa_code":"045","allow_poa_access":true,"allow_poa_c_add":null} :: Location:...
```

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/sidekiq/claims_api/poa_assign_dependent_claimant_job.rb
	modified:   modules/claims_api/app/sidekiq/claims_api/poa_vbms_updater.rb
	modified:   modules/claims_api/app/sidekiq/claims_api/service_base.rb
	modified:   modules/claims_api/spec/sidekiq/poa_assign_dependent_claimant_job_spec.rb
	modified:   modules/claims_api/spec/sidekiq/poa_vbms_updater_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
