### PR TITLE
[99974] Create poa request orchestration service - part 2 

### DIFF
--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/power_of_attorney_request_service/create/form_data_adapter.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/power_of_attorney_request_service/create/form_data_adapter.rb
@@ -5,7 +5,9 @@ module AccreditedRepresentativePortal
     class Create
       class FormDataAdapter
         def initialize(data:, dependent: false, service_branch: nil)
-          @data = data.transform_values(&:presence)
+          @data = data.transform_values do |value|
+            value == '' ? nil : value
+          end
           @dependent = dependent
           @service_branch = service_branch
         end

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/power_of_attorney_request_service/create/form_data_adapter_spec.rb
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/power_of_attorney_request_service/create/form_data_adapter_spec.rb
@@ -133,6 +133,15 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestService::Cr
       end
     end
 
+    context 'when an attribute is an empty string' do
+      it 'sets the value to nil' do
+        data[:claimant_address_line2] = ''
+
+        expect(subject.call[:data]['dependent']['addressLine2']).to eq(nil)
+        expect(subject.call[:errors]).to eq([])
+      end
+    end
+
     context 'when there is an error with validation' do
       it 'adds the error message to the errors attribute' do
         data[:consent_limits] = ['abc']

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/power_of_attorney_request_service/create/form_data_adapter_spec.rb
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/power_of_attorney_request_service/create/form_data_adapter_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestService::Cr
       it 'sets the value to nil' do
         data[:claimant_address_line2] = ''
 
-        expect(subject.call[:data]['dependent']['addressLine2']).to eq(nil)
+        expect(subject.call[:data]['dependent']['addressLine2']).to be_nil
         expect(subject.call[:errors]).to eq([])
       end
     end

--- a/modules/representation_management/app/controllers/representation_management/v0/power_of_attorney_requests_controller.rb
+++ b/modules/representation_management/app/controllers/representation_management/v0/power_of_attorney_requests_controller.rb
@@ -7,14 +7,13 @@ module RepresentationManagement
       before_action :feature_enabled
 
       def create
-        form = RepresentationManagement::Form2122Data.new(flatten_form_params)
-
-        if flatten_form_params[:veteran_service_number].present?
-          render json: { errors: ['render_error_state_for_failed_submission'] }, status: :unprocessable_entity
-        elsif form.valid?
-          render json: { message: 'Email enqueued' }, status: :ok
-        else
+        if !form.valid?
           render json: { errors: form.errors.full_messages }, status: :unprocessable_entity
+        elsif orchestrate_response[:errors]&.any?
+          render json: { errors: orchestrate_response[:errors] }, status: :unprocessable_entity
+        else
+          render json: RepresentationManagement::PowerOfAttorneyRequestSerializer.new(orchestrate_response[:request]),
+                 status: :created
         end
       end
 
@@ -29,14 +28,45 @@ module RepresentationManagement
       end
 
       def flatten_form_params
-        {
-          representative_id: form_params[:representative][:id],
-          organization_id: form_params[:representative][:organization_id],
-          record_consent: form_params[:record_consent],
-          consent_limits: form_params[:consent_limits],
-          consent_address_change: form_params[:consent_address_change]
-        }.merge(flatten_veteran_params(form_params))
+        @flatten_form_params ||=
+          {
+            representative_id: form_params[:representative][:id],
+            organization_id: form_params[:representative][:organization_id],
+            record_consent: [true, 'true'].include?(form_params[:record_consent]),
+            consent_limits:,
+            consent_address_change: [true, 'true'].include?(form_params[:consent_address_change])
+          }.merge(flatten_veteran_params(form_params))
           .merge(flatten_claimant_params(form_params))
+      end
+
+      def dependent
+        form_params[:claimant].present?
+      end
+
+      def service_branch
+        form_params.dig(:veteran, :service_branch)
+      end
+
+      def consent_limits
+        if form_params[:consent_limits].all?(&:blank?)
+          []
+        else
+          form_params[:consent_limits]
+        end
+      end
+
+      def form
+        @form ||= RepresentationManagement::Form2122Data.new(flatten_form_params)
+      end
+
+      def orchestrate_response
+        @orchestrate_response ||=
+          RepresentationManagement::PowerOfAttorneyRequestService::Orchestrate.new(
+            data: flatten_form_params,
+            dependent:,
+            service_branch:,
+            user: current_user
+          ).call
       end
     end
   end

--- a/modules/representation_management/app/serializers/representation_management/power_of_attorney_request_serializer.rb
+++ b/modules/representation_management/app/serializers/representation_management/power_of_attorney_request_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module RepresentationManagement
+  class PowerOfAttorneyRequestSerializer
+    include JSONAPI::Serializer
+
+    attributes :created_at, :expires_at
+  end
+end

--- a/modules/representation_management/app/services/representation_management/power_of_attorney_request_service/orchestrate.rb
+++ b/modules/representation_management/app/services/representation_management/power_of_attorney_request_service/orchestrate.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module RepresentationManagement
+  module PowerOfAttorneyRequestService
+    class Orchestrate
+      def initialize(data:, dependent:, service_branch:, user:)
+        @data = data
+        @dependent = dependent
+        @service_branch = service_branch
+        @user = user
+
+        @errors = []
+      end
+
+      def call
+        if adapter_response[:errors].any?
+          @errors << adapter_response[:errors]
+          @errors.flatten!
+
+          return { errors: @errors }
+        end
+
+        if create_response[:errors]&.any?
+          @errors << create_response[:errors]
+          @errors.flatten!
+
+          return { errors: @errors }
+        end
+
+        destroy_related_form
+
+        {
+          request: create_response[:request]
+        }
+      rescue => e
+        @errors << e.message
+
+        {
+          errors: @errors
+        }
+      end
+
+      private
+
+      def adapter_response
+        @adapter_response ||=
+          AccreditedRepresentativePortal::PowerOfAttorneyRequestService::Create::FormDataAdapter.new(
+            data: @data,
+            dependent: @dependent,
+            service_branch: @service_branch
+          ).call
+      end
+
+      def create_response
+        @create_response ||=
+          AccreditedRepresentativePortal::PowerOfAttorneyRequestService::Create.new(
+            claimant: @user.user_account,
+            form_data: adapter_response[:data],
+            poa_code: @data[:organization_id],
+            registration_number: @data[:representative_id]
+          ).call
+      end
+
+      def destroy_related_form
+        InProgressForm.form_for_user('21-22', @user)&.destroy!
+      end
+    end
+  end
+end

--- a/modules/representation_management/spec/requests/representation_management/v0/power_of_attorney_requests_controller_spec.rb
+++ b/modules/representation_management/spec/requests/representation_management/v0/power_of_attorney_requests_controller_spec.rb
@@ -5,14 +5,15 @@ require 'rails_helper'
 RSpec.describe 'RepresentationManagement::V0::PowerOfAttorneyRequests', type: :request do
   describe 'POST #create' do
     let(:user) { create(:user, :loa3) }
+    let!(:user_verification) { create(:idme_user_verification, idme_uuid: user.idme_uuid) }
     let(:base_path) { '/representation_management/v0/power_of_attorney_requests' }
