### PR TITLE
Refactor DebtsApi - Income Calculator

### DIFF
--- a/modules/debts_api/app/controllers/debts_api/v0/financial_status_reports_calculations_controller.rb
+++ b/modules/debts_api/app/controllers/debts_api/v0/financial_status_reports_calculations_controller.rb
@@ -16,7 +16,7 @@ module DebtsApi
       end
 
       def monthly_income
-        render json: income_calculator.get_monthly_income
+        render json: income_calculator.combined_monthly_income_statement
       end
 
       def monthly_expenses

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/discretionary_income_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/discretionary_income_calculator.rb
@@ -13,7 +13,7 @@ module DebtsApi
         def initialize(form)
           @form = form
           income_calculator = DebtsApi::V0::FsrFormTransform::IncomeCalculator.new(form)
-          @total_monthly_net_income = income_calculator.get_monthly_income[:totalMonthlyNetIncome]
+          @total_monthly_net_income = income_calculator.total_monthly_net_income
           @expense_calculator = DebtsApi::V0::FsrFormTransform::ExpenseCalculator.build(form)
         end
 

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/full_transform_service.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/full_transform_service.rb
@@ -19,7 +19,7 @@ module DebtsApi
 
         def initialize(form)
           @assets = AssetCalculator.new(form).transform_assets
-          @income = IncomeCalculator.new(form).combined_monthly_income_statement_as_json
+          @income = IncomeCalculator.new(form).monthly_income_statements_as_json
           @expenses = ExpenseCalculator.build(form).transform_expenses
           @additional_data = AdditionalDataCalculator.new(form).get_data
           @discretionary_income = DiscretionaryIncomeCalculator.new(form).get_data

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/full_transform_service.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/full_transform_service.rb
@@ -19,7 +19,7 @@ module DebtsApi
 
         def initialize(form)
           @assets = AssetCalculator.new(form).transform_assets
-          @income = IncomeCalculator.new(form).get_transformed_income
+          @income = IncomeCalculator.new(form).combined_monthly_income_statement_as_json
           @expenses = ExpenseCalculator.build(form).transform_expenses
           @additional_data = AdditionalDataCalculator.new(form).get_data
           @discretionary_income = DiscretionaryIncomeCalculator.new(form).get_data

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/income.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/income.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require 'debts_api/v0/fsr_form_transform/utils'
+
+module DebtsApi
+  module V0
+    module FsrFormTransform
+      class Income
+        include ::FsrFormTransform::Utils
+
+        BENEFICIARY_MAP = {
+          'veteran' => 'VETERAN',
+          'spouse' => 'SPOUSE'
+        }.freeze
+        TAX_FILTERS = ['State tax', 'Federal tax', 'Local tax'].freeze
+        RETIREMENT_FILTERS = [
+          'Retirement accounts (401k, IRAs, 403b, TSP)',
+          '401K',
+          'IRA',
+          'Pension'
+        ].freeze
+        SOCIAL_SEC_FILTERS = ['FICA (Social Security and Medicare)'].freeze
+        ALL_FILTERS = TAX_FILTERS + RETIREMENT_FILTERS + SOCIAL_SEC_FILTERS
+
+        def initialize(income_params)
+          @additional_income = income_params[:additional_income]
+          @employment_records = income_params[:employment_records]
+          @current_employment = income_params[:current_employment]
+          @social_security = income_params[:social_security]
+          @compensation_and_pension = income_params[:compensation_and_pension]
+          @education = income_params[:education]
+          @beneficiary_type = income_params[:beneficiary_type]
+          @enhanced_fsr_active = income_params[:enhanced_fsr_active]
+        end
+
+        def income_statement
+          {
+            grossSalary: gross_salary,
+            deductions: {
+              taxes: tax_deductions,
+              retirement: retirement_deductions,
+              socialSecurity: social_security_deductions,
+              otherDeductions: other_deductions
+            },
+            totalDeductions: total_deductions,
+            netTakeHomePay: net_take_home_pay,
+            otherIncome: other_income,
+            totalMonthlyNetIncome: total_monthly_net_income
+          }
+        end
+
+        def income_statement_as_json
+          {
+            'veteranOrSpouse' => BENEFICIARY_MAP[@beneficiary_type],
+            'monthlyGrossSalary' => dollars_cents(gross_salary),
+            'deductions' => {
+              'taxes' => dollars_cents(tax_deductions),
+              'retirement' => dollars_cents(retirement_deductions),
+              'socialSecurity' => dollars_cents(social_security_deductions),
+              'otherDeductions' => {
+                'name' => other_deductions[:name],
+                'amount' => dollars_cents(other_deductions[:amount].to_f)
+              }
+            },
+            'totalDeductions' => dollars_cents(total_deductions),
+            'netTakeHomePay' => dollars_cents(net_take_home_pay),
+            'otherIncome' => {
+              'name' => other_income[:name],
+              'amount' => dollars_cents(other_income[:amount])
+            },
+            'totalMonthlyNetIncome' => dollars_cents(total_monthly_net_income)
+          }
+        end
+
+        def total_monthly_net_income
+          (gross_salary - total_deductions + other_income[:amount]).round(2)
+        end
+
+        private
+
+        def gross_salary
+          gross_salary = if @enhanced_fsr_active
+            @employment_records.map do |emp|
+              if emp['gross_monthly_income'].nil?
+                0
+              else
+                emp['gross_monthly_income'].to_f
+              end
+            end.sum
+          else
+            @current_employment.sum do |emp|
+              emp["#{beneficiary_type}_gross_salary"].to_f
+            end
+          end
+          gross_salary.to_f.round(2)
+        end
+
+        def deductions
+          if @enhanced_fsr_active
+            @employment_records
+              .select { |emp| emp['is_current'] }
+              .map do |emp|
+              if emp['deductions'].nil?
+                0
+              else
+                emp['deductions']
+              end
+            end
+            .flatten
+          else
+            @current_employment.pluck('deductions').flatten
+          end
+        end
+
+        def tax_deductions
+          filter_reduce_by_name(deductions, TAX_FILTERS)
+        end
+
+        def retirement_deductions
+          filter_reduce_by_name(deductions, RETIREMENT_FILTERS)
+        end
+
+        def social_security_deductions
+          filter_reduce_by_name(deductions, SOCIAL_SEC_FILTERS)
+        end
+
+        def other_deductions
+          {
+            name: other_deductions_name(deductions, ALL_FILTERS),
+            amount: other_deductions_amt(deductions, ALL_FILTERS)
+          }
+        end
+
+        def total_deductions
+          [tax_deductions, retirement_deductions, social_security_deductions].sum + other_deductions[:amount]
+        end
+
+        def other_income
+          addl_inc = @additional_income.sum { |i| i['amount'].to_f }
+          soc_sec_amt = @social_security
+          comp = @compensation_and_pension
+          edu =  @education
+
+          other_income_total = addl_inc.to_f.round(2) + comp.to_f.round(2) + edu.to_f.round(2) + soc_sec_amt.to_f.round(2)
+
+          {
+            name: name_str(soc_sec_amt, comp, edu, @additional_income),
+            amount: other_income_total.round(2)
+          }
+        end
+
+        def net_take_home_pay
+          (gross_salary - total_deductions)
+        end
+
+        # formerly filter_reduce_by_name
+        def filter_reduce_by_name(deductions, filters)
+          return 0.0 unless deductions&.any?
+
+          deductions
+            .select { |deduction| filters.include?(deduction['name']) }
+            .reduce(0.0) do |acc, curr|
+              acc + curr['amount']&.gsub(/[^0-9.-]/, '').to_f
+            end
+        end
+
+        def other_deductions_name(deductions, filters)
+          return '' if deductions.empty?
+
+          deductions.reject { |deduction| filters.include?(deduction['name']) }
+                    .pluck('name')
+                    .join(', ')
+        end
+
+        # formerly other_deductions_amt
+        def other_deductions_amt(deductions, filters)
+          return 0 if deductions.empty?
+
+          deductions
+            .reject { |deduction| deduction['name'].nil? || filters.include?(deduction['name']) }
+            .sum { |deduction| deduction['amount']&.gsub(/[^0-9.-]/, '')&.to_f || 0 }
+        end
+
+        # formerly name_str
+        def name_str(social_security, compensation, education, addl_inc)
+          benefit_types = []
+          benefit_types.push('Social Security') if social_security.positive?
+          benefit_types.push('Disability Compensation') if compensation.positive?
+          benefit_types.push('Education') if education.positive?
+
+          vet_addl_names = addl_inc&.pluck('name') || []
+          other_inc_names = [*benefit_types, *vet_addl_names]
+
+          other_inc_names&.join(', ') || ''
+        end
+
+      end
+    end
+  end
+end

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/income.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/income.rb
@@ -97,21 +97,21 @@ module DebtsApi
         end
 
         def tax_deductions
