### PR TITLE
Move RV1 reclassification upstream into the service

### DIFF
--- a/app/controllers/v0/benefits_claims_controller.rb
+++ b/app/controllers/v0/benefits_claims_controller.rb
@@ -27,13 +27,6 @@ module V0
       claim = service.get_claim(params[:id])
       update_claim_type_language(claim['data'])
 
-      # Manual status override for certain tracked items
-      # See https://github.com/department-of-veterans-affairs/va.gov-team/issues/101447
-      # This should be removed when the items are re-categorized by BGS
-      # We are not doing this in the Lighthouse service because we want web and mobile to have
-      # separate rollouts and testing.
-      claim = rename_rv1(claim) if Flipper.enabled?(:cst_override_reserve_records_website)
-
       # https://github.com/department-of-veterans-affairs/va.gov-team/issues/98364
       # This should be removed when the items are removed by BGS
       claim = suppress_evidence_requests(claim) if Flipper.enabled?(:cst_suppress_evidence_requests_website)
@@ -135,14 +128,6 @@ module V0
                               tracked_item_type: ti['displayName'],
                               tracked_item_status: ti['status'] })
       end
-    end
-
-    def rename_rv1(claim)
-      tracked_items = claim.dig('data', 'attributes', 'trackedItems')
-      tracked_items&.select { |i| i['displayName'] == 'RV1 - Reserve Records Request' }&.each do |i|
-        i['status'] = 'NEEDED_FROM_OTHERS'
-      end
-      claim
     end
 
     def suppress_evidence_requests(claim)

--- a/app/controllers/v0/virtual_agent/virtual_agent_claim_status_controller.rb
+++ b/app/controllers/v0/virtual_agent/virtual_agent_claim_status_controller.rb
@@ -55,25 +55,9 @@ module V0
 
       def get_claim_from_lighthouse(id)
         claim = lighthouse_service.get_claim(id)
-        # Manual status override for certain tracked items
-        # See https://github.com/department-of-veterans-affairs/va.gov-team/issues/101447
-        # This should be removed when the items are re-categorized by BGS
-        # We are not doing this in the Lighthouse service because we want web and mobile to have
-        # separate rollouts and testing.
-        claim = override_rv1(claim) if Flipper.enabled?(:cst_override_reserve_records_website)
         # https://github.com/department-of-veterans-affairs/va.gov-team/issues/98364
         # This should be removed when the items are removed by BGS
         claim = suppress_evidence_requests(claim) if Flipper.enabled?(:cst_suppress_evidence_requests_website)
-        claim
-      end
-
-      def override_rv1(claim)
-        tracked_items = claim.dig('data', 'attributes', 'trackedItems')
-        return claim unless tracked_items
-
-        tracked_items.select { |i| i['displayName'] == 'RV1 - Reserve Records Request' }.each do |i|
-          i['status'] = 'NEEDED_FROM_OTHERS'
-        end
         claim
       end
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -352,13 +352,9 @@ features:
     actor_type: user
     description: When enabled, CST overrides PMR Pending tracked items to be NEEDED_FROM_OTHERS
     enable_in_development: true
-  cst_override_reserve_records_website:
+  cst_override_reserve_records:
     actor_type: user
     description: When enabled, CST overrides RV1 - Reserve Records Request tracked items to be NEEDED_FROM_OTHERS on vets-website
-    enable_in_development: true
-  cst_override_reserve_records_mobile:
-    actor_type: user
-    description: When enabled, CST overrides RV1 - Reserve Records Request tracked items to be NEEDED_FROM_OTHERS on mobile app
     enable_in_development: true
   letters_hide_service_verification_letter:
     actor_type: user

--- a/lib/lighthouse/benefits_claims/service.rb
+++ b/lib/lighthouse/benefits_claims/service.rb
@@ -279,6 +279,12 @@ module BenefitsClaims
           i['displayName'] = 'Private Medical Record'
         end
       end
+
+      if Flipper.enabled?(:cst_override_reserve_records)
+        tracked_items.select { |i| i['displayName'] == 'RV1 - Reserve Records Request' }.each do |i|
+          i['status'] = 'NEEDED_FROM_OTHERS'
+        end
+      end
       tracked_items
     end
 

--- a/modules/mobile/app/services/mobile/v0/lighthouse_claims/proxy.rb
+++ b/modules/mobile/app/services/mobile/v0/lighthouse_claims/proxy.rb
@@ -35,7 +35,6 @@ module Mobile
         # separate rollouts and testing.
         def get_claim(id)
           claim = claims_service.get_claim(id)
-          claim = override_rv1(claim) if Flipper.enabled?(:cst_override_reserve_records_mobile)
           # https://github.com/department-of-veterans-affairs/va.gov-team/issues/98364
           # This should be removed when the items are removed by BGS
           claim = suppress_evidence_requests(claim) if Flipper.enabled?(:cst_suppress_evidence_requests_mobile)
