### PR TITLE
Filtering Sensitive Parameters from Vets API Logs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1714,6 +1714,7 @@ spec/requests/v0/evss_claims_async_spec.rb @department-of-veterans-affairs/vfs-a
 spec/requests/v0/evss_claims_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/root_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/exceptions_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/requests/filter_parameter_logging_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/flipper_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/v0/messaging/health/folders_spec.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/requests/v0/form1095_bs_spec.rb @department-of-veterans-affairs/vfs-1095-b @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -35,6 +35,24 @@ ALLOWLIST = %w[
   filter
   startedFormVersion
 ].freeze
-Rails.application.config.filter_parameters = [lambda do |k, v|
-  v.replace('FILTERED') if v.is_a?(String) && ALLOWLIST.exclude?(k)
-end]
+
+Rails.application.config.filter_parameters = [
+  lambda do |k, v|
+    case v
+    when Hash # Recursively iterate over each key value pair in hashes
+      v.each do |nested_key, nested_value|
+        Rails.application.config.filter_parameters.first.call(nested_key, nested_value)
+      end
+    when Array # Recursively map all elements in arrays
+      v.map! { |element| Rails.application.config.filter_parameters.first.call(k, element) }
+    when ActionDispatch::Http::UploadedFile # Base case
+      v.instance_variables.each do |var| # could put specific instance vars here, but made more generic
+        var_name = var.to_s.delete_prefix('@')
+        v.instance_variable_set(var, '[FILTERED!]') unless ALLOWLIST.include?(var_name)
+      end
+    when String # Base case
+      # Apply filtering only if the key is NOT in the ALLOWLIST
+      v.replace('[FILTERED]') unless ALLOWLIST.include?(k.to_s)
+    end
+  end
+]

--- a/spec/fixtures/files/test_file_with_pii.txt
+++ b/spec/fixtures/files/test_file_with_pii.txt
@@ -1,0 +1,46 @@
+# Bad Logs with PII (Thse Should be Filtered)
+
+Processing by TestParamsController#create as JSON
+  Parameters: {"file"=>
+    #<ActionDispatch::Http::UploadedFile:0x00007f9342f1a3c0
+      @tempfile=#<File:/tmp/RackMultipart20250110-1234-xyz.png>,
+      @original_filename="sensitive_document.pdf",
+      @content_type="application/pdf",
+      @headers="Content-Disposition: form-data; name=\"attachment\"; filename=\"sensitive_document.pdf\"\r\nContent-Type: application/pdf\r\n">
+  }
+
+  Parameters: {"attachment"=>
+    {
+      "file"=>"Sensitive binary content here",
+      "original_filename"=>"private_file.docx",
+      "headers"=>"Content-Disposition: form-data; name=\"attachment\"; filename=\"private_file.docx\"\r\nContent-Type: application/msword\r\n",
+      "tempfile"=>"#<File:/tmp/sensitive_file.docx>"
+    }
+  }
+
+TestParamsController -- Completed #create --
+{ :controller => "TestParamsController", :action => "create", :params =>
+  { "upload" => #<ActionDispatch::Http::UploadedFile:0x000072113126d950
+    @tempfile=#<Tempfile:/tmp/RackMultipart20250130-142160-hlocps.txt>,
+    @content_type="text/plain",
+    @original_filename="PII FILENAME",
+    @headers="PII HEADERS">
+  },
+  :format => "HTML",
+  :method => "POST",
+  :path => "/test_params",
+  :status => 200,
+  :view_runtime => 0.18,
+  :db_runtime => 0.0,
+  :queries_count => 0,
+  :cached_queries_count => 0,
+  :allocations => 325,
+  :status_message => "OK"
+}
+
+User Information:
+  Name: John Doe
+  SSN: 123-45-6789
+  Email: johndoe@example.com
+
+Request Completed 200 OK

--- a/spec/requests/filter_parameter_logging_spec.rb
+++ b/spec/requests/filter_parameter_logging_spec.rb
@@ -77,6 +77,23 @@ RSpec.describe 'Filter Parameter Logging', type: :request do
 
     expect(logs).to include('"attachment"')
   end
+
+  it 'filters SSN from logs' do
+    sensitive_params = {
+      name: 'John Doe',
+      ssn: '123-45-6789',
+      email: 'johndoe@example.com'
+    }
+
+    post '/test_params', params: sensitive_params
+    logs = @log_output.string
+
+    puts "DEBUG LOG OUTPUT 3: #{logs}" # Debugging output
+
+    expect(logs).not_to include('123-45-6789') # SSN should be wiped out
+    expect(logs).not_to include('johndoe@example.com') # Ensure emails are also wiped
+    expect(logs).to include('"ssn":"[FILTERED]"') # Confirm it's being replaced
+  end
 end
 
 class TestParamsController < ActionController::API

--- a/spec/requests/filter_parameter_logging_spec.rb
+++ b/spec/requests/filter_parameter_logging_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Filter Parameter Logging', type: :request do
     post '/test_params', params: { attachment: file }
     logs = @log_output.string
 
-    # puts "DEBUG LOG OUTPUT TEST 1: #{logs}"
+    puts "DEBUG LOG OUTPUT TEST 1: #{logs}"
 
     expect(logs).to include('"attachment"')
 
@@ -64,7 +64,7 @@ RSpec.describe 'Filter Parameter Logging', type: :request do
     post '/test_params', params: { attachment: file_params }
     logs = @log_output.string
 
-    # puts "DEBUG LOG OUTPUT TEST 2: #{logs}"
+    puts "DEBUG LOG OUTPUT TEST 2: #{logs}"
 
     expect(logs).not_to include('private_file.docx')
     expect(logs).not_to include('sensitive binary content')

