### PR TITLE
Pass form_data to FormSubmission in Form Upload tool

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
@@ -91,6 +91,7 @@ module SimpleFormsApi
       def create_form_submission
         FormSubmission.create(
           form_type: params[:form_number],
+          form_data: params[:form_data].to_json,
           user_account: @current_user&.user_account
         )
       end

--- a/modules/simple_forms_api/spec/fixtures/form_json/form_upload_flow_21_0779.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/form_upload_flow_21_0779.json
@@ -1,0 +1,17 @@
+{
+  "confirmation_code": "123456",
+  "form_number": "21-0779",
+  "form_data": {
+    "id_number": {
+      "ssn": "234232345",
+      "va_file_number": "456454567"
+    },
+    "postal_code": "12345",
+    "full_name": {
+      "first": "John",
+      "last": "Veteran"
+    },
+    "email": "john@veteran.com",
+    "form_name": "Request for Nursing Home Information in Connection with Claim for Aid and Attendance"
+  }
+}

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/scanned_form_uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/scanned_form_uploads_spec.rb
@@ -5,33 +5,26 @@ require 'simple_forms_api_submission/metadata_validator'
 require 'common/file_helpers'
 
 RSpec.describe 'SimpleFormsApi::V1::ScannedFormsUploader', type: :request do
+  let(:user) { build(:user, :loa3) }
+  let(:form_number) { '21-0779' }
+
   before do
-    sign_in
+    sign_in(user)
   end
 
   describe '#submit' do
-    let(:form_number) { '21-0779' }
+    let(:fixture_path) do
+      Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json', 'form_upload_flow_21_0779.json')
+    end
+    let(:params) { JSON.parse(fixture_path.read) }
     let(:form_name) { 'Request for Nursing Home Information in Connection with Claim for Aid and Attendance' }
     let(:metadata_file) { "#{file_seed}.SimpleFormsApi.metadata.json" }
     let(:file_seed) { 'tmp/some-unique-simple-forms-file-seed' }
     let(:random_string) { 'some-unique-simple-forms-file-seed' }
     let(:pdf_path) { Rails.root.join('spec', 'fixtures', 'files', 'doctors-note.pdf') }
     let(:pdf_stamper) { double(stamp_pdf: nil) }
-    let(:confirmation_code) { 'a-random-guid' }
+    let(:confirmation_code) { '123456' }
     let(:attachment) { double }
-    let(:params) do
-      { form_number:, form_name:, confirmation_code:, form_data: {
-        full_name: {
-          first: 'fake-first-name',
-          last: 'fake-last-name'
-        },
-        postal_code: '12345',
-        id_number: {
-          ssn: '444444444'
-        },
-        email: 'fake-email'
-      } }
-    end
 
     before do
       VCR.insert_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location')
@@ -68,6 +61,23 @@ RSpec.describe 'SimpleFormsApi::V1::ScannedFormsUploader', type: :request do
       expect(response).to have_http_status(:ok)
     end
 
+    it 'saves the FormSubmission and FormSubmissionAttempt' do
+      form_submission = double
+      expect(FormSubmission).to receive(:create).with(
+        form_type: form_number,
+        form_data: params['form_data'].to_json,
+        user_account: user.user_account
+      ).and_return(form_submission)
+      expect(FormSubmissionAttempt).to receive(:create).with(
+        form_submission:,
+        benefits_intake_uuid: anything
+      )
+
+      post '/simple_forms_api/v1/submit_scanned_form', params: params
+
+      expect(response).to have_http_status(:ok)
+    end
+
     it 'checks if the prefill data has been changed' do
       prefill_data = double
       prefill_data_service = double
@@ -95,7 +105,7 @@ RSpec.describe 'SimpleFormsApi::V1::ScannedFormsUploader', type: :request do
       allow(Common::VirusScan).to receive(:scan).and_return(clamscan)
       file = fixture_file_upload('doctors-note.gif')
 
-      params = { form_id: '21-0779', file: }
+      params = { form_id: form_number, file: }
 
       expect do
         post '/simple_forms_api/v1/scanned_form_upload', params:


### PR DESCRIPTION
## Summary
This PR supplies the `form_data` to the `FormSubmission` in the Form Upload tool. We're already supplying this data in other cases but it was originally omitted for Form Upload because I (mistakenly) thought it wouldn't be necessary. This was before we knew we wanted to be sending emails on form submission status. We'll definitely need the form data to be saved so that we can at least fetch the email later, on form submission status updates.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/1968
