### PR TITLE
Remove all_claims_add_disabilities_enhancement Feature Toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -27,10 +27,6 @@ features:
     actor_type: user
     description: Enables the VADX experimental features in the AEDP application
     enable_in_development: true
-  all_claims_add_disabilities_enhancement:
-    actor_type: user
-    description: Enables enhancement to the 21-526EZ "Add Disabilities" page being implemented by the Conditions Team.
-    enable_in_development: true
   appointments_consolidation:
     actor_type: user
     description: For features being tested while merging logic for appointments between web and mobile


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): It removes a feature toggle
- Summarize the changes that have been made to the platform: Remove the all_claims_add_disabilities_enhancement feature toggle which was removed from the frontend with this PR: [Conditions 671 Remove Previous Add Conditions Content and Feature Toggle #34453](https://github.com/department-of-veterans-affairs/vets-website/pull/34453)

## Related issue(s)
- [Replace Combobox and All Claims ArrayField with Autocomplete and Platform ArrayField #671](https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/671)