@@ -61,16 +60,6 @@ module Mobile
                                   data: {})
           end
           claim.update(list_data: raw_claim)
-        end
-
-        def override_rv1(claim)
-          tracked_items = claim.dig('data', 'attributes', 'trackedItems')
-          return claim unless tracked_items
-
-          tracked_items.select { |i| i['displayName'] == 'RV1 - Reserve Records Request' }.each do |i|
-            i['status'] = 'NEEDED_FROM_OTHERS'
-          end
-          claim
         end
 
         def suppress_evidence_requests(claim)

--- a/modules/mobile/spec/requests/mobile/v0/lighthouse_claim_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/lighthouse_claim_spec.rb
@@ -57,10 +57,10 @@ RSpec.describe 'Mobile::V0::Claim', type: :request do
         expect(response.parsed_body.dig('data', 'attributes', 'claimTypeCode')).to eq('020NEW')
       end
 
-      context 'when cst_override_reserve_records_mobile flipper is enabled' do
+      context 'when cst_override_reserve_records flipper is enabled' do
         before do
           allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:cst_override_reserve_records_mobile).and_return(true)
+          allow(Flipper).to receive(:enabled?).with(:cst_override_reserve_records).and_return(true)
         end
 
         it 'overrides the tracked item status to NEEDED_FROM_OTHERS', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do
@@ -75,10 +75,10 @@ RSpec.describe 'Mobile::V0::Claim', type: :request do
         end
       end
 
-      context 'when cst_override_reserve_records_mobile flipper is disabled' do
+      context 'when cst_override_reserve_records flipper is disabled' do
         before do
           allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:cst_override_reserve_records_mobile).and_return(false)
+          allow(Flipper).to receive(:enabled?).with(:cst_override_reserve_records).and_return(false)
         end
 
         it 'leaves the tracked item status as NEEDED_FROM_YOU', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do

--- a/spec/controllers/v0/benefits_claims_controller_spec.rb
+++ b/spec/controllers/v0/benefits_claims_controller_spec.rb
@@ -114,10 +114,10 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
 
   describe '#show' do
     context 'when successful' do
-      context 'when cst_override_reserve_records_website flipper is enabled' do
+      context 'when cst_override_reserve_records flipper is enabled' do
         before do
           allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:cst_override_reserve_records_website).and_return(true)
+          allow(Flipper).to receive(:enabled?).with(:cst_override_reserve_records).and_return(true)
         end
 
         it 'overrides the tracked item status to NEEDED_FROM_OTHERS' do
@@ -132,10 +132,10 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
         end
       end
 
-      context 'when cst_override_reserve_records_website flipper is disabled' do
+      context 'when cst_override_reserve_records flipper is disabled' do
         before do
           allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:cst_override_reserve_records_website).and_return(false)
+          allow(Flipper).to receive(:enabled?).with(:cst_override_reserve_records).and_return(false)
         end
 
         it 'leaves the tracked item status as NEEDED_FROM_YOU' do

--- a/spec/controllers/v0/virtual_agent/virtual_agent_claim_status_spec.rb
+++ b/spec/controllers/v0/virtual_agent/virtual_agent_claim_status_spec.rb
@@ -167,10 +167,10 @@ RSpec.describe 'VirtualAgentClaimStatusController', type: :request do
           .and_return(@mock_cxdw_reporting_service)
       end
 
-      context 'when cst_override_reserve_records_website flipper is enabled' do
+      context 'when cst_override_reserve_records flipper is enabled' do
         before do
           allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:cst_override_reserve_records_website).and_return(true)
+          allow(Flipper).to receive(:enabled?).with(:cst_override_reserve_records).and_return(true)
         end
 
         it 'overrides the tracked item status to NEEDED_FROM_OTHERS' do
@@ -185,10 +185,10 @@ RSpec.describe 'VirtualAgentClaimStatusController', type: :request do
         end
       end
 
-      context 'when cst_override_reserve_records_website flipper is disabled' do
+      context 'when cst_override_reserve_records flipper is disabled' do
         before do
           allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:cst_override_reserve_records_website).and_return(false)
+          allow(Flipper).to receive(:enabled?).with(:cst_override_reserve_records).and_return(false)
         end
 
         it 'leaves the tracked item status as NEEDED_FROM_YOU' do


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): **YES**
- Identical functionality is now gated behind one single flipper at the service level, rather than two flippers that bifurcate website and mobile.
- I am on **BMT2**

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103093
- Previous work that added the actual functionality: https://github.com/department-of-veterans-affairs/vets-api/pull/20530

## Testing done

- [X] *New code is covered by unit tests*