### PR TITLE
103415: Handle schema read errors for DR SavedClaim models

### DIFF
--- a/app/models/saved_claim/higher_level_review.rb
+++ b/app/models/saved_claim/higher_level_review.rb
@@ -3,6 +3,7 @@
 class SavedClaim::HigherLevelReview < SavedClaim
   has_one :appeal_submission, class_name: 'AppealSubmission', foreign_key: :submitted_appeal_uuid, primary_key: :guid,
                               dependent: nil, inverse_of: :saved_claim_hlr, required: false
+
   FORM = '20-0996'
 
   def form_matches_schema
@@ -14,10 +15,13 @@ class SavedClaim::HigherLevelReview < SavedClaim
     validation_errors = JSON::Validator.fully_validate(schema, parsed_form)
 
     unless validation_errors.empty?
-      Rails.logger.warn("SavedClaim: form schema errors detected for form #{FORM}", validation_errors)
+      Rails.logger.warn("SavedClaim: schema validation error detected for form #{FORM}", validation_errors)
     end
 
-    true # allow storage of invalid requests for debugging
+    true # allow storage of all requests for debugging
+  rescue JSON::Schema::ReadFailed => e
+    Rails.logger.warn("SavedClaim: form_matches_schema error raised for form #{FORM}", e)
+    true
   end
 
   def process_attachments!

--- a/app/models/saved_claim/notice_of_disagreement.rb
+++ b/app/models/saved_claim/notice_of_disagreement.rb
@@ -3,6 +3,7 @@
 class SavedClaim::NoticeOfDisagreement < SavedClaim
   has_one :appeal_submission, class_name: 'AppealSubmission', foreign_key: :submitted_appeal_uuid, primary_key: :guid,
                               dependent: nil, inverse_of: :saved_claim_nod, required: false
+
   FORM = '10182'
 
   def form_matches_schema
@@ -14,10 +15,13 @@ class SavedClaim::NoticeOfDisagreement < SavedClaim
     validation_errors = JSON::Validator.fully_validate(schema, parsed_form)
 
     unless validation_errors.empty?
-      Rails.logger.warn("SavedClaim: form schema errors detected for form #{FORM}", validation_errors)
+      Rails.logger.warn("SavedClaim: schema validation error detected for form #{FORM}", validation_errors)
     end
 
-    true # allow storage of invalid requests for debugging
+    true # allow storage of all requests for debugging
+  rescue JSON::Schema::ReadFailed => e
+    Rails.logger.warn("SavedClaim: form_matches_schema error raised for form #{FORM}", e)
+    true
   end
 
   def process_attachments!

--- a/app/models/saved_claim/supplemental_claim.rb
+++ b/app/models/saved_claim/supplemental_claim.rb
@@ -15,10 +15,13 @@ class SavedClaim::SupplementalClaim < SavedClaim
     validation_errors = JSON::Validator.fully_validate(schema, parsed_form)
 
     unless validation_errors.empty?
-      Rails.logger.warn("SavedClaim: form schema errors detected for form #{FORM}", validation_errors)
+      Rails.logger.warn("SavedClaim: schema validation error detected for form #{FORM}", validation_errors)
     end
 
-    true # allow storage of invalid requests for debugging
+    true # allow storage of all requests for debugging
+  rescue JSON::Schema::ReadFailed => e
+    Rails.logger.warn("SavedClaim: form_matches_schema error raised for form #{FORM}", e)
+    true
   end
 
   def process_attachments!

--- a/spec/models/saved_claim/higher_level_review_spec.rb
+++ b/spec/models/saved_claim/higher_level_review_spec.rb
@@ -4,22 +4,14 @@ require 'rails_helper'
 require 'decision_review_v1/service'
 
 RSpec.describe SavedClaim::HigherLevelReview, type: :model do
-  subject { described_class.new }
+  let(:guid) { SecureRandom.uuid }
+  let(:form_data) do
+    { stuff: 'things' }
+  end
+  let!(:appeal_submission) { create(:appeal_submission, type_of_appeal: 'SC', submitted_appeal_uuid: guid) }
 
   describe 'AppealSubmission association' do
-    let(:guid) { SecureRandom.uuid }
-    let(:form_data) do
-      { stuff: 'things' }
-    end
-    let!(:appeal_submission) { create(:appeal_submission, type_of_appeal: 'SC', submitted_appeal_uuid: guid) }
-    let!(:saved_claim_hlr) do
-      SavedClaim::HigherLevelReview.create!(
-        form_id: '20-0996',
-        guid:,
-        form: form_data.to_json,
-        form_start_date: Time.current
-      )
-    end
+    let!(:saved_claim_hlr) { described_class.create!(guid:, form: form_data.to_json) }
 
     it 'has one AppealSubmission' do
       expect(saved_claim_hlr.appeal_submission).to eq appeal_submission
