### PR TITLE
Vi 1056 add user action event validations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,17 +131,6 @@ PATH
     vye (0.1.0)
 
 GEM
-  remote: https://enterprise.contribsys.com/
-  specs:
-    sidekiq-ent (7.3.4)
-      einhorn (~> 1.0)
-      gserver
-      sidekiq (>= 7.3.7, < 8)
-      sidekiq-pro (>= 7.3.4, < 8)
-    sidekiq-pro (7.3.5)
-      sidekiq (>= 7.3.7, < 8)
-
-GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (2.0.1)
@@ -419,7 +408,6 @@ GEM
       dry-initializer (~> 3.2)
       dry-schema (~> 1.14)
       zeitwerk (~> 2.6)
-    einhorn (1.0.0)
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
@@ -540,7 +528,6 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    gserver (0.0.1)
     guard (2.18.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -1322,8 +1309,6 @@ DEPENDENCIES
   shoulda-matchers
   shrine
   sidekiq
-  sidekiq-ent!
-  sidekiq-pro!
   sign_in_service
   simple_forms_api!
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,17 @@ PATH
     vye (0.1.0)
 
 GEM
+  remote: https://enterprise.contribsys.com/
+  specs:
+    sidekiq-ent (7.3.4)
+      einhorn (~> 1.0)
+      gserver
+      sidekiq (>= 7.3.7, < 8)
+      sidekiq-pro (>= 7.3.4, < 8)
+    sidekiq-pro (7.3.5)
+      sidekiq (>= 7.3.7, < 8)
+
+GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (2.0.1)
@@ -408,6 +419,7 @@ GEM
       dry-initializer (~> 3.2)
       dry-schema (~> 1.14)
       zeitwerk (~> 2.6)
+    einhorn (1.0.0)
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
@@ -528,6 +540,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
+    gserver (0.0.1)
     guard (2.18.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -1309,6 +1322,8 @@ DEPENDENCIES
   shoulda-matchers
   shrine
   sidekiq
+  sidekiq-ent!
+  sidekiq-pro!
   sign_in_service
   simple_forms_api!
   simplecov

--- a/app/models/user_action_event.rb
+++ b/app/models/user_action_event.rb
@@ -4,4 +4,24 @@ class UserActionEvent < ApplicationRecord
   has_many :user_actions, dependent: :restrict_with_exception
 
   validates :details, presence: true
+  validates :event_id, presence: true, uniqueness: true
+  validates :event_type, presence: true
+
+  enum :event_type, { authentication: 0, profile: 1 }
+
+  before_validation :strip_event_id
+  before_update :prevent_event_id_change
+
+  private
+
+  def strip_event_id
+    self.event_id = event_id.strip if event_id.present?
+  end
+
+  def prevent_event_id_change
+    if event_id_changed? && persisted?
+      errors.add(:event_id, 'cannot be changed')
+      throw(:abort)
+    end
+  end
 end

--- a/app/models/user_action_event.rb
+++ b/app/models/user_action_event.rb
@@ -4,7 +4,9 @@ class UserActionEvent < ApplicationRecord
   has_many :user_actions, dependent: :restrict_with_exception
 
   validates :details, presence: true
-  validates :event_id, presence: true, uniqueness: true
+  # rubocop:disable Rails/UniqueValidationWithoutIndex
+  validates :event_id, presence: true, uniqueness: { case_sensitive: true }
+  # rubocop:enable Rails/UniqueValidationWithoutIndex
   validates :event_type, presence: true
 
   enum :event_type, { authentication: 0, profile: 1 }

--- a/spec/factories/user_action_events.rb
+++ b/spec/factories/user_action_events.rb
@@ -3,5 +3,7 @@
 FactoryBot.define do
   factory :user_action_event do
     details { Faker::Lorem.sentence }
+    event_id { "event_#{SecureRandom.hex(4)}" }
+    event_type { :authentication }
   end
 end

--- a/spec/factories/user_action_events.rb
+++ b/spec/factories/user_action_events.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :user_action_event do
     details { Faker::Lorem.sentence }
-    event_id { "event_#{SecureRandom.hex(4)}" }
+    event_id { SecureRandom.uuid }
     event_type { :authentication }
   end
 end

--- a/spec/models/user_action_event_spec.rb
+++ b/spec/models/user_action_event_spec.rb
@@ -4,7 +4,51 @@ require 'rails_helper'
 
 RSpec.describe UserActionEvent, type: :model do
   describe 'validations' do
+    subject { build(:user_action_event) }
+
     it { is_expected.to validate_presence_of(:details) }
+    it { is_expected.to validate_presence_of(:event_id) }
+    it { is_expected.to validate_uniqueness_of(:event_id) }
+    it { is_expected.to validate_presence_of(:event_type) }
+  end
+
+  describe 'enums' do
+    it { is_expected.to define_enum_for(:event_type).with_values(authentication: 0, profile: 1) }
+
+    describe 'event types' do
+      let(:auth_event) { build(:user_action_event, event_type: :authentication) }
+      let(:profile_event) { build(:user_action_event, event_type: :profile) }
+
+      it 'allows setting authentication type' do
+        expect(auth_event).to be_valid
+        expect(auth_event).to be_authentication
+      end
+
+      it 'allows setting profile type' do
+        expect(profile_event).to be_valid
+        expect(profile_event).to be_profile
+      end
+
+      it 'prevents invalid event types' do
+        expect { 
+          build(:user_action_event, event_type: :invalid)
+        }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe 'event_id format' do
+    let(:event1) { create(:user_action_event) }
+    let(:event2) { create(:user_action_event) }
+    let(:auth_event) { create(:user_action_event, event_type: :authentication) }
+
+    it 'generates unique event_ids' do
+      expect(event1.event_id).not_to eq(event2.event_id)
+    end
+
+    it 'prefixes authentication events correctly' do
+      expect(auth_event.event_id).to start_with('event_')
+    end
   end
 
   describe 'associations' do
@@ -18,6 +62,72 @@ RSpec.describe UserActionEvent, type: :model do
       it 'restricts destruction when user actions exist' do
         expect { user_action_event.destroy }.to raise_error(ActiveRecord::DeleteRestrictionError)
       end
+    end
+  end
+
+  describe 'event_id validations' do
+    let(:event) { build(:user_action_event) }
+    
+    it 'rejects duplicate event_ids' do
+      create(:user_action_event, event_id: 'duplicate_id')
+      duplicate_event = build(:user_action_event, event_id: 'duplicate_id')
+      expect(duplicate_event).not_to be_valid
+      expect(duplicate_event.errors[:event_id]).to include('has already been taken')
+    end
+
+    it 'is case sensitive with event_ids' do
+      create(:user_action_event, event_id: 'TEST_ID')
+      duplicate_event = build(:user_action_event, event_id: 'test_id')
+      expect(duplicate_event).to be_valid
+    end
+  end
+
+  describe 'event type transitions' do
+    let(:event) { create(:user_action_event, event_type: :authentication) }
+
+    it 'allows changing event type' do
+      event.profile!
+      expect(event).to be_profile
+      expect(event).not_to be_authentication
+    end
+
+    it 'persists event type changes' do
+      event.profile!
+      event.reload
+      expect(event).to be_profile
+    end
+  end
+
+  describe 'scopes' do
+    let!(:auth_event) { create(:user_action_event, event_type: :authentication) }
+    let!(:profile_event) { create(:user_action_event, event_type: :profile) }
+
+    it 'filters authentication events' do
+      expect(described_class.authentication).to include(auth_event)
+      expect(described_class.authentication).not_to include(profile_event)
+    end
+
+    it 'filters profile events' do
+      expect(described_class.profile).to include(profile_event)
+      expect(described_class.profile).not_to include(auth_event)
+    end
+  end
+
+  describe 'data integrity' do
+    let(:event) { build(:user_action_event) }
+
+    it 'strips whitespace from event_id' do
+      event.event_id = ' test_id '
+      event.valid?
+      expect(event.event_id).to eq('test_id')
+    end
+
+    it 'prevents changing event_id after creation' do
+      event.save!
+      original_id = event.event_id
+      event.update(event_id: 'new_id')
+      event.reload
+      expect(event.event_id).to eq(original_id)
     end
   end
 end

--- a/spec/models/user_action_event_spec.rb
+++ b/spec/models/user_action_event_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe UserActionEvent, type: :model do
   end
 
   describe 'enums' do
-    it { is_expected.to define_enum_for(:event_type).with_values(authentication: 0, profile: 1) }
+    let(:expected_event_types) { { authentication: 0, profile: 1 } }
+
+    it { is_expected.to define_enum_for(:event_type).with_values(expected_event_types) }
 
     describe 'event types' do
       let(:auth_event) { build(:user_action_event, event_type: :authentication) }
@@ -21,12 +23,12 @@ RSpec.describe UserActionEvent, type: :model do
 
       it 'allows setting authentication type' do
         expect(auth_event).to be_valid
-        expect(auth_event).to be_authentication
+        expect(auth_event.event_type).to eq('authentication')
       end
 
       it 'allows setting profile type' do
         expect(profile_event).to be_valid
-        expect(profile_event).to be_profile
+        expect(profile_event.event_type).to eq('profile')
       end
 
       it 'prevents invalid event types' do
@@ -34,20 +36,6 @@ RSpec.describe UserActionEvent, type: :model do
           build(:user_action_event, event_type: :invalid)
         end.to raise_error(ArgumentError)
       end
-    end
-  end
-
-  describe 'event_id format' do
-    let(:event1) { create(:user_action_event) }
-    let(:event2) { create(:user_action_event) }
-    let(:auth_event) { create(:user_action_event, event_type: :authentication) }
-
-    it 'generates unique event_ids' do
-      expect(event1.event_id).not_to eq(event2.event_id)
-    end
-
-    it 'prefixes authentication events correctly' do
-      expect(auth_event.event_id).to start_with('event_')
     end
   end
 

--- a/spec/models/user_action_event_spec.rb
+++ b/spec/models/user_action_event_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe UserActionEvent, type: :model do
       end
 
       it 'prevents invalid event types' do
-        expect { 
+        expect do
           build(:user_action_event, event_type: :invalid)
-        }.to raise_error(ArgumentError)
+        end.to raise_error(ArgumentError)
       end
     end
   end
@@ -67,7 +67,7 @@ RSpec.describe UserActionEvent, type: :model do
 
   describe 'event_id validations' do
     let(:event) { build(:user_action_event) }
-    
+
     it 'rejects duplicate event_ids' do
       create(:user_action_event, event_id: 'duplicate_id')
       duplicate_event = build(:user_action_event, event_id: 'duplicate_id')


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Adding model validations and enums for UserActionEvent:
  - Validates presence and uniqueness of event_id
  - Validates presence of event_type
  - Adds enum for event types (authentication, profile)
  - Adds data integrity callbacks for event_id handling
- Part of Identity team's work on improving audit logging structure
- Third PR in a series to implement user action event tracking

## Related issue(s)

- [VI-1056](https://jira.devops.va.gov/browse/VI-1056) - User event table - event type
- Related to:
  - PR1 - First PR that added columns
  - PR2 - Second PR that added constraints

## Testing done

- [x] New code is covered by unit tests
- Previous: Database columns and constraints existed
- Current: Added model validations and behavior
- Testing steps:
  1. Run model specs to verify validations
  2. Test enum behavior for event types
  3. Verify data integrity callbacks
  4. Ensure factory creates valid records
  5. Run `bundle exec rspec spec/models/user_action_event_spec.rb`

## What areas of the site does it impact?

- UserActionEvent model behavior
- Event type categorization
- Data integrity for event tracking
- No direct UI impact

## Acceptance criteria

- [x] Added model validations for required fields
- [x] Implemented event type enum
- [x] Added data integrity callbacks
- [x] All tests passing
- [x] No sensitive information in code
- [x] Factory creates valid records

## Requested Feedback

This is PR3 of 3:
1. PR1: Add columns and fix tests (merged)
2. PR2: Add constraints and indexes (merged)
3. PR3 (current): Add model validations