### PR TITLE
[VI-1078] Pass user_verification_id in UserLoader

### DIFF
--- a/app/services/sign_in/user_loader.rb
+++ b/app/services/sign_in/user_loader.rb
@@ -29,6 +29,7 @@ module SignIn
       current_user.last_signed_in = session.created_at
       current_user.fingerprint = request_ip
       current_user.session_handle = access_token.session_handle
+      current_user.user_verification_id = user_verification.id
       current_user.save && user_identity.save
       current_user.invalidate_mpi_cache
       current_user.validate_mpi_profile

--- a/spec/services/sign_in/user_loader_spec.rb
+++ b/spec/services/sign_in/user_loader_spec.rb
@@ -70,6 +70,18 @@ RSpec.describe SignIn::UserLoader do
           it 'reloads user object with expected backing idme uuid' do
             expect(subject.idme_uuid).to eq user_verification.backing_idme_uuid
           end
+
+          context 'and the user has an unverified idme user_verification' do
+            let(:unverified_user_account) { create(:user_account, icn: nil) }
+            let!(:idme_user_verification) do
+              create(:idme_user_verification, idme_uuid: user_verification.backing_idme_uuid, verified_at: nil,
+                                              user_account: unverified_user_account)
+            end
+
+            it 'reloads the user object with the expected user_verification' do
+              expect(subject.user_verification).to eq user_verification
+            end
+          end
         end
 
         context 'and user is authenticated with mhv' do
@@ -77,6 +89,18 @@ RSpec.describe SignIn::UserLoader do
 
           it 'reloads user object with expected backing idme uuid' do
             expect(subject.idme_uuid).to eq user_verification.backing_idme_uuid
+          end
+
+          context 'and the user has an unverified idme user_verification' do
+            let(:unverified_user_account) { create(:user_account, icn: nil) }
+            let!(:idme_user_verification) do
+              create(:idme_user_verification, idme_uuid: user_verification.backing_idme_uuid, verified_at: nil,
+                                              user_account: unverified_user_account)
+            end
+
+            it 'reloads the user object with the expected user_verification' do
+              expect(subject.user_verification).to eq user_verification
+            end
           end
         end
 
@@ -115,6 +139,7 @@ RSpec.describe SignIn::UserLoader do
           expect(reloaded_user.identity_sign_in).to eq(sign_in)
           expect(reloaded_user.multifactor).to eq(multifactor)
           expect(reloaded_user.fingerprint).to eq(request_ip)
+          expect(reloaded_user.user_verification).to eq(user_verification)
         end
 
         it 'reloads user object so that MPI can be called for additional attributes' do


### PR DESCRIPTION
## Summary

- If a user has a verified `mhv` or `dslogon` account with a `backing_idme_uuid` and an unverified `idme` account with the same `idme_uuid` it will find the unverified `UserVerification` in `User`. 
- This happens if a user has a verified mhv/dslogon account that shares the same email with an unverified `idme`
- Pass the `user_verification_id` in the `UserLoader` to make sure the correct one is set

## Related issue(s)
- https://jira.devops.va.gov/browse/VI-1078

## Test
- Test Sign In service auth
- will need to test MHV on staging


## What areas of the site does it impact?
Sign In service

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
x- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
