### PR TITLE
[ARP] Register cron for ARP allowlist sync

### DIFF
--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -225,6 +225,9 @@ PERIODIC_JOBS = lambda { |mgr| # rubocop:disable Metrics/BlockLength
   # Every 15min job that sends missing Pega statuses to DataDog
   mgr.register('*/15 * * * *', 'IvcChampva::MissingFormStatusJob')
 
+  # Every 15min job that syncs ARP's allowlist
+  mgr.register('*/15 * * * *', 'AccreditedRepresentativePortal::AllowListSyncJob')
+
   # Engine version: Sync non-final DR SavedClaims to LH status
   mgr.register('10 */4 * * *', 'DecisionReviews::HlrStatusUpdaterJob')
   mgr.register('15 1-21/4 * * *', 'DecisionReviews::NodStatusUpdaterJob')


### PR DESCRIPTION
@stevenjcumming This will cron up that allowlist sync job!

FYI, we might intentionally get the cron going before we update parameter store with some values (this will cause the job to error but we can just look at the errors in DD and that would be pretty neat).

Then after parameter store values are set we'll merge in the final piece of code that bases our authorization on this allowlist and the sidekiq pods would at that point get new'd with the necessary env vars.