-          filter_reduce_by_name(deductions, TAX_FILTERS)
+          deduction_amounts_by_type(deductions, TAX_FILTERS)
         end
 
         def retirement_deductions
-          filter_reduce_by_name(deductions, RETIREMENT_FILTERS)
+          deduction_amounts_by_type(deductions, RETIREMENT_FILTERS)
         end
 
         def social_security_deductions
-          filter_reduce_by_name(deductions, SOCIAL_SEC_FILTERS)
+          deduction_amounts_by_type(deductions, SOCIAL_SEC_FILTERS)
         end
 
         def other_deductions
           {
             name: other_deductions_name(deductions, ALL_FILTERS),
-            amount: other_deductions_amt(deductions, ALL_FILTERS)
+            amount: other_deductions_amount(deductions, ALL_FILTERS)
           }
         end
 
@@ -128,7 +128,7 @@ module DebtsApi
           other_income_total = addl_inc + comp + edu + soc_sec_amt
 
           {
-            name: name_str(soc_sec_amt, comp, edu, @additional_income),
+            name: other_incomes_name(soc_sec_amt, comp, edu, @additional_income),
             amount: other_income_total.round(2)
           }
         end
@@ -138,7 +138,7 @@ module DebtsApi
         end
 
         # formerly filter_reduce_by_name
-        def filter_reduce_by_name(deductions, filters)
+        def deduction_amounts_by_type(deductions, filters)
           return 0.0 unless deductions&.any?
 
           deductions
@@ -157,7 +157,7 @@ module DebtsApi
         end
 
         # formerly other_deductions_amt
-        def other_deductions_amt(deductions, filters)
+        def other_deductions_amount(deductions, filters)
           return 0 if deductions.empty?
 
           deductions
@@ -166,14 +166,14 @@ module DebtsApi
         end
 
         # formerly name_str
-        def name_str(social_security, compensation, education, addl_inc)
+        def other_incomes_name(social_security, compensation, education, addl_inc)
           benefit_types = []
           benefit_types.push('Social Security') if social_security.positive?
           benefit_types.push('Disability Compensation') if compensation.positive?
           benefit_types.push('Education') if education.positive?
 
-          vet_addl_names = addl_inc&.pluck('name') || []
-          other_inc_names = [*benefit_types, *vet_addl_names]
+          addl_inc_names = addl_inc&.pluck('name') || []
+          other_inc_names = [*benefit_types, *addl_inc_names]
 
           other_inc_names&.join(', ') || ''
         end

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/income_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/income_calculator.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
-require 'debts_api/v0/fsr_form_transform/utils'
+require 'debts_api/v0/fsr_form_transform/income'
 
 module DebtsApi
   module V0
     module FsrFormTransform
       class IncomeCalculator
