### PR TITLE
VCR ignore datadog trace and EC2 metadata uris

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -84,13 +84,16 @@ end
 
 VCR.configure do |config|
   ignored_uris = [
-    'http://127.0.0.1:8126/v0.4/traces', # datadog
     'http://169.254.169.254/latest/api/token' # ec2
   ]
 
   config.ignore_request do |request|
     ignored_uris.include?(request.uri)
   end
+end
+
+Datadog.configure do |c|
+  c.tracing.enabled = false
 end
 
 ActiveRecord::Migration.maintain_test_schema!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,6 +82,18 @@ VCR.configure do |c|
   end
 end
 
+VCR.configure do |config|
+
+  ignored_uris = [
+    "http://127.0.0.1:8126/v0.4/traces", # datadog
+    "http://169.254.169.254/latest/api/token" # ec2
+  ]
+
+  config.ignore_request do |request|
+    ignored_uris.include?(request.uri)
+  end
+end
+
 ActiveRecord::Migration.maintain_test_schema!
 
 require 'sidekiq/testing'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -83,10 +83,9 @@ VCR.configure do |c|
 end
 
 VCR.configure do |config|
-
   ignored_uris = [
-    "http://127.0.0.1:8126/v0.4/traces", # datadog
-    "http://169.254.169.254/latest/api/token" # ec2
+    'http://127.0.0.1:8126/v0.4/traces', # datadog
+    'http://169.254.169.254/latest/api/token' # ec2
   ]
 
   config.ignore_request do |request|


### PR DESCRIPTION
## Summary

- The CI logs have 26 instances of VCR errors for:
    - unhandled requests to datadog trace and ec2 metadata
- This adds over 550 log lines which is roughly 40% of the total lines
- They should be ignored by VCR

## Related issue(s)

- n/a

## Testing done

- [ ] only testing on CI

## Acceptance criteria

- [ ] Datadog and EC2 VCRs warnings are ignored in CI logs