### PR TITLE
103567 - Update OHI form feature toggle actor type to be `cookie_id` - form 10-7959c

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -846,7 +846,7 @@ features:
     actor_type: user
     description: Datadog RUM monitoring for form 10-10d (IVC CHAMPVA)
   form107959c:
-    actor_type: user
+    actor_type: cookie_id
     description: If enabled shows the digital form experience for form 10-7959c (IVC CHAMPVA other health insurance)
   form107959a:
     actor_type: user


### PR DESCRIPTION
## Summary

This PR updates the actor type on the `form107959c` feature toggle to be `cookie_id` so that users will have a consistent flipper experience across both the static entry page and the actual form intro page (rather than having the flipper re-roll the dice in those two locations and potentially giving users confusing results).

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103567

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA
