### PR TITLE
Adds feature to exclude Service Verification from list of letters

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -352,6 +352,10 @@ features:
     actor_type: user
     description: When enabled, CST overrides RV1 - Reserve Records Request tracked items to be NEEDED_FROM_OTHERS on mobile app
     enable_in_development: true
+  cst_hide_service_verification_letter:
+    actor_type: user
+    description: When enabled, CST does not include Service Verification in the list of letters on vets-website
+    enable_in_development: true
   coe_access:
     actor_type: user
     description: Feature gates the certificate of eligibility application

--- a/lib/lighthouse/letters_generator/service.rb
+++ b/lib/lighthouse/letters_generator/service.rb
@@ -20,19 +20,6 @@ module Lighthouse
     end
 
     class Service < Common::Client::Base
-      LETTER_TYPES = %w[
-        benefit_summary
-        benefit_summary_dependent
-        benefit_verification
-        certificate_of_eligibility
-        civil_service
-        commissary
-        medicare_partd
-        minimum_essential_coverage
-        proof_of_service
-        service_verification
-      ].to_set.freeze
-
       BENEFICIARY_KEY_TRANFORMS = {
         awardEffectiveDateTime: :awardEffectiveDate,
         chapter35Eligibility: :hasChapter35Eligibility,
@@ -88,10 +75,27 @@ module Lighthouse
       end
 
       def valid_type?(letter_type)
-        LETTER_TYPES.include? letter_type.downcase
+        letter_types.include? letter_type.downcase
       end
 
       private
+
+      def letter_types
+        list = %w[
+          benefit_summary
+          benefit_summary_dependent
+          benefit_verification
+          certificate_of_eligibility
+          civil_service
+          commissary
+          medicare_partd
+          minimum_essential_coverage
+          proof_of_service
+          service_verification
+        ]
+        list = list.excluding('service_verification') if Flipper.enabled?(:cst_hide_service_verification_letter)
+        list.to_set.freeze
+      end
 
       def get_from_lighthouse(endpoint, params, log)
         Lighthouse::LettersGenerator.measure_time(log) do
@@ -120,6 +124,7 @@ module Lighthouse
       end
 
       def transform_letters(letters)
+        letters.select! { |l| valid_type?(l['letterType']) }
         letters.map do |letter|
           {
             letterType: letter['letterType'].downcase,


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): **YES**
- When the `cst_hide_service_verification_letter` is enabled, the "Service Verification" letter is not shown to the user in their list of letters. It is not available to download.
- I am on **BMT2**.

## Related issue(s)

- [Link to ticket created in va.gov-team repo](https://github.com/department-of-veterans-affairs/va.gov-team/issues/101478)

## Testing done

- [X] *New code is covered by unit tests*
- Before the change, the "Service Verification" letter was shown to the user. With this change, when the flipper is enabled, this letter is suppressed.
