### PR TITLE
API-44372-claim-uploader-schedule-fix

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -101,7 +101,7 @@ module ClaimsApi
 
             ClaimsApi::Logger.log('526', claim_id: pending_claim.id, detail: 'Uploaded PDF to S3')
             ClaimsApi::ClaimEstablisher.perform_async(pending_claim.id)
-            ClaimsApi::ClaimUploader.perform_async(pending_claim.id)
+            ClaimsApi::ClaimUploader.perform_async(pending_claim.id, 'claim')
 
             render json: ClaimsApi::AutoEstablishedClaimSerializer.new(pending_claim)
 
@@ -136,7 +136,7 @@ module ClaimsApi
             claim_document = claim.supporting_documents.build
             claim_document.set_file_data!(document, EVSS_DOCUMENT_TYPE, params[:description])
             claim_document.save!
-            ClaimsApi::ClaimUploader.perform_async(claim_document.id)
+            ClaimsApi::ClaimUploader.perform_async(claim_document.id, 'document')
           end
 
           render json: ClaimsApi::ClaimDetailSerializer.new(claim, { params: { uuid: claim.id } })

--- a/modules/claims_api/app/sidekiq/claims_api/claim_uploader.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/claim_uploader.rb
@@ -21,7 +21,7 @@ module ClaimsApi
         if auto_claim.status == errored_state_value
           msg = "Auto claim with id: #{auto_claim.id} is errored, " \
                 'not rescheduling the Claim Uploader job called with' \
-                "a #{record_type} id"
+                " a #{record_type} id"
           ClaimsApi::Logger.log('lighthouse_claim_uploader',
                                 detail: msg)
           slack_alert_on_failure('ClaimsApi::ClaimUploader', msg)

--- a/modules/claims_api/app/sidekiq/claims_api/claim_uploader.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/claim_uploader.rb
@@ -7,7 +7,7 @@ module ClaimsApi
   class ClaimUploader < ClaimsApi::ServiceBase
     sidekiq_options retry: true, unique_until: :success
 
-    def perform(uuid) # rubocop:disable Metrics/MethodLength
+    def perform(uuid, record_type) # rubocop:disable Metrics/MethodLength
       claim_object = ClaimsApi::SupportingDocument.find_by(id: uuid) ||
                      ClaimsApi::AutoEstablishedClaim.find_by(id: uuid)
 
@@ -17,7 +17,17 @@ module ClaimsApi
       if auto_claim.evss_id.nil?
         ClaimsApi::Logger.log('lighthouse_claim_uploader',
                               detail: "evss id: #{auto_claim&.evss_id} was nil, for uuid: #{uuid}")
-        self.class.perform_in(30.minutes, uuid)
+
+        if auto_claim.status == errored_state_value
+          msg = "Auto claim with id: #{auto_claim.id} is errored, " \
+                'not rescheduling the Claim Uploader job called with' \
+                "a #{record_type} id"
+          ClaimsApi::Logger.log('lighthouse_claim_uploader',
+                                detail: msg)
+          slack_alert_on_failure('ClaimsApi::ClaimUploader', msg)
+        else
+          self.class.perform_in(30.minutes, uuid, record_type)
+        end
       else
         auth_headers = auto_claim.auth_headers
         uploader = claim_object.uploader

--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_documents.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_documents.rb
@@ -19,7 +19,10 @@ module ClaimsApi
           claim_document = @claim.supporting_documents.build
           claim_document.set_file_data!(document, EVSS_DOCUMENT_TYPE, @params[:description])
           claim_document.save!
-          ClaimsApi::ClaimUploader.perform_async(claim_document.id) unless Flipper.enabled? :claims_load_testing
+          unless Flipper.enabled? :claims_load_testing
+            ClaimsApi::ClaimUploader.perform_async(claim_document.id,
+                                                   'document')
+          end
         end
       end
 

--- a/modules/claims_api/spec/sidekiq/claim_uploader_spec.rb
+++ b/modules/claims_api/spec/sidekiq/claim_uploader_spec.rb
@@ -45,7 +45,33 @@ RSpec.describe ClaimsApi::ClaimUploader, type: :job do
   end
 
   let(:auto_claim) do
