### PR TITLE
Fix broken ClaimantVerificationSerializer spec

### DIFF
--- a/modules/vye/spec/serializers/claimant_verification_serializer_spec.rb
+++ b/modules/vye/spec/serializers/claimant_verification_serializer_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require Vye::Engine.root / 'spec/rails_helper'
+require 'vye/vye_serializer'
 
 RSpec.describe Vye::ClaimantVerificationSerializer, type: :serializer do
   let(:json_body) { 'modules/vye/spec/fixtures/claimant_response.json' }


### PR DESCRIPTION
## Summary

- The class wasn't loading on local test runs
- This spec doesn't test the class it only tests the fixture 

## Related issue(s)

- n/a

## Testing done

- [ ] local testing

## Acceptance criteria

- [x]  Spec pass locally