### PR TITLE
Update fwdproxy URLs

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -122,7 +122,7 @@ dmc:
   client_secret: "secret"
   mock_debts: false
   mock_fsr: false
-  url: https://internal-dsva-vagov-dev-fwdproxy-1893365470.us-gov-west-1.elb.amazonaws.com:4465/api/v1/digital-services/
+  url: https://fwdproxy-dev.vfs.va.gov:4465/api/v1/digital-services/
   debts_endpoint: debt-letter/get
   fsr_payment_window: 30
 
@@ -1093,7 +1093,7 @@ forms:
   mock: false
 
 vbms:
-  url: "https://internal-dsva-vagov-dev-fwdproxy-1893365470.us-gov-west-1.elb.amazonaws.com:4449"
+  url: "https://fwdproxy-dev.vfs.va.gov:4449"
   saml: "vetsapi.client.vbms.aide.oit.va.gov.saml-token.xml"
   ca_cert: VBMS-Client-Signing-CA.crt
   cert: vetsapi.client.vbms.aide.oit.va.gov.crt

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -315,7 +315,7 @@ ihub:
 # Settings for Medical Devices Ordering Tool
 mdot:
   prefill: true
-  url: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4466
+  url: https://fwdproxy-staging.vfs.va.gov:4466
   api_key: abcd1234abcd1234abcd1234abcd1234abcd1234
   mock: false
 
@@ -1107,7 +1107,7 @@ github_stats:
   token: fake_token
 
 google_analytics:
-  url: "https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4473"
+  url: "https://fwdproxy-staging.vfs.va.gov:4473"
   tracking_id: ~
 
 virtual_agent:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -117,7 +117,7 @@ bgs:
   application: VAgovAPI
   client_station_id: 281
   client_username: VAgovAPI
-  url: https://internal-dsva-vagov-dev-fwdproxy-1893365470.us-gov-west-1.elb.amazonaws.com:4447
+  url: https://fwdproxy-dev.vfs.va.gov:4447
   external_uid: xUid
   external_key: xKey
 # You can use this in `config/settings/test.local.yml`.

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -330,8 +330,8 @@ mcp:
     service_name: VBS
     mock: true
   vbs_v2:
-    url: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4491
-    host: internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4491
+    url: https://fwdproxy-staging.vfs.va.gov:4491
+    host: fwdproxy-staging.vfs.va.gov:4491
     base_path: /vbsapi
     service_name: VBS
     mock: true

--- a/spec/lib/debt_management_center/vbs/request_spec.rb
+++ b/spec/lib/debt_management_center/vbs/request_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DebtManagementCenter::VBS::Request do
 
   describe 'settings' do
     it 'has a host' do
-      expect(subject.host).to eq('internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4491')
+      expect(subject.host).to eq('fwdproxy-staging.vfs.va.gov:4491')
     end
 
     it 'has base_path' do
@@ -26,7 +26,7 @@ RSpec.describe DebtManagementCenter::VBS::Request do
     end
 
     it 'has a url' do
-      expect(subject.url).to eq('https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4491')
+      expect(subject.url).to eq('https://fwdproxy-staging.vfs.va.gov:4491')
     end
   end
 
@@ -44,7 +44,7 @@ RSpec.describe DebtManagementCenter::VBS::Request do
 
   describe '#headers' do
     it 'has request headers' do
