### PR TITLE
fix(tests): ensure compatibility with Rack 3.x

### DIFF
--- a/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
+++ b/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
@@ -458,9 +458,10 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
   end
 
   def index_request_with(poa_codes:, auth_header:, filter: {})
+    headers = auth_header.merge 'Content-Type' => 'application/json'
     post v2_veterans_power_of_attorney_requests_path,
          params: { data: { attributes: { poaCodes: poa_codes, filter: } } }.to_json,
-         headers: auth_header
+         headers: headers
   end
 
   def show_request_with(id:, auth_header:)
@@ -468,16 +469,18 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
   end
 
   def decide_request_with(id:, decision:, auth_header:, representative_id: nil)
+    headers = auth_header.merge 'Content-Type' => 'application/json'
     post "/services/claims/v2/veterans/power-of-attorney-requests/#{id}/decide",
          params: { data: { attributes: { id: id,
                                          decision:,
                                          representativeId: representative_id } } }.to_json,
-         headers: auth_header
+         headers: headers
   end
 
   def create_request_with(veteran_id:, form_attributes:, auth_header:)
+    headers = auth_header.merge 'Content-Type' => 'application/json'
     post "/services/claims/v2/veterans/#{veteran_id}/power-of-attorney-request",
          params: { data: { attributes: form_attributes } }.to_json,
-         headers: auth_header
+         headers: headers
   end
 end

--- a/modules/claims_api/spec/requests/v1/forms/2122_spec.rb
+++ b/modules/claims_api/spec/requests/v1/forms/2122_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::2122', type: :request do
                   VCR.use_cassette('claims_api/bgs/intent_to_file_web_service/insert_intent_to_file') do
                     allow_any_instance_of(MPIData)
                       .to receive(:mvi_response).and_return(multi_profile)
-                    post path, params: data, headers: auth_header
+                    post path, params: JSON.parse(data), headers: auth_header, as: :json
 
                     response_body = JSON.parse response.body
                     expect(response).to have_http_status(:unprocessable_entity)
@@ -216,7 +216,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::2122', type: :request do
 
                 expect(ClaimsApi::V1::PoaFormBuilderJob).to receive(:perform_async)
 
-                post path, params: params.to_json, headers: headers.merge(auth_header)
+                post path, params: params, headers: headers.merge(auth_header), as: :json
               end
             end
           end
@@ -676,7 +676,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::2122', type: :request do
           allow_any_instance_of(ClaimsApi::PowerOfAttorneyUploader).to receive(:store!)
           expect(power_of_attorney.file_data).to be_nil
           put("#{path}/#{power_of_attorney.id}",
-              params: base64_params, headers: headers.merge(auth_header))
+              params: base64_params, headers: headers.merge(auth_header), as: :json)
           power_of_attorney.reload
           expect(power_of_attorney.file_data).not_to be_nil
           expect(power_of_attorney.status).to eq('submitted')
@@ -712,7 +712,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::2122', type: :request do
                 .to receive(:find_by_ssn).and_raise(BGS::ShareError.new('HelloWorld'))
               expect(power_of_attorney.file_data).to be_nil
               put("#{path}/#{power_of_attorney.id}",
-                  params: base64_params, headers: headers.merge(auth_header))
+                  params: base64_params, headers: headers.merge(auth_header), as: :json)
               power_of_attorney.reload
               parsed = JSON.parse(response.body)
               expect(power_of_attorney.file_data).to be_nil
@@ -738,7 +738,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::2122', type: :request do
                   .to receive(:find_by_ssn).and_return(nil)
                 expect(power_of_attorney.file_data).to be_nil
                 put("#{path}/#{power_of_attorney.id}",
-                    params: base64_params, headers: headers.merge(auth_header))
+                    params: base64_params, headers: headers.merge(auth_header), as: :json)
                 power_of_attorney.reload
                 parsed = JSON.parse(response.body)
                 expect(power_of_attorney.file_data).to be_nil