--- a/spec/requests/filter_parameter_logging_spec.rb
+++ b/spec/requests/filter_parameter_logging_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'stringio'
+
+RSpec.describe 'Filter Parameter Logging', type: :request do
+  before do
+    @original_logger = Rails.logger
+    @log_output = StringIO.new
+
+    # Ensure we remove any existing appenders before adding a new one
+    SemanticLogger.appenders.each { |appender| SemanticLogger.remove_appender(appender) }
+
+    # Add StringIO as a new appender for SemanticLogger
+    @test_appender = SemanticLogger.add_appender(io: @log_output, formatter: :json)
+    SemanticLogger.default_level = :debug
+
+    # Ensure Rails.logger is also set to use SemanticLogger
+    Rails.logger = SemanticLogger['TestLogger']
+    allow(Rails).to receive(:logger).and_return(Rails.logger)
+
+    Rails.application.routes.draw do
+      post '/test_params' => 'test_params#create'
+    end
+  end
+
+  after do
+    SemanticLogger.remove_appender(@test_appender)
+    Rails.logger = @original_logger
+  end
+
+  it 'filters uploaded file parameters but logs HTTP upload object' do
+    file = fixture_file_upload(
+      Rails.root.join('spec', 'fixtures', 'files', 'test_file_with_pii.txt'), 'text/plain'
+    )
+
+    post '/test_params', params: { attachment: file }
+    logs = @log_output.string
+
+    # puts "DEBUG LOG OUTPUT TEST 1: #{logs}"
+
+    expect(logs).to include('"attachment"')
+
+    expect(logs).not_to include('test_file_with_pii.txt')
+    expect(logs).not_to include('John Doe')
+    expect(logs).not_to include('123-45-6789')
+    expect(logs).not_to include('johndoe@example.com')
+
+    expect(logs).to include('"original_filename":"[FILTERED!]"')
+    expect(logs).to include('"headers":"[FILTERED!]"')
+    expect(logs).to include('"tempfile":"[FILTERED!]"')
+  end
+
+  it 'filters file parameters when represented as a hash' do
+    file_params = {
+      'content_type' => 'application/pdf',
+      'file' => 'sensitive binary content',
+      'original_filename' => 'private_file.docx',
+      'headers' => 'Content-Disposition: form-data; name="attachment"; filename="private_file.docx"',
+      'tempfile' => '#<File:/tmp/sensitive_file.docx>'
+    }
+
+    post '/test_params', params: { attachment: file_params }
+    logs = @log_output.string
+
+    # puts "DEBUG LOG OUTPUT TEST 2: #{logs}"
+
+    expect(logs).not_to include('private_file.docx')
+    expect(logs).not_to include('sensitive binary content')
+    expect(logs).not_to include('sensitive_file.docx')
+
+    expect(logs).to include('"file":"[FILTERED]"')
+    expect(logs).to include('"original_filename":"[FILTERED]"')
+    expect(logs).to include('"headers":"[FILTERED]"')
+    expect(logs).to include('"tempfile":"[FILTERED]"')
+
+    expect(logs).to include('"attachment"')
+  end
+end
+
+class TestParamsController < ActionController::API
+  def create
+    # Rails.logger.info("params BEFORE filtering: #{request.parameters.inspect}")
+    render json: { status: 'ok' }, status: :ok
+  end
+end

--- a/spec/requests/filter_parameter_logging_spec.rb
+++ b/spec/requests/filter_parameter_logging_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'Filter Parameter Logging', type: :request do
   after do
     SemanticLogger.remove_appender(@test_appender)
     Rails.logger = @original_logger
+    Rails.application.reload_routes!
   end
 
   it 'filters uploaded file parameters but logs HTTP upload object' do


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

This PR changes the `filter_parameter_logging.rb` initializer to improve PII filtering beyond just strings. Prior to this, only string based parameters were being filtered, leaving potential PII exposure in `ActionDispatch::Http::UploadedFile` objects, Hashes and Arrays. This update ensures that uploaded files and structured data containing sensitive info are properly filtered. The filter parameter method uses recursion to iterate over both arrays and hashes, allowing it to filter `ActionDispatch::Http::UploadedFile` objects and strings effectively, with recursion base cases handling the HTTP objects and string values as the base cases. We have some category filters and remappers in place as a temporary solution in the Datadog UI to mask the PII, but it's more secure to filter the logs before they even reach the agent at the Vets API layer for better security. The spec tests and test log file confirm that this filtering works as expected. See the screenshot below for an example of specs being filtered with the newly implemented filtering:

<img width="1288" alt="Screenshot 2025-02-03 at 11 06 22 AM" src="https://github.com/user-attachments/assets/9363293b-7848-429f-9e2a-1a620220a8bb" />

This PR also includes a SemanticLogger appender in the spec tests to fix an issue where logs were staying in a buffer and not flushing, causing tests to fail. By removing the existing appender and adding the new StringIO appender, logs are forced to flush properly. This guarantees that the log based rpsec specs reflect the expected output during test runs.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/2157
## Testing done

- [x] *New code is covered by unit tests*
- **Before this change:** filtering relied on a combination of category filters and remappers in the Datadog UI as a temporary workaround until a more permanent, long term solution could be implemented. We want to avoid exposing PII at unnecessary layers such as the Agent.
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing* The specs verify that the changes are working as expected and I compared the output in the debug output to what we would expect from the filters. After this we will need to turn off the mapping behavior in the Datadog UI to verify this is working properly.
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x] I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
