### PR TITLE
Consolidate evidence suppression upstream at service level

### DIFF
--- a/app/controllers/v0/benefits_claims_controller.rb
+++ b/app/controllers/v0/benefits_claims_controller.rb
@@ -34,10 +34,6 @@ module V0
       # separate rollouts and testing.
       claim = rename_rv1(claim) if Flipper.enabled?(:cst_override_reserve_records_website)
 
-      # https://github.com/department-of-veterans-affairs/va.gov-team/issues/98364
-      # This should be removed when the items are removed by BGS
-      claim = suppress_evidence_requests(claim) if Flipper.enabled?(:cst_suppress_evidence_requests_website)
-
       # Document uploads to EVSS require a birls_id; This restriction should
       # be removed when we move to Lighthouse Benefits Documents for document uploads
       claim['data']['attributes']['canUpload'] = !@current_user.birls_id.nil?
@@ -142,14 +138,6 @@ module V0
       tracked_items&.select { |i| i['displayName'] == 'RV1 - Reserve Records Request' }&.each do |i|
         i['status'] = 'NEEDED_FROM_OTHERS'
       end
-      claim
-    end
-
-    def suppress_evidence_requests(claim)
-      tracked_items = claim.dig('data', 'attributes', 'trackedItems')
-      return unless tracked_items
-
-      tracked_items.reject! { |i| BenefitsClaims::Service::SUPPRESSED_EVIDENCE_REQUESTS.include?(i['displayName']) }
       claim
     end
   end

--- a/app/controllers/v0/virtual_agent/virtual_agent_claim_status_controller.rb
+++ b/app/controllers/v0/virtual_agent/virtual_agent_claim_status_controller.rb
@@ -61,9 +61,6 @@ module V0
         # We are not doing this in the Lighthouse service because we want web and mobile to have
         # separate rollouts and testing.
         claim = override_rv1(claim) if Flipper.enabled?(:cst_override_reserve_records_website)
-        # https://github.com/department-of-veterans-affairs/va.gov-team/issues/98364
-        # This should be removed when the items are removed by BGS
-        claim = suppress_evidence_requests(claim) if Flipper.enabled?(:cst_suppress_evidence_requests_website)
         claim
       end
 
@@ -74,14 +71,6 @@ module V0
         tracked_items.select { |i| i['displayName'] == 'RV1 - Reserve Records Request' }.each do |i|
           i['status'] = 'NEEDED_FROM_OTHERS'
         end
-        claim
-      end
-
-      def suppress_evidence_requests(claim)
-        tracked_items = claim.dig('data', 'attributes', 'trackedItems')
-        return unless tracked_items
-
-        tracked_items.reject! { |i| BenefitsClaims::Service::SUPPRESSED_EVIDENCE_REQUESTS.include?(i['displayName']) }
         claim
       end
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -340,13 +340,9 @@ features:
     actor_type: user
     description: When enabled, claims status tool uses DataDog's Real User Monitoring logging
     enable_in_development: false
-  cst_suppress_evidence_requests_website:
+  cst_suppress_evidence_requests:
     actor_type: user
     description: When enabled, CST does not show Attorney Fees, Secondary Action Required, or Stage 2 Development on website
-    enable_in_development: false
-  cst_suppress_evidence_requests_mobile:
-    actor_type: user
-    description: When enabled, CST does not show Attorney Fees, Secondary Action Required, or Stage 2 Development on mobile
     enable_in_development: false
   cst_override_pmr_pending_tracked_items:
     actor_type: user

--- a/lib/lighthouse/benefits_claims/service.rb
+++ b/lib/lighthouse/benefits_claims/service.rb
@@ -35,6 +35,9 @@ module BenefitsClaims
 
     def get_claim(id, lighthouse_client_id = nil, lighthouse_rsa_key_path = nil, options = {})
       claim = config.get("#{@icn}/claims/#{id}", lighthouse_client_id, lighthouse_rsa_key_path, options).body
+      # https://github.com/department-of-veterans-affairs/va.gov-team/issues/98364
+      # This should be removed when the items are removed by BGS
+      suppress_evidence_requests(claim['data']) if Flipper.enabled?(:cst_suppress_evidence_requests)
       # Manual status override for certain tracked items
       # See https://github.com/department-of-veterans-affairs/va-mobile-app/issues/9671
       # This should be removed when the items are re-categorized by BGS
@@ -280,6 +283,13 @@ module BenefitsClaims
         end
       end
       tracked_items
+    end
+
+    def suppress_evidence_requests(claim)
+      tracked_items = claim['attributes']['trackedItems']
+      return unless tracked_items
+
+      tracked_items.reject! { |i| SUPPRESSED_EVIDENCE_REQUESTS.include?(i['displayName']) }
     end
 
     def handle_error(error, lighthouse_client_id, endpoint)

--- a/modules/mobile/app/services/mobile/v0/lighthouse_claims/proxy.rb
+++ b/modules/mobile/app/services/mobile/v0/lighthouse_claims/proxy.rb
@@ -36,9 +36,6 @@ module Mobile
         def get_claim(id)
           claim = claims_service.get_claim(id)
           claim = override_rv1(claim) if Flipper.enabled?(:cst_override_reserve_records_mobile)
-          # https://github.com/department-of-veterans-affairs/va.gov-team/issues/98364
-          # This should be removed when the items are removed by BGS
-          claim = suppress_evidence_requests(claim) if Flipper.enabled?(:cst_suppress_evidence_requests_mobile)
           claim
         end
 
@@ -70,14 +67,6 @@ module Mobile
           tracked_items.select { |i| i['displayName'] == 'RV1 - Reserve Records Request' }.each do |i|
             i['status'] = 'NEEDED_FROM_OTHERS'
           end
-          claim
-        end
-
-        def suppress_evidence_requests(claim)
-          tracked_items = claim.dig('data', 'attributes', 'trackedItems')
-          return unless tracked_items
-
-          tracked_items.reject! { |i| BenefitsClaims::Service::SUPPRESSED_EVIDENCE_REQUESTS.include?(i['displayName']) }
           claim
         end
       end

--- a/modules/mobile/spec/requests/mobile/v0/lighthouse_claim_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/lighthouse_claim_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Mobile::V0::Claim', type: :request do
     context 'when the claim is found' do
       before do
         allow(Flipper).to receive(:enabled?).and_call_original
-        allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests_mobile).and_return(false)
+        allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests).and_return(false)
       end
 
       it 'matches our schema is successfully returned with the 200 status',
@@ -93,10 +93,10 @@ RSpec.describe 'Mobile::V0::Claim', type: :request do
         end
       end
 
-      context 'when :cst_suppress_evidence_requests_mobile is enabled' do
+      context 'when :cst_suppress_evidence_requests is enabled' do
         before do
           allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests_mobile).and_return(true)
+          allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests).and_return(true)
         end
 
         it 'excludes Attorney Fees, Secondary Action Required, and Stage 2 Development tracked items' do
@@ -110,10 +110,10 @@ RSpec.describe 'Mobile::V0::Claim', type: :request do
         end
       end
 
-      context 'when :cst_suppress_evidence_requests_mobile is disabled' do
+      context 'when :cst_suppress_evidence_requests is disabled' do
         before do
           allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests_mobile).and_return(false)
+          allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests).and_return(false)
         end
 
         it 'includes Attorney Fees, Secondary Action Required, and Stage 2 Development tracked items' do

--- a/spec/controllers/v0/benefits_claims_controller_spec.rb
+++ b/spec/controllers/v0/benefits_claims_controller_spec.rb
@@ -150,10 +150,10 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
         end
       end
 
-      context 'when :cst_suppress_evidence_requests_website is enabled' do
+      context 'when :cst_suppress_evidence_requests is enabled' do
         before do
           allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests_website).and_return(true)
+          allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests).and_return(true)
         end
 
         it 'excludes Attorney Fees, Secondary Action Required, and Stage 2 Development tracked items' do
@@ -169,10 +169,10 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
         end
       end
 
-      context 'when :cst_suppress_evidence_requests_website is disabled' do
+      context 'when :cst_suppress_evidence_requests is disabled' do
         before do
           allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests_website).and_return(false)
+          allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests).and_return(false)
         end
 
         it 'includes Attorney Fees, Secondary Action Required, and Stage 2 Development tracked items' do

--- a/spec/controllers/v0/virtual_agent/virtual_agent_claim_status_spec.rb
+++ b/spec/controllers/v0/virtual_agent/virtual_agent_claim_status_spec.rb
@@ -203,10 +203,10 @@ RSpec.describe 'VirtualAgentClaimStatusController', type: :request do
         end
       end
 
-      context 'when :cst_suppress_evidence_requests_website is enabled' do
+      context 'when :cst_suppress_evidence_requests is enabled' do
         before do
           allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests_website).and_return(true)
+          allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests).and_return(true)
         end
 
         it 'excludes Attorney Fees, Secondary Action Required, and Stage 2 Development tracked items' do
@@ -222,10 +222,10 @@ RSpec.describe 'VirtualAgentClaimStatusController', type: :request do
         end
       end
 
-      context 'when :cst_suppress_evidence_requests_website is disabled' do
+      context 'when :cst_suppress_evidence_requests is disabled' do
         before do
           allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests_website).and_return(false)
+          allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests).and_return(false)
         end
 
         it 'includes Attorney Fees, Secondary Action Required, and Stage 2 Development tracked items' do


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): **YES**
- Brings the evidence suppression logic upstream into the service layer under a single feature flipper, rather than under two flippers that bifurcate mobile and web.
- I am on **BMT2**

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103092
- This PR split the functionality into two flippers: https://github.com/department-of-veterans-affairs/vets-api/pull/20618

## Testing done

- [X] *New code is covered by unit tests*
