### PR TITLE
Change urls for disability_max_ratings_api and contention_classification_api

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1530,13 +1530,13 @@ virtual_regional_office:
   max_cfi_path: employee-experience/max-ratings
 
 disability_max_ratings_api:
-  url: http://disability-max-ratings-api-dev.vfs.va.gov
+  url: http://disability-max-ratings-api.vfs.va.gov
   ratings_path: /disability-max-ratings
   open_timeout: 5
   read_timeout: 10
 
 contention_classification_api:
-  url: http://contention-classification-api-dev.vfs.va.gov/
+  url: http://contention-classification-api.vfs.va.gov/
   expanded_contention_classification_path: expanded-contention-classification
   open_timeout: 5
   read_timeout: 10


### PR DESCRIPTION
## Summary
- *This work is behind a feature toggle (flipper): YES*
- This PR changes the urls used in the `settings.yml` to point to the production pods for the two services disability_max_ratings_api and contention_classification_api. The lower environment values are overridden by the use of the devops SSM parameter store normalization effort. However, that effort is not yet used in production. 
   - The use of the production urls poses no risk because both services hold no state and are essentially data looks up services of publicly available information.
   - The use of the services is only available on the VA network

## Related issue(s)
- See slack platform support [issue](https://dsva.slack.com/archives/CBU0KDSB1/p1739991968983469)
- https://github.com/department-of-veterans-affairs/abd-vro/issues/4035
- https://github.com/department-of-veterans-affairs/abd-vro/issues/4051

## Testing done
- Changes to settings.yml only. The old urls were pointing the dev deployments of those services, and now point to prod deployments. 

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
None yet, the use of these services is protected by feature flags.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

