### PR TITLE
Discovery: Add approximateDate to disabilities within 526EZ

### DIFF
--- a/app/swagger/swagger/schemas/form526/disability.rb
+++ b/app/swagger/swagger/schemas/form526/disability.rb
@@ -30,7 +30,6 @@ module Swagger
           property :worsenedEffects, type: :string
           property :vaMistreatmentDescription, type: :string
           property :vaMistreatmentLocation, type: :string
-          property :vaMistreatmentDate, type: :string
         end
 
         swagger_schema :RatedDisability do

--- a/lib/evss/disability_compensation_form/data_translation_all_claim.rb
+++ b/lib/evss/disability_compensation_form/data_translation_all_claim.rb
@@ -664,7 +664,6 @@ module EVSS
       # @option input_disability [Array<String>] :specialIssues Optional list of associated special issues
       # @option input_disability [String] :vaMistreatmentDescription The disabilities description
       # @option input_disability [String] :vaMistreatmentLocation The location the disability occurred
-      # @option input_disability [String] :vaMistreatmentDate The Date the disability occurred
       # @return [Hash] Transformed disability to match EVSS's validation
       def map_va(input_disability)
         {
@@ -676,7 +675,6 @@ module EVSS
           'serviceRelevance' => "Caused by VA care\n" \
                                 "Event: #{input_disability['vaMistreatmentDescription']}\n" \
                                 "Location: #{input_disability['vaMistreatmentLocation']}\n" \
-                                "TimeFrame: #{input_disability['vaMistreatmentDate']}"
         }.compact
       end
 

--- a/lib/evss/disability_compensation_form/data_translation_all_claim.rb
+++ b/lib/evss/disability_compensation_form/data_translation_all_claim.rb
@@ -626,6 +626,7 @@ module EVSS
       def map_new(input_disability)
         {
           'name' => input_disability['condition'],
+          'approximateDate' => input_disability['approximateDate'],
           'classificationCode' => input_disability['classificationCode'],
           'disabilityActionType' => 'NEW',
           'specialIssues' => input_disability['specialIssues'].presence,
@@ -646,6 +647,7 @@ module EVSS
       def map_worsened(input_disability)
         {
           'name' => input_disability['condition'],
+          'approximateDate' => input_disability['approximateDate'],
           'classificationCode' => input_disability['classificationCode'],
           'disabilityActionType' => 'NEW',
           'specialIssues' => input_disability['specialIssues'].presence,
@@ -667,6 +669,7 @@ module EVSS
       def map_va(input_disability)
         {
           'name' => input_disability['condition'],
+          'approximateDate' => input_disability['approximateDate'],
           'classificationCode' => input_disability['classificationCode'],
           'disabilityActionType' => 'NEW',
           'specialIssues' => input_disability['specialIssues'].presence,
@@ -689,6 +692,7 @@ module EVSS
       def map_secondary(input_disability, disabilities)
         disability = {
           'name' => input_disability['condition'],
+          'approximateDate' => input_disability['approximateDate'],
           'classificationCode' => input_disability['classificationCode'],
           'disabilityActionType' => 'SECONDARY',
           'specialIssues' => input_disability['specialIssues'].presence,

--- a/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb
@@ -1582,7 +1582,6 @@ describe EVSS::DisabilityCompensationForm::DataTranslationAllClaim do
                 'specialIssues' => ['POW'],
                 'vaMistreatmentDescription' => 'va condition description',
                 'vaMistreatmentLocation' => 'va location',
-                'vaMistreatmentDate' => 'the third of october'
               }
             ]
           }

--- a/spec/support/disability_compensation_form/526_in_progress_form_maixmal.json
+++ b/spec/support/disability_compensation_form/526_in_progress_form_maixmal.json
@@ -80,7 +80,6 @@
                 "condition": "myocardial infarction (MI)",
                 "view:serviceConnectedDisability": {},
                 "view:vaFollowUp": {
-                    "vaMistreatmentDate": "A while ago",
                     "vaMistreatmentDescription": "A thing happened.",
                     "vaMistreatmentLocation": "Somewhereville"
                 }

--- a/spec/support/disability_compensation_form/bdd_large_fe_submission.json
+++ b/spec/support/disability_compensation_form/bdd_large_fe_submission.json
@@ -85,7 +85,6 @@
         "cause": "VA",
         "vaMistreatmentDescription": "in the hospital stuff happened",
         "vaMistreatmentLocation": "VA hospital",
-        "vaMistreatmentDate": "yesterday",
         "condition": "asdfasdasdf",
         "unemployabilityDisability": true
       },


### PR DESCRIPTION
## Summary

- Summarize the changes that have been made to the platform:  See this [backend section of Discovery: Add approximateDate to disabilities within 526EZ](https://docs.google.com/document/d/1wwA6VvEyPsZIGTCaSRA6ObINgltbLfqRYpt4Z0Wl4p8/edit?tab=t.0#heading=h.iy7027i75hw6)

## Related issue(s)
- [Technical Discovery: Date disabilities began or worsened #98707](https://github.com/department-of-veterans-affairs/va.gov-team/issues/98707)