### PR TITLE
Improving Parameter Filtering for Nested Hashes

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -39,8 +39,10 @@ ALLOWLIST = %w[
 Rails.application.config.filter_parameters = [
   lambda do |k, v|
     case v
-    when Hash # Recursively iterate over each key value pair in hashes
-      v.transform_values { |nested_value| Rails.application.config.filter_parameters.first.call(k, nested_value) }
+    when Hash
+      v.each do |nested_key, nested_value|
+        v[nested_key] = Rails.application.config.filter_parameters.first.call(nested_key, nested_value)
+      end
     when Array # Recursively map all elements in arrays
       v.map { |element| Rails.application.config.filter_parameters.first.call(k, element) }
     when ActionDispatch::Http::UploadedFile # Base case


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
This PR improves how we filter sensitive params in logs by ensuring nested hash structures are properly filtered while preserving the nested hash structure. The approach using `transform_values` - ([PR to address this here](https://github.com/department-of-veterans-affairs/vets-api/pull/20619/files)) applied filtering at a single level (see image below), but it did not properly recurse into deeply nested hashes. The led to the case where entire hashes were replaced with `[FILTERED]` instead of filtering individually. The code is improved to iterate over key/value pairs in a loop to explicitly reassigns the transformed value. Doing this ensures that filtering applies correctly at every nested level while preserving key/value pairs. Sensitive data is consistently redacted while maintaining structured logging for debugging purposes

[Original PR](https://github.com/department-of-veterans-affairs/vets-api/pull/20571)

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/2157

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

Deeply nested hashes are still being replaced with `[FILTERED]` instead of filtering individually

![Screenshot 2025-02-05 at 10 56 52 AM](https://github.com/user-attachments/assets/9d668fca-c0fb-482a-a70d-6b7ee8660568)

vs

![Screenshot 2025-02-05 at 10 57 17 AM](https://github.com/user-attachments/assets/96531a02-9425-4aca-82fc-a2051437b870)


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