@@ -27,6 +19,42 @@ RSpec.describe SavedClaim::HigherLevelReview, type: :model do
 
     it 'can be accessed from the AppealSubmission' do
       expect(appeal_submission.saved_claim_hlr).to eq saved_claim_hlr
+    end
+  end
+
+  describe 'validation' do
+    subject { described_class.new(guid:, form: form_data.to_json) }
+
+    context 'no validation errors' do
+      it 'returns true' do
+        allow(JSON::Validator).to receive(:fully_validate).and_return([])
+
+        expect(subject.validate).to be true
+      end
+    end
+
+    context 'with validation errors' do
+      let(:validation_errors) { ['error', 'error 2'] }
+
+      it 'returns true' do
+        allow(JSON::Validator).to receive(:fully_validate).and_return(validation_errors)
+        expect(Rails.logger).to receive(:warn).with('SavedClaim: schema validation error detected for form 20-0996',
+                                                    validation_errors)
+
+        expect(subject.validate).to be true
+      end
+    end
+
+    context 'with JSON validator exception' do
+      let(:exception) { JSON::Schema::ReadFailed.new('location', 'type') }
+
+      it 'returns true' do
+        allow(JSON::Validator).to receive(:fully_validate).and_raise(exception)
+        expect(Rails.logger).to receive(:warn).with('SavedClaim: form_matches_schema error raised for form 20-0996',
+                                                    exception)
+
+        expect(subject.validate).to be true
+      end
     end
   end
 end

--- a/spec/models/saved_claim/higher_level_review_spec.rb
+++ b/spec/models/saved_claim/higher_level_review_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe SavedClaim::HigherLevelReview, type: :model do
   end
 
   describe 'validation' do
-    subject { described_class.new(guid:, form: form_data.to_json) }
+    let!(:saved_claim_hlr) { described_class.new(guid:, form: form_data.to_json) }
 
     context 'no validation errors' do
       it 'returns true' do
         allow(JSON::Validator).to receive(:fully_validate).and_return([])
 
-        expect(subject.validate).to be true
+        expect(saved_claim_hlr.validate).to be true
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe SavedClaim::HigherLevelReview, type: :model do
         expect(Rails.logger).to receive(:warn).with('SavedClaim: schema validation error detected for form 20-0996',
                                                     validation_errors)
 
-        expect(subject.validate).to be true
+        expect(saved_claim_hlr.validate).to be true
       end
     end
 
@@ -53,7 +53,7 @@ RSpec.describe SavedClaim::HigherLevelReview, type: :model do
         expect(Rails.logger).to receive(:warn).with('SavedClaim: form_matches_schema error raised for form 20-0996',
                                                     exception)
 
-        expect(subject.validate).to be true
+        expect(saved_claim_hlr.validate).to be true
       end
     end
   end

--- a/spec/models/saved_claim/higher_level_review_spec.rb
+++ b/spec/models/saved_claim/higher_level_review_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe SavedClaim::HigherLevelReview, type: :model do
   describe 'validation' do
     let!(:saved_claim_hlr) { described_class.new(guid:, form: form_data.to_json) }
 
+    before do
+      allow(Rails.logger).to receive(:warn)
+    end
+
     context 'no validation errors' do
       it 'returns true' do
         allow(JSON::Validator).to receive(:fully_validate).and_return([])

--- a/spec/models/saved_claim/notice_of_disagreement_spec.rb
+++ b/spec/models/saved_claim/notice_of_disagreement_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe SavedClaim::NoticeOfDisagreement, type: :model do
   end
 
   describe 'validation' do
-    subject { described_class.new(guid:, form: form_data.to_json) }
+    let!(:saved_claim_nod) { described_class.new(guid:, form: form_data.to_json) }
 
     context 'no validation errors' do
       it 'returns true' do
         allow(JSON::Validator).to receive(:fully_validate).and_return([])
 
-        expect(subject.validate).to be true
+        expect(saved_claim_nod.validate).to be true
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe SavedClaim::NoticeOfDisagreement, type: :model do
         expect(Rails.logger).to receive(:warn).with('SavedClaim: schema validation error detected for form 10182',
                                                     validation_errors)
 
-        expect(subject.validate).to be true
+        expect(saved_claim_nod.validate).to be true
       end
     end
 
@@ -53,7 +53,7 @@ RSpec.describe SavedClaim::NoticeOfDisagreement, type: :model do
         expect(Rails.logger).to receive(:warn).with('SavedClaim: form_matches_schema error raised for form 10182',
                                                     exception)
 