-        include ::FsrFormTransform::Utils
 
         # Refactoring Steps
         # 1. Remove duplicate instance variables related to `get_monthly_income`
@@ -15,265 +14,71 @@ module DebtsApi
         # 4. Extract private methods from calculate_income
         # 5. Move calculate_income hash to (vet|spouse)_income
 
-        BENEFICIARY_MAP = {
-          'veteran' => 'VETERAN',
-          'spouse' => 'SPOUSE'
-        }.freeze
-        TAX_FILTERS = ['State tax', 'Federal tax', 'Local tax'].freeze
-        RETIREMENT_FILTERS = [
-          'Retirement accounts (401k, IRAs, 403b, TSP)',
-          '401K',
-          'IRA',
-          'Pension'
-        ].freeze
-        SOCIAL_SEC_FILTERS = ['FICA (Social Security and Medicare)'].freeze
-        ALL_FILTERS = TAX_FILTERS + RETIREMENT_FILTERS + SOCIAL_SEC_FILTERS
-
         def initialize(form)
           @form = form
-          @sp_addl_income = @form.dig('additional_income', 'spouse', 'sp_addl_income') || []
-          @addl_inc_records = @form.dig('additional_income', 'addl_inc_records') || []
-          @vet_employment_records = @form.dig('personal_data', 'employment_history', 'veteran',
-                                              'employment_records') || []
-          @sp_employment_records = @form.dig('personal_data', 'employment_history', 'spouse',
-                                             'sp_employment_records') || []
+          @additional_income = @form['additional_income']
+          @employment_history = @form.dig('personal_data', 'employment_history')
           @social_security = @form['social_security'] || {}
           @benefits = @form['benefits'] || {}
-          @curr_employment = @form['curr_employment'] || []
-          @sp_curr_employment = @form['sp_curr_employment'] || []
           @income = @form['income'] || []
           @enhanced_fsr_active = @form['view:enhanced_financial_status_report']
         end
 
         def get_monthly_income
-          sp_sum = sp_income.empty? ? 0 : sp_income[:totalMonthlyNetIncome]
-          total_monthly_net_income = vet_income[:totalMonthlyNetIncome] + sp_sum
+          sp_sum = sp_income.income_statement.empty? ? 0 : sp_income.total_monthly_net_income
+          total_monthly_net_income = vet_income.total_monthly_net_income + sp_sum
 
           {
-            vetIncome: vet_income,
-            spIncome: sp_income,
+            vetIncome: vet_income.income_statement,
+            spIncome: sp_income.income_statement,
             totalMonthlyNetIncome: total_monthly_net_income
           }
         end
 
         def vet_income
-          @vet_income ||= {
-            grossSalary: veteran_gross_salary,
-            deductions: veteran_deductions,
-            totalDeductions: veteran_total_deductions,
-            netTakeHomePay: (veteran_gross_salary - veteran_total_deductions),
-            otherIncome: veteran_other_income,
-            totalMonthlyNetIncome: (veteran_gross_salary - veteran_total_deductions + veteran_other_income[:amount]).round(2)
-          }
+          @vet_income ||= begin
+            Income.new(veteran_income_params)
+          end
         end
 
         def sp_income
-          @sp_income ||= {
-            grossSalary: spouse_gross_salary,
-            deductions: spouse_deductions,
-            totalDeductions: spouse_total_deductions,
-            netTakeHomePay: (spouse_gross_salary - spouse_total_deductions),
-            otherIncome: spouse_other_income,
-            totalMonthlyNetIncome: (spouse_gross_salary - spouse_total_deductions + spouse_other_income[:amount]).round(2)
-          }
+          @sp_income ||= begin
+            Income.new(spouse_income_params)
+          end
         end
 
         def get_transformed_income
-          [transformed_vet_income, transformed_sp_income]
-        end
-
-        def transformed_vet_income
-          transform_income('veteran', vet_income)
-        end
-
-        def transformed_sp_income
-          transform_income('spouse', sp_income)
+          [vet_income.income_statement_as_json, sp_income.income_statement_as_json]
         end
 
         private
 
-        def transform_income(beneficiary_type, income)
+        def veteran_income_params
           {
-            'veteranOrSpouse' => BENEFICIARY_MAP[beneficiary_type],
-            'monthlyGrossSalary' => dollars_cents(income[:grossSalary]),
-            'deductions' => {
-              'taxes' => dollars_cents(income[:deductions][:taxes]),
-              'retirement' => dollars_cents(income[:deductions][:retirement]),
-              'socialSecurity' => dollars_cents(income[:deductions][:socialSecurity]),
-              'otherDeductions' => {
-                'name' => income[:deductions][:otherDeductions][:name],
-                'amount' => dollars_cents(income[:deductions][:otherDeductions][:amount].to_f)
-              }
-            },
-            'totalDeductions' => dollars_cents(income[:totalDeductions]),
-            'netTakeHomePay' => dollars_cents(income[:netTakeHomePay]),
-            'otherIncome' => {
-              'name' => income[:otherIncome][:name],
-              'amount' => dollars_cents(income[:otherIncome][:amount])
-            },
-            'totalMonthlyNetIncome' => dollars_cents(income[:totalMonthlyNetIncome])
+            additional_income: @additional_income.fetch('addl_inc_records',[]),
+            employment_records: @employment_history.dig('veteran', 'employment_records') || [],
+            curr_employment: @form['curr_employment'] || [],
+            social_security: @social_security['social_sec_amt'].to_f || 0,
+            compensation_and_pension: @income.sum { |item| item['compensation_and_pension'].to_f },
+            education: @income.sum { |item| item['education'].to_f },
+            beneficiary_type: 'veteran',
+            enhanced_fsr_active: @enhanced_fsr_active
           }
         end
 
