### PR TITLE
[ARP][PR stack #1] fix seed spec

### DIFF
--- a/modules/accredited_representative_portal/lib/tasks/seed/staging_seed.rb
+++ b/modules/accredited_representative_portal/lib/tasks/seed/staging_seed.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative 'staging_seed/methods'
+require_relative 'staging_seed/constants'
+
+module AccreditedRepresentativePortal
+  module StagingSeeds
+    class << self
+      include Methods
+      include Constants
+
+      def run
+        ActiveRecord::Base.transaction do
+          cleanup_existing_data
+
+          options = build_seeding_options
+          orgs = fetch_organizations
+          process_organizations(orgs, options)
+
+          Rails.logger.info(
+            "Seeding complete: Created #{options[:totals][:requests]} requests " \
+            "and #{options[:totals][:resolutions]} resolutions"
+          )
+        end
+      end
+
+      private
+
+      def build_seeding_options
+        total_created = { requests: 0, resolutions: 0 }
+
+        {
+          claimant_cycle: create_claimants.cycle,
+          resolution_cycle: RESOLUTION_HISTORY_CYCLE,
+          resolved_time: RESOLVED_TIME_TRAVELER,
+          unresolved_time: UNRESOLVED_TIME_TRAVELER,
+          totals: total_created
+        }
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/lib/tasks/seed/staging_seed/constants.rb
+++ b/modules/accredited_representative_portal/lib/tasks/seed/staging_seed/constants.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  module StagingSeeds
+    module Constants
+      RESOLUTION_HISTORY_CYCLE = %i[expiration decision].cycle
+
+      RESOLVED_TIME_TRAVELER =
+        Enumerator.new do |yielder|
+          time = 30.days.ago
+          loop do
+            yielder << time
+            time += 6.hours
+          end
+        end
+
+      UNRESOLVED_TIME_TRAVELER =
+        Enumerator.new do |yielder|
+          time = 10.days.ago
+          loop do
+            yielder << time
+            time += 6.hours
+          end
+        end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/lib/tasks/seed/staging_seed/methods.rb
+++ b/modules/accredited_representative_portal/lib/tasks/seed/staging_seed/methods.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  module StagingSeeds
+    RequestOptions = Struct.new(
+      :org, :rep, :claimant, :resolution_cycle,
+      :resolved_time, :unresolved_time, :totals,
+      keyword_init: true
+    )
+
+    module RequestMethods
+      def create_claimants(count = 10)
+        # just grab users to be claimants
+        UserAccount.limit(count).to_a
+      end
+
+      def create_request_with_resolution(options)
+        if rand < 0.5
+          created_at = options.resolved_time.next
+          request = create_poa_request(options.org, options.rep, options.claimant, created_at)
+          create_resolution(request, options.resolution_cycle.next)
+          options.totals[:resolutions] += 1
+        else
+          create_poa_request(options.org, options.rep, options.claimant, options.unresolved_time.next)
+        end
+
+        options.totals[:requests] += 1
+      end
+
+      def create_poa_request(org, rep, claimant, created_at)
+        request = PowerOfAttorneyRequest.new(
+          claimant_id: claimant.id,
+          claimant_type: 'veteran',
+          power_of_attorney_holder_type: org ? 'AccreditedOrganization' : 'AccreditedIndividual',
+          power_of_attorney_holder_poa_code: org&.poa,
+          accredited_individual_registration_number: rep.representative_id,
+          created_at: created_at
+        )
+
+        form = AccreditedRepresentativePortal::PowerOfAttorneyForm.new(
+          data: FormMethods.build_poa_form_data.to_json,
+          power_of_attorney_request: request
+        )
+
+        form.save!
+        request.power_of_attorney_form = form
+        request.save!
+
+        request
+      end
+
+      def create_resolution(request, resolution_type)
+        resolving = case resolution_type
+                    when :expiration
+                      exp = AccreditedRepresentativePortal::PowerOfAttorneyRequestExpiration.new
+                      exp.save! && exp
+                    when :decision
+                      type = resolution_type_cycle.next
+                      dec = AccreditedRepresentativePortal::PowerOfAttorneyRequestDecision.new(
+                        type: type,
+                        creator_id: request.claimant_id
+                      )
+                      dec.save! && dec
+                    end
+        (res = AccreditedRepresentativePortal::PowerOfAttorneyRequestResolution.new(
+          power_of_attorney_request: request,
+          resolving: resolving,
+          created_at: request.created_at + 1.day
+        )).save! && res
+      end
+
+      private
+
+      def resolution_type_cycle
+        [
+          AccreditedRepresentativePortal::PowerOfAttorneyRequestDecision::Types::ACCEPTANCE,
+          AccreditedRepresentativePortal::PowerOfAttorneyRequestDecision::Types::DECLINATION
+        ].cycle
+      end
+    end
+
+    module OrganizationMethods
+      def fetch_organizations
+        {
+          ct: Veteran::Service::Organization.find_by(poa: '008'),
+          digital: Veteran::Service::Organization
+            .where(can_accept_digital_poa_requests: true)
+            .where.not(poa: '008')
+            .limit(2),
+          non_digital: Veteran::Service::Organization
+            .where(can_accept_digital_poa_requests: false)
+            .limit(2)
+        }
+      end
+
+      def process_organizations(orgs, options)
+        process_matched_orgs(orgs, options)
+      end
+
+      private
+
+      def process_matched_orgs(orgs, options)
+        [orgs[:ct], *orgs[:digital], *orgs[:non_digital]].each do |org|
+          process_org_reps(org, options)
+        end
+      end
+
+      def process_org_reps(org, options)
+        matching_reps = Veteran::Service::Representative
+                        .where('poa_codes && ARRAY[?]::varchar[]', [org.poa])
+                        .limit(2)
+
+        matching_reps.each do |rep|
+          create_request_with_resolution(build_request_options(org, rep, options))
+        end
+      end
+
+      def build_request_options(org, rep, options)
+        RequestOptions.new(
+          org: org,
+          rep: rep,
+          claimant: options[:claimant_cycle].next,
+          resolution_cycle: options[:resolution_cycle],
+          resolved_time: options[:resolved_time],
+          unresolved_time: options[:unresolved_time],
+          totals: options[:totals]
+        )
+      end
+    end
+
+    module FormMethods
+      module_function
+
+      def build_poa_form_data
+        {
+          authorizations: build_authorizations,
+          veteran: build_veteran_info,
+          dependent: nil
+        }
+      end
+
+      def build_authorizations
+        {
+          record_disclosure: true,
+          record_disclosure_limitations: [],
+          address_change: false
+        }
+      end
+
+      def build_veteran_info
+        {
+          name: build_name,
+          address: build_address,
+          ssn: '123456789',
+          va_file_number: '123456789',
+          date_of_birth: '1980-01-01',
+          service_number: nil,
+          service_branch: 'ARMY',
+          phone: '1234567890',
+          email: 'test@example.com'
+        }
+      end
+
+      def build_name
+        {
+          first: 'Test',
+          middle: nil,
+          last: 'Veteran'
+        }
+      end
+
+      def build_address
+        {
+          address_line1: '123 Test St',
+          address_line2: nil,
+          city: 'Testville',
+          state_code: 'TS',
+          country: 'US',
+          zip_code: '12345',
+          zip_code_suffix: nil
+        }
+      end
+    end
+
+    module Methods
+      include RequestMethods
+      include OrganizationMethods
+
+      def cleanup_existing_data
+        AccreditedRepresentativePortal::PowerOfAttorneyRequestExpiration.destroy_all
+        AccreditedRepresentativePortal::PowerOfAttorneyRequestDecision.destroy_all
+        AccreditedRepresentativePortal::PowerOfAttorneyRequestResolution.destroy_all
+        AccreditedRepresentativePortal::PowerOfAttorneyForm.destroy_all
+        AccreditedRepresentativePortal::PowerOfAttorneyRequest.destroy_all
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/lib/tasks/seed/staging_seed/methods.rb
+++ b/modules/accredited_representative_portal/lib/tasks/seed/staging_seed/methods.rb
@@ -38,8 +38,10 @@ module AccreditedRepresentativePortal
         )
 
         form = AccreditedRepresentativePortal::PowerOfAttorneyForm.new(
-          data: FormMethods.build_poa_form_data.to_json,
-          power_of_attorney_request: request
+          power_of_attorney_request: request,
+          data: FormMethods.build_poa_form_data.deep_transform_keys! do |key|
+            key.to_s.camelize(:lower)
+          end.to_json
         )
 
         form.save!

--- a/modules/accredited_representative_portal/lib/tasks/seed/staging_seed/methods.rb
+++ b/modules/accredited_representative_portal/lib/tasks/seed/staging_seed/methods.rb
@@ -14,8 +14,8 @@ module AccreditedRepresentativePortal
         UserAccount.limit(count).to_a
       end
 
-      def create_request_with_resolution(options)
-        if rand < 0.5
+      def create_request_with_resolution(options, i)
+        if i.even?
           created_at = options.resolved_time.next
           request = create_poa_request(options.org, options.rep, options.claimant, created_at)
           create_resolution(request, options.resolution_cycle.next)
@@ -112,8 +112,8 @@ module AccreditedRepresentativePortal
                         .where('poa_codes && ARRAY[?]::varchar[]', [org.poa])
                         .limit(2)
 
-        matching_reps.each do |rep|
-          create_request_with_resolution(build_request_options(org, rep, options))
+        matching_reps.each_with_index do |rep, i|
+          create_request_with_resolution(build_request_options(org, rep, options), i)
         end
       end
 

--- a/modules/accredited_representative_portal/lib/tasks/staging_seed.rake
+++ b/modules/accredited_representative_portal/lib/tasks/staging_seed.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative 'seed/staging_seed'
+
+namespace :accredited_representative_portal do
+  desc 'Seeds POA requests using existing organizations and representatives'
+  task seed_poa_requests: :environment do
+    AccreditedRepresentativePortal::StagingSeeds.run
+  end
+end

