### PR TITLE
Fix hash access in Form Upload email notifications

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/form_upload_notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/form_upload_notification_email.rb
@@ -64,7 +64,7 @@ module SimpleFormsApi
 
     def send_email_now
       VANotify::EmailJob.perform_async(
-        form_data[:email],
+        form_data['email'],
         template_id,
         get_personalization,
         *email_args
@@ -74,7 +74,7 @@ module SimpleFormsApi
     def enqueue_email(at)
       VANotify::EmailJob.perform_at(
         at,
-        form_data[:email],
+        form_data['email'],
         template_id,
         get_personalization,
         *email_args
@@ -90,9 +90,9 @@ module SimpleFormsApi
 
     def get_personalization
       {
-        'first_name' => form_data.dig(:full_name, :first)&.titleize,
+        'first_name' => form_data.dig('full_name', 'first')&.titleize,
         'form_number' => form_number,
-        'form_name' => form_data[:form_name],
+        'form_name' => form_data['form_name'],
         'date_submitted' => date_submitted,
         'confirmation_number' => confirmation_number
       }.tap do |personalization|

--- a/modules/simple_forms_api/spec/services/form_upload_notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/form_upload_notification_email_spec.rb
@@ -104,14 +104,14 @@ describe SimpleFormsApi::FormUploadNotificationEmail do
     end
     let(:date_submitted) { Time.zone.today.strftime('%B %d, %Y') }
     let(:email) { 'fake@email.com' }
-    let(:full_name) { { first: 'fake', last: 'name' } }
+    let(:full_name) { { 'first' => 'fake', 'last' => 'name' } }
     let(:form_name) { 'fake-form' }
     let(:form_data) do
-      { email:, full_name:, form_name: }
+      { 'email' => email, 'full_name' => full_name, 'form_name' => form_name }
     end
     let(:expected_personalization) do
       {
-        'first_name' => full_name[:first].titleize,
+        'first_name' => full_name['first'].titleize,
         'form_number' => form_number,
         'form_name' => form_name,
         'date_submitted' => date_submitted,


### PR DESCRIPTION
## Summary
This PR fixes a confusion I had between symbols and strings in the form data hash in form submissions. We need this to be correct for the Form Upload tool to be able to send email notifications.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=93337233&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1968