### PR TITLE
Add welcome-va-setup-review-information to source_app_middleware.rb

### DIFF
--- a/lib/source_app_middleware.rb
+++ b/lib/source_app_middleware.rb
@@ -144,6 +144,7 @@ class SourceAppMiddleware
     view-payments
     view-representative
     virtual-agent
+    welcome-va-setup-review-information
     yellow-ribbon
     your-debt
   ].freeze


### PR DESCRIPTION
## Summary

Datadog alert: [vets-api source app monitor - un-mapped source app detected](https://dsva.slack.com/archives/C30LCU8S3/p1738949981312379)
The logs in the alert show 
```
Unrecognized value for HTTP_SOURCE_APP_NAME request header... [welcome-va-setup-review-information]
```

## Related issue(s)

Noticed while on support. 

## Testing done

- [ ] Alert is resolved after the PR is deployed.
