### PR TITLE
Add confirmation_number to callback_metadata for simple forms

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/form_upload_notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_upload_notification_email.rb
@@ -84,7 +84,7 @@ module SimpleFormsApi
     def email_args
       [
         Settings.vanotify.services.va_gov.api_key,
-        { callback_metadata: { notification_type:, form_number:, statsd_tags: } }
+        { callback_metadata: { notification_type:, form_number:, confirmation_number:, statsd_tags: } }
       ]
     end
 

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -145,8 +145,7 @@ module SimpleFormsApi
           email,
           template_id,
           get_personalization(first_name),
-          Settings.vanotify.services.va_gov.api_key,
-          { callback_metadata: { notification_type:, form_number:, statsd_tags: } }
+          *email_args
         )
       else
         VANotify::EmailJob.perform_at(
@@ -168,8 +167,7 @@ module SimpleFormsApi
           user_account.id,
           template_id,
           get_personalization(first_name_from_user_account),
-          Settings.vanotify.services.va_gov.api_key,
-          { callback_metadata: { notification_type:, form_number:, statsd_tags: } }
+          *email_args
         )
       else
         VANotify::UserAccountJob.perform_at(
@@ -425,6 +423,13 @@ module SimpleFormsApi
       else
         form_data.dig('application', 'applicant', 'name', 'first')
       end
+    end
+
+    def email_args
+      [
+        Settings.vanotify.services.va_gov.api_key,
+        { callback_metadata: { notification_type:, form_number:, confirmation_number:, statsd_tags: } }
+      ]
     end
 
     def statsd_tags

--- a/modules/simple_forms_api/spec/services/form_upload_notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_upload_notification_email_spec.rb
@@ -121,7 +121,7 @@ describe SimpleFormsApi::FormUploadNotificationEmail do
     let(:email_args) do
       [
         Settings.vanotify.services.va_gov.api_key,
-        { callback_metadata: { notification_type:, form_number:, statsd_tags: } }
+        { callback_metadata: { notification_type:, form_number:, confirmation_number:, statsd_tags: } }
       ]
     end
     let(:config) do

--- a/modules/simple_forms_api/spec/services/notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/notification_email_spec.rb
@@ -171,6 +171,7 @@ describe SimpleFormsApi::NotificationEmail do
 
       context 'send at time is specified' do
         context 'user_account is passed in' do
+          let(:confirmation_number) { 'confirmation_number' }
           let(:data) do
             fixture_path = Rails.root.join(
               'modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'vba_21_10210-min.json'
@@ -194,7 +195,7 @@ describe SimpleFormsApi::NotificationEmail do
               user_account.id,
               "form21_10210_#{notification_type}_email_template_id",
               {
-                'confirmation_number' => 'confirmation_number',
+                'confirmation_number' => confirmation_number,
                 'date_submitted' => time.strftime('%B %d, %Y'),
                 'first_name' => 'Bob',
                 'lighthouse_updated_at' => lighthouse_updated_at
@@ -204,6 +205,7 @@ describe SimpleFormsApi::NotificationEmail do
                 callback_metadata: {
                   form_number: 'vba_21_10210',
                   notification_type:,
+                  confirmation_number:,
                   statsd_tags: {
                     'function' => 'vba_21_10210 form submission to Lighthouse', 'service' => 'veteran-facing-forms'
                   }


### PR DESCRIPTION
## Summary
This PR tracks `confirmation_number` with the `callback_metadata` that we send back to VANotify. This should help us tie specific Notifications to the corresponding submission attempt.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/2008
