### PR TITLE
102922 Fix bug that prevented overflow PDFs from generating on retried submissions - form 10-10d

### DIFF
--- a/modules/ivc_champva/app/services/ivc_champva/attachments.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/attachments.rb
@@ -92,7 +92,9 @@ module IvcChampva
     end
 
     def generate_additional_pdf(additional_data, index)
-      additional_form_data = @data
+      # Deep copy @data so we don't clobber the ADDITIONAL_PDF_KEY array:
+      additional_form_data = Marshal.load(Marshal.dump(@data))
+
       additional_form_data[self.class::ADDITIONAL_PDF_KEY] = additional_data
       filler = IvcChampva::PdfFiller.new(
         form_number: form_id,


### PR DESCRIPTION
## Summary

This PR fixes a bug that prevents failed form submit retries from producing the correct amount of overflow PDFs.

On form 10-10d, only 3 applicants fit per page. To work around this without limiting users in the online form, we have a routine that generates a new 10-10d PDF with the next 3 applicants and so on and so forth until all applicants are represented on 10-10d PDFs.

Currently, there is a bug in that logic which causes the applicants array to be overwritten as it's iterated over in groups of 3. This doesn't impact normal form submissions, but in cases where we encounter an error and need to regenerate the PDF, we have now lost the necessary data to recompute what should be on the overflow 10-10ds.

- This work is behind a feature toggle (flipper): NO
- Changes are that we now deep copy the object before making changes so as not to disturb the original form data
- To reproduce this bug:
  1. run vets-website and vets-api locally
  2. Add a `byebug` just above the return statement in [this method](https://github.com/department-of-veterans-affairs/vets-api/blob/17e8b9894b8df81769fe1095e5f4dc4a5fb41548/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb#L185)
  3. Submit a [form 10-10d](http://localhost:3001/family-and-caregiver-benefits/health-and-disability/champva/apply-form-10-10d) locally with > 3 applicants
  4. When the `byebug` breakpoint is triggered, note the number of generated 10-10d form PDFs in `vets-api/tmp/`
  5. Delete any of the newly generated PDFs (this triggers the retry logic)
  6. Continue past the breakpoint
  7. Note that on the second attempt, there will only be one single 10-10d, rather than the appropriate amount of 10-10ds needed to include > 3 applicants.
- The solution is to not overwrite the `@data` property while iterating over the applicants array and generating additional 10-10d PDFs. This solution allows us to regenerate all the PDFs since we have not destroyed the `applicants` array when iterating through it the first time.
- Team: IVC CHAMPVA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/102922

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

IVC CHAMPVA forms

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA
