### PR TITLE
Add JSON Schema validation to in-0995 form 4142

### DIFF
--- a/lib/decision_review_v1/utilities/form_4142_processor.rb
+++ b/lib/decision_review_v1/utilities/form_4142_processor.rb
@@ -101,6 +101,8 @@ module DecisionReviewV1
       end
 
       def validate_form4142
+        return unless Flipper.enabled?(:form4142_validate_schema)
+
         schema = VetsJsonSchema::SCHEMAS[FORM_ID]
         errors = JSON::Validator.fully_validate(schema, @form, errors_as_objects: true)
 

--- a/lib/decision_review_v1/utilities/form_4142_processor.rb
+++ b/lib/decision_review_v1/utilities/form_4142_processor.rb
@@ -7,6 +7,13 @@ require 'simple_forms_api_submission/metadata_validator'
 
 module DecisionReviewV1
   module Processor
+    class Form4142ValidationError < StandardError
+      def initialize(errors)
+        super
+        @errors = errors
+      end
+    end
+
     class Form4142Processor
       SIGNATURE_DATE_KEY = 'signatureDate'
       SIGNATURE_TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S'
@@ -99,7 +106,7 @@ module DecisionReviewV1
 
         unless errors.empty?
           Rails.logger.error('Form 4142 failed validation', { errors: })
-          raise "Form 4142 validation failed: #{errors.inspect}"
+          raise Form4142ValidationError.new({ errors: })
         end
       end
     end

--- a/modules/decision_reviews/lib/decision_reviews/v1/supplemental_claim_services.rb
+++ b/modules/decision_reviews/lib/decision_reviews/v1/supplemental_claim_services.rb
@@ -101,7 +101,7 @@ module DecisionReviews
                                message: 'Supplemental Claim Form4142 Persistence Errored',
                                appeal_submission_id:,
                                lighthouse_submission: {
-                                 id: uuid
+                                 id: guid
                                }
                              })
         raise e

--- a/modules/decision_reviews/spec/requests/v1/supplemental_claims_spec.rb
+++ b/modules/decision_reviews/spec/requests/v1/supplemental_claims_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe 'DecisionReviews::V1::SupplementalClaims', type: :request do
   end
 
   describe '#create with 4142' do
