### PR TITLE
Submission Status Job: Assign lighthouse_updated_at before running callbacks upon state change

### DIFF
--- a/lib/lighthouse/benefits_intake/sidekiq/submission_status_job.rb
+++ b/lib/lighthouse/benefits_intake/sidekiq/submission_status_job.rb
@@ -135,6 +135,7 @@ module BenefitsIntake
     def update_attempt_record(uuid, status, submission)
       form_submission_attempt = pending_attempts_hash[uuid]
       lighthouse_updated_at = submission.dig('attributes', 'updated_at')
+      form_submission_attempt.update(lighthouse_updated_at:)
 
       case status
       when 'expired'
@@ -152,7 +153,7 @@ module BenefitsIntake
         form_submission_attempt.vbms!
       end
 
-      form_submission_attempt.update(lighthouse_updated_at:, error_message:)
+      form_submission_attempt.update(error_message:) if error_message
     end
 
     # monitoring of the submission attempt status


### PR DESCRIPTION
## Summary
This PR fixes a small bug where we would update state on a `FormSubmissionAttempt` (triggering an email to send) before populating the `lighthouse_updated_at` field. The emails, without this field set, would fail. Currently this whole Job is behind a feature flag (`:benefits_intake_submission_status_job`) which is OFF. Once we fix this, I believe we are safe to turn the feature flag back on.
