### PR TITLE
Vets.env to complement Rails.env

### DIFF
--- a/lib/vets/environment.rb
+++ b/lib/vets/environment.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# .to_s and .inspect are required to output a string
+# and still work with the predicate methods
+module Vets
+
+  # Vets::Env provides methods to get and check the
+  # current vsp_environment similar to Rails.env.
+  class Environment
+    class << self
+      def current
+        ENV["VSP_ENVIRONMENT"] || "localhost"
+      end
+
+      def to_s
+        current
+      end
+
+      def inspect
+        current.inspect
+      end
+
+      def development?
+        current == "development"
+      end
+
+      def production?
+        current == "production"
+      end
+
+      def staging?
+        current == "staging"
+      end
+
+      def sandbox?
+        current == "sandbox"
+      end
+
+      def local?
+        test? || localhost?
+      end
+
+      def lower?
+        development? || staging?
+      end
+
+      def higher?
+        sandbox? || production?
+      end
+
+      def deployed?
+        !local?
+      end
+
+      private
+
+      def test?
+        current == "test"
+      end
+
+      def localhost?
+        current == "localhost"
+      end
+    end
+  end
+
+  # Vets.env allows you to access the Env class and call its methods.
+  # Example usage:
+  #   Vets.env              # => "development" (or "production", etc.)
+  #   Vets.env.to_s         # => "development"
+  #   Vets.env.production?  # => false (if not in production)
+  #   Vets.env.development? # => true (if in development)
+  def self.env
+    Environment
+  end
+end

--- a/lib/vets/environment.rb
+++ b/lib/vets/environment.rb
@@ -17,6 +17,14 @@ module Vets
 
       delegate :inspect, to: :current
 
+      def localhost?
+        current == 'localhost'
+      end
+
+      def test?
+        current == 'test'
+      end
+
       def development?
         current == 'development'
       end
@@ -47,16 +55,6 @@ module Vets
 
       def deployed?
         !local?
-      end
-
-      private
-
-      def test?
-        current == 'test'
-      end
-
-      def localhost?
-        current == 'localhost'
       end
     end
   end

--- a/lib/vets/environment.rb
+++ b/lib/vets/environment.rb
@@ -3,37 +3,34 @@
 # .to_s and .inspect are required to output a string
 # and still work with the predicate methods
 module Vets
-
   # Vets::Env provides methods to get and check the
   # current vsp_environment similar to Rails.env.
   class Environment
     class << self
       def current
-        ENV["VSP_ENVIRONMENT"] || "localhost"
+        ENV['VSP_ENVIRONMENT'] || 'localhost'
       end
 
       def to_s
         current
       end
 
-      def inspect
-        current.inspect
-      end
+      delegate :inspect, to: :current
 
       def development?
-        current == "development"
+        current == 'development'
       end
 
       def production?
-        current == "production"
+        current == 'production'
       end
 
       def staging?
-        current == "staging"
+        current == 'staging'
       end
 
       def sandbox?
-        current == "sandbox"
+        current == 'sandbox'
       end
 
       def local?
@@ -55,11 +52,11 @@ module Vets
       private
 
       def test?
-        current == "test"
+        current == 'test'
       end
 
       def localhost?
-        current == "localhost"
+        current == 'localhost'
       end
     end
   end

--- a/lib/vets/environment.rb
+++ b/lib/vets/environment.rb
@@ -3,7 +3,7 @@
 # .to_s and .inspect are required to output a string
 # and still work with the predicate methods
 module Vets
-  # Vets::Env provides methods to get and check the
+  # Vets::Environment provides methods to get and check the
   # current vsp_environment similar to Rails.env.
   class Environment
     class << self

--- a/spec/lib/vets/environment_spec.rb
+++ b/spec/lib/vets/environment_spec.rb
@@ -3,12 +3,11 @@
 require 'rails_helper'
 require 'vets/environment'
 
-
 RSpec.describe Vets::Environment do
   let(:environment_value) { nil }
 
   before do
-    allow(ENV).to receive(:[]).with("VSP_ENVIRONMENT").and_return(environment_value)
+    allow(ENV).to receive(:[]).with('VSP_ENVIRONMENT').and_return(environment_value)
   end
 
   describe '.current' do
@@ -16,36 +15,36 @@ RSpec.describe Vets::Environment do
       let(:environment_value) { nil }
 
       it 'returns "localhost" as the default value' do
-        expect(described_class.current).to eq("localhost")
+        expect(described_class.current).to eq('localhost')
       end
     end
 
     context 'when VSP_ENVIRONMENT is set to "development"' do
-      let(:environment_value) { "development" }
+      let(:environment_value) { 'development' }
 
       it 'returns "development"' do
-        expect(described_class.current).to eq("development")
+        expect(described_class.current).to eq('development')
       end
     end
   end
 
   describe '.to_s' do
     it 'returns the current environment as a string' do
-      allow(ENV).to receive(:[]).with("VSP_ENVIRONMENT").and_return("production")
-      expect(described_class.to_s).to eq("production")
+      allow(ENV).to receive(:[]).with('VSP_ENVIRONMENT').and_return('production')
+      expect(described_class.to_s).to eq('production')
     end
   end
 
   describe '.inspect' do
     it 'returns the current environment as a string (formatted for inspection)' do
-      allow(ENV).to receive(:[]).with("VSP_ENVIRONMENT").and_return("staging")
-      expect(described_class.inspect).to eq("\"staging\"")
+      allow(ENV).to receive(:[]).with('VSP_ENVIRONMENT').and_return('staging')
+      expect(described_class.inspect).to eq('"staging"')
     end
   end
 
   describe '.development?' do
     context 'when environment is "development"' do
-      let(:environment_value) { "development" }
+      let(:environment_value) { 'development' }
 
       it 'returns true' do
         expect(described_class.development?).to be(true)
@@ -53,7 +52,7 @@ RSpec.describe Vets::Environment do
     end
 
     context 'when environment is not "development"' do
-      let(:environment_value) { "production" }
+      let(:environment_value) { 'production' }
 
       it 'returns false' do
         expect(described_class.development?).to be(false)
@@ -63,7 +62,7 @@ RSpec.describe Vets::Environment do
 
   describe '.production?' do
     context 'when environment is "production"' do
-      let(:environment_value) { "production" }
+      let(:environment_value) { 'production' }
 
       it 'returns true' do
         expect(described_class.production?).to be(true)
@@ -71,7 +70,7 @@ RSpec.describe Vets::Environment do
     end
 
     context 'when environment is not "production"' do
-      let(:environment_value) { "staging" }
+      let(:environment_value) { 'staging' }
 
       it 'returns false' do
         expect(described_class.production?).to be(false)
@@ -81,7 +80,7 @@ RSpec.describe Vets::Environment do
 
   describe '.staging?' do
     context 'when environment is "staging"' do
-      let(:environment_value) { "staging" }
+      let(:environment_value) { 'staging' }
 
       it 'returns true' do
         expect(described_class.staging?).to be(true)
@@ -89,7 +88,7 @@ RSpec.describe Vets::Environment do
     end
 
     context 'when environment is not "staging"' do
-      let(:environment_value) { "production" }
+      let(:environment_value) { 'production' }
 
       it 'returns false' do
         expect(described_class.staging?).to be(false)
@@ -99,7 +98,7 @@ RSpec.describe Vets::Environment do
 
   describe '.sandbox?' do
     context 'when environment is "sandbox"' do
-      let(:environment_value) { "sandbox" }
+      let(:environment_value) { 'sandbox' }
 
       it 'returns true' do
         expect(described_class.sandbox?).to be(true)
@@ -107,7 +106,7 @@ RSpec.describe Vets::Environment do
     end
 
     context 'when environment is not "sandbox"' do
-      let(:environment_value) { "test" }
+      let(:environment_value) { 'test' }
 
       it 'returns false' do
         expect(described_class.sandbox?).to be(false)
@@ -117,7 +116,7 @@ RSpec.describe Vets::Environment do
 
   describe '.local?' do
     context 'when environment is "localhost"' do
-      let(:environment_value) { "localhost" }
+      let(:environment_value) { 'localhost' }
 
       it 'returns true' do
         expect(described_class.local?).to be(true)
@@ -125,7 +124,7 @@ RSpec.describe Vets::Environment do
     end
 
     context 'when environment is "test"' do
-      let(:environment_value) { "test" }
+      let(:environment_value) { 'test' }
 
       it 'returns true' do
         expect(described_class.local?).to be(true)
@@ -133,7 +132,7 @@ RSpec.describe Vets::Environment do
     end
 
     context 'when environment is not "localhost" or "test"' do
-      let(:environment_value) { "production" }
+      let(:environment_value) { 'production' }
 
       it 'returns false' do
         expect(described_class.local?).to be(false)
@@ -143,7 +142,7 @@ RSpec.describe Vets::Environment do
 
   describe '.lower?' do
     context 'when environment is "development"' do
-      let(:environment_value) { "development" }
+      let(:environment_value) { 'development' }
 
       it 'returns true' do
         expect(described_class.lower?).to be(true)
@@ -151,7 +150,7 @@ RSpec.describe Vets::Environment do
     end
 
     context 'when environment is "staging"' do
-      let(:environment_value) { "staging" }
+      let(:environment_value) { 'staging' }
 
       it 'returns true' do
         expect(described_class.lower?).to be(true)
@@ -159,7 +158,7 @@ RSpec.describe Vets::Environment do
     end
 
     context 'when environment is "production"' do
-      let(:environment_value) { "production" }
+      let(:environment_value) { 'production' }
 
       it 'returns false' do
         expect(described_class.lower?).to be(false)
@@ -169,7 +168,7 @@ RSpec.describe Vets::Environment do
 
   describe '.higher?' do
     context 'when environment is "sandbox"' do
-      let(:environment_value) { "sandbox" }
+      let(:environment_value) { 'sandbox' }
 
       it 'returns true' do
         expect(described_class.higher?).to be(true)
@@ -177,7 +176,7 @@ RSpec.describe Vets::Environment do
     end
 
     context 'when environment is "production"' do
-      let(:environment_value) { "production" }
+      let(:environment_value) { 'production' }
 
       it 'returns true' do
         expect(described_class.higher?).to be(true)
@@ -185,7 +184,7 @@ RSpec.describe Vets::Environment do
     end
 
     context 'when environment is "development"' do
-      let(:environment_value) { "development" }
+      let(:environment_value) { 'development' }
 
       it 'returns false' do
         expect(described_class.higher?).to be(false)
@@ -195,7 +194,7 @@ RSpec.describe Vets::Environment do
 
   describe '.deployed?' do
     context 'when environment is local' do
-      let(:environment_value) { "localhost" }
+      let(:environment_value) { 'localhost' }
 
       it 'returns false' do
         expect(described_class.deployed?).to be(false)
@@ -203,7 +202,7 @@ RSpec.describe Vets::Environment do
     end
 
     context 'when environment is deployed' do
-      let(:environment_value) { "production" }
+      let(:environment_value) { 'production' }
 
       it 'returns true' do
         expect(described_class.deployed?).to be(true)

--- a/spec/lib/vets/environment_spec.rb
+++ b/spec/lib/vets/environment_spec.rb
@@ -42,6 +42,42 @@ RSpec.describe Vets::Environment do
     end
   end
 
+  describe '.localhost?' do
+    context 'when environment is "localhost"' do
+      let(:environment_value) { 'localhost' }
+
+      it 'returns true' do
+        expect(described_class.localhost?).to be(true)
+      end
+    end
+
+    context 'when environment is not "localhost"' do
+      let(:environment_value) { 'production' }
+
+      it 'returns false' do
+        expect(described_class.localhost?).to be(false)
+      end
+    end
+  end
+
+  describe '.test?' do
+    context 'when environment is "test"' do
+      let(:environment_value) { 'test' }
+
+      it 'returns true' do
+        expect(described_class.test?).to be(true)
+      end
+    end
+
+    context 'when environment is not "test"' do
+      let(:environment_value) { 'production' }
+
+      it 'returns false' do
+        expect(described_class.test?).to be(false)
+      end
+    end
+  end
+  
   describe '.development?' do
     context 'when environment is "development"' do
       let(:environment_value) { 'development' }

