### PR TITLE
[VI-1089] - Add sub to user_info response

### DIFF
--- a/app/controllers/sign_in/user_info_controller.rb
+++ b/app/controllers/sign_in/user_info_controller.rb
@@ -14,6 +14,7 @@ module SignIn
 
     def user_info_json
       {
+        sub: current_user.uuid,
         credential_uuid: current_user.uuid,
         icn: current_user.icn,
         sec_id: current_user.sec_id,

--- a/spec/controllers/sign_in/user_info_controller_spec.rb
+++ b/spec/controllers/sign_in/user_info_controller_spec.rb
@@ -33,6 +33,7 @@ describe SignIn::UserInfoController do
     context 'when the client_id is in the list of valid clients' do
       let(:expected_user_info_json) do
         {
+          sub: credential_uuid,
           credential_uuid:,
           icn:,
           sec_id:,


### PR DESCRIPTION
## Summary

- Add `sub` to user info response. This should match the `sub` in the access token which is currently `csp_uuid`

## Related issue(s)
- https://jira.devops.va.gov/browse/VI-1089

## Testing
- Add `vaweb` to `Settings.sign_in.user_info_clients`
- Sign in
- go to http://localhost:3000/sign_in/user_info
  - you should see a response like:
    ```json
      {
        "sub": "ba8028fc-bb4d-47aa-8fee-46f740cc3bb4",
        "credential_uuid": "ba8028fc-bb4d-47aa-8fee-46f740cc3bb4",
        "icn": "112345678V54321",
        "sec_id": "0000012345",
        "first_name": "First",
        "last_name": "Last",
        "email": "user@gmail.com"
      }
    ```

## What areas of the site does it impact?
Sign-in service

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

