### PR TITLE
API-42638 - 526 v2 - Update docs for treatment info validations

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -335,7 +335,7 @@
                   "202 without a transactionId": {
                     "value": {
                       "data": {
-                        "id": "c21ca745-8f00-4222-af2c-6e1fb2216813",
+                        "id": "db8972c4-5f94-48b8-a3fc-44a59edc97d6",
                         "type": "forms/526",
                         "attributes": {
                           "claimId": "600442191",
@@ -520,7 +520,7 @@
                             },
                             "federalActivation": {
                               "activationDate": "2023-10-01",
-                              "anticipatedSeparationDate": "2025-01-30"
+                              "anticipatedSeparationDate": "2025-02-06"
                             },
                             "confinements": [
                               {
@@ -566,7 +566,7 @@
                   "202 with a transactionId": {
                     "value": {
                       "data": {
-                        "id": "56ad67d7-fe14-41c4-a98e-f3683d85ec74",
+                        "id": "797c2738-5de4-4a17-b661-638a358396c9",
                         "type": "forms/526",
                         "attributes": {
                           "claimId": "600442191",
@@ -730,7 +730,7 @@
                                 "serviceBranch": "Public Health Service",
                                 "serviceComponent": "Active",
                                 "activeDutyBeginDate": "2008-11-14",
-                                "activeDutyEndDate": "2025-01-30",
+                                "activeDutyEndDate": "2025-02-06",
                                 "separationLocationCode": "98282"
                               }
                             ],
@@ -751,7 +751,7 @@
                             },
                             "federalActivation": {
                               "activationDate": "2023-10-01",
-                              "anticipatedSeparationDate": "2025-01-30"
+                              "anticipatedSeparationDate": "2025-02-06"
                             },
                             "confinements": [
                               {
@@ -1523,7 +1523,7 @@
                               }
                             },
                             "treatments": {
-                              "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
+                              "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 10,000 characters to successfully generate a PDF.",
                               "type": "array",
                               "nullable": true,
                               "uniqueItems": true,
@@ -2907,7 +2907,7 @@
                             }
                           },
                           "treatments": {
-                            "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
+                            "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 10,000 characters to successfully generate a PDF.",
                             "type": "array",
                             "nullable": true,
                             "uniqueItems": true,
@@ -3994,7 +3994,7 @@
                               "serviceBranch": "Public Health Service",
                               "serviceComponent": "Active",
                               "activeDutyBeginDate": "2008-11-14",
-                              "activeDutyEndDate": "2025-01-30",
+                              "activeDutyEndDate": "2025-02-06",
                               "separationLocationCode": "98282"
                             }
                           ],
@@ -4015,7 +4015,7 @@
                           },
                           "federalActivation": {
                             "activationDate": "2023-10-01",
-                            "anticipatedSeparationDate": "2025-01-30"
+                            "anticipatedSeparationDate": "2025-02-06"
                           },
                           "confinements": [
                             {
@@ -5061,7 +5061,7 @@
                             }
                           },
                           "treatments": {
-                            "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
+                            "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 10,000 characters to successfully generate a PDF.",
                             "type": "array",
                             "nullable": true,
                             "uniqueItems": true,
@@ -6586,7 +6586,7 @@
                             }
                           },
                           "treatments": {
-                            "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
+                            "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 10,000 characters to successfully generate a PDF.",
                             "type": "array",
                             "nullable": true,
                             "maxItems": 5000,
@@ -8537,8 +8537,8 @@
                     "id": "1",
                     "type": "intent_to_file",
                     "attributes": {
-                      "creationDate": "2025-01-28",
-                      "expirationDate": "2026-01-28",
+                      "creationDate": "2025-02-04",
+                      "expirationDate": "2026-02-04",
                       "type": "compensation",
                       "status": "active"
                     }
@@ -9428,7 +9428,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "2d72d148-095d-4ff7-9826-f7e1fac3686e",
+                    "id": "2265779d-aa6a-40d5-803f-bac34543cdb7",
                     "type": "power-of-attorney-request",
                     "attributes": {
                       "veteran": {
@@ -12225,7 +12225,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "912b967f-c833-4e3d-8421-109a02ba368e",
+                    "id": "4414cba8-a7fe-4e28-95d4-1c91c4172ed1",
                     "type": "organization",
                     "attributes": {
                       "code": "083",
@@ -13723,7 +13723,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "44f0935e-3c9b-42a1-babf-c22490474922",
+                    "id": "bfac9e00-83f6-4383-84cc-22aea75f50f1",
                     "type": "individual",
                     "attributes": {
                       "code": "067",
@@ -14571,10 +14571,10 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "2051bd6b-7e4c-4c03-83b9-b9545e837167",
+                    "id": "14cbfe09-c52a-48ba-b1b2-b489a47ba15a",
                     "type": "claimsApiPowerOfAttorneys",
                     "attributes": {
-                      "createdAt": "2025-01-28T14:23:53.918Z",
+                      "createdAt": "2025-02-04T15:09:41.326Z",
                       "representative": {
                         "serviceOrganization": {
                           "poaCode": "074"

--- a/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
@@ -335,7 +335,7 @@
                   "202 without a transactionId": {
                     "value": {
                       "data": {
-                        "id": "f7f66fc3-ea97-45a5-bb38-0a1037b74b7b",
+                        "id": "f559385d-0abd-4a65-b14a-47c1a0e37ea2",
                         "type": "forms/526",
                         "attributes": {
                           "claimId": "600442191",
@@ -520,7 +520,7 @@
                             },
                             "federalActivation": {
                               "activationDate": "2023-10-01",
-                              "anticipatedSeparationDate": "2025-01-30"
+                              "anticipatedSeparationDate": "2025-02-06"
                             },
                             "confinements": [
                               {
@@ -566,7 +566,7 @@
                   "202 with a transactionId": {
                     "value": {
                       "data": {
-                        "id": "74dc787d-aa66-4658-b87c-4153ecc968b9",
+                        "id": "3c24c6e4-12ba-4765-b187-f051d9dc29e5",
                         "type": "forms/526",
                         "attributes": {
                           "claimId": "600442191",
@@ -730,7 +730,7 @@
                                 "serviceBranch": "Public Health Service",
                                 "serviceComponent": "Active",
                                 "activeDutyBeginDate": "2008-11-14",
-                                "activeDutyEndDate": "2025-01-30",
+                                "activeDutyEndDate": "2025-02-06",
                                 "separationLocationCode": "98282"
                               }
                             ],
@@ -751,7 +751,7 @@
                             },
                             "federalActivation": {
                               "activationDate": "2023-10-01",
-                              "anticipatedSeparationDate": "2025-01-30"
+                              "anticipatedSeparationDate": "2025-02-06"
                             },
                             "confinements": [
                               {
@@ -1523,7 +1523,7 @@
                               }
                             },
                             "treatments": {
-                              "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
+                              "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 10,000 characters to successfully generate a PDF.",
                               "type": "array",
                               "nullable": true,
                               "uniqueItems": true,
@@ -2907,7 +2907,7 @@
                             }
                           },
                           "treatments": {
-                            "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
+                            "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 10,000 characters to successfully generate a PDF.",
                             "type": "array",
                             "nullable": true,
                             "uniqueItems": true,
@@ -3994,7 +3994,7 @@
                               "serviceBranch": "Public Health Service",
                               "serviceComponent": "Active",
                               "activeDutyBeginDate": "2008-11-14",
-                              "activeDutyEndDate": "2025-01-30",
+                              "activeDutyEndDate": "2025-02-06",
                               "separationLocationCode": "98282"
                             }
                           ],
@@ -4015,7 +4015,7 @@
                           },
                           "federalActivation": {
                             "activationDate": "2023-10-01",
-                            "anticipatedSeparationDate": "2025-01-30"
+                            "anticipatedSeparationDate": "2025-02-06"
                           },
                           "confinements": [
                             {
@@ -5061,7 +5061,7 @@
                             }
                           },
                           "treatments": {
-                            "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
+                            "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 10,000 characters to successfully generate a PDF.",
                             "type": "array",
                             "nullable": true,
                             "uniqueItems": true,
@@ -6586,7 +6586,7 @@
                             }
                           },
                           "treatments": {
-                            "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
+                            "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 10,000 characters to successfully generate a PDF.",
                             "type": "array",
                             "nullable": true,
                             "maxItems": 5000,
@@ -8537,8 +8537,8 @@
                     "id": "1",
                     "type": "intent_to_file",
                     "attributes": {
-                      "creationDate": "2025-01-28",
-                      "expirationDate": "2026-01-28",
+                      "creationDate": "2025-02-04",
+                      "expirationDate": "2026-02-04",
                       "type": "compensation",
                       "status": "active"
                     }
@@ -10112,7 +10112,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "cee0496e-0a27-4c19-b18b-3bba4821d900",
+                    "id": "86ad5d89-281d-4bb6-a1bf-8028f687c9c3",
                     "type": "organization",
                     "attributes": {
                       "code": "083",
@@ -11610,7 +11610,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "b01df28a-6961-479f-ad9c-0c91feac5839",
+                    "id": "96056478-c9ec-4151-aa71-42aba99f6fe7",
                     "type": "individual",
                     "attributes": {
                       "code": "067",
@@ -12458,10 +12458,10 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "9b3813b9-0811-4a6d-adc1-97b0c1df5cd2",
+                    "id": "14a9ae99-06d4-4cd0-baed-448eeb347e53",
                     "type": "claimsApiPowerOfAttorneys",
                     "attributes": {
-                      "createdAt": "2025-01-28T14:25:25.171Z",
+                      "createdAt": "2025-02-04T15:12:15.875Z",
                       "representative": {
                         "serviceOrganization": {
                           "poaCode": "074"

--- a/modules/claims_api/config/schemas/v2/526.json
+++ b/modules/claims_api/config/schemas/v2/526.json
@@ -669,7 +669,7 @@
       }
     },
     "treatments": {
-      "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
+      "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 10,000 characters to successfully generate a PDF.",
       "type": ["array", "null"],
       "nullable": true,
       "uniqueItems": true,

--- a/modules/claims_api/config/schemas/v2/generate_pdf_526.json
+++ b/modules/claims_api/config/schemas/v2/generate_pdf_526.json
@@ -656,7 +656,7 @@
       }
     },
     "treatments": {
-      "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 1000 characters to successfully generate a PDF.",
+      "description": "Identifies the Service Treatment information of the Veteran. The combination of treatedDisabilityName, center name, center city, and center state must be less than 10,000 characters to successfully generate a PDF.",
       "type": ["array", "null"],
       "nullable": true,
       "maxItems": 5000,


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Updates json schemas and adds generated swagger documentation for change to update treatments documentation to reflect true max number of characters allowed.

## Related issue(s)

[API-42638](https://jira.devops.va.gov/browse/API-42638)

## Testing done

- [ ] *New code is covered by unit tests*
- Previewed documentation locally to ensure documentation updates are present and correct.

## Screenshots
![Screenshot 2025-02-04 at 10 15 24 AM](https://github.com/user-attachments/assets/c4c6c04d-ab3d-4a13-9367-28266a40c08b)


## What areas of the site does it impact?
526 documentation for synchronous, validate, and generatePDF/minimum-validations.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