-    let(:organization) { create(:organization) } # This is the legacy organization
-    let(:representative) { create(:representative) } # This is the legacy representative
+    let(:organization) { create(:organization) }
+    let(:representative) { create(:representative) }
     let(:params) do
       {
         power_of_attorney_request: {
-          record_consent: '',
-          consent_address_change: '',
+          record_consent: true,
+          consent_address_change: true,
           consent_limits: [],
           claimant: {
             date_of_birth: '1980-12-31',
@@ -21,7 +22,7 @@ RSpec.describe 'RepresentationManagement::V0::PowerOfAttorneyRequests', type: :r
             email: 'claimant@example.com',
             name: {
               first: 'John',
-              middle: 'Middle', # This is a middle name as submitted by the frontend
+              middle: 'Middle',
               last: 'Claimant'
             },
             address: {
@@ -29,7 +30,7 @@ RSpec.describe 'RepresentationManagement::V0::PowerOfAttorneyRequests', type: :r
               address_line2: '',
               city: 'Portland',
               state_code: 'OR',
-              country: 'USA', # This is a 3 character country code as submitted by the frontend
+              country: 'USA',
               zip_code: '12345',
               zip_code_suffix: '6789'
             }
@@ -44,7 +45,7 @@ RSpec.describe 'RepresentationManagement::V0::PowerOfAttorneyRequests', type: :r
             email: 'veteran@example.com',
             name: {
               first: 'John',
-              middle: 'Middle', # This is a middle name as submitted by the frontend
+              middle: 'Middle',
               last: 'Veteran'
             },
             address: {
@@ -52,7 +53,7 @@ RSpec.describe 'RepresentationManagement::V0::PowerOfAttorneyRequests', type: :r
               address_line2: '',
               city: 'Portland',
               state_code: 'OR',
-              country: 'USA', # This is a 3 character country code as submitted by the frontend
+              country: 'USA',
               zip_code: '12345',
               zip_code_suffix: '6789'
             }
@@ -65,53 +66,54 @@ RSpec.describe 'RepresentationManagement::V0::PowerOfAttorneyRequests', type: :r
       }
     end
 
-    context 'with a signed in user' do
-      before do
-        sign_in_as(user)
-      end
-
-      context 'When submitting all fields with valid data' do
+    context 'when appoint_a_representative_enable_v2_features is enabled' do
+      context 'with a signed in user' do
         before do
-          params[:power_of_attorney_request][:veteran][:service_number] = nil # TEMPORARY FOR FRONTEND TESTING
-          post(base_path, params:)
+          sign_in_as(user)
+          Flipper.enable(:appoint_a_representative_enable_v2_features)
         end
 
-        it 'responds with a ok status' do
-          expect(response).to have_http_status(:ok)
+        context 'When submitting all fields with valid data' do
+          let(:poa_request) do
+            OpenStruct.new(id: 'efd18b43-4421-4539-941a-7397fadfe5dc',
+                           created_at: '2025-02-21T00:00:00.000000000Z'.to_datetime,
+                           expires_at: '2025-04-22T00:00:00.000000000Z'.to_datetime)
+          end
+
+          before do
+            allow_any_instance_of(RepresentationManagement::PowerOfAttorneyRequestService::Orchestrate)
+              .to receive(:call)
+              .and_return({ request: poa_request })
+          end
+
+          it 'responds with a 201/created status' do
+            post(base_path, params:)
+
+            expect(response).to have_http_status(:created)
+          end
+
+          it 'responds with the newly created PowerOfAttorneyRequest' do
+            post(base_path, params:)
+
+            parsed_response = JSON.parse(response.body)
+
+            expect(parsed_response['data']['id']).to eq(poa_request.id)
+          end
         end
 
-        it 'responds with the expected message' do
-          expect(response.body).to eq({ message: 'Email enqueued' }.to_json)
-        end
-      end
+        context 'when an error occurs' do
+          before do
+            params[:power_of_attorney_request][:veteran][:name][:first] = nil
+            post(base_path, params:)
+          end
 
-      context 'when submitting with a veteran service number - TEMPORARY FOR FRONTEND TESTING' do
-        before do
-          post(base_path, params:)
-        end
+          it 'responds with an unprocessable entity status' do
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
 
-        it 'responds with the unprocessable_entity status' do
-          expect(response).to have_http_status(:unprocessable_entity)
-        end
-
-        it 'responds with the expected body' do
-          expect(response.body).to eq({ errors: ['render_error_state_for_failed_submission'] }.to_json)
-        end
-      end
-
-      context 'when submitting without the veteran first name for a single validation error' do
-        before do
-          params[:power_of_attorney_request][:veteran][:service_number] = nil # TEMPORARY FOR FRONTEND TESTING
-          params[:power_of_attorney_request][:veteran][:name][:first] = nil
-          post(base_path, params:)
-        end
-
-        it 'responds with an unprocessable entity status' do
-          expect(response).to have_http_status(:unprocessable_entity)
-        end
-
-        it 'responds with the expected body' do
-          expect(response.body).to eq({ errors: ["Veteran first name can't be blank"] }.to_json)
+          it 'responds with a meaningful error message' do
+            expect(response.body).to eq({ errors: ["Veteran first name can't be blank"] }.to_json)
+          end
         end
       end
     end
@@ -121,6 +123,19 @@ RSpec.describe 'RepresentationManagement::V0::PowerOfAttorneyRequests', type: :r
         post(base_path, params:)
 
         expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when appoint_a_representative_enable_v2_features is disabled' do
+      before do
+        sign_in_as(user)
+        Flipper.disable(:appoint_a_representative_enable_v2_features)
+      end
+
+      it 'returns a 404/not_found status' do
+        post(base_path, params:)
+
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/modules/representation_management/spec/serializers/power_of_attorney_request_serializer_spec.rb
+++ b/modules/representation_management/spec/serializers/power_of_attorney_request_serializer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RepresentationManagement::PowerOfAttorneyRequestSerializer, type: :serializer do
+  subject { serialize(example, serializer_class: described_class) }
+
+  let(:example) do
+    OpenStruct.new(id: 'efd18b43-4421-4539-941a-7397fadfe5dc',
+                   created_at: '2025-02-21T00:00:00.000000000Z'.to_datetime,
+                   expires_at: '2025-04-22T00:00:00.000000000Z'.to_datetime)
+  end
+  let(:data) { JSON.parse(subject)['data'] }
+  let(:attributes) { data['attributes'] }
+
+  it 'includes :id' do
+    expect(data['id']).to eq example.id
+  end
+
+  it 'includes :type' do
+    expect(data['type']).to eq 'power_of_attorney_request'
+  end
+
+  it 'includes :created_at' do
+    expect_time_eq(attributes['created_at'], example.created_at)
+  end
+
+  it 'includes :expires_at' do
+    expect_time_eq(attributes['expires_at'], example.expires_at)
+  end
+end

--- a/modules/representation_management/spec/services/power_of_attorney_request_service/orchestrate_spec.rb
+++ b/modules/representation_management/spec/services/power_of_attorney_request_service/orchestrate_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RepresentationManagement::PowerOfAttorneyRequestService::Orchestrate do
+  describe '#call' do
+    subject do
+      described_class.new(data:, dependent:, service_branch:, user:)
+    end
+
+    let(:user) { create(:user, :loa3) }
+    let!(:user_verification) { create(:idme_user_verification, idme_uuid: user.idme_uuid) }
+    let(:organization) { create(:organization, poa: 'B12') }
+    let(:representative) { create(:representative, representative_id: '86753') }
+    let(:dependent) { true }
+    let(:service_branch) { 'ARMY' }
+    let(:data) do
+      {
+        record_consent: true,
+        consent_limits: ['HIV'],
+        consent_address_change: true,
+        veteran_first_name: 'John',
+        veteran_middle_initial: 'M',
+        veteran_last_name: 'Veteran',
+        veteran_social_security_number: '123456789',
+        veteran_va_file_number: '987654321',
+        veteran_date_of_birth: '1980-12-31',
+        veteran_service_number: '123123123',
+        veteran_address_line1: '123 Fake Veteran St',
+        veteran_address_line2: 'Apt 1',
+        veteran_city: 'Portland',
+        veteran_state_code: 'OR',
+        veteran_country: 'US',
+        veteran_zip_code: '12345',
+        veteran_zip_code_suffix: '6789',
+        veteran_phone: '5555555555',
+        veteran_email: 'veteran@example.com',
+        claimant_first_name: 'Bob',
+        claimant_middle_initial: 'E',
+        claimant_last_name: 'Claimant',
+        claimant_date_of_birth: '1981-12-31',
+        claimant_relationship: 'Spouse',
+        claimant_address_line1: '123 Fake Claimant St',
+        claimant_address_line2: 'Apt 2',
+        claimant_city: 'Eugene',
+        claimant_state_code: 'OR',
+        claimant_country: 'US',
+        claimant_zip_code: '54321',
+        claimant_zip_code_suffix: '9876',
+        claimant_phone: '2225555555',
+        claimant_email: 'claimant@example.com',
+        organization_id: organization.poa,
+        representative_id: representative.representative_id
+      }
+    end
+
+    it 'creates a new AccreditedRepresentativePortal::PowerOfAttorneyRequest' do
+      expect { subject.call }.to change(AccreditedRepresentativePortal::PowerOfAttorneyRequest, :count).by(1)
+    end
+
+    it 'creates a new AccreditedRepresentativePortal::PowerOfAttorneyForm' do
+      expect { subject.call }.to change(AccreditedRepresentativePortal::PowerOfAttorneyForm, :count).by(1)
+    end
+
+    context 'when there is a form in progress' do
+      let!(:form) { create(:in_progress_form, user_account: user.user_account, form_id: '21-22') }
+
+      it 'destroys the form' do
+        expect { subject.call }.to change(InProgressForm, :count).by(-1)
+      end
+    end
+
+    context 'when there is no form in progress' do
+      it 'does not destroy a form' do
+        expect { subject.call }.not_to change(InProgressForm, :count)
+      end
+    end
+
+    it 'returns a PowerOfAttorneyRequest' do
+      result = subject.call
+
+      expect(result[:request]).to be_a(AccreditedRepresentativePortal::PowerOfAttorneyRequest)
+    end
+
+    context 'when there is an error' do
+      before do
+        data[:record_consent] = 'abc'
+      end
+
+      it 'returns a meaningful error message' do
+        result = subject.call
+
+        expect(result[:errors]).to eq(['value at `/authorizations/recordDisclosure` is not a boolean'])
+      end
+
+      it 'does not create a new AccreditedRepresentativePortal::PowerOfAttorneyRequest' do
+        expect { subject.call }.not_to change(AccreditedRepresentativePortal::PowerOfAttorneyRequest, :count)
+      end
+
+      it 'does not create a new AccreditedRepresentativePortal::PowerOfAttorneyForm' do
+        expect { subject.call }.not_to change(AccreditedRepresentativePortal::PowerOfAttorneyForm, :count)
+      end
+
+      it 'does not attempt to destroy a form in progress' do
+        expect(InProgressForm).not_to receive(:form_for_user)
+
+        subject.call
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- This pr creates an orchestration service for Power of Attorney request creation
  - adapt the form data
  - make the request and form records
  - delete form in progress if applicable
- This pr calls the orchestration service in ARM's poa request controller
- This pr fixes a data transformation issue in the adapter 

## Related issue(s)

- [99974](https://github.com/department-of-veterans-affairs/va.gov-team/issues/99974)

## Testing done

- [x] *New code is covered by unit tests*
- Went through the Appoint a Rep flow locally with authed user and hit the endpoint to make sure records were created

## What areas of the site does it impact?
This impacts ARP and Appoint a Rep 21-22 once the feature flag is enabled

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature