### PR TITLE
Remove :benefits_intake_submission_status_job from BenefitsIntakeStatusJob

### DIFF
--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -27,8 +27,6 @@ class BenefitsIntakeStatusJob
   end
 
   def perform
-    return if Flipper.enabled?(:benefits_intake_submission_status_job)
-
     Rails.logger.info('BenefitsIntakeStatusJob started')
     pending_form_submission_attempts = FormSubmissionAttempt.where(aasm_state: 'pending')
     total_handled, result = batch_process(pending_form_submission_attempts)

--- a/spec/sidekiq/benefits_intake_status_job_spec.rb
+++ b/spec/sidekiq/benefits_intake_status_job_spec.rb
@@ -3,25 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe BenefitsIntakeStatusJob, type: :job do
-  before do
-    allow(Flipper).to receive(:enabled?).with(anything).and_call_original
-    allow(Flipper).to receive(:enabled?).with(:benefits_intake_submission_status_job).and_return false
-  end
-
   describe '#perform' do
-    context 'other job flipper is enabled' do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:benefits_intake_submission_status_job).and_return true
-      end
-
-      it 'does nothing' do
-        expect(Rails.logger).not_to receive(:info)
-        expect(Rails.logger).not_to receive(:error)
-        expect(BenefitsIntake::Service).not_to receive(:new)
-        BenefitsIntakeStatusJob.new.perform
-      end
-    end
-
     describe 'submission to the bulk status report endpoint' do
       context 'multiple attempts and multiple form submissions' do
         before do


### PR DESCRIPTION
## Summary
This PR removes a conditional around a feature flag that we don't anticipate using. There are no plans currently to replace this job (`BenefitsIntakeStatusJob`) with another job.
