### PR TITLE
Vi 1056 add user action event constraints fresh

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,17 @@ PATH
     vye (0.1.0)
 
 GEM
+  remote: https://enterprise.contribsys.com/
+  specs:
+    sidekiq-ent (7.3.4)
+      einhorn (~> 1.0)
+      gserver
+      sidekiq (>= 7.3.7, < 8)
+      sidekiq-pro (>= 7.3.4, < 8)
+    sidekiq-pro (7.3.5)
+      sidekiq (>= 7.3.7, < 8)
+
+GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (2.0.1)
@@ -408,6 +419,7 @@ GEM
       dry-initializer (~> 3.2)
       dry-schema (~> 1.14)
       zeitwerk (~> 2.6)
+    einhorn (1.0.0)
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
@@ -528,6 +540,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
+    gserver (0.0.1)
     guard (2.18.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -1310,6 +1323,8 @@ DEPENDENCIES
   shoulda-matchers
   shrine
   sidekiq
+  sidekiq-ent!
+  sidekiq-pro!
   sign_in_service
   simple_forms_api!
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,17 +131,6 @@ PATH
     vye (0.1.0)
 
 GEM
-  remote: https://enterprise.contribsys.com/
-  specs:
-    sidekiq-ent (7.3.4)
-      einhorn (~> 1.0)
-      gserver
-      sidekiq (>= 7.3.7, < 8)
-      sidekiq-pro (>= 7.3.4, < 8)
-    sidekiq-pro (7.3.5)
-      sidekiq (>= 7.3.7, < 8)
-
-GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (2.0.1)
@@ -419,7 +408,6 @@ GEM
       dry-initializer (~> 3.2)
       dry-schema (~> 1.14)
       zeitwerk (~> 2.6)
-    einhorn (1.0.0)
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
@@ -540,7 +528,6 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    gserver (0.0.1)
     guard (2.18.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -1323,8 +1310,6 @@ DEPENDENCIES
   shoulda-matchers
   shrine
   sidekiq
-  sidekiq-ent!
-  sidekiq-pro!
   sign_in_service
   simple_forms_api!
   simplecov

--- a/db/migrate/20250219221956_add_constraints_to_user_action_event.rb
+++ b/db/migrate/20250219221956_add_constraints_to_user_action_event.rb
@@ -1,0 +1,11 @@
+class AddConstraintsToUserActionEvent < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured do
+      add_index :user_action_events, :event_id, unique: true
+      add_index :user_action_events, :event_type
+      
+      change_column_null :user_action_events, :event_id, false
+      change_column_null :user_action_events, :event_type, false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_18_222532) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_19_221956) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -1404,8 +1404,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_18_222532) do
     t.string "details", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "event_id"
-    t.integer "event_type"
+    t.string "event_id", null: false
+    t.integer "event_type", null: false
+    t.index ["event_id"], name: "index_user_action_events_on_event_id", unique: true
+    t.index ["event_type"], name: "index_user_action_events_on_event_type"
   end
 
   create_table "user_actions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Adding database constraints to user_action_events table:
  - NOT NULL constraints for event_id and event_type
  - Unique index on event_id
  - Index on event_type
- Part of Identity team's work on improving audit logging structure
- Second PR in a series to ensure data integrity

## Related issue(s)

- [VI-1056](https://jira.devops.va.gov/browse/VI-1056) - User event table - event type
- Related to PR [#20828](link-to-pr-1) - First PR that added the columns

## Testing done

- [x] Migration tested in development
- Previous: Columns existed but without constraints
- Current: Added NOT NULL and index constraints
- Testing steps:
  1. Run migration to add constraints
  2. Verify in psql that constraints are in place:
     ```sql
     \d user_action_events
     ```
  3. Verify rollback works correctly

## What areas of the site does it impact?

- UserActionEvent database schema
- Database constraints and indexes
- No direct UI impact

## Acceptance criteria

- [x] Migration adds NOT NULL constraints
- [x] Migration adds correct indexes
- [x] Migration is reversible
- [x] Schema updated correctly
- [x] No sensitive information in migrations