### PR TITLE
Form Upload - allow png and jpeg to be validated

### DIFF
--- a/lib/shrine/plugins/validate_correct_form.rb
+++ b/lib/shrine/plugins/validate_correct_form.rb
@@ -7,7 +7,7 @@ class Shrine
     module ValidateCorrectForm
       module AttacherMethods
         WRONG_FORM = 'wrong_form'
-        ALLOWED_MIME_TYPE_STRINGS = [Mime[:pdf], Mime[:png], Mime[:jpeg]].map(&:to_s)
+        ALLOWED_MIME_TYPE_STRINGS = %i[pdf png jpeg].map { |type| Mime[type].to_s }
 
         def validate_correct_form(form_id: nil)
           return unless ALLOWED_MIME_TYPE_STRINGS.include?(get.mime_type) && form_id

--- a/lib/shrine/plugins/validate_correct_form.rb
+++ b/lib/shrine/plugins/validate_correct_form.rb
@@ -7,9 +7,10 @@ class Shrine
     module ValidateCorrectForm
       module AttacherMethods
         WRONG_FORM = 'wrong_form'
+        ALLOWED_MIME_TYPE_STRINGS = [Mime[:pdf], Mime[:png], Mime[:jpeg]].map(&:to_s)
 
         def validate_correct_form(form_id: nil)
-          return unless get.mime_type == Mime[:pdf].to_s && form_id
+          return unless ALLOWED_MIME_TYPE_STRINGS.include?(get.mime_type) && form_id
 
           image_path = Rails.root.join("#{Common::FileHelpers.random_file_path}.jpg").to_s
           file = get.download


### PR DESCRIPTION
## Summary
This PR allows `png`s and `jpeg`s to be validated in the Form Upload tool. Currently, we're only validating `pdf`s but this allows other file types to pass through and not warn the Veteran that they may be uploading the wrong file. I had expected more modifications to be necessary but I tested this locally (both for pngs and jpegs that should have passed and failed validation) and it all works great!

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=98818140&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C2030
