### PR TITLE
Migration to add bpds_uuid to saved_claims

### DIFF
--- a/db/migrate/20250210175014_add_bpd_uuid_to_saved_claims.rb
+++ b/db/migrate/20250210175014_add_bpd_uuid_to_saved_claims.rb
@@ -1,0 +1,5 @@
+class AddBpdUuidToSavedClaims < ActiveRecord::Migration[7.2]
+  def change
+    add_column :saved_claims, :bpd_uuid, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_04_175219) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_10_175014) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -1163,6 +1163,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_04_175219) do
     t.text "metadata"
     t.datetime "metadata_updated_at"
     t.bigint "user_account_id"
+    t.uuid "bpd_uuid"
     t.index ["created_at", "type"], name: "index_saved_claims_on_created_at_and_type"
     t.index ["delete_date"], name: "index_saved_claims_on_delete_date"
     t.index ["guid"], name: "index_saved_claims_on_guid", unique: true


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Migration to add a new `bpd_uuid` field to the saved_claims table. This field will be used to record UUIDs generated from submitting data to BPDS endpoint.
- Pension Burial Program team to own this change

## Related issue(s)

- [*Link to ticket created in va.gov-team repo*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/99548)

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