-    claim = create(:auto_established_claim, evss_id: '12345')
+    claim = create(:auto_established_claim, evss_id: '12345', status: 'pending')
+    claim.set_file_data!(
+      Rack::Test::UploadedFile.new(
+        Rails.root.join(*'/modules/claims_api/spec/fixtures/extras.pdf'.split('/')).to_s
+      ),
+      'docType',
+      'description'
+    )
+    claim.save!
+    claim
+  end
+
+  let(:pending_auto_claim) do
+    claim = create(:auto_established_claim, evss_id: nil, status: 'pending')
+    claim.set_file_data!(
+      Rack::Test::UploadedFile.new(
+        Rails.root.join(*'/modules/claims_api/spec/fixtures/extras.pdf'.split('/')).to_s
+      ),
+      'docType',
+      'description'
+    )
+    claim.save!
+    claim
+  end
+
+  let(:errored_auto_claim) do
+    claim = create(:auto_established_claim, evss_id: nil, status: 'errored')
     claim.set_file_data!(
       Rack::Test::UploadedFile.new(
         Rails.root.join(*'/modules/claims_api/spec/fixtures/extras.pdf'.split('/')).to_s
@@ -69,7 +95,7 @@ RSpec.describe ClaimsApi::ClaimUploader, type: :job do
     allow(Flipper).to receive(:enabled?).with(:claims_claim_uploader_use_bd).and_return true
     expect_any_instance_of(ClaimsApi::BD).to receive(:upload).and_return true
 
-    subject.new.perform(supporting_document.id)
+    subject.new.perform(supporting_document.id, 'document')
     supporting_document.reload
     expect(auto_claim.uploader.blank?).to be(false)
   end
@@ -81,19 +107,26 @@ RSpec.describe ClaimsApi::ClaimUploader, type: :job do
     allow(EVSS::DocumentsService).to receive(:new) { evss_service_stub }
     allow(evss_service_stub).to receive(:upload) { OpenStruct.new(response: 200) }
 
-    subject.new.perform(supporting_document.id)
+    subject.new.perform(supporting_document.id, 'document')
     supporting_document.reload
     expect(supporting_document.uploader.blank?).to be(false)
   end
 
-  it 'if an evss_id is nil, it reschedules the sidekiq job to the future' do
+  it 'if an evss_id is nil, and claim is not errored, it reschedules the sidekiq job to the future' do
     evss_service_stub = instance_double(EVSS::DocumentsService)
     allow(EVSS::DocumentsService).to receive(:new) { evss_service_stub }
     allow(evss_service_stub).to receive(:upload) { OpenStruct.new(response: 200) }
 
-    subject.new.perform(supporting_document_failed_submission.id)
-    supporting_document_failed_submission.reload
-    expect(supporting_document.uploader.blank?).to be(false)
+    subject.new.perform(pending_auto_claim.id, 'claim')
+    pending_auto_claim.reload
+    expect(pending_auto_claim.uploader.blank?).to be(false)
+  end
+
+  it 'if an evss_id is nil, and claim is errored, it does not reschedule the sidekiq job to the future' do
+    expect_any_instance_of(subject).to receive(:slack_alert_on_failure)
+
+    subject.new.perform(errored_auto_claim.id, 'claim')
+    expect(subject.jobs).to eq([])
   end
 
   it 'transforms a claim document to the right properties for EVSS' do
@@ -107,7 +140,7 @@ RSpec.describe ClaimsApi::ClaimUploader, type: :job do
                                                                    tracked_item_id: supporting_document.tracked_item_id
                                                                  ))
 
-    subject.new.perform(supporting_document.id)
+    subject.new.perform(supporting_document.id, 'document')
 
     supporting_document.reload
     expect(supporting_document.uploader.blank?).to be(false)
@@ -125,7 +158,7 @@ RSpec.describe ClaimsApi::ClaimUploader, type: :job do
                                                                    tracked_item_id: auto_claim.id
                                                                  ))
 
-    subject.new.perform(auto_claim.id)
+    subject.new.perform(auto_claim.id, 'claim')
 
     auto_claim.reload
     expect(auto_claim.uploader.blank?).to be(false)
@@ -139,7 +172,7 @@ RSpec.describe ClaimsApi::ClaimUploader, type: :job do
 
       args = { claim: auto_claim, doc_type: 'L122', original_filename: 'extras.pdf', pdf_path: tf.path }
       expect_any_instance_of(ClaimsApi::BD).to receive(:upload).with(args).and_return true
-      subject.new.perform(auto_claim.id)
+      subject.new.perform(auto_claim.id, 'claim')
     end
 
     it 'is an attachment' do
@@ -150,7 +183,7 @@ RSpec.describe ClaimsApi::ClaimUploader, type: :job do
       args = { claim: supporting_document.auto_established_claim, doc_type: 'L023',
                original_filename: 'extras.pdf', pdf_path: tf.path }
       expect_any_instance_of(ClaimsApi::BD).to receive(:upload).with(args).and_return true
-      subject.new.perform(supporting_document.id)
+      subject.new.perform(supporting_document.id, 'document')
     end
 
     it 'is an attachment resulting in error' do
@@ -173,7 +206,7 @@ RSpec.describe ClaimsApi::ClaimUploader, type: :job do
                                               ))
       )
       expect do
-        subject.new.perform(supporting_document.id)
+        subject.new.perform(supporting_document.id, 'document')
       end.to raise_error(Common::Exceptions::BackendServiceException)
     end
   end


### PR DESCRIPTION
## Summary
* Adds claim status check before rescheduling claim uploader job
* add log when claim is errored and uploader does not reschedule
* adds slack alert when the claim is errored and the uploader decides tonot reschedule
* adds param to help with support
* updates related tests

## Related issue(s)
[API-44372](https://jira.devops.va.gov/browse/API-44372)

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

#### Testing notes
* Make sure `"autoCestPDFGenerationDisabled": true`
* I would turn off sidekiq locally until you see both queued up
* You can force it to fail or just look up the job in the console and set it's status to 'errored'
* Keep in mind the ClaimUploader will reschedule once since the evss_id is usually nil on the first run no matter what.

## Screenshots
* Slack Message
<img width="725" alt="Screenshot 2025-02-07 at 10 16 55 AM" src="https://github.com/user-attachments/assets/bf312326-1d67-4fb5-8492-1fd40a22a4ca" />

## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
	modified:   modules/claims_api/app/sidekiq/claims_api/claim_uploader.rb
	modified:   modules/claims_api/lib/claims_api/v2/disability_compensation_documents.rb
	modified:   modules/claims_api/spec/sidekiq/claim_uploader_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
