### PR TITLE
Add feature flag for past appointment date range selection

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1570,6 +1570,10 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle to use VaDate/VaDateField.
+  va_online_scheduling_past_appt_date_range:
+    actor_type: user
+    enable_in_development: true
+    description: Toggle for modifying the date range selection on the Past appointments page.
   va_v2_person_service:
     actor_type: user
     description: When enabled, the VAProfile::V2::Person::Service will be enabled


### PR DESCRIPTION
## Summary

- Adding a feature toggle for modifying the date range selection on the Past appointments page
- Appointments Tool Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103201

## Testing done

N/A

## Screenshots

N/A

## What areas of the site does it impact?

Appointments Tool

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

