### PR TITLE
Separate Rails and Sentry Logging Methods Part 1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1015,6 +1015,7 @@ lib/search_gsa @department-of-veterans-affairs/va-api-engineers @department-of-v
 lib/search_typeahead @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/sentry @department-of-veterans-affairs/backend-review-group
 lib/sentry_logging.rb @department-of-veterans-affairs/backend-review-group
+lib/shared_rails_logging.rb @department-of-veterans-affairs/backend-review-group
 lib/sftp_writer @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 lib/shrine @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 lib/sidekiq/attr_package.rb @department-of-veterans-affairs/octo-identity @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,7 +40,6 @@ app/controllers/concerns/instrumentation.rb @department-of-veterans-affairs/va-a
 app/controllers/concerns/json_api_pagination_links.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/mhv_controller_concerns.rb @department-of-veterans-affairs/vfs-health-modernization-initiative @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/sentry_controller_logging.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/controllers/concerns/controller_logging_context.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/sign_in @department-of-veterans-affairs/octo-identity
 app/controllers/concerns/third_party_transaction_logging.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/traceable.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,6 +40,7 @@ app/controllers/concerns/instrumentation.rb @department-of-veterans-affairs/va-a
 app/controllers/concerns/json_api_pagination_links.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/mhv_controller_concerns.rb @department-of-veterans-affairs/vfs-health-modernization-initiative @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/sentry_controller_logging.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/controllers/concerns/controller_logging_context.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/sign_in @department-of-veterans-affairs/octo-identity
 app/controllers/concerns/third_party_transaction_logging.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/controllers/concerns/traceable.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 require 'feature_flipper'
 require 'aes_256_cbc_encryptor'
 require 'shared_rails_logging'
+require 'combined_logging'
 
 class ApplicationController < ActionController::API
   include AuthenticationAndSSOConcerns
@@ -11,7 +12,6 @@ class ApplicationController < ActionController::API
   include Headers
   include Instrumentation
   include Pundit::Authorization
-  include SharedRailsLogging
   include ControllerLoggingContext
   include SentryLogging
   include SentryControllerLogging

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 require 'feature_flipper'
 require 'aes_256_cbc_encryptor'
+require 'shared_rails_logging'
 
 class ApplicationController < ActionController::API
   include AuthenticationAndSSOConcerns
@@ -10,6 +11,7 @@ class ApplicationController < ActionController::API
   include Headers
   include Instrumentation
   include Pundit::Authorization
+  include SharedRailsLogging
   include ControllerLoggingContext
   include SentryLogging
   include SentryControllerLogging

--- a/app/controllers/concerns/accountable.rb
+++ b/app/controllers/concerns/accountable.rb
@@ -45,7 +45,7 @@ module Accountable
   end
 
   def no_account_log_message
-    log_message_to_sentry(
+    log_message_all(
       'No account found for user',
       :warn,
       { idme_uuid: @current_user.idme_uuid,

--- a/app/controllers/concerns/exception_handling.rb
+++ b/app/controllers/concerns/exception_handling.rb
@@ -74,7 +74,8 @@ module ExceptionHandling
       Rails.logger.error "#{exception.message}.", backtrace: exception.backtrace
     elsif exception.is_a?(Common::Exceptions::BackendServiceException) && exception.generic_error?
       # Warn about VA900 needing to be added to exception.en.yml
-      log_message_to_sentry(exception.va900_warning, :warn, i18n_exception_hint: exception.va900_hint)
+      log_message(exception.va900_warning, :warn, { i18n_exception_hint: exception.va900_hint })
+      log_message_to_sentry(exception.va900_warning, :warn, { i18n_exception_hint: exception.va900_hint }, {}, false)
     end
   end
 

--- a/app/controllers/concerns/exception_handling.rb
+++ b/app/controllers/concerns/exception_handling.rb
@@ -4,9 +4,11 @@ require 'common/exceptions'
 require 'common/client/errors'
 require 'json_schema/json_api_missing_attribute'
 require 'datadog'
+require 'combined_logging'
 
 module ExceptionHandling
   extend ActiveSupport::Concern
+  include CombinedLogging
 
   # In addition to Common::Exceptions::BackendServiceException that have sentry_type :none the following exceptions
   # will also be skipped.
@@ -74,8 +76,7 @@ module ExceptionHandling
       Rails.logger.error "#{exception.message}.", backtrace: exception.backtrace
     elsif exception.is_a?(Common::Exceptions::BackendServiceException) && exception.generic_error?
       # Warn about VA900 needing to be added to exception.en.yml
-      log_message(exception.va900_warning, :warn, { i18n_exception_hint: exception.va900_hint })
-      log_message_to_sentry(exception.va900_warning, :warn, { i18n_exception_hint: exception.va900_hint }, {}, false)
+      log_message_all(exception.va900_warning, :warn, { i18n_exception_hint: exception.va900_hint }, {})
     end
   end
 

--- a/app/controllers/concerns/form_attachment_create.rb
+++ b/app/controllers/concerns/form_attachment_create.rb
@@ -7,7 +7,7 @@ module FormAttachmentCreate
   def create
     debug_timestamp = Time.current.iso8601
     if Flipper.enabled?(:hca_log_form_attachment_create)
-      log_message_to_sentry(
+      log_message_all(
         'begin form attachment creation',
         :info,
         file_data_present: filtered_params[:file_data].present?,
@@ -23,7 +23,7 @@ module FormAttachmentCreate
     serialized = serializer_klass.new(form_attachment)
 
     if Flipper.enabled?(:hca_log_form_attachment_create)
-      log_message_to_sentry('finish form attachment creation', :info, serialized: serialized.present?, debug_timestamp:)
+      log_message_all('finish form attachment creation', :info, serialized: serialized.present?, debug_timestamp:)
     end
 
     render json: serialized
@@ -41,7 +41,7 @@ module FormAttachmentCreate
       raise Common::Exceptions::InvalidFieldValue.new('file_data', filtered_params[:file_data].class.name)
     end
   rescue => e
-    log_message_to_sentry(
+    log_message_all(
       'form attachment error 1 - validate class',
       :info,
       phase: 'FAC_validate',
@@ -54,7 +54,7 @@ module FormAttachmentCreate
   def save_attachment_to_cloud!
     form_attachment.set_file_data!(filtered_params[:file_data], filtered_params[:password])
   rescue => e
-    log_message_to_sentry(
+    log_message_all(
       'form attachment error 2 - save to cloud',
       :info,
       has_pass: filtered_params[:password].present?,
@@ -68,7 +68,7 @@ module FormAttachmentCreate
   def save_attachment_to_db!
     form_attachment.save!
   rescue => e
-    log_message_to_sentry(
+    log_message_all(
       'form attachment error 3 - save to db',
       :info,
       phase: 'FAC_db',

--- a/app/controllers/concerns/form_attachment_create.rb
+++ b/app/controllers/concerns/form_attachment_create.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require 'combined_logging'
+
 module FormAttachmentCreate
   extend ActiveSupport::Concern
-  include SentryLogging
+  include CombinedLogging
 
   def create
     debug_timestamp = Time.current.iso8601

--- a/app/controllers/concerns/sign_in/authentication.rb
+++ b/app/controllers/concerns/sign_in/authentication.rb
@@ -74,7 +74,7 @@ module SignIn
         access_token_cookie: cookie_access_token(access_token_cookie_name:)
       }.compact
 
-      log_message_to_sentry(error.message, :error, context) if context.present?
+      log_message_all(error.message, :error, context) if context.present?
       render json: { errors: error }, status: :unauthorized
     end
 

--- a/app/controllers/concerns/sign_in/service_account_authentication.rb
+++ b/app/controllers/concerns/sign_in/service_account_authentication.rb
@@ -32,7 +32,7 @@ module SignIn
     end
 
     def handle_authenticate_error(error)
-      log_message_to_sentry(error.message, :error, { access_token_authorization_header: bearer_token })
+      log_message_all(error.message, :error, { access_token_authorization_header: bearer_token })
       render json: { errors: error }, status: :unauthorized
     end
 

--- a/app/controllers/sign_in/application_controller.rb
+++ b/app/controllers/sign_in/application_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'shared_rails_logging'
+
 module SignIn
   class ApplicationController < ActionController::API
     include SignIn::Authentication
@@ -9,6 +11,7 @@ module SignIn
     include ExceptionHandling
     include Headers
     include ControllerLoggingContext
+    include SharedRailsLogging
     include SentryLogging
     include SentryControllerLogging
     include Traceable

--- a/app/controllers/sign_in/application_controller.rb
+++ b/app/controllers/sign_in/application_controller.rb
@@ -11,7 +11,6 @@ module SignIn
     include ExceptionHandling
     include Headers
     include ControllerLoggingContext
-    include SharedRailsLogging
     include SentryLogging
     include SentryControllerLogging
     include Traceable

--- a/app/controllers/sign_in/service_account_application_controller.rb
+++ b/app/controllers/sign_in/service_account_application_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'shared_rails_logging'
+
 module SignIn
   class ServiceAccountApplicationController < ActionController::API
     include SignIn::Authentication
@@ -7,6 +9,7 @@ module SignIn
     include Pundit::Authorization
     include ExceptionHandling
     include Headers
+    include SharedRailsLogging
     include ControllerLoggingContext
     include SentryLogging
     include SentryControllerLogging

--- a/app/controllers/sign_in/service_account_application_controller.rb
+++ b/app/controllers/sign_in/service_account_application_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'shared_rails_logging'
-
 module SignIn
   class ServiceAccountApplicationController < ActionController::API
     include SignIn::Authentication
@@ -9,7 +7,6 @@ module SignIn
     include Pundit::Authorization
     include ExceptionHandling
     include Headers
-    include SharedRailsLogging
     include ControllerLoggingContext
     include SentryLogging
     include SentryControllerLogging

--- a/app/controllers/v0/claim_documents_controller.rb
+++ b/app/controllers/v0/claim_documents_controller.rb
@@ -66,7 +66,7 @@ module V0
         file_regex = %r{/(?:\w+/)*[\w-]+\.pdf\b}
         password_regex = /(input_pw).*?(output)/
         sanitized_message = e.message.gsub(file_regex, '[FILTERED FILENAME]').gsub(password_regex, '\1 [FILTERED] \2')
-        log_message_to_sentry(sanitized_message, 'warn')
+        log_message_all(sanitized_message, 'warn')
         raise Common::Exceptions::UnprocessableEntity.new(
           detail: I18n.t('errors.messages.uploads.pdf.incorrect_password'),
           source: 'PersistentAttachment.unlock_file'

--- a/app/controllers/v0/profile/personal_informations_controller.rb
+++ b/app/controllers/v0/profile/personal_informations_controller.rb
@@ -40,7 +40,7 @@ module V0
 
       def log_errors_for(response)
         if response.gender.nil? || response.birth_date.nil?
-          log_message_to_sentry(
+          log_message_all(
             'mpi missing data bug',
             :info,
             {

--- a/app/controllers/v0/sign_in_controller.rb
+++ b/app/controllers/v0/sign_in_controller.rb
@@ -44,7 +44,7 @@ module V0
       StatsD.increment(SignIn::Constants::Statsd::STATSD_SIS_AUTHORIZE_FAILURE)
       handle_pre_login_error(e, client_id)
     rescue => e
-      log_message_to_sentry(e.message, :error)
+      log_message_all(e.message, :error)
       StatsD.increment(SignIn::Constants::Statsd::STATSD_SIS_AUTHORIZE_FAILURE)
       handle_pre_login_error(e, client_id)
     end
@@ -83,7 +83,7 @@ module V0
       StatsD.increment(SignIn::Constants::Statsd::STATSD_SIS_CALLBACK_FAILURE)
       handle_pre_login_error(e, state_payload&.client_id)
     rescue => e
-      log_message_to_sentry(e.message, :error)
+      log_message_all(e.message, :error)
       StatsD.increment(SignIn::Constants::Statsd::STATSD_SIS_CALLBACK_FAILURE)
       handle_pre_login_error(e, state_payload&.client_id)
     end

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -399,7 +399,7 @@ module V1
       if invalid_message_timestamp_error?(message)
         Rails.logger.warn("SessionsController version:v1 context:#{context} message:#{message}")
       else
-        log_message_to_sentry(message, level, extra_context: context)
+        log_message_all(message, level, extra_context: context)
       end
     end
 

--- a/app/models/evss_claim_document.rb
+++ b/app/models/evss_claim_document.rb
@@ -2,11 +2,12 @@
 
 require 'common/models/base'
 require 'pdf_info'
+require 'combined_logging'
 
 class EVSSClaimDocument < Common::Base
   include ActiveModel::Validations
   include ActiveModel::Validations::Callbacks
-  include SentryLogging
+  include CombinedLogging
 
   attribute :evss_claim_id, Integer
   attribute :tracked_item_id, Integer
@@ -126,7 +127,7 @@ class EVSSClaimDocument < Common::Base
       file_regex = %r{/(?:\w+/)*[\w-]+\.pdf\b}
       password_regex = /(input_pw).*?(output)/
       sanitized_message = e.message.gsub(file_regex, '[FILTERED FILENAME]').gsub(password_regex, '\1 [FILTERED] \2')
-      log_message_to_sentry(sanitized_message, 'warn')
+      log_message_all(sanitized_message, 'warn')
       errors.add(:base, I18n.t('errors.messages.uploads.pdf.incorrect_password'))
     end
 

--- a/app/models/form_attachment.rb
+++ b/app/models/form_attachment.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
+require 'combined_logging'
+
 class FormAttachment < ApplicationRecord
   include SetGuid
   include SentryLogging
+  include CombinedLogging
 
   has_kms_key
   has_encrypted :file_data, key: :kms_key, **lockbox_options
@@ -45,7 +48,7 @@ class FormAttachment < ApplicationRecord
       file_regex = %r{/(?:\w+/)*[\w-]+\.pdf\b}i
       password_regex = /(input_pw).*?(output)/
       sanitized_message = e.message.gsub(file_regex, '[FILTERED FILENAME]').gsub(password_regex, '\1 [FILTERED] \2')
-      log_message_to_sentry(sanitized_message, 'warn')
+      log_message_all(sanitized_message, 'warn')
       raise Common::Exceptions::UnprocessableEntity.new(
         detail: I18n.t('errors.messages.uploads.pdf.incorrect_password'),
         source: 'FormAttachment.unlock_pdf'

--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -7,9 +7,10 @@ require 'hca/enrollment_eligibility/service'
 require 'hca/enrollment_eligibility/status_matcher'
 require 'mpi/service'
 require 'hca/overrides_parser'
+require 'combined_logging'
 
 class HealthCareApplication < ApplicationRecord
-  include SentryLogging
+  include CombinedLogging
   include VA1010Forms::Utils
   include FormValidation
 
@@ -283,7 +284,7 @@ class HealthCareApplication < ApplicationRecord
       error_class: 'HealthCareApplication FailedWontRetry'
     )
 
-    log_message_to_sentry(
+    log_message_all(
       'HCA total failure',
       :error,
       {

--- a/app/models/iam_user_identity.rb
+++ b/app/models/iam_user_identity.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require 'sentry_logging'
+require 'combined_logging'
 
 # Subclasses the `UserIdentity` model. Adds a unique redis namespace for IAM user identities.
 # Like the it's base model it acts as an adapter for the attributes from the IAMSSOeOAuth::Service's
 # introspect endpoint.Adds IAM sourced versions of ICN, EDIPI, and SEC ID to pass to the IAMUser model.
 #
 class IAMUserIdentity < UserIdentity
-  extend SentryLogging
+  extend CombinedLogging
   extend Identity::Parsers::GCIdsHelper
 
   PREMIUM_LOAS = [2, 3].freeze
@@ -82,9 +82,7 @@ class IAMUserIdentity < UserIdentity
     # to features using this identifier if this happens.
     mhv_ids = (id_from_profile == 'NOT_FOUND' ? nil : id_from_profile)
     mhv_ids = mhv_ids&.split(',')&.uniq
-    if mhv_ids&.size.to_i > 1
-      log_message_to_sentry('OAuth: Multiple MHV IDs present', :warn, { mhv_ien: id_from_profile })
-    end
+    log_message_all('OAuth: Multiple MHV IDs present', :warn, { mhv_ien: id_from_profile }) if mhv_ids&.size.to_i > 1
     mhv_ids&.first
   end
 

--- a/lib/combined_logging.rb
+++ b/lib/combined_logging.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'sentry_logging'
+require 'shared_rails_logging'
+
+module CombinedLogging
+  include SentryLogging
+  include SharedRailsLogging
+
+  def log_message_all(message, level, extra_context = {}, tags_context = {})
+    log_message(message, level, extra_context)
+    log_message_to_sentry(message, level, extra_context, tags_context, false)
+  end
+end

--- a/lib/sentry_logging.rb
+++ b/lib/sentry_logging.rb
@@ -5,10 +5,12 @@ require 'sentry_logging'
 module SentryLogging
   extend self
 
-  def log_message_to_sentry(message, level, extra_context = {}, tags_context = {})
+  def log_message_to_sentry(message, level, extra_context = {}, tags_context = {}, log_to_rails = true)
     level = normalize_level(level, nil)
-    formatted_message = extra_context.empty? ? message : "#{message} : #{extra_context}"
-    rails_logger(level, formatted_message)
+    if log_to_rails
+      formatted_message = extra_context.empty? ? message : "#{message} : #{extra_context}"
+      rails_logger(level, formatted_message)
+    end
 
     if Settings.sentry.dsn.present?
       set_sentry_metadata(extra_context, tags_context)

--- a/lib/sentry_logging.rb
+++ b/lib/sentry_logging.rb
@@ -5,6 +5,7 @@ require 'sentry_logging'
 module SentryLogging
   extend self
 
+  # rubocop:disable Style/OptionalBooleanParameter
   def log_message_to_sentry(message, level, extra_context = {}, tags_context = {}, log_to_rails = true)
     level = normalize_level(level, nil)
     if log_to_rails
@@ -17,6 +18,7 @@ module SentryLogging
       Sentry.capture_message(message, level:)
     end
   end
+  # rubocop:enable Style/OptionalBooleanParameter
 
   def log_exception_to_sentry(exception, extra_context = {}, tags_context = {}, level = 'error')
     level = normalize_level(level, exception)

--- a/lib/shared_rails_logging.rb
+++ b/lib/shared_rails_logging.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module SharedRailsLogging
+  extend ActiveSupport::Concern
+
+  def log_message(message, level, extra_context = {})
+    level = normalize_level(level, nil)
+    formatted_message = extra_context.empty? ? message : "#{message} : #{extra_context}"
+    rails_logger(level, formatted_message)
+  end
+
+  def normalize_level(level, exception)
+    level = case exception
+            when Pundit::NotAuthorizedError
+              'info'
+            else
+              level.to_s
+            end
+
+    return 'warn' if level == 'warning'
+
+    level
+  end
+
+  def rails_logger(level, message, errors = nil, backtrace = nil)
+    if errors.present?
+      error_details = errors.first.attributes.compact.reject { |_k, v| v.try(:empty?) }
+      Rails.logger.send(level, message, error_details.merge(backtrace:))
+    else
+      Rails.logger.send(level, message)
+    end
+  end
+end

--- a/lib/shared_rails_logging.rb
+++ b/lib/shared_rails_logging.rb
@@ -4,12 +4,12 @@ module SharedRailsLogging
   extend ActiveSupport::Concern
 
   def log_message(message, level, extra_context = {})
-    level = normalize_level(level, nil)
+    level = normalize_rails_level(level, nil)
     formatted_message = extra_context.empty? ? message : "#{message} : #{extra_context}"
-    rails_logger(level, formatted_message)
+    rails_logger_isolated(level, formatted_message)
   end
 
-  def normalize_level(level, exception)
+  def normalize_rails_level(level, exception)
     level = case exception
             when Pundit::NotAuthorizedError
               'info'
@@ -22,7 +22,7 @@ module SharedRailsLogging
     level
   end
 
-  def rails_logger(level, message, errors = nil, backtrace = nil)
+  def rails_logger_isolated(level, message, errors = nil, backtrace = nil)
     if errors.present?
       error_details = errors.first.attributes.compact.reject { |_k, v| v.try(:empty?) }
       Rails.logger.send(level, message, error_details.merge(backtrace:))

--- a/modules/decision_reviews/app/controllers/decision_reviews/application_controller.rb
+++ b/modules/decision_reviews/app/controllers/decision_reviews/application_controller.rb
@@ -2,6 +2,7 @@
 
 require 'feature_flipper'
 require 'aes_256_cbc_encryptor'
+require 'shared_rails_logging'
 
 module DecisionReviews
   class ApplicationController < ActionController::API
@@ -11,6 +12,7 @@ module DecisionReviews
     include Headers
     include Pundit::Authorization
     include Traceable
+    include SharedRailsLogging
     include ControllerLoggingContext
 
     protect_from_forgery with: :exception, if: -> { ActionController::Base.allow_forgery_protection }

--- a/spec/concerns/form_attachment_create_spec.rb
+++ b/spec/concerns/form_attachment_create_spec.rb
@@ -47,14 +47,14 @@ RSpec.describe FormAttachmentCreate, type: :controller do
 
         expect(Flipper).to receive(:enabled?).with(:hca_log_form_attachment_create).twice.and_return(true)
 
-        expect(@controller).to receive(:log_message_to_sentry).with(
+        expect(@controller).to receive(:log_message_all).with(
           'begin form attachment creation',
           :info,
           file_data_present: true,
           klass: 'ActionDispatch::Http::UploadedFile',
           debug_timestamp: anything
         )
-        expect(@controller).to receive(:log_message_to_sentry).with(
+        expect(@controller).to receive(:log_message_all).with(
           'finish form attachment creation',
           :info,
           serialized: true,
@@ -72,14 +72,14 @@ RSpec.describe FormAttachmentCreate, type: :controller do
       it 'logs validation failure when attachment is not a type of UploadedFile' do
         file_data = 'foo'
         expect(Flipper).to receive(:enabled?).with(:hca_log_form_attachment_create).and_return(true)
-        expect(@controller).to receive(:log_message_to_sentry).with(
+        expect(@controller).to receive(:log_message_all).with(
           'begin form attachment creation',
           :info,
           file_data_present: true,
           klass: 'String',
           debug_timestamp: anything
         )
-        expect(@controller).to receive(:log_message_to_sentry).with(
+        expect(@controller).to receive(:log_message_all).with(
           'form attachment error 1 - validate class',
           :info,
           phase: 'FAC_validate',
@@ -94,14 +94,14 @@ RSpec.describe FormAttachmentCreate, type: :controller do
 
         expect(Flipper).to receive(:enabled?).with(:hca_log_form_attachment_create).and_return(true)
 
-        expect(@controller).to receive(:log_message_to_sentry).with(
+        expect(@controller).to receive(:log_message_all).with(
           'begin form attachment creation',
           :info,
           file_data_present: true,
           klass: 'ActionDispatch::Http::UploadedFile',
           debug_timestamp: anything
         )
-        expect(@controller).to receive(:log_message_to_sentry).with(
+        expect(@controller).to receive(:log_message_all).with(
           'form attachment error 2 - save to cloud',
           :info,
           has_pass: false,
@@ -122,14 +122,14 @@ RSpec.describe FormAttachmentCreate, type: :controller do
 
         expect(Flipper).to receive(:enabled?).with(:hca_log_form_attachment_create).and_return(true)
 
-        expect(@controller).to receive(:log_message_to_sentry).with(
+        expect(@controller).to receive(:log_message_all).with(
           'begin form attachment creation',
           :info,
           file_data_present: true,
           klass: 'ActionDispatch::Http::UploadedFile',
           debug_timestamp: anything
         )
-        expect(@controller).to receive(:log_message_to_sentry).with(
+        expect(@controller).to receive(:log_message_all).with(
           'form attachment error 3 - save to db',
           :info,
           phase: 'FAC_db',

--- a/spec/controllers/sign_in/application_controller_spec.rb
+++ b/spec/controllers/sign_in/application_controller_spec.rb
@@ -81,7 +81,9 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
       it 'logs error to sentry' do
         expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(expected_error,
                                                                                       sentry_log_level,
-                                                                                      sentry_context)
+                                                                                      sentry_context,
+                                                                                      {},
+                                                                                      false)
         subject
       end
     end
@@ -504,7 +506,9 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
       it 'logs error to sentry' do
         expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(expected_error,
                                                                                       sentry_log_level,
-                                                                                      sentry_context)
+                                                                                      sentry_context,
+                                                                                      {},
+                                                                                      false)
         subject
       end
 

--- a/spec/controllers/sign_in/service_account_application_controller_spec.rb
+++ b/spec/controllers/sign_in/service_account_application_controller_spec.rb
@@ -36,7 +36,9 @@ RSpec.describe SignIn::ServiceAccountApplicationController, type: :controller do
       it 'logs error to sentry' do
         expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(expected_error,
                                                                                       sentry_log_level,
-                                                                                      sentry_context)
+                                                                                      sentry_context,
+                                                                                      {},
+                                                                                      false)
         subject
       end
     end

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -719,7 +719,7 @@ RSpec.describe V1::SessionsController, type: :controller do
       end
 
       it 'redirects to an auth failure page' do
-        expect(controller).to receive(:log_message_to_sentry)
+        expect(controller).to receive(:log_message_all)
         expect(call_endpoint).to redirect_to(expected_redirect)
         expect(response).to have_http_status(:found)
       end
@@ -729,7 +729,7 @@ RSpec.describe V1::SessionsController, type: :controller do
           uuid: login_uuid,
           payload: { type: 'idme', application: 'vaweb' }
         )
-        expect(controller).to receive(:log_message_to_sentry)
+        expect(controller).to receive(:log_message_all)
         expect { call_endpoint }
           .to trigger_statsd_increment(described_class::STATSD_SSO_SAMLRESPONSE_KEY,
                                        tags: ['type:idme',
@@ -780,7 +780,7 @@ RSpec.describe V1::SessionsController, type: :controller do
         let(:expected_redirect_params) { { auth: 'fail', code: error_code, request_id:, type: }.to_query }
 
         it 'redirects to an auth failure page' do
-          expect(controller).to receive(:log_message_to_sentry)
+          expect(controller).to receive(:log_message_all)
           expect(call_endpoint).to redirect_to(expected_redirect)
           expect(response).to have_http_status(:found)
         end
@@ -1032,7 +1032,7 @@ RSpec.describe V1::SessionsController, type: :controller do
         before { allow(SAML::Responses::Login).to receive(:new).and_return(saml_response_unknown_error) }
 
         it 'logs a generic error', :aggregate_failures do
-          expect(controller).to receive(:log_message_to_sentry)
+          expect(controller).to receive(:log_message_all)
             .with(
               'Login Failed! Other SAML Response Error(s)',
               :error,
@@ -1081,7 +1081,7 @@ RSpec.describe V1::SessionsController, type: :controller do
         end
 
         it 'logs status_detail message to sentry' do
-          expect(controller).to receive(:log_message_to_sentry)
+          expect(controller).to receive(:log_message_all)
             .with(
               "<fim:FIMStatusDetail MessageID='could_not_perform_token_exchange'/>",
               :error,
@@ -1161,7 +1161,7 @@ RSpec.describe V1::SessionsController, type: :controller do
         end
 
         it 'logs a generic error' do
-          expect(controller).to receive(:log_message_to_sentry)
+          expect(controller).to receive(:log_message_all)
             .with(
               'Login Failed! Subject did not consent to attribute release Multiple SAML Errors',
               :warn,
@@ -1224,7 +1224,7 @@ RSpec.describe V1::SessionsController, type: :controller do
         before { allow(SAML::User).to receive(:new).and_return(saml_user) }
 
         it 'logs a generic user validation error', :aggregate_failures do
-          expect(controller).to receive(:log_message_to_sentry)
+          expect(controller).to receive(:log_message_all)
             .with(
               'Login Failed! on User/Session Validation',
               :error,
@@ -1298,7 +1298,7 @@ RSpec.describe V1::SessionsController, type: :controller do
         before { allow(SAML::User).to receive(:new).and_return(saml_user) }
 
         it 'redirects to the auth failed endpoint with a specific code', :aggregate_failures do
-          expect(controller).to receive(:log_message_to_sentry)
+          expect(controller).to receive(:log_message_all)
           expect(call_endpoint).to redirect_to(expected_redirect)
           expect(response).to have_http_status(:found)
         end
@@ -1325,7 +1325,7 @@ RSpec.describe V1::SessionsController, type: :controller do
         before { allow(SAML::User).to receive(:new).and_return(saml_user) }
 
         it 'logs a generic user validation error', :aggregate_failures do
-          expect(controller).to receive(:log_message_to_sentry)
+          expect(controller).to receive(:log_message_all)
           expect(call_endpoint).to redirect_to(expected_redirect)
           expect(response).to have_http_status(:found)
         end

--- a/spec/lib/sidekiq/error_tag_spec.rb
+++ b/spec/lib/sidekiq/error_tag_spec.rb
@@ -18,7 +18,7 @@ describe Sidekiq::ErrorTag do
     req.request_id = '123'
     allow_any_instance_of(ApplicationController).to receive(:request).and_return(req)
 
-    ApplicationController.new.send(:set_sentry_tags_and_extra_context)
+    ApplicationController.new.send(:set_context)
   end
 
   it 'tags sentry before each sidekiq job' do

--- a/spec/lib/sidekiq/error_tag_spec.rb
+++ b/spec/lib/sidekiq/error_tag_spec.rb
@@ -18,7 +18,7 @@ describe Sidekiq::ErrorTag do
     req.request_id = '123'
     allow_any_instance_of(ApplicationController).to receive(:request).and_return(req)
 
-    ApplicationController.new.send(:set_context)
+    ApplicationController.new.send(:set_sentry_tags_and_extra_context)
   end
 
   it 'tags sentry before each sidekiq job' do

--- a/spec/models/form_attachment_spec.rb
+++ b/spec/models/form_attachment_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe FormAttachment do
       context 'when provided password is incorrect' do
         it 'logs a sanitized message to Sentry' do
           error_message = nil
-          allow_any_instance_of(FormAttachment).to receive(:log_message_to_sentry) do |_, message, _level|
+          allow_any_instance_of(FormAttachment).to receive(:log_message_all) do |_, message, _level|
             error_message = message
           end
 

--- a/spec/models/health_care_application_spec.rb
+++ b/spec/models/health_care_application_spec.rb
@@ -785,7 +785,7 @@ RSpec.describe HealthCareApplication, type: :model do
         end
 
         it 'logs message to sentry' do
-          expect(health_care_application).to receive(:log_message_to_sentry).with(
+          expect(health_care_application).to receive(:log_message_all).with(
             'HCA total failure',
             :error,
             {
@@ -815,7 +815,7 @@ RSpec.describe HealthCareApplication, type: :model do
           end
 
           it 'does not log message to sentry' do
-            expect(health_care_application).not_to receive(:log_message_to_sentry)
+            expect(health_care_application).not_to receive(:log_message_all)
             subject
           end
         end
@@ -833,7 +833,7 @@ RSpec.describe HealthCareApplication, type: :model do
           end
 
           it 'logs message to sentry' do
-            expect(health_care_application).to receive(:log_message_to_sentry).with(
+            expect(health_care_application).to receive(:log_message_all).with(
               'HCA total failure',
               :error,
               {


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- *(Summarize the changes that have been made to the platform)*
Create option for separate helper methods to log to Sentry vs Rails. 
### Previously: 
- `SentryLogging.log_message_to_sentry` logs to both Sentry and Rails.
### Now: 
- `SentryLogging.log_message_to_sentry` can log to both, but can also be passed a flag to only log to Sentry
- `SharedRailsLogging.log_message` logs to Rails
- `CombinedLogging.log_message_all` calls both `SentryLogging.log_message_to_sentry(rails: false)` and `SharedRailsLogging.log_message`, making `log_message_all` a drop in replacement for the old version of `log_message_to_sentry`

I have started replacing  SentryLogging.log_message_to_sentry with CombinedLogging.log_message_all, but only partially in order to keep the PR manageable and the list of reviewers contained.

Please Note: Because this refactor is going to be split up over a couple PRs for easier reviews, the SentryLogging helper still includes some Rails logging code. That will be removed when the refactor is complete.

Overall Goal: make it possible to easily transition away from Sentry in stages. In any given place, just remove `CombinedLogging.log_message_all` and use `SharedRailsLogging.log_message`.
- *(Which team do you work for, does your team own the maintenance of this component?)*
Decision Reviews, no. This is shared platform code, but we use it in our module.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/102065

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
Single method triggered Sentry and Rails logging, couldn't do one without the other.
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- Ensure expected logs still appear in DataDog with expected context.

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
No changes to behavior. Changes in structure of logging helpers.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature