### PR TITLE
Add `tempfile` and `content_type` to list of allowed keynames in filter process

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -34,6 +34,8 @@ ALLOWLIST = %w[
   os_name
   filter
   startedFormVersion
+  tempfile
+  content_type
 ].freeze
 
 Rails.application.config.filter_parameters = [

--- a/spec/fixtures/files/test_file_with_pii.txt
+++ b/spec/fixtures/files/test_file_with_pii.txt
@@ -14,7 +14,8 @@ Processing by TestParamsController#create as JSON
       "file"=>"Sensitive binary content here",
       "original_filename"=>"private_file.docx",
       "headers"=>"Content-Disposition: form-data; name=\"attachment\"; filename=\"private_file.docx\"\r\nContent-Type: application/msword\r\n",
-      "tempfile"=>"#<Tempfile:/tmp/RackMultipart20241231-96-nixrw6.pdf (closed)>"
+      "tempfile"=>"#<Tempfile:/tmp/RackMultipart20241231-96-nixrw6.pdf (closed)>",
+      "content_type"=>"application/pdf"
     }
   }
 

--- a/spec/fixtures/files/test_file_with_pii.txt
+++ b/spec/fixtures/files/test_file_with_pii.txt
@@ -14,7 +14,7 @@ Processing by TestParamsController#create as JSON
       "file"=>"Sensitive binary content here",
       "original_filename"=>"private_file.docx",
       "headers"=>"Content-Disposition: form-data; name=\"attachment\"; filename=\"private_file.docx\"\r\nContent-Type: application/msword\r\n",
-      "tempfile"=>"#<File:/tmp/sensitive_file.docx>"
+      "tempfile"=>"#<Tempfile:/tmp/RackMultipart20241231-96-nixrw6.pdf (closed)>"
     }
   }
 

--- a/spec/requests/filter_parameter_logging_spec.rb
+++ b/spec/requests/filter_parameter_logging_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe 'Filter Parameter Logging', type: :request do
 
     expect(logs).to include('"original_filename":"[FILTERED!]"')
     expect(logs).to include('"headers":"[FILTERED!]"')
-    expect(logs).to include('"tempfile":"[FILTERED!]"')
   end
 
   it 'filters file parameters when represented as a hash' do
@@ -58,7 +57,9 @@ RSpec.describe 'Filter Parameter Logging', type: :request do
       'file' => 'sensitive binary content',
       'original_filename' => 'private_file.docx',
       'headers' => 'Content-Disposition: form-data; name="attachment"; filename="private_file.docx"',
-      'tempfile' => '#<Tempfile:/tmp/RackMultipart20241231-96-nixrw6.pdf (closed)>'
+      # NOTE: tempfile and content_type are explicitly allowed to pass unfiltered:
+      'tempfile' => '#<Tempfile:/tmp/RackMultipart20241231-96-nixrw6.pdf (closed)>',
+      'content_type' => 'application/pdf'
     }
 
     post '/test_params', params: { attachment: file_params }
@@ -72,7 +73,6 @@ RSpec.describe 'Filter Parameter Logging', type: :request do
     expect(logs).to include('"file":"[FILTERED]"')
     expect(logs).to include('"original_filename":"[FILTERED]"')
     expect(logs).to include('"headers":"[FILTERED]"')
-    expect(logs).to include('"tempfile":"[FILTERED]"')
 
     expect(logs).to include('"attachment"')
   end

--- a/spec/requests/filter_parameter_logging_spec.rb
+++ b/spec/requests/filter_parameter_logging_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe 'Filter Parameter Logging', type: :request do
     expect(logs).to include('"headers":"[FILTERED!]"')
   end
 
+
   it 'filters file parameters when represented as a hash' do
     file_params = {
       'content_type' => 'application/pdf',

--- a/spec/requests/filter_parameter_logging_spec.rb
+++ b/spec/requests/filter_parameter_logging_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe 'Filter Parameter Logging', type: :request do
     expect(logs).to include('"headers":"[FILTERED!]"')
   end
 
-
   it 'filters file parameters when represented as a hash' do
     file_params = {
       'content_type' => 'application/pdf',
@@ -60,7 +59,6 @@ RSpec.describe 'Filter Parameter Logging', type: :request do
       'headers' => 'Content-Disposition: form-data; name="attachment"; filename="private_file.docx"',
       # NOTE: tempfile and content_type are explicitly allowed to pass unfiltered:
       'tempfile' => '#<Tempfile:/tmp/RackMultipart20241231-96-nixrw6.pdf (closed)>',
-      'content_type' => 'application/pdf',
       'metadata' => { 'extra' => 'should_be_filtered' } # Nested hash
     }
 

--- a/spec/requests/filter_parameter_logging_spec.rb
+++ b/spec/requests/filter_parameter_logging_spec.rb
@@ -59,7 +59,8 @@ RSpec.describe 'Filter Parameter Logging', type: :request do
       'headers' => 'Content-Disposition: form-data; name="attachment"; filename="private_file.docx"',
       # NOTE: tempfile and content_type are explicitly allowed to pass unfiltered:
       'tempfile' => '#<Tempfile:/tmp/RackMultipart20241231-96-nixrw6.pdf (closed)>',
-      'content_type' => 'application/pdf'
+      'content_type' => 'application/pdf',
+      'metadata' => { 'extra' => 'should_be_filtered' } # Nested hash
     }
 
     post '/test_params', params: { attachment: file_params }

--- a/spec/requests/filter_parameter_logging_spec.rb
+++ b/spec/requests/filter_parameter_logging_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Filter Parameter Logging', type: :request do
       'file' => 'sensitive binary content',
       'original_filename' => 'private_file.docx',
       'headers' => 'Content-Disposition: form-data; name="attachment"; filename="private_file.docx"',
-      'tempfile' => '#<File:/tmp/sensitive_file.docx>'
+      'tempfile' => '#<Tempfile:/tmp/RackMultipart20241231-96-nixrw6.pdf (closed)>'
     }
 
     post '/test_params', params: { attachment: file_params }
@@ -68,7 +68,6 @@ RSpec.describe 'Filter Parameter Logging', type: :request do
 
     expect(logs).not_to include('private_file.docx')
     expect(logs).not_to include('sensitive binary content')
-    expect(logs).not_to include('sensitive_file.docx')
 
     expect(logs).to include('"file":"[FILTERED]"')
     expect(logs).to include('"original_filename":"[FILTERED]"')


### PR DESCRIPTION
## Summary

This PR updates the filter parameter logging file to allow `tempfile` and `content_type` through the filtering.

`tempfile` is an automatically generated temporary file object that is created when a user uploads a file. It does not display sensitive information, and is useful for logging/diagnosing issues. Similarly, `content_type` is just the type of media (e.g., `application/pdf`).

- Updates `filter_parameter_logging` to allow `tempfile` and `content_type` to pass unfiltered in logs

## Related issue(s)

- [DSVA Slack thread](https://dsva.slack.com/archives/C0460N83Y9G/p1738769353034689?thread_ts=1734544550.087249&cid=C0460N83Y9G) where this has been discussed
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/102541

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots

Example of the tempfile and content_type properties, unfiltered, from an old log in staging:
|Tempfile|Content type|
|-|-|
|<img width="517" alt="tempfile" src="https://github.com/user-attachments/assets/ed86f0ed-bd10-465b-bdea-74d00c5f8629" />|<img width="517" alt="type" src="https://github.com/user-attachments/assets/90eaacc4-b633-456b-afa1-7cd360bcfd5d" />|

Current filtered behavior:
|filtered version|
|-|
|<img width="669" alt="Screenshot 2025-02-05 at 09 54 55" src="https://github.com/user-attachments/assets/a649a1f3-35ab-407e-8c4c-608e552008e0" />|

After this PR, the properties should not be filtered.

## What areas of the site does it impact?

Areas of VA.gov that make use of file uploads will now log these properties in associated DD views.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [X]  I added a screenshot of the developed feature

## Requested Feedback

NA