### PR TITLE
Use existing database_url for development and test audit_db

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -7,14 +7,14 @@ development:
   primary:
     url: <%= Settings.database_url %>
   audit:
-    url: <%= "#{Settings.audit_db.url}_development" %>
+    url: <%= URI(Settings.database_url).tap { |uri| uri.path = '/vets_api_audit_development'}.to_s %>
     migrations_paths: db/audit_migrate
 
 test:
   primary:
     url: <%= Settings.test_database_url %><%= ENV['TEST_ENV_NUMBER'] %>
   audit:
-    url: <%= "#{Settings.audit_db.url}_test#{ENV['TEST_ENV_NUMBER']}" %>
+    url: <%= URI(Settings.test_database_url).tap { |uri| uri.path = "/vets_api_audit_test#{ENV['TEST_ENV_NUMBER']}"}.to_s %>
     migrations_paths: db/audit_migrate
 
 production:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,7 +9,7 @@ web_origin: http://localhost:3000,http://localhost:3001,http://127.0.0.1:3000,ht
 web_origin_regex: \Ahttps?:\/\/www\.va\.gov\z
 
 audit_db:
-  url: postgis:///vets_api_audit
+  url: ~
 
 logingov:
   client_id: https://sqa.eauth.va.gov/isam/sps/saml20sp/saml20

--- a/docker-compose.review.yml
+++ b/docker-compose.review.yml
@@ -11,7 +11,6 @@ x-app: &common
     BUNDLE_ENTERPRISE__CONTRIBSYS__COM: "${BUNDLE_ENTERPRISE__CONTRIBSYS__COM}"
     SETTINGS__DATABASE_URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_development}?pool=4"
     SETTINGS__TEST_DATABASE_URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_test}"
-    SETTINGS__AUDIT_DB__URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_audit}"
     SETTINGS__REDIS__APP_DATA__URL: "redis://redis:6379"
     SETTINGS__REDIS__SIDEKIQ__URL: "redis://redis:6379"
     SETTINGS__REDIS__RAILS_CACHE__URL: "redis://redis:6379"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -22,7 +22,6 @@ services:
     environment:
       SETTINGS__DATABASE_URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_development}?pool=4"
       SETTINGS__TEST_DATABASE_URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_test}"
-      SETTINGS__AUDIT_DB__URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_audit}"
       SETTINGS__REDIS__APP_DATA__URL: "redis://redis:6379"
       SETTINGS__REDIS__SIDEKIQ__URL: "redis://redis:6379"
       POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ x-app: &common
     BUNDLE_ENTERPRISE__CONTRIBSYS__COM: "${BUNDLE_ENTERPRISE__CONTRIBSYS__COM}"
     SETTINGS__DATABASE_URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_development}?pool=4"
     SETTINGS__TEST_DATABASE_URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_test}"
-    SETTINGS__AUDIT_DB__URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_audit}"
     SETTINGS__REDIS__APP_DATA__URL: "redis://redis:6379"
     SETTINGS__REDIS__SIDEKIQ__URL: "redis://redis:6379"
     SETTINGS__REDIS__RAILS_CACHE__URL: "redis://redis:6379"


### PR DESCRIPTION
## Summary

- Since developers have a variety of configurations use the existing `database_url` and `test_database_url` scheme and host when constructing the audit database url


## Testing done

- setup databases, you should see that they are already created
  ```bash
  rails db:setup
  ```

## What areas of the site does it impact?
Database config

