### PR TITLE
chore: Use private ECR for GHA docker images

### DIFF
--- a/.github/workflows/audit_service_tags.yml
+++ b/.github/workflows/audit_service_tags.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: image=${{ steps.ecr-login.outputs.registry }}/moby/buildkit:buildx-stable-1
 
       - name: Build Docker Image
         uses: docker/build-push-action@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           aws-region: us-gov-west-1
 
       - name: Login to ECR
-        id: login-ecr
+        id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
       - name: Build Postman Docker Image
         uses: docker/build-push-action@v6
@@ -51,7 +51,7 @@ jobs:
           file: ./postman/Dockerfile
           push: true
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/dsva/vets-api-postman:${{ github.event.workflow_run.head_commit.id }}
+            ${{ steps.ecr-login.outputs.registry }}/dsva/vets-api-postman:${{ github.event.workflow_run.head_commit.id }}
       - name: Build vets-api Docker Image
         uses: docker/build-push-action@v6
         env:
@@ -64,7 +64,7 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:${{ github.event.workflow_run.head_commit.id }}
+            ${{ steps.ecr-login.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:${{ github.event.workflow_run.head_commit.id }}
           cache-from: type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY
           cache-to: type=inline
   deploy:

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -95,6 +95,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: image=${{ steps.ecr-login.outputs.registry }}/moby/buildkit:buildx-stable-1
 
       - name: Build Docker Image
         uses: docker/build-push-action@v6

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -50,7 +50,7 @@ jobs:
           aws-region: "us-gov-west-1"
 
       - name: Log into ECR
-        id: login-ecr
+        id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Get bot token from Parameter Store
@@ -77,7 +77,7 @@ jobs:
 
       - name: Update vets-api image and version name in Manifest repo for parent helm
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
           ECR_REPOSITORY: dsva/${{inputs.ecr_repository}}
         run: |
           cd vsp-infra-application-manifests/apps/${{inputs.manifests_directory}}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,9 +1,9 @@
 version: '3.4'
 services:
   redis:
-    image: public.ecr.aws/docker/library/redis:6.2-alpine
+    image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/redis:6.2-alpine
   postgres:
-    image: postgis/postgis:14-3.3-alpine
+    image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/postgis/postgis:14-3.3-alpine
     command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all -c max_connections=200
     environment:
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-password}"


### PR DESCRIPTION
Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/90369

As the developers and engineers on the VA Platform,
We need to pull images for gh-actions from a private ECR repo.
So that we can avoid failed gh-actions due to rate limiting.