### PR TITLE
chore: pull ECR registry from ENV var

### DIFF
--- a/.github/workflows/audit_service_tags.yml
+++ b/.github/workflows/audit_service_tags.yml
@@ -12,6 +12,7 @@ jobs:
     name: Audit Service Tags
     env:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
+      ECR_REGISTRY_WITH_SLASH: "${{ secrets.ECR_REGISTRY }}/"
       CI: true
       RAILS_ENV: test
       TERM: xterm-256color

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -58,6 +58,7 @@ jobs:
     name: Test
     env:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
+      ECR_REGISTRY_WITH_SLASH: "${{ secrets.ECR_REGISTRY }}/"
       CI: true
       RAILS_ENV: test
       TERM: xterm-256color

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,9 +1,9 @@
 version: '3.4'
 services:
   redis:
-    image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/redis:6.2-alpine
+    image: ${ECR_REGISTRY_WITH_SLASH}redis:6.2-alpine
   postgres:
-    image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/postgis/postgis:14-3.3-alpine
+    image: ${ECR_REGISTRY_WITH_SLASH}postgis/postgis:14-3.3-alpine
     command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all -c max_connections=200
     environment:
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-password}"


### PR DESCRIPTION
The trailing slash allows the use of docker-compose.test.yml locally with Docker Hub.

I also confirmed it was actually pulling by checking the digests. They differ between docker hub and our private ecr. I ran this script in GHA (which should have failed if it hadn't pulled the image yet) and the digest matched with ECR:

```yaml
- name: Check ECR_REGISTRY
  run: |
    docker inspect --format='{{index .RepoDigests 0}}' 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/redis:6.2-alpine
```

<img width="1553" alt="image" src="https://github.com/user-attachments/assets/0eed7a4d-179b-4896-8085-cf365298e4f3" />

