### PR TITLE
100832 Financial Management: Do not register Silent Errors for Sharepoint errors

### DIFF
--- a/modules/debts_api/app/models/debts_api/v0/form5655_submission.rb
+++ b/modules/debts_api/app/models/debts_api/v0/form5655_submission.rb
@@ -74,7 +74,6 @@ module DebtsApi
         submission.submitted!
         StatsD.increment("#{STATS_KEY}.vha.success")
       else
-        # we are not registering a failure for Sharepoint requests
         submission.register_failure("VHA set completed state: #{status.failure_info}")
         StatsD.increment("#{STATS_KEY}.vha.failure")
         Rails.logger.error('Batch FSR Processing Failed', status.failure_info)

--- a/modules/debts_api/app/models/debts_api/v0/form5655_submission.rb
+++ b/modules/debts_api/app/models/debts_api/v0/form5655_submission.rb
@@ -74,7 +74,10 @@ module DebtsApi
         submission.submitted!
         StatsD.increment("#{STATS_KEY}.vha.success")
       else
-        submission.register_failure("VHA set completed state: #{status.failure_info}")
+        # we are not registering a failure for Sharepoint requests
+        unless status.failure_info.include?('SharepointRequest')
+          submission.register_failure("VHA set completed state: #{status.failure_info}")
+        end
         StatsD.increment("#{STATS_KEY}.vha.failure")
         Rails.logger.error('Batch FSR Processing Failed', status.failure_info)
       end

--- a/modules/debts_api/spec/models/debt_api/v0/form5655_submission_spec.rb
+++ b/modules/debts_api/spec/models/debt_api/v0/form5655_submission_spec.rb
@@ -235,6 +235,21 @@ RSpec.describe DebtsApi::V0::Form5655Submission do
         form5655_submission.register_failure(message)
         expect(form5655_submission.error_message).to eq(message)
       end
+
+      it 'alerts silent error when not sharepoint error' do
+        expect(form5655_submission).to receive(:alert_silent_error)
+        form5655_submission.register_failure(message)
+      end
+
+      it 'does not alert silent error when sharepoint error' do
+        message =
+          "VHA set completed state: [#<struct Sidekiq::Batch::Status::Failure jid=\"058f2988d02722166392ff66\", " \
+            "error_class=\"Common::Exceptions::BackendServiceException\", " \
+            "error_message=\"BackendServiceException: {:status=>500, :detail=>\\\"Internal Server Error\\\", " \
+            ":source=>\\\"SharepointRequest\\\", :code=>\\\"SHAREPOINT_PDF_502\\\"}\", backtrace=nil>]"
+        expect(form5655_submission).not_to receive(:alert_silent_error)
+        form5655_submission.register_failure(message)
+      end
     end
   end
 

--- a/modules/debts_api/spec/models/debt_api/v0/form5655_submission_spec.rb
+++ b/modules/debts_api/spec/models/debt_api/v0/form5655_submission_spec.rb
@@ -243,10 +243,10 @@ RSpec.describe DebtsApi::V0::Form5655Submission do
 
       it 'does not alert silent error when sharepoint error' do
         message =
-          "VHA set completed state: [#<struct Sidekiq::Batch::Status::Failure jid=\"058f2988d02722166392ff66\", " \
-            "error_class=\"Common::Exceptions::BackendServiceException\", " \
-            "error_message=\"BackendServiceException: {:status=>500, :detail=>\\\"Internal Server Error\\\", " \
-            ":source=>\\\"SharepointRequest\\\", :code=>\\\"SHAREPOINT_PDF_502\\\"}\", backtrace=nil>]"
+          'VHA set completed state: [#<struct Sidekiq::Batch::Status::Failure jid=\"058f2988d02722166392ff66\", ' \
+          'error_class=\"Common::Exceptions::BackendServiceException\", ' \
+          'error_message=\"BackendServiceException: {:status=>500, :detail=>\\\"Internal Server Error\\\", ' \
+          ':source=>\\\"SharepointRequest\\\", :code=>\\\"SHAREPOINT_PDF_502\\\"}\", backtrace=nil>]'
         expect(form5655_submission).not_to receive(:alert_silent_error)
         form5655_submission.register_failure(message)
       end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO*: Sort of. We have a feature flag that enables a different error class that would effectively fire/not fire this conditional.
- *(Summarize the changes that have been made to the platform)*: We've been alerting Watchtower about Sharepoint errors we're getting. It's not great that we're erroring but also, it's not _really_ a silent error. The Veteran's data gets where it needs to go even if sharepoint errors. We enabled a new error class(es) via Flipper and confirmed this is working as expected. Now, we're adding this to not fire silent errors when there's a sharepoint error.
- *(If bug, how to reproduce)*: N/A
- *(What is the solution, why is this the solution?)*: This will get our alerts to watchtower so we can be alerted to a _real_ problem in the future.
- *(Which team do you work for, does your team own the maintenance of this component?)*: Financial Management (#finanical-management in Octo Slack)
- *(If introducing a flipper, what is the success criteria being targeted?)*: N/A

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/100832
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
