### PR TITLE
Update mocked auth docs link

### DIFF
--- a/modules/mocked_authentication/app/views/mocked_authentication/credential/index.html.erb
+++ b/modules/mocked_authentication/app/views/mocked_authentication/credential/index.html.erb
@@ -161,7 +161,7 @@
           <p>
             Read through our
             <a
-              href="https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/identity/Mocked%20Authentication"
+              href="https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity/Products/Mocked%20Authentication/readme.md"
               rel="noopener noreferrer"
               target="_blank"
               >documentation</a


### PR DESCRIPTION
Just fixing the link to the docs page on the Mocked Authentication page :-)