-        def veteran_gross_salary
-          gross_salary = if @enhanced_fsr_active
-            @vet_employment_records.map do |emp|
-              if emp['gross_monthly_income'].nil?
-                0
-              else
-                emp['gross_monthly_income'].to_f
-              end
-            end.sum
-          else
-            @curr_employment.sum do |emp|
-              emp["#{beneficiary_type}_gross_salary"].to_f
-            end
-          end
-          gross_salary.to_f.round(2)
-        end
-
-        def spouse_gross_salary
-          gross_salary = if @enhanced_fsr_active
-            @sp_employment_records.map do |emp|
-              if emp['gross_monthly_income'].nil?
-                0
-              else
-                emp['gross_monthly_income'].to_f
-              end
-            end.sum
-          else
-            @sp_curr_employment.sum do |emp|
-              emp["#{beneficiary_type}_gross_salary"].to_f
-            end
-          end
-          gross_salary.to_f.round(2)
-        end
-
-        def veteran_deductions
-          deductions = if @enhanced_fsr_active
-            @vet_employment_records
-              .select { |emp| emp['is_current'] }
-              .map do |emp|
-              if emp['deductions'].nil?
-                0
-              else
-                emp['deductions']
-              end
-            end
-            .flatten
-          else
-            @curr_employment.pluck('deductions').flatten
-          end
-
-          deduction_details(deductions)
-        end
-
-        def spouse_deductions
-          deductions = if @enhanced_fsr_active
-            @sp_employment_records
-              .select { |emp| emp['is_current'] }
-              .map do |emp|
-              if emp['deductions'].nil?
-                0
-              else
-                emp['deductions']
-              end
-            end
-            .flatten
-          else
-            @sp_curr_employment.pluck('deductions').flatten
-          end
-
-          deduction_details(deductions)
-        end
-
-        def deduction_details(deductions)
+        def spouse_income_params
           {
-            taxes: filter_reduce_by_name(deductions, TAX_FILTERS),
-            retirement: filter_reduce_by_name(deductions, RETIREMENT_FILTERS),
-            socialSecurity: filter_reduce_by_name(deductions, SOCIAL_SEC_FILTERS),
-            otherDeductions: {
-              name: other_deductions_name(deductions, ALL_FILTERS),
-              amount: other_deductions_amt(deductions, ALL_FILTERS)
-            }
+            additional_income: @additional_income.dig('spouse', 'sp_addl_income') || [],
+            employment_records: @employment_history.dig('spouse', 'sp_employment_records') || [],
+            curr_employment: @form['sp_curr_employment'] || [],
+            social_security: @social_security.dig('spouse', 'social_sec_amt').to_f || 0,
+            compensation_and_pension: @benefits.dig('spouse_benefits', 'compensation_and_pension').to_f || 0,
+            education: @benefits.dig('spouse_benefits', 'education').to_f || 0,
+            beneficiary_type: 'spouse',
+            enhanced_fsr_active: @enhanced_fsr_active
           }
         end
 
-        def veteran_total_deductions
-          # taxes + retirement + socialSecurity + other deductions
-          veteran_deductions.except(:otherDeductions).values.sum + veteran_deductions[:otherDeductions][:amount]
-        end
-
-        def spouse_total_deductions
-          # taxes + retirement + socialSecurity + other deductions
-          spouse_deductions.except(:otherDeductions).values.sum + spouse_deductions[:otherDeductions][:amount]
-        end
-
-        def veteran_other_income
-          addl_inc = @addl_inc_records.sum { |record| record['amount'].to_f }
-          soc_sec_amt = @enhanced_fsr_active ? 0 : @social_security['social_sec_amt'].to_f || 0
-          comp = @income.sum { |item| item['compensation_and_pension'].to_f }
-          edu =  @income.sum { |item| item['education'].to_f }
-
-          other_income_total = addl_inc.to_f.round(2) + comp.to_f.round(2) + edu.to_f.round(2) + soc_sec_amt.to_f.round(2)
-
-          {
-            name: name_str(soc_sec_amt, comp, edu, @addl_inc_records),
-            amount: other_income_total.round(2)
-          }
-        end
-
-        def spouse_other_income
-          addl_inc = @sp_addl_income.sum { |record| record['amount'].to_f }
-          soc_sec_amt = @enhanced_fsr_active ? 0 : @social_security.dig('spouse', 'social_sec_amt').to_f || 0
-          comp = @benefits.dig('spouse_benefits', 'compensation_and_pension').to_f || 0
-          edu = @benefits.dig('spouse_benefits', 'education').to_f || 0
-
-          other_income_total = addl_inc.to_f.round(2) + comp.to_f.round(2) + edu.to_f.round(2) + soc_sec_amt.to_f.round(2)
-
-          {
-            name: name_str(soc_sec_amt, comp, edu, @sp_addl_income),
-            amount: other_income_total.round(2)
-          }
-        end
-
-        def filter_reduce_by_name(deductions, filters)
-          return 0.0 unless deductions&.any?
-
-          deductions
-            .select { |deduction| filters.include?(deduction['name']) }
-            .reduce(0.0) do |acc, curr|
-              acc + curr['amount']&.gsub(/[^0-9.-]/, '').to_f
-            end
-        end
-
-        def other_deductions_name(deductions, filters)
-          return '' if deductions.empty?
-
-          deductions.reject { |deduction| filters.include?(deduction['name']) }
-                    .pluck('name')
-                    .join(', ')
-        end
-
-        def other_deductions_amt(deductions, filters)
-          return 0 if deductions.empty?
-
-          deductions
-            .reject { |deduction| deduction['name'].nil? || filters.include?(deduction['name']) }
-            .sum { |deduction| deduction['amount']&.gsub(/[^0-9.-]/, '')&.to_f || 0 }
-        end
-
-        def name_str(social_security, compensation, education, addl_inc)
-          benefit_types = []
-          benefit_types.push('Social Security') if social_security.positive?
-          benefit_types.push('Disability Compensation') if compensation.positive?
-          benefit_types.push('Education') if education.positive?
-
-          vet_addl_names = addl_inc&.pluck('name') || []
-          other_inc_names = [*benefit_types, *vet_addl_names]
-
-          other_inc_names&.join(', ') || ''
-        end
       end
     end
   end

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/income_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/income_calculator.rb
@@ -6,12 +6,6 @@ module DebtsApi
   module V0
     module FsrFormTransform
       class IncomeCalculator
