### PR TITLE
Refactor S3 PutObject response and error handling

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -183,6 +183,9 @@ features:
   champva_vanotify_custom_confirmation_callback:
     actor_type: user
     description: Enables the custom callback_klass when sending IVC CHAMPVA confirmation emails with VA Notify
+  champva_log_all_s3_uploads:
+    actor_type: user
+    description: Enables logging for all s3 uploads using UUID or keys for monitoring
   champva_multiple_stamp_retry:
     actor_type: user
     description: Enables retry of file creation for some errors in CHAMPVA PDF stamping

--- a/modules/ivc_champva/app/services/ivc_champva/s3.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/s3.rb
@@ -52,6 +52,16 @@ module IvcChampva
 
     private
 
+    ##
+    # Handles the response from a put_object operation.
+    #
+    # Extracts the status code from the response and tracks successful uploads.
+    # If the status code is not 200, logs and returns an error message.
+    #
+    # @param response [Aws::S3::Types::PutObjectOutput] the S3 response object.
+    # @param key [String] the key of the uploaded file.
+    # @param file [String] the path to the file uploaded.
+    # @return [Hash] a hash containing { success: true } on success, or { success: false, error_message: String } on failure.
     def handle_put_object_response(response, key, file)
       status_code = response.context.http_response.status_code
       if status_code == 200
@@ -67,6 +77,13 @@ module IvcChampva
       end
     end
 
+    ##
+    # Handles errors raised during the put_object operation.
+    #
+    # Logs the error and returns an error message.
+    #
+    # @param error [Exception] the exception raised.
+    # @return [Hash] a hash containing { success: false, error_message: String }.
     def handle_put_object_error(error)
       Rails.logger.error "S3 PutObject unexpected error: #{error.message}"
       { success: false, error_message: "S3 PutObject unexpected error: #{error.message.strip}" }

--- a/modules/ivc_champva/app/services/ivc_champva/s3.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/s3.rb
@@ -67,7 +67,6 @@ module IvcChampva
       end
     end
 
-
     def handle_put_object_error(error)
       Rails.logger.error "S3 PutObject unexpected error: #{error.message}"
       { success: false, error_message: "S3 PutObject unexpected error: #{error.message.strip}" }

--- a/modules/ivc_champva/app/services/ivc_champva/s3.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/s3.rb
@@ -52,19 +52,21 @@ module IvcChampva
 
     private
 
-    def handle_put_object_response(response, key, file)
-      if response.status == 200
-        monitor.track_all_successful_s3_uploads(key)
-        { success: true }
-      else
-        error_message = "S3 PutObject failure for #{file}: Status code: #{response.status}"
-        if response.respond_to?(:body) && response.body.respond_to?(:read)
-          error_message += ", Body: #{response.body.read}"
-        end
-        Rails.logger.error error_message
-        { success: false, error_message: error_message }
-      end
+def handle_put_object_response(response, key, file)
+  status_code = response.context.http_response.status_code
+  if status_code == 200
+    monitor.track_all_successful_s3_uploads(key)
+    { success: true }
+  else
+    error_message = "S3 PutObject failure for #{file}: Status code: #{status_code}"
+    if response.respond_to?(:body) && response.body.respond_to?(:read)
+      error_message += ", Body: #{response.body.read}"
     end
+    Rails.logger.error error_message
+    { success: false, error_message: error_message }
+  end
+end
+
 
     def handle_put_object_error(error)
       Rails.logger.error "S3 PutObject unexpected error: #{error.message}"

--- a/modules/ivc_champva/app/services/ivc_champva/s3.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/s3.rb
@@ -52,20 +52,20 @@ module IvcChampva
 
     private
 
-  def handle_put_object_response(response, key, file)
-    status_code = response.context.http_response.status_code
-    if status_code == 200
-      monitor.track_all_successful_s3_uploads(key)
-      { success: true }
-    else
-      error_message = "S3 PutObject failure for #{file}: Status code: #{status_code}"
-      if response.respond_to?(:body) && response.body.respond_to?(:read)
-        error_message += ", Body: #{response.body.read}"
+    def handle_put_object_response(response, key, file)
+      status_code = response.context.http_response.status_code
+      if status_code == 200
+        monitor.track_all_successful_s3_uploads(key)
+        { success: true }
+      else
+        error_message = "S3 PutObject failure for #{file}: Status code: #{status_code}"
+        if response.respond_to?(:body) && response.body.respond_to?(:read)
+          error_message += ", Body: #{response.body.read}"
+        end
+        Rails.logger.error error_message
+        { success: false, error_message: error_message }
       end
