### PR TITLE
Run "Require backend-review-group approval" when a PR is labeled

### DIFF
--- a/.github/workflows/require_be_approval.yml
+++ b/.github/workflows/require_be_approval.yml
@@ -1,5 +1,7 @@
 name: Require backend-review-group approval
 on:
+  pull_request:
+    types: [labeled]
   pull_request_review:
     types: [submitted]
     branches: master

--- a/modules/decision_reviews/app/controllers/decision_reviews/application_controller.rb
+++ b/modules/decision_reviews/app/controllers/decision_reviews/application_controller.rb
@@ -67,6 +67,7 @@ module DecisionReviews
 
     def rails_logger(level, message, errors = nil, backtrace = nil)
       # rails logger uses 'warn' instead of 'warning'
+
       level = 'warn' if level == 'warning'
       if errors.present?
         error_details = errors.first.attributes.compact.reject { |_k, v| v.try(:empty?) }


### PR DESCRIPTION
## Summary

my attempt at testing https://github.com/department-of-veterans-affairs/vets-api/pull/20640 since this can only be tested on a PR that is first opened as a draft.

## Testing done
 - [x] open as draft.
 - [x] get approval by owning team
 - [x] mark as ready for review
 - [ ] "Require backend-review-group approval" should run.

## Screenshots
### 1. Approved by one owning team. Action skipped
![image](https://github.com/user-attachments/assets/a4bd8e2e-f642-4fff-ba82-5809895d0694)


### 2. Marked as ready for review but it's STILL being skipped 😩 
![image](https://github.com/user-attachments/assets/eb6f94ab-c18f-4a1b-8cfb-253c1026b3ef)
