### PR TITLE
[ARP - lower camel responses - 5] bypass olive branch

### DIFF
--- a/modules/accredited_representative_portal/config/initializers/bypass_olive_branch.rb
+++ b/modules/accredited_representative_portal/config/initializers/bypass_olive_branch.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  ##
+  # `olive_branch` transforms (a) request and (b) response payloads.
+  #
+  # (a) It deeply transforms request and query param keys.
+  # At times it is convenient for params to act as snake-cased setters at a Ruby
+  # interface, but not always. Form resources are a possible example where not.
+  #
+  # For now, let's wait to encounter the cases where we really want this
+  # convenience. If we do encounter some, we may discover that we want a more
+  # explicit and collocated way to opt in.
+  #
+  # (b) It reloads the response from JSON, deeply transforms keys, and dumps
+  # back to JSON.
+  # This is superfluous because our serialization layer `jsonapi-serializer`
+  # already has a configuration option for key casing. This realizes our desired
+  # casing the one and only time it is visiting an object during serialization.
+  #
+  module BypassOliveBranch
+    def call(env)
+      exclude_arp_route?(env) ? @app.call(env) : super
+    end
+
+    private
+
+    ARP_PATH_INFO_PREFIX = '/accredited_representative_portal'
+
+    def exclude_arp_route?(env)
+      env['PATH_INFO'].to_s.start_with?(ARP_PATH_INFO_PREFIX)
+    end
+  end
+end
+
+module OliveBranch
+  class Middleware
+    prepend AccreditedRepresentativePortal::BypassOliveBranch
+  end
+end

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/bypass_olive_branch_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/bypass_olive_branch_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccreditedRepresentativePortal::BypassOliveBranch, type: :request do
+  before(:all) do
+    class BypassOliveBranchTestController < ActionController::API
+      def arp = render json: {}
+      def normal = render json: {}
+    end
+
+    Rails.application.routes.draw do
+      get '/accredited_representative_portal/bypass_olive_branch_test', to: 'bypass_olive_branch_test#arp'
+      get '/bypass_olive_branch_test', to: 'bypass_olive_branch_test#normal'
+    end
+  end
+
+  after(:all) do
+    Rails.application.reload_routes!
+  end
+
+  subject do
+    get "#{path_prefix}/bypass_olive_branch_test", headers: {
+      'X-Key-Inflection' => 'camel',
+      'Content-Type' => 'application/json'
+    }
+  end
+
+  context 'when the request is for an accredited representative portal route' do
+    let(:path_prefix) { '/accredited_representative_portal' }
+
+    it 'bypasses OliveBranch processing' do
+      expect(OliveBranch::Transformations).not_to receive(:underscore_params)
+      expect(OliveBranch::Transformations).not_to receive(:transform)
+      subject
+    end
+  end
+
+  context 'when the request is for a normal route' do
+    let(:path_prefix) { '' }
+
+    it 'applies OliveBranch processing' do
+      expect(OliveBranch::Transformations).to receive(:underscore_params)
+      expect(OliveBranch::Transformations).to receive(:transform)
+      subject
+    end
+  end
+end
+
+

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/bypass_olive_branch_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/bypass_olive_branch_spec.rb
@@ -2,13 +2,20 @@
 
 require 'rails_helper'
 
-RSpec.describe AccreditedRepresentativePortal::BypassOliveBranch, type: :request do
-  before(:all) do
-    class BypassOliveBranchTestController < ActionController::API
-      def arp = render json: {}
-      def normal = render json: {}
-    end
+class BypassOliveBranchTestController < ActionController::API
+  def arp = render json: {}
+  def normal = render json: {}
+end
 
+RSpec.describe AccreditedRepresentativePortal::BypassOliveBranch, type: :request do
+  subject do
+    get "#{path_prefix}/bypass_olive_branch_test", headers: {
+      'X-Key-Inflection' => 'camel',
+      'Content-Type' => 'application/json'
+    }
+  end
+
+  before(:all) do
     Rails.application.routes.draw do
       get '/accredited_representative_portal/bypass_olive_branch_test', to: 'bypass_olive_branch_test#arp'
       get '/bypass_olive_branch_test', to: 'bypass_olive_branch_test#normal'
@@ -17,13 +24,6 @@ RSpec.describe AccreditedRepresentativePortal::BypassOliveBranch, type: :request
 
   after(:all) do
     Rails.application.reload_routes!
-  end
-
-  subject do
-    get "#{path_prefix}/bypass_olive_branch_test", headers: {
-      'X-Key-Inflection' => 'camel',
-      'Content-Type' => 'application/json'
-    }
   end
 
   context 'when the request is for an accredited representative portal route' do
@@ -46,5 +46,3 @@ RSpec.describe AccreditedRepresentativePortal::BypassOliveBranch, type: :request
     end
   end
 end
-
-


### PR DESCRIPTION
See head of PR stack: #20621

> `olive_branch` transforms (a) request and (b) response payloads.
>
> (a) It deeply transforms request and query param keys.
At times it is convenient for params to act as snake-cased setters at a Ruby interface, but not always. Form resources are a possible example where not.
>
> For now, let's wait to encounter the cases where we really want this convenience. If we do encounter some, we may discover that we want a more explicit and collocated way to opt in.
>
> (b) It reloads the response from JSON, deeply transforms keys, and dumps back to JSON.
This is superfluous because our serialization layer `jsonapi-serializer` already has a configuration option for key casing. This realizes our desired casing the one and only time it is visiting an object during serialization.
