### PR TITLE
API-45258-fix-rubocop-linting-error

### DIFF
--- a/modules/claims_api/app/services/claims_api/slack/client.rb
+++ b/modules/claims_api/app/services/claims_api/slack/client.rb
@@ -18,8 +18,8 @@ module ClaimsApi
       def notify(text, blocks: nil, channel: nil)
         delivery_channels(channel).each do |chan|
           payload = ClaimsApi::Slack::Payload.new(
-            text: text,
-            blocks: blocks,
+            text:,
+            blocks:,
             channel: chan,
             username: @username,
             icon_url: @icon_url,

--- a/modules/claims_api/app/services/claims_api/slack/payload.rb
+++ b/modules/claims_api/app/services/claims_api/slack/payload.rb
@@ -28,14 +28,14 @@ module ClaimsApi
 
       def to_hash
         hash = {
-          text: text,
-          username: username,
-          channel: channel,
-          icon_url: icon_url,
-          icon_emoji: icon_emoji,
-          link_names: link_names,
-          unfurl_links: unfurl_links,
-          blocks: blocks
+          text:,
+          username:,
+          channel:,
+          icon_url:,
+          icon_emoji:,
+          link_names:,
+          unfurl_links:,
+          blocks:
         }
 
         hash.delete_if { |_, v| v.nil? }

--- a/modules/claims_api/spec/services/failed_submissions_messenger_spec.rb
+++ b/modules/claims_api/spec/services/failed_submissions_messenger_spec.rb
@@ -21,14 +21,14 @@ RSpec.describe ClaimsApi::Slack::FailedSubmissionsMessenger do
 
     it 'sends a well formatted slack message' do
       messenger = described_class.new(
-        errored_disability_claims: errored_disability_claims,
-        errored_va_gov_claims: errored_va_gov_claims,
-        errored_poa: errored_poa,
-        errored_itf: errored_itf,
-        errored_ews: errored_ews,
-        from: from,
-        to: to,
-        environment: environment
+        errored_disability_claims:,
+        errored_va_gov_claims:,
+        errored_poa:,
+        errored_itf:,
+        errored_ews:,
+        from:,
+        to:,
+        environment:
       )
 
       expect(notifier).to receive(:notify) do |_text, args|
@@ -103,10 +103,10 @@ RSpec.describe ClaimsApi::Slack::FailedSubmissionsMessenger do
 
     it 'sends error ids with links to logs' do
       messenger = described_class.new(
-        errored_va_gov_claims: errored_va_gov_claims,
-        from: from,
-        to: to,
-        environment: environment
+        errored_va_gov_claims:,
+        from:,
+        to:,
+        environment:
       )
 
       expect(notifier).to receive(:notify) do |_text, args|
@@ -151,7 +151,7 @@ RSpec.describe ClaimsApi::Slack::FailedSubmissionsMessenger do
 
       it 'only sends the title and total block' do
         messenger = described_class.new(
-          errored_itf: errored_itf
+          errored_itf:
         )
 
         expect(notifier).to receive(:notify) do |_text, args|


### PR DESCRIPTION
## Summary
* Fixes a missed Rubocop linting error
    * Screenshots below for each files changes
    
## Related issue(s)
[API-44287](https://jira.devops.va.gov/browse/API-44287)

## Testing done
- [x] * Same tests just working with the adjusted syntax
ure?*

#### Testing Notes
* Need to run the Rubocop lint on the claim_api module, it should pass without any issues.

## Screenshots
<img width="473" alt="Screenshot 2025-02-25 at 10 06 51 AM" src="https://github.com/user-attachments/assets/691b1cbc-b3d7-4bfa-887d-e2eb5695be56" />

<img width="603" alt="Screenshot 2025-02-25 at 10 06 43 AM" src="https://github.com/user-attachments/assets/52276008-8249-46d5-88f0-99c64f617cd0" />

<img width="499" alt="Screenshot 2025-02-25 at 10 06 32 AM" src="https://github.com/user-attachments/assets/93de59bc-27d6-4f9f-b9b3-070c9875460b" />

## What areas of the site does it impact?
	modified:   modules/claims_api/app/services/claims_api/slack/client.rb
	modified:   modules/claims_api/app/services/claims_api/slack/payload.rb
	modified:   modules/claims_api/spec/services/failed_submissions_messenger_spec.rb

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
