### PR TITLE
99558: Migrate burial form profile logic to module

### DIFF
--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -182,7 +182,8 @@ class FormProfile
   #
   def self.prepend_module(form_class, form_id)
     namespaces = {
-      '21P-527EZ' => 'Pensions'
+      '21P-527EZ' => 'Pensions',
+      '21P-530EZ' => 'Burials'
     }
 
     namespace = namespaces[form_id]

--- a/config/features.yml
+++ b/config/features.yml
@@ -1879,6 +1879,9 @@ features:
   burial_browser_monitoring_enabled:
     actor_type: user
     description: Burial Datadog RUM monitoring
+  burial_form_profile_module_enabled:
+    actor_type: user
+    description: Use the module version of the FormProfile
   pension_form_enabled:
     actor_type: user
     description: Enable the pension form

--- a/modules/burials/app/models/burials/form_profiles/va_21p530ez.rb
+++ b/modules/burials/app/models/burials/form_profiles/va_21p530ez.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'iso_country_codes'
+
+module Burials
+  # extends app/models/form_profile.rb, which handles form prefill
+  class FormProfiles::VA21p530ez < FormProfile
+    ##
+    # Returns metadata related to the form profile
+    #
+    # @return [Hash]
+    def metadata
+      {
+        version: 0,
+        prefill: true,
+        returnUrl: '/claimant-information'
+      }
+    end
+
+    ##
+    # Prefills the form data with identity and contact information
+    #
+    # This method initializes identity and contact information, converts the country code
+    # to ISO2 format if present, and maps data according to form-specific mappings
+    #
+    # @return [Hash]
+    def prefill
+      @identity_information = initialize_identity_information
+      @contact_information = initialize_contact_information
+      if @contact_information&.address&.country.present?
+        @contact_information.address.country = convert_to_iso2(@contact_information.address.country)
+      end
+
+      mappings = self.class.mappings_for_form(form_id)
+
+      form_data = generate_prefill(mappings) if FormProfile.prefill_enabled_forms.include?(form_id)
+
+      { form_data:, metadata: }
+    end
+
+    private
+
+    ##
+    # Converts a country code to ISO2 format
+    #
+    # @param country_code [String]
+    # @return [String]
+    def convert_to_iso2(country_code)
+      code = IsoCountryCodes.find(country_code)
+      code.alpha3
+    end
+  end
+end

--- a/modules/burials/spec/lib/burials/form_profiles/va_21p530ez_spec.rb
+++ b/modules/burials/spec/lib/burials/form_profiles/va_21p530ez_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Burials::FormProfiles::VA21p530ez, type: :model do
+  subject { described_class.new(form_id: form_id, user: user) }
+
+  let(:user) { build(:user, :loa3) }
+  let(:form_id) { '21P-530EZ' }
+  let(:address) { instance_double(Address, country: 'USA') }
+
+  before do
+    allow(FormProfile).to receive(:prefill_enabled_forms).and_return([form_id])
+  end
+
+  describe '#metadata' do
+    it 'returns correct metadata' do
+      expect(subject.metadata).to eq(
+        version: 0,
+        prefill: true,
+        returnUrl: '/claimant-information'
+      )
+
+      subject.metadata
+    end
+  end
+
+  describe '#prefill' do
+    it 'initializes identity and contact information' do
+      expect(subject.prefill).to match({
+                                         form_data: {
+                                           'claimantFullName' =>
+                                         { 'first' => 'Abraham', 'last' => 'Lincoln', 'suffix' => 'Jr.' },
+                                           'claimantAddress' =>
+                                         { 'street' => '140 Rock Creek Rd', 'city' => 'Washington', 'state' => 'DC',
+                                           'country' => 'USA', 'postalCode' => '20011' },
+                                           'claimantPhone' => '3035551234',
+                                           'claimantEmail' => kind_of(String)
+                                         },
+                                         metadata: { version: 0, prefill: true, returnUrl: '/claimant-information' }
+                                       })
+    end
+  end
+end

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -2022,6 +2022,8 @@ RSpec.describe FormProfile, type: :model do
         before do
           allow_any_instance_of(FormProfiles::VA21p530ez)
             .to receive(:initialize_contact_information).and_return(FormContactInformation.new)
+          allow_any_instance_of(Burials::FormProfiles::VA21p530ez)
+            .to receive(:initialize_contact_information).and_return(FormContactInformation.new)
         end
 
         it "doesn't throw an exception" do


### PR DESCRIPTION
Migrate the form_profile (prefill) logic for Burials 21P-530EZ over to the module space.


## Summary

- Updated FormProfile so that people can easily switch to a module version of their form profile
- Added `burial_form_profile_module_enabled` flipper
- Added tests for 100% coverage
- Ported over form profile files for Burial

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99558

## Testing done

- [x] *New code is covered by unit tests*
- [x] *Rails Console*

## Screenshots
<img width="850" alt="Screenshot 2025-02-20 at 11 59 09 AM" src="https://github.com/user-attachments/assets/90893bf3-56d5-414e-bd4d-54db4f65297f" />

<img width="466" alt="Screenshot 2025-02-20 at 11 57 47 AM" src="https://github.com/user-attachments/assets/ac0e1e28-3d2c-481a-bd6f-e1378871339d" />

<img width="1475" alt="Screenshot 2025-02-20 at 11 58 01 AM" src="https://github.com/user-attachments/assets/99607e45-f247-4938-a054-520a8c0933dd" />

## What areas of the site does it impact?
Burial Module and FormProfile

## Acceptance criteria

- [x]  flipper functions with clear indication of path being used (ie. the module vs app)
- [x]  100% test coverage
- [x]  all code documented
