### PR TITLE
[ARP - lower camel responses - 1] `set_key_transform :camel_lower`

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/in_progress_forms_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/in_progress_forms_controller.rb
@@ -8,7 +8,7 @@ module AccreditedRepresentativePortal
       def update
         form = find_form || build_form
         form.update!(
-          form_data: params[:form_data],
+          form_data: params[:formData],
           metadata: params[:metadata]
         )
 

--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_users_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_users_controller.rb
@@ -11,18 +11,18 @@ module AccreditedRepresentativePortal
         # serialization layer.
         render json: {
           account: {
-            account_uuid: @current_user.user_account_uuid
+            accountUuid: @current_user.user_account_uuid
           },
           profile: {
-            first_name: @current_user.first_name,
-            last_name: @current_user.last_name,
+            firstName: @current_user.first_name,
+            lastName: @current_user.last_name,
             verified: @current_user.user_account.verified?,
-            sign_in: {
-              service_name: @current_user.sign_in[:service_name]
+            signIn: {
+              serviceName: @current_user.sign_in[:service_name]
             }
           },
-          prefills_available: [],
-          in_progress_forms:
+          prefillsAvailable: [],
+          inProgressForms: in_progress_forms
         }
       end
 

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_form.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_form.rb
@@ -49,8 +49,8 @@ module AccreditedRepresentativePortal
       return unless address
 
       self.claimant_city = address['city']
-      self.claimant_state_code = address['state_code']
-      self.claimant_zip_code = address['zip_code']
+      self.claimant_state_code = address['stateCode']
+      self.claimant_zip_code = address['zipCode']
     end
 
     def data_must_comply_with_schema
@@ -83,11 +83,11 @@ module AccreditedRepresentativePortal
           "authorizations": {
             "type": "object",
             "properties": {
-              "record_disclosure": {
+              "recordDisclosure": {
                 "type": "boolean",
                 "example": true
               },
-              "record_disclosure_limitations": {
+              "recordDisclosureLimitations": {
                 "type": "array",
                 "items": {
                   "type": "string",
@@ -105,15 +105,15 @@ module AccreditedRepresentativePortal
                   "SICKLE_CELL"
                 ]
               },
-              "address_change": {
+              "addressChange": {
                 "type": "boolean",
                 "example": false
               }
             },
             "required": [
-              "record_disclosure",
-              "record_disclosure_limitations",
-              "address_change"
+              "recordDisclosure",
+              "recordDisclosureLimitations",
+              "addressChange"
             ]
           },
           "dependent": {
@@ -144,11 +144,11 @@ module AccreditedRepresentativePortal
               "address": {
                 "type": "object",
                 "properties": {
-                  "address_line1": {
+                  "addressLine1": {
                     "type": "string",
                     "example": "123 Main St"
                   },
-                  "address_line2": {
+                  "addressLine2": {
                     "type": ["string", "null"],
                     "example": "Apt 1"
                   },
@@ -156,7 +156,7 @@ module AccreditedRepresentativePortal
                     "type": "string",
                     "example": "Springfield"
                   },
-                  "state_code": {
+                  "stateCode": {
                     "type": "string",
                     "example": "IL"
                   },
@@ -164,26 +164,26 @@ module AccreditedRepresentativePortal
                     "type": "string",
                     "example": "US"
                   },
-                  "zip_code": {
+                  "zipCode": {
                     "type": "string",
                     "example": "62704"
                   },
-                  "zip_code_suffix": {
+                  "zipCodeSuffix": {
                     "type": ["string", "null"],
                     "example": "6789"
                   }
                 },
                 "required": [
-                  "address_line1",
-                  "address_line2",
+                  "addressLine1",
+                  "addressLine2",
                   "city",
-                  "state_code",
+                  "stateCode",
                   "country",
-                  "zip_code",
-                  "zip_code_suffix"
+                  "zipCode",
+                  "zipCodeSuffix"
                 ]
               },
-              "date_of_birth": {
+              "dateOfBirth": {
                 "type": "string",
                 "format": "date",
                 "example": "1980-12-31"
@@ -204,7 +204,7 @@ module AccreditedRepresentativePortal
             "required": [
               "name",
               "address",
-              "date_of_birth",
+              "dateOfBirth",
               "relationship",
               "phone",
               "email"
@@ -238,11 +238,11 @@ module AccreditedRepresentativePortal
               "address": {
                 "type": "object",
                 "properties": {
-                  "address_line1": {
+                  "addressLine1": {
                     "type": "string",
                     "example": "123 Main St"
                   },
-                  "address_line2": {
+                  "addressLine2": {
                     "type": ["string", "null"],
                     "example": "Apt 1"
                   },
@@ -250,7 +250,7 @@ module AccreditedRepresentativePortal
                     "type": "string",
                     "example": "Springfield"
                   },
-                  "state_code": {
+                  "stateCode": {
                     "type": "string",
                     "example": "IL"
                   },
@@ -258,43 +258,43 @@ module AccreditedRepresentativePortal
                     "type": "string",
                     "example": "US"
                   },
-                  "zip_code": {
+                  "zipCode": {
                     "type": "string",
                     "example": "62704"
                   },
-                  "zip_code_suffix": {
+                  "zipCodeSuffix": {
                     "type": ["string", "null"],
                     "example": "6789"
                   }
                 },
                 "required": [
-                  "address_line1",
-                  "address_line2",
+                  "addressLine1",
+                  "addressLine2",
                   "city",
-                  "state_code",
+                  "stateCode",
                   "country",
-                  "zip_code",
-                  "zip_code_suffix"
+                  "zipCode",
+                  "zipCodeSuffix"
                 ]
               },
               "ssn": {
                 "type": "string",
                 "example": "123456789"
               },
-              "va_file_number": {
+              "vaFileNumber": {
                 "type": ["string", "null"],
                 "example": "123456789"
               },
-              "date_of_birth": {
+              "dateOfBirth": {
                 "type": "string",
                 "format": "date",
                 "example": "1980-12-31"
               },
-              "service_number": {
+              "serviceNumber": {
                 "type": ["string", "null"],
                 "example": "123456789"
               },
-              "service_branch": {
+              "serviceBranch": {
                 "type": ["string", "null"],
                 "enum": [
                   "ARMY",
@@ -321,10 +321,10 @@ module AccreditedRepresentativePortal
               "name",
               "address",
               "ssn",
-              "va_file_number",
-              "date_of_birth",
-              "service_number",
-              "service_branch",
+              "vaFileNumber",
+              "dateOfBirth",
+              "serviceNumber",
+              "serviceBranch",
               "phone",
               "email"
             ]

--- a/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/application_serializer.rb
+++ b/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/application_serializer.rb
@@ -4,6 +4,8 @@ module AccreditedRepresentativePortal
   class ApplicationSerializer
     include JSONAPI::Serializer
 
+    set_key_transform :camel_lower
+
     # We're not building to JSONAPI.
     def serializable_hash
       data = super[:data]

--- a/modules/accredited_representative_portal/config/initializers/bypass_olive_branch.rb
+++ b/modules/accredited_representative_portal/config/initializers/bypass_olive_branch.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  ##
+  # `olive_branch` transforms (a) request and (b) response payloads.
+  #
+  # (a) It deeply transforms request and query param keys.
+  # At times it is convenient for params to act as snake-cased setters at a Ruby
+  # interface, but not always. Form resources are a possible example where not.
+  #
+  # For now, let's wait to encounter the cases where we really want this
+  # convenience. If we do encounter some, we may discover that we want a more
+  # explicit and collocated way to opt in.
+  #
+  # (b) It reloads the response from JSON, deeply transforms keys, and dumps
+  # back to JSON.
+  # This is superfluous because our serialization layer `jsonapi-serializer`
+  # already has a configuration option for key casing. This realizes our desired
+  # casing the one and only time it is visiting an object during serialization.
+  #
+  module BypassOliveBranch
+    def call(env)
+      exclude_arp_route?(env) ? @app.call(env) : super
+    end
+
+    private
+
+    ARP_PATH_INFO_PREFIX = '/accredited_representative_portal'
+
+    def exclude_arp_route?(env)
+      env['PATH_INFO'].to_s.start_with?(ARP_PATH_INFO_PREFIX)
+    end
+  end
+end
+
+module OliveBranch
+  class Middleware
+    prepend AccreditedRepresentativePortal::BypassOliveBranch
+  end
+end

--- a/modules/accredited_representative_portal/spec/factories/power_of_attorney_form.rb
+++ b/modules/accredited_representative_portal/spec/factories/power_of_attorney_form.rb
@@ -2,9 +2,9 @@
 
 dependent_claimant_data_hash = {
   authorizations: {
-    record_disclosure: true,
-    record_disclosure_limitations: [],
-    address_change: true
+    recordDisclosure: true,
+    recordDisclosureLimitations: [],
+    addressChange: true
   },
   dependent: {
     name: {
@@ -13,15 +13,15 @@ dependent_claimant_data_hash = {
       last: 'Doe'
     },
     address: {
-      address_line1: '123 Main St',
-      address_line2: 'Apt 1',
+      addressLine1: '123 Main St',
+      addressLine2: 'Apt 1',
       city: 'Springfield',
-      state_code: 'IL',
+      stateCode: 'IL',
       country: 'US',
-      zip_code: '62704',
-      zip_code_suffix: '6789'
+      zipCode: '62704',
+      zipCodeSuffix: '6789'
     },
-    date_of_birth: '1980-12-31',
+    dateOfBirth: '1980-12-31',
     relationship: 'Spouse',
     phone: '1234567890',
     email: 'veteran@example.com'
@@ -33,19 +33,19 @@ dependent_claimant_data_hash = {
       last: 'Doe'
     },
     address: {
-      address_line1: '123 Main St',
-      address_line2: 'Apt 1',
+      addressLine1: '123 Main St',
+      addressLine2: 'Apt 1',
       city: 'Springfield',
-      state_code: 'IL',
+      stateCode: 'IL',
       country: 'US',
-      zip_code: '62704',
-      zip_code_suffix: '6789'
+      zipCode: '62704',
+      zipCodeSuffix: '6789'
     },
     ssn: '123456789',
-    va_file_number: '123456789',
-    date_of_birth: '1980-12-31',
-    service_number: '123456789',
-    service_branch: 'ARMY',
+    vaFileNumber: '123456789',
+    dateOfBirth: '1980-12-31',
+    serviceNumber: '123456789',
+    serviceBranch: 'ARMY',
     phone: '1234567890',
     email: 'veteran@example.com'
   }
@@ -53,12 +53,12 @@ dependent_claimant_data_hash = {
 
 veteran_claimant_data_hash = {
   authorizations: {
-    record_disclosure: true,
-    record_disclosure_limitations: %w[
+    recordDisclosure: true,
+    recordDisclosureLimitations: %w[
       HIV
       DRUG_ABUSE
     ],
-    address_change: true
+    addressChange: true
   },
   dependent: nil,
   veteran: {
@@ -68,19 +68,19 @@ veteran_claimant_data_hash = {
       last: 'Doe'
     },
     address: {
-      address_line1: '123 Main St',
-      address_line2: 'Apt 1',
+      addressLine1: '123 Main St',
+      addressLine2: 'Apt 1',
       city: 'Springfield',
-      state_code: 'IL',
+      stateCode: 'IL',
       country: 'US',
-      zip_code: '62704',
-      zip_code_suffix: '6789'
+      zipCode: '62704',
+      zipCodeSuffix: '6789'
     },
     ssn: '123456789',
-    va_file_number: '123456789',
-    date_of_birth: '1980-12-31',
-    service_number: '123456789',
-    service_branch: 'ARMY',
+    vaFileNumber: '123456789',
+    dateOfBirth: '1980-12-31',
+    serviceNumber: '123456789',
+    serviceBranch: 'ARMY',
     phone: '1234567890',
     email: 'veteran@example.com'
   }
@@ -94,14 +94,14 @@ FactoryBot.define do
       data_hash do
         {
           authorizations: {
-            record_disclosure: Faker::Boolean.boolean,
-            record_disclosure_limitations: %w[
+            recordDisclosure: Faker::Boolean.boolean,
+            recordDisclosureLimitations: %w[
               ALCOHOLISM
               DRUG_ABUSE
               HIV
               SICKLE_CELL
             ].select { rand < 0.5 },
-            address_change: Faker::Boolean.boolean
+            addressChange: Faker::Boolean.boolean
           },
           dependent: nil,
           veteran: {
@@ -111,19 +111,19 @@ FactoryBot.define do
               last: Faker::Name.first_name
             },
             address: {
-              address_line1: Faker::Address.street_address,
-              address_line2: nil,
+              addressLine1: Faker::Address.street_address,
+              addressLine2: nil,
               city: Faker::Address.city,
-              state_code: Faker::Address.state_abbr,
+              stateCode: Faker::Address.state_abbr,
               country: 'US',
-              zip_code: Faker::Address.zip_code,
-              zip_code_suffix: nil
+              zipCode: Faker::Address.zip_code,
+              zipCodeSuffix: nil
             },
             ssn: Faker::Number.number(digits: 9).to_s,
-            va_file_number: Faker::Number.number(digits: 9).to_s,
-            date_of_birth: Faker::Date.birthday(min_age: 21, max_age: 100).to_s,
-            service_number: Faker::Number.number(digits: 9).to_s,
-            service_branch: %w[
+            vaFileNumber: Faker::Number.number(digits: 9).to_s,
+            dateOfBirth: Faker::Date.birthday(min_age: 21, max_age: 100).to_s,
+            serviceNumber: Faker::Number.number(digits: 9).to_s,
+            serviceBranch: %w[
               ARMY
               NAVY
               AIR_FORCE

--- a/modules/accredited_representative_portal/spec/factories/representative_user.rb
+++ b/modules/accredited_representative_portal/spec/factories/representative_user.rb
@@ -39,7 +39,11 @@ FactoryBot.define do
           {
             form_id: evaluator.in_progress_form_id,
             user_account: user.user_account,
-            user_uuid: user.uuid
+            user_uuid: user.uuid,
+            metadata: {
+              version: 1,
+              returnUrl: 'foo.com'
+            }
           }
         )
       end

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/bypass_olive_branch_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/bypass_olive_branch_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+class BypassOliveBranchTestController < ActionController::API
+  def arp = render json: {}
+  def normal = render json: {}
+end
+
+RSpec.describe AccreditedRepresentativePortal::BypassOliveBranch, type: :request do
+  subject do
+    get "#{path_prefix}/bypass_olive_branch_test", headers: {
+      'X-Key-Inflection' => 'camel',
+      'Content-Type' => 'application/json'
+    }
+  end
+
+  before(:all) do
+    Rails.application.routes.draw do
+      get '/accredited_representative_portal/bypass_olive_branch_test', to: 'bypass_olive_branch_test#arp'
+      get '/bypass_olive_branch_test', to: 'bypass_olive_branch_test#normal'
+    end
+  end
+
+  after(:all) do
+    Rails.application.reload_routes!
+  end
+
+  context 'when the request is for an accredited representative portal route' do
+    let(:path_prefix) { '/accredited_representative_portal' }
+
+    it 'bypasses OliveBranch processing' do
+      expect(OliveBranch::Transformations).not_to receive(:underscore_params)
+      expect(OliveBranch::Transformations).not_to receive(:transform)
+      subject
+    end
+  end
+
+  context 'when the request is for a normal route' do
+    let(:path_prefix) { '' }
+
+    it 'applies OliveBranch processing' do
+      expect(OliveBranch::Transformations).to receive(:underscore_params)
+      expect(OliveBranch::Transformations).to receive(:transform)
+      subject
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/in_progress_forms_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/in_progress_forms_spec.rb
@@ -22,7 +22,11 @@ RSpec.describe AccreditedRepresentativePortal::V0::InProgressFormsController, ty
           :in_progress_form,
           user_uuid: representative_user.uuid,
           form_data: { field: 'value' },
-          form_id:
+          form_id:,
+          metadata: {
+            version: 1,
+            returnUrl: 'foo.com'
+          }
         )
 
         get("/accredited_representative_portal/v0/in_progress_forms/#{form_id}")
@@ -33,14 +37,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::InProgressFormsController, ty
             },
             'metadata' => {
               'version' => 1,
-              'return_url' => 'foo.com',
-              'submission' => {
-                'status' => false,
-                'error_message' => false,
-                'id' => false,
-                'timestamp' => false,
-                'has_attempted_submit' => false
-              },
+              'returnUrl' => 'foo.com',
               'createdAt' => 1_646_370_367,
               'expiresAt' => 1_651_554_367,
               'lastUpdated' => 1_646_370_367,
@@ -57,7 +54,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::InProgressFormsController, ty
 
         put(
           "/accredited_representative_portal/v0/in_progress_forms/#{form_id}",
-          params: { 'form_data' => { another_field: 'foo' } }.to_json,
+          params: { 'formData' => { anotherField: 'foo' } }.to_json,
           headers:
         )
 
@@ -85,7 +82,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::InProgressFormsController, ty
         expect(parsed_response).to eq(
           {
             'formData' => {
-              'another_field' => 'foo'
+              'anotherField' => 'foo'
             },
             'metadata' => {
               'createdAt' => 1_646_456_767,
@@ -101,7 +98,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::InProgressFormsController, ty
 
         put(
           "/accredited_representative_portal/v0/in_progress_forms/#{form_id}",
-          params: { 'form_data' => { another_field: 'foo', sample_field: 'sample' } }.to_json,
+          params: { 'formData' => { anotherField: 'foo', sampleField: 'sample' } }.to_json,
           headers:
         )
 
@@ -129,8 +126,8 @@ RSpec.describe AccreditedRepresentativePortal::V0::InProgressFormsController, ty
         expect(parsed_response).to eq(
           {
             'formData' => {
-              'another_field' => 'foo',
-              'sample_field' => 'sample'
+              'anotherField' => 'foo',
+              'sampleField' => 'sample'
             },
             'metadata' => {
               'createdAt' => 1_646_456_767,

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
             'accreditedIndividual' => {
               'id' => poa_requests[0].accredited_individual.id,
               'fullName' => "#{poa_requests[0].accredited_individual.first_name} " \
-                             "#{poa_requests[0].accredited_individual.last_name}"
+                            "#{poa_requests[0].accredited_individual.last_name}"
             },
             'powerOfAttorneyHolder' => {
               'type' => 'veteran_service_organization',
@@ -116,7 +116,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
             'accreditedIndividual' => {
               'id' => poa_requests[1].accredited_individual.id,
               'fullName' => "#{poa_requests[1].accredited_individual.first_name} " \
-                             "#{poa_requests[1].accredited_individual.last_name}"
+                            "#{poa_requests[1].accredited_individual.last_name}"
             },
             'powerOfAttorneyHolder' => {
               'type' => 'veteran_service_organization',
@@ -141,7 +141,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
             'accreditedIndividual' => {
               'id' => poa_requests[2].accredited_individual.id,
               'fullName' => "#{poa_requests[2].accredited_individual.first_name} " \
-                             "#{poa_requests[2].accredited_individual.last_name}"
+                            "#{poa_requests[2].accredited_individual.last_name}"
             },
             'powerOfAttorneyHolder' => {
               'type' => 'veteran_service_organization',
@@ -163,7 +163,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
             'accreditedIndividual' => {
               'id' => poa_requests[3].accredited_individual.id,
               'fullName' => "#{poa_requests[3].accredited_individual.first_name} " \
-                             "#{poa_requests[3].accredited_individual.last_name}"
+                            "#{poa_requests[3].accredited_individual.last_name}"
             },
             'powerOfAttorneyHolder' => {
               'type' => 'veteran_service_organization',
@@ -238,7 +238,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
           'accreditedIndividual' => {
             'id' => poa_request.accredited_individual.id,
             'fullName' => "#{poa_request.accredited_individual.first_name} " \
-                           "#{poa_request.accredited_individual.last_name}"
+                          "#{poa_request.accredited_individual.last_name}"
           },
           'powerOfAttorneyHolder' => {
             'type' => 'veteran_service_organization',

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
 
     resolution.power_of_attorney_request
   end
+
   let(:time) { '2024-12-21T04:45:37.000Z' }
   let(:time_plus_one_day) { '2024-12-22T04:45:37.000Z' }
   let(:expires_at) { '2025-02-19T04:45:37.000Z' }
@@ -83,17 +84,17 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
         [
           {
             'id' => poa_requests[0].id,
-            'claimant_id' => poa_requests[0].claimant_id,
-            'created_at' => time,
-            'expires_at' => (Time.zone.parse(time) + 60.days).iso8601(3),
-            'power_of_attorney_form' => veteran_claimant_power_of_attorney_form,
+            'claimantId' => poa_requests[0].claimant_id,
+            'createdAt' => time,
+            'expiresAt' => (Time.zone.parse(time) + 60.days).iso8601(3),
+            'powerOfAttorneyForm' => veteran_claimant_power_of_attorney_form,
             'resolution' => nil,
-            'accredited_individual' => {
+            'accreditedIndividual' => {
               'id' => poa_requests[0].accredited_individual.id,
-              'full_name' => "#{poa_requests[0].accredited_individual.first_name} " \
+              'fullName' => "#{poa_requests[0].accredited_individual.first_name} " \
                              "#{poa_requests[0].accredited_individual.last_name}"
             },
-            'power_of_attorney_holder' => {
+            'powerOfAttorneyHolder' => {
               'type' => 'veteran_service_organization',
               'name' => poa_requests[0].accredited_organization.name,
               'id' => poa_requests[0].accredited_organization.poa
@@ -101,23 +102,23 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
           },
           {
             'id' => poa_requests[1].id,
-            'claimant_id' => poa_requests[1].claimant_id,
-            'created_at' => time,
-            'expires_at' => nil,
-            'power_of_attorney_form' => dependent_claimant_power_of_attorney_form,
+            'claimantId' => poa_requests[1].claimant_id,
+            'createdAt' => time,
+            'expiresAt' => nil,
+            'powerOfAttorneyForm' => dependent_claimant_power_of_attorney_form,
             'resolution' => {
               'id' => poa_requests[1].resolution.id,
               'type' => 'decision',
-              'created_at' => time,
-              'creator_id' => poa_requests[1].resolution.resolving.creator_id,
-              'decision_type' => 'acceptance'
+              'createdAt' => time,
+              'creatorId' => poa_requests[1].resolution.resolving.creator_id,
+              'decisionType' => 'acceptance'
             },
-            'accredited_individual' => {
+            'accreditedIndividual' => {
               'id' => poa_requests[1].accredited_individual.id,
-              'full_name' => "#{poa_requests[1].accredited_individual.first_name} " \
+              'fullName' => "#{poa_requests[1].accredited_individual.first_name} " \
                              "#{poa_requests[1].accredited_individual.last_name}"
             },
-            'power_of_attorney_holder' => {
+            'powerOfAttorneyHolder' => {
               'type' => 'veteran_service_organization',
               'name' => poa_requests[1].accredited_organization.name,
               'id' => poa_requests[1].accredited_organization.poa
@@ -125,24 +126,24 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
           },
           {
             'id' => poa_requests[2].id,
-            'claimant_id' => poa_requests[2].claimant_id,
-            'created_at' => time,
-            'expires_at' => nil,
-            'power_of_attorney_form' => dependent_claimant_power_of_attorney_form,
+            'claimantId' => poa_requests[2].claimant_id,
+            'createdAt' => time,
+            'expiresAt' => nil,
+            'powerOfAttorneyForm' => dependent_claimant_power_of_attorney_form,
             'resolution' => {
               'id' => poa_requests[2].resolution.id,
               'type' => 'decision',
-              'created_at' => time,
-              'creator_id' => poa_requests[2].resolution.resolving.creator_id,
+              'createdAt' => time,
+              'creatorId' => poa_requests[2].resolution.resolving.creator_id,
               'reason' => 'Didn\'t authorize treatment record disclosure',
-              'decision_type' => 'declination'
+              'decisionType' => 'declination'
             },
-            'accredited_individual' => {
+            'accreditedIndividual' => {
               'id' => poa_requests[2].accredited_individual.id,
-              'full_name' => "#{poa_requests[2].accredited_individual.first_name} " \
+              'fullName' => "#{poa_requests[2].accredited_individual.first_name} " \
                              "#{poa_requests[2].accredited_individual.last_name}"
             },
-            'power_of_attorney_holder' => {
+            'powerOfAttorneyHolder' => {
               'type' => 'veteran_service_organization',
               'name' => poa_requests[2].accredited_organization.name,
               'id' => poa_requests[2].accredited_organization.poa
@@ -150,21 +151,21 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
           },
           {
             'id' => poa_requests[3].id,
-            'claimant_id' => poa_requests[3].claimant_id,
-            'created_at' => time,
-            'expires_at' => nil,
-            'power_of_attorney_form' => dependent_claimant_power_of_attorney_form,
+            'claimantId' => poa_requests[3].claimant_id,
+            'createdAt' => time,
+            'expiresAt' => nil,
+            'powerOfAttorneyForm' => dependent_claimant_power_of_attorney_form,
             'resolution' => {
               'id' => poa_requests[3].resolution.id,
               'type' => 'expiration',
-              'created_at' => time
+              'createdAt' => time
             },
-            'accredited_individual' => {
+            'accreditedIndividual' => {
               'id' => poa_requests[3].accredited_individual.id,
-              'full_name' => "#{poa_requests[3].accredited_individual.first_name} " \
+              'fullName' => "#{poa_requests[3].accredited_individual.first_name} " \
                              "#{poa_requests[3].accredited_individual.last_name}"
             },
-            'power_of_attorney_holder' => {
+            'powerOfAttorneyHolder' => {
               'type' => 'veteran_service_organization',
               'name' => poa_requests[3].accredited_organization.name,
               'id' => poa_requests[3].accredited_organization.poa
@@ -193,7 +194,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
         expect(parsed_response.map { |poa| poa['id'] }).not_to include(declined_request.id)
         expect(parsed_response.map { |poa| poa['id'] }).not_to include(accepted_request.id)
         expect(parsed_response.map { |poa| poa['id'] }).not_to include(expired_request.id)
-        expect(parsed_response.map { |h| h['created_at'] }).to eq([time, time_plus_one_day])
+        expect(parsed_response.map { |h| h['createdAt'] }).to eq([time, time_plus_one_day])
       end
 
       it 'returns the list of completed power of attorney requests sorted by resolution creation descending' do
@@ -204,7 +205,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
         expect(parsed_response.map { |poa| poa['id'] }).not_to include(pending_request1.id)
         expect(parsed_response.map { |poa| poa['id'] }).not_to include(pending_request2.id)
         expect(parsed_response.map { |poa| poa['id'] }).not_to include(expired_request.id)
-        expect(parsed_response.map { |h| h['resolution']['created_at'] }).to eq([time_plus_one_day, time])
+        expect(parsed_response.map { |h| h['resolution']['createdAt'] }).to eq([time_plus_one_day, time])
       end
 
       it 'throws an error if any other status filter provided' do
@@ -215,14 +216,6 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
   end
 
   describe 'GET /accredited_representative_portal/v0/power_of_attorney_requests/:id' do
-    let(:poa_request) { create(:power_of_attorney_request, :with_declination) }
-    let(:power_of_attorney_form) do
-      poa_request.power_of_attorney_form.parsed_data.tap do |data|
-        data.delete('dependent')
-        data['claimant'] = data.delete('veteran')
-      end
-    end
-
     it 'returns the details of a specific power of attorney request' do
       get("/accredited_representative_portal/v0/power_of_attorney_requests/#{poa_request.id}")
 
@@ -230,24 +223,24 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
       expect(parsed_response).to eq(
         {
           'id' => poa_request.id,
-          'claimant_id' => poa_request.claimant_id,
-          'created_at' => time,
-          'expires_at' => nil,
-          'power_of_attorney_form' => power_of_attorney_form,
+          'claimantId' => poa_request.claimant_id,
+          'createdAt' => time,
+          'expiresAt' => nil,
+          'powerOfAttorneyForm' => veteran_claimant_power_of_attorney_form,
           'resolution' => {
             'id' => poa_request.resolution.id,
             'type' => 'decision',
-            'created_at' => time,
-            'creator_id' => poa_request.resolution.resolving.creator_id,
+            'createdAt' => time,
+            'creatorId' => poa_request.resolution.resolving.creator_id,
             'reason' => 'Didn\'t authorize treatment record disclosure',
-            'decision_type' => 'declination'
+            'decisionType' => 'declination'
           },
-          'accredited_individual' => {
+          'accreditedIndividual' => {
             'id' => poa_request.accredited_individual.id,
-            'full_name' => "#{poa_request.accredited_individual.first_name} " \
+            'fullName' => "#{poa_request.accredited_individual.first_name} " \
                            "#{poa_request.accredited_individual.last_name}"
           },
-          'power_of_attorney_holder' => {
+          'powerOfAttorneyHolder' => {
             'type' => 'veteran_service_organization',
             'name' => poa_request.accredited_organization.name,
             'id' => poa_request.accredited_organization.poa

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec/responses/dependent_claimant_power_of_attorney_form.json
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec/responses/dependent_claimant_power_of_attorney_form.json
@@ -1,8 +1,8 @@
 {
   "authorizations": {
-    "record_disclosure": true,
-    "record_disclosure_limitations": [],
-    "address_change": true
+    "recordDisclosure": true,
+    "recordDisclosureLimitations": [],
+    "addressChange": true
   },
   "veteran": {
     "name": {
@@ -11,19 +11,19 @@
       "last": "Doe"
     },
     "address": {
-      "address_line1": "123 Main St",
-      "address_line2": "Apt 1",
+      "addressLine1": "123 Main St",
+      "addressLine2": "Apt 1",
       "city": "Springfield",
-      "state_code": "IL",
+      "stateCode": "IL",
       "country": "US",
-      "zip_code": "62704",
-      "zip_code_suffix": "6789"
+      "zipCode": "62704",
+      "zipCodeSuffix": "6789"
     },
     "ssn": "123456789",
-    "va_file_number": "123456789",
-    "date_of_birth": "1980-12-31",
-    "service_number": "123456789",
-    "service_branch": "ARMY",
+    "vaFileNumber": "123456789",
+    "dateOfBirth": "1980-12-31",
+    "serviceNumber": "123456789",
+    "serviceBranch": "ARMY",
     "phone": "1234567890",
     "email": "veteran@example.com"
   },
@@ -34,15 +34,15 @@
       "last": "Doe"
     },
     "address": {
-      "address_line1": "123 Main St",
-      "address_line2": "Apt 1",
+      "addressLine1": "123 Main St",
+      "addressLine2": "Apt 1",
       "city": "Springfield",
-      "state_code": "IL",
+      "stateCode": "IL",
       "country": "US",
-      "zip_code": "62704",
-      "zip_code_suffix": "6789"
+      "zipCode": "62704",
+      "zipCodeSuffix": "6789"
     },
-    "date_of_birth": "1980-12-31",
+    "dateOfBirth": "1980-12-31",
     "relationship": "Spouse",
     "phone": "1234567890",
     "email": "veteran@example.com"

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec/responses/veteran_claimant_power_of_attorney_form.json
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec/responses/veteran_claimant_power_of_attorney_form.json
@@ -1,11 +1,11 @@
 {
   "authorizations": {
-    "record_disclosure": true,
-    "record_disclosure_limitations": [
+    "recordDisclosure": true,
+    "recordDisclosureLimitations": [
       "HIV",
       "DRUG_ABUSE"
     ],
-    "address_change": true
+    "addressChange": true
   },
   "claimant": {
     "name": {
@@ -14,19 +14,19 @@
       "last": "Doe"
     },
     "address": {
-      "address_line1": "123 Main St",
-      "address_line2": "Apt 1",
+      "addressLine1": "123 Main St",
+      "addressLine2": "Apt 1",
       "city": "Springfield",
-      "state_code": "IL",
+      "stateCode": "IL",
       "country": "US",
-      "zip_code": "62704",
-      "zip_code_suffix": "6789"
+      "zipCode": "62704",
+      "zipCodeSuffix": "6789"
     },
     "ssn": "123456789",
-    "va_file_number": "123456789",
-    "date_of_birth": "1980-12-31",
-    "service_number": "123456789",
-    "service_branch": "ARMY",
+    "vaFileNumber": "123456789",
+    "dateOfBirth": "1980-12-31",
+    "serviceNumber": "123456789",
+    "serviceBranch": "ARMY",
     "phone": "1234567890",
     "email": "veteran@example.com"
   }

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/user_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/user_spec.rb
@@ -46,30 +46,23 @@ RSpec.describe 'AccreditedRepresentativePortal::V0::User', type: :request do
           expect(parsed_response).to eq(
             {
               'account' => {
-                'account_uuid' => user.user_account.id
+                'accountUuid' => user.user_account.id
               },
               'profile' => {
-                'first_name' => first_name,
-                'last_name' => last_name,
+                'firstName' => first_name,
+                'lastName' => last_name,
                 'verified' => true,
-                'sign_in' => {
-                  'service_name' => sign_in_service_name
+                'signIn' => {
+                  'serviceName' => sign_in_service_name
                 }
               },
-              'prefills_available' => [],
-              'in_progress_forms' => [
+              'prefillsAvailable' => [],
+              'inProgressForms' => [
                 {
                   'form' => in_progress_form_id,
                   'metadata' => {
                     'version' => 1,
-                    'return_url' => 'foo.com',
-                    'submission' => {
-                      'status' => false,
-                      'error_message' => false,
-                      'id' => false,
-                      'timestamp' => false,
-                      'has_attempted_submit' => false
-                    },
+                    'returnUrl' => 'foo.com',
                     'createdAt' => Time.current.to_i,
                     'expiresAt' => 60.days.from_now.to_i,
                     'lastUpdated' => Time.current.to_i,

--- a/modules/accredited_representative_portal/spec/serializers/accredited_representative_portal/power_of_attorney_request_serializer_spec.rb
+++ b/modules/accredited_representative_portal/spec/serializers/accredited_representative_portal/power_of_attorney_request_serializer_spec.rb
@@ -26,20 +26,20 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestSerializer,
     end
 
     it 'includes :claimant_id' do
-      expect(veteran_declined_data[:claimant_id]).to eq veteran_declined_poa_request.claimant_id
+      expect(veteran_declined_data[:claimantId]).to eq veteran_declined_poa_request.claimant_id
     end
 
     it 'includes :created_at' do
-      expect(veteran_declined_data[:created_at]).to eq veteran_declined_poa_request.created_at
+      expect(veteran_declined_data[:createdAt]).to eq veteran_declined_poa_request.created_at
     end
 
     it 'includes :expires_at' do
-      expect(veteran_declined_data[:expires_at]).to eq veteran_declined_poa_request.expires_at.as_json
+      expect(veteran_declined_data[:expiresAt]).to eq veteran_declined_poa_request.expires_at.as_json
     end
 
     describe ':power_of_attorney_form' do
       it 'modifies claimant key based on claimant type for veteran type' do
-        veteran_declined_serialized_form = veteran_declined_data[:power_of_attorney_form]
+        veteran_declined_serialized_form = veteran_declined_data[:powerOfAttorneyForm]
 
         expect(veteran_declined_serialized_form['claimant']).to be_present
         expect(veteran_declined_serialized_form).not_to be_key('dependent')
@@ -47,7 +47,7 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestSerializer,
       end
 
       it 'modifies claimant key based on claimant type for dependent type' do
-        dependent_expiration_serialized_form = dependent_expiration_data[:power_of_attorney_form]
+        dependent_expiration_serialized_form = dependent_expiration_data[:powerOfAttorneyForm]
 
         expect(dependent_expiration_serialized_form['claimant']).to be_present
         expect(dependent_expiration_serialized_form).not_to be_key('dependent')
@@ -60,10 +60,10 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestSerializer,
         it 'includes the decision resolution' do
           veteran_declined_resolution_data = veteran_declined_data[:resolution]
           expect(veteran_declined_resolution_data[:type]).to eq 'decision'
-          expect(veteran_declined_resolution_data[:decision_type]).to eq 'declination'
+          expect(veteran_declined_resolution_data[:decisionType]).to eq 'declination'
           expect(veteran_declined_resolution_data[:reason]).to eq "Didn't authorize treatment record disclosure"
           expect(veteran_declined_resolution_data[:id]).to eq veteran_declined_resolution.id
-          expect(veteran_declined_resolution_data[:creator_id]).to eq veteran_declined_resolution.resolving.creator_id
+          expect(veteran_declined_resolution_data[:creatorId]).to eq veteran_declined_resolution.resolving.creator_id
         end
       end
 
@@ -86,7 +86,7 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestSerializer,
     describe ':power_of_attorney_holder' do
       context 'when the holder is an AccreditedOrganization' do
         it 'serializes the accredited organization' do
-          veteran_declined_holder_data = veteran_declined_data[:power_of_attorney_holder]
+          veteran_declined_holder_data = veteran_declined_data[:powerOfAttorneyHolder]
           expect(veteran_declined_holder_data[:type]).to eq 'veteran_service_organization'
           expect(veteran_declined_holder_data[:name]).to eq veteran_declined_poa_request.accredited_organization.name
         end


### PR DESCRIPTION
This is the head of a PR stack that switches all existing ARP endpoints to input and output camel cased request and response payloads explicitly and in particular bypasses `olive_branch` middleware. The PRs sequence the work like `1 <- 2 <- 3 <- 4 <- 5` and can each be approved one at a time in that order. Then that whole chain can get merged into this head PR and platform can re-approve a final time to go into `master`. 

⚠️ _Please feel free to visit the 5 minimal diffs in quick succession!_ ⚠️

The PR titles and minimal diffs are self explanatory:
- #20621
- #20622
- #20623
- #20624
- #20625

It is worth reiterating the code comment that exists in the final PR of the PR stack that bypasses `olive_branch` for ARP endpoints:
> `olive_branch` transforms (a) request and (b) response payloads.
>
> (a) It deeply transforms request and query param keys.
At times it is convenient for params to act as snake-cased setters at a Ruby interface, but not always. Form resources are a possible example where not.
>
> For now, let's wait to encounter the cases where we really want this convenience. If we do encounter some, we may discover that we want a more explicit and collocated way to opt in.
>
> (b) It reloads the response from JSON, deeply transforms keys, and dumps back to JSON.
This is superfluous because our serialization layer `jsonapi-serializer` already has a configuration option for key casing. This realizes our desired casing the one and only time it is visiting an object during serialization.

