### PR TITLE
dbex/94200: add Form526SubmittedEmailJob

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -649,13 +649,13 @@ app/sidekiq/feature_cleaner_job.rb @department-of-veterans-affairs/va-api-engine
 app/sidekiq/form1010cg @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form1095 @department-of-veterans-affairs/vfs-1095-b @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_confirmation_email_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/sidekiq/form526_submitted_email_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_failure_state_snapshot_job.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_paranoid_success_polling_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_status_polling_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_submission_failed_email_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_submission_failure_email_job.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_submission_processing_report_job.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/sidekiq/form526_submitted_email_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/gi_bill_feedback_submission_job.rb @department-of-veterans-affairs/my-education-benefits @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/hca @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/identity @department-of-veterans-affairs/octo-identity

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -649,6 +649,7 @@ app/sidekiq/feature_cleaner_job.rb @department-of-veterans-affairs/va-api-engine
 app/sidekiq/form1010cg @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form1095 @department-of-veterans-affairs/vfs-1095-b @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_confirmation_email_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/sidekiq/form526_submitted_email_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_failure_state_snapshot_job.rb @department-of-veterans-affairs/disability-experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_paranoid_success_polling_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/sidekiq/form526_status_polling_job.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -476,7 +476,8 @@ class Form526Submission < ApplicationRecord
 
   # Send the Submitted Email - when the Veteran has clicked the "submit" button in va.gov
   # Primary Path: when the response from getting a claim id is successful
