### PR TITLE
Fix class loading issue for lib/vets

### DIFF
--- a/lib/vets/type/primitive.rb
+++ b/lib/vets/type/primitive.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'vets/type/base'
-require 'vets/model' # this is required for Bools
 
 module Vets
   module Type

--- a/spec/lib/vets/type/base_spec.rb
+++ b/spec/lib/vets/type/base_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'vets/type/base'
 
 RSpec.describe Vets::Type::Base do
   let(:name) { 'example_name' }


### PR DESCRIPTION
## Summary

- Two specs where failing locally because of a loading issue 
    - spec/lib/vets/type/base_spec.rb
    - spec/lib/vets/attributes_spec.rb

## Related issue(s)

- n/a

## Testing done

- [ ] tested locally



## Acceptance criteria

- [x]  Both tests pass locally
