### PR TITLE
VACMS-11589 Remove unused flipper

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -612,9 +612,6 @@ features:
   facilities_ppms_suppress_all:
     actor_type: user
     description: Hide all ppms search options
-  facilities_ppms_suppress_pharmacies:
-    actor_type: user
-    description: Front End Flag to suppress the ability to search for pharmacies
   facility_locator_mobile_map_update:
     actor_type: user
     description: Use new mobile map features for research


### PR DESCRIPTION
## Summary
We are combining two flippers together:

- `facilities_ppms_suppress_all`
- `facilities_ppms_suppress_pharmacies`

The code for these two flippers will all be used under the `facilities_ppms_suppress_all` flipper, so we can remove the pharmacies-specific flipper.

vets-website PR for removal of the flipper code for pharmacies: https://github.com/department-of-veterans-affairs/vets-website/pull/34567

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11589