### PR TITLE
1429 1095b missing icn

### DIFF
--- a/app/sidekiq/form1095/new1095_bs_job.rb
+++ b/app/sidekiq/form1095/new1095_bs_job.rb
@@ -109,8 +109,6 @@ module Form1095
     end
 
     def save_data?(form_data, corrected)
-      return true if form_data[:veteran_icn].blank?
-
       existing_form = Form1095B.find_by(veteran_icn: form_data[:veteran_icn], tax_year: form_data[:tax_year])
 
       if !corrected && existing_form.present? # returns true to indicate successful entry
@@ -133,6 +131,9 @@ module Form1095
 
     def process_line?(form, file_details)
       data = parse_form(form)
+      # we can't save records without icns and should not retain the file in cases
+      # where the icn is missing
+      return true if data[:veteran_icn].blank?
 
       corrected = !file_details[:isOg?]
 

--- a/app/sidekiq/form1095/new1095_bs_job.rb
+++ b/app/sidekiq/form1095/new1095_bs_job.rb
@@ -110,6 +110,7 @@ module Form1095
 
     def save_data?(form_data, corrected)
       return true if form_data[:veteran_icn].blank?
+
       existing_form = Form1095B.find_by(veteran_icn: form_data[:veteran_icn], tax_year: form_data[:tax_year])
 
       if !corrected && existing_form.present? # returns true to indicate successful entry

--- a/app/sidekiq/form1095/new1095_bs_job.rb
+++ b/app/sidekiq/form1095/new1095_bs_job.rb
@@ -166,7 +166,6 @@ module Form1095
 
       all_succeeded
     rescue => e
-      Rails.logger.error "#{e.message}."
       log_exception_to_sentry(e, 'context' => "Error processing file: #{file_details}, on line #{lines}")
       false
     end

--- a/app/sidekiq/form1095/new1095_bs_job.rb
+++ b/app/sidekiq/form1095/new1095_bs_job.rb
@@ -109,6 +109,7 @@ module Form1095
     end
 
     def save_data?(form_data, corrected)
+      return true if form_data[:veteran_icn].blank?
       existing_form = Form1095B.find_by(veteran_icn: form_data[:veteran_icn], tax_year: form_data[:tax_year])
 
       if !corrected && existing_form.present? # returns true to indicate successful entry

--- a/spec/sidekiq/form1095/new1095_bs_job_spec.rb
+++ b/spec/sidekiq/form1095/new1095_bs_job_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Form1095::New1095BsJob, type: :job do
       expect { subject.perform }.to change(Form1095B, :count).from(0).to(8)
     end
 
-    it 'does not save save data and deletes file when user data is missing icn' do
+    it 'does not log errors or save data but does deletes file when user data is missing icn' do
       allow(objects).to receive(:collect).and_return(file_names3)
       allow(Tempfile).to receive(:new).and_return(tempfile3)
 
@@ -87,7 +87,6 @@ RSpec.describe Form1095::New1095BsJob, type: :job do
       allow(Tempfile).to receive(:new).and_return(tempfile3)
       allow(tempfile3).to receive(:each_line).and_raise(RuntimeError, 'Bad file')
 
-      # happens once
       expect(Rails.logger).to receive(:error).once.with('Bad file.')
       expect(Rails.logger).to receive(:error).once # log_exception_to_sentry stacktrace error
       expect(Rails.logger).to receive(:error).once.with(
@@ -113,7 +112,7 @@ RSpec.describe Form1095::New1095BsJob, type: :job do
 
         expect do
           subject.perform
-        end.to change { [JSON.parse(form1.reload.form_data), JSON.parse(form2.reload.form_data)] }
+        end.to change { [form1.reload.form_data, form2.reload.form_data] }
       end
     end
   end

--- a/spec/sidekiq/form1095/new1095_bs_job_spec.rb
+++ b/spec/sidekiq/form1095/new1095_bs_job_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Form1095::New1095BsJob, type: :job do
       expect { subject.perform }.to change(Form1095B, :count).from(0).to(8)
     end
 
-    it 'does not log errors or save data but does deletes file when user data is missing icn' do
+    it 'does not log errors or save form but does deletes file when user data is missing icn' do
       allow(objects).to receive(:collect).and_return(file_names3)
       allow(Tempfile).to receive(:new).and_return(tempfile3)
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): No. This work impacts non-client facing data ingestion code. 
- This changes the 1095b data ingestion job–which ingests data placed on an s3 bucket by the enrollment team–to no longer retain the data file if a veteran's icn is missing in the data. That is expected behavior and should not be considered a failure. We should just skip that record and delete the data ingestion file. 

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-iir/issues/1429

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change* 
The data ingestion job raised an error when the veteran's icn was missing from the data. It also did not delete the data file.
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
The only way to test this is through monitoring or checking s3. Currently, you can find instances of this logging in prod:
```
Failed to save form with unique ID: 
```
and this logging:
```
Rails.logger.error  "failed to save #{@error_count} forms from file: #{file_name}; successfully saved #{@form_count} forms"
```
After this change, we should no longer see that in logs. Also, currently there are very old data files on s3 because the job doesn't delete them. after this change, we expect them to be deleted. 
- *If this work is behind a flipper:*
No. It doesn't need to be.
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*
Check back on logging and ensure that it's no longer happening. Also check logging to confirm that no new bugs have been introduced.

## Screenshots


## What areas of the site does it impact?
Just the 1095b data ingestion job.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
