### PR TITLE
Update source_app_middleware.rb with 10-7959C

### DIFF
--- a/lib/source_app_middleware.rb
+++ b/lib/source_app_middleware.rb
@@ -33,6 +33,7 @@ class SourceAppMiddleware
     10206-pa
     10207-pp
     10210-lay-witness-statement
+    10-7959C
     10-7959f-1-FMP
     1330m2-medallions
     1330m-medallions


### PR DESCRIPTION
## Summary
This fixes https://vagov.ddog-gov.com/monitors/200229, which alerted [the oncall channel](https://dsva.slack.com/archives/C30LCU8S3/p1740504820935559).

## Related issue(s)
None. Saw while I was covering for support. 

## Testing done
Once deployed (tomorrow at 1pm ET), the monitor will resolve. 

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
**vets-api source app monitor - un-mapped source app detected** monitor