--- a/spec/lib/vets/environment_spec.rb
+++ b/spec/lib/vets/environment_spec.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'vets/environment'
+
+
+RSpec.describe Vets::Environment do
+  let(:environment_value) { nil }
+
+  before do
+    allow(ENV).to receive(:[]).with("VSP_ENVIRONMENT").and_return(environment_value)
+  end
+
+  describe '.current' do
+    context 'when VSP_ENVIRONMENT is not set' do
+      let(:environment_value) { nil }
+
+      it 'returns "localhost" as the default value' do
+        expect(described_class.current).to eq("localhost")
+      end
+    end
+
+    context 'when VSP_ENVIRONMENT is set to "development"' do
+      let(:environment_value) { "development" }
+
+      it 'returns "development"' do
+        expect(described_class.current).to eq("development")
+      end
+    end
+  end
+
+  describe '.to_s' do
+    it 'returns the current environment as a string' do
+      allow(ENV).to receive(:[]).with("VSP_ENVIRONMENT").and_return("production")
+      expect(described_class.to_s).to eq("production")
+    end
+  end
+
+  describe '.inspect' do
+    it 'returns the current environment as a string (formatted for inspection)' do
+      allow(ENV).to receive(:[]).with("VSP_ENVIRONMENT").and_return("staging")
+      expect(described_class.inspect).to eq("\"staging\"")
+    end
+  end
+
+  describe '.development?' do
+    context 'when environment is "development"' do
+      let(:environment_value) { "development" }
+
+      it 'returns true' do
+        expect(described_class.development?).to be(true)
+      end
+    end
+
+    context 'when environment is not "development"' do
+      let(:environment_value) { "production" }
+
+      it 'returns false' do
+        expect(described_class.development?).to be(false)
+      end
+    end
+  end
+
+  describe '.production?' do
+    context 'when environment is "production"' do
+      let(:environment_value) { "production" }
+
+      it 'returns true' do
+        expect(described_class.production?).to be(true)
+      end
+    end
+
+    context 'when environment is not "production"' do
+      let(:environment_value) { "staging" }
+
+      it 'returns false' do
+        expect(described_class.production?).to be(false)
+      end
+    end
+  end
+
+  describe '.staging?' do
+    context 'when environment is "staging"' do
+      let(:environment_value) { "staging" }
+
+      it 'returns true' do
+        expect(described_class.staging?).to be(true)
+      end
+    end
+
+    context 'when environment is not "staging"' do
+      let(:environment_value) { "production" }
+
+      it 'returns false' do
+        expect(described_class.staging?).to be(false)
+      end
+    end
+  end
+
+  describe '.sandbox?' do
+    context 'when environment is "sandbox"' do
+      let(:environment_value) { "sandbox" }
+
+      it 'returns true' do
+        expect(described_class.sandbox?).to be(true)
+      end
+    end
+
+    context 'when environment is not "sandbox"' do
+      let(:environment_value) { "test" }
+
+      it 'returns false' do
+        expect(described_class.sandbox?).to be(false)
+      end
+    end
+  end
+
+  describe '.local?' do
+    context 'when environment is "localhost"' do
+      let(:environment_value) { "localhost" }
+
+      it 'returns true' do
+        expect(described_class.local?).to be(true)
+      end
+    end
+
+    context 'when environment is "test"' do
+      let(:environment_value) { "test" }
+
+      it 'returns true' do
+        expect(described_class.local?).to be(true)
+      end
+    end
+
+    context 'when environment is not "localhost" or "test"' do
+      let(:environment_value) { "production" }
+
+      it 'returns false' do
+        expect(described_class.local?).to be(false)
+      end
+    end
+  end
+
+  describe '.lower?' do
+    context 'when environment is "development"' do
+      let(:environment_value) { "development" }
+
+      it 'returns true' do
+        expect(described_class.lower?).to be(true)
+      end
+    end
+
+    context 'when environment is "staging"' do
+      let(:environment_value) { "staging" }
+
+      it 'returns true' do
+        expect(described_class.lower?).to be(true)
+      end
+    end
+
+    context 'when environment is "production"' do
+      let(:environment_value) { "production" }
+
+      it 'returns false' do
+        expect(described_class.lower?).to be(false)
+      end
+    end
+  end
+
+  describe '.higher?' do
+    context 'when environment is "sandbox"' do
+      let(:environment_value) { "sandbox" }
+
+      it 'returns true' do
+        expect(described_class.higher?).to be(true)
+      end
+    end
+
+    context 'when environment is "production"' do
+      let(:environment_value) { "production" }
+
+      it 'returns true' do
+        expect(described_class.higher?).to be(true)
+      end
+    end
+
+    context 'when environment is "development"' do
+      let(:environment_value) { "development" }
+
+      it 'returns false' do
+        expect(described_class.higher?).to be(false)
+      end
+    end
+  end
+
+  describe '.deployed?' do
+    context 'when environment is local' do
+      let(:environment_value) { "localhost" }
+
+      it 'returns false' do
+        expect(described_class.deployed?).to be(false)
+      end
+    end
+
+    context 'when environment is deployed' do
+      let(:environment_value) { "production" }
+
+      it 'returns true' do
+        expect(described_class.deployed?).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `Vets::Environment` creates a complementary utility to `Rails.env` for deployed environments
- doesn't restrict `Rails.env` usage
   - `Rails.env.production?` and `Vets.env.deploy?` are effectively the same

This class could be used to replace Settings that track deployed environments, such as `Setting.my_service.mock`. 

```ruby
# Example usage:
Vets.env              # => "development" (or "production", etc.)
Vets.env.to_s         # => "development"
Vets.env.production?  # => false (if not in production)
Vets.env.development? # => true (if in development)
```

## Related issue(s)

- n/a

## Testing done

- [x] New test added

## Acceptance criteria

- [x] Mimics `Rails.env` functionality for deployed environment
- [x] Doesn't restrict `Rails.env` usage