-        expect(subject.validate).to be true
+        expect(saved_claim_nod.validate).to be true
       end
     end
   end

--- a/spec/models/saved_claim/notice_of_disagreement_spec.rb
+++ b/spec/models/saved_claim/notice_of_disagreement_spec.rb
@@ -4,22 +4,14 @@ require 'rails_helper'
 require 'decision_review_v1/service'
 
 RSpec.describe SavedClaim::NoticeOfDisagreement, type: :model do
-  subject { described_class.new }
+  let(:guid) { SecureRandom.uuid }
+  let(:form_data) do
+    { stuff: 'things' }
+  end
+  let!(:appeal_submission) { create(:appeal_submission, type_of_appeal: 'SC', submitted_appeal_uuid: guid) }
 
   describe 'AppealSubmission association' do
-    let(:guid) { SecureRandom.uuid }
-    let(:form_data) do
-      { stuff: 'things' }
-    end
-    let!(:appeal_submission) { create(:appeal_submission, type_of_appeal: 'SC', submitted_appeal_uuid: guid) }
-    let!(:saved_claim_nod) do
-      SavedClaim::NoticeOfDisagreement.create!(
-        form_id: '19182',
-        guid:,
-        form: form_data.to_json,
-        form_start_date: Time.current
-      )
-    end
+    let!(:saved_claim_nod) { described_class.create!(guid:, form: form_data.to_json) }
 
     it 'has one AppealSubmission' do
       expect(saved_claim_nod.appeal_submission).to eq appeal_submission
@@ -27,6 +19,42 @@ RSpec.describe SavedClaim::NoticeOfDisagreement, type: :model do
 
     it 'can be accessed from the AppealSubmission' do
       expect(appeal_submission.saved_claim_nod).to eq saved_claim_nod
+    end
+  end
+
+  describe 'validation' do
+    subject { described_class.new(guid:, form: form_data.to_json) }
+
+    context 'no validation errors' do
+      it 'returns true' do
+        allow(JSON::Validator).to receive(:fully_validate).and_return([])
+
+        expect(subject.validate).to be true
+      end
+    end
+
+    context 'with validation errors' do
+      let(:validation_errors) { ['error', 'error 2'] }
+
+      it 'returns true' do
+        allow(JSON::Validator).to receive(:fully_validate).and_return(validation_errors)
+        expect(Rails.logger).to receive(:warn).with('SavedClaim: schema validation error detected for form 10182',
+                                                    validation_errors)
+
+        expect(subject.validate).to be true
+      end
+    end
+
+    context 'with JSON validator exception' do
+      let(:exception) { JSON::Schema::ReadFailed.new('location', 'type') }
+
+      it 'returns true' do
+        allow(JSON::Validator).to receive(:fully_validate).and_raise(exception)
+        expect(Rails.logger).to receive(:warn).with('SavedClaim: form_matches_schema error raised for form 10182',
+                                                    exception)
+
+        expect(subject.validate).to be true
+      end
     end
   end
 end

--- a/spec/models/saved_claim/notice_of_disagreement_spec.rb
+++ b/spec/models/saved_claim/notice_of_disagreement_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe SavedClaim::NoticeOfDisagreement, type: :model do
   describe 'validation' do
     let!(:saved_claim_nod) { described_class.new(guid:, form: form_data.to_json) }
 
+    before do
+      allow(Rails.logger).to receive(:warn)
+    end
+
     context 'no validation errors' do
       it 'returns true' do
         allow(JSON::Validator).to receive(:fully_validate).and_return([])

--- a/spec/models/saved_claim/supplemental_claim_spec.rb
+++ b/spec/models/saved_claim/supplemental_claim_spec.rb
@@ -4,22 +4,14 @@ require 'rails_helper'
 require 'decision_review_v1/service'
 
 RSpec.describe SavedClaim::SupplementalClaim, type: :model do
-  subject { described_class.new }
+  let(:guid) { SecureRandom.uuid }
+  let(:form_data) do
+    { stuff: 'things' }
+  end
+  let!(:appeal_submission) { create(:appeal_submission, type_of_appeal: 'SC', submitted_appeal_uuid: guid) }
 
   describe 'AppealSubmission association' do
-    let(:guid) { SecureRandom.uuid }
-    let(:form_data) do
-      { stuff: 'things' }
-    end
-    let!(:appeal_submission) { create(:appeal_submission, type_of_appeal: 'SC', submitted_appeal_uuid: guid) }
-    let!(:saved_claim_sc) do
-      SavedClaim::SupplementalClaim.create!(
-        form_id: '20-0995',
-        guid:,
-        form: form_data.to_json,
-        form_start_date: Time.current
-      )
-    end
+    let!(:saved_claim_sc) { described_class.create!(guid:, form: form_data.to_json) }
 
     it 'has one AppealSubmission' do
       expect(saved_claim_sc.appeal_submission).to eq appeal_submission
@@ -27,6 +19,42 @@ RSpec.describe SavedClaim::SupplementalClaim, type: :model do
 
     it 'can be accessed from the AppealSubmission' do
       expect(appeal_submission.saved_claim_sc).to eq saved_claim_sc
+    end
+  end
+
+  describe 'validation' do
+    subject { described_class.new(guid:, form: form_data.to_json) }
+
+    context 'no validation errors' do
+      it 'returns true' do
+        allow(JSON::Validator).to receive(:fully_validate).and_return([])
+
+        expect(subject.validate).to be true
+      end
+    end
+
+    context 'with validation errors' do
+      let(:validation_errors) { ['error', 'error 2'] }
+
+      it 'returns true' do
+        allow(JSON::Validator).to receive(:fully_validate).and_return(validation_errors)
+        expect(Rails.logger).to receive(:warn).with('SavedClaim: schema validation error detected for form 20-0995',
+                                                    validation_errors)
+
+        expect(subject.validate).to be true
+      end
+    end
+
+    context 'with JSON validator exception' do
+      let(:exception) { JSON::Schema::ReadFailed.new('location', 'type') }
+
+      it 'returns true' do
+        allow(JSON::Validator).to receive(:fully_validate).and_raise(exception)
+        expect(Rails.logger).to receive(:warn).with('SavedClaim: form_matches_schema error raised for form 20-0995',
+                                                    exception)
+
+        expect(subject.validate).to be true
+      end
     end
   end
 end

--- a/spec/models/saved_claim/supplemental_claim_spec.rb
+++ b/spec/models/saved_claim/supplemental_claim_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe SavedClaim::SupplementalClaim, type: :model do
   describe 'validation' do
     let!(:saved_claim_sc) { described_class.new(guid:, form: form_data.to_json) }
 
+    before do
+      allow(Rails.logger).to receive(:warn)
+    end
+
     context 'no validation errors' do
       it 'returns true' do
         allow(JSON::Validator).to receive(:fully_validate).and_return([])

--- a/spec/models/saved_claim/supplemental_claim_spec.rb
+++ b/spec/models/saved_claim/supplemental_claim_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe SavedClaim::SupplementalClaim, type: :model do
   end
 
   describe 'validation' do
-    subject { described_class.new(guid:, form: form_data.to_json) }
+    let!(:saved_claim_sc) { described_class.new(guid:, form: form_data.to_json) }
 
     context 'no validation errors' do
       it 'returns true' do
         allow(JSON::Validator).to receive(:fully_validate).and_return([])
 
-        expect(subject.validate).to be true
+        expect(saved_claim_sc.validate).to be true
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe SavedClaim::SupplementalClaim, type: :model do
         expect(Rails.logger).to receive(:warn).with('SavedClaim: schema validation error detected for form 20-0995',
                                                     validation_errors)
 
-        expect(subject.validate).to be true
+        expect(saved_claim_sc.validate).to be true
       end
     end
 
@@ -53,7 +53,7 @@ RSpec.describe SavedClaim::SupplementalClaim, type: :model do
         expect(Rails.logger).to receive(:warn).with('SavedClaim: form_matches_schema error raised for form 20-0995',
                                                     exception)
 
-        expect(subject.validate).to be true
+        expect(saved_claim_sc.validate).to be true
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
- No

This PR adds error handling and logging for JSON schema read errors related to the DR SavedClaim child models (`SavedClaim::HigherLevelReview`, `SavedClaim::NoticeOfDisagreement`, and `SavedClaim::SupplementalClaim`). The errors are related to the JSON schema gem being used for validation and is not an underlying schema issue, resulting in occasional submission failures. These exceptions can be ignored as the schema validation step for these SavedClaim models occurs after a different schema validation step has already succeeded.

This is owned by the Benefits Decision Review team.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/103415

## Testing done

- [x] *New code is covered by unit tests*
The SavedClaim models would occasionally error out with a schema read error, resulting in a DB rollback and the user being presented an error message. This change allows the SavedClaim model to handle any schema exceptions and continue with saving the SavedClaim record.

## What areas of the site does it impact?
Decision Review models `SavedClaim::HigherLevelReview`, `SavedClaim::NoticeOfDisagreement`, and `SavedClaim::SupplementalClaim`

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
