### PR TITLE
add auth token generation for kafka

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -245,3 +245,5 @@ else
     gem 'sidekiq-pro'
   end
 end
+
+gem "aws-sdk-kafka", "~> 1.89"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,6 +244,9 @@ GEM
       aws-sigv4 (~> 1.9)
       base64
       jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kafka (1.89.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sigv4 (~> 1.5)
     aws-sdk-kms (1.98.0)
       aws-sdk-core (~> 3, >= 3.216.0)
       aws-sigv4 (~> 1.5)
@@ -1160,6 +1163,7 @@ DEPENDENCIES
   ask_va_api!
   avs!
   awesome_print
+  aws-sdk-kafka (~> 1.89)
   aws-sdk-kms
   aws-sdk-s3 (~> 1)
   aws-sdk-sns (~> 1)

--- a/lib/kafka/credentials_resolver.rb
+++ b/lib/kafka/credentials_resolver.rb
@@ -1,0 +1,22 @@
+require "aws-sigv4"
+require 'aws-sdk-kafka'
+
+module Kafka
+  class CredentialsResolver
+    def from_credential_provider_chain(region)
+      client = Aws::Kafka::Client.new(region: region)
+      raise "No credentials found" unless client.config.credentials
+
+      client.config.credentials
+    end
+
+    def from_profile(profile)
+      Aws::SharedCredentials.new(profile_name: profile)
+    end
+
+    def from_role_arn(role_arn:, session_name:)
+      sts = Aws::STS::Client.new
+      sts.assume_role({ role_arn: role_arn, role_session_name: session_name })
+    end
+  end
+end

--- a/lib/kafka/msk_token_provider.rb.rb
+++ b/lib/kafka/msk_token_provider.rb.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "aws-sdk-kafka"
+require "aws-sigv4"
+require "base64"
+require "uri"
+
+module Kafka
+  class MSKTokenProvider
+    ENDPOINT_URL_TEMPLATE = "kafka.{}.amazonaws.com"
+    DEFAULT_TOKEN_EXPIRY_SECONDS = 900
+    LIB_NAME = "aws-msk-iam-sasl-signer-msk-iam-sasl-signer-ruby"
+    USER_AGENT_KEY = "User-Agent"
+    SESSION_NAME = "MSKSASLDefaultSession"
+    CallerIdentity = Struct.new(:user_id, :account, :arn)
+    AuthToken = Struct.new(:token, :expiration_time_ms, :caller_identity)
+
+    def initialize(region:)
+      @region = region
+    end
+
+    def generate_auth_token(aws_debug: false)
+      credentials = CredentialsResolver.new.from_credential_provider_chain(@region)
+      caller_identity = caller_identity(credentials, @region) if aws_debug
+      url = presign(credentials, endpoint_url)
+      AuthToken.new(
+        urlsafe_encode64(user_agent(url)),
+        expiration_time_ms(url),
+        caller_identity
+      )
+    end
+
+    def generate_auth_token_from_profile(profile)
+      credentials = CredentialsResolver.new.from_profile(profile)
+      url = presign(credentials, endpoint_url)
+      AuthToken.new(
+        urlsafe_encode64(user_agent(url)),
+        expiration_time_ms(url)
+      )
+    end
+
+    def generate_auth_token_from_role_arn(role_arn, session_name=nil)
+      session_name ||= SESSION_NAME
+      credentials = CredentialsResolver.new.from_role_arn(
+        role_arn: role_arn,
+        session_name: session_name
+      )
+      url = presign(credentials, endpoint_url)
+      AuthToken.new(
+        urlsafe_encode64(user_agent(url)),
+        expiration_time_ms(url)
+      )
+    end
+
+    def generate_auth_token_from_credentials_provider(credentials_provider)
+      raise "Invalid credentials provider" unless credentials_provider.respond_to?(:credentials)
+
+      url = presign(credentials_provider, endpoint_url)
+      AuthToken.new(
+        urlsafe_encode64(user_agent(url)),
+        expiration_time_ms(url)
+      )
+    end
+
+    private
+
+    def endpoint_url
+      host = ENDPOINT_URL_TEMPLATE.gsub("{}", @region)
+      query_params = {
+        Action: "kafka-cluster:Connect"
+      }
+      URI::HTTPS.build(host: host, path: "/", query: URI.encode_www_form(query_params))
+    end
+
+    def presign(credentials_provider, url)
+      signer = Aws::Sigv4::Signer.new(
+        service: "kafka-cluster",
+        region: @region,
+        credentials_provider: credentials_provider
+      )
+      signer.presign_url(
+        http_method: "GET",
+        url: url,
+        expires_in: DEFAULT_TOKEN_EXPIRY_SECONDS
+      )
+    end
+
+    def user_agent(url)
+      new_query_ar = URI.decode_www_form(url.query) << [USER_AGENT_KEY, "#{LIB_NAME}/#{VERSION}"]
+      url.query = URI.encode_www_form(new_query_ar)
+      url.to_s
+    end
+
+    def urlsafe_encode64(url)
+      Base64.urlsafe_encode64(url, padding: false)
+    end
+
+    def expiration_time_ms(url)
+      params = URI.decode_www_form(String(url.query))
+      signing_date = params.find { |param| param[0] == "X-Amz-Date" }
+      signing_time = DateTime.strptime(signing_date[1], "%Y%m%dT%H%M%SZ")
+      1000 * (signing_time.to_time.to_i + DEFAULT_TOKEN_EXPIRY_SECONDS)
+    end
+
+    def caller_identity(credentials_provider, region)
+      sts = Aws::STS::Client.new(
+        region: region,
+        access_key_id: credentials_provider.credentials.access_key_id,
+        secret_access_key: credentials_provider.credentials.secret_access_key,
+        session_token: credentials_provider.credentials.session_token
+      )
+      CallerIdentity.new(
+        sts.get_caller_identity.user_id,
+        sts.get_caller_identity.account,
+        sts.get_caller_identity.arn
+      )
+    end
+  end
+end

--- a/spec/lib/kafka/credentials_resolver_spec.rb
+++ b/spec/lib/kafka/credentials_resolver_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "aws-sdk-kafka"
+
+RSpec.describe Kafka::CredentialsResolver, type: :model do
+  describe "#from_credential_provider_chain" do
+    context "when no credentials are available" do
+      it "raises an error" do
+        stub = Aws::Kafka::Client.new(stub_responses: true, credentials: nil)
+        Aws::Kafka::Client.stub :new, stub do
+          resolver = Kafka::CredentialsResolver.new
+          expect { resolver.from_credential_provider_chain("us-east-1") }.to raise_error(RuntimeError)
+        end
+      end
+    end
+
+    context "when credentials are available" do
+      it "returns an Aws::Credentials object" do
+        stub = Aws::Kafka::Client.new(stub_responses: true)
+        Aws::Kafka::Client.stub :new, stub do
+          resolver = Kafka::CredentialsResolver.new
+          credentials = resolver.from_credential_provider_chain("us-east-1")
+          expect(credentials).to be_a(Aws::Credentials)
+        end
+      end
+    end
+  end
+
+  describe "#from_profile" do
+    it "returns an Aws::Credentials object" do
+      creds = Aws::Credentials.new("access_key_id", "secret_access", "session_token")
+      Aws::SharedCredentials.stub :new, creds do
+        resolver = Kafka::CredentialsResolver.new
+        credentials = resolver.from_profile("test-profile")
+        expect(credentials).to be_a(Aws::Credentials)
+      end
+    end
+  end
+
+  describe "#from_role_arn" do
+    it "returns a credentials provider" do
+      stub = Aws::STS::Client.new(stub_responses: true)
+      Aws::STS::Client.stub :new, stub do
+        resolver = Kafka::CredentialsResolver.new
+        credentials_provider = resolver.from_role_arn(
+          role_arn: "arn:aws-msk-iam-sasl-signer:iam::123456789012:role/role-name",
+          session_name: "test-session"
+        )
+        expect(credentials_provider).to respond_to(:credentials)
+      end
+    end
+  end
+end

--- a/spec/lib/kafka/test/msk_token_provider_spec.rb
+++ b/spec/lib/kafka/test/msk_token_provider_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "aws-sdk-kafka"
+require "aws-sdk-sts"
+require "base64"
+
+class TestCredentialsProvider
+  include Aws::CredentialProvider
+
+  def initialize
+    @credentials = Aws::Credentials.new(
+      "access_key_id",
+      "secret_access_key",
+      "session_token"
+    )
+  end
+
+  attr_reader :credentials
+end
+
+RSpec.describe Kafka::MSKTokenProvider do
+  let(:token_provider) { described_class.new(region: "us-east-1") }
+  let(:creds) { Aws::Credentials.new("access_key_id", "secret_access", "session_token") }
+
+  describe "#generate_auth_token" do
+    it "generates a valid auth token" do
+      allow_any_instance_of(Kafka::CredentialsResolver)
+        .to receive(:from_credential_provider_chain)
+        .and_return(creds)
+
+      auth_token = token_provider.generate_auth_token
+      assert_token(auth_token)
+    end
+  end
+
+  describe "#generate_auth_token with AWS debug" do
+    it "includes caller identity when aws_debug is true" do
+      allow_any_instance_of(Kafka::CredentialsResolver)
+        .to receive(:from_credential_provider_chain)
+        .and_return(creds)
+
+      allow(Aws::STS::Client).to receive(:new).and_return(Aws::STS::Client.new(stub_responses: true))
+
+      auth_token = token_provider.generate_auth_token(aws_debug: true)
+
+      expect(auth_token.caller_identity).not_to be_nil
+      expect(auth_token.caller_identity).to be_a(Kafka::MSKTokenProvider::CallerIdentity)
+    end
+  end
+
+  describe "#generate_auth_token_from_profile" do
+    it "generates a valid auth token from profile" do
+      allow_any_instance_of(Kafka::CredentialsResolver)
+        .to receive(:from_profile)
+        .and_return(creds)
+
+      auth_token = token_provider.generate_auth_token_from_profile("test-profile")
+      assert_token(auth_token)
+    end
+  end
+
+  describe "#generate_auth_token_from_role_arn" do
+    it "generates a valid auth token from role ARN" do
+      allow_any_instance_of(Kafka::CredentialsResolver)
+        .to receive(:from_role_arn)
+        .and_return(creds)
+
+      auth_token = token_provider.generate_auth_token_from_role_arn("role_arn")
+      assert_token(auth_token)
+    end
+  end
+
+  describe "#generate_auth_token_from_credentials_provider" do
+    it "generates a valid auth token from a credentials provider" do
+      auth_token = token_provider.generate_auth_token_from_credentials_provider(TestCredentialsProvider.new)
+      assert_token(auth_token)
+    end
+  end
+
+  def assert_token(auth_token)
+    decoded_signed_url, params = parse_url(auth_token.token)
+
+    assert_url(decoded_signed_url)
+    assert_query_parameters(params)
+    assert_credentials(params)
+    assert_expiration_time_ms(params, auth_token.expiration_time_ms)
+  end
+
+  def parse_url(signed_url)
+    decoded_signed_url = Base64.urlsafe_decode64(signed_url)
+    uri = URI.parse(decoded_signed_url)
+    params = URI.decode_www_form(uri.query).group_by(&:first).transform_values { |a| a.map(&:last) }
+    [decoded_signed_url, params]
+  end
+
+  def assert_url(decoded_signed_url)
+    expect(decoded_signed_url).to match("https://kafka.us-east-1.amazonaws.com/?Action=kafka-cluster%3AConnect")
+  end
+
+  def assert_query_parameters(params)
+    expect(params["Action"].first).to eq("kafka-cluster:Connect")
+    expect(params["X-Amz-Algorithm"].first).to eq("AWS4-HMAC-SHA256")
+    expect(params["X-Amz-Security-Token"].first).to eq("session_token")
+    expect(params["X-Amz-SignedHeaders"].first).to eq("host")
+    expect(params["X-Amz-Expires"].first).to eq("900")
+    expect(params["User-Agent"].first).to match("aws-msk-iam-sasl-signer-msk-iam-sasl-signer-ruby")
+  end
+
+  def assert_credentials(params)
+    credentials = params["X-Amz-Credential"].first
+    split_credentials = credentials.split("/")
+    expect(split_credentials[0]).to eq("access_key_id")
+    expect(split_credentials[2]).to eq("us-east-1")
+    expect(split_credentials[3]).to eq("kafka-cluster")
+    expect(split_credentials[4]).to eq("aws4_request")
+  end
+
+  def assert_expiration_time_ms(params, expiration_time_ms)
+    date_obj = DateTime.strptime(params["X-Amz-Date"].first, "%Y%m%dT%H%M%SZ")
+    current_time = Time.now.utc.to_i
+    expect(date_obj.to_time.to_i).to be <= current_time
+
+    actual_expires = 1000 * (params["X-Amz-Expires"].first.to_i + date_obj.to_time.to_i)
+    expect(expiration_time_ms).to eq(actual_expires)
+  end
+end


### PR DESCRIPTION
In order to use a named profile to generate the token, replace the `generate_auth_token` function with code below:

```ruby
  signer = AwsMskIamSaslSigner::MSKTokenProvider.new(region: 'us-east-1')
  auth_token = signer.generate_auth_token_from_profile(
    aws_profile: 'my-profile'
  )
```

In order to use a role arn to generate the token, replace the `generate_auth_token` function with code below:

```ruby
    signer = AwsMskIamSaslSigner::MSKTokenProvider.new(region: 'us-east-1')
    auth_token = signer.generate_auth_token_from_role_arn(
        role_arn: 'arn:aws:iam::1234567890:role/my-role'
    )
```

In order to use a custom credentials provider, replace the `generate_auth_token` function with code below :

```ruby
    signer = AwsMskIamSaslSigner::MSKTokenProvider.new(region: 'us-east-1')
    auth_token = signer.generate_auth_token_from_credentials_provider(
      'your-credentials-provider'
    )
```