-      expect(subject.headers).to eq({ 'Host' => 'internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4491', # rubocop:disable Layout/LineLength
+      expect(subject.headers).to eq({ 'Host' => 'fwdproxy-staging.vfs.va.gov:4491',
                                       'Content-Type' => 'application/json',
                                       'apiKey' => 'abcd1234abcd1234abcd1234abcd1234abcd1234' })
     end

--- a/spec/services/medical_copays/request_spec.rb
+++ b/spec/services/medical_copays/request_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe MedicalCopays::Request do
 
   describe 'settings' do
     it 'has a host' do
-      expect(subject.host).to eq('internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4491')
+      expect(subject.host).to eq('fwdproxy-staging.vfs.va.gov:4491')
     end
 
     it 'has base_path' do
@@ -25,7 +25,7 @@ RSpec.describe MedicalCopays::Request do
     end
 
     it 'has a url' do
-      url = 'https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4491'
+      url = 'https://fwdproxy-staging.vfs.va.gov:4491'
       expect(subject.url).to eq(url)
     end
   end
@@ -44,7 +44,7 @@ RSpec.describe MedicalCopays::Request do
 
   describe '#headers' do
     it 'has request headers' do
-      host = 'internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4491'
+      host = 'fwdproxy-staging.vfs.va.gov:4491'
       expect(subject.headers).to eq({ 'Host' => host,
                                       'Content-Type' => 'application/json',
                                       'apiKey' => 'abcd1234abcd1234abcd1234abcd1234abcd1234' })

--- a/spec/support/vcr_cassettes/debts/get_letters.yml
+++ b/spec/support/vcr_cassettes/debts/get_letters.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://internal-dsva-vagov-dev-fwdproxy-1893365470.us-gov-west-1.elb.amazonaws.com:4465/api/v1/digital-services/debt-letter/get
+    uri: https://fwdproxy-dev.vfs.va.gov:4465/api/v1/digital-services/debt-letter/get
     body:
       encoding: UTF-8
       string: '{"fileNumber":"796043735"}'

--- a/spec/support/vcr_cassettes/debts/get_letters_empty_response.yml
+++ b/spec/support/vcr_cassettes/debts/get_letters_empty_response.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://internal-dsva-vagov-dev-fwdproxy-1893365470.us-gov-west-1.elb.amazonaws.com:4465/api/v1/digital-services/debt-letter/get
+    uri: https://fwdproxy-dev.vfs.va.gov:4465/api/v1/digital-services/debt-letter/get
     body:
       encoding: UTF-8
       string: '{"fileNumber":"796043735"}'

--- a/spec/support/vcr_cassettes/debts/get_letters_empty_ssn.yml
+++ b/spec/support/vcr_cassettes/debts/get_letters_empty_ssn.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://internal-dsva-vagov-dev-fwdproxy-1893365470.us-gov-west-1.elb.amazonaws.com:4465/api/v1/digital-services/debt-letter/get
+    uri: https://fwdproxy-dev.vfs.va.gov:4465/api/v1/digital-services/debt-letter/get
     body:
       encoding: UTF-8
       string: '{"fileNumber":""}'

--- a/spec/support/vcr_cassettes/debts/person_data_and_letters.yml
+++ b/spec/support/vcr_cassettes/debts/person_data_and_letters.yml
@@ -713,7 +713,7 @@ http_interactions:
   recorded_at: Fri, 12 Jun 2020 02:57:31 GMT
 - request:
     method: post
-    uri: https://internal-dsva-vagov-dev-fwdproxy-1893365470.us-gov-west-1.elb.amazonaws.com:4465/api/v1/digital-services/debt-letter/get
+    uri: https://fwdproxy-dev.vfs.va.gov:4465/api/v1/digital-services/debt-letter/get
     body:
       encoding: UTF-8
       string: '{"fileNumber":"796043735"}'

--- a/spec/support/vcr_cassettes/dmc/download_pdf.yml
+++ b/spec/support/vcr_cassettes/dmc/download_pdf.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://internal-dsva-vagov-dev-fwdproxy-1893365470.us-gov-west-1.elb.amazonaws.com:4465/api/v1/digital-services/financial-status-report/documentstream?objectId=ABCD-1234
+    uri: https://fwdproxy-dev.vfs.va.gov:4465/api/v1/digital-services/financial-status-report/documentstream?objectId=ABCD-1234
     body:
       encoding: UTF-8
       string: ''

--- a/spec/support/vcr_cassettes/dmc/submit_fsr.yml
+++ b/spec/support/vcr_cassettes/dmc/submit_fsr.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://internal-dsva-vagov-dev-fwdproxy-1893365470.us-gov-west-1.elb.amazonaws.com:4465/api/v1/digital-services/financial-status-report/formtopdf
+    uri: https://fwdproxy-dev.vfs.va.gov:4465/api/v1/digital-services/financial-status-report/formtopdf
     body:
       encoding: UTF-8
       string: '{"personalIdentification":{"fsrReason":"Compromise"},"personalData":{"veteranFullName":{"first":"Greg","middle":"A","last":"Anderson"},"address":{"addresslineOne":"123

--- a/spec/support/vcr_cassettes/dmc/submit_fsr_error.yml
+++ b/spec/support/vcr_cassettes/dmc/submit_fsr_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://internal-dsva-vagov-dev-fwdproxy-1893365470.us-gov-west-1.elb.amazonaws.com:4465/api/v1/digital-services/financial-status-report/formtopdf
+    uri: https://fwdproxy-dev.vfs.va.gov:4465/api/v1/digital-services/financial-status-report/formtopdf
     body:
       encoding: UTF-8
       string: '{"bad":"data"}'

--- a/spec/support/vcr_cassettes/dmc/submit_to_vbs.yml
+++ b/spec/support/vcr_cassettes/dmc/submit_to_vbs.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4491/vbsapi/UploadFSRJsonDocument
+    uri: https://fwdproxy-staging.vfs.va.gov:4491/vbsapi/UploadFSRJsonDocument
     body:
       encoding: UTF-8
       string: '{"jsonDocument":"{\"facilityNum\":\"635\",\"personalIdentification\":{\"ssn\":\"7696608890\",\"fileNumber\":\"3170033099\",\"fsrReason\":\"et\"},\"personalData\":{\"veteranFullName\":{\"first\":\"Jamal\",\"middle\":\"E\",\"last\":\"Swaniawski\"},\"address\":{\"addresslineOne\":\"874
@@ -32,7 +32,7 @@ http_interactions:
         Abshire V\",\"veteranDateSigned\":\"10/13/2022\"},\"transactionId\":\"67715598-713e-4ffe-838c-97f824e44001\",\"timestamp\":\"20230911T172207\"}"}'
     headers:
       Host:
-      - internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4491
+      - fwdproxy-staging.vfs.va.gov:4491
       Content-Type:
       - application/json
       Apikey:

--- a/spec/support/vcr_cassettes/govdelivery_emails.yml
+++ b/spec/support/vcr_cassettes/govdelivery_emails.yml
@@ -51,7 +51,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"sid":"d153285bef879dc7bf59824b2fada476","_links":{"self":"/","keywords":"/keywords","command_types":"/command_types","inbound_sms_messages":"/inbound/sms","sms_messages":"/messages/sms","sms_templates":"/templates/sms","reports_messages_sms_statistics":"/reports/messages/sms/statistics","email_messages":"/messages/email","email_templates":"/templates/email","from_addresses":"/from_addresses","message_types":"/message_types","reports_messages_email_statistics":"/reports/messages/email/statistics","webhooks":"/webhooks","session_info":"/session/info"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 May 2018 18:17:56 GMT
 - request:
     method: get
@@ -156,7 +156,7 @@ http_interactions:
         {"id":51677931,"subject":"We can''t process your health care application","created_at":"2018-05-29T19:46:00Z","status":"completed","_links":{"self":"/messages/email/51677931","recipients":"/messages/email/51677931/recipients","failed":"/messages/email/51677931/recipients/failed","sent":"/messages/email/51677931/recipients/sent","clicked":"/messages/email/51677931/recipients/clicked","opened":"/messages/email/51677931/recipients/opened"}},
         {"id":51677795,"subject":"We can''t process your health care application","created_at":"2018-05-29T19:30:16Z","status":"completed","_links":{"self":"/messages/email/51677795","recipients":"/messages/email/51677795/recipients","failed":"/messages/email/51677795/recipients/failed","sent":"/messages/email/51677795/recipients/sent","clicked":"/messages/email/51677795/recipients/clicked","opened":"/messages/email/51677795/recipients/opened"}},
         {"id":51678831,"subject":"Confirmation - Your direct deposit information changed on VA.gov","created_at":"2018-05-29T19:46:00Z","status":"completed","_links":{"self":"/messages/email/51678831","recipients":"/messages/email/51678831/recipients","failed":"/messages/email/51678831/recipients/failed","sent":"/messages/email/51678831/recipients/sent","clicked":"/messages/email/51678831/recipients/clicked","opened":"/messages/email/51678831/recipients/opened"}}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 May 2018 18:18:00 GMT
 
 - request:
@@ -262,7 +262,7 @@ http_interactions:
         to date report","created_at":"2018-05-29T08:00:01Z","status":"completed","_links":{"self":"/messages/email/51817502","recipients":"/messages/email/51817502/recipients","failed":"/messages/email/51817502/recipients/failed","sent":"/messages/email/51817502/recipients/sent","clicked":"/messages/email/51817502/recipients/clicked","opened":"/messages/email/51817502/recipients/opened"}},
         {"id":51677931,"subject":"We can''t process your health care application","created_at":"2018-05-29T07:46:00Z","status":"completed","_links":{"self":"/messages/email/51677931","recipients":"/messages/email/51677931/recipients","failed":"/messages/email/51677931/recipients/failed","sent":"/messages/email/51677931/recipients/sent","clicked":"/messages/email/51677931/recipients/clicked","opened":"/messages/email/51677931/recipients/opened"}},
         {"id":51677795,"subject":"We can''t process your health care application","created_at":"2018-05-29T07:30:16Z","status":"completed","_links":{"self":"/messages/email/51677795","recipients":"/messages/email/51677795/recipients","failed":"/messages/email/51677795/recipients/failed","sent":"/messages/email/51677795/recipients/sent","clicked":"/messages/email/51677795/recipients/clicked","opened":"/messages/email/51677795/recipients/opened"}}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 May 2018 18:18:06 GMT
 - request:
     method: get
@@ -315,7 +315,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 May 2018 18:18:00 GMT
 - request:
     method: get
@@ -368,11 +368,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 May 2018 18:18:00 GMT
 - request:
     method: post
-    uri: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4473/collect
+    uri: https://fwdproxy-staging.vfs.va.gov:4473/collect
     body:
       encoding: US-ASCII
       string: v=1&tid=UA-119746669-1&cid=ed64bded-52fa-43aa-9d1b-3b3b8335a261&t=event&ni=1&cn=application-failure&cm=email&ec=API+Calls&ea=GovDelivery+-+Email+HCA+Failure&el=completed
@@ -416,7 +416,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         R0lGODlhAQABAID/AP///wAAACwAAAAAAQABAAACAkQBADs=
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 May 2018 18:18:00 GMT
 - request:
     method: get
@@ -469,11 +469,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"status":"failed"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 May 2018 18:18:00 GMT
 - request:
     method: post
-    uri: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4473/collect
+    uri: https://fwdproxy-staging.vfs.va.gov:4473/collect
     body:
       encoding: US-ASCII
       string: v=1&tid=UA-119746669-1&cid=ed64bded-52fa-43aa-9d1b-3b3b8335a261&t=event&ni=1&cn=application-failure&cm=email&ec=API+Calls&ea=GovDelivery+-+Email+HCA+Failure&el=completed
@@ -517,6 +517,6 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         R0lGODlhAQABAID/AP///wAAACwAAAAAAQABAAACAkQBADs=
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 May 2018 18:18:00 GMT
 recorded_with: VCR 3.0.3

--- a/spec/support/vcr_cassettes/mdot/get_supplies_403.yml
+++ b/spec/support/vcr_cassettes/mdot/get_supplies_403.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4466/supplies
+    uri: https://fwdproxy-staging.vfs.va.gov:4466/supplies
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/mdot/get_supplies_422.yml
+++ b/spec/support/vcr_cassettes/mdot/get_supplies_422.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4466/supplies
+    uri: https://fwdproxy-staging.vfs.va.gov:4466/supplies
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/mdot/get_supplies_502.yml
+++ b/spec/support/vcr_cassettes/mdot/get_supplies_502.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4466/supplies
+    uri: https://fwdproxy-staging.vfs.va.gov:4466/supplies
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/mdot/get_supplies_503.yml
+++ b/spec/support/vcr_cassettes/mdot/get_supplies_503.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4466/supplies
+    uri: https://fwdproxy-staging.vfs.va.gov:4466/supplies
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/mdot/get_supplies_no_perm_address_200.yml
+++ b/spec/support/vcr_cassettes/mdot/get_supplies_no_perm_address_200.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4466/supplies
+    uri: https://fwdproxy-staging.vfs.va.gov:4466/supplies
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/mdot/get_supplies_no_temp_address_200.yml
+++ b/spec/support/vcr_cassettes/mdot/get_supplies_no_temp_address_200.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4466/supplies
+    uri: https://fwdproxy-staging.vfs.va.gov:4466/supplies
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/mdot/get_supplies_null_perm_address_200.yml
+++ b/spec/support/vcr_cassettes/mdot/get_supplies_null_perm_address_200.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4466/supplies
+    uri: https://fwdproxy-staging.vfs.va.gov:4466/supplies
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/mdot/get_supplies_null_temp_address_200.yml
+++ b/spec/support/vcr_cassettes/mdot/get_supplies_null_temp_address_200.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4466/supplies
+    uri: https://fwdproxy-staging.vfs.va.gov:4466/supplies
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/mdot/submit_order.yml
+++ b/spec/support/vcr_cassettes/mdot/submit_order.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4466/supplies
+    uri: https://fwdproxy-staging.vfs.va.gov:4466/supplies
     body:
       encoding: UTF-8
       string: '{"useVeteranAddress":true,"useTemporaryAddress":false,"vetEmail":"vet1@va.gov","order":[{"productId":2499}],"permanentAddress":{"street":"125 SOME RD","street2":"APT 101","city":"DENVER","state":"CO","country":"United States","postalCode":"111119999"},"temporaryAddress":{"street":"17250 w colfax ave","street2":"a-204","city":"Golden","state":"CO","country":"United States","postalCode":"80401"}}'

--- a/spec/support/vcr_cassettes/mdot/submit_order_400.yml
+++ b/spec/support/vcr_cassettes/mdot/submit_order_400.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4466/supplies
+    uri: https://fwdproxy-staging.vfs.va.gov:4466/supplies
     body:
       encoding: UTF-8
       string: '{}'

--- a/spec/support/vcr_cassettes/mdot/submit_order_502.yml
+++ b/spec/support/vcr_cassettes/mdot/submit_order_502.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4466/supplies
+    uri: https://fwdproxy-staging.vfs.va.gov:4466/supplies
     body:
       encoding: UTF-8
       string: '{"veteranFullName":{"first":"Greg","middle":"A","last":"Anderson"},"veteranAddress":{"street":"101 Example Street","street2":"Apt 2","city":"Kansas City","state":"MO","country":"USA","postalCode":"64117"},"order":[{"productId":"1"},{"productId":"4"}],"additionalRequests":""}'

--- a/spec/support/vcr_cassettes/mdot/submit_order_missing_body_400.yml
+++ b/spec/support/vcr_cassettes/mdot/submit_order_missing_body_400.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4466/supplies
+    uri: https://fwdproxy-staging.vfs.va.gov:4466/supplies
     body:
       encoding: UTF-8
       string: '{}'

--- a/spec/support/vcr_cassettes/staccato/event.yml
+++ b/spec/support/vcr_cassettes/staccato/event.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4473/collect
+    uri: https://fwdproxy-staging.vfs.va.gov:4473/collect
     body:
       encoding: US-ASCII
       string: v=1&tid=foo&cid=8c5efa3b-a57f-447e-b728-bc92cc519834&t=event&ec=foo
@@ -14,7 +14,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - internal-dsva-vagov-staging-fwdproxy-1821450725.us-gov-west-1.elb.amazonaws.com:4473
+      - fwdproxy-staging.vfs.va.gov:4473
       Content-Type:
       - application/x-www-form-urlencoded
   response:


### PR DESCRIPTION
## Summary
This PR replaces the old fwdproxy URL with the new one. But only in the non-spec files. Some tests and cassettes still refer to the old URL but I don't think we need to change those.

These changes are required to correct issues seen in our Review Instances where the build picks up on these configurations that still point to our old fwdproxy URLs. I tried getting away with _not_ updating the VCR cassettes, but tests were failing without the url update.

Working with Hector on this.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101001

## Testing done
- I confirmed that these were the URLs in AWS. 
- Hector [discovered](https://github.com/department-of-veterans-affairs/va.gov-team/issues/101001#issuecomment-2674718409) that these are showing up in Review Instances. 

## What areas of the site does it impact?
Nothing, really. Getting rid of old fwdproxy references and replacing them with the new.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
