### PR TITLE
Add back previously removed Data Dog trace for submitted forms - IVC CHAMPVA forms

### DIFF
--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
@@ -16,8 +16,9 @@ module IvcChampva
       }.freeze
 
       def submit
-        begin
+        Datadog::Tracing.trace('Start IVC File Submission') do
           form_id = get_form_id
+          Datadog::Tracing.active_trace&.set_tag('form_id', form_id)
           parsed_form_data = JSON.parse(params.to_json)
           statuses, error_message = handle_file_uploads(form_id, parsed_form_data)
 


### PR DESCRIPTION
## Summary

During the refactoring of [this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/20727/), we removed a data dog trace that was useful in our dashboard. This PR adds it back.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/102270

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots

|Form ID|
|-|
|<img width="597" alt="err_msg" src="https://github.com/user-attachments/assets/ad06e392-71e8-47af-847a-e305b6cdc76d" />|

## What areas of the site does it impact?

IVC CHAMPVA forms only

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA
