### PR TITLE
1430 do not save 1095b data prior to current tax year

### DIFF
--- a/app/controllers/v0/form1095_bs_controller.rb
+++ b/app/controllers/v0/form1095_bs_controller.rb
@@ -8,7 +8,7 @@ module V0
 
     def available_forms
       form = Form1095B.find_by(veteran_icn: current_user.icn, tax_year: Form1095B.current_tax_year)
-      forms = [{ year: form&.tax_year, last_updated: form&.updated_at }]
+      forms = form.nil? ? [] : [{ year: form.tax_year, last_updated: form.updated_at }]
       render json: { available_forms: forms }
     end
 

--- a/app/controllers/v0/form1095_bs_controller.rb
+++ b/app/controllers/v0/form1095_bs_controller.rb
@@ -5,15 +5,11 @@ module V0
     service_tag 'deprecated'
     before_action { authorize :form1095, :access? }
     before_action :set_form, only: %i[download_pdf download_txt]
-    before_action :set_available_forms, only: :available_forms
 
     def available_forms
-      # we are currently restricting access to only the most recent tax year
-      last_year = Date.current.year - 1
-      last_years_tax_form = @available_forms.select { |form| form.tax_year == last_year }.map do |form|
-        { year: form.tax_year, last_updated: form.updated_at }
-      end
-      render json: { available_forms: last_years_tax_form }
+      form = Form1095B.find_by(veteran_icn: current_user.icn, tax_year: Form1095B.current_tax_year)
+      forms = [{ year: form&.tax_year, last_updated: form&.updated_at }]
+      render json: { available_forms: forms }
     end
 
     def download_pdf
@@ -35,10 +31,6 @@ module V0
         Rails.logger.error("Form 1095-B for #{download_params[:tax_year]} not found", user_uuid: @current_user&.uuid)
         raise Common::Exceptions::RecordNotFound, download_params[:tax_year]
       end
-    end
-
-    def set_available_forms
-      @available_forms = Form1095B.available_forms(@current_user[:icn])
     end
 
     def download_params

--- a/app/models/form1095_b.rb
+++ b/app/models/form1095_b.rb
@@ -4,15 +4,10 @@ class Form1095B < ApplicationRecord
   has_kms_key
   has_encrypted :form_data, key: :kms_key, **lockbox_options
 
-  # validations
   validates :veteran_icn, :tax_year,  presence: true
   validates :veteran_icn, uniqueness: { scope: :tax_year }
   validate :proper_form_data_schema
 
-  # scopes
-  scope :available_forms, ->(icn) { where(veteran_icn: icn).order(tax_year: :desc) }
-
-  # methods
   def txt_file
     unless File.exist?(txt_template_path)
       Rails.logger.error "1095-B template for year #{tax_year} does not exist."
@@ -43,6 +38,11 @@ class Form1095B < ApplicationRecord
     end
 
     generate_pdf(pdftk, tmp_file)
+  end
+
+  # we are currently restricting access to only the most recent tax year
+  def self.current_tax_year
+    Date.current.year - 1
   end
 
   private

--- a/app/sidekiq/form1095/new1095_bs_job.rb
+++ b/app/sidekiq/form1095/new1095_bs_job.rb
@@ -182,7 +182,6 @@ module Form1095
 
       file_details = parse_file_name(file_name)
 
-      # should this be true?
       return false if file_details.blank?
 
       return true if file_details[:tax_year] < Form1095B.current_tax_year

--- a/app/sidekiq/form1095/new1095_bs_job.rb
+++ b/app/sidekiq/form1095/new1095_bs_job.rb
@@ -182,7 +182,10 @@ module Form1095
 
       file_details = parse_file_name(file_name)
 
+      # should this be true?
       return false if file_details.blank?
+
+      return true if file_details[:tax_year] < Form1095B.current_tax_year
 
       # downloads S3 file into local file, allows for processing large files this way
       temp_file = Tempfile.new(file_name, encoding: 'ascii-8bit')

--- a/spec/models/form1095_b_spec.rb
+++ b/spec/models/form1095_b_spec.rb
@@ -67,24 +67,4 @@ RSpec.describe Form1095B, type: :model do
       end
     end
   end
-
-  describe 'scopes' do
-    let!(:multi_search_form_2) { create(:form1095_b, veteran_icn: '123456787654321', tax_year: 2020) }
-    let!(:multi_search_form_1) { create(:form1095_b, veteran_icn: '123456787654321') }
-    let!(:multi_search_form_3) { create(:form1095_b, veteran_icn: '123456787654321', tax_year: 2019) }
-
-    it 'returns individual available form' do
-      expect(Form1095B.available_forms(subject.veteran_icn)).to eq([subject])
-    end
-
-    it 'returns available forms in descending order by tax year' do
-      expect(Form1095B.available_forms(multi_search_form_1.veteran_icn)).to eq(
-        [multi_search_form_1, multi_search_form_2, multi_search_form_3]
-      )
-    end
-
-    it 'expects empty array if no available forms exist' do
-      expect(Form1095B.available_forms('876543234567')).to eq([])
-    end
-  end
 end

--- a/spec/requests/swagger_spec.rb
+++ b/spec/requests/swagger_spec.rb
@@ -3331,7 +3331,7 @@ RSpec.describe 'the v0 API documentation', order: :defined, type: %i[apivore req
       let(:bad_headers) { { '_headers' => { 'Cookie' => sign_in(mhv_user, nil, true) } } }
 
       before do
-        create(:form1095_b)
+        create(:form1095_b, tax_year: Form1095B.current_tax_year)
       end
 
       context 'available forms' do

--- a/spec/requests/v0/form1095_bs_spec.rb
+++ b/spec/requests/v0/form1095_bs_spec.rb
@@ -96,17 +96,17 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
       create(:form1095_b, tax_year: this_year - 2)
       get '/v0/form1095_bs/available_forms'
       expect(response).to have_http_status(:success)
-      expect(JSON.parse(response.body)).to eq(
-        { 'available_forms' => [{ 'year' => last_year_form.tax_year,
-                                  'last_updated' => last_year_form.updated_at.strftime('%Y-%m-%dT%H:%M:%S.%LZ') }] }
+      expect(response.parsed_body.deep_symbolize_keys).to eq(
+        { available_forms: [{ year: last_year_form.tax_year,
+                              last_updated: last_year_form.updated_at.strftime('%Y-%m-%dT%H:%M:%S.%LZ') }] }
       )
     end
 
     it 'returns success with no available forms when user has no form data' do
       get '/v0/form1095_bs/available_forms'
       expect(response).to have_http_status(:success)
-      expect(JSON.parse(response.body)).to eq(
-        { 'available_forms' => [] }
+      expect(response.parsed_body.symbolize_keys).to eq(
+        { available_forms: [] }
       )
     end
   end

--- a/spec/sidekiq/form1095/new1095_bs_job_spec.rb
+++ b/spec/sidekiq/form1095/new1095_bs_job_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe Form1095::New1095BsJob, type: :job do
       allow(s3_resource).to receive(:bucket).and_return(bucket)
       allow(bucket).to receive_messages(objects:, delete_objects: true, object:)
       allow(object).to receive(:get).and_return(nil)
+      time = Time.utc(2021, 9, 21, 0, 0, 0)
+      Timecop.freeze(time)
+    end
+
+    after do
+      Timecop.return
     end
 
     it 'saves valid form from S3 file' do

--- a/spec/sidekiq/form1095/new1095_bs_job_spec.rb
+++ b/spec/sidekiq/form1095/new1095_bs_job_spec.rb
@@ -49,76 +49,96 @@ RSpec.describe Form1095::New1095BsJob, type: :job do
       allow(s3_resource).to receive(:bucket).and_return(bucket)
       allow(bucket).to receive_messages(objects:, delete_objects: true, object:)
       allow(object).to receive(:get).and_return(nil)
-      time = Time.utc(2021, 9, 21, 0, 0, 0)
-      Timecop.freeze(time)
     end
 
-    after do
-      Timecop.return
+    context 'when file is for a past tax year' do
+      it 'does not save data and deletes the file' do
+        allow(objects).to receive(:collect).and_return(file_names1)
+        allow(Tempfile).to receive(:new).and_return(tempfile1)
+
+        expect(Rails.logger).not_to receive(:error)
+        expect(Rails.logger).not_to receive(:warn)
+        expect(bucket).to receive(:delete_objects)
+
+        expect { subject.perform }.not_to change(Form1095B, :count).from(0)
+      end
     end
 
-    it 'saves valid form from S3 file' do
-      allow(objects).to receive(:collect).and_return(file_names1)
-      allow(Tempfile).to receive(:new).and_return(tempfile1)
-
-      expect(Rails.logger).not_to receive(:error)
-      expect(Rails.logger).not_to receive(:warn)
-
-      expect { subject.perform }.to change(Form1095B, :count).from(0).to(1)
-    end
-
-    it 'saves multiple forms from a file' do
-      allow(objects).to receive(:collect).and_return(file_names2)
-      allow(Tempfile).to receive(:new).and_return(tempfile2)
-
-      expect(Rails.logger).not_to receive(:error)
-      expect(Rails.logger).not_to receive(:warn)
-
-      expect { subject.perform }.to change(Form1095B, :count).from(0).to(8)
-    end
-
-    it 'does not log errors or save form but does deletes file when user data is missing icn' do
-      allow(objects).to receive(:collect).and_return(file_names3)
-      allow(Tempfile).to receive(:new).and_return(tempfile3)
-
-      expect(Rails.logger).not_to receive(:error)
-      expect(Rails.logger).not_to receive(:warn)
-      expect(bucket).to receive(:delete_objects)
-
-      expect { subject.perform }.not_to change(Form1095B, :count).from(0)
-    end
-
-    it 'raises an error and does not delete file when error is encountered processing the file' do
-      allow(objects).to receive(:collect).and_return(file_names3)
-      allow(Tempfile).to receive(:new).and_return(tempfile3)
-      allow(tempfile3).to receive(:each_line).and_raise(RuntimeError, 'Bad file')
-
-      expect(Rails.logger).to receive(:error).once.with('Bad file.')
-      expect(Rails.logger).to receive(:error).once # log_exception_to_sentry stacktrace error
-      expect(Rails.logger).to receive(:error).once.with(
-        "failed to save 0 forms from file: #{file_names3.first}; successfully saved 0 forms"
-      )
-      expect(bucket).not_to receive(:delete_objects)
-
-      expect { subject.perform }.not_to change(Form1095B, :count).from(0)
-    end
-
-    context 'saves form corrections from a corrected file' do
-      let!(:form1) { create(:form1095_b, tax_year: 2020, veteran_icn: '23456789098765437') }
-      let!(:form2) { create(:form1095_b, tax_year: 2020, veteran_icn: '23456789098765464') }
-
+    context 'when file is for the current tax year or later' do
       before do
-        allow(objects).to receive(:collect).and_return(file_names4)
-        allow(Tempfile).to receive(:new).and_return(tempfile4)
+        time = Time.utc(2021, 9, 21, 0, 0, 0)
+        Timecop.freeze(time)
       end
 
-      it 'updates forms without errors' do
+      after { Timecop.return }
+
+      it 'saves valid form from S3 file' do
+        allow(objects).to receive(:collect).and_return(file_names1)
+        allow(Tempfile).to receive(:new).and_return(tempfile1)
+
         expect(Rails.logger).not_to receive(:error)
         expect(Rails.logger).not_to receive(:warn)
 
-        expect do
-          subject.perform
-        end.to change { [form1.reload.form_data, form2.reload.form_data] }
+        expect { subject.perform }.to change(Form1095B, :count).from(0).to(1)
+      end
+
+      it 'saves multiple forms from a file' do
+        allow(objects).to receive(:collect).and_return(file_names2)
+        allow(Tempfile).to receive(:new).and_return(tempfile2)
+
+        expect(Rails.logger).not_to receive(:error)
+        expect(Rails.logger).not_to receive(:warn)
+
+        expect { subject.perform }.to change(Form1095B, :count).from(0).to(8)
+      end
+
+      context 'when user data is missing icn' do
+        it 'does not log errors or save form but does deletes file' do
+          allow(objects).to receive(:collect).and_return(file_names3)
+          allow(Tempfile).to receive(:new).and_return(tempfile3)
+
+          expect(Rails.logger).not_to receive(:error)
+          expect(Rails.logger).not_to receive(:warn)
+          expect(bucket).to receive(:delete_objects)
+
+          expect { subject.perform }.not_to change(Form1095B, :count).from(0)
+        end
+      end
+
+      context 'when error is encountered processing the file' do
+        it 'raises an error and does not delete file' do
+          allow(objects).to receive(:collect).and_return(file_names3)
+          allow(Tempfile).to receive(:new).and_return(tempfile3)
+          allow(tempfile3).to receive(:each_line).and_raise(RuntimeError, 'Bad file')
+
+          expect(Rails.logger).to receive(:error).once.with('Bad file.')
+          expect(Rails.logger).to receive(:error).once # log_exception_to_sentry stacktrace error
+          expect(Rails.logger).to receive(:error).once.with(
+            "failed to save 0 forms from file: #{file_names3.first}; successfully saved 0 forms"
+          )
+          expect(bucket).not_to receive(:delete_objects)
+
+          expect { subject.perform }.not_to change(Form1095B, :count).from(0)
+        end
+      end
+
+      context 'saves form corrections from a corrected file' do
+        let!(:form1) { create(:form1095_b, tax_year: 2020, veteran_icn: '23456789098765437') }
+        let!(:form2) { create(:form1095_b, tax_year: 2020, veteran_icn: '23456789098765464') }
+
+        before do
+          allow(objects).to receive(:collect).and_return(file_names4)
+          allow(Tempfile).to receive(:new).and_return(tempfile4)
+        end
+
+        it 'updates forms without errors' do
+          expect(Rails.logger).not_to receive(:error)
+          expect(Rails.logger).not_to receive(:warn)
+
+          expect do
+            subject.perform
+          end.to change { [form1.reload.form_data, form2.reload.form_data] }
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- This change modifies a job that ingests files placed on S3 by the enrollment team. The job is being changed to not process records for tax years prior to the current tax year.
- I work for the IIR team and we will maintain this code. 


## Related issue(s)

https://github.com/department-of-veterans-affairs/va-iir/issues/1430

## Testing done

Because this is being done in a job that relies on s3, local tests are the best we can do.

## Screenshots


## What areas of the site does it impact?
Only touches 1095b code. 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

