### PR TITLE
API-45087-fix-ebenefit-definition

### DIFF
--- a/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
+++ b/modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
@@ -189,7 +189,7 @@ module ClaimsApi
       ##
       # EBenefitsBnftClaimStatusWebServiceBean
       #
-      module EBenefitsBenefitClaimStatusWebServiceBean
+      module EbenefitsBnftClaimStatusWebServiceBean
         DEFINITION =
           Bean.new(
             path: 'EBenefitsBnftClaimStatusWebServiceBean',
@@ -200,11 +200,11 @@ module ClaimsApi
           )
       end
 
-      module EBenefitsBenefitClaimStatusWebService
+      module EbenefitsBnftClaimStatusWebService
         DEFINITION =
           Service.new(
-            bean: EBenefitsBenefitClaimStatusWebServiceBean::DEFINITION,
-            path: 'EBenefitsBnftClaimStatusWebService'
+            bean: EbenefitsBnftClaimStatusWebServiceBean::DEFINITION,
+            path: 'EbenefitsBnftClaimStatusWebService'
           )
       end
 

--- a/modules/claims_api/app/services/claims_api/dependent_claimant_poa_assignment_service.rb
+++ b/modules/claims_api/app/services/claims_api/dependent_claimant_poa_assignment_service.rb
@@ -125,11 +125,11 @@ module ClaimsApi
     end
 
     def dependent_claims
-      bgs_claim_status_service = ClaimsApi::EbenefitsBnftClaimStatusWebService.new(
+      @bgs_claim_status_service ||= ClaimsApi::EbenefitsBnftClaimStatusWebService.new(
         external_uid: @dependent_participant_id,
         external_key: @dependent_participant_id
       )
-      res = bgs_claim_status_service.find_benefit_claims_status_by_ptcpnt_id(@dependent_participant_id)
+      res = @bgs_claim_status_service.find_benefit_claims_status_by_ptcpnt_id(@dependent_participant_id)
       benefit_claims = Array.wrap(res&.dig(:benefit_claims_dto, :benefit_claim))
 
       return benefit_claims if benefit_claims.present? && benefit_claims.is_a?(Array) && benefit_claims.first.present?

--- a/modules/claims_api/lib/bgs_service/e_benefits_bnft_claim_status_web_service.rb
+++ b/modules/claims_api/lib/bgs_service/e_benefits_bnft_claim_status_web_service.rb
@@ -11,7 +11,7 @@ module ClaimsApi
         <ptcpntId>#{id}</ptcpntId>
       EOXML
 
-      make_request(endpoint: 'EBenefitsBnftClaimStatusWebServiceBean/EBenefitsBnftClaimStatusWebService',
+      make_request(endpoint: bean_name,
                    action: 'findBenefitClaimsStatusByPtcpntId', body:)
     end
 
@@ -20,7 +20,7 @@ module ClaimsApi
         <bnftClaimId>#{id}</bnftClaimId>
       EOXML
 
-      make_request(endpoint: 'EBenefitsBnftClaimStatusWebServiceBean/EBenefitsBnftClaimStatusWebService',
+      make_request(endpoint: bean_name,
                    action: 'findBenefitClaimDetailsByBnftClaimId', body:)
     end
 


### PR DESCRIPTION
## Summary

- Corrects definition. 
- Adds caching to dep claimant poa assignment. 
- Replaces hard coded bean and service in ebenefitsbnftclaimstatusweb service.

## Related issue(s)

- [API-45087](https://jira.devops.va.gov/browse/API-45087)

## Testing done

- [x] v1 poa 2122 submit
- [x] v2 poa submit
- [x] v1 claims index
- [x] v2 claims index

## What areas of the site does it impact?
	modified:   modules/claims_api/app/clients/claims_api/bgs_client/definitions.rb
	modified:   modules/claims_api/app/services/claims_api/dependent_claimant_poa_assignment_service.rb
	modified:   modules/claims_api/lib/bgs_service/e_benefits_bnft_claim_status_web_service.rb

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