-  # Backup Path: when Form526StatusPollingJob reaches "paranoid_success" status
+  # Backup Path: when SubmitForm526 Job has exhausted,
+  # or when we get a non_retryable_error response from claim establishment flow
   # @param invoker: string where the Received Email trigger is being called from
   def send_submitted_email(invoker)
     Rails.logger.info("Form526SubmittedEmailJob called for user #{user_uuid},

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -480,11 +480,13 @@ class Form526Submission < ApplicationRecord
   # or when we get a non_retryable_error response from claim establishment flow
   # @param invoker: string where the Received Email trigger is being called from
   def send_submitted_email(invoker)
-    Rails.logger.info("Form526SubmittedEmailJob called for user #{user_uuid},
+    if Flipper.enabled?(:disability_526_send_form526_submitted_email)
+      Rails.logger.info("Form526SubmittedEmailJob called for user #{user_uuid},
                                                           submission: #{id} from #{invoker}")
-    first_name = get_first_name
-    params = personalization_parameters(first_name)
-    Form526SubmittedEmailJob.perform_async(params)
+      first_name = get_first_name
+      params = personalization_parameters(first_name)
+      Form526SubmittedEmailJob.perform_async(params)
+    end
   end
 
   # Send the Received Confirmation Email - when we have confirmed VBMS can start processing the claim

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -474,6 +474,18 @@ class Form526Submission < ApplicationRecord
     Account.lookup_by_user_uuid(user_uuid)
   end
 
+  # Send the Submitted Email - when the Veteran has clicked the "submit" button in va.gov
+  # Primary Path: when the response from getting a claim id is successful
+  # Backup Path: when Form526StatusPollingJob reaches "paranoid_success" status
+  # @param invoker: string where the Received Email trigger is being called from
+  def send_submitted_email(invoker)
+    Rails.logger.info("Form526SubmittedEmailJob called for user #{user_uuid},
+                                                          submission: #{id} from #{invoker}")
+    first_name = get_first_name
+    params = personalization_parameters(first_name)
+    Form526SubmittedEmailJob.perform_async(params)
+  end
+
   # Send the Received Confirmation Email - when we have confirmed VBMS can start processing the claim
   # Primary Path: when the poll for PollForm526PDF job is successful
   # Backup Path: when Form526StatusPollingJob reaches "paranoid_success" status

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -52,11 +52,6 @@ module EVSS
             silence_errors_and_log_to_sentry: true,
             extra_content_for_sentry: { job_class: msg['class'].demodulize, job_id: msg['jid'] }
           )
-
-          # send "Submitted" email without claim id here for backup path
-          if next_birls_jid.blank?
-            submission.send_submitted_email("#{self.class}#sidekiq_retries_exhausted backup path")
-          end
         rescue => e
           log_exception_to_sentry(e)
         end
@@ -238,15 +233,10 @@ module EVSS
                                 OpenStruct.new({ flipper_id: submission.user_uuid })) ||
                Flipper.enabled?(:disability_compensation_fail_submission,
                                 OpenStruct.new({ flipper_id: submission.user_uuid }))
-          next_birls_jid = submission.submit_with_birls_id_that_hasnt_been_tried_yet!(
+          submission.submit_with_birls_id_that_hasnt_been_tried_yet!(
             silence_errors_and_log_to_sentry: true,
             extra_content_for_sentry: { job_class: self.class.to_s.demodulize, job_id: jid }
           )
-
-          # send "Submitted" email without claim id here for backup path
-          if next_birls_jid.blank?
-            submission.send_submitted_email("#{self.class}#non_retryable_error_handler backup path")
-          end
         end
       end
 

--- a/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form526.rb
@@ -54,7 +54,7 @@ module EVSS
           )
 
           # send "Submitted" email without claim id here for backup path
-          if next_birls_jid.blank? && Flipper.enabled?(:disability_526_send_form526_submitted_email)
+          if next_birls_jid.blank?
             submission.send_submitted_email("#{self.class}#sidekiq_retries_exhausted backup path")
           end
         rescue => e
@@ -175,9 +175,7 @@ module EVSS
         submission.submitted_claim_id = response.claim_id
         submission.save
         # send "Submitted" email with claim id here for primary path
-        if Flipper.enabled?(:disability_526_send_form526_submitted_email)
-          submission.send_submitted_email("#{self.class}#response_handler primary path")
-        end
+        submission.send_submitted_email("#{self.class}#response_handler primary path")
       end
 
       def send_post_evss_notifications(submission, send_notifications)
@@ -246,7 +244,7 @@ module EVSS
           )
 
           # send "Submitted" email without claim id here for backup path
-          if next_birls_jid.blank? && Flipper.enabled?(:disability_526_send_form526_submitted_email)
+          if next_birls_jid.blank?
             submission.send_submitted_email("#{self.class}#non_retryable_error_handler backup path")
           end
         end

--- a/app/sidekiq/form526_submitted_email_job.rb
+++ b/app/sidekiq/form526_submitted_email_job.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'sentry_logging'
+require 'va_notify/service'
+
+class Form526SubmittedEmailJob
+  include Sidekiq::Job
+  include SentryLogging
+  sidekiq_options expires_in: 1.day
+
+  STATSD_ERROR_NAME = 'worker.form526_submitted_email.error'
+  STATSD_SUCCESS_NAME = 'worker.form526_submitted_email.success'
+
+  def perform(personalization_parameters)
+    @notify_client ||= VaNotify::Service.new(Settings.vanotify.services.va_gov.api_key)
+    @template_id ||= Settings.vanotify.services.va_gov.template_id.form526_submitted_email
+    @notify_client.send_email(
+      email_address: personalization_parameters['email'],
+      template_id: @template_id,
+      personalisation: {
+        'claim_id' => personalization_parameters['submitted_claim_id'],
+        'date_submitted' => personalization_parameters['date_submitted'],
+        'date_received' => personalization_parameters['date_received'],
+        'first_name' => personalization_parameters['first_name']
+      }
+    )
+    StatsD.increment(STATSD_SUCCESS_NAME)
+  rescue => e
+    handle_errors(e)
+  end
+
+  def handle_errors(ex)
+    log_exception_to_sentry(ex)
+    StatsD.increment(STATSD_ERROR_NAME)
+
+    raise ex if ex.status_code.between?(500, 599)
+  end
+end

--- a/app/sidekiq/form526_submitted_email_job.rb
+++ b/app/sidekiq/form526_submitted_email_job.rb
@@ -20,7 +20,6 @@ class Form526SubmittedEmailJob
       personalisation: {
         'claim_id' => personalization_parameters['submitted_claim_id'],
         'date_submitted' => personalization_parameters['date_submitted'],
-        'date_received' => personalization_parameters['date_received'],
         'first_name' => personalization_parameters['first_name']
       }
     )

