### PR TITLE
[10-10EZ] Remove retry_form_validation toggle logic

### DIFF
--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -314,23 +314,9 @@ class HealthCareApplication < ApplicationRecord
   def form_matches_schema
     if form.present?
       schema = VetsJsonSchema::SCHEMAS[self.class::FORM_ID]
-
-      if Flipper.enabled?(:retry_form_validation)
-        validation_errors = validate_form_with_retries(schema, parsed_form)
-        validation_errors.each do |v|
-          errors.add(:form, v.to_s)
-        end
-      else
-        begin
-          JSON::Validator.fully_validate(schema, parsed_form).each do |v|
-            errors.add(:form, v.to_s)
-          end
-        rescue => e
-          PersonalInformationLog.create(data: { schema:, parsed_form: },
-                                        error_class: 'HealthCareApplication FormValidationError')
-          Rails.logger.error("[#{FORM_ID}] Error during schema validation!", { error: e.message, schema: })
-          raise
-        end
+      validation_errors = validate_form_with_retries(schema, parsed_form)
+      validation_errors.each do |v|
+        errors.add(:form, v.to_s)
       end
     end
   end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Remove usage and logic for `retry_form_validation` toggle. It is currently on and we always want it on going forward.
- Future PR to remove the toggle itself and delete the toggles from the environment DBs
- 1010 Health Apps

## Related issue(s)

- Functionality added [in this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/20442).

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
