### PR TITLE
API-34450 POA decide endpoint request mocking

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -7,7 +7,10 @@
   :endpoints:
     - :method: :post
       :path: "/VDC/ManageRepresentativeService"
-      :file_path: "/bgs/manage_representative_service/read_poa_request/default"
+      :file_path: "/bgs/manage_representative_service/"
+      :cache_multiple_responses:
+        :uid_location: body
+        :uid_locator: '<tns:(\w+)>'
 
 #CRM API GET endpoint
 - :name: "CRM API GET endpoint"

--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -82,14 +82,12 @@ module ClaimsApi
                                                                external_key: Settings.bgs.external_key)
 
           ptcpnt_id = fetch_ptcpnt_id(vet_icn)
-          if decision == 'declined'
-            poa_request = validate_ptcpnt_id!(ptcpnt_id:, proc_id:, representative_id:, service:)
-          end
+          validate_ptcpnt_id!(ptcpnt_id:, proc_id:, representative_id:, service:) if decision == 'declined'
 
           first_name = poa_request['claimantFirstName'].presence || poa_request['vetFirstName'] if poa_request
 
           res = service.update_poa_request(proc_id:, secondary_status: decision,
-                                           declined_reason: form_attributes['declinedReason'])
+                                           declined_reason: form_attributes['declinedReason'], use_mocks: true)
 
           raise Common::Exceptions::Lighthouse::BadGateway if res.blank?
 

--- a/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/show.rb
+++ b/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/show.rb
@@ -11,7 +11,7 @@ module ClaimsApi
         service = ClaimsApi::ManageRepresentativeService.new(external_uid: Settings.bgs.external_uid,
                                                              external_key: Settings.bgs.external_key)
 
-        res = service.read_poa_request_by_ptcpnt_id(ptcpnt_id: @participant_id)
+        res = service.read_poa_request_by_ptcpnt_id(ptcpnt_id: @participant_id, use_mocks: true)
         res['poaRequestRespondReturnVOList']
       end
     end

--- a/modules/claims_api/lib/bgs_service/manage_representative_service.rb
+++ b/modules/claims_api/lib/bgs_service/manage_representative_service.rb
@@ -58,7 +58,7 @@ module ClaimsApi
                    namespaces: { 'data' => '/data' }, transform_response: false, use_mocks:)
     end
 
-    def read_poa_request_by_ptcpnt_id(ptcpnt_id:)
+    def read_poa_request_by_ptcpnt_id(ptcpnt_id:, use_mocks: false)
       builder = Nokogiri::XML::Builder.new do
         PtcpntId ptcpnt_id
       end
@@ -66,10 +66,11 @@ module ClaimsApi
       body = builder_to_xml(builder)
 
       make_request(endpoint: bean_name, action: 'readPOARequestByPtcpntId', body:, key: 'POARequestRespondReturnVO',
-                   namespaces: { 'data' => '/data' }, transform_response: false)
+                   namespaces: { 'data' => '/data' }, transform_response: false, use_mocks:)
     end
 
-    def update_poa_request(proc_id:, representative: {}, secondary_status: 'obsolete', declined_reason: nil)
+    def update_poa_request(proc_id:, representative: {}, secondary_status: 'obsolete', declined_reason: nil,
+                           use_mocks: false)
       first_name = representative[:first_name].presence || 'vets-api'
       last_name = representative[:last_name].presence || 'vets-api'
 
@@ -87,7 +88,7 @@ module ClaimsApi
       body = builder_to_xml(builder)
 
       make_request(endpoint: bean_name, action: 'updatePOARequest', body:, key: 'POARequestUpdate',
-                   namespaces: { 'data' => '/data' }, transform_response: false)
+                   namespaces: { 'data' => '/data' }, transform_response: false, use_mocks:)
     end
   end
 end


### PR DESCRIPTION
## Summary

- Updates the betamocks service config for BGS calls to ManageRepresentativeService
- Adds optional mocking parameter to ManageRepresentativeService calls for update_poa_request & read_poa_request_by_ptcpnt_id, threads through calls from POA controllers to use mocking

## Related issue(s)

[API-34450](https://jira.devops.va.gov/browse/API-34450)

## Testing done

- [x] There should be no change to current functionality

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
