### PR TITLE
[VANotify] Remove va_notify_metadata_statsd_tags flipper toggle logic

### DIFF
--- a/modules/va_notify/lib/va_notify/default_callback.rb
+++ b/modules/va_notify/lib/va_notify/default_callback.rb
@@ -21,15 +21,7 @@ module VANotify
 
     def call_with_metadata
       notification_type = metadata['notification_type']
-
-      if Flipper.enabled?(:va_notify_metadata_statsd_tags)
-        tags = validate_and_normalize_statsd_tags
-      else
-        statsd_tags = metadata['statsd_tags']
-        service = statsd_tags['service']
-        function = statsd_tags['function']
-        tags = ["service:#{service}", "function:#{function}"]
-      end
+      tags = validate_and_normalize_statsd_tags
 
       case notification_record.status
       when 'delivered'

--- a/modules/va_notify/spec/lib/default_callback_spec.rb
+++ b/modules/va_notify/spec/lib/default_callback_spec.rb
@@ -5,226 +5,27 @@ require 'va_notify/default_callback'
 
 describe VANotify::DefaultCallback do
   describe '#call' do
-    # All toggles are turned on by default in specs so we don't have to explicitly turn it on
-    context 'va_notify_metadata_statsd_tags flipper enabled' do
+    let(:tags) do
+      ['service:service-name',
+       'function:function description']
+    end
+
+    context 'notification of error' do
+      let(:notification_type) { :error }
+
       let(:tags) do
         ['service:service-name',
          'function:function description']
       end
 
-      context 'notification of error' do
-        let(:notification_type) { :error }
-
-        let(:tags) do
-          ['service:service-name',
-           'function:function description']
+      context 'metadata is provided with statsd_tags as hash' do
+        let(:callback_metadata) do
+          { notification_type:, statsd_tags: { 'service' => 'service-name', 'function' => 'function description' } }
         end
 
-        context 'metadata is provided with statsd_tags as hash' do
-          let(:callback_metadata) do
-            { notification_type:, statsd_tags: { 'service' => 'service-name', 'function' => 'function description' } }
-          end
-
-          context 'delivered' do
-            let(:notification_record) do
-              build(:notification, status: 'delivered', callback_metadata:)
-            end
-
-            it 'increments StatsD' do
-              allow(StatsD).to receive(:increment)
-
-              VANotify::DefaultCallback.new(notification_record).call
-
-              expect(StatsD).to have_received(:increment).with('silent_failure_avoided', tags:)
-            end
-          end
-
-          context 'temporary failed' do
-            let(:notification_record) do
-              build(:notification, status: 'temporary-failure', callback_metadata:)
-            end
-
-            it 'increments StatsD' do
-              allow(StatsD).to receive(:increment)
-
-              VANotify::DefaultCallback.new(notification_record).call
-
-              expect(StatsD).to have_received(:increment).with('silent_failure', tags:)
-            end
-          end
-
-          context 'permanently failed' do
-            let(:notification_record) do
-              build(:notification, status: 'permanent-failure', callback_metadata:)
-            end
-
-            it 'increments StatsD' do
-              allow(StatsD).to receive(:increment)
-
-              VANotify::DefaultCallback.new(notification_record).call
-
-              expect(StatsD).to have_received(:increment).with('silent_failure', tags:)
-            end
-          end
-
-          context 'missing required statsd_tag keys' do
-            let(:callback_metadata) do
-              { notification_type:, statsd_tags: {} }
-            end
-            let(:notification_record) do
-              build(:notification, status: 'delivered', callback_metadata:)
-            end
-
-            it 'raises KeyError' do
-              expect do
-                VANotify::DefaultCallback.new(notification_record).call
-              end.to raise_error(KeyError,
-                                 'Missing required keys in default_callback metadata statsd_tags: service, function')
-            end
-          end
-        end
-
-        context 'metadata is provided with statsd_tags as array' do
-          let(:tags) do
-            ['service:service-name',
-             'function:function description',
-             'some-non-required-tag:some-tag']
-          end
-
-          let(:callback_metadata) do
-            { notification_type:, statsd_tags: tags }
-          end
-
-          context 'delivered' do
-            let(:notification_record) do
-              build(:notification, status: 'delivered', callback_metadata:)
-            end
-
-            it 'increments StatsD' do
-              allow(StatsD).to receive(:increment)
-
-              VANotify::DefaultCallback.new(notification_record).call
-
-              expect(StatsD).to have_received(:increment).with('silent_failure_avoided', tags:)
-            end
-          end
-
-          context 'temporary failed' do
-            let(:notification_record) do
-              build(:notification, status: 'temporary-failure', callback_metadata:)
-            end
-
-            it 'increments StatsD' do
-              allow(StatsD).to receive(:increment)
-
-              VANotify::DefaultCallback.new(notification_record).call
-
-              expect(StatsD).to have_received(:increment).with('silent_failure', tags:)
-            end
-          end
-
-          context 'permanently failed' do
-            let(:notification_record) do
-              build(:notification, status: 'permanent-failure', callback_metadata:)
-            end
-
-            it 'increments StatsD' do
-              allow(StatsD).to receive(:increment)
-
-              VANotify::DefaultCallback.new(notification_record).call
-
-              expect(StatsD).to have_received(:increment).with('silent_failure', tags:)
-            end
-          end
-
-          context 'missing required statsd_tag keys' do
-            let(:callback_metadata) do
-              { notification_type:, statsd_tags: {} }
-            end
-            let(:notification_record) do
-              build(:notification, status: 'delivered', callback_metadata:)
-            end
-
-            it 'raises KeyError' do
-              expect do
-                VANotify::DefaultCallback.new(notification_record).call
-              end.to raise_error(KeyError,
-                                 'Missing required keys in default_callback metadata statsd_tags: service, function')
-            end
-          end
-        end
-
-        context 'invalid metadata format is provided' do
-          context 'missing required statsd_tag keys' do
-            let(:callback_metadata) { 'this is not how we should pass metadata' }
-            let(:notification_record) do
-              build(:notification, status: 'delivered', callback_metadata:)
-            end
-
-            it 'raises KeyError' do
-              expect do
-                VANotify::DefaultCallback.new(notification_record).call
-              end.to raise_error(TypeError,
-                                 'Invalid metadata statsd_tags format: must be a Hash or Array')
-            end
-          end
-        end
-      end
-
-      context 'notification of receipt' do
-        let(:notification_type) { :received }
-
-        context 'metadata is provided' do
-          let(:callback_metadata) { { notification_type:, statsd_tags: tags } }
-
-          context 'delivered' do
-            let(:notification_record) do
-              build(:notification, status: 'delivered', callback_metadata:)
-            end
-
-            it 'does not increment StatsD' do
-              allow(StatsD).to receive(:increment)
-
-              VANotify::DefaultCallback.new(notification_record).call
-
-              expect(StatsD).not_to have_received(:increment)
-            end
-          end
-
-          context 'temporary-failure' do
-            let(:notification_record) do
-              build(:notification, status: 'temporary-failure', callback_metadata:)
-            end
-
-            it 'does not increment StatsD' do
-              allow(StatsD).to receive(:increment)
-
-              VANotify::DefaultCallback.new(notification_record).call
-
-              expect(StatsD).not_to have_received(:increment)
-            end
-          end
-
-          context 'permanent-failure' do
-            let(:notification_record) do
-              build(:notification, status: 'permanent-failure', callback_metadata:)
-            end
-
-            it 'does not increment StatsD' do
-              allow(StatsD).to receive(:increment)
-
-              VANotify::DefaultCallback.new(notification_record).call
-
-              expect(StatsD).not_to have_received(:increment)
-            end
-          end
-        end
-      end
-
-      context 'metadata is not provided' do
         context 'delivered' do
           let(:notification_record) do
-            build(:notification, status: 'delivered')
+            build(:notification, status: 'delivered', callback_metadata:)
           end
 
           it 'increments StatsD' do
@@ -232,14 +33,13 @@ describe VANotify::DefaultCallback do
 
             VANotify::DefaultCallback.new(notification_record).call
 
-            expect(StatsD).to have_received(:increment).with('silent_failure_avoided',
-                                                             tags: ['service:none-provided', 'function:none-provided'])
+            expect(StatsD).to have_received(:increment).with('silent_failure_avoided', tags:)
           end
         end
 
         context 'temporary failed' do
           let(:notification_record) do
-            build(:notification, status: 'temporary-failure')
+            build(:notification, status: 'temporary-failure', callback_metadata:)
           end
 
           it 'increments StatsD' do
@@ -247,14 +47,13 @@ describe VANotify::DefaultCallback do
 
             VANotify::DefaultCallback.new(notification_record).call
 
-            expect(StatsD).to have_received(:increment).with('silent_failure',
-                                                             tags: ['service:none-provided', 'function:none-provided'])
+            expect(StatsD).to have_received(:increment).with('silent_failure', tags:)
           end
         end
 
         context 'permanently failed' do
           let(:notification_record) do
-            build(:notification, status: 'permanent-failure')
+            build(:notification, status: 'permanent-failure', callback_metadata:)
           end
 
           it 'increments StatsD' do
@@ -262,171 +61,207 @@ describe VANotify::DefaultCallback do
 
             VANotify::DefaultCallback.new(notification_record).call
 
-            expect(StatsD).to have_received(:increment).with('silent_failure',
-                                                             tags: ['service:none-provided', 'function:none-provided'])
+            expect(StatsD).to have_received(:increment).with('silent_failure', tags:)
+          end
+        end
+
+        context 'missing required statsd_tag keys' do
+          let(:callback_metadata) do
+            { notification_type:, statsd_tags: {} }
+          end
+          let(:notification_record) do
+            build(:notification, status: 'delivered', callback_metadata:)
+          end
+
+          it 'raises KeyError' do
+            expect do
+              VANotify::DefaultCallback.new(notification_record).call
+            end.to raise_error(KeyError,
+                               'Missing required keys in default_callback metadata statsd_tags: service, function')
+          end
+        end
+      end
+
+      context 'metadata is provided with statsd_tags as array' do
+        let(:tags) do
+          ['service:service-name',
+           'function:function description',
+           'some-non-required-tag:some-tag']
+        end
+
+        let(:callback_metadata) do
+          { notification_type:, statsd_tags: tags }
+        end
+
+        context 'delivered' do
+          let(:notification_record) do
+            build(:notification, status: 'delivered', callback_metadata:)
+          end
+
+          it 'increments StatsD' do
+            allow(StatsD).to receive(:increment)
+
+            VANotify::DefaultCallback.new(notification_record).call
+
+            expect(StatsD).to have_received(:increment).with('silent_failure_avoided', tags:)
+          end
+        end
+
+        context 'temporary failed' do
+          let(:notification_record) do
+            build(:notification, status: 'temporary-failure', callback_metadata:)
+          end
+
+          it 'increments StatsD' do
+            allow(StatsD).to receive(:increment)
+
+            VANotify::DefaultCallback.new(notification_record).call
+
+            expect(StatsD).to have_received(:increment).with('silent_failure', tags:)
+          end
+        end
+
+        context 'permanently failed' do
+          let(:notification_record) do
+            build(:notification, status: 'permanent-failure', callback_metadata:)
+          end
+
+          it 'increments StatsD' do
+            allow(StatsD).to receive(:increment)
+
+            VANotify::DefaultCallback.new(notification_record).call
+
+            expect(StatsD).to have_received(:increment).with('silent_failure', tags:)
+          end
+        end
+
+        context 'missing required statsd_tag keys' do
+          let(:callback_metadata) do
+            { notification_type:, statsd_tags: {} }
+          end
+          let(:notification_record) do
+            build(:notification, status: 'delivered', callback_metadata:)
+          end
+
+          it 'raises KeyError' do
+            expect do
+              VANotify::DefaultCallback.new(notification_record).call
+            end.to raise_error(KeyError,
+                               'Missing required keys in default_callback metadata statsd_tags: service, function')
+          end
+        end
+      end
+
+      context 'invalid metadata format is provided' do
+        context 'missing required statsd_tag keys' do
+          let(:callback_metadata) { 'this is not how we should pass metadata' }
+          let(:notification_record) do
+            build(:notification, status: 'delivered', callback_metadata:)
+          end
+
+          it 'raises KeyError' do
+            expect do
+              VANotify::DefaultCallback.new(notification_record).call
+            end.to raise_error(TypeError,
+                               'Invalid metadata statsd_tags format: must be a Hash or Array')
           end
         end
       end
     end
 
-    context 'va_notify_metadata_statsd_tags flipper disabled' do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:va_notify_metadata_statsd_tags).and_return(false)
-      end
+    context 'notification of receipt' do
+      let(:notification_type) { :received }
 
-      let(:tags) do
-        ['service:service-name',
-         'function:function description']
-      end
+      context 'metadata is provided' do
+        let(:callback_metadata) { { notification_type:, statsd_tags: tags } }
 
-      context 'notification of error' do
-        let(:notification_type) { :error }
-
-        context 'metadata is provided with statsd_tags as hash' do
-          let(:callback_metadata) do
-            { notification_type:, statsd_tags: { 'service' => 'service-name', 'function' => 'function description' } }
-          end
-
-          context 'delivered' do
-            let(:notification_record) do
-              build(:notification, status: 'delivered', callback_metadata:)
-            end
-
-            it 'increments StatsD' do
-              allow(StatsD).to receive(:increment)
-
-              VANotify::DefaultCallback.new(notification_record).call
-
-              expect(StatsD).to have_received(:increment).with('silent_failure_avoided', tags:)
-            end
-          end
-
-          context 'temporary failed' do
-            let(:notification_record) do
-              build(:notification, status: 'temporary-failure', callback_metadata:)
-            end
-
-            it 'increments StatsD' do
-              allow(StatsD).to receive(:increment)
-
-              VANotify::DefaultCallback.new(notification_record).call
-
-              expect(StatsD).to have_received(:increment).with('silent_failure', tags:)
-            end
-          end
-
-          context 'permanently failed' do
-            let(:notification_record) do
-              build(:notification, status: 'permanent-failure', callback_metadata:)
-            end
-
-            it 'increments StatsD' do
-              allow(StatsD).to receive(:increment)
-
-              VANotify::DefaultCallback.new(notification_record).call
-
-              expect(StatsD).to have_received(:increment).with('silent_failure', tags:)
-            end
-          end
-        end
-      end
-
-      context 'notification of receipt' do
-        let(:notification_type) { :received }
-
-        context 'metadata is provided' do
-          let(:callback_metadata) do
-            { notification_type:, statsd_tags: { 'service' => 'service-name', 'function' => 'function description' } }
-          end
-
-          context 'delivered' do
-            let(:notification_record) do
-              build(:notification, status: 'delivered', callback_metadata:)
-            end
-
-            it 'does not increment StatsD' do
-              allow(StatsD).to receive(:increment)
-
-              VANotify::DefaultCallback.new(notification_record).call
-
-              expect(StatsD).not_to have_received(:increment)
-            end
-          end
-
-          context 'temporary-failure' do
-            let(:notification_record) do
-              build(:notification, status: 'temporary-failure', callback_metadata:)
-            end
-
-            it 'does not increment StatsD' do
-              allow(StatsD).to receive(:increment)
-
-              VANotify::DefaultCallback.new(notification_record).call
-
-              expect(StatsD).not_to have_received(:increment)
-            end
-          end
-
-          context 'permanent-failure' do
-            let(:notification_record) do
-              build(:notification, status: 'permanent-failure', callback_metadata:)
-            end
-
-            it 'does not increment StatsD' do
-              allow(StatsD).to receive(:increment)
-
-              VANotify::DefaultCallback.new(notification_record).call
-
-              expect(StatsD).not_to have_received(:increment)
-            end
-          end
-        end
-      end
-
-      context 'metadata is not provided' do
         context 'delivered' do
           let(:notification_record) do
-            build(:notification, status: 'delivered')
+            build(:notification, status: 'delivered', callback_metadata:)
           end
 
-          it 'increments StatsD' do
+          it 'does not increment StatsD' do
             allow(StatsD).to receive(:increment)
 
             VANotify::DefaultCallback.new(notification_record).call
 
-            expect(StatsD).to have_received(:increment).with('silent_failure_avoided',
-                                                             tags: ['service:none-provided', 'function:none-provided'])
+            expect(StatsD).not_to have_received(:increment)
           end
         end
 
-        context 'temporary failed' do
+        context 'temporary-failure' do
           let(:notification_record) do
-            build(:notification, status: 'temporary-failure')
+            build(:notification, status: 'temporary-failure', callback_metadata:)
           end
 
-          it 'increments StatsD' do
+          it 'does not increment StatsD' do
             allow(StatsD).to receive(:increment)
 
             VANotify::DefaultCallback.new(notification_record).call
 
-            expect(StatsD).to have_received(:increment).with('silent_failure',
-                                                             tags: ['service:none-provided', 'function:none-provided'])
+            expect(StatsD).not_to have_received(:increment)
           end
         end
 
-        context 'permanently failed' do
+        context 'permanent-failure' do
           let(:notification_record) do
-            build(:notification, status: 'permanent-failure')
+            build(:notification, status: 'permanent-failure', callback_metadata:)
           end
 
-          it 'increments StatsD' do
+          it 'does not increment StatsD' do
             allow(StatsD).to receive(:increment)
 
             VANotify::DefaultCallback.new(notification_record).call
 
-            expect(StatsD).to have_received(:increment).with('silent_failure',
-                                                             tags: ['service:none-provided', 'function:none-provided'])
+            expect(StatsD).not_to have_received(:increment)
           end
+        end
+      end
+    end
+
+    context 'metadata is not provided' do
+      context 'delivered' do
+        let(:notification_record) do
+          build(:notification, status: 'delivered')
+        end
+
+        it 'increments StatsD' do
+          allow(StatsD).to receive(:increment)
+
+          VANotify::DefaultCallback.new(notification_record).call
+
+          expect(StatsD).to have_received(:increment).with('silent_failure_avoided',
+                                                           tags: ['service:none-provided', 'function:none-provided'])
+        end
+      end
+
+      context 'temporary failed' do
+        let(:notification_record) do
+          build(:notification, status: 'temporary-failure')
+        end
+
+        it 'increments StatsD' do
+          allow(StatsD).to receive(:increment)
+
+          VANotify::DefaultCallback.new(notification_record).call
+
+          expect(StatsD).to have_received(:increment).with('silent_failure',
+                                                           tags: ['service:none-provided', 'function:none-provided'])
+        end
+      end
+
+      context 'permanently failed' do
+        let(:notification_record) do
+          build(:notification, status: 'permanent-failure')
+        end
+
+        it 'increments StatsD' do
+          allow(StatsD).to receive(:increment)
+
+          VANotify::DefaultCallback.new(notification_record).call
+
+          expect(StatsD).to have_received(:increment).with('silent_failure',
+                                                           tags: ['service:none-provided', 'function:none-provided'])
         end
       end
     end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- This PR removes the logic using the `va_notify_metadata_statsd_tags ` toggle introduced in https://github.com/department-of-veterans-affairs/vets-api/pull/20235. The toggle has been on in production for a while and we no longer need to be able to turn it off. 
- [This PR was created to delete the actual toggle from the feature file](https://github.com/department-of-veterans-affairs/vets-api/pull/20729)
- 1010 Health Apps

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-api/pull/20235

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
VANotify Default Callbacks

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
