### PR TITLE
Revert "Bump mini_magick from 4.13.2 to 5.1.2"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -589,8 +589,8 @@ GEM
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    image_processing (1.14.0)
-      mini_magick (>= 4.9.5, < 6)
+    image_processing (1.13.0)
+      mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
     io-console (0.8.0)
     io-console (0.8.0-java)
@@ -668,9 +668,7 @@ GEM
     mimemagic (0.4.3)
       nokogiri (~> 1)
       rake
-    mini_magick (5.1.2)
-      benchmark
-      logger
+    mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
     minitest (5.25.4)


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#20802

I'd like to re-run tests on this branch a few times to rule out the possibility that this gem bump is causing the `spec/uploaders/evss_claim_document_uploader_spec.rb` failures. [Example here](https://github.com/department-of-veterans-affairs/vets-api/actions/runs/13397629727/job/37421765625).