### PR TITLE
Encode BPDS JWT

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -854,6 +854,7 @@ lib/benefits_intake_service @department-of-veterans-affairs/benefits-dependents-
 lib/bgs @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/bid @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/bip_claims @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+lib/bpds @department-of-veterans-affairs/pension-and-burials @department-of-veterans-affairs/backend-review-group 
 lib/carma @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/caseflow @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/central_mail @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1430,6 +1431,7 @@ spec/lib/benefits_intake_service @department-of-veterans-affairs/va-api-engineer
 spec/lib/bgs @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/bid @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/bip_claims @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/lib/bpds @department-of-veterans-affairs/pension-and-burials @department-of-veterans-affairs/backend-review-group 
 spec/lib/breakers @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/carma @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/caseflow @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -250,6 +250,9 @@ pension_burial:
   sftp:
     relative_path: "../VETSGOV_PENSION"
 
+bpds:
+  jwt_secret: abcd1234abcd1234abcd1234abcd1234abcd1234
+
 central_mail:
   upload:
     enabled: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -42,6 +42,9 @@ pension_burial:
   sftp:
     relative_path: 'VETSGOV_PENSION'
 
+bpds:
+  jwt_secret: "FAKE_SECRET"
+
 hca:
   prefill: true
 

--- a/lib/bpds/jwt_encoder.rb
+++ b/lib/bpds/jwt_encoder.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module BPDS
+  class JwtEncoder
+    VALIDITY_LENGTH = 30.minutes
+    JWT_ENCODE_ALGORITHM = 'HS256'
+    ISSUER = 'vets-api'
+
+    # uses HMAC symmetric signing algorithm
+    def get_token
+      JWT.encode(payload, private_key, JWT_ENCODE_ALGORITHM, {
+                   typ: 'JWT',
+                   alg: 'HS256'
+                 })
+    end
+
+    private
+
+    def payload
+      {
+        iss: ISSUER, # issuer
+        jti: SecureRandom.uuid, # random id to identify a unique JWT
+        expires: expiration_time.to_i, # expiration date
+        iat: created_time.to_i # issued_at
+      }
+    end
+
+    def private_key
+      Settings.bpds.jwt_secret
+    end
+
+    def expiration_time
+      Time.zone.now + VALIDITY_LENGTH
+    end
+
+    def created_time
+      Time.zone.now
+    end
+  end
+end

--- a/spec/lib/bpds/jwt_encoder_spec.rb
+++ b/spec/lib/bpds/jwt_encoder_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'bpds/jwt_encoder'
+
+RSpec.describe BPDS::JwtEncoder do
+  describe '#get_token' do
+    it 'returns a token with required fields' do
+      encoded_jwt = BPDS::JwtEncoder.new.get_token
+      decoded_jwt = JWT.decode(encoded_jwt, Settings.bpds.jwt_secret, true, {
+                                 typ: 'JWT',
+                                 alg: 'HS256'
+                               }).first
+      expect(decoded_jwt.keys).to include('iss', 'jti', 'expires', 'iat')
+      expect(decoded_jwt['iss']).to eq('vets-api')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Adds a class to encode the JWT for the new BPDS service

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99544

## Testing done

- [ ] *New code is covered by unit tests*
- [ ] Get token:
     - Add `bpds.jwt_secret` to settings.local
     - Run `bundle exec rails c` and in the terminal:
```
require 'bpds/jwt_encoder'
BPDS::JwtEncoder.new.get_token
```
- [ ] Send a request to BPDS:
     - Follow the directions [here](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/digital-health-modernization/engineering/mhv-api-tunnel-setup.md) but instead of making a tunnel, just SSH into a fwdproxy instance
     - Send a request from the fwdproxy instance using the token from earlier: `curl -X GET "https://bpds-dev.dev.bip.va.gov/api/v1/bpd/1" -H "accept: application/json" -H "Authorization: Bearer {TOKEN}"`
     - It should return a 404 or 200

## What areas of the site does it impact?
Pensions (eventually)

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