-      Rails.logger.error error_message
-      { success: false, error_message: error_message }
     end
-  end
 
 
     def handle_put_object_error(error)

--- a/modules/ivc_champva/app/services/ivc_champva/s3.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/s3.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ivc_champva/monitor'
+
 module IvcChampva
   class S3
     attr_reader :region, :bucket
@@ -13,15 +15,23 @@ module IvcChampva
       Datadog::Tracing.trace('S3 Put File(s)') do
         metadata&.transform_values! { |value| value || '' }
 
-        client.put_object({
-                            bucket:,
-                            key:,
-                            body: File.read(file),
-                            metadata:
-                          })
-        { success: true }
-      rescue => e
-        { success: false, error_message: "S3 PutObject failure for #{file}: #{e.message}" }
+        begin
+          response = client.put_object(
+            bucket:,
+            key:,
+            body: File.read(file),
+            metadata: metadata
+          )
+          result = { success: true }
+        rescue => e
+          result = { success: false, error_message: "S3 PutObject failure for #{file}: #{e.message}" }
+        end
+
+        if Flipper.enabled?(:champva_log_all_s3_uploads, @current_user)
+          response ? handle_put_object_response(response, key, file) : handle_put_object_error(e)
+        else
+          result
+        end
       end
     end
 
@@ -36,7 +46,30 @@ module IvcChampva
       end
     end
 
+    def monitor
+      @monitor ||= IvcChampva::Monitor.new
+    end
+
     private
