### PR TITLE
Add new form 21-0966 confirmation page feature toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -716,6 +716,10 @@ features:
     actor_type: user
     description: Enables form 21-0966 email submission confirmation (VaNotify)
     enable_in_development: true
+  form21_0966_confirmation_page:
+    actor_type: user
+    description: Enables form 21-0966 new confirmation page
+    enable_in_development: true
   form21_0972_confirmation_email:
     actor_type: user
     description: Enables form 21-0972 email submission confirmation (VaNotify)


### PR DESCRIPTION
## Summary

This adds a new feature toggle for form 21-0966 to enable/disable the new confirmation page.

## Related issue(s)

department-of-veterans-affairs/va.gov-team-forms#2031

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature