### PR TITLE
Refactor to use safe constant initialization

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -7,7 +7,7 @@ require 'flipper/adapters/active_support_cache_store'
 require 'flipper/ui/action_patch'
 require 'flipper/instrumentation/event_subscriber'
 
-FLIPPER_FEATURE_CONFIG = YAML.safe_load(Rails.root.join('config', 'features.yml').read)
+FLIPPER_FEATURE_CONFIG ||= YAML.safe_load(Rails.root.join('config', 'features.yml').read)
 
 Rails.application.configure do
   config.flipper.test_help = false
@@ -15,8 +15,8 @@ Rails.application.configure do
 end
 
 Rails.application.reloader.to_prepare do
-  FLIPPER_ACTOR_USER = 'user'
-  FLIPPER_ACTOR_STRING = 'cookie_id'
+  FLIPPER_ACTOR_USER ||= 'user'
+  FLIPPER_ACTOR_STRING ||= 'cookie_id'
 
   # Modify Flipper::UI::Action to use our custom views
   Flipper::UI::Action.prepend(Flipper::UI::ActionPatch)

--- a/modules/decision_reviews/spec/support/vcr_helper.rb
+++ b/modules/decision_reviews/spec/support/vcr_helper.rb
@@ -3,7 +3,7 @@
 require 'support/vcr'
 require 'support/vcr_multipart_matcher_helper'
 
-VCR::MATCH_EVERYTHING = { match_requests_on: %i[method uri headers body] }.freeze
+VCR::MATCH_EVERYTHING ||= { match_requests_on: %i[method uri headers body] }.freeze
 
 module VCR
   def self.all_matches


### PR DESCRIPTION
- Change constant assignment to use conditional initialization
  with `||=`, ensuring it's only assigned once.