-        # Refactoring Steps
-        # 1. Remove duplicate instance variables related to `get_monthly_income`
-        # 2. Replace `calculate_income` parameters with respective instance variables
-        # 3. Refactor `transformed_income` to be stringify calculate_income output
-        # 4. Extract private methods from calculate_income
-        # 5. Move calculate_income hash to (vet|spouse)_income
 
         def initialize(form)
           @form = form

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/income_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/income_calculator.rb
@@ -6,7 +6,6 @@ module DebtsApi
   module V0
     module FsrFormTransform
       class IncomeCalculator
-
         def initialize(form)
           @form = form
           @additional_income = @form['additional_income']

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/income_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/income_calculator.rb
@@ -8,6 +8,13 @@ module DebtsApi
       class IncomeCalculator
         include ::FsrFormTransform::Utils
 
+        # Refactoring Steps
+        # 1. Remove duplicate instance variables related to `get_monthly_income`
+        # 2. Replace `calculate_income` parameters with respective instance variables
+        # 3. Refactor `transformed_income` to be stringify calculate_income output
+        # 4. Extract private methods from calculate_income
+        # 5. Move calculate_income hash to (vet|spouse)_income
+
         BENEFICIARY_MAP = {
           'veteran' => 'VETERAN',
           'spouse' => 'SPOUSE'
@@ -38,49 +45,7 @@ module DebtsApi
           @enhanced_fsr_active = @form['view:enhanced_financial_status_report']
         end
 
-        # rubocop:disable Metrics/MethodLength
         def get_monthly_income
-          sp_addl_income = @form.dig('additional_income', 'spouse', 'sp_addl_income') || []
-          addl_inc_records = @form.dig('additional_income', 'addl_inc_records') || []
-          vet_employment_records = @form.dig(
-            'personal_data',
-            'employment_history',
-            'veteran',
-            'employment_records'
-          ) || []
-          sp_employment_records = @form.dig(
-            'personal_data',
-            'employment_history',
-            'spouse',
-            'sp_employment_records'
-          ) || []
-          social_security = @form['social_security'] || {}
-          benefits = @form['benefits'] || {}
-          curr_employment = @form['curr_employment'] || []
-          sp_curr_employment = @form['sp_curr_employment'] || []
-          income = @form['income'] || []
-          enhanced_fsr_active = @form['view:enhanced_financial_status_report']
-          vet_income = calculate_income(
-            enhanced_fsr_active,
-            'veteran',
-            vet_employment_records,
-            curr_employment,
-            addl_inc_records,
-            social_security,
-            income,
-            benefits
-          )
-          sp_income = calculate_income(
-            enhanced_fsr_active,
-            'spouse',
-            sp_employment_records,
-            sp_curr_employment,
-            sp_addl_income,
-            social_security,
-            income,
-            benefits
-          )
-
           sp_sum = sp_income.empty? ? 0 : sp_income[:totalMonthlyNetIncome]
           total_monthly_net_income = vet_income[:totalMonthlyNetIncome] + sp_sum
 
@@ -92,29 +57,25 @@ module DebtsApi
         end
 
         def vet_income
-          calculate_income(
-            @enhanced_fsr_active,
-            'veteran',
-            @vet_employment_records,
-            @curr_employment,
-            @addl_inc_records,
-            @social_security,
-            @income,
-            @benefits
-          )
+          @vet_income ||= {
+            grossSalary: veteran_gross_salary,
+            deductions: veteran_deductions,
+            totalDeductions: veteran_total_deductions,
+            netTakeHomePay: (veteran_gross_salary - veteran_total_deductions),
+            otherIncome: veteran_other_income,
+            totalMonthlyNetIncome: (veteran_gross_salary - veteran_total_deductions + veteran_other_income[:amount]).round(2)
+          }
         end
 
         def sp_income
-          calculate_income(
-            @enhanced_fsr_active,
-            'spouse',
-            @sp_employment_records,
-            @sp_curr_employment,
-            @sp_addl_income,
-            @social_security,
-            @income,
-            @benefits
-          )
+          @sp_income ||= {
+            grossSalary: spouse_gross_salary,
+            deductions: spouse_deductions,
+            totalDeductions: spouse_total_deductions,
+            netTakeHomePay: (spouse_gross_salary - spouse_total_deductions),
+            otherIncome: spouse_other_income,
+            totalMonthlyNetIncome: (spouse_gross_salary - spouse_total_deductions + spouse_other_income[:amount]).round(2)
+          }
         end
 
         def get_transformed_income
@@ -122,32 +83,159 @@ module DebtsApi
         end
 
         def transformed_vet_income
-          transform_income(
-            @enhanced_fsr_active,
-            'veteran',
-            @vet_employment_records,
-            @curr_employment,
-            @addl_inc_records,
-            @social_security,
-            @income,
-            @benefits
-          )
+          transform_income('veteran', vet_income)
         end
 
         def transformed_sp_income
-          transform_income(
-            @enhanced_fsr_active,
-            'spouse',
-            @sp_employment_records,
-            @sp_curr_employment,
-            @sp_addl_income,
-            @social_security,
-            @income,
-            @benefits
-          )
+          transform_income('spouse', sp_income)
         end
 
         private
+
+        def transform_income(beneficiary_type, income)
+          {
+            'veteranOrSpouse' => BENEFICIARY_MAP[beneficiary_type],
+            'monthlyGrossSalary' => dollars_cents(income[:grossSalary]),
+            'deductions' => {
+              'taxes' => dollars_cents(income[:deductions][:taxes]),
+              'retirement' => dollars_cents(income[:deductions][:retirement]),
+              'socialSecurity' => dollars_cents(income[:deductions][:socialSecurity]),
+              'otherDeductions' => {
+                'name' => income[:deductions][:otherDeductions][:name],
+                'amount' => dollars_cents(income[:deductions][:otherDeductions][:amount].to_f)
+              }
+            },
+            'totalDeductions' => dollars_cents(income[:totalDeductions]),
+            'netTakeHomePay' => dollars_cents(income[:netTakeHomePay]),
+            'otherIncome' => {
+              'name' => income[:otherIncome][:name],
+              'amount' => dollars_cents(income[:otherIncome][:amount])
+            },
+            'totalMonthlyNetIncome' => dollars_cents(income[:totalMonthlyNetIncome])
+          }
+        end
+
+        def veteran_gross_salary
+          gross_salary = if @enhanced_fsr_active
+            @vet_employment_records.map do |emp|
+              if emp['gross_monthly_income'].nil?
+                0
+              else
+                emp['gross_monthly_income'].to_f
+              end
+            end.sum
+          else
+            @curr_employment.sum do |emp|
+              emp["#{beneficiary_type}_gross_salary"].to_f
+            end
+          end
+          gross_salary.to_f.round(2)
+        end
+
+        def spouse_gross_salary
+          gross_salary = if @enhanced_fsr_active
+            @sp_employment_records.map do |emp|
+              if emp['gross_monthly_income'].nil?
+                0
+              else
+                emp['gross_monthly_income'].to_f
+              end
+            end.sum
+          else
+            @sp_curr_employment.sum do |emp|
+              emp["#{beneficiary_type}_gross_salary"].to_f
+            end
+          end
+          gross_salary.to_f.round(2)
+        end
+
+        def veteran_deductions
+          deductions = if @enhanced_fsr_active
+            @vet_employment_records
+              .select { |emp| emp['is_current'] }
+              .map do |emp|
+              if emp['deductions'].nil?
+                0
+              else
+                emp['deductions']
+              end
+            end
+            .flatten
+          else
+            @curr_employment.pluck('deductions').flatten
+          end
+
+          deduction_details(deductions)
+        end
+
+        def spouse_deductions
+          deductions = if @enhanced_fsr_active
+            @sp_employment_records
+              .select { |emp| emp['is_current'] }
+              .map do |emp|
+              if emp['deductions'].nil?
+                0
+              else
+                emp['deductions']
+              end
+            end
+            .flatten
+          else
+            @sp_curr_employment.pluck('deductions').flatten
+          end
+
+          deduction_details(deductions)
+        end
+
+        def deduction_details(deductions)
+          {
+            taxes: filter_reduce_by_name(deductions, TAX_FILTERS),
+            retirement: filter_reduce_by_name(deductions, RETIREMENT_FILTERS),
+            socialSecurity: filter_reduce_by_name(deductions, SOCIAL_SEC_FILTERS),
+            otherDeductions: {
+              name: other_deductions_name(deductions, ALL_FILTERS),
+              amount: other_deductions_amt(deductions, ALL_FILTERS)
+            }
+          }
+        end
+
+        def veteran_total_deductions
+          # taxes + retirement + socialSecurity + other deductions
+          veteran_deductions.except(:otherDeductions).values.sum + veteran_deductions[:otherDeductions][:amount]
+        end
+
+        def spouse_total_deductions
+          # taxes + retirement + socialSecurity + other deductions
+          spouse_deductions.except(:otherDeductions).values.sum + spouse_deductions[:otherDeductions][:amount]
+        end
+
+        def veteran_other_income
+          addl_inc = @addl_inc_records.sum { |record| record['amount'].to_f }
+          soc_sec_amt = @enhanced_fsr_active ? 0 : @social_security['social_sec_amt'].to_f || 0
+          comp = @income.sum { |item| item['compensation_and_pension'].to_f }
+          edu =  @income.sum { |item| item['education'].to_f }
+
+          other_income_total = addl_inc.to_f.round(2) + comp.to_f.round(2) + edu.to_f.round(2) + soc_sec_amt.to_f.round(2)
+
+          {
+            name: name_str(soc_sec_amt, comp, edu, @addl_inc_records),
+            amount: other_income_total.round(2)
+          }
+        end
+
+        def spouse_other_income
+          addl_inc = @sp_addl_income.sum { |record| record['amount'].to_f }
+          soc_sec_amt = @enhanced_fsr_active ? 0 : @social_security.dig('spouse', 'social_sec_amt').to_f || 0
+          comp = @benefits.dig('spouse_benefits', 'compensation_and_pension').to_f || 0
+          edu = @benefits.dig('spouse_benefits', 'education').to_f || 0
+
+          other_income_total = addl_inc.to_f.round(2) + comp.to_f.round(2) + edu.to_f.round(2) + soc_sec_amt.to_f.round(2)
+
+          {
+            name: name_str(soc_sec_amt, comp, edu, @sp_addl_income),
+            amount: other_income_total.round(2)
+          }
+        end
 
         def filter_reduce_by_name(deductions, filters)
           return 0.0 unless deductions&.any?
@@ -186,183 +274,7 @@ module DebtsApi
 
           other_inc_names&.join(', ') || ''
         end
-
-        # rubocop:disable Metrics/ParameterLists
-        def transform_income(enhanced_fsr_active, beneficiary_type, employment_records = [], curr_employment = [],
-                             addl_inc_records = [], social_security = {}, income = [], benefits = {})
-          gross_salary = if enhanced_fsr_active
-                           employment_records.map do |emp|
-                             if emp['gross_monthly_income'].nil?
-                               0
-                             else
-                               emp['gross_monthly_income'].to_f
-                             end
-                           end.sum
-                         else
-                           curr_employment.sum do |emp|
-                             emp["#{beneficiary_type}_gross_salary"].to_f
-                           end
-                         end
-
-          addl_inc = addl_inc_records.sum { |record| record['amount'].to_f }
-
-          soc_sec_amt = if enhanced_fsr_active
-                          0
-                        elsif beneficiary_type == 'spouse'
-                          social_security.dig('spouse', 'social_sec_amt').to_f || 0
-                        else
-                          social_security['social_sec_amt'].to_f || 0
-                        end
-
-          comp = if beneficiary_type == 'spouse'
-                   benefits.dig('spouse_benefits', 'compensation_and_pension').to_f || 0
-                 else
-                   income.sum { |item| item['compensation_and_pension'].to_f }
-                 end
-
-          edu = if beneficiary_type == 'spouse'
-                  benefits.dig('spouse_benefits', 'education').to_f || 0
-                else
-                  income.sum { |item| item['education'].to_f }
-                end
-
-          benefits_amount = comp + edu
-
-          deductions = if enhanced_fsr_active
-                         employment_records
-                           .select { |emp| emp['is_current'] }
-                           .map do |emp|
-                           if emp['deductions'].nil?
-                             0
-                           else
-                             emp['deductions']
-                           end
-                         end
-                         .flatten
-                       else
-                         curr_employment.pluck('deductions').flatten
-                       end
-
-          gross_salary = gross_salary.to_f.round(2)
-          taxes_values = filter_reduce_by_name(deductions, TAX_FILTERS)
-          retirement_values = filter_reduce_by_name(deductions, RETIREMENT_FILTERS)
-          social_sec = filter_reduce_by_name(deductions, SOCIAL_SEC_FILTERS)
-          other = other_deductions_amt(deductions, ALL_FILTERS)
-          tot_deductions = taxes_values + retirement_values + social_sec + other
-          other_income = addl_inc.to_f.round(2) + benefits_amount.to_f.round(2) + soc_sec_amt.to_f.round(2)
-          net_income = gross_salary - tot_deductions
-          total_monthly_net_income = (net_income + other_income)
-
-          {
-            'veteranOrSpouse' => BENEFICIARY_MAP[beneficiary_type],
-            'monthlyGrossSalary' => dollars_cents(gross_salary),
-            'deductions' => {
-              'taxes' => dollars_cents(taxes_values),
-              'retirement' => dollars_cents(retirement_values),
-              'socialSecurity' => dollars_cents(social_sec),
-              'otherDeductions' => {
-                'name' => other_deductions_name(deductions, ALL_FILTERS),
-                'amount' => dollars_cents(other.to_f)
-              }
-            },
-            'totalDeductions' => dollars_cents(tot_deductions),
-            'netTakeHomePay' => dollars_cents(net_income),
-            'otherIncome' => {
-              'name' => name_str(soc_sec_amt, comp, edu, addl_inc_records),
-              'amount' => dollars_cents(other_income.round(2))
-            },
-            'totalMonthlyNetIncome' => dollars_cents(total_monthly_net_income.round(2))
-          }
-        end
-
-        def calculate_income(enhanced_fsr_active, beneficiary_type, employment_records = [], curr_employment = [],
-                             addl_inc_records = [], social_security = {}, income = [], benefits = {})
-          gross_salary = if enhanced_fsr_active
-                           employment_records.map do |emp|
-                             if emp['gross_monthly_income'].nil?
-                               0
-                             else
-                               emp['gross_monthly_income'].to_f
-                             end
-                           end.sum
-                         else
-                           curr_employment.sum do |emp|
-                             emp["#{beneficiary_type}_gross_salary"].to_f
-                           end
-                         end
-
-          addl_inc = addl_inc_records.sum { |record| record['amount'].to_f }
-
-          soc_sec_amt = if enhanced_fsr_active
-                          0
-                        elsif beneficiary_type == 'spouse'
-                          social_security.dig('spouse', 'social_sec_amt').to_f || 0
-                        else
-                          social_security['social_sec_amt'].to_f || 0
-                        end
-
-          comp = if beneficiary_type == 'spouse'
-                   benefits.dig('spouse_benefits', 'compensation_and_pension').to_f || 0
-                 else
-                   income.sum { |item| item['compensation_and_pension'].to_f }
-                 end
-
-          edu = if beneficiary_type == 'spouse'
-                  benefits.dig('spouse_benefits', 'education').to_f
-                else
-                  income.sum { |item| item['education'].to_f }
-                end
-
-          benefits_amount = comp + edu
-
-          deductions = if enhanced_fsr_active
-                         employment_records
-                           .select { |emp| emp['is_current'] }
-                           .map do |emp|
-                           if emp['deductions'].nil?
-                             0
-                           else
-                             emp['deductions']
-                           end
-                         end
-                         .flatten
-                       else
-                         curr_employment.pluck('deductions').flatten
-                       end
-
-          gross_salary = gross_salary.to_f.round(2)
-          taxes_values = filter_reduce_by_name(deductions, TAX_FILTERS)
-          retirement_values = filter_reduce_by_name(deductions, RETIREMENT_FILTERS)
-          social_sec = filter_reduce_by_name(deductions, SOCIAL_SEC_FILTERS)
-          other = other_deductions_amt(deductions, ALL_FILTERS)
-          tot_deductions = taxes_values + retirement_values + social_sec + other
-          other_income = addl_inc.to_f.round(2) + benefits_amount.to_f.round(2) + soc_sec_amt.to_f.round(2)
-          net_income = gross_salary - tot_deductions
-          total_monthly_net_income = net_income + other_income
-
-          {
-            grossSalary: gross_salary,
-            deductions: {
-              taxes: taxes_values,
-              retirement: retirement_values,
-              socialSecurity: social_sec,
-              otherDeductions: {
-                name: other_deductions_name(deductions, ALL_FILTERS),
-                amount: other
-              }
-            },
-            totalDeductions: tot_deductions,
-            netTakeHomePay: net_income,
-            otherIncome: {
-              name: name_str(soc_sec_amt, comp, edu, addl_inc_records),
-              amount: other_income.round(2)
-            },
-            totalMonthlyNetIncome: total_monthly_net_income.round(2)
-          }
-        end
       end
     end
   end
 end
-# rubocop:enable Metrics/MethodLength
-# rubocop:enable Metrics/ParameterLists

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/income_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/income_calculator.rb
@@ -20,20 +20,19 @@ module DebtsApi
         # formerly get_monthly_income
         def combined_monthly_income_statement
           {
-            vetIncome: vet_income.income_statement,
-            spIncome: sp_income.income_statement,
+            vetIncome: veteran_income.income_statement,
+            spIncome: spouse_income.income_statement,
             totalMonthlyNetIncome: total_monthly_net_income
           }
         end
 
         # formerly get_transformed_income
         def monthly_income_statements_as_json
-          [vet_income.income_statement_as_json, sp_income.income_statement_as_json]
+          [veteran_income.income_statement_as_json, spouse_income.income_statement_as_json]
         end
 
         def total_monthly_net_income
-          sp_sum = sp_income.income_statement.empty? ? 0 : sp_income.total_monthly_net_income
-          vet_income.total_monthly_net_income + sp_sum
+          veteran_income.total_monthly_net_income + spouse_income.total_monthly_net_income
         end
 
         def total_annual_net_income
@@ -42,12 +41,12 @@ module DebtsApi
 
         private
 
-        def vet_income
-          @vet_income ||= Income.new(veteran_income_params)
+        def veteran_income
+          @veteran_income ||= Income.new(veteran_income_params)
         end
 
-        def sp_income
-          @sp_income ||= Income.new(spouse_income_params)
+        def spouse_income
+          @spouse_income ||= Income.new(spouse_income_params)
         end
 
         def veteran_income_params

--- a/modules/debts_api/lib/debts_api/v0/fsr_form_transform/streamlined_calculator.rb
+++ b/modules/debts_api/lib/debts_api/v0/fsr_form_transform/streamlined_calculator.rb
@@ -16,7 +16,7 @@ module DebtsApi
         def initialize(form)
           @form = form
           @gmt_data = @form['gmt_data']
-          @income_data = DebtsApi::V0::FsrFormTransform::IncomeCalculator.new(form).get_monthly_income
+          @income_data = DebtsApi::V0::FsrFormTransform::IncomeCalculator.new(form)
           @asset_data = DebtsApi::V0::FsrFormTransform::AssetCalculator.new(form).transform_assets
           @enhanced_expense_calculator = DebtsApi::V0::FsrFormTransform::EnhancedExpenseCalculator.new(
             re_camel(form)
@@ -41,14 +41,11 @@ module DebtsApi
         private
 
         def total_annual_income
-          vet_income = @income_data.dig(:vetIncome, :totalMonthlyNetIncome).to_f
-          spouse_income = @income_data.dig(:spIncome, :totalMonthlyNetIncome).to_f
-          total_income = (vet_income + spouse_income)
-          total_income * 12
+          @income_data.total_annual_net_income
         end
 
         def total_discretionary_income
-          monthly_net_income = @income_data[:totalMonthlyNetIncome]
+          monthly_net_income = @income_data.total_monthly_net_income
           monthly_expenses = @enhanced_expense_calculator['totalMonthlyExpenses']&.to_f
 
           monthly_net_income - monthly_expenses

--- a/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/income_calculator_spec.rb
+++ b/modules/debts_api/spec/lib/debt_api/v0/fsr_form_transform/income_calculator_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::IncomeCalculator, type: :service 
 
   def populate_monthly_income
     calculations_controller = described_class.new(maximal_fsr_form_data)
-    @monthly_income = calculations_controller.get_monthly_income
+    @monthly_income = calculations_controller.combined_monthly_income_statement
   end
 
   def populate_transformed_income
     calculations_controller = described_class.new(maximal_fsr_form_data)
-    @monthly_income = calculations_controller.get_transformed_income
+    @monthly_income = calculations_controller.monthly_income_statements_as_json
   end
 
   describe '#calculate_income' do
@@ -214,7 +214,7 @@ RSpec.describe DebtsApi::V0::FsrFormTransform::IncomeCalculator, type: :service 
     end
   end
 
-  describe '#get_transformed_income' do
+  describe '#monthly_income_statements_as_json' do
     before do
       populate_transformed_income
     end


### PR DESCRIPTION
## Summary

- extracted "income" methods to `Income` class
- renamed `get_monthly_income` to `combined_monthly_income_statement`
- renamed `get_transformed_income` to `monthly_income_statements_as_json`
- added `total_monthly_net_income` and `total_annual_net_income`
- `total_monthly_net_income` had a check for empty spouse income data, but that not possible because of the defaults

Note: `income_statement` has camel case for the `FinancialStatusReportsCalculationsController` response. This could be moved into a serializer in another refactor PR. 

## Related issue(s)

- n/a

## Testing done

- [ ] local testing

## Acceptance criteria

- [x] Rubocop disable Metrics/MethodLength is removed 
- [x] Classes are easier to read & understand after refactor