### PR TITLE
Add optional `applicant_email` to PDF metadata - IVC CHAMPVA forms

### DIFF
--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
@@ -31,7 +31,7 @@ module IvcChampva
         'uuid' => @uuid,
         'primaryContactInfo' => @data['primary_contact_info'],
         'primaryContactEmail' => @data.dig('primary_contact_info', 'email').to_s,
-        'applicantEmail' => @data['applicant_email']&.to_s || ''
+        'applicantEmail' => @data['applicant_email'] || ''
       }
     end
 

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
@@ -30,7 +30,8 @@ module IvcChampva
         'businessLine' => 'CMP',
         'uuid' => @uuid,
         'primaryContactInfo' => @data['primary_contact_info'],
-        'primaryContactEmail' => @data.dig('primary_contact_info', 'email').to_s
+        'primaryContactEmail' => @data.dig('primary_contact_info', 'email').to_s,
+        'applicantEmail' => @data['applicant_email']&.to_s || ''
       }
     end
 

--- a/modules/ivc_champva/spec/fixtures/form_json/vha_10_7959c.json
+++ b/modules/ivc_champva/spec/fixtures/form_json/vha_10_7959c.json
@@ -21,6 +21,7 @@
     "postal_code": "12323"
   },
   "has_other_health_insurance": true,
+  "applicant_email": "applicant@email.gov",
   "applicant_phone": "3331233456",
   "applicant_medicare_status": true,
   "applicant_medicare_part_a_carrier": "Test A Carrier",

--- a/modules/ivc_champva/spec/models/vha_10_7959c_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959c_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe IvcChampva::VHA107959c do
       'veteran_supporting_documents' => [
         { 'confirmation_code' => 'abc123' },
         { 'confirmation_code' => 'def456' }
-      ]
+      ],
+      'applicant_email' => 'applicant@email.gov'
     }
   end
   let(:vha107959c) { described_class.new(data) }
@@ -59,7 +60,8 @@ RSpec.describe IvcChampva::VHA107959c do
           },
           'email' => false
         },
-        'primaryContactEmail' => 'false'
+        'primaryContactEmail' => 'false',
+        'applicantEmail' => 'applicant@email.gov'
       )
     end
   end


### PR DESCRIPTION
## Summary

This PR updates the metadata for IVC CHAMPVA form 10-7959c to include the `applicantEmail` property. This is so that submitted attachments will contain the the applicant's email address embedded in the file metadata upon submission to S3. 

- Updates IVC form 10-7959c metadata constructor to include new email prop
- Update relevant test data in spec files


## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/102728

## Testing done

- [X] *New code is covered by unit tests*

## Screenshots

NA

## What areas of the site does it impact?

IVC CHAMPVA form 10-7959c

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA
