### PR TITLE
Enforce shorthand hash syntax in vets-api

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,7 +44,6 @@ Style/GlobalVars:
   AllowedVariables:
     - $redis
 
-
 Style/HashSyntax:
   EnforcedShorthandSyntax: always
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,10 @@ Style/GlobalVars:
   AllowedVariables:
     - $redis
 
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: always
+
 # Bug in 1.11.0
 RSpec/VariableName:
   Exclude:

--- a/app/mailers/create_excel_files_mailer.rb
+++ b/app/mailers/create_excel_files_mailer.rb
@@ -19,7 +19,7 @@ class CreateExcelFilesMailer < ApplicationMailer
 
     mail(
       to: recipients,
-      subject: subject
+      subject:
     ) do |format|
       format.text { render plain: "CSV file for #{date} is attached." }
       format.html { render html: "CSV file for #{date} is attached." }

--- a/app/models/async_transaction/va_profile/base.rb
+++ b/app/models/async_transaction/va_profile/base.rb
@@ -52,7 +52,7 @@ module AsyncTransaction
         create(
           user_uuid: user.uuid,
           user_account: user.user_account,
-          source_id: source_id,
+          source_id:,
           source: 'va_profile',
           status: REQUESTED,
           transaction_id: response.transaction.id,

--- a/app/models/excel_file_event.rb
+++ b/app/models/excel_file_event.rb
@@ -15,6 +15,6 @@ class ExcelFileEvent < ApplicationRecord
       return event
     end
 
-    create(filename: filename)
+    create(filename:)
   end
 end

--- a/app/models/saved_claim.rb
+++ b/app/models/saved_claim.rb
@@ -133,7 +133,7 @@ class SavedClaim < ApplicationRecord
     claim_va_notifications.create!(
       form_type: form_id,
       email_sent: true,
-      email_template_id: email_template_id
+      email_template_id:
     )
   end
 
@@ -146,7 +146,7 @@ class SavedClaim < ApplicationRecord
   def va_notification?(email_template_id)
     claim_va_notifications.find_by(
       form_type: form_id,
-      email_template_id: email_template_id
+      email_template_id:
     )
   end
 

--- a/app/services/claim_fast_tracking/flash_picker.rb
+++ b/app/services/claim_fast_tracking/flash_picker.rb
@@ -68,7 +68,7 @@ module ClaimFastTracking
       if distance - 1 == threshold
         Rails.logger.info(
           'FlashPicker close fuzzy match for condition',
-          { name: name, match_term: term, distance: distance, threshold: threshold }
+          { name:, match_term: term, distance:, threshold: }
         )
       end
       distance <= threshold

--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -134,7 +134,7 @@ class BenefitsIntakeStatusJob
     # Remove this logic after SubmissionStatusJob replaces this one
     claim = SavedClaim.find_by(id: saved_claim_id)
     context = {
-      form_id: form_id,
+      form_id:,
       claim_id: saved_claim_id,
       benefits_intake_uuid: bi_uuid
     }
@@ -161,7 +161,7 @@ class BenefitsIntakeStatusJob
   # rubocop:disable Metrics/MethodLength
   def monitor_failure(form_id, saved_claim_id, bi_uuid)
     context = {
-      form_id: form_id,
+      form_id:,
       claim_id: saved_claim_id,
       benefits_intake_uuid: bi_uuid
     }

--- a/app/sidekiq/bgs/submit_form674_job.rb
+++ b/app/sidekiq/bgs/submit_form674_job.rb
@@ -95,8 +95,8 @@ module BGS
       Rails.logger.warn(
         'BGS::SubmitForm674Job backup submission failed...',
         {
-          user_uuid: user_uuid,
-          saved_claim_id: saved_claim_id,
+          user_uuid:,
+          saved_claim_id:,
           error: e.message,
           nested_error: e.cause&.message
         }

--- a/app/sidekiq/evss/disability_compensation_form/submit_uploads.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_uploads.rb
@@ -95,7 +95,7 @@ module EVSS
           type: ApiProviderFactory::FACTORIES[:supplemental_document_upload],
           options: {
             form526_submission: submission,
-            document_type: document_type,
+            document_type:,
             statsd_metric_prefix: STATSD_KEY_PREFIX,
             supporting_evidence_attachment:
           },

--- a/lib/decision_review_v1/appeals/supplemental_claim_services.rb
+++ b/lib/decision_review_v1/appeals/supplemental_claim_services.rb
@@ -89,8 +89,8 @@ module DecisionReviewV1
         form_record = SecondaryAppealForm.new(
           form: rejiggered_payload.to_json,
           form_id: '21-4142',
-          appeal_submission_id: appeal_submission_id,
-          guid: guid
+          appeal_submission_id:,
+          guid:
         )
         form_record.save!
       rescue => e

--- a/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider.rb
+++ b/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider.rb
@@ -158,7 +158,7 @@ class LighthouseSupplementalDocumentUploadProvider
     Lighthouse526DocumentUpload.create!(
       form526_submission: @form526_submission,
       document_type: polling_record_document_type,
-      lighthouse_document_request_id: lighthouse_document_request_id,
+      lighthouse_document_request_id:,
       # The Lighthouse526DocumentUpload form_attachment association is
       # required for uploads of type Lighthouse526DocumentUpload::VETERAN_UPLOAD_DOCUMENT_TYPE
       **form_attachment_params

--- a/lib/slack/service.rb
+++ b/lib/slack/service.rb
@@ -45,7 +45,7 @@ module Slack
         type: 'section',
         text: {
           type: text_type,
-          text: text
+          text:
         }
       }
     end

--- a/lib/vets/collections/pagination.rb
+++ b/lib/vets/collections/pagination.rb
@@ -26,7 +26,7 @@ module Vets
           pagination: {
             current_page: @page,
             per_page: @per_page,
-            total_pages: total_pages,
+            total_pages:,
             total_entries: @total_entries
           }
         }

--- a/modules/accredited_representative_portal/lib/tasks/seed.rake
+++ b/modules/accredited_representative_portal/lib/tasks/seed.rake
@@ -189,7 +189,7 @@ module AccreditedRepresentativePortal
           .build_class
           .insert_all(
             records,
-            unique_by: unique_by
+            unique_by:
           )
       end
 

--- a/modules/accredited_representative_portal/lib/tasks/seed/staging_seed/methods.rb
+++ b/modules/accredited_representative_portal/lib/tasks/seed/staging_seed/methods.rb
@@ -35,7 +35,7 @@ module AccreditedRepresentativePortal
           power_of_attorney_holder_type: org ? 'veteran_service_organization' : 'individual_representative',
           power_of_attorney_holder_poa_code: org&.poa,
           accredited_individual_registration_number: rep.representative_id,
-          created_at: created_at
+          created_at:
         )
 
         form_data = {
@@ -65,14 +65,14 @@ module AccreditedRepresentativePortal
                     when :decision
                       type = resolution_type_cycle.next
                       dec = AccreditedRepresentativePortal::PowerOfAttorneyRequestDecision.new(
-                        type: type,
+                        type:,
                         creator_id: request.claimant_id
                       )
                       dec.save! && dec
                     end
         (res = AccreditedRepresentativePortal::PowerOfAttorneyRequestResolution.new(
           power_of_attorney_request: request,
-          resolving: resolving,
+          resolving:,
           created_at: request.created_at + 1.day
         )).save! && res
       end
@@ -160,8 +160,8 @@ module AccreditedRepresentativePortal
 
       def build_request_options(org, rep, options)
         RequestOptions.new(
-          org: org,
-          rep: rep,
+          org:,
+          rep:,
           claimant: options[:claimant_cycle].next,
           resolution_cycle: options[:resolution_cycle],
           resolved_time: options[:resolved_time],

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/power_of_attorney_request_service/create/form_data_adapter_spec.rb
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/power_of_attorney_request_service/create/form_data_adapter_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestService::Create::FormDataAdapter do
   describe '#call' do
-    subject { described_class.new(data: data, dependent: dependent, service_branch: service_branch) }
+    subject { described_class.new(data:, dependent:, service_branch:) }
 
     let(:dependent) { true }
     let(:service_branch) { 'ARMY' }

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/power_of_attorney_request_service/create_spec.rb
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/power_of_attorney_request_service/create_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestService::Create do
   describe '#call' do
     subject do
-      described_class.new(claimant: claimant, form_data: form_data, poa_code: poa_code,
-                          registration_number: registration_number)
+      described_class.new(claimant:, form_data:, poa_code:,
+                          registration_number:)
     end
 
     let(:claimant) { create(:user_account_with_verification) }

--- a/modules/appeals_api/spec/requests/appeals_api/v0/appeals_spec.rb
+++ b/modules/appeals_api/spec/requests/appeals_api/v0/appeals_spec.rb
@@ -132,7 +132,7 @@ Rspec.describe 'AppealsApi::V0::Appeals', type: :request do
                     } do
       def make_request(headers)
         VCR.use_cassette('caseflow/appeals') do
-          get(path, params: nil, headers: headers)
+          get(path, params: nil, headers:)
         end
       end
     end

--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/creator.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/creator.rb
@@ -27,7 +27,7 @@ module AskVAApi
       end
 
       def build_payload(inquiry_params)
-        PayloadBuilder::InquiryPayload.new(inquiry_params:, user: user).call
+        PayloadBuilder::InquiryPayload.new(inquiry_params:, user:).call
       end
 
       def post_data(payload)

--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/inquiry_details.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/inquiry_details.rb
@@ -56,11 +56,11 @@ module AskVAApi
 
         def handle_self_inquiry(inquiry_params, inquiry_details)
           if inquiry_params[:relationship_to_veteran] == "I'm the Veteran"
-            build_inquiry_details(inquiry_details: inquiry_details, inquiry_about: 'About Me, the Veteran')
+            build_inquiry_details(inquiry_details:, inquiry_about: 'About Me, the Veteran')
           elsif inquiry_params[:relationship_to_veteran] == "I'm a family member of a Veteran" &&
                 inquiry_params[:more_about_your_relationship_to_veteran]
             build_inquiry_details(
-              inquiry_details: inquiry_details,
+              inquiry_details:,
               inquiry_about: 'For the dependent of a Veteran',
               veteran_relationship: inquiry_params[:more_about_your_relationship_to_veteran]
             )
@@ -71,7 +71,7 @@ module AskVAApi
           if inquiry_params[:relationship_to_veteran] == "I'm the Veteran" &&
              inquiry_params[:about_your_relationship_to_family_member]
             build_inquiry_details(
-              inquiry_details: inquiry_details,
+              inquiry_details:,
               inquiry_about: 'For the dependent of a Veteran',
               dependent_relationship: inquiry_params[:about_your_relationship_to_family_member]
             )
@@ -79,7 +79,7 @@ module AskVAApi
             handle_family_inquiry(inquiry_params, inquiry_details)
           elsif inquiry_params[:your_role]
             build_inquiry_details(
-              inquiry_details: inquiry_details,
+              inquiry_details:,
               inquiry_about: 'On Behalf of a Veteran',
               veteran_relationship: inquiry_params[:your_role],
               level_of_authentication: 'Business'
@@ -91,14 +91,14 @@ module AskVAApi
           if inquiry_params[:is_question_about_veteran_or_someone_else] == 'Veteran' &&
              inquiry_params[:more_about_your_relationship_to_veteran]
             build_inquiry_details(
-              inquiry_details: inquiry_details,
+              inquiry_details:,
               inquiry_about: 'On Behalf of a Veteran',
               veteran_relationship: inquiry_params[:more_about_your_relationship_to_veteran]
             )
           elsif inquiry_params[:is_question_about_veteran_or_someone_else] == 'Someone else' &&
                 inquiry_params[:their_relationship_to_veteran]
             build_inquiry_details(
-              inquiry_details: inquiry_details,
+              inquiry_details:,
               inquiry_about: 'For the dependent of a Veteran',
               dependent_relationship: inquiry_params[:their_relationship_to_veteran]
             )

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/submitter_profile_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/submitter_profile_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::SubmitterProfile do
         inquiry_about: 'For the dependent of a Veteran',
         dependent_relationship: nil,
         veteran_relationship: nil,
-        level_of_authentication: level_of_authentication
+        level_of_authentication:
       }
     end
     let(:pronouns) do
@@ -53,7 +53,7 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::SubmitterProfile do
         phone_number: '987-654-3210',
         postal_code: '12345',
         preferred_name: 'Test User',
-        pronouns: pronouns,
+        pronouns:,
         school_obj: {
           institution_name: 'University of California',
           school_facility_code: '123456',

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/veteran_profile_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/veteran_profile_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::VeteranProfile do
           inquiry_about: 'For the dependent of a Veteran',
           dependent_relationship: nil,
           veteran_relationship: nil,
-          level_of_authentication: level_of_authentication
+          level_of_authentication:
         }
       end
       let(:expected_result) do
@@ -122,7 +122,7 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::VeteranProfile do
           phone_number: '987-654-3210',
           postal_code: '12345',
           preferred_name: 'Test User',
-          pronouns: pronouns,
+          pronouns:,
           school_obj: {
             institution_name: 'University of California',
             school_facility_code: '123456',
@@ -137,7 +137,7 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::VeteranProfile do
           inquiry_about: 'About Me, the Veteran',
           dependent_relationship: nil,
           veteran_relationship: nil,
-          level_of_authentication: level_of_authentication
+          level_of_authentication:
         }
       end
       let(:expected_result) do

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/retriever_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/retriever_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe AskVAApi::Inquiries::Retriever do
           end
 
           it 'returns an inquiry entity with expected attributes' do
-            result = retriever.fetch_by_id(id: id)
+            result = retriever.fetch_by_id(id:)
 
             # Inquiry-level expectations
             expect(result).to be_a(AskVAApi::Inquiries::Entity)

--- a/modules/banners/app/models/banner.rb
+++ b/modules/banners/app/models/banner.rb
@@ -24,7 +24,7 @@ class Banner < ApplicationRecord
                                   [
                                     { entity:
                                      { entityUrl:
-                                      { path: path } } }
+                                      { path: } } }
                                   ].to_json)
                             .or(where('banners.context @> ?',
                                       [
@@ -32,7 +32,7 @@ class Banner < ApplicationRecord
                                           { fieldOffice:
                                             { entity:
                                               { entityUrl:
-                                                { path: path } } } } }
+                                                { path: } } } } }
                                       ].to_json))
 
     # Subpage inheritance check: Matches on any `entityUrl` where `limit_subpage_inheritance` is false.