+
+    def handle_put_object_response(response, key, file)
+      if response.status == 200
+        monitor.track_all_successful_s3_uploads(key)
+        { success: true }
+      else
+        error_message = "S3 PutObject failure for #{file}: Status code: #{response.status}"
+        if response.respond_to?(:body) && response.body.respond_to?(:read)
+          error_message += ", Body: #{response.body.read}"
+        end
+        Rails.logger.error error_message
+        { success: false, error_message: error_message }
+      end
+    end
+
+    def handle_put_object_error(error)
+      Rails.logger.error "S3 PutObject unexpected error: #{error.message}"
+      { success: false, error_message: "S3 PutObject unexpected error: #{error.message.strip}" }
+    end
 
     def client
       @client ||= Aws::S3::Client.new(

--- a/modules/ivc_champva/app/services/ivc_champva/s3.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/s3.rb
@@ -61,7 +61,8 @@ module IvcChampva
     # @param response [Aws::S3::Types::PutObjectOutput] the S3 response object.
     # @param key [String] the key of the uploaded file.
     # @param file [String] the path to the file uploaded.
-    # @return [Hash] a hash containing { success: true } on success, or { success: false, error_message: String } on failure.
+    # @return [Hash] a hash containing { success: true } on success, or { success: false, error_message: String } on 
+    # failure.
     def handle_put_object_response(response, key, file)
       status_code = response.context.http_response.status_code
       if status_code == 200

--- a/modules/ivc_champva/app/services/ivc_champva/s3.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/s3.rb
@@ -52,20 +52,20 @@ module IvcChampva
 
     private
 
-def handle_put_object_response(response, key, file)
-  status_code = response.context.http_response.status_code
-  if status_code == 200
-    monitor.track_all_successful_s3_uploads(key)
-    { success: true }
-  else
-    error_message = "S3 PutObject failure for #{file}: Status code: #{status_code}"
-    if response.respond_to?(:body) && response.body.respond_to?(:read)
-      error_message += ", Body: #{response.body.read}"
+  def handle_put_object_response(response, key, file)
+    status_code = response.context.http_response.status_code
+    if status_code == 200
+      monitor.track_all_successful_s3_uploads(key)
+      { success: true }
+    else
+      error_message = "S3 PutObject failure for #{file}: Status code: #{status_code}"
+      if response.respond_to?(:body) && response.body.respond_to?(:read)
+        error_message += ", Body: #{response.body.read}"
+      end
+      Rails.logger.error error_message
+      { success: false, error_message: error_message }
     end
-    Rails.logger.error error_message
-    { success: false, error_message: error_message }
   end
-end
 
 
     def handle_put_object_error(error)

--- a/modules/ivc_champva/app/services/ivc_champva/s3.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/s3.rb
@@ -61,8 +61,8 @@ module IvcChampva
     # @param response [Aws::S3::Types::PutObjectOutput] the S3 response object.
     # @param key [String] the key of the uploaded file.
     # @param file [String] the path to the file uploaded.
-    # @return [Hash] a hash containing { success: true } on success, or { success: false, error_message: String } on 
-    # failure.
+    # @return [Hash] a hash containing { success: true } on success or { success: false, error_message: String }
+    # on failure.
     def handle_put_object_response(response, key, file)
       status_code = response.context.http_response.status_code
       if status_code == 200

--- a/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/uploads_spec.rb
+++ b/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/uploads_spec.rb
@@ -39,7 +39,10 @@ RSpec.describe 'IvcChampva::V1::Forms::Uploads', type: :request do
         allow(PersistentAttachments::MilitaryRecords).to receive(:find_by)
           .and_return(double('Record1', created_at: 1.day.ago, id: 'some_uuid', file: double(id: 'file0')))
         allow(IvcChampvaForm).to receive(:first).and_return(mock_form)
-        allow_any_instance_of(Aws::S3::Client).to receive(:put_object).and_return(double('response', status: 200))
+        allow_any_instance_of(Aws::S3::Client).to receive(:put_object).and_return(
+          double('response', 
+                 context: double('context', http_response: double('http_response', status_code: 200)))
+        )
 
         post '/ivc_champva/v1/forms', params: data
 

--- a/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/uploads_spec.rb
+++ b/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/uploads_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'IvcChampva::V1::Forms::Uploads', type: :request do
           .and_return(double('Record1', created_at: 1.day.ago, id: 'some_uuid', file: double(id: 'file0')))
         allow(IvcChampvaForm).to receive(:first).and_return(mock_form)
         allow_any_instance_of(Aws::S3::Client).to receive(:put_object).and_return(
-          double('response', 
+          double('response',
                  context: double('context', http_response: double('http_response', status_code: 200)))
         )
 

--- a/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/uploads_spec.rb
+++ b/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/uploads_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'IvcChampva::V1::Forms::Uploads', type: :request do
         allow(PersistentAttachments::MilitaryRecords).to receive(:find_by)
           .and_return(double('Record1', created_at: 1.day.ago, id: 'some_uuid', file: double(id: 'file0')))
         allow(IvcChampvaForm).to receive(:first).and_return(mock_form)
-        allow_any_instance_of(Aws::S3::Client).to receive(:put_object).and_return(true)
+        allow_any_instance_of(Aws::S3::Client).to receive(:put_object).and_return(double('response', status: 200))
 
         post '/ivc_champva/v1/forms', params: data
 

--- a/modules/ivc_champva/spec/services/s3_spec.rb
+++ b/modules/ivc_champva/spec/services/s3_spec.rb
@@ -21,8 +21,12 @@ describe IvcChampva::S3 do
     let(:file_path) { 'spec/fixtures/files/doctors-note.pdf' }
 
     context 'when upload is successful' do
-      let(:response_double) { double('Aws::S3::Types::PutObjectOutput', status: 200) }
-
+      let(:http_response_double) { double('http_response', status_code: 200) }
+      let(:context_double)      { double('context', http_response: http_response_double) }
+      let(:response_double) do
+        double('Aws::S3::Types::PutObjectOutput', context: context_double)
+      end
+      
       before do
         allow_any_instance_of(Aws::S3::Client).to receive(:put_object).and_return(response_double)
       end
@@ -38,8 +42,14 @@ describe IvcChampva::S3 do
     end
 
     context 'when upload fails with non-200 status' do
+      let(:http_response_double) { double('http_response', status_code: 500) }
+      let(:context_double)      { double('context', http_response: http_response_double) }
       let(:response_double) do
-        double('Aws::S3::Types::PutObjectOutput', status: 500, body: double(read: 'Internal Server Error'))
+        double(
+          'Aws::S3::Types::PutObjectOutput',
+          context: context_double,
+          body: double(read: 'Internal Server Error')
+        )
       end
 
       before do
@@ -80,7 +90,11 @@ describe IvcChampva::S3 do
     end
 
     context 'when response body does not respond to read' do
-      let(:response_double) { double('Aws::S3::Types::PutObjectOutput', status: 500, body: 'Internal Server Error') }
+      let(:http_response_double) { double('http_response', status_code: 500) }
+      let(:context_double) { double('context', http_response: http_response_double) }
+      let(:response_double) do
+        double('Aws::S3::Types::PutObjectOutput', context: context_double, body: 'Internal Server Error')
+      end
 
       before do
         allow_any_instance_of(Aws::S3::Client).to receive(:put_object).and_return(response_double)

--- a/modules/ivc_champva/spec/services/s3_spec.rb
+++ b/modules/ivc_champva/spec/services/s3_spec.rb
@@ -22,11 +22,11 @@ describe IvcChampva::S3 do
 
     context 'when upload is successful' do
       let(:http_response_double) { double('http_response', status_code: 200) }
-      let(:context_double)      { double('context', http_response: http_response_double) }
+      let(:context_double) { double('context', http_response: http_response_double) }
       let(:response_double) do
         double('Aws::S3::Types::PutObjectOutput', context: context_double)
       end
-      
+
       before do
         allow_any_instance_of(Aws::S3::Client).to receive(:put_object).and_return(response_double)
       end
@@ -43,7 +43,7 @@ describe IvcChampva::S3 do
 
     context 'when upload fails with non-200 status' do
       let(:http_response_double) { double('http_response', status_code: 500) }
-      let(:context_double)      { double('context', http_response: http_response_double) }
+      let(:context_double) { double('context', http_response: http_response_double) }
       let(:response_double) do
         double(
           'Aws::S3::Types::PutObjectOutput',

--- a/modules/ivc_champva/spec/services/s3_spec.rb
+++ b/modules/ivc_champva/spec/services/s3_spec.rb
@@ -54,6 +54,10 @@ describe IvcChampva::S3 do
 
       before do
         allow_any_instance_of(Aws::S3::Client).to receive(:put_object).and_return(response_double)
+        allow(Flipper).to receive(:enabled?)
+          .with(:champva_log_all_s3_uploads, @current_user)
+          .and_return(true)
+        Flipper.enable(:champva_log_all_s3_uploads)
       end
 
       it 'returns failure response with status code and body' do
@@ -74,6 +78,10 @@ describe IvcChampva::S3 do
         allow_any_instance_of(Aws::S3::Client).to receive(:put_object).and_raise(
           Aws::S3::Errors::ServiceError.new(nil, 'Service Unavailable')
         )
+        allow(Flipper).to receive(:enabled?)
+          .with(:champva_log_all_s3_uploads, @current_user)
+          .and_return(true)
+        Flipper.enable(:champva_log_all_s3_uploads)
       end
 
       it 'returns failure response with exception message' do
@@ -98,6 +106,10 @@ describe IvcChampva::S3 do
 
       before do
         allow_any_instance_of(Aws::S3::Client).to receive(:put_object).and_return(response_double)
+        allow(Flipper).to receive(:enabled?)
+          .with(:champva_log_all_s3_uploads, @current_user)
+          .and_return(true)
+        Flipper.enable(:champva_log_all_s3_uploads)
       end
 
       it 'returns failure response with status code' do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES
- Added `require 'ivc_champva/monitor'` to integrate the `IvcChampva::Monitor` class.
- Introduced a `monitor` method to initialize an instance of `IvcChampva::Monitor` for tracking successful S3 uploads.
- Enhanced `put_object` method:
  - Added explicit error handling using a `begin/rescue` block.
  - Improved response handling by introducing `handle_put_object_response` and `handle_put_object_error` methods.
  - Introduced Flipper-based conditional logging for S3 uploads.
- Introduced `handle_put_object_response`:
  - Logs failures and tracks successful S3 uploads via `monitor.track_all_successful_s3_uploads(key)`.
- Introduced `handle_put_object_error`:
  - Logs unexpected errors encountered during S3 PutObject operations.
- Updated `put_object` method to correctly pass metadata.
- Retained `upload_file` method functionality.
- No changes to `client` and `resource` methods.


## Related issue(s)

This the 2nd part of the PR.
https://github.com/department-of-veterans-affairs/vets-api/pull/20464


## Testing done

- [ ] *New code is covered by unit tests*
Yes

## What areas of the site does it impact?
All IVC CHAMPVA forms
