### PR TITLE
API-44520 - Update VDC_STATUS value to uppercase for call to BGS

### DIFF
--- a/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/create_request.rb
+++ b/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/create_request.rb
@@ -16,7 +16,7 @@ module ClaimsApi
       PHONE_TYPE = 'Daytime'
       PTCPNT_TYPE = 'Person'
       REPRESENTATIVE_TYPE = 'Recognized Veterans Service Organization'
-      VDC_STATUS = 'Submitted'
+      VDC_STATUS = 'SUBMITTED'
 
       def initialize(veteran_participant_id, form_data, claimant_participant_id = nil, poa_key = :serviceOrganization)
         @veteran_participant_id = veteran_participant_id


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Updates the alphabetic case of the VDC_STATUS value used in calls to BGS createVeteranRepresentative, so that the resulting request is correctly populated and appears as expected in the VNP_PROC_LC_STATUS Corp DB table.

## Related issue(s)

- [API-44520](https://jira.devops.va.gov/browse/API-44520)

## Testing done

- [ ] *New code is covered by unit tests*
- Testing done in concert with Michael Harlow to confirm that our POA requests are being correctly populated in BGS and the Corporate DB table VNP_PROC_LC_STATUS.


## What areas of the site does it impact?
Calls to POA endpoint POST veterans/{{veteranId}}/power-of-attorney-request

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

