### PR TITLE
[1010 Health Apps] Add rake task to generate pdf form field metadata when adding new pdf fill class

### DIFF
--- a/rakelib/extract_pdf_fields.rake
+++ b/rakelib/extract_pdf_fields.rake
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'pdf_forms'
+
+namespace :pdf do
+  desc 'Extract PDF form field metadata and save them to a Ruby file. ' \
+       'Used when adding a new form to PdfFill::Filler' \
+       'Example: bundle exec rake pdf:extract_fields[lib/pdf_fill/forms/pdfs/10-10EZ.pdf]' \
+       'generated file will be in lib/pdf_fill/forms/10-10EZ_field_data.json'
+  task :extract_fields, [:pdf_path] => :environment do |_t, args|
+    pdf_path = args[:pdf_path]
+
+    unless pdf_path
+      puts 'Usage: rake pdf:extract_fields[pdf_path]'
+      exit 1
+    end
+
+    unless File.exist?(pdf_path)
+      puts "Error: File '#{pdf_path}' does not exist."
+      exit 1
+    end
+
+    # Extract filename without extension
+    file_name = File.basename(pdf_path, File.extname(pdf_path))
+
+    # Initialize PdfForms
+    pdf_forms = PdfForms.new(Settings.binaries.pdftk)
+
+    # Extract fields
+    fields = pdf_forms.get_fields(pdf_path)
+
+    # Map fields into a structured format
+    fields_map = fields.map do |field|
+      {
+        key: field.name,
+        question_text: field.name_alt,
+        options: field.options,
+        type: field.type
+      }
+    end
+
+    # Pretty format the fields_map as a JSON-like string
+    formatted_data = JSON.pretty_generate(fields_map)
+
+    # Generate output file name
+    output_file = "lib/pdf_fill/forms/#{file_name}_field_data.json"
+    FileUtils.mkdir_p(File.dirname(output_file)) # Ensure directory exists
+
+    # Write the extracted data to a file
+    File.write(output_file, formatted_data)
+    puts "✅ Extracted PDF fields saved to: #{File.expand_path(output_file)}"
+  end
+end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- New rake task to use PdfForms to get all form fields in a pdf and write to a file with the metadata that is needed when adding a new pdf form to the `PdfFill:Filler` module. This rake task can be used by engineers to more easily add new forms to the fill module. 
- If this is valuable, where is the best place to document that it exists and you can use it? Maybe a comment in the `PdfFill:Filler` module? 
-  Example:  `bundle exec rake pdf:extract_fields[lib/pdf_fill/forms/pdfs/10-10EZ.pdf]` and a file will be added in `lib/pdf_fill/forms/10-10EZ_field_data.json` will the field metadata.
- 1010 Health Apps

## Related issue(s)

- This work was added since I used it when working on https://github.com/department-of-veterans-affairs/va.gov-team/issues/60909

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
<img width="871" alt="Screenshot 2025-02-26 at 10 59 03 AM" src="https://github.com/user-attachments/assets/a458ca95-ca17-4082-b292-281ffd823ce7" />


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
