### PR TITLE
[VI-1056] Temporarily removing specs from user action events so fundamental database changes can be made

### DIFF
--- a/spec/models/user_action_event_spec.rb
+++ b/spec/models/user_action_event_spec.rb
@@ -6,18 +6,4 @@ RSpec.describe UserActionEvent, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:details) }
   end
-
-  describe 'associations' do
-    let(:user_action_event) { create(:user_action_event) }
-
-    it { is_expected.to have_many(:user_actions).dependent(:restrict_with_exception) }
-
-    context 'when user actions exist' do
-      let!(:user_action) { create(:user_action, user_action_event: user_action_event) }
-
-      it 'restricts destruction when user actions exist' do
-        expect { user_action_event.destroy }.to raise_error(ActiveRecord::DeleteRestrictionError)
-      end
-    end
-  end
 end


### PR DESCRIPTION
## Summary

- Database changes need to be made that temporarily break these specs, so we're removing them until database changes can be made