### PR TITLE
[#101130] Travel Pay, service error nil response body handling

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/service_error.rb
+++ b/modules/travel_pay/app/services/travel_pay/service_error.rb
@@ -18,6 +18,11 @@ module TravelPay
 
     def self.raise_mapped_error(error)
       begin
+        if error.nil?
+          Rails.logger.warn(message: 'raise_mapped_error received nil error')
+          return
+        end
+
         status_code = error.response_status
         symbolized_body = error.response_body.deep_symbolize_keys
         message = symbolized_body[:message]

--- a/modules/travel_pay/spec/services/service_error_spec.rb
+++ b/modules/travel_pay/spec/services/service_error_spec.rb
@@ -4,26 +4,25 @@ require 'rails_helper'
 
 describe TravelPay::ServiceError do
   context 'raise_mapped_error' do
-    # it 'throws error that has error map match' do
-    #   faraday = Faraday.new("https://test.com/") do |config|
-    #     config.response :raise_error
-    #   end
+    let(:error) do
+      env = Faraday::Env.new.tap do |e|
+        e.status = 500
+        e.define_singleton_method(:response_body) { nil }
+      end
+      Faraday::Error.new('There was a problem', env)
+    end
 
-    #   begin
-    #     faraday.get("a", "b" => "c")
-    #   rescue Faraday::Error => e
-    #     expect do
-    #       TravelPay::ServiceError.raise_mapped_error(e)
-    #     end
-    #       .to raise_error(ServerError, /There was a problem/i)
-    #   end
-    # end
+    it 'returns custom server error if response_body is nil' do
+      expect(Rails.logger).to receive(:error).with(
+        message: "raise_mapped_error received nil response_body. status: #{error.response_status}, returning 500. message: #{error.message}"
+      )
 
-    it 'disregards nil arguments' do
-      expect(TravelPay::ServiceError.raise_mapped_error(nil)).to equal(nil)
-      expect do
-        TravelPay::ServiceError.raise_mapped_error(nil)
-      end.not_to raise_error
+      expect { TravelPay::ServiceError.raise_mapped_error(error) }.to raise_error(
+        Common::Exceptions::ExternalServerInternalServerError
+      ) do |e|
+        expect(e.errors.first[:title]).to eq('There was a problem')
+        expect(e.errors.first[:status]).to eq(500)
+      end
     end
   end
 end

--- a/modules/travel_pay/spec/services/service_error_spec.rb
+++ b/modules/travel_pay/spec/services/service_error_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe TravelPay::ServiceError do
+  context 'raise_mapped_error' do
+    # it 'throws error that has error map match' do
+    #   faraday = Faraday.new("https://test.com/") do |config|
+    #     config.response :raise_error
+    #   end
+
+    #   begin
+    #     faraday.get("a", "b" => "c")
+    #   rescue Faraday::Error => e
+    #     expect do
+    #       TravelPay::ServiceError.raise_mapped_error(e)
+    #     end
+    #       .to raise_error(ServerError, /There was a problem/i)
+    #   end
+    # end
+
+    it 'disregards nil arguments' do
+      expect(TravelPay::ServiceError.raise_mapped_error(nil)).to equal(nil)
+      expect do
+        TravelPay::ServiceError.raise_mapped_error(nil)
+      end.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary

* This work is behind a feature toggle (flipper): YES

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/101130

## Testing done

- [x] *New code is covered by unit tests*

Adding error handling for cases when errors are missing a response body.

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