-    let(:params) { VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').clone }
+    let(:params) { VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').deep_dup }
 
     def personal_information_logs
       PersonalInformationLog.where 'error_class like ?',
@@ -133,7 +133,7 @@ RSpec.describe 'DecisionReviews::V1::SupplementalClaims', type: :request do
     end
 
     context 'when schema validation fails' do
-      let(:invalid_params) { VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').clone }
+      let(:invalid_params) { VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV').deep_dup }
 
       before do
         allow(Flipper).to receive(:enabled?).with(:decision_review_track_4142_submissions).and_return(true)

--- a/spec/lib/decision_review_v1/processor/form4142_processor_spec.rb
+++ b/spec/lib/decision_review_v1/processor/form4142_processor_spec.rb
@@ -27,73 +27,76 @@ describe DecisionReviewV1::Processor::Form4142Processor do
   let(:form4142) { JSON.parse(form_json)['form4142'].merge({ 'signatureDate' => received_date }) }
 
   describe '#initialize' do
-    context 'with valid form data' do
-      it 'initializes with submission and jid' do
-        expect(PdfFill::Filler).to receive(:fill_ancillary_form)
-          .and_call_original
-          .once
-          .with(form4142, anything, '21-4142')
-        # Note on the expectation: #anything is a special keyword that matches any argument.
-        # We used it here since the uuid is created at runtime.
-
-        expect(processor.instance_variable_get(:@submission)).to eq(submission)
-        expect(processor.instance_variable_get(:@pdf_path)).to be_a(String)
-        expect(processor.instance_variable_get(:@request_body)).to be_a(Hash)
+    context 'when schema validation is not enabled' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:form4142_validate_schema).and_return(false)
       end
 
-      context 'when more than 5 providers are submitted' do
-        let(:overflow_form_data) do
-          form4142.tap do |data|
-            # If the number of providers is greater than 5, the overflow page is added
-            extra_providers = data['providerFacility'].first.dup
-            data['providerFacility'] += [extra_providers] * 5
-          end
-        end
+      context 'with invalid form data' do
+        context 'when a required field is missing' do
+          let(:invalid_form_data) { form4142.except('providerFacility') }
 
-        it 'does not raise a validation error' do
-          expect { described_class.new(form_data: overflow_form_data, submission_id: submission.id) }
-            .not_to raise_error
+          it 'does not raise a validation error' do
+            expect { described_class.new(form_data: invalid_form_data, submission_id: submission.id) }
+              .not_to raise_error
+          end
         end
       end
     end
 
-    context 'with invalid form data' do
-      context 'when a required field is missing' do
-        let(:invalid_form_data) { form4142.except('providerFacility') }
+    context 'when schema validation flag is enabled' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:form4142_validate_schema).and_return(true)
+      end
 
-        it 'raises a validation error' do
-          expect { described_class.new(form_data: invalid_form_data, submission_id: submission.id) }
-            .to raise_error do |error|
-              expect(error).to be_a DecisionReviewV1::Processor::Form4142ValidationError
-              expect(error.message).to include("did not contain a required property of 'providerFacility'")
+      context 'with valid form data' do
+        it 'initializes with submission and jid' do
+          expect(PdfFill::Filler).to receive(:fill_ancillary_form)
+            .and_call_original
+            .once
+            .with(form4142, anything, '21-4142')
+          # Note on the expectation: #anything is a special keyword that matches any argument.
+          # We used it here since the uuid is created at runtime.
+
+          expect(processor.instance_variable_get(:@submission)).to eq(submission)
+          expect(processor.instance_variable_get(:@pdf_path)).to be_a(String)
+          expect(processor.instance_variable_get(:@request_body)).to be_a(Hash)
+        end
+
+        context 'when more than 5 providers are submitted' do
+          let(:overflow_form_data) do
+            form4142.tap do |data|
+              # If the number of providers is greater than 5, the overflow page is added
+              extra_providers = data['providerFacility'].first.dup
+              data['providerFacility'] += [extra_providers] * 5
             end
+          end
+
+          it 'does not raise a validation error' do
+            expect { described_class.new(form_data: overflow_form_data, submission_id: submission.id) }
+              .not_to raise_error
+          end
         end
       end
 
-      context 'with invalid provider data' do
-        context 'when dates are malformed' do
-          let(:invalid_form_data) do
-            form4142.tap do |data|
-              data['providerFacility'].first['treatmentDateRange'].first['from'] = 'not-a-date'
-            end
-          end
+      context 'with invalid form data' do
+        context 'when a required field is missing' do
+          let(:invalid_form_data) { form4142.except('providerFacility') }
 
           it 'raises a validation error' do
             expect { described_class.new(form_data: invalid_form_data, submission_id: submission.id) }
               .to raise_error do |error|
-              expect(error).to be_a DecisionReviewV1::Processor::Form4142ValidationError
-              expect(error.message).to include('value \"not-a-date\" did not match the regex')
-            end
+                expect(error).to be_a DecisionReviewV1::Processor::Form4142ValidationError
+                expect(error.message).to include("did not contain a required property of 'providerFacility'")
+              end
           end
         end
-      end
 
-      context 'when required provider fields are missing' do
-        %w[providerFacilityName providerFacilityAddress treatmentDateRange].each do |field|
-          context "when #{field} is missing" do
+        context 'with invalid provider data' do
+          context 'when dates are malformed' do
             let(:invalid_form_data) do
               form4142.tap do |data|
-                data['providerFacility'].first.delete(field)
+                data['providerFacility'].first['treatmentDateRange'].first['from'] = 'not-a-date'
               end
             end
 
@@ -101,42 +104,62 @@ describe DecisionReviewV1::Processor::Form4142Processor do
               expect { described_class.new(form_data: invalid_form_data, submission_id: submission.id) }
                 .to raise_error do |error|
                 expect(error).to be_a DecisionReviewV1::Processor::Form4142ValidationError
-                expect(error.message).to include("did not contain a required property of '#{field}'")
+                expect(error.message).to include('value \"not-a-date\" did not match the regex')
               end
             end
           end
         end
-      end
 
-      context 'when provider state code is invalid' do
-        let(:invalid_form_data) do
-          form4142.tap do |data|
-            data['providerFacility'].first['providerFacilityAddress']['state'] = 'NotAState'
+        context 'when required provider fields are missing' do
+          %w[providerFacilityName providerFacilityAddress treatmentDateRange].each do |field|
+            context "when #{field} is missing" do
+              let(:invalid_form_data) do
+                form4142.tap do |data|
+                  data['providerFacility'].first.delete(field)
+                end
+              end
+
+              it 'raises a validation error' do
+                expect { described_class.new(form_data: invalid_form_data, submission_id: submission.id) }
+                  .to raise_error do |error|
+                  expect(error).to be_a DecisionReviewV1::Processor::Form4142ValidationError
+                  expect(error.message).to include("did not contain a required property of '#{field}'")
+                end
+              end
+            end
           end
         end
 
-        it 'raises a validation error' do
-          expect { described_class.new(form_data: invalid_form_data, submission_id: submission.id) }
-            .to raise_error do |error|
-              expect(error).to be_a DecisionReviewV1::Processor::Form4142ValidationError
-              expect(error.message).to include('value \"USA\" did not match one of the following values: CAN')
+        context 'when provider state code is invalid' do
+          let(:invalid_form_data) do
+            form4142.tap do |data|
+              data['providerFacility'].first['providerFacilityAddress']['state'] = 'NotAState'
             end
+          end
+
+          it 'raises a validation error' do
+            expect { described_class.new(form_data: invalid_form_data, submission_id: submission.id) }
+              .to raise_error do |error|
+                expect(error).to be_a DecisionReviewV1::Processor::Form4142ValidationError
+                expect(error.message).to include('value \"USA\" did not match one of the following values: CAN')
+              end
+          end
         end
       end
-    end
-  end
 
-  context 'setting a correct signed-at date' do
-    context 'when a submission was created more than a day before processing' do
-      let!(:created_at) { 6.months.ago.in_time_zone(described_class::TIMEZONE) }
+      context 'setting a correct signed-at date' do
+        context 'when a submission was created more than a day before processing' do
+          let!(:created_at) { 6.months.ago.in_time_zone(described_class::TIMEZONE) }
 
-      it 'sets the signed at date to the date of submission creation' do
-        Timecop.freeze(created_at) { submission }
+          it 'sets the signed at date to the date of submission creation' do
+            Timecop.freeze(created_at) { submission }
 
-        key = described_class::SIGNATURE_DATE_KEY
-        time_format = described_class::SIGNATURE_TIMESTAMP_FORMAT
-        sig_dat = processor.instance_variable_get('@form')[key]
-        expect(sig_dat).to eq(created_at.strftime(time_format))
+            key = described_class::SIGNATURE_DATE_KEY
+            time_format = described_class::SIGNATURE_TIMESTAMP_FORMAT
+            sig_dat = processor.instance_variable_get('@form')[key]
+            expect(sig_dat).to eq(created_at.strftime(time_format))
+          end
+        end
       end
     end
   end

--- a/spec/lib/decision_review_v1/processor/form4142_processor_spec.rb
+++ b/spec/lib/decision_review_v1/processor/form4142_processor_spec.rb
@@ -63,7 +63,10 @@ describe DecisionReviewV1::Processor::Form4142Processor do
 
         it 'raises a validation error' do
           expect { described_class.new(form_data: invalid_form_data, submission_id: submission.id) }
-            .to raise_error(RuntimeError, /Form 4142 validation failed/)
+            .to raise_error do |error|
+              expect(error).to be_a DecisionReviewV1::Processor::Form4142ValidationError
+              expect(error.message).to include("did not contain a required property of 'providerFacility'")
+            end
         end
       end
 
@@ -77,7 +80,10 @@ describe DecisionReviewV1::Processor::Form4142Processor do
 
           it 'raises a validation error' do
             expect { described_class.new(form_data: invalid_form_data, submission_id: submission.id) }
-              .to raise_error(RuntimeError, /Form 4142 validation failed/)
+              .to raise_error do |error|
+              expect(error).to be_a DecisionReviewV1::Processor::Form4142ValidationError
+              expect(error.message).to include('value \"not-a-date\" did not match the regex')
+            end
           end
         end
       end
@@ -93,7 +99,10 @@ describe DecisionReviewV1::Processor::Form4142Processor do
 
             it 'raises a validation error' do
               expect { described_class.new(form_data: invalid_form_data, submission_id: submission.id) }
-                .to raise_error(RuntimeError, /Form 4142 validation failed/)
+                .to raise_error do |error|
+                expect(error).to be_a DecisionReviewV1::Processor::Form4142ValidationError
+                expect(error.message).to include("did not contain a required property of '#{field}'")
+              end
             end
           end
         end
@@ -108,7 +117,10 @@ describe DecisionReviewV1::Processor::Form4142Processor do
 
         it 'raises a validation error' do
           expect { described_class.new(form_data: invalid_form_data, submission_id: submission.id) }
-            .to raise_error(RuntimeError, /Form 4142 validation failed/)
+            .to raise_error do |error|
+              expect(error).to be_a DecisionReviewV1::Processor::Form4142ValidationError
+              expect(error.message).to include('value \"USA\" did not match one of the following values: CAN')
+            end
         end
       end
     end

--- a/spec/lib/decision_review_v1/processor/form4142_processor_spec.rb
+++ b/spec/lib/decision_review_v1/processor/form4142_processor_spec.rb
@@ -21,21 +21,96 @@ describe DecisionReviewV1::Processor::Form4142Processor do
            submitted_claim_id: 1)
   end
   let(:processor) { described_class.new(form_data: submission.form['form4142'], submission_id: submission.id) }
-  let(:received_date) { submission.created_at.in_time_zone('Central Time (US & Canada)').strftime('%Y-%m-%d %H:%M:%S') }
+  let(:received_date) do
+    submission.created_at.in_time_zone('Central Time (US & Canada)').strftime('%Y-%m-%d %H:%M:%S')
+  end
   let(:form4142) { JSON.parse(form_json)['form4142'].merge({ 'signatureDate' => received_date }) }
 
   describe '#initialize' do
-    it 'initializes with submission and jid' do
-      expect(PdfFill::Filler).to receive(:fill_ancillary_form)
-        .and_call_original
-        .once
-        .with(form4142, anything, '21-4142')
-      # Note on the expectation: #anything is a special keyword that matches any argument.
-      # We used it here since the uuid is created at runtime.
+    context 'with valid form data' do
+      it 'initializes with submission and jid' do
+        expect(PdfFill::Filler).to receive(:fill_ancillary_form)
+          .and_call_original
+          .once
+          .with(form4142, anything, '21-4142')
+        # Note on the expectation: #anything is a special keyword that matches any argument.
+        # We used it here since the uuid is created at runtime.
 
-      expect(processor.instance_variable_get(:@submission)).to eq(submission)
-      expect(processor.instance_variable_get(:@pdf_path)).to be_a(String)
-      expect(processor.instance_variable_get(:@request_body)).to be_a(Hash)
+        expect(processor.instance_variable_get(:@submission)).to eq(submission)
+        expect(processor.instance_variable_get(:@pdf_path)).to be_a(String)
+        expect(processor.instance_variable_get(:@request_body)).to be_a(Hash)
+      end
+    end
+
+    context 'with invalid form data' do
+      context 'when a required field is missing' do
+        let(:invalid_form_data) { form4142.except('providerFacility') }
+
+        it 'raises a validation error' do
+          expect { described_class.new(form_data: invalid_form_data, submission_id: submission.id) }
+            .to raise_error(RuntimeError, /Form 4142 validation failed/)
+        end
+      end
+
+      context 'with invalid provider data' do
+        context 'when more than 5 providers are submitted' do
+          let(:invalid_form_data) do
+            form4142.tap do |data|
+              # Add providers to exceed the 5 provider limit
+              extra_providers = data['providerFacility'].first.dup
+              data['providerFacility'] += [extra_providers] * 5
+            end
+          end
+
+          it 'raises a validation error' do
+            expect { described_class.new(form_data: invalid_form_data, submission_id: submission.id) }
+              .to raise_error(RuntimeError, /Form 4142 validation failed/)
+          end
+        end
+
+        context 'when dates are malformed' do
+          let(:invalid_form_data) do
+            form4142.tap do |data|
+              data['providerFacility'].first['treatmentDateRange'].first['from'] = 'not-a-date'
+            end
+          end
+
+          it 'raises a validation error' do
+            expect { described_class.new(form_data: invalid_form_data, submission_id: submission.id) }
+              .to raise_error(RuntimeError, /Form 4142 validation failed/)
+          end
+        end
+      end
+
+      context 'when required provider fields are missing' do
+        %w[providerFacilityName providerFacilityAddress treatmentDateRange].each do |field|
+          context "when #{field} is missing" do
+            let(:invalid_form_data) do
+              form4142.tap do |data|
+                data['providerFacility'].first.delete(field)
+              end
+            end
+
+            it 'raises a validation error' do
+              expect { described_class.new(form_data: invalid_form_data, submission_id: submission.id) }
+                .to raise_error(RuntimeError, /Form 4142 validation failed/)
+            end
+          end
+        end
+      end
+
+      context 'when provider state code is invalid' do
+        let(:invalid_form_data) do
+          form4142.tap do |data|
+            data['providerFacility'].first['providerFacilityAddress']['state'] = 'NotAState'
+          end
+        end
+
+        it 'raises a validation error' do
+          expect { described_class.new(form_data: invalid_form_data, submission_id: submission.id) }
+            .to raise_error(RuntimeError, /Form 4142 validation failed/)
+        end
+      end
     end
   end
 

--- a/spec/support/disability_compensation_form/submissions/with_4142.json
+++ b/spec/support/disability_compensation_form/submissions/with_4142.json
@@ -163,12 +163,12 @@
         "providerFacilityName": "provider 1",
         "treatmentDateRange": [
           {
-            "from": "1980-1-1",
-            "to": "1985-1-1"
+            "from": "1980-01-01",
+            "to": "1985-01-01"
           },
           {
-            "from": "1986-1-1",
-            "to": "1987-1-1"
+            "from": "1986-01-01",
+            "to": "1987-01-01"
           }
         ],
         "providerFacilityAddress": {
@@ -184,12 +184,12 @@
         "providerFacilityName": "provider 2",
         "treatmentDateRange": [
           {
-            "from": "1980-2-1",
-            "to": "1985-2-1"
+            "from": "1980-02-01",
+            "to": "1985-02-01"
           },
           {
-            "from": "1986-2-1",
-            "to": "1987-2-1"
+            "from": "1986-02-01",
+            "to": "1987-02-01"
           }
         ],
         "providerFacilityAddress": {
@@ -205,12 +205,12 @@
         "providerFacilityName": "provider 3",
         "treatmentDateRange": [
           {
-            "from": "1980-3-1",
-            "to": "1985-3-1"
+            "from": "1980-03-01",
+            "to": "1985-03-01"
           },
           {
-            "from": "1986-3-1",
-            "to": "1987-3-1"
+            "from": "1986-03-01",
+            "to": "1987-03-01"
           }
         ],
         "providerFacilityAddress": {
@@ -226,12 +226,12 @@
         "providerFacilityName": "provider 4",
         "treatmentDateRange": [
           {
-            "from": "1980-4-1",
-            "to": "1985-4-1"
+            "from": "1980-04-01",
+            "to": "1985-04-01"
           },
           {
-            "from": "1986-4-1",
-            "to": "1987-4-1"
+            "from": "1986-04-01",
+            "to": "1987-04-01"
           }
         ],
         "providerFacilityAddress": {
@@ -247,12 +247,12 @@
         "providerFacilityName": "provider 5",
         "treatmentDateRange": [
           {
-            "from": "1980-5-1",
-            "to": "1985-5-1"
+            "from": "1980-05-01",
+            "to": "1985-05-01"
           },
           {
-            "from": "1986-5-1",
-            "to": "1987-5-1"
+            "from": "1986-05-01",
+            "to": "1987-05-01"
           }
         ],
         "providerFacilityAddress": {


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- Used `vets-json-schema` to add JSON Schema validation to Supplemental Claim (0995) Form 4142 submission processing. This allows us to detect `form4142` payload issues (e.g. missing fields, incorrect format for dates/state codes) before PDF generation is attempted, similar to how `SupplementalClaimsController#handle_saved_claim` currently uses the `SC-CREATE-REQUEST-BODY_V1` JSON schema.


## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-json-schema/pull/981
- https://github.com/department-of-veterans-affairs/vets-website/pull/34995

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
- Impacts the processing and PDF template fill of in-0995 VA Form 21-4142 submissions

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

## Requested Feedback

- Consider a follow-up PR to vets-website that uses the updated vets-json-schema definition to ensure alignment between frontend and backend.