### PR TITLE
Update codeowners for top-level lib/pdf_fill

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -967,7 +967,7 @@ lib/okta/directory_service.rb @department-of-veterans-affairs/lighthouse-pivot
 lib/olive_branch_patch.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/pagerduty @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/pcpg @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-lib/pdf_fill @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/vfs-1095-b
+lib/pdf_fill @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/vfs-10-10
 lib/pdf_fill/forms/pdfs/21P-0969.pdf @department-of-veterans-affairs/pension-and-burials @department-of-veterans-affairs/backend-review-group
 lib/pdf_fill/forms/va21p0969.rb @department-of-veterans-affairs/pension-and-burials @department-of-veterans-affairs/backend-review-group
 lib/pdf_fill/forms/pdfs/28-1900.pdf @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group


### PR DESCRIPTION
## Summary

The Employee Experience team is embarking on a redesign of the PDF generator overflow page, to be rolled out on a form-by-form basis in collaboration with teams maintaining each form. This effort will touch `lib/pdf_fill` many times, which currently has a handful of form-specific teams tagged as codeowner.

I reached out to each of those teams on Slack for guidance; debt resolution and 1095b prefer to be untagged, and 10-10 preferred to stay codeowner.

## Related issue(s)

#20628 is the PR that brought this to my attention.