--- a/modules/banners/spec/controllers/v0/banners_controller_spec.rb
+++ b/modules/banners/spec/controllers/v0/banners_controller_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe V0::BannersController, type: :controller do
 
     # Create banners that should match the query
     let!(:matching_banner) do
-      create(:banner, entity_bundle: banner_type, context: [{ entity: { entityUrl: { path: path } } }])
+      create(:banner, entity_bundle: banner_type, context: [{ entity: { entityUrl: { path: } } }])
     end
     let!(:non_matching_banner) do
       create(:banner, entity_bundle: 'different_type', context: [{ entity: { entityUrl: { path: '/other/path' } } }])
     end
 
     it 'returns banners matching the specified path and banner type' do
-      get :by_path, params: { path: path, type: banner_type }
+      get :by_path, params: { path:, type: banner_type }
 
       expect(response).to have_http_status(:ok)
       json_response = JSON.parse(response.body)

--- a/modules/banners/spec/lib/builder_spec.rb
+++ b/modules/banners/spec/lib/builder_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Banners::Builder do
   let(:entity_id) { '123' }
   let(:banner_data) do
     {
-      entity_id: entity_id,
+      entity_id:,
       title: 'Test Banner',
       content: 'Test Content'
     }
@@ -62,7 +62,7 @@ RSpec.describe Banners::Builder do
 
     it 'finds or initializes banner by entity_id' do
       builder.banner
-      expect(Banner).to have_received(:find_or_initialize_by).with(entity_id: entity_id)
+      expect(Banner).to have_received(:find_or_initialize_by).with(entity_id:)
     end
 
     it 'memoizes the banner' do

--- a/modules/banners/spec/models/banner_spec.rb
+++ b/modules/banners/spec/models/banner_spec.rb
@@ -36,7 +36,7 @@ Rspec.describe Banner, type: :model do
              context: [
                {
                  entity: {
-                   entityUrl: { path: path },
+                   entityUrl: { path: },
                    fieldOffice: {
                      entity: {
                        entityUrl: { path: '/some-other-path' }
@@ -57,7 +57,7 @@ Rspec.describe Banner, type: :model do
                    entityUrl: { path: '/some-other-path' },
                    fieldOffice: {
                      entity: {
-                       entityUrl: { path: path }
+                       entityUrl: { path: }
                      }
                    }
                  }
@@ -72,7 +72,7 @@ Rspec.describe Banner, type: :model do
              context: [
                {
                  entity: {
-                   entityUrl: { path: path },
+                   entityUrl: { path: },
                    fieldOffice: {
                      entity: {
                        entityUrl: { path: '/some-other-path' }

--- a/modules/burials/lib/burials/monitor.rb
+++ b/modules/burials/lib/burials/monitor.rb
@@ -169,7 +169,7 @@ module Burials
       user_account_uuid = msg['args'].length <= 1 ? nil : msg['args'][1]
       additional_context = {
         confirmation_number: claim&.confirmation_number,
-        user_account_uuid: user_account_uuid,
+        user_account_uuid:,
         form_id: claim&.form_id,
         claim_id: msg['args'].first,
         message: msg,

--- a/modules/burials/spec/models/burials/saved_claim_spec.rb
+++ b/modules/burials/spec/models/burials/saved_claim_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Burials::SavedClaim do
         x: 400,
         y: 675,
         text_only: true,
-        timestamp: timestamp,
+        timestamp:,
         page_number: 6,
         template: "lib/pdf_fill/forms/pdfs/#{form_id}.pdf",
         multistamp: true

--- a/modules/check_in/spec/exceptions/check_in/v2/checkin_service_exception_spec.rb
+++ b/modules/check_in/spec/exceptions/check_in/v2/checkin_service_exception_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CheckIn::V2::CheckinServiceException do
     subject.new(status: '401', original_body: error_message)
   end
   let(:cie_exception_code) { 'CIE-VETS-API_' }
-  let(:response_value) { { status: status, detail: [error_message], code: cie_exception_code + status } }
+  let(:response_value) { { status:, detail: [error_message], code: cie_exception_code + status } }
 
   describe '.build' do
     it 'returns an instance of cie exception' do

--- a/modules/claims_api/app/services/claims_api/jwt_encoder.rb
+++ b/modules/claims_api/app/services/claims_api/jwt_encoder.rb
@@ -17,7 +17,7 @@ module ClaimsApi
     def va_notify_headers(alg)
       {
         typ: 'JWT',
-        alg: alg
+        alg:
       }
     end
 

--- a/modules/claims_api/lib/claims_api/evidence_waiver_pdf/pdf.rb
+++ b/modules/claims_api/lib/claims_api/evidence_waiver_pdf/pdf.rb
@@ -34,7 +34,7 @@ module ClaimsApi
         'checkbox.yes': response == false ? 0 : 1,
         'checkbox.no': response == false ? 1 : 0,
         date: I18n.l(Time.zone.now.to_date, format: :va_form),
-        signature: signature
+        signature:
       }
     end
 

--- a/modules/claims_api/spec/controllers/v1/application_controller_spec.rb
+++ b/modules/claims_api/spec/controllers/v1/application_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ClaimsApi::V1::ApplicationController, type: :controller do
   describe '#veteran_from_headers' do
     it 'calls the recache method when building from headers' do
       allow(@veteran_instance).to receive(:recache_mpi_data)
-      controller.send(:veteran_from_headers, with_gender: with_gender)
+      controller.send(:veteran_from_headers, with_gender:)
 
       expect(@veteran_instance).to have_received(:recache_mpi_data)
     end

--- a/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
+++ b/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
@@ -572,7 +572,7 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
 
   def decide_request_with(id:, decision:, auth_header:, representative_id: nil)
     post "/services/claims/v2/veterans/power-of-attorney-requests/#{id}/decide",
-         params: { data: { attributes: { id: id,
+         params: { data: { attributes: { id:,
                                          decision:,
                                          representativeId: representative_id } } }.to_json,
          headers: auth_header.merge('Content-Type' => 'application/json')

--- a/modules/claims_api/spec/lib/claims_api/bgs/itf_web_service_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/bgs/itf_web_service_spec.rb
@@ -20,7 +20,7 @@ describe ClaimsApi::IntentToFileWebService do
         participant_vet_id: '600043201',
         received_date: '2025-02-07T13:12:40+00:00',
         submitter_application_icn_type_code: 'LH-B',
-        ssn: ssn,
+        ssn:,
         participant_claimant_id: '600043201'
       }
     end

--- a/modules/claims_api/spec/lib/claims_api/bgs/manage_representative_service_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/bgs/manage_representative_service_spec.rb
@@ -90,10 +90,10 @@ describe ClaimsApi::ManageRepresentativeService do
         poa_code = '083'
 
         res = subject.update_poa_relationship(
-          pctpnt_id: pctpnt_id,
-          file_number: file_number,
-          ssn: ssn,
-          poa_code: poa_code
+          pctpnt_id:,
+          file_number:,
+          ssn:,
+          poa_code:
         )
 
         expect(res['vetPtcpntId']).to eq(pctpnt_id)

--- a/modules/claims_api/spec/requests/v1/forms/2122_spec.rb
+++ b/modules/claims_api/spec/requests/v1/forms/2122_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe 'ClaimsApi::V1::Forms::2122', type: :request do
 
                 expect(ClaimsApi::V1::PoaFormBuilderJob).to receive(:perform_async)
 
-                post path, params: params, headers: auth_header, as: :json
+                post path, params:, headers: auth_header, as: :json
               end
             end
           end
@@ -434,15 +434,15 @@ RSpec.describe 'ClaimsApi::V1::Forms::2122', type: :request do
             {
               data: {
                 attributes: {
-                  veteran: { address: address },
+                  veteran: { address: },
                   serviceOrganization: {
                     poaCode: '074',
-                    address: address
+                    address:
                   },
                   claimant: {
                     firstName: 'John',
                     lastName: 'Doe',
-                    address: address,
+                    address:,
                     relationship: 'spouse'
                   }
                 }
@@ -496,15 +496,15 @@ RSpec.describe 'ClaimsApi::V1::Forms::2122', type: :request do
             {
               data: {
                 attributes: {
-                  veteran: { address: address },
+                  veteran: { address: },
                   serviceOrganization: {
                     poaCode: '074',
-                    address: address
+                    address:
                   },
                   claimant: {
                     firstName: 'John',
                     lastName: 'Doe',
-                    address: address,
+                    address:,
                     relationship: 'spouse'
                   }
                 }

--- a/modules/claims_api/spec/sidekiq/poa_assign_dependent_claimant_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/poa_assign_dependent_claimant_job_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ClaimsApi::PoaAssignDependentClaimantJob, type: :job do
   describe '#perform' do
     let(:poa) do
       create(:power_of_attorney,
-             auth_headers: auth_headers,
+             auth_headers:,
              form_data: claimant_form_data,
              status: ClaimsApi::PowerOfAttorney::SUBMITTED)
     end
@@ -194,7 +194,7 @@ RSpec.describe ClaimsApi::PoaAssignDependentClaimantJob, type: :job do
 
     let(:poa) do
       create(:power_of_attorney,
-             auth_headers: auth_headers,
+             auth_headers:,
              form_data: claimant_form_data,
              status: ClaimsApi::PowerOfAttorney::SUBMITTED)
     end

--- a/modules/claims_api/spec/sidekiq/va_notify_declined_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/va_notify_declined_job_spec.rb
@@ -54,7 +54,7 @@ describe ClaimsApi::VANotifyDeclinedJob, type: :job do
         .with({
                 recipient_identifier: ptcpnt_id,
                 personalisation: {
-                  first_name: first_name,
+                  first_name:,
                   representative_type: 'claims agent',
                   representative_type_abbreviated: 'claims agent',
                   form_type: 'Appointment of Individual as Claimantʼs Representative (VA Form 21-22a)'

--- a/modules/debts_api/app/controllers/debts_api/v0/digital_disputes_controller.rb
+++ b/modules/debts_api/app/controllers/debts_api/v0/digital_disputes_controller.rb
@@ -71,7 +71,7 @@ module DebtsApi
                              selected_debt_id],
           veteran_information: [:email,
                                 {
-                                  mobile_phone: mobile_phone,
+                                  mobile_phone:,
                                   mailing_address: address
                                 }]
         )

--- a/modules/debts_api/spec/requests/debts_api/v0/digital_disputes_spec.rb
+++ b/modules/debts_api/spec/requests/debts_api/v0/digital_disputes_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'DebtsApi::V0::DigitalDisputes', type: :request do
       expect(StatsD).to receive(:increment).with('api.digital_dispute_submission.initiated')
       post(
         '/debts_api/v0/digital_disputes',
-        params: params,
+        params:,
         as: :json
       )
 
@@ -45,7 +45,7 @@ RSpec.describe 'DebtsApi::V0::DigitalDisputes', type: :request do
 
         post(
           '/debts_api/v0/digital_disputes',
-          params: params,
+          params:,
           as: :json
         )
 
@@ -65,7 +65,7 @@ RSpec.describe 'DebtsApi::V0::DigitalDisputes', type: :request do
 
         post(
           '/debts_api/v0/digital_disputes',
-          params: params,
+          params:,
           as: :json
         )
 

--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
@@ -15,7 +15,7 @@ module IvcChampva
 
         unless data.is_a?(Hash)
           # Log the failure due to invalid JSON format
-          StatsD.increment('silent_failure_avoided_no_confirmation', tags: tags)
+          StatsD.increment('silent_failure_avoided_no_confirmation', tags:)
           render json: JSON.generate({ status: 500, error: 'Invalid JSON format: Expected a JSON object' })
           return
         end
@@ -24,14 +24,14 @@ module IvcChampva
           if valid_keys?(data)
             update_data(data['form_uuid'], data['file_names'], data['status'], data['case_id'])
           else
-            StatsD.increment('silent_failure_avoided_no_confirmation', tags: tags)
+            StatsD.increment('silent_failure_avoided_no_confirmation', tags:)
             { json: { error_message: 'Invalid JSON keys' }, status: :bad_request }
           end
 
         render json: response[:json], status: response[:status]
       rescue JSON::ParserError => e
         # Log the JSON parsing error
-        StatsD.increment('silent_failure_avoided_no_confirmation', tags: tags)
+        StatsD.increment('silent_failure_avoided_no_confirmation', tags:)
         render json: { error_message: "JSON parsing error: #{e.message}" }, status: :internal_server_error
       end
 

--- a/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
+++ b/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
@@ -54,7 +54,7 @@ module IvcChampva
         file_count: nil,
         pega_status: form.pega_status,
         date_submitted: form.created_at.strftime('%B %d, %Y'),
-        template_id: template_id,
+        template_id:,
         form_uuid: form.form_uuid }
     end
 

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
@@ -66,7 +66,7 @@ module IvcChampva
     # rubocop:disable Naming/BlockForwarding
     def method_missing(method_name, *args, &block)
       super unless respond_to_missing?(method_name)
-      { method: method_name, args: args }
+      { method: method_name, args: }
     end
     # rubocop:enable Naming/BlockForwarding
 

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
@@ -55,7 +55,7 @@ module IvcChampva
     # rubocop:disable Naming/BlockForwarding
     def method_missing(method_name, *args, &block)
       super unless respond_to_missing?(method_name)
-      { method: method_name, args: args }
+      { method: method_name, args: }
     end
     # rubocop:enable Naming/BlockForwarding
 

--- a/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
@@ -95,7 +95,7 @@ module IvcChampva
         first_name: @metadata&.dig('primaryContactInfo', 'name', 'first'),
         last_name: @metadata&.dig('primaryContactInfo', 'name', 'last'),
         form_number: @metadata['docType'],
-        file_name: file_name,
+        file_name:,
         s3_status: response_status,
         pega_status:
       )

--- a/modules/ivc_champva/app/services/ivc_champva/s3.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/s3.rb
@@ -19,7 +19,7 @@ module IvcChampva
           bucket:,
           key:,
           body: File.read(file),
-          metadata: metadata
+          metadata:
         )
         result = { success: true }
       rescue => e
@@ -70,7 +70,7 @@ module IvcChampva
           error_message += ", Body: #{response.body.read}"
         end
         Rails.logger.error error_message
-        { success: false, error_message: error_message }
+        { success: false, error_message: }
       end
     end
 

--- a/modules/ivc_champva/lib/ivc_champva/monitor.rb
+++ b/modules/ivc_champva/lib/ivc_champva/monitor.rb
@@ -98,7 +98,7 @@ module IvcChampva
 
     def track_s3_put_object_error(key, error, response = nil)
       additional_context = {
-        key: key,
+        key:,
         error_message: error.message,
         error_class: error.class.name,
         backtrace: error.backtrace&.join("\n") # Safe navigation operator
@@ -116,7 +116,7 @@ module IvcChampva
 
     def track_s3_upload_file_error(key, error)
       additional_context = {
-        key: key,
+        key:,
         error_message: error.message,
         error_class: error.class.name,
         backtrace: error.backtrace&.join("\n") # Safe navigation operator

--- a/modules/ivc_champva/spec/services/pdf_filler_spec.rb
+++ b/modules/ivc_champva/spec/services/pdf_filler_spec.rb
@@ -17,7 +17,7 @@ describe IvcChampva::PdfFiller do
         data = JSON.parse(File.read(file_path))
         form = "IvcChampva::#{form_number.titleize.gsub(' ', '')}".constantize.new(data)
         expect do
-          described_class.new(form_number: nil, form: form)
+          described_class.new(form_number: nil, form:)
         end.to raise_error(RuntimeError, 'form_number is required')
       end
     end
@@ -26,7 +26,7 @@ describe IvcChampva::PdfFiller do
       it 'throws an error' do
         form_number = forms.first
         expect do
-          described_class.new(form_number: form_number, form: nil)
+          described_class.new(form_number:, form: nil)
         end.to raise_error(RuntimeError, 'form needs a data attribute')
       end
     end
@@ -41,7 +41,7 @@ describe IvcChampva::PdfFiller do
         expect(File.exist?(file_path)).to be(true), "Fixture file not found: #{file_path}"
         data = JSON.parse(File.read(file_path))
         form = "IvcChampva::#{form_number.titleize.gsub(' ', '')}".constantize.new(data)
-        pdf_filler = described_class.new(form_number: form_number, form: form, uuid: uuid)
+        pdf_filler = described_class.new(form_number:, form:, uuid:)
 
         allow(File).to receive(:exist?).and_return(true)
         allow(IvcChampva::PdfStamper).to receive(:stamp_pdf)
@@ -59,7 +59,7 @@ describe IvcChampva::PdfFiller do
         expect(File.exist?(file_path)).to be(true), "Fixture file not found: #{file_path}"
         data = JSON.parse(File.read(file_path))
         form = "IvcChampva::#{form_number.titleize.gsub(' ', '')}".constantize.new(data)
-        pdf_filler = described_class.new(form_number: form_number, form: form)
+        pdf_filler = described_class.new(form_number:, form:)
 
         allow(File).to receive(:exist?).and_return(false)
 
@@ -75,7 +75,7 @@ describe IvcChampva::PdfFiller do
         expect(File.exist?(file_path)).to be(true), "Fixture file not found: #{file_path}"
         data = JSON.parse(File.read(file_path))
         form = "IvcChampva::#{form_number.titleize.gsub(' ', '')}".constantize.new(data)
-        pdf_filler = described_class.new(form_number: form_number, form: form, uuid: uuid)
+        pdf_filler = described_class.new(form_number:, form:, uuid:)
 
         allow(File).to receive(:exist?).and_return(true)
         allow(IvcChampva::PdfStamper).to receive(:stamp_pdf)
@@ -95,7 +95,7 @@ describe IvcChampva::PdfFiller do
         expect(File.exist?(file_path)).to be(true), "Fixture file not found: #{file_path}"
         data = JSON.parse(File.read(file_path))
         form = "IvcChampva::#{form_number.titleize.gsub(' ', '')}".constantize.new(data)
-        pdf_filler = described_class.new(form_number: form_number, form: form)
+        pdf_filler = described_class.new(form_number:, form:)
 
         template_path = "#{IvcChampva::PdfFiller::TEMPLATE_BASE}/#{form_number}.pdf"
         tempfile = double('Tempfile')

--- a/modules/ivc_champva/spec/services/s3_spec.rb
+++ b/modules/ivc_champva/spec/services/s3_spec.rb
@@ -11,7 +11,7 @@ describe IvcChampva::S3 do
 
   let(:s3_instance) do
     IvcChampva::S3.new(
-      region: region,
+      region:,
       bucket: bucket_name
     )
   end

--- a/modules/pensions/lib/pensions/monitor.rb
+++ b/modules/pensions/lib/pensions/monitor.rb
@@ -254,7 +254,7 @@ module Pensions
       user_account_uuid = msg['args'].length <= 1 ? nil : msg['args'][1]
       additional_context = {
         confirmation_number: claim&.confirmation_number,
-        user_account_uuid: user_account_uuid,
+        user_account_uuid:,
         claim_id: msg['args'].first,
         form_id: claim&.form_id,
         message: msg,

--- a/modules/pensions/spec/lib/pensions/form_profiles/va_21p527ez_spec.rb
+++ b/modules/pensions/spec/lib/pensions/form_profiles/va_21p527ez_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Pensions::FormProfiles::VA21p527ez, type: :model do
 
   describe '#metadata' do
     it 'returns correct metadata' do
-      form = described_class.new(form_id: form_id, user: user)
+      form = described_class.new(form_id:, user:)
       expect(form.metadata).to eq(
         version: 0,
         prefill: true,
@@ -30,7 +30,7 @@ RSpec.describe Pensions::FormProfiles::VA21p527ez, type: :model do
         expect(military_info_instance).to receive(:public_send).exactly(
           Pensions::MilitaryInformation::PREFILL_METHODS.count
         ).times
-        form = described_class.new(form_id: form_id, user: user)
+        form = described_class.new(form_id:, user:)
         expect(form.initialize_military_information).to be_a(Pensions::FormMilitaryInformation)
       end
     end
@@ -41,14 +41,14 @@ RSpec.describe Pensions::FormProfiles::VA21p527ez, type: :model do
       end
 
       it 'returns an empty hash' do
-        form = described_class.new(form_id: form_id, user: user)
+        form = described_class.new(form_id:, user:)
         expect(form.initialize_military_information).to eq({})
       end
     end
   end
 
   describe '#initialize_va_profile_prefill_military_information' do
-    let(:form) { described_class.new(form_id: form_id, user: user) }
+    let(:form) { described_class.new(form_id:, user:) }
 
     before do
       allow(military_info_instance).to receive(:public_send).and_return('2009-4-1')

--- a/modules/representation_management/lib/representation_management/v0/pdf_constructor/base.rb
+++ b/modules/representation_management/lib/representation_management/v0/pdf_constructor/base.rb
@@ -25,7 +25,7 @@ module RepresentationManagement
         #
         def construct(data, flatten: true)
           set_template_path
-          fill_and_combine_pdf(data, flatten: flatten)
+          fill_and_combine_pdf(data, flatten:)
         end
 
         protected
@@ -151,7 +151,7 @@ module RepresentationManagement
         #
         def fill_and_combine_pdf(data, flatten: true)
           pdftk = PdfForms.new(Settings.binaries.pdftk)
-          template_tempfile = fill_template_form(pdftk, data, flatten: flatten)
+          template_tempfile = fill_template_form(pdftk, data, flatten:)
           # Only combine PDFs if needed.  Otherwise directly write the template to the output tempfile.
           if next_steps_page?
             next_steps_tempfile = generate_next_steps_page(data)
@@ -206,7 +206,7 @@ module RepresentationManagement
         def fill_template_form(pdftk, data, flatten: true)
           tempfile = Tempfile.new
           # This is the point where the flatten option is actually used, not just passed down the method chain.
-          pdftk.fill_form(@template_path, tempfile.path, template_options(data), flatten: flatten)
+          pdftk.fill_form(@template_path, tempfile.path, template_options(data), flatten:)
           @template_path = tempfile.path
           tempfile.rewind
           tempfile

--- a/modules/representation_management/spec/models/representation_management/power_of_attorney_request_email_data_spec.rb
+++ b/modules/representation_management/spec/models/representation_management/power_of_attorney_request_email_data_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RepresentationManagement::PowerOfAttorneyRequestEmailData, type: 
   end
 
   describe 'methods' do
-    subject { described_class.new(form_data: form_data) }
+    subject { described_class.new(form_data:) }
 
     let(:organization) { create(:accredited_organization, name: 'Org Name') }
     let(:representative) do

--- a/modules/representation_management/spec/requests/representation_management/v0/power_of_attorney_requests_controller_spec.rb
+++ b/modules/representation_management/spec/requests/representation_management/v0/power_of_attorney_requests_controller_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'RepresentationManagement::V0::PowerOfAttorneyRequests', type: :r
 
       context 'when submitting with a veteran service number - TEMPORARY FOR FRONTEND TESTING' do
         before do
-          post(base_path, params: params)
+          post(base_path, params:)
         end
 
         it 'responds with the unprocessable_entity status' do

--- a/modules/representation_management/spec/support/rswag_config.rb
+++ b/modules/representation_management/spec/support/rswag_config.rb
@@ -42,8 +42,8 @@ class RepresentationManagement::RswagConfig
     {
       accreditedIndividual: accredited_individual_schema,
       accreditedOrganization: accredited_organization_schema,
-      error: error,
-      errors: errors,
+      error:,
+      errors:,
       errorModel: error_model,
       powerOfAttorneyResponse: power_of_attorney_response,
       veteranServiceOrganization: veteran_service_organization_schema,
@@ -190,7 +190,7 @@ class RepresentationManagement::RswagConfig
         }
       }
     )
-    accredited_data_structure(data_structure_type, attributes, uuid: uuid)
+    accredited_data_structure(data_structure_type, attributes, uuid:)
   end
 
   def accredited_organization_schema
@@ -199,7 +199,7 @@ class RepresentationManagement::RswagConfig
 
   def veteran_service_organization_schema
     optional_attributes = { can_accept_digital_poa_requests: { type: :boolean, example: true } }
-    build_organization_schema(uuid: false, optional_attributes: optional_attributes)
+    build_organization_schema(uuid: false, optional_attributes:)
   end
 
   def common_organization_attributes
@@ -214,7 +214,7 @@ class RepresentationManagement::RswagConfig
 
   def build_organization_schema(uuid: true, optional_attributes: {})
     attributes = common_organization_attributes.merge(optional_attributes)
-    accredited_data_structure('organization', attributes, uuid: uuid)
+    accredited_data_structure('organization', attributes, uuid:)
   end
 
   def accredited_data_structure(type, attributes, uuid: true)

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/scanned_form_uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/scanned_form_uploads_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'SimpleFormsApi::V1::ScannedFormsUploader', type: :request do
     it 'makes the request' do
       expect(PersistentAttachment).to receive(:find_by).with(guid: confirmation_code).and_return(attachment)
 
-      post '/simple_forms_api/v1/submit_scanned_form', params: params
+      post('/simple_forms_api/v1/submit_scanned_form', params:)
 
       expect(response).to have_http_status(:ok)
     end
@@ -56,7 +56,7 @@ RSpec.describe 'SimpleFormsApi::V1::ScannedFormsUploader', type: :request do
     it 'stamps the pdf' do
       expect(pdf_stamper).to receive(:stamp_pdf)
 
-      post '/simple_forms_api/v1/submit_scanned_form', params: params
+      post('/simple_forms_api/v1/submit_scanned_form', params:)
 
       expect(response).to have_http_status(:ok)
     end
@@ -73,7 +73,7 @@ RSpec.describe 'SimpleFormsApi::V1::ScannedFormsUploader', type: :request do
         benefits_intake_uuid: anything
       )
 
-      post '/simple_forms_api/v1/submit_scanned_form', params: params
+      post('/simple_forms_api/v1/submit_scanned_form', params:)
 
       expect(response).to have_http_status(:ok)
     end
@@ -93,7 +93,7 @@ RSpec.describe 'SimpleFormsApi::V1::ScannedFormsUploader', type: :request do
 
       expect(prefill_data_service).to receive(:check_for_changes)
 
-      post '/simple_forms_api/v1/submit_scanned_form', params: params
+      post('/simple_forms_api/v1/submit_scanned_form', params:)
 
       expect(response).to have_http_status(:ok)
     end

--- a/modules/simple_forms_api/spec/services/notification_email_spec.rb
+++ b/modules/simple_forms_api/spec/services/notification_email_spec.rb
@@ -611,7 +611,7 @@ describe SimpleFormsApi::NotificationEmail do
       let(:config) do
         {
           form_number: 'vba_40_10007',
-          form_data: form_data,
+          form_data:,
           confirmation_number: '8679305',
           date_submitted: Time.zone.today.strftime('%B %d, %Y')
         }

--- a/modules/travel_pay/spec/requests/travel_pay/claims_spec.rb
+++ b/modules/travel_pay/spec/requests/travel_pay/claims_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe TravelPay::V0::ClaimsController, type: :request do
       headers = { 'Authorization' => 'Bearer vagov_token' }
       params = {}
 
-      post '/travel_pay/v0/claims', headers: headers, params: params
+      post('/travel_pay/v0/claims', headers:, params:)
 
       expect(response).to have_http_status(:service_unavailable)
     end
@@ -126,7 +126,7 @@ RSpec.describe TravelPay::V0::ClaimsController, type: :request do
         headers = { 'Authorization' => 'Bearer vagov_token' }
         params = { 'appointment_datetime' => '2024-01-01T16:45:34.465Z' }
 
-        post '/travel_pay/v0/claims', headers: headers, params: params
+        post('/travel_pay/v0/claims', headers:, params:)
         expect(response).to have_http_status(:created)
       end
     end
@@ -139,7 +139,7 @@ RSpec.describe TravelPay::V0::ClaimsController, type: :request do
         headers = { 'Authorization' => 'Bearer vagov_token' }
         params = { 'appointment_datetime' => 'My birthday, 4 years ago' }
 
-        post '/travel_pay/v0/claims', headers: headers, params: params
+        post('/travel_pay/v0/claims', headers:, params:)
 
         expect(response).to have_http_status(:bad_request)
       end
@@ -153,7 +153,7 @@ RSpec.describe TravelPay::V0::ClaimsController, type: :request do
         headers = { 'Authorization' => 'Bearer vagov_token' }
         params = { 'appointment_datetime' => '1970-01-01T00:00:00.000Z' }
 
-        post '/travel_pay/v0/claims', headers: headers, params: params
+        post('/travel_pay/v0/claims', headers:, params:)
 
         error_detail = JSON.parse(response.body)['errors'][0]['detail']
         expect(response).to have_http_status(:not_found)
@@ -172,7 +172,7 @@ RSpec.describe TravelPay::V0::ClaimsController, type: :request do
         headers = { 'Authorization' => 'Bearer vagov_token' }
         params = { 'appointment_datetime' => '2024-01-01T16:45:34.465Z' }
 
-        post '/travel_pay/v0/claims', headers: headers, params: params
+        post('/travel_pay/v0/claims', headers:, params:)
 
         expect(response).to have_http_status(:internal_server_error)
       end

--- a/modules/va_notify/app/controllers/va_notify/callbacks_controller.rb
+++ b/modules/va_notify/app/controllers/va_notify/callbacks_controller.rb
@@ -16,7 +16,7 @@ module VANotify
     def create
       notification_id = params[:id]
 
-      if (notification = VANotify::Notification.find_by(notification_id: notification_id))
+      if (notification = VANotify::Notification.find_by(notification_id:))
         notification.update(notification_params)
         Rails.logger.info("va_notify callbacks - Updating notification: #{notification.id}",
                           {

--- a/modules/va_notify/lib/va_notify/service.rb
+++ b/modules/va_notify/lib/va_notify/service.rb
@@ -117,7 +117,7 @@ module VaNotify
         source_location: find_caller_locations,
         callback_klass: callback_options[:callback_klass] || callback_options['callback_klass'],
         callback_metadata: callback_options[:callback_metadata] || callback_options['callback_metadata'],
-        template_id: template_id
+        template_id:
       )
 
       if notification.save
@@ -135,7 +135,7 @@ module VaNotify
         'VANotify notification record failed to save',
         {
           error_messages: notification.errors,
-          template_id: template_id
+          template_id:
         }
       )
     end
@@ -145,7 +145,7 @@ module VaNotify
         "VANotify notification: #{notification.id} saved",
         {
           source_location: notification.source_location,
-          template_id: template_id,
+          template_id:,
           callback_metadata: notification.callback_metadata,
           callback_klass: notification.callback_klass
         }

--- a/modules/va_notify/spec/requests/callbacks_spec.rb
+++ b/modules/va_notify/spec/requests/callbacks_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe 'VANotify Callbacks', type: :request do
       context 'with found notification' do
         it 'updates notification' do
           template_id = SecureRandom.uuid
-          notification = VANotify::Notification.create(notification_id: notification_id,
+          notification = VANotify::Notification.create(notification_id:,
                                                        source_location: 'some_location',
                                                        callback_metadata: 'some_callback_metadata',
-                                                       template_id: template_id)
+                                                       template_id:)
           expect(notification.status).to be_nil
           allow(Rails.logger).to receive(:info)
           callback_obj = double('VANotify::DefaultCallback')
@@ -42,7 +42,7 @@ RSpec.describe 'VANotify Callbacks', type: :request do
 
           expect(Rails.logger).to have_received(:info).with(
             "va_notify callbacks - Updating notification: #{notification.id}",
-            { source_location: 'some_location', template_id: template_id, callback_metadata: 'some_callback_metadata',
+            { source_location: 'some_location', template_id:, callback_metadata: 'some_callback_metadata',
               status: 'delivered' }
           )
           expect(response.body).to include('success')

--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -72,7 +72,7 @@ module VAOS
 
         response_data = OpenStruct.new(
           id: draft_appointment.id,
-          provider: provider,
+          provider:,
           slots: fetch_provider_slots,
           drive_time: fetch_drive_times(provider)
         )

--- a/modules/vaos/app/controllers/vaos/v2/eps_appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/eps_appointments_controller.rb
@@ -13,7 +13,7 @@ module VAOS
 
         response = OpenStruct.new({
                                     id: appointment[:id],
-                                    appointment: appointment,
+                                    appointment:,
                                     provider: unless appointment[:provider_service_id].nil?
                                                 provider_service.get_provider_service(
                                                   provider_id: appointment[:provider_service_id]

--- a/modules/vaos/app/services/eps/jwt_wrapper.rb
+++ b/modules/vaos/app/services/eps/jwt_wrapper.rb
@@ -34,7 +34,7 @@ module Eps
 
     def jwt_headers
       {
-        kid: kid,
+        kid:,
         typ: 'JWT',
         alg: SIGNING_ALGORITHM
       }

--- a/modules/vaos/app/services/eps/provider_service.rb
+++ b/modules/vaos/app/services/eps/provider_service.rb
@@ -44,8 +44,8 @@ module Eps
     #
     def get_drive_times(destinations:, origin:)
       payload = {
-        destinations: destinations,
-        origin: origin
+        destinations:,
+        origin:
       }
 
       response = perform(:post, "/#{config.base_path}/drive-times", payload, headers)

--- a/modules/vaos/app/services/vaos/v2/relationships_service.rb
+++ b/modules/vaos/app/services/vaos/v2/relationships_service.rb
@@ -20,7 +20,7 @@ module VAOS
           data = VAOS::V2::VAOSSerializer.new.serialize(relationships, 'relationship')
           data.each { |relationship| relationship.delete(:id) }
 
-          { data: data, meta: partial_errors(response) }
+          { data:, meta: partial_errors(response) }
         end
       end
 

--- a/modules/vaos/spec/serializers/eps/draft_appointment_serializer_spec.rb
+++ b/modules/vaos/spec/serializers/eps/draft_appointment_serializer_spec.rb
@@ -68,9 +68,9 @@ RSpec.describe Eps::DraftAppointmentSerializer do
   let(:draft_appointment) do
     double(
       id: 123,
-      provider: provider,
-      slots: slots,
-      drive_time: drive_time
+      provider:,
+      slots:,
+      drive_time:
     )
   end
 

--- a/modules/vaos/spec/serializers/eps/eps_appointment_serializer_spec.rb
+++ b/modules/vaos/spec/serializers/eps/eps_appointment_serializer_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe Eps::EpsAppointmentSerializer do
   let(:eps_appointment) do
     double(
       id: 123,
-      appointment: appointment,
-      provider: provider
+      appointment:,
+      provider:
     )
   end
 

--- a/modules/vaos/spec/services/eps/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/eps/appointment_service_spec.rb
@@ -14,7 +14,7 @@ describe Eps::AppointmentService do
 
   before do
     allow(config).to receive(:base_path).and_return('api/v1')
-    allow_any_instance_of(Eps::BaseService).to receive_messages(config: config, headers: headers)
+    allow_any_instance_of(Eps::BaseService).to receive_messages(config:, headers:)
   end
 
   describe '#get_appointment' do

--- a/modules/vaos/spec/services/eps/provider_service_spec.rb
+++ b/modules/vaos/spec/services/eps/provider_service_spec.rb
@@ -11,7 +11,7 @@ describe Eps::ProviderService do
 
   before do
     allow(config).to receive(:base_path).and_return('api/v1')
-    allow(service).to receive_messages(config: config, headers: headers)
+    allow(service).to receive_messages(config:, headers:)
   end
 
   describe '#get_provider_services' do

--- a/modules/vba_documents/lib/vba_documents/monthly_stats_generator.rb
+++ b/modules/vba_documents/lib/vba_documents/monthly_stats_generator.rb
@@ -11,7 +11,7 @@ module VBADocuments
     end
 
     def generate_and_save_stats
-      VBADocuments::MonthlyStat.find_or_create_by(month: @month, year: @year).update(stats: stats)
+      VBADocuments::MonthlyStat.find_or_create_by(month: @month, year: @year).update(stats:)
     end
 
     private
@@ -82,7 +82,7 @@ module VBADocuments
         {
           consumer_name: consumer,
           expired_count: expired_records.for_consumer(consumer).count,
-          errored_count: errored_count,
+          errored_count:,
           processing_count: processing_records.for_consumer(consumer).count,
           success_count: success_records.for_consumer(consumer).count,
           vbms_count: vbms_records.for_consumer(consumer).count,

--- a/modules/vye/spec/controllers/vye/v1/dgib_verifications_controller_spec.rb
+++ b/modules/vye/spec/controllers/vye/v1/dgib_verifications_controller_spec.rb
@@ -83,10 +83,10 @@ RSpec.describe Vye::V1::DgibVerificationsController, type: :controller do
         expect_any_instance_of(Vye::DGIB::Service).to receive(:verify_claimant)
 
         post :verify_claimant, params: {
-          claimant_id: claimant_id,
-          verified_period_begin_date: verified_period_begin_date,
-          verified_period_end_date: verified_period_end_date,
-          verified_through_date: verified_through_date
+          claimant_id:,
+          verified_period_begin_date:,
+          verified_period_end_date:,
+          verified_through_date:
         }
       end
 
@@ -94,10 +94,10 @@ RSpec.describe Vye::V1::DgibVerificationsController, type: :controller do
         expect(controller).to receive(:render).with(json: serializer.serializable_hash.to_json)
 
         post :verify_claimant, params: {
-          claimant_id: claimant_id,
-          verified_period_begin_date: verified_period_begin_date,
-          verified_period_end_date: verified_period_end_date,
-          verified_through_date: verified_through_date
+          claimant_id:,
+          verified_period_begin_date:,
+          verified_period_end_date:,
+          verified_through_date:
         }
       end
     end

--- a/modules/vye/spec/lib/vye/batch_transfer/chunk_spec.rb
+++ b/modules/vye/spec/lib/vye/batch_transfer/chunk_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Vye::BatchTransfer::Chunk do
 
         allow(Vye::BatchTransfer::Chunking)
           .to receive(:new)
-          .with(filename: filename, block_size: anything)
+          .with(filename:, block_size: anything)
           .and_return(mock_chunking)
 
         allow(mock_chunking).to receive(:split).and_return(mock_chunks)

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe V1::SessionsController, type: :controller do
           end
 
           context 'and the operation param is invalid' do
-            subject(:call_endpoint) { get(:new, params: params) }
+            subject(:call_endpoint) { get(:new, params:) }
 
             let(:params) { { type: 'idme_verified', clientId: '123123', operation: 'asdf' } }
 

--- a/spec/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/document_upload/lighthouse_supplemental_document_upload_provider_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe LighthouseSupplementalDocumentUploadProvider do
         form526_submission_id: submission.id,
         # Polling record type mapped to L023 used in tests
         document_type: Lighthouse526DocumentUpload::BDD_INSTRUCTIONS_DOCUMENT_TYPE,
-        lighthouse_document_request_id: lighthouse_document_request_id
+        lighthouse_document_request_id:
       }
 
       expect do
@@ -172,7 +172,7 @@ RSpec.describe LighthouseSupplementalDocumentUploadProvider do
         aasm_state: 'pending',
         form526_submission_id: submission.id,
         document_type: Lighthouse526DocumentUpload::VETERAN_UPLOAD_DOCUMENT_TYPE,
-        lighthouse_document_request_id: lighthouse_document_request_id,
+        lighthouse_document_request_id:,
         form_attachment: supporting_evidence_attachment
       }
 

--- a/spec/lib/medical_records/bb_internal/client_spec.rb
+++ b/spec/lib/medical_records/bb_internal/client_spec.rb
@@ -445,7 +445,7 @@ describe BBInternal::Client do
   end
 
   describe '#invalid?' do
-    let(:session_data) { OpenStruct.new(icn: icn, patient_id: patient_id, expired?: session_expired) }
+    let(:session_data) { OpenStruct.new(icn:, patient_id:, expired?: session_expired) }
 
     context 'when session is expired' do
       let(:session_expired) { true }

--- a/spec/lib/vets/collections/pagination_spec.rb
+++ b/spec/lib/vets/collections/pagination_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe Vets::Collections::Pagination do
   describe '#initialize' do
     context 'without WillPaginate' do
       it 'paginates the data correctly' do
-        pagination = described_class.new(page: 2, per_page: 10, total_entries: data.size, data: data)
+        pagination = described_class.new(page: 2, per_page: 10, total_entries: data.size, data:)
         expect(pagination.data).to eq((11..20).to_a)
       end
 
       it 'returns an empty array for out-of-bounds page' do
-        pagination = described_class.new(page: 6, per_page: 10, total_entries: data.size, data: data)
+        pagination = described_class.new(page: 6, per_page: 10, total_entries: data.size, data:)
         expect(pagination.data).to eq([])
       end
 
@@ -34,7 +34,7 @@ RSpec.describe Vets::Collections::Pagination do
       end
 
       it 'uses WillPaginate::Collection for pagination' do
-        described_class.new(page: 1, per_page: 10, total_entries: data.size, data: data,
+        described_class.new(page: 1, per_page: 10, total_entries: data.size, data:,
                             use_will_paginate: true)
         expect(WillPaginate::Collection).to have_received(:create).with(1, 10, data.size)
       end
@@ -43,7 +43,7 @@ RSpec.describe Vets::Collections::Pagination do
         allow_any_instance_of(WillPaginate::Collection).to receive(:out_of_bounds?).and_return(true)
 
         expect do
-          described_class.new(page: 10, per_page: 10, total_entries: data.size, data: data, use_will_paginate: true)
+          described_class.new(page: 10, per_page: 10, total_entries: data.size, data:, use_will_paginate: true)
         end.to raise_error(Common::Exceptions::InvalidPaginationParams)
       end
     end
@@ -51,7 +51,7 @@ RSpec.describe Vets::Collections::Pagination do
 
   describe '#metadata' do
     it 'returns the correct pagination metadata' do
-      pagination = described_class.new(page: 2, per_page: 10, total_entries: data.size, data: data)
+      pagination = described_class.new(page: 2, per_page: 10, total_entries: data.size, data:)
       expected_metadata = {
         pagination: {
           current_page: 2,

--- a/spec/models/concerns/form_validation_spec.rb
+++ b/spec/models/concerns/form_validation_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe FormValidation do
                                          backtrace: anything })
 
             expect(PersonalInformationLog).to receive(:create).with(
-              data: { schema: schema,
-                      parsed_form: parsed_form,
+              data: { schema:,
+                      parsed_form:,
                       params: { errors_as_objects: true } },
               error_class: "#{instance.class} FormValidationError"
             )
@@ -130,8 +130,8 @@ RSpec.describe FormValidation do
                                          backtrace: anything })
 
             expect(PersonalInformationLog).to receive(:create).with(
-              data: { schema: schema,
-                      parsed_form: parsed_form,
+              data: { schema:,
+                      parsed_form:,
                       params: { errors_as_objects: true } },
               error_class: "#{instance.class} FormValidationError"
             )

--- a/spec/models/saved_claim/higher_level_review_spec.rb
+++ b/spec/models/saved_claim/higher_level_review_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SavedClaim::HigherLevelReview, type: :model do
     let!(:saved_claim_hlr) do
       SavedClaim::HigherLevelReview.create!(
         form_id: '20-0996',
-        guid: guid,
+        guid:,
         form: form_data.to_json,
         form_start_date: Time.current
       )

--- a/spec/models/saved_claim/notice_of_disagreement_spec.rb
+++ b/spec/models/saved_claim/notice_of_disagreement_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SavedClaim::NoticeOfDisagreement, type: :model do
     let!(:saved_claim_nod) do
       SavedClaim::NoticeOfDisagreement.create!(
         form_id: '19182',
-        guid: guid,
+        guid:,
         form: form_data.to_json,
         form_start_date: Time.current
       )

--- a/spec/models/saved_claim/supplemental_claim_spec.rb
+++ b/spec/models/saved_claim/supplemental_claim_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SavedClaim::SupplementalClaim, type: :model do
     let!(:saved_claim_sc) do
       SavedClaim::SupplementalClaim.create!(
         form_id: '20-0995',
-        guid: guid,
+        guid:,
         form: form_data.to_json,
         form_start_date: Time.current
       )

--- a/spec/models/saved_claim_spec.rb
+++ b/spec/models/saved_claim_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe TestSavedClaim, type: :model do # rubocop:disable RSpec/SpecFileP
     let(:form_data) { { some_key: [{ confirmationCode: confirmation_code }] }.to_json }
 
     it 'processes attachments associated with the claim' do
-      attachment = create(:persistent_attachment, guid: confirmation_code, saved_claim: saved_claim)
+      attachment = create(:persistent_attachment, guid: confirmation_code, saved_claim:)
       saved_claim.process_attachments!
 
       expect(attachment.reload.saved_claim_id).to eq(saved_claim.id)
@@ -175,7 +175,7 @@ RSpec.describe TestSavedClaim, type: :model do # rubocop:disable RSpec/SpecFileP
 
     let!(:notification) do
       ClaimVANotification.create(
-        saved_claim: saved_claim,
+        saved_claim:,
         email_template_id:,
         form_type: saved_claim.form_id,
         email_sent: false

--- a/spec/requests/v0/test_account_user_emails_spec.rb
+++ b/spec/requests/v0/test_account_user_emails_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'V0::TestAccountUserEmails', type: :request do
 
     let(:email) { 'some-email' }
     let(:email_redis_key) { 'some-email-redis-key' }
-    let(:params) { { email: email } }
+    let(:params) { { email: } }
     let(:rendered_error) { { 'errors' => 'invalid params' } }
 
     before do
@@ -37,7 +37,7 @@ RSpec.describe 'V0::TestAccountUserEmails', type: :request do
     end
 
     context 'when params include email' do
-      let(:params) { { email: email } }
+      let(:params) { { email: } }
 
       context 'and email param is empty' do
         let(:email) { '' }

--- a/spec/services/user_audit_logger_spec.rb
+++ b/spec/services/user_audit_logger_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe UserAuditLogger do
 
       user_action = UserAction.last
       expect(user_action).to have_attributes(
-        user_action_event: user_action_event,
-        acting_user_verification: acting_user_verification,
-        subject_user_verification: subject_user_verification,
+        user_action_event:,
+        acting_user_verification:,
+        subject_user_verification:,
         status: 'initial',
-        acting_ip_address: acting_ip_address,
-        acting_user_agent: acting_user_agent
+        acting_ip_address:,
+        acting_user_agent:
       )
     end
 

--- a/spec/sidekiq/evss/document_upload_spec.rb
+++ b/spec/sidekiq/evss/document_upload_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe EVSS::DocumentUpload, type: :job do
         allow(EvidenceSubmission).to receive(:find_by).with({ job_id: job_id.to_s })
                                                       .and_return(evidence_submission_pending)
         described_class.drain
-        evidence_submission = EvidenceSubmission.find_by(job_id: job_id)
+        evidence_submission = EvidenceSubmission.find_by(job_id:)
         expect(evidence_submission.upload_status).to eql(BenefitsDocuments::Constants::UPLOAD_STATUS[:SUCCESS])
         expect(evidence_submission.delete_date).not_to be_nil
       end
@@ -132,7 +132,7 @@ RSpec.describe EVSS::DocumentUpload, type: :job do
                                                      tags: ['service:claim-status', "function: #{message}"])
         end
         expect(EvidenceSubmission.va_notify_email_not_queued.length).to equal(1)
-        evidence_submission = EvidenceSubmission.find_by(job_id: job_id)
+        evidence_submission = EvidenceSubmission.find_by(job_id:)
         current_personalisation = JSON.parse(evidence_submission.template_metadata)['personalisation']
         expect(evidence_submission.upload_status).to eql(BenefitsDocuments::Constants::UPLOAD_STATUS[:FAILED])
         expect(evidence_submission.error_message).to eql('EVSS::DocumentUpload document upload failure')

--- a/spec/sidekiq/evss/failure_notification_spec.rb
+++ b/spec/sidekiq/evss/failure_notification_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe EVSS::FailureNotification, type: :job do
             recipient_identifier: { id_value: user_account.icn, id_type: 'ICN' },
             template_id: 'fake_template_id',
             personalisation: {
-              first_name: first_name,
+              first_name:,
               document_type: document_description,
               filename: file_name,
               date_submitted: formatted_submit_date,

--- a/spec/sidekiq/lighthouse/evidence_submissions/document_upload_spec.rb
+++ b/spec/sidekiq/lighthouse/evidence_submissions/document_upload_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Lighthouse::EvidenceSubmissions::DocumentUpload, type: :job do
         described_class.drain # runs all queued jobs of this class
         # After running DocumentUpload job, there should be an updated EvidenceSubmission record
         # with the response request_id
-        new_evidence_submission = EvidenceSubmission.find_by(job_id: job_id)
+        new_evidence_submission = EvidenceSubmission.find_by(job_id:)
         expect(new_evidence_submission.request_id).to eql(success_response.body.dig('data', 'requestId'))
         expect(new_evidence_submission.upload_status).to eql(BenefitsDocuments::Constants::UPLOAD_STATUS[:PENDING])
       end
@@ -155,7 +155,7 @@ RSpec.describe Lighthouse::EvidenceSubmissions::DocumentUpload, type: :job do
                                                      tags: ['service:claim-status', "function: #{message}"])
         end
         expect(EvidenceSubmission.va_notify_email_not_queued.length).to equal(1)
-        evidence_submission = EvidenceSubmission.find_by(job_id: job_id)
+        evidence_submission = EvidenceSubmission.find_by(job_id:)
         current_personalisation = JSON.parse(evidence_submission.template_metadata)['personalisation']
         expect(evidence_submission.upload_status).to eql(BenefitsDocuments::Constants::UPLOAD_STATUS[:FAILED])
         expect(evidence_submission.error_message)

--- a/spec/sidekiq/lighthouse/evidence_submissions/failure_notification_email_job_spec.rb
+++ b/spec/sidekiq/lighthouse/evidence_submissions/failure_notification_email_job_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Lighthouse::EvidenceSubmissions::FailureNotificationEmailJob, typ
         expect(Rails.logger)
           .to receive(:error)
           .with(error_message, { message: 'StandardError' })
-        expect(StatsD).to receive(:increment).with('silent_failure', tags: tags)
+        expect(StatsD).to receive(:increment).with('silent_failure', tags:)
         subject.new.perform
       end
     end
@@ -98,7 +98,7 @@ RSpec.describe Lighthouse::EvidenceSubmissions::FailureNotificationEmailJob, typ
         expect(vanotify_service).to receive(:send_email).with(send_email_params)
         expect(evidence_submission_failed).to receive(:update).and_call_original
         expect(Rails.logger).to receive(:info).with(message)
-        expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation', tags: tags)
+        expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation', tags:)
         subject.new.perform
         expect(EvidenceSubmission.va_notify_email_queued.length).to eq(1)
       end
@@ -125,7 +125,7 @@ RSpec.describe Lighthouse::EvidenceSubmissions::FailureNotificationEmailJob, typ
         expect(Rails.logger)
           .to receive(:error)
           .with(error_message, { message: 'StandardError' })
-        expect(StatsD).to receive(:increment).with('silent_failure', tags: tags)
+        expect(StatsD).to receive(:increment).with('silent_failure', tags:)
         subject.new.perform
       end
     end
@@ -162,7 +162,7 @@ RSpec.describe Lighthouse::EvidenceSubmissions::FailureNotificationEmailJob, typ
         expect(vanotify_service).to receive(:send_email).with(send_email_params)
         expect(evidence_submission_failed).to receive(:update).and_call_original
         expect(Rails.logger).to receive(:info).with(message)
-        expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation', tags: tags)
+        expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation', tags:)
         subject.new.perform
         expect(EvidenceSubmission.va_notify_email_queued.length).to eq(1)
       end
@@ -189,7 +189,7 @@ RSpec.describe Lighthouse::EvidenceSubmissions::FailureNotificationEmailJob, typ
         expect(Rails.logger)
           .to receive(:error)
           .with(error_message, { message: 'StandardError' })
-        expect(StatsD).to receive(:increment).with('silent_failure', tags: tags)
+        expect(StatsD).to receive(:increment).with('silent_failure', tags:)
         subject.new.perform
       end
     end
@@ -226,7 +226,7 @@ RSpec.describe Lighthouse::EvidenceSubmissions::FailureNotificationEmailJob, typ
         expect(vanotify_service).to receive(:send_email).with(send_email_params)
         expect(evidence_submission_failed).to receive(:update).and_call_original
         expect(Rails.logger).to receive(:info).with(message)
-        expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation', tags: tags)
+        expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation', tags:)
         subject.new.perform
         expect(EvidenceSubmission.va_notify_email_queued.length).to eq(1)
       end

--- a/spec/sidekiq/lighthouse/failure_notification_spec.rb
+++ b/spec/sidekiq/lighthouse/failure_notification_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Lighthouse::FailureNotification, type: :job do
             recipient_identifier: { id_value: user_account.icn, id_type: 'ICN' },
             template_id: 'fake_template_id',
             personalisation: {
-              first_name: first_name,
+              first_name:,
               document_type: document_description,
               filename: file_name,
               date_submitted: formatted_submit_date,

--- a/spec/sidekiq/lighthouse/submit_benefits_intake_claim_spec.rb
+++ b/spec/sidekiq/lighthouse/submit_benefits_intake_claim_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Lighthouse::SubmitBenefitsIntakeClaim, :uploader_helpers do
       expect(record).to receive(:to_pdf).and_return('path1')
       expect(PDFUtilities::DatestampPdf).to receive(:new).with('path1').and_return(datestamp_double1)
       expect(datestamp_double1).to receive(:run).with(text: 'VA.GOV', x: 5, y: 5,
-                                                      timestamp: timestamp).and_return('path2')
+                                                      timestamp:).and_return('path2')
       expect(PDFUtilities::DatestampPdf).to receive(:new).with('path2').and_return(datestamp_double2)
       expect(datestamp_double2).to receive(:run).with(
         text: 'FDC Reviewed - va.gov Submission',


### PR DESCRIPTION
## Summary

- add rubocop rule to always enforce shorthand hash syntax
- safe autocorrect

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103399

## Testing done

- [ ] testing on CI

## Acceptance criteria

- [x] Add a hash without shorthand syntax to a file.
- [x] Run `rubocop` on that file.
- [x] Rubocop fails with the HashSyntax error. 