--- a/modules/accredited_representative_portal/spec/lib/tasks/staging_seed_spec.rb
+++ b/modules/accredited_representative_portal/spec/lib/tasks/staging_seed_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../../lib/tasks/seed/staging_seed'
+
+RSpec.describe AccreditedRepresentativePortal::StagingSeeds do
+  # claimants
+  let!(:test_accounts) { create_list(:user_account, 10) }
+
+  # Digital VSOs
+  let!(:ct_digital_org) do
+    create(:organization,
+           name: 'Connecticut Veterans Affairs',
+           poa: '008',
+           can_accept_digital_poa_requests: true)
+  end
+
+  let!(:other_digital_org) do
+    create(:organization,
+           name: 'Digital VSO',
+           poa: 'ABC',
+           can_accept_digital_poa_requests: true)
+  end
+
+  # Non-digital VSO
+  let!(:non_digital_org) do
+    create(:organization,
+           name: 'Paper Only VSO',
+           poa: 'XYZ',
+           can_accept_digital_poa_requests: false)
+  end
+
+  # Representatives with various affiliations
+  let!(:digital_only_rep) do
+    create(:representative,
+           first_name: 'Digital',
+           last_name: 'Rep',
+           representative_id: 'DR123',
+           poa_codes: ['008']) # CT only
+  end
+
+  let!(:non_digital_rep) do
+    create(:representative,
+           first_name: 'Paper',
+           last_name: 'Rep',
+           representative_id: 'PR456',
+           poa_codes: ['XYZ']) # Non-digital only
+  end
+
+  let!(:multi_org_rep) do
+    create(:representative,
+           first_name: 'Multi',
+           last_name: 'Rep',
+           representative_id: 'MR789',
+           poa_codes: %w[008 ABC XYZ]) # Both digital and non-digital
+  end
+
+  let!(:no_org_rep) do
+    create(:representative,
+           first_name: 'Lonely',
+           last_name: 'Rep',
+           representative_id: 'LR000',
+           poa_codes: ['ZZZ']) # No matching org
+  end
+
+  describe '.run' do
+    before { described_class.run }
+
+    it 'creates POA requests for reps with matching organizations' do
+      expect(AccreditedRepresentativePortal::PowerOfAttorneyRequest.count).to be_positive
+    end
+
+    it 'creates POA requests for CT digital org' do
+      ct_requests = AccreditedRepresentativePortal::PowerOfAttorneyRequest
+                    .where(power_of_attorney_holder_poa_code: '008')
+      expect(ct_requests).to exist
+      expect(ct_requests).to(be_all { |req| req.accredited_organization == ct_digital_org })
+    end
+
+    it 'creates both resolved and unresolved requests' do
+      expect(AccreditedRepresentativePortal::PowerOfAttorneyRequest.resolved).to exist
+      expect(AccreditedRepresentativePortal::PowerOfAttorneyRequest.unresolved).to exist
+    end
+
+    it 'creates requests with proper claimant data' do
+      requests = AccreditedRepresentativePortal::PowerOfAttorneyRequest.all
+
+      expect(requests).to(be_all { |req| req.claimant.is_a?(UserAccount) })
+      expect(requests).to(be_all { |req| req.claimant_type == 'veteran' })
+    end
+
+    it 'creates requests for multi-org reps' do
+      multi_rep_requests = AccreditedRepresentativePortal::PowerOfAttorneyRequest
+                           .where(accredited_individual_registration_number: 'MR789')
+      expect(multi_rep_requests.pluck(:power_of_attorney_holder_poa_code))
+        .to include('008', 'ABC', 'XYZ')
+      # verify they all have orgs
+      expect(multi_rep_requests).to(be_all { |req| req.accredited_organization.present? })
+    end
+  end
+end


### PR DESCRIPTION
Fixes seed data to comply with camel casing expectation of POA form schema. 

Also, use of rand + assertion on existence of resolved and unresolved failed w/ seed:
`bundle exec rspec --seed 41240 modules/accredited_representative_portal/spec/`

Is switching to have every other one be resolved / unresolved acceptable for our staging seed approach @chumpy ?