### PR TITLE
Remove GFE appointment modality

### DIFF
--- a/modules/vaos/app/docs/vaos/v2/vaos_v2.yaml
+++ b/modules/vaos/app/docs/vaos/v2/vaos_v2.yaml
@@ -1117,7 +1117,6 @@ components:
         - vaInPerson
         - vaInPersonVaccine
         - vaVideoCareAtHome
-        - vaVideoCareOnGfe
         - vaVideoCareAtAVaLocation
         - vaVideoCareAtAnAtlasLocation
         - vaPhone

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -882,8 +882,7 @@ module VAOS
           service_category_text: appointment.dig(:service_category, 0, :text),
           kind: appointment[:kind],
           atlas: appointment.dig(:telehealth, :atlas),
-          vvs_kind: appointment.dig(:telehealth, :vvs_kind),
-          gfe: appointment.dig(:extension, :patient_has_mobile_gfe)
+          vvs_kind: appointment.dig(:telehealth, :vvs_kind)
         }.to_json
         Rails.logger.warn("VAOS appointment id #{appointment[:id]} modality cannot be determined", context)
       end
@@ -895,7 +894,7 @@ module VAOS
         elsif %w[CLINIC_BASED STORE_FORWARD].include?(vvs_kind)
           'vaVideoCareAtAVaLocation'
         elsif vvs_kind.nil? || vvs_kind == 'MOBILE_ANY' || vvs_kind == 'ADHOC'
-          appointment.dig(:extension, :patient_has_mobile_gfe) ? 'vaVideoCareOnGfe' : 'vaVideoCareAtHome'
+          'vaVideoCareAtHome'
         end
       end
 

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -1927,26 +1927,12 @@ describe VAOS::V2::AppointmentsService do
       expect(appt[:modality]).to eq('vaVideoCareAtAVaLocation')
     end
 
-    describe 'for vvsKind' do
-      [nil, 'MOBILE_ANY', 'ADHOC'].each do |input|
-        context "#{input} when patient has GFE" do
-          it 'returns vaVideoCareOnGfe' do
-            appt = build(:appointment_form_v2, :telehealth).attributes
-            appt[:telehealth][:vvs_kind] = input
-            appt[:extension][:patient_has_mobile_gfe] = true
-            subject.send(:set_modality, appt)
-            expect(appt[:modality]).to eq('vaVideoCareOnGfe')
-          end
-        end
-
-        context "#{input} when patient does not have GFE" do
-          it 'returns vaVideoCareAtHome' do
-            appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth).attributes
-            appt[:telehealth][:vvs_kind] = input
-            subject.send(:set_modality, appt)
-            expect(appt[:modality]).to eq('vaVideoCareAtHome')
-          end
-        end
+    [nil, 'MOBILE_ANY', 'ADHOC'].each do |input|
+      it "is vaVideoCareAtHome for #{input} vvsKind" do
+        appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth).attributes
+        appt[:telehealth][:vvs_kind] = input
+        subject.send(:set_modality, appt)
+        expect(appt[:modality]).to eq('vaVideoCareAtHome')
       end
     end
 


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- We no longer differentiate between GFE and non-GFE video appointments on the front end so this PR removes the logic that makes this distinction.
- Appointments tool team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101540

## Testing done

- [x] *New code is covered by unit tests*
- Updated unit tests to account for the new behavior

## Screenshots
N/A

## What areas of the site does it impact?

Appointments tool

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
