### PR TITLE
recover logging tags for DR module controllers

### DIFF
--- a/modules/decision_reviews/app/controllers/decision_reviews/application_controller.rb
+++ b/modules/decision_reviews/app/controllers/decision_reviews/application_controller.rb
@@ -14,10 +14,21 @@ module DecisionReviews
 
     protect_from_forgery with: :exception, if: -> { ActionController::Base.allow_forgery_protection }
     after_action :set_csrf_header, if: -> { ActionController::Base.allow_forgery_protection }
+    before_action :set_tags
 
     private
 
     attr_reader :current_user
+
+    def set_tags
+      RequestStore.store['request_id'] = request.uuid
+      RequestStore.store['additional_request_attributes'] = {
+        'remote_ip' => request.remote_ip,
+        'user_agent' => request.user_agent,
+        'user_uuid' => current_user&.uuid,
+        'source' => request.headers['Source-App-Name']
+      }
+    end
 
     def set_csrf_header
       token = form_authenticity_token


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
- NO
- *(Summarize the changes that have been made to the platform)*
Add additional logging context to controllers in the DecisionReviews module. This context used to be inherited from the shared ApplicationController, but now needs to be explicitly included in the module.
- *(Which team do you work for, does your team own the maintenance of this component?)*
- Decision Reviews, yes

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/102061

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- Logs from DR module controllers did not include context like source
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- Verify log queries in DataDog return logs from DR module controllers

## What areas of the site does it impact?
Decision Reviews module controller behavior logging

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature