### PR TITLE
Add feature flag for VADate/VaDateField adoption

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1550,6 +1550,10 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle to remove Podiatry from the type of care list when scheduling an online appointment.
+  vaos_online_scheduling_use_va_date:
+    actor_type: user
+    enable_in_development: true
+    description: Toggle to use VaDate/VaDateField.
   va_v2_person_service:
     actor_type: user
     description: When enabled, the VAProfile::V2::Person::Service will be enabled


### PR DESCRIPTION
## Summary

- Adding a feature toggle for VaDate/VaDateField adoption
- Appointments (VAOS) Team
- No exact target date for removal since it will depend on the deployment of the feature which has no explicit deadline. However, the engineering work will likely start next sprint and deployment will begin immediately after. Deployment and removal will likely be in Q1 2025.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103076

## Testing done

N/A

## Screenshots

N/A

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

