### PR TITLE
101565 Update metadata for each IVC forms with primary contact email - IVC CHAMPVA forms

### DIFF
--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
@@ -35,7 +35,8 @@ module IvcChampva
         'ssn_or_tin' => @data.dig('veteran', 'ssn_or_tin'),
         'uuid' => @uuid,
         'primaryContactInfo' => @data['primary_contact_info'],
-        'hasApplicantOver65' => @data['has_applicant_over65'].to_s
+        'hasApplicantOver65' => @data['has_applicant_over65'].to_s,
+        'primaryContactEmail' => @data.dig('primary_contact_info', 'email').to_s
       }
     end
 

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
@@ -31,7 +31,8 @@ module IvcChampva
         'fileNumber' => @data['applicant_member_number'],
         'country' => @data.dig('applicant_address', 'country') || 'USA',
         'uuid' => @uuid,
-        'primaryContactInfo' => @data['primary_contact_info']
+        'primaryContactInfo' => @data['primary_contact_info'],
+        'primaryContactEmail' => @data.dig('primary_contact_info', 'email').to_s
       }
     end
 

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
@@ -29,7 +29,8 @@ module IvcChampva
         'docType' => @data['form_number'],
         'businessLine' => 'CMP',
         'uuid' => @uuid,
-        'primaryContactInfo' => @data['primary_contact_info']
+        'primaryContactInfo' => @data['primary_contact_info'],
+        'primaryContactEmail' => @data.dig('primary_contact_info', 'email').to_s
       }
     end
 

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_1.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_1.rb
@@ -29,7 +29,8 @@ module IvcChampva
         'docType' => @data['form_number'],
         'businessLine' => 'CMP',
         'uuid' => @uuid,
-        'primaryContactInfo' => @data['primary_contact_info']
+        'primaryContactInfo' => @data['primary_contact_info'],
+        'primaryContactEmail' => @data.dig('primary_contact_info', 'email').to_s
       }
     end
 

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_2.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_2.rb
@@ -29,7 +29,8 @@ module IvcChampva
         'docType' => @data['form_number'],
         'businessLine' => 'CMP',
         'uuid' => @uuid,
-        'primaryContactInfo' => @data['primary_contact_info']
+        'primaryContactInfo' => @data['primary_contact_info'],
+        'primaryContactEmail' => @data.dig('primary_contact_info', 'email').to_s
       }
     end
 

--- a/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
@@ -62,7 +62,8 @@ RSpec.describe IvcChampva::VHA1010d do
             'last' => 'Surname'
           },
           'email' => false
-        }
+        },
+        'primaryContactEmail' => 'false'
       )
     end
   end

--- a/modules/ivc_champva/spec/models/vha_10_7959a_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959a_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe IvcChampva::VHA107959a do
             'last' => 'Surname'
           },
           'email' => false
-        }
+        },
+        'primaryContactEmail' => 'false'
       )
     end
   end

--- a/modules/ivc_champva/spec/models/vha_10_7959c_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959c_spec.rb
@@ -58,7 +58,8 @@ RSpec.describe IvcChampva::VHA107959c do
             'last' => 'Surname'
           },
           'email' => false
-        }
+        },
+        'primaryContactEmail' => 'false'
       )
     end
   end

--- a/modules/ivc_champva/spec/models/vha_10_7959f_1_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959f_1_spec.rb
@@ -54,7 +54,8 @@ RSpec.describe IvcChampva::VHA107959f1 do
             'last' => 'Surname'
           },
           'email' => 'email@address.com'
-        }
+        },
+        'primaryContactEmail' => 'email@address.com'
       )
     end
   end

--- a/modules/ivc_champva/spec/models/vha_10_7959f_2_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959f_2_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe IvcChampva::VHA107959f2 do
             'last' => 'Surname'
           },
           'email' => 'email@address.com'
-        }
+        },
+        'primaryContactEmail' => 'email@address.com'
       )
     end
   end


### PR DESCRIPTION
## Summary

This PR updates the metadata for all IVC forms to include the `primaryContactEmail` property so that submitted attachments will contain an email address embedded in the file metadata upon submission to S3.

- Update all IVC form metadata constructors to include new email prop
- Update relevant test data in spec files

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101565

## Testing done

- [X] *New code is covered by unit tests*
- Old behavior: metadata did not include this email prop
- To verify behavior, file was submitted to a development S3 bucket and the metadata was confirmed to contain the email property

## Screenshots

|S3 metadata|
|-|
|<img width="959" alt="Screenshot 2025-02-05 at 14 55 17" src="https://github.com/user-attachments/assets/1d604e25-f6f7-428e-9393-a97570c6305c" />|

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA