### PR TITLE
Travel Pay / Add `statsd` logging

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/appointments_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/appointments_client.rb
@@ -19,21 +19,22 @@ module TravelPay
     # @return [TravelPay::Appointment]
     #
     def get_all_appointments(veis_token, btsss_token, params = {})
-      btsss_url = Settings.travel_pay.base_url
-      correlation_id = SecureRandom.uuid
-      Rails.logger.debug(message: 'Correlation ID', correlation_id:)
+      log_to_statsd('appointments', 'get_all') do
+        btsss_url = Settings.travel_pay.base_url
+        correlation_id = SecureRandom.uuid
+        Rails.logger.debug(message: 'Correlation ID', correlation_id:)
 
-      query_path = if params.empty?
-                     'api/v1.2/appointments'
-                   else
-                     "api/v1.2/appointments?#{params.to_query}"
-                   end
-
-      connection(server_url: btsss_url).get(query_path) do |req|
-        req.headers['Authorization'] = "Bearer #{veis_token}"
-        req.headers['BTSSS-Access-Token'] = btsss_token
-        req.headers['X-Correlation-ID'] = correlation_id
-        req.headers.merge!(claim_headers)
+        query_path = if params.empty?
+                       'api/v1.2/appointments'
+                     else
+                       "api/v1.2/appointments?#{params.to_query}"
+                     end
+        connection(server_url: btsss_url).get(query_path) do |req|
+          req.headers['Authorization'] = "Bearer #{veis_token}"
+          req.headers['BTSSS-Access-Token'] = btsss_token
+          req.headers['X-Correlation-ID'] = correlation_id
+          req.headers.merge!(claim_headers)
+        end
       end
     end
   end

--- a/modules/travel_pay/app/services/travel_pay/appointments_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/appointments_client.rb
@@ -19,16 +19,16 @@ module TravelPay
     # @return [TravelPay::Appointment]
     #
     def get_all_appointments(veis_token, btsss_token, params = {})
-      log_to_statsd('appointments', 'get_all') do
-        btsss_url = Settings.travel_pay.base_url
-        correlation_id = SecureRandom.uuid
-        Rails.logger.debug(message: 'Correlation ID', correlation_id:)
+      btsss_url = Settings.travel_pay.base_url
+      correlation_id = SecureRandom.uuid
+      Rails.logger.debug(message: 'Correlation ID', correlation_id:)
 
-        query_path = if params.empty?
-                       'api/v1.2/appointments'
-                     else
-                       "api/v1.2/appointments?#{params.to_query}"
-                     end
+      query_path = if params.empty?
+                     'api/v1.2/appointments'
+                   else
+                     "api/v1.2/appointments?#{params.to_query}"
+                   end
+      log_to_statsd('appointments', 'get_all') do
         connection(server_url: btsss_url).get(query_path) do |req|
           req.headers['Authorization'] = "Bearer #{veis_token}"
           req.headers['BTSSS-Access-Token'] = btsss_token

--- a/modules/travel_pay/app/services/travel_pay/base_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/base_client.rb
@@ -49,9 +49,10 @@ module TravelPay
     # when calling the external Travel Pay API
     def log_to_statsd(service, tag_value)
       start_time = Time.current
-      yield
+      result = yield
       elapsed_time = Time.current - start_time
       StatsD.measure("travel_pay.#{service}.response_time", elapsed_time, tags: ["travel_pay:#{tag_value}"])
+      result
     end
   end
 end

--- a/modules/travel_pay/app/services/travel_pay/base_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/base_client.rb
@@ -43,5 +43,15 @@ module TravelPay
     def mock_enabled?
       Settings.travel_pay.mock
     end
+
+    ##
+    # Helper function to measure xTIC latency
+    # when calling the external Travel Pay API
+    def log_to_statsd(service, tag_value)
+      start_time = Time.current
+      yield
+      elapsed_time = Time.current - start_time
+      StatsD.measure("travel_pay.#{service}.response_time", elapsed_time, tags: ["travel_pay:#{tag_value}"])
+    end
   end
 end

--- a/modules/travel_pay/app/services/travel_pay/claims_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/claims_client.rb
@@ -12,15 +12,17 @@ module TravelPay
     # @return [TravelPay::Claim]
     #
     def get_claims(veis_token, btsss_token)
-      btsss_url = Settings.travel_pay.base_url
-      correlation_id = SecureRandom.uuid
-      Rails.logger.debug(message: 'Correlation ID', correlation_id:)
+      log_to_statsd('claims', 'get_all') do
+        btsss_url = Settings.travel_pay.base_url
+        correlation_id = SecureRandom.uuid
+        Rails.logger.debug(message: 'Correlation ID', correlation_id:)
 
-      connection(server_url: btsss_url).get('api/v1.2/claims') do |req|
-        req.headers['Authorization'] = "Bearer #{veis_token}"
-        req.headers['BTSSS-Access-Token'] = btsss_token
-        req.headers['X-Correlation-ID'] = correlation_id
-        req.headers.merge!(claim_headers)
+        connection(server_url: btsss_url).get('api/v1.2/claims') do |req|
+          req.headers['Authorization'] = "Bearer #{veis_token}"
+          req.headers['BTSSS-Access-Token'] = btsss_token
+          req.headers['X-Correlation-ID'] = correlation_id
+          req.headers.merge!(claim_headers)
+        end
       end
     end
 
@@ -39,19 +41,21 @@ module TravelPay
     # @return [TravelPay::Claim]
     #
     def get_claims_by_date(veis_token, btsss_token, params = {})
-      btsss_url = Settings.travel_pay.base_url
-      correlation_id = SecureRandom.uuid
-      Rails.logger.debug(message: 'Correlation ID', correlation_id:)
+      log_to_statsd('claims', 'get_single') do
+        btsss_url = Settings.travel_pay.base_url
+        correlation_id = SecureRandom.uuid
+        Rails.logger.debug(message: 'Correlation ID', correlation_id:)
 
-      url_params = params.transform_keys { |k| k.to_s.camelize(:lower) }
+        url_params = params.transform_keys { |k| k.to_s.camelize(:lower) }
 
-      connection(server_url: btsss_url)
-        # URL subject to change once v1.2 is available (proposed endpoint: '/search')
-        .get("api/v1.2/claims/search-by-appointment-date?#{url_params.to_query}") do |req|
-        req.headers['Authorization'] = "Bearer #{veis_token}"
-        req.headers['BTSSS-Access-Token'] = btsss_token
-        req.headers['X-Correlation-ID'] = correlation_id
-        req.headers.merge!(claim_headers)
+        connection(server_url: btsss_url)
+          # URL subject to change once v1.2 is available (proposed endpoint: '/search')
+          .get("api/v1.2/claims/search-by-appointment-date?#{url_params.to_query}") do |req|
+          req.headers['Authorization'] = "Bearer #{veis_token}"
+          req.headers['BTSSS-Access-Token'] = btsss_token
+          req.headers['X-Correlation-ID'] = correlation_id
+          req.headers.merge!(claim_headers)
+        end
       end
     end
 
@@ -68,20 +72,22 @@ module TravelPay
     # @return claimID => string
     #
     def create_claim(veis_token, btsss_token, params = {})
-      btsss_url = Settings.travel_pay.base_url
-      correlation_id = SecureRandom.uuid
-      Rails.logger.debug(message: 'Correlation ID', correlation_id:)
+      log_to_statsd('claims', 'create') do
+        btsss_url = Settings.travel_pay.base_url
+        correlation_id = SecureRandom.uuid
+        Rails.logger.debug(message: 'Correlation ID', correlation_id:)
 
-      connection(server_url: btsss_url).post('api/v1.2/claims') do |req|
-        req.headers['Authorization'] = "Bearer #{veis_token}"
-        req.headers['BTSSS-Access-Token'] = btsss_token
-        req.headers['X-Correlation-ID'] = correlation_id
-        req.headers.merge!(claim_headers)
-        req.body = {
-          'appointmentId' => params['btsss_appt_id'],
-          'claimName' => params['claim_name'] || 'Travel reimbursement',
-          'claimantType' => params['claimant_type'] || 'Veteran'
-        }.to_json
+        connection(server_url: btsss_url).post('api/v1.2/claims') do |req|
+          req.headers['Authorization'] = "Bearer #{veis_token}"
+          req.headers['BTSSS-Access-Token'] = btsss_token
+          req.headers['X-Correlation-ID'] = correlation_id
+          req.headers.merge!(claim_headers)
+          req.body = {
+            'appointmentId' => params['btsss_appt_id'],
+            'claimName' => params['claim_name'] || 'Travel reimbursement',
+            'claimantType' => params['claimant_type'] || 'Veteran'
+          }.to_json
+        end
       end
     end
 
@@ -96,15 +102,17 @@ module TravelPay
     # @return Faraday::Response claim submission payload
     #
     def submit_claim(veis_token, btsss_token, claim_id)
-      btsss_url = Settings.travel_pay.base_url
-      correlation_id = SecureRandom.uuid
-      Rails.logger.debug(message: 'Correlation ID', correlation_id:)
+      log_to_statsd('claims', 'submit') do
+        btsss_url = Settings.travel_pay.base_url
+        correlation_id = SecureRandom.uuid
+        Rails.logger.debug(message: 'Correlation ID', correlation_id:)
 
-      connection(server_url: btsss_url).patch("api/v1.2/claims/#{claim_id}/submit") do |req|
-        req.headers['Authorization'] = "Bearer #{veis_token}"
-        req.headers['BTSSS-Access-Token'] = btsss_token
-        req.headers['X-Correlation-ID'] = correlation_id
-        req.headers.merge!(claim_headers)
+        connection(server_url: btsss_url).patch("api/v1.2/claims/#{claim_id}/submit") do |req|
+          req.headers['Authorization'] = "Bearer #{veis_token}"
+          req.headers['BTSSS-Access-Token'] = btsss_token
+          req.headers['X-Correlation-ID'] = correlation_id
+          req.headers.merge!(claim_headers)
+        end
       end
     end
   end

--- a/modules/travel_pay/app/services/travel_pay/claims_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/claims_client.rb
@@ -41,7 +41,7 @@ module TravelPay
     # @return [TravelPay::Claim]
     #
     def get_claims_by_date(veis_token, btsss_token, params = {})
-      log_to_statsd('claims', 'get_single') do
+      log_to_statsd('claims', 'get_by_date') do
         btsss_url = Settings.travel_pay.base_url
         correlation_id = SecureRandom.uuid
         Rails.logger.debug(message: 'Correlation ID', correlation_id:)

--- a/modules/travel_pay/app/services/travel_pay/claims_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/claims_client.rb
@@ -12,11 +12,10 @@ module TravelPay
     # @return [TravelPay::Claim]
     #
     def get_claims(veis_token, btsss_token)
+      btsss_url = Settings.travel_pay.base_url
+      correlation_id = SecureRandom.uuid
+      Rails.logger.debug(message: 'Correlation ID', correlation_id:)
       log_to_statsd('claims', 'get_all') do
-        btsss_url = Settings.travel_pay.base_url
-        correlation_id = SecureRandom.uuid
-        Rails.logger.debug(message: 'Correlation ID', correlation_id:)
-
         connection(server_url: btsss_url).get('api/v1.2/claims') do |req|
           req.headers['Authorization'] = "Bearer #{veis_token}"
           req.headers['BTSSS-Access-Token'] = btsss_token
@@ -41,13 +40,12 @@ module TravelPay
     # @return [TravelPay::Claim]
     #
     def get_claims_by_date(veis_token, btsss_token, params = {})
+      btsss_url = Settings.travel_pay.base_url
+      correlation_id = SecureRandom.uuid
+      Rails.logger.debug(message: 'Correlation ID', correlation_id:)
+
+      url_params = params.transform_keys { |k| k.to_s.camelize(:lower) }
       log_to_statsd('claims', 'get_by_date') do
-        btsss_url = Settings.travel_pay.base_url
-        correlation_id = SecureRandom.uuid
-        Rails.logger.debug(message: 'Correlation ID', correlation_id:)
-
-        url_params = params.transform_keys { |k| k.to_s.camelize(:lower) }
-
         connection(server_url: btsss_url)
           # URL subject to change once v1.2 is available (proposed endpoint: '/search')
           .get("api/v1.2/claims/search-by-appointment-date?#{url_params.to_query}") do |req|
@@ -72,11 +70,10 @@ module TravelPay
     # @return claimID => string
     #
     def create_claim(veis_token, btsss_token, params = {})
+      btsss_url = Settings.travel_pay.base_url
+      correlation_id = SecureRandom.uuid
+      Rails.logger.debug(message: 'Correlation ID', correlation_id:)
       log_to_statsd('claims', 'create') do
-        btsss_url = Settings.travel_pay.base_url
-        correlation_id = SecureRandom.uuid
-        Rails.logger.debug(message: 'Correlation ID', correlation_id:)
-
         connection(server_url: btsss_url).post('api/v1.2/claims') do |req|
           req.headers['Authorization'] = "Bearer #{veis_token}"
           req.headers['BTSSS-Access-Token'] = btsss_token
@@ -102,11 +99,10 @@ module TravelPay
     # @return Faraday::Response claim submission payload
     #
     def submit_claim(veis_token, btsss_token, claim_id)
+      btsss_url = Settings.travel_pay.base_url
+      correlation_id = SecureRandom.uuid
+      Rails.logger.debug(message: 'Correlation ID', correlation_id:)
       log_to_statsd('claims', 'submit') do
-        btsss_url = Settings.travel_pay.base_url
-        correlation_id = SecureRandom.uuid
-        Rails.logger.debug(message: 'Correlation ID', correlation_id:)
-
         connection(server_url: btsss_url).patch("api/v1.2/claims/#{claim_id}/submit") do |req|
           req.headers['Authorization'] = "Bearer #{veis_token}"
           req.headers['BTSSS-Access-Token'] = btsss_token

--- a/modules/travel_pay/app/services/travel_pay/expenses_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/expenses_client.rb
@@ -26,21 +26,23 @@ module TravelPay
     # @return expenseId => string
     #
     def add_mileage_expense(veis_token, btsss_token, params = {})
-      btsss_url = Settings.travel_pay.base_url
-      correlation_id = SecureRandom.uuid
-      Rails.logger.debug(message: 'Correlation ID', correlation_id:)
+      log_to_statsd('expense', 'add_mileage') do
+        btsss_url = Settings.travel_pay.base_url
+        correlation_id = SecureRandom.uuid
+        Rails.logger.debug(message: 'Correlation ID', correlation_id:)
 
-      connection(server_url: btsss_url).post('api/v1.2/expenses/mileage') do |req|
-        req.headers['Authorization'] = "Bearer #{veis_token}"
-        req.headers['BTSSS-Access-Token'] = btsss_token
-        req.headers['X-Correlation-ID'] = correlation_id
-        req.headers.merge!(claim_headers)
-        req.body = {
-          'claimId' => params['claim_id'],
-          'dateIncurred' => params['appt_date'],
-          'tripType' => params['trip_type'] || 'RoundTrip', # default to Round Trip if not specified
-          'description' => params['description'] || 'mileage' # this is required, default to mileage
-        }.to_json
+        connection(server_url: btsss_url).post('api/v1.2/expenses/mileage') do |req|
+          req.headers['Authorization'] = "Bearer #{veis_token}"
+          req.headers['BTSSS-Access-Token'] = btsss_token
+          req.headers['X-Correlation-ID'] = correlation_id
+          req.headers.merge!(claim_headers)
+          req.body = {
+            'claimId' => params['claim_id'],
+            'dateIncurred' => params['appt_date'],
+            'tripType' => params['trip_type'] || 'RoundTrip', # default to Round Trip if not specified
+            'description' => params['description'] || 'mileage' # this is required, default to mileage
+          }.to_json
+        end
       end
     end
   end

--- a/modules/travel_pay/app/services/travel_pay/expenses_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/expenses_client.rb
@@ -26,11 +26,10 @@ module TravelPay
     # @return expenseId => string
     #
     def add_mileage_expense(veis_token, btsss_token, params = {})
+      btsss_url = Settings.travel_pay.base_url
+      correlation_id = SecureRandom.uuid
+      Rails.logger.debug(message: 'Correlation ID', correlation_id:)
       log_to_statsd('expense', 'add_mileage') do
-        btsss_url = Settings.travel_pay.base_url
-        correlation_id = SecureRandom.uuid
-        Rails.logger.debug(message: 'Correlation ID', correlation_id:)
-
         connection(server_url: btsss_url).post('api/v1.2/expenses/mileage') do |req|
           req.headers['Authorization'] = "Bearer #{veis_token}"
           req.headers['BTSSS-Access-Token'] = btsss_token

--- a/modules/travel_pay/app/services/travel_pay/token_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/token_client.rb
@@ -15,15 +15,17 @@ module TravelPay
     # @return [Faraday::Response]
     #
     def request_veis_token
-      auth_url = Settings.travel_pay.veis.auth_url
-      tenant_id = Settings.travel_pay.veis.tenant_id
+      log_to_statsd('token', 'veis') do
+        auth_url = Settings.travel_pay.veis.auth_url
+        tenant_id = Settings.travel_pay.veis.tenant_id
 
-      response = connection(server_url: auth_url).post("#{tenant_id}/oauth2/token") do |req|
-        req.headers[:content_type] = 'application/x-www-form-urlencoded'
-        req.body = URI.encode_www_form(veis_params)
+        response = connection(server_url: auth_url).post("#{tenant_id}/oauth2/token") do |req|
+          req.headers[:content_type] = 'application/x-www-form-urlencoded'
+          req.body = URI.encode_www_form(veis_params)
+        end
+
+        response.body['access_token']
       end
-
-      response.body['access_token']
     end
 
     ##
@@ -38,31 +40,35 @@ module TravelPay
       correlation_id = SecureRandom.uuid
       Rails.logger.debug(message: 'Correlation ID', correlation_id:)
 
-      response = connection(server_url: btsss_url).post('api/v1.2/Auth/access-token') do |req|
-        req.headers['Authorization'] = "Bearer #{veis_token}"
-        req.headers['BTSSS-API-Client-Number'] = @client_number.to_s
-        req.headers['X-Correlation-ID'] = correlation_id
-        req.headers.merge!(claim_headers)
-        req.body = { authJwt: sts_token }
-      end
+      log_to_statsd('token', 'btsss') do
+        response = connection(server_url: btsss_url).post('api/v1.2/Auth/access-token') do |req|
+          req.headers['Authorization'] = "Bearer #{veis_token}"
+          req.headers['BTSSS-API-Client-Number'] = @client_number.to_s
+          req.headers['X-Correlation-ID'] = correlation_id
+          req.headers.merge!(claim_headers)
+          req.body = { authJwt: sts_token }
+        end
 
-      response.body['data']['accessToken']
+        response.body['data']['accessToken']
+      end
     end
 
     def request_sts_token(user)
-      private_key_file = Settings.sign_in.sts_client.key_path
-      private_key = OpenSSL::PKey::RSA.new(File.read(private_key_file))
+      log_to_statsd('token', 'sts') do
+        private_key_file = Settings.sign_in.sts_client.key_path
+        private_key = OpenSSL::PKey::RSA.new(File.read(private_key_file))
 
-      assertion = build_sts_assertion(user)
-      jwt = JWT.encode(assertion, private_key, 'RS256')
+        assertion = build_sts_assertion(user)
+        jwt = JWT.encode(assertion, private_key, 'RS256')
 
-      # send to sis
-      response = connection(server_url: host).post('/v0/sign_in/token') do |req|
-        req.params['grant_type'] = 'urn:ietf:params:oauth:grant-type:jwt-bearer'
-        req.params['assertion'] = jwt
+        # send to sis
+        response = connection(server_url: host).post('/v0/sign_in/token') do |req|
+          req.params['grant_type'] = 'urn:ietf:params:oauth:grant-type:jwt-bearer'
+          req.params['assertion'] = jwt
+        end
+
+        response.body['data']['access_token']
       end
-
-      response.body['data']['access_token']
     end
 
     def build_sts_assertion(user)

--- a/modules/travel_pay/spec/services/appointments_client_spec.rb
+++ b/modules/travel_pay/spec/services/appointments_client_spec.rb
@@ -90,6 +90,7 @@ describe TravelPay::AppointmentsClient do
 
   context '/appointments' do
     expected_log_prefix = 'travel_pay.appointments.response_time'
+    expected_log_tag = ['travel_pay:get_all']
 
     it 'returns a response only with appointments with no claims' do
       @stubs.get('/api/v1.2/appointments?excludeWithClaims=true') do
@@ -111,7 +112,7 @@ describe TravelPay::AppointmentsClient do
       expect(StatsD).to have_received(:measure)
         .with(expected_log_prefix,
               kind_of(Numeric),
-              tags: ['travel_pay:get_all'])
+              tags: expected_log_tag)
       expect(actual_appt_ids).to eq(expected_ids)
     end
 
@@ -135,7 +136,7 @@ describe TravelPay::AppointmentsClient do
       expect(StatsD).to have_received(:measure)
         .with(expected_log_prefix,
               kind_of(Numeric),
-              tags: ['travel_pay:get_all'])
+              tags: expected_log_tag)
       expect(actual_appt_ids).to eq(expected_ids)
     end
   end

--- a/modules/travel_pay/spec/services/claims_client_spec.rb
+++ b/modules/travel_pay/spec/services/claims_client_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 describe TravelPay::ClaimsClient do
   let(:user) { build(:user) }
 
+  expected_log_prefix = 'travel_pay.claims.response_time'
+
   before do
     @stubs = Faraday::Adapter::Test::Stubs.new
 
@@ -13,6 +15,8 @@ describe TravelPay::ClaimsClient do
       c.response :json
       c.request :json
     end
+
+    allow(StatsD).to receive(:measure)
   end
 
   context 'prod settings' do
@@ -81,6 +85,10 @@ describe TravelPay::ClaimsClient do
       claims_response = client.get_claims('veis_token', 'btsss_token')
       actual_claim_ids = claims_response.body['data'].pluck('id')
 
+      expect(StatsD).to have_received(:measure)
+        .with(expected_log_prefix,
+              kind_of(Numeric),
+              tags: ['travel_pay:get_all'])
       expect(actual_claim_ids).to eq(expected_ids)
     end
 
@@ -123,6 +131,10 @@ describe TravelPay::ClaimsClient do
                                                     'end_date' => '2024-02-01T16:45:34.465Z' })
       actual_ids = claims_response.body['data'].pluck('id')
 
+      expect(StatsD).to have_received(:measure)
+        .with(expected_log_prefix,
+              kind_of(Numeric),
+              tags: ['travel_pay:get_by_date'])
       expect(actual_ids).to eq(expected)
     end
 
@@ -149,6 +161,10 @@ describe TravelPay::ClaimsClient do
       new_claim_response = client.create_claim('veis_token', 'btsss_token', body)
       actual_claim_id = new_claim_response.body['data']['claimId']
 
+      expect(StatsD).to have_received(:measure)
+        .with(expected_log_prefix,
+              kind_of(Numeric),
+              tags: ['travel_pay:create'])
       expect(actual_claim_id).to eq(claim_id)
     end
 
@@ -160,6 +176,10 @@ describe TravelPay::ClaimsClient do
 
       client = TravelPay::ClaimsClient.new
       client.submit_claim('veis_token', 'btsss_token', claim_id)
+      expect(StatsD).to have_received(:measure)
+        .with(expected_log_prefix,
+              kind_of(Numeric),
+              tags: ['travel_pay:submit'])
     end
   end
 end

--- a/modules/travel_pay/spec/services/token_client_spec.rb
+++ b/modules/travel_pay/spec/services/token_client_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 describe TravelPay::TokenClient do
   let(:user) { build(:user) }
 
+  expected_log_prefix = 'travel_pay.token.response_time'
+
   before do
     @stubs = Faraday::Adapter::Test::Stubs.new
 
@@ -15,6 +17,7 @@ describe TravelPay::TokenClient do
     end
 
     allow_any_instance_of(TravelPay::TokenClient).to receive(:connection).and_return(conn)
+    allow(StatsD).to receive(:measure)
   end
 
   context 'request_veis_token' do
@@ -30,6 +33,10 @@ describe TravelPay::TokenClient do
       token_client = TravelPay::TokenClient.new(123)
       token = token_client.request_veis_token
 
+      expect(StatsD).to have_received(:measure)
+        .with(expected_log_prefix,
+              kind_of(Numeric),
+              tags: ['travel_pay:veis'])
       expect(token).to eq('fake_veis_token')
       @stubs.verify_stubbed_calls
     end
@@ -54,6 +61,10 @@ describe TravelPay::TokenClient do
       token_client = TravelPay::TokenClient.new(123)
       token = token_client.request_btsss_token('veis_token', user)
 
+      expect(StatsD).to have_received(:measure)
+        .with(expected_log_prefix,
+              kind_of(Numeric),
+              tags: ['travel_pay:btsss'])
       expect(token).to eq('fake_btsss_token')
       @stubs.verify_stubbed_calls
     end
@@ -95,6 +106,10 @@ describe TravelPay::TokenClient do
       end
       token_client = TravelPay::TokenClient.new(123)
       sts_token = token_client.request_sts_token(user)
+      expect(StatsD).to have_received(:measure)
+        .with(expected_log_prefix,
+              kind_of(Numeric),
+              tags: ['travel_pay:sts'])
       expect(sts_token).to eq('fake_sts_token')
       @stubs.verify_stubbed_calls
     end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO* No
- *(Summarize the changes that have been made to the platform)*
  - Adding `statsd` logging to our external API calls to measure response time

- *(What is the solution, why is this the solution?)*
  - We need a way to measure how long it takes for each response individually to track latency when calling the external API. 
  - We are currently only tracking the latency for the entire process, not each step individually (i.e. getting tokens, then getting the claims takes `a` ms vs. getting the first token takes `x` ms, the second token takes `y` ms and actually getting the claims response takes `z` ms)
- *(Which team do you work for, does your team own the maintenance of this component?)*
  - Travel Pay


## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
https://github.com/department-of-veterans-affairs/va.gov-team/issues/103016

- *Link to epic if not included in ticket*
https://github.com/department-of-veterans-affairs/va.gov-team/issues/83829

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- We were logging only the total time to make each call at the controller level, now each individual step can be measured independently
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- Update unit tests to check that the correct tags/prefixes were being sent to `statsd`, but I believe we won't know if it's logging correctly until it's merged and we start seeing metrics show up in datadog

 
## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
Travel Pay module only


## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

I would love feedback as to the `statsd` prefix and tags we have chosen as we're not 100% sure if this is the best way to go about tracking/sorting/grouping/tagging the different metrics.