--- a/config/features.yml
+++ b/config/features.yml
@@ -568,6 +568,9 @@ features:
     actor_type: user
     description: enables a new form flow for 0781 and 0781a in the 526 submission workflow
     enable_in_development: true
+  disability_526_send_form526_submitted_email:
+    actor_type: user
+    description: enables sending submitted email in both primary and backup paths
   disability_526_send_received_email_from_backup_path:
     actor_type: user
     description: enables received email in complete success state of backup path

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1177,6 +1177,7 @@ vanotify:
         form40_0247_error_email: form40_0247_error_email_template_id
         form40_10007_error_email: form40_10007_error_email_template_id
         form526_confirmation_email: fake_template_id
+        form526_submitted_email: fake_template_id
         form526_submission_failed_email: fake_template_id
         form5490_confirmation_email: form5490_confirmation_email_template_id
         form5495_confirmation_email: form5495_confirmation_email_template_id

--- a/lib/sidekiq/form526_job_status_tracker/backup_submission.rb
+++ b/lib/sidekiq/form526_job_status_tracker/backup_submission.rb
@@ -33,6 +33,8 @@ module Sidekiq
 
         if send_backup_submission
           backup_job_jid = Sidekiq::Form526BackupSubmissionProcess::Submit.perform_async(form526_submission_id)
+          # send "Submitted" email without claim id here for backup path
+          submission_obj.send_submitted_email("#{self.class}#send_backup_submission_if_enabled backup path")
         end
         vagov_id = JSON.parse(submission_obj.auth_headers_json)['va_eauth_service_transaction_id']
         log_message = {

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -729,7 +729,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
             .and_return(true)
         end
 
-        it 'behaves sends the submitted email' do
+        it 'behaves sends the submitted email in the backup path' do
           expect(Form526SubmittedEmailJob).to receive(:perform_async).once
           subject.perform_async(submission.id)
           described_class.drain
@@ -743,7 +743,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
             .and_return(false)
         end
 
-        it 'behaves does not send the submitted email' do
+        it 'behaves does not send the submitted email in the backup path' do
           expect(Form526SubmittedEmailJob).not_to receive(:perform_async)
           subject.perform_async(submission.id)
           described_class.drain

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -555,8 +555,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
         context 'when disability_526_send_form526_submitted_email is enabled' do
           before do
             allow(Flipper).to receive(:enabled?)
-                                .with(:disability_526_send_form526_submitted_email)
-                                .and_return(true)
+              .with(:disability_526_send_form526_submitted_email)
+              .and_return(true)
           end
 
           it 'sends the submitted email' do
@@ -569,8 +569,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
         context 'when disability_526_send_form526_submitted_email is disabled' do
           before do
             allow(Flipper).to receive(:enabled?)
-                                .with(:disability_526_send_form526_submitted_email)
-                                .and_return(false)
+              .with(:disability_526_send_form526_submitted_email)
+              .and_return(false)
           end
 
           it 'does not send the submitted email' do
@@ -725,8 +725,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
       context 'when disability_526_send_form526_submitted_email is enabled' do
         before do
           allow(Flipper).to receive(:enabled?)
-                              .with(:disability_526_send_form526_submitted_email)
-                              .and_return(true)
+            .with(:disability_526_send_form526_submitted_email)
+            .and_return(true)
         end
 
         it 'behaves sends the submitted email' do
@@ -739,8 +739,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
       context 'when disability_526_send_form526_submitted_email is disabled' do
         before do
           allow(Flipper).to receive(:enabled?)
-                              .with(:disability_526_send_form526_submitted_email)
-                              .and_return(false)
+            .with(:disability_526_send_form526_submitted_email)
+            .and_return(false)
         end
 
         it 'behaves does not send the submitted email' do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- feature flag: `disability_526_send_form526_submitted_email`
- `Form526Submission#send_submitted_email`
- call submitted email in two places: primary success, backup path start

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/94200

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
n/a

## What areas of the site does it impact?
- Form 526 primary path success
- Form 526 backup path call

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature