### PR TITLE
101978 add EPS get_appointment method

### DIFF
--- a/modules/vaos/app/services/eps/appointment_service.rb
+++ b/modules/vaos/app/services/eps/appointment_service.rb
@@ -3,6 +3,21 @@
 module Eps
   class AppointmentService < BaseService
     ##
+    # Get a specific appointment from EPS by ID
+    #
+    # @param appointment_id [String] The ID of the appointment to retrieve
+    # @param retrieve_latest_details [Boolean] Whether to fetch latest details from provider service
+    # @raise [ArgumentError] If appointment_id is blank
+    # @return OpenStruct response from EPS get appointment endpoint
+    #
+    def get_appointment(appointment_id:, retrieve_latest_details: false)
+      query_params = retrieve_latest_details ? '?retrieveLatestDetails=true' : ''
+
+      response = perform(:get, "/#{config.base_path}/appointments/#{appointment_id}#{query_params}", {}, headers)
+      OpenStruct.new(response.body)
+    end
+
+    ##
     # Get appointments data from EPS
     #
     # @return OpenStruct response from EPS appointments endpoint


### PR DESCRIPTION
## Summary
This PR adds a get_appointment method to EPSService which calls the EPS endpoint to get details of a specific appointment.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/101978

## Testing done
- [X] *New code is covered by unit tests*

## What areas of the site does it impact?
VAOS EPS code

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
