### PR TITLE
20382 refactor IVC email VA Notify param logic + associated test - IVC CHAMPVA forms

### DIFF
--- a/modules/ivc_champva/app/services/ivc_champva/email.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/email.rb
@@ -30,7 +30,10 @@ module IvcChampva
         VANotify::EmailJob.perform_async(
           data[:email],
           (data[:template_id] ? EMAIL_TEMPLATE_MAP[data[:template_id]] : EMAIL_TEMPLATE_MAP[data[:form_number]]),
-          data.slice(:first_name, :last_name, :file_count, :pega_status, :date_submitted, :form_uuid),
+          # Create a subset of `data` - Using .index_with rather than .slice so that keys
+          # default to `nil` if not present in `data`. This helps us w/ testing.
+          %i[first_name last_name file_count pega_status date_submitted form_uuid]
+            .index_with { |k| data[k] },
           Settings.vanotify.services.ivc_champva.api_key,
           # If no callback_klass is provided, should fail safely per va_notify implementation.
           # See: https://github.com/department-of-veterans-affairs/vets-api/tree/master/modules/va_notify#how-teams-can-integrate-with-callbacks

--- a/modules/ivc_champva/spec/services/email_spec.rb
+++ b/modules/ivc_champva/spec/services/email_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe IvcChampva::Email, type: :service do
       last_name: 'Doe',
       file_count: 3,
       pega_status: 'Processed',
-      created_at: Time.zone.now.to_s
+      created_at: Time.zone.now.to_s,
+      date_submitted: Time.zone.now.to_s,
+      form_uuid: '4171e61a-03b5-49f3-8717-dbf340310473'
     }
   end
 


### PR DESCRIPTION
## Summary

This PR is a follow-up to this [previous bugfix](https://github.com/department-of-veterans-affairs/vets-api/pull/20382). This PR configures the VA Notify email params to have default `nil` values so that the unit test can more accurately catch when properties are missing/misconfigured. It also updates the associated unit test `data` object with the current list of necessary keys.

This will help prevent future misconfigurations to the parameter list in `IvcChampva::Email::send_email` from going unnoticed (as was the case when the [bug referenced here](https://github.com/department-of-veterans-affairs/vets-api/pull/20382) was introduced).

- This work is not behind a feature toggle
- Team: IVC CHAMPVA

## Related issue(s)

- [Original bugfix](https://github.com/department-of-veterans-affairs/vets-api/pull/20382) that this builds on

## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