@@ -758,7 +758,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::2122', type: :request do
                   .to receive(:find_by_ssn).and_return({ file_nbr: nil })
                 expect(power_of_attorney.file_data).to be_nil
                 put("#{path}/#{power_of_attorney.id}",
-                    params: base64_params, headers: headers.merge(auth_header))
+                    params: base64_params, headers: headers.merge(auth_header), as: :json)
                 power_of_attorney.reload
                 parsed = JSON.parse(response.body)
                 expect(power_of_attorney.file_data).to be_nil
@@ -778,7 +778,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::2122', type: :request do
                   .to receive(:find_by_ssn).and_return({ file_nbr: '' })
                 expect(power_of_attorney.file_data).to be_nil
                 put("#{path}/#{power_of_attorney.id}",
-                    params: base64_params, headers: headers.merge(auth_header))
+                    params: base64_params, headers: headers.merge(auth_header), as: :json)
                 power_of_attorney.reload
                 parsed = JSON.parse(response.body)
                 expect(power_of_attorney.file_data).to be_nil

--- a/modules/claims_api/spec/requests/v1/forms/526_spec.rb
+++ b/modules/claims_api/spec/requests/v1/forms/526_spec.rb
@@ -1345,7 +1345,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
                     allow_any_instance_of(MPIData).to receive(:mvi_response)
                       .and_return(profile_with_edipi)
 
-                    post path, params: data, headers: auth_header
+                    post path, params: data, headers: headers.merge(auth_header)
                     expect(response).to have_http_status(:ok)
                   end
                 end
@@ -1370,7 +1370,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
                 allow_any_instance_of(MPIData)
                   .to receive(:mvi_response).and_return(multi_profile)
 
-                post path, params: data, headers: auth_header
+                post path, params: JSON.parse(data), headers: auth_header, as: :json
 
                 json_response = JSON.parse(response.body)
                 expect(response).to have_http_status(:unprocessable_entity)
@@ -3151,7 +3151,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
       mock_acg(scopes) do |auth_header|
         allow_any_instance_of(ClaimsApi::SupportingDocumentUploader).to receive(:store!)
         put("/services/claims/v1/forms/526/#{auto_claim.id}",
-            params: base64_params, headers: headers.merge(auth_header))
+            params: base64_params, headers: headers.merge(auth_header), as: :json)
         expect(response).to have_http_status(:ok)
         auto_claim.reload
         expect(auto_claim.file_data).to be_truthy
@@ -3184,7 +3184,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
         allow_any_instance_of(ClaimsApi::SupportingDocumentUploader).to receive(:store!)
         count = auto_claim.supporting_documents.count
         post("/services/claims/v1/forms/526/#{auto_claim.id}/attachments",
-             params: base64_params, headers: headers.merge(auth_header))
+             params: base64_params, headers: headers.merge(auth_header), as: :json)
         expect(response).to have_http_status(:ok)
         auto_claim.reload
         expect(auto_claim.supporting_documents.count).to eq(count + 2)
@@ -3220,7 +3220,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::526', type: :request do
         )
         count = auto_claim.supporting_documents.count
         post("/services/claims/v1/forms/526/#{auto_claim.id}/attachments",
-             params: base64_params, headers: headers.merge(auth_header))
+             params: base64_params, headers: headers.merge(auth_header), as: :json)
         expect(response).to have_http_status(:ok)
         auto_claim.reload
         expect(auto_claim.supporting_documents.count).to eq(count + 2)

--- a/modules/claims_api/spec/requests/v2/veterans/claims/5103_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/claims/5103_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require_relative '../../../../rails_helper'
+require 'bgs_service/person_web_service'
 
 RSpec.describe 'ClaimsApi::V2::Veterans::Claims::5103', type: :request do
   let(:veteran_id) { '1012667145V762142' }
@@ -268,7 +269,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::Claims::5103', type: :request do
 
                 mock_ccg(scopes) do |auth_header|
                   VCR.use_cassette('claims_api/bgs/benefit_claim/update_5103_200') do
-                    post(sub_path, headers: auth_header, params: json_params)
+                    post sub_path, headers: auth_header, params: json_params, as: :json
                     expect(response).to have_http_status(:unprocessable_entity)
                   end
                 end
@@ -279,7 +280,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::Claims::5103', type: :request do
                 json_params['data']['attributes']['trackedItemIds'] = [false]
                 mock_ccg(scopes) do |auth_header|
                   VCR.use_cassette('claims_api/bgs/benefit_claim/update_5103_200') do
-                    post(sub_path, headers: auth_header, params: json_params)
+                    post sub_path, headers: auth_header, params: json_params, as: :json
                     parsed_response = JSON.parse(response.body)
                     expect(response).to have_http_status(:unprocessable_entity)
                     expect(parsed_response['errors'][0]['detail']).to eq(

--- a/modules/claims_api/spec/requests/v2/veterans/intent_to_files_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/intent_to_files_spec.rb
@@ -344,7 +344,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
         context 'when provided' do
           it 'returns a 200' do
             mock_ccg(scopes) do |auth_header|
-              post itf_submit_path, params: data, headers: auth_header
+              post itf_submit_path, params: data, headers: auth_header, as: :json
               expect(response).to have_http_status(:ok)
             end
           end
@@ -369,7 +369,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
         context 'when payload is valid' do
           it 'returns a 200' do
             mock_ccg(scopes) do |auth_header|
-              post itf_submit_path, params: data, headers: auth_header
+              post itf_submit_path, params: data, headers: auth_header, as: :json
               expect(response).to have_http_status(:ok)
             end
           end
@@ -388,7 +388,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
 
               it 'returns a 400' do
                 mock_ccg(scopes) do |auth_header|
-                  post itf_submit_path, params: invalid_data, headers: auth_header
+                  post itf_submit_path, params: invalid_data, headers: auth_header, as: :json
                   expect(response).to have_http_status(:bad_request)
                 end
               end
@@ -400,7 +400,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
                   invalid_data = data
                   invalid_data[:data][:attributes][:type] = ''
 
-                  post itf_submit_path, params: invalid_data, headers: auth_header
+                  post itf_submit_path, params: invalid_data, headers: auth_header, as: :json
                   expect(response).to have_http_status(:bad_request)
                 end
               end
@@ -412,7 +412,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
                   invalid_data = data
                   invalid_data[:data][:attributes][:type] = nil
 
-                  post itf_submit_path, params: invalid_data, headers: auth_header
+                  post itf_submit_path, params: invalid_data, headers: auth_header, as: :json
                   expect(response).to have_http_status(:bad_request)
                 end
               end
@@ -424,7 +424,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
                   invalid_data = data
                   invalid_data[:data][:attributes][:type] = 'foo'
 
-                  post itf_submit_path, params: invalid_data, headers: auth_header
+                  post itf_submit_path, params: invalid_data, headers: auth_header, as: :json
                   expect(response).to have_http_status(:bad_request)
                 end
               end
@@ -438,7 +438,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
                   survivor_data = data
                   survivor_data[:data][:attributes][:type] = 'survivor'
                   survivor_data[:data][:attributes][:claimantSsn] = '123456789'
-                  post itf_submit_path, params: survivor_data, headers: auth_header
+                  post itf_submit_path, params: survivor_data, headers: auth_header, as: :json
                   expect(response).to have_http_status(:ok)
                 end
               end
@@ -449,7 +449,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
                     survivor_data = data
                     survivor_data[:data][:attributes][:type] = 'survivor'
                     survivor_data[:data][:attributes][:claimantSsn] = '123-45-6789'
-                    post itf_submit_path, params: survivor_data, headers: auth_header
+                    post itf_submit_path, params: survivor_data, headers: auth_header, as: :json
                     expect(response).to have_http_status(:ok)
                   end
                 end
@@ -461,7 +461,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
                 mock_ccg(scopes) do |auth_header|
                   survivor_data = data
                   survivor_data[:data][:attributes][:type] = 'survivor'
-                  post itf_submit_path, params: survivor_data, headers: auth_header
+                  post itf_submit_path, params: survivor_data, headers: auth_header, as: :json
                   expect(response).to have_http_status(:unprocessable_entity)
                 end
               end
@@ -473,7 +473,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
                   survivor_data = data
                   survivor_data[:data][:attributes][:type] = 'survivor'
                   survivor_data[:data][:attributes][:claimantSsn] = 'abcdefghi'
-                  post itf_submit_path, params: survivor_data, headers: auth_header
+                  post itf_submit_path, params: survivor_data, headers: auth_header, as: :json
                   expect(response).to have_http_status(:unprocessable_entity)
                 end
               end
@@ -487,7 +487,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
               valid_data = data
               valid_data[:data][:attributes][:type] = 'CoMpEnSaTiOn'
 
-              post itf_submit_path, params: valid_data, headers: auth_header
+              post itf_submit_path, params: valid_data, headers: auth_header, as: :json
               expect(response).to have_http_status(:ok)
             end
           end
@@ -499,7 +499,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
           context 'when valid' do
             it 'returns a 200' do
               mock_ccg(scopes) do |auth_header|
-                post itf_submit_path, params: data, headers: auth_header
+                post itf_submit_path, params: data, headers: auth_header, as: :json
               end
               expect(response).to have_http_status(:ok)
             end
@@ -549,7 +549,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
         context 'when provided' do
           it 'returns a 200' do
             mock_ccg(scopes) do |auth_header|
-              post itf_validate_path, params: data, headers: auth_header
+              post itf_validate_path, params: data, headers: auth_header, as: :json
               expect(response).to have_http_status(:ok)
             end
           end
@@ -567,7 +567,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
         context 'when payload is valid' do
           it 'returns a 200' do
             mock_ccg(scopes) do |auth_header|
-              post itf_validate_path, params: data, headers: auth_header
+              post itf_validate_path, params: data, headers: auth_header, as: :json
               expect(response).to have_http_status(:ok)
             end
           end
@@ -581,7 +581,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
                   invalid_data = data
                   invalid_data[:data][:attributes][:type] = 'survivor'
                   invalid_data[:data][:attributes][:claimantSsn] = ''
-                  post itf_validate_path, params: invalid_data, headers: auth_header
+                  post itf_validate_path, params: invalid_data, headers: auth_header, as: :json
                   expect(response).to have_http_status(:unprocessable_entity)
                 end
               end
@@ -595,7 +595,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
                   invalid_data = data
                   invalid_data[:data][:attributes][:type] = ''
 
-                  post itf_validate_path, params: invalid_data, headers: auth_header
+                  post itf_validate_path, params: invalid_data, headers: auth_header, as: :json
                   expect(response).to have_http_status(:bad_request)
                 end
               end
@@ -607,7 +607,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
                   invalid_data = data
                   invalid_data[:data][:attributes][:type] = nil
 
-                  post itf_validate_path, params: invalid_data, headers: auth_header
+                  post itf_validate_path, params: invalid_data, headers: auth_header, as: :json
                   expect(response).to have_http_status(:bad_request)
                 end
               end
@@ -619,7 +619,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
                   invalid_data = data
                   invalid_data[:data][:attributes][:type] = 'foo'
 
-                  post itf_validate_path, params: invalid_data, headers: auth_header
+                  post itf_validate_path, params: invalid_data, headers: auth_header, as: :json
                   expect(response).to have_http_status(:bad_request)
                 end
               end
@@ -633,7 +633,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
               valid_data = data
               valid_data[:data][:attributes][:type] = 'CoMpEnSaTiOn'
 
-              post itf_validate_path, params: valid_data, headers: auth_header
+              post itf_validate_path, params: valid_data, headers: auth_header, as: :json
               expect(response).to have_http_status(:ok)
             end
           end
@@ -645,7 +645,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
           context 'when valid' do
             it 'returns a 200' do
               mock_ccg(scopes) do |auth_header|
-                post itf_validate_path, params: data, headers: auth_header
+                post itf_validate_path, params: data, headers: auth_header, as: :json
               end
 
               expect(response).to have_http_status(:ok)
@@ -697,7 +697,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
       context 'should validate the request data is nested inside an attributes object that is inside a data object' do
         it 'returns 200 when submitting to SUBMIT with correct body format' do
           mock_ccg(scopes) do |auth_header|
-            post itf_submit_path, params: data, headers: auth_header
+            post itf_submit_path, params: data, headers: auth_header, as: :json
             expect(response).to have_http_status(:ok)
           end
         end
@@ -705,14 +705,14 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
         it 'returns 400 when submitting to SUBMIT with incorrect body format' do
           mock_ccg(scopes) do |auth_header|
             invalid_data_format = data[:data][:attributes]
-            post itf_submit_path, params: invalid_data_format, headers: auth_header
+            post itf_submit_path, params: invalid_data_format, headers: auth_header, as: :json
             expect(response).to have_http_status(:bad_request)
           end
         end
 
         it 'returns 200 when submitting to VALIDATE with correct body format' do
           mock_ccg(scopes) do |auth_header|
-            post itf_validate_path, params: data, headers: auth_header
+            post itf_validate_path, params: data, headers: auth_header, as: :json
             expect(response).to have_http_status(:ok)
           end
         end
@@ -720,7 +720,7 @@ RSpec.describe 'ClaimsApi::V2::Veterans::IntentToFile', type: :request do
         it 'returns 422 when submitting to VALIDATE with incorrect body format' do
           mock_ccg(scopes) do |auth_header|
             invalid_data_format = data[:data][:attributes]
-            post itf_validate_path, params: invalid_data_format, headers: auth_header
+            post itf_validate_path, params: invalid_data_format, headers: auth_header, as: :json
             expect(response).to have_http_status(:bad_request)
           end
         end

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney/2122_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney/2122_spec.rb
@@ -553,7 +553,7 @@ RSpec.describe 'ClaimsApi::V1::PowerOfAttorney::2122', type: :request do
                   expect(response).to have_http_status(:unprocessable_entity)
                   expect(response_body['title']).to eq('Unprocessable entity')
                   expect(response_body['status']).to eq('422')
-                  expect(response_body['detail']).to eq(detail)
+                  expect(response_body['detail']).to include(detail)
                 end
               end
             end

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney/2122a_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney/2122a_spec.rb
@@ -503,7 +503,7 @@ RSpec.describe 'ClaimsApi::V2::PowerOfAttorney::2122a', type: :request do
                   expect(response).to have_http_status(:unprocessable_entity)
                   expect(response_body['title']).to eq('Unprocessable entity')
                   expect(response_body['status']).to eq('422')
-                  expect(response_body['detail']).to eq(detail)
+                  expect(response_body['detail']).to include(detail)
                 end
               end
             end

--- a/modules/claims_api/spec/requests/v2/veterans/power_of_attorney/power_of_attorney_request_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/power_of_attorney/power_of_attorney_request_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'ClaimsApi::V1::PowerOfAttorney::PowerOfAttorneyRequest', type: :
               expect(response).to have_http_status(:not_found)
               expect(response_body['title']).to eq('Resource not found')
               expect(response_body['status']).to eq('404')
-              expect(response_body['detail']).to eq(detail)
+              expect(response_body['detail']).to include(detail)
             end
           end
         end
@@ -56,7 +56,7 @@ RSpec.describe 'ClaimsApi::V1::PowerOfAttorney::PowerOfAttorneyRequest', type: :
               expect(response).to have_http_status(:unprocessable_entity)
               expect(response_body['title']).to eq('Unprocessable entity')
               expect(response_body['status']).to eq('422')
-              expect(response_body['detail']).to eq(detail)
+              expect(response_body['detail']).to include(detail)
             end
           end
         end
@@ -80,7 +80,7 @@ RSpec.describe 'ClaimsApi::V1::PowerOfAttorney::PowerOfAttorneyRequest', type: :
                   expect(response).to have_http_status(:unprocessable_entity)
                   expect(response_body['title']).to eq('Unprocessable entity')
                   expect(response_body['status']).to eq('422')
-                  expect(response_body['detail']).to eq(detail)
+                  expect(response_body['detail']).to include(detail)
                 end
               end
             end
@@ -105,7 +105,7 @@ RSpec.describe 'ClaimsApi::V1::PowerOfAttorney::PowerOfAttorneyRequest', type: :
                   expect(response).to have_http_status(:unprocessable_entity)
                   expect(response_body['title']).to eq('Unprocessable Entity')
                   expect(response_body['status']).to eq('422')
-                  expect(response_body['detail']).to eq(detail)
+                  expect(response_body['detail']).to include(detail)
                 end
               end
             end
@@ -131,7 +131,7 @@ RSpec.describe 'ClaimsApi::V1::PowerOfAttorney::PowerOfAttorneyRequest', type: :
                 expect(response).to have_http_status(:not_found)
                 expect(response_body['title']).to eq('Resource not found')
                 expect(response_body['status']).to eq('404')
-                expect(response_body['detail']).to eq(detail)
+                expect(response_body['detail']).to include(detail)
               end
             end
           end

--- a/modules/claims_api/spec/support/auth_helper.rb
+++ b/modules/claims_api/spec/support/auth_helper.rb
@@ -7,7 +7,7 @@ def mock_acg(_scopes)
       profile_response = build(:find_profile_response, profile:)
       allow_any_instance_of(MPI::Service).to receive(:find_profile_by_identifier).and_return(profile_response)
 
-      auth_header = { authorization: 'Bearer token' }
+      auth_header = { authorization: 'Bearer token', 'Content-Type': 'application/json' }
       yield(auth_header)
     end
   end
@@ -15,7 +15,7 @@ end
 
 def mock_ccg(_scopes, vcr_options = {})
   VCR.use_cassette('claims_api/token_validation/v3/shows_token_is_valid', vcr_options) do
-    auth_header = { authorization: 'Bearer token' }
+    auth_header = { authorization: 'Bearer token', 'Content-Type': 'application/json' }
     yield(auth_header)
   end
 end
@@ -23,7 +23,7 @@ end
 def mock_ccg_for_fine_grained_scope(scope_names)
   VCR.use_cassette('claims_api/token_validation/v3/shows_token_is_valid_with_fine_grained_scope',
                    erb: { scopes: scope_names }) do
-    auth_header = { authorization: 'Bearer token' }
+    auth_header = { authorization: 'Bearer token', 'Content-Type': 'application/json' }
     yield(auth_header)
   end
 end

--- a/modules/my_health/spec/requests/my_health/v1/prescriptions_spec.rb
+++ b/modules/my_health/spec/requests/my_health/v1/prescriptions_spec.rb
@@ -259,7 +259,8 @@ RSpec.describe 'MyHealth::V1::Prescriptions', type: :request do
 
       it 'responds to GET #index with filter metadata for specific disp_status' do
         VCR.use_cassette('rx_client/prescriptions/index_with_disp_status_filter') do
-          get '/my_health/v1/prescriptions?filter[[disp_status][eq]]=Active,Expired'
+          get '/my_health/v1/prescriptions?filter[[disp_status][eq]]=Active,Expired',
+              headers: { 'Content-Type' => 'application/json' }, as: :json
         end
         expect(response).to be_successful
         json_response = JSON.parse(response.body)
@@ -385,7 +386,8 @@ RSpec.describe 'MyHealth::V1::Prescriptions', type: :request do
 
       it 'responds to GET #index with filter and pagination' do
         VCR.use_cassette('rx_client/prescriptions/gets_a_list_of_all_prescriptions_vagov') do
-          get '/my_health/v1/prescriptions?page=1&per_page=100&filter[[disp_status][eq]]=Active: Refill in Process'
+          get '/my_health/v1/prescriptions?page=1&per_page=100&filter[[disp_status][eq]]=Active: Refill in Process',
+              headers: { 'Content-Type' => 'application/json' }, as: :json
         end
 
         filtered_response = JSON.parse(response.body)['data'].select do |i|
@@ -473,7 +475,8 @@ RSpec.describe 'MyHealth::V1::Prescriptions', type: :request do
 
         it 'responds to GET #show of nested tracking resource when camel-inflected' do
           VCR.use_cassette('rx_client/prescriptions/nested_resources/gets_a_list_of_tracking_history_for_a_prescription') do
-            get '/my_health/v1/prescriptions/13650541/trackings', headers: inflection_header
+            get '/my_health/v1/prescriptions/13650541/trackings',
+                headers: inflection_header.merge('Content-Type' => 'application/json'), as: :json
           end
 
           expect(response).to be_successful


### PR DESCRIPTION
Prepare specs for Rack 3.x by setting the `Content-Type: application/json` header in JSON requests. This is a backwards compatible change that prevents issues where Rails does not parse the request body correctly, which would lead to unexpected 422 errors after the upgrade.
