### PR TITLE
fix(tests): ensure Rack session secret meets minimum length requirement

### DIFF
--- a/spec/lib/github_authentication/sidekiq_web_spec.rb
+++ b/spec/lib/github_authentication/sidekiq_web_spec.rb
@@ -20,7 +20,7 @@ describe GithubAuthentication::SidekiqWeb do
   before do
     allow_any_instance_of(Warden::Proxy).to receive(:authenticate!).and_return(user)
     allow_any_instance_of(Warden::Proxy).to receive(:user).and_return(user)
-    Sidekiq::Web.use Rack::Session::Cookie, secret: 'secret', same_site: true
+    Sidekiq::Web.use Rack::Session::Cookie, secret: 'a' * 64, same_site: true
     Sidekiq::Web.use Warden::Manager do |config|
       config.failure_app = Sidekiq::Web
     end


### PR DESCRIPTION
Prepare for a future Rack 3.x upgrade by updating the Sidekiq Web session secret  in our sidekiq spec to meet the new minimum length requirement (64 characters). In Rack 3.0, session  secrets shorter than 64 characters result in an `ArgumentError`, preventing tests from passing.

This change allows Sidekiq Web authentication tests to pass consistently in both current and future Rack versions.
