### PR TITLE
[VI-1066] - createUserInfo endpoint

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -366,6 +366,7 @@ app/policies/mhv_prescriptions_policy.rb @department-of-veterans-affairs/vfs-hea
 app/policies/mhv_user_account_policy.rb @department-of-veterans-affairs/octo-identity
 app/policies/mpi_policy.rb @department-of-veterans-affairs/octo-identity
 app/policies/ppiu_policy.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/policies/sign_in/ @department-of-veterans-affairs/octo-identity
 app/policies/vet360_policy.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/policies/va_profile_policy.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/policies/vye_policy.rb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
@@ -863,7 +864,7 @@ lib/benefits_intake_service @department-of-veterans-affairs/benefits-dependents-
 lib/bgs @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/bid @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/bip_claims @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-lib/bpds @department-of-veterans-affairs/pension-and-burials @department-of-veterans-affairs/backend-review-group 
+lib/bpds @department-of-veterans-affairs/pension-and-burials @department-of-veterans-affairs/backend-review-group
 lib/carma @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/caseflow @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/central_mail @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1453,7 +1454,7 @@ spec/lib/benefits_intake_service @department-of-veterans-affairs/va-api-engineer
 spec/lib/bgs @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/bid @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/bip_claims @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/lib/bpds @department-of-veterans-affairs/pension-and-burials @department-of-veterans-affairs/backend-review-group 
+spec/lib/bpds @department-of-veterans-affairs/pension-and-burials @department-of-veterans-affairs/backend-review-group
 spec/lib/breakers @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/carma @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/caseflow @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1718,6 +1719,7 @@ spec/policies/medical_copays_policy_spec.rb @department-of-veterans-affairs/vsa-
 spec/policies/mhv_user_account_policy_spec.rb @department-of-veterans-affairs/octo-identity
 spec/policies/mpi_policy_spec.rb @department-of-veterans-affairs/octo-identity
 spec/policies/ppiu_policy_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/policies/sign_in/ @department-of-veterans-affairs/octo-identity
 spec/policies/vet360_policy_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/rails_helper.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/rakelib/fixtures @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/sign_in/user_info_controller.rb
+++ b/app/controllers/sign_in/user_info_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module SignIn
+  class UserInfoController < ApplicationController
+    service_tag 'identity'
+
+    def show
+      authorize access_token, policy_class: SignIn::UserInfoPolicy
+
+      render json: user_info_json, status: :ok
+    end
+
+    private
+
+    def user_info_json
+      {
+        credential_uuid: current_user.uuid,
+        icn: current_user.icn,
+        sec_id: current_user.sec_id,
+        first_name: current_user.first_name,
+        last_name: current_user.last_name,
+        email:
+      }
+    end
+
+    def email
+      user_verification&.user_credential_email&.credential_email
+    end
+
+    def user_verification
+      current_user.user_verification
+    end
+  end
+end

--- a/app/policies/sign_in/user_info_policy.rb
+++ b/app/policies/sign_in/user_info_policy.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module SignIn
+  class UserInfoPolicy
+    attr_reader :user, :record
+
+    def initialize(user, record)
+      @user = user
+      @record = record
+    end
+
+    def show?
+      user.present? && client_id.in?(Settings.sign_in.user_info_clients)
+    end
+
+    private
+
+    def client_id
+      record.client_id
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
     unless Settings.vsp_environment == 'production'
       resources :client_configs, param: :client_id
       resources :service_account_configs, param: :service_account_id
+      get '/user_info', to: 'user_info#show'
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -81,6 +81,7 @@ sign_in:
   vaweb_client_id: vaweb
   vamobile_client_id: vamobile
   arp_client_id: arp
+  user_info_clients: ['okta_test']
   sts_client:
     base_url: http://localhost:3000
     key_path: spec/fixtures/sign_in/sts_client.pem

--- a/spec/controllers/sign_in/user_info_controller_spec.rb
+++ b/spec/controllers/sign_in/user_info_controller_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SignIn::UserInfoController do
+  let!(:client_config) { create(:client_config, client_id:) }
+  let!(:session) { create(:oauth_session, client_id:) }
+  let!(:user_credential_email) do
+    create(:user_credential_email, user_verification: session.user_verification, credential_email: email)
+  end
+
+  let!(:user) { create(:user, uuid: credential_uuid, idme_uuid: credential_uuid, mpi_profile:) }
+  let(:mpi_profile) { build(:mpi_profile, icn:, sec_id:, given_names: [first_name], family_name: last_name) }
+
+  let(:credential_uuid) { 'some-uuid' }
+  let(:icn) { 'some-icn' }
+  let(:sec_id) { 'some-sec-id' }
+  let(:first_name) { 'some-first-name' }
+  let(:last_name) { 'some-last-name' }
+  let(:email) { 'some-email' }
+  let(:client_id) { 'some-client-id' }
+  let(:user_info_clients) { [client_id] }
+
+  let(:access_token) { create(:access_token, user_uuid: user.uuid, client_id:, session_handle: session.handle) }
+  let(:encoded_access_token) { SignIn::AccessTokenJwtEncoder.new(access_token: access_token).perform }
+
+  before do
+    allow(Settings.sign_in).to receive(:user_info_clients).and_return(user_info_clients)
+    request.headers['Authorization'] = "Bearer #{encoded_access_token}"
+  end
+
+  describe 'GET #show' do
+    context 'when the client_id is in the list of valid clients' do
+      let(:expected_user_info_json) do
+        {
+          credential_uuid:,
+          icn:,
+          sec_id:,
+          first_name:,
+          last_name:,
+          email: email
+        }
+      end
+
+      it 'returns the user info' do
+        get :show
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq(expected_user_info_json.to_json)
+      end
+    end
+
+    context 'when the client_id is not in the list of valid clients' do
+      let(:user_info_clients) { ['some-other-client-id'] }
+
+      it 'returns a forbidden response' do
+        get :show
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/policies/sign_in/user_info_policy_spec.rb
+++ b/spec/policies/sign_in/user_info_policy_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SignIn::UserInfoPolicy do
+  subject { described_class }
+
+  let(:user) { build(:user) }
+  let(:access_token) { build(:access_token, client_id:) }
+  let(:client_id) { 'some-client-id' }
+  let(:user_info_clients) { [client_id] }
+
+  before do
+    allow(Settings.sign_in).to receive(:user_info_clients).and_return(user_info_clients)
+  end
+
+  permissions :show? do
+    context 'when the current_user is present' do
+      let(:user) { build(:user) }
+
+      context 'when the client_id is in the list of valid clients' do
+        it 'grants access' do
+          expect(subject).to permit(user, access_token)
+        end
+      end
+
+      context 'when the client_id is not in the list of valid clients' do
+        let(:user_info_clients) { ['some-other-client-id'] }
+
+        it 'denies access' do
+          expect(subject).not_to permit(user, access_token)
+        end
+      end
+    end
+
+    context 'when the current_user is not present' do
+      let(:user) { nil }
+
+      it 'denies access' do
+        expect(subject).not_to permit(user, access_token)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Creat a user info endpoint that returns `credential_uuid`, `email`, `first_name`, `last_name`, `icn`, `sec_id`
- Restrict access to specific SiS clients
- route not available in production

## Related issue(s)
- https://jira.devops.va.gov/browse/VI-1066

## Testing done

- Add `vaweb` to `Settings.sign_in.user_info_clients`
- Sign in
- go to http://localhost:3000/sign_in/user_info
  - you should see a response like:
    ```json
      {
        "credential_uuid": "ba8028fc-bb4d-47aa-8fee-46f740cc3bb4",
        "icn": "112345678V54321",
        "sec_id": "0000012345",
        "first_name": "First",
        "last_name": "Last",
        "email": "user@gmail.com"
      }
    ```
- remove `vaweb` from settings
- sign in
- go to http://localhost:3000/sign_in/user_info
  - you should get a `403`

## What areas of the site does it impact?
Sign-in service

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

