### PR TITLE
API-40902 - Remove flipper for VA Notify, update associated tests

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1004,10 +1004,6 @@ features:
     actor_type: user
     description: Enable/disable dependent claimant support for POA requests
     enable_in_development: true
-  lighthouse_claims_api_v2_poa_va_notify:
-    actor_type: user
-    description: Enable/disable the VA notification emails in V2 POA
-    enable_in_development: false
   lighthouse_claims_v2_poa_requests_skip_bgs:
     actor_type: user
     description: Enable/disable skipping BGS calls for POA Requests

--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -188,8 +188,6 @@ module ClaimsApi
         end
 
         def send_declined_notification(ptcpnt_id:, first_name:, representative_id:)
-          return unless Flipper.enabled?(:lighthouse_claims_api_v2_poa_va_notify)
-
           lockbox = Lockbox.new(key: Settings.lockbox.master_key)
           encrypted_ptcpnt_id = Base64.strict_encode64(lockbox.encrypt(ptcpnt_id))
           encrypted_first_name = Base64.strict_encode64(lockbox.encrypt(first_name))

--- a/modules/claims_api/app/sidekiq/claims_api/service_base.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/service_base.rb
@@ -238,8 +238,7 @@ module ClaimsApi
 
     def vanotify?(auth_headers, rep_id)
       rep = ::Veteran::Service::Representative.where(representative_id: rep_id).order(created_at: :desc).first
-      Flipper.enabled?(:lighthouse_claims_api_v2_poa_va_notify) &&
-        auth_headers.key?(ClaimsApi::V2::Veterans::PowerOfAttorney::BaseController::VA_NOTIFY_KEY) && rep.present?
+      auth_headers.key?(ClaimsApi::V2::Veterans::PowerOfAttorney::BaseController::VA_NOTIFY_KEY) && rep.present?
     end
 
     def evss_mapper_service(auto_claim)

--- a/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
+++ b/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
@@ -327,36 +327,13 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
         allow(Lockbox).to receive(:new).and_return(mock_lockbox)
       end
 
-      context 'when the feature flag is enabled' do
-        before do
-          allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_v2_poa_va_notify).and_return(true)
-        end
-
-        it 'enqueues the VANotifyDeclinedJob' do
-          mock_ccg(scopes) do |auth_header|
-            VCR.use_cassette('mpi/find_candidate/valid') do
-              expect do
-                decide_request_with(id:, decision:, auth_header:,
-                                    representative_id:)
-              end.to change(ClaimsApi::VANotifyDeclinedJob.jobs, :size).by(1)
-            end
-          end
-        end
-      end
-
-      context 'when the feature flag is disabled' do
-        before do
-          allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_v2_poa_va_notify).and_return(false)
-        end
-
-        it 'does not enqueue the VANotifyDeclinedJob' do
+      it 'enqueues the VANotifyDeclinedJob' do
+        mock_ccg(scopes) do |auth_header|
           VCR.use_cassette('mpi/find_candidate/valid') do
-            mock_ccg(scopes) do |auth_header|
-              expect do
-                decide_request_with(id:, decision:, auth_header:,
-                                    representative_id:)
-              end.not_to change(ClaimsApi::VANotifyDeclinedJob.jobs, :size)
-            end
+            expect do
+              decide_request_with(id:, decision:, auth_header:,
+                                  representative_id:)
+            end.to change(ClaimsApi::VANotifyDeclinedJob.jobs, :size).by(1)
           end
         end
       end

--- a/modules/claims_api/spec/sidekiq/poa_assign_dependent_claimant_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/poa_assign_dependent_claimant_job_spec.rb
@@ -189,7 +189,6 @@ RSpec.describe ClaimsApi::PoaAssignDependentClaimantJob, type: :job do
   context 'Sending the VA Notify email' do
     before do
       create_mock_lighthouse_service
-      allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_v2_poa_va_notify).and_return true
     end
 
     let(:poa) do
@@ -210,21 +209,6 @@ RSpec.describe ClaimsApi::PoaAssignDependentClaimantJob, type: :job do
           .and_return(nil)
         allow_any_instance_of(ClaimsApi::ServiceBase).to receive(:vanotify?).and_return true
         expect(ClaimsApi::VANotifyAcceptedJob).to receive(:perform_async)
-
-        described_class.new.perform(poa.id, '12345678')
-      end
-    end
-
-    context 'when the flipper is off' do
-      it 'does not send the vanotify job' do
-        allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_v2_poa_va_notify).and_return false
-        poa.auth_headers.merge!({
-                                  header_key => 'this_value'
-                                })
-        poa.save!
-        allow_any_instance_of(ClaimsApi::DependentClaimantPoaAssignmentService).to receive(:assign_poa_to_dependent!)
-          .and_return(nil)
-        expect(ClaimsApi::VANotifyAcceptedJob).not_to receive(:perform_async)
 
         described_class.new.perform(poa.id, '12345678')
       end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Removes flipper lighthouse_claims_api_v2_poa_va_notify as part of follow-on cleanup work for the VA Notify functionality used with POA requests.
- Updates associated rspec tests

## Related issue(s)

[API-40902](https://jira.devops.va.gov/browse/API-40902)

## Testing done

- [x] *New code is covered by unit tests*
- Confirmed that calls to POA request decide endpoint result in appropriate VA Notify emails being sent for declined & approved decisions for both representative and organization requests.

## What areas of the site does it impact?
modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
modules/claims_api/spec/sidekiq/poa_assign_dependent_claimant_job_spec.rb
modules/claims_api/spec/sidekiq/poa_updater_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

