### PR TITLE
[101855] Add poa request submission swagger docs

### DIFF
--- a/modules/representation_management/app/swagger/v0/swagger.json
+++ b/modules/representation_management/app/swagger/v0/swagger.json
@@ -14,6 +14,10 @@
     {
       "name": "Power of Attorney",
       "description": "Retrieves the Power of Attorney for a veteran, if any."
+    },
+    {
+      "name": "Power of Attorney Requests",
+      "description": "Digital Submission of VA Form 21-22"
     }
   ],
   "components": {
@@ -645,6 +649,45 @@
             }
           }
         }
+      },
+      "poaRequest": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "example": "0bfddcc5-fe3c-4ffb-a4c7-70f5e23bde23",
+                "description": "The identifier of the newly created Power of Attorney Request"
+              },
+              "type": {
+                "type": "string",
+                "description": "The type of resource created",
+                "example": "power_of_attorney_request"
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "created_at": {
+                    "type": "string",
+                    "description": "The timestamp of when the resource was created",
+                    "example": "2020-01-01T12:00:00.000Z"
+                  },
+                  "expires_at": {
+                    "type": "string",
+                    "description": "The timestamp of when the resource expires",
+                    "example": "2020-03-01T12:00:00.000Z"
+                  }
+                },
+                "required": [
+                  "created_at",
+                  "expires_at"
+                ]
+              }
+            }
+          }
+        }
       }
     }
   },
@@ -1110,6 +1153,244 @@
                         "type": "string",
                         "example": "8c3b3b53-02a1-4dbd-bd23-2b556f5ef635",
                         "description": "This is an AccreditedIndividual#id or a Veteran::Service::Representative#representative_id"
+                      }
+                    }
+                  },
+                  "veteran": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "object",
+                        "properties": {
+                          "first": {
+                            "type": "string",
+                            "example": "John"
+                          },
+                          "middle": {
+                            "type": "string",
+                            "example": "Middle"
+                          },
+                          "last": {
+                            "type": "string",
+                            "example": "Doe"
+                          }
+                        }
+                      },
+                      "address": {
+                        "type": "object",
+                        "properties": {
+                          "address_line1": {
+                            "type": "string",
+                            "example": "123 Main St"
+                          },
+                          "address_line2": {
+                            "type": "string",
+                            "example": "Apt 1"
+                          },
+                          "city": {
+                            "type": "string",
+                            "example": "Springfield"
+                          },
+                          "state_code": {
+                            "type": "string",
+                            "example": "IL"
+                          },
+                          "country": {
+                            "type": "string",
+                            "example": "US"
+                          },
+                          "zip_code": {
+                            "type": "string",
+                            "example": "62704"
+                          },
+                          "zip_code_suffix": {
+                            "type": "string",
+                            "example": "6789"
+                          }
+                        }
+                      },
+                      "ssn": {
+                        "type": "string",
+                        "example": "123456789"
+                      },
+                      "va_file_number": {
+                        "type": "string",
+                        "example": "123456789"
+                      },
+                      "date_of_birth": {
+                        "type": "string",
+                        "format": "date",
+                        "example": "1980-12-31"
+                      },
+                      "service_number": {
+                        "type": "string",
+                        "example": "123456789"
+                      },
+                      "service_branch": {
+                        "type": "string",
+                        "example": "Army"
+                      },
+                      "phone": {
+                        "type": "string",
+                        "example": "1234567890"
+                      },
+                      "email": {
+                        "type": "string",
+                        "example": "veteran@example.com"
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "record_consent",
+                  "veteran"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/representation_management/v0/power_of_attorney_requests": {
+      "post": {
+        "summary": "Submit a Power of Attorney Request (Form 21-22)",
+        "tags": [
+          "Power of Attorney Requests"
+        ],
+        "operationId": "createPOARequest",
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": "POA Request Submitted Successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/poaRequest"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "unprocessable entity response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "record_consent": {
+                    "type": "boolean",
+                    "example": true
+                  },
+                  "consent_address_change": {
+                    "type": "boolean",
+                    "example": false
+                  },
+                  "consent_limits": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "ALCOHOLISM",
+                      "DRUG_ABUSE",
+                      "HIV",
+                      "SICKLE_CELL"
+                    ]
+                  },
+                  "claimant": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "object",
+                        "properties": {
+                          "first": {
+                            "type": "string",
+                            "example": "John"
+                          },
+                          "middle": {
+                            "type": "string",
+                            "example": "Middle"
+                          },
+                          "last": {
+                            "type": "string",
+                            "example": "Doe"
+                          }
+                        }
+                      },
+                      "address": {
+                        "type": "object",
+                        "properties": {
+                          "address_line1": {
+                            "type": "string",
+                            "example": "123 Main St"
+                          },
+                          "address_line2": {
+                            "type": "string",
+                            "example": "Apt 1"
+                          },
+                          "city": {
+                            "type": "string",
+                            "example": "Springfield"
+                          },
+                          "state_code": {
+                            "type": "string",
+                            "example": "IL"
+                          },
+                          "country": {
+                            "type": "string",
+                            "example": "US"
+                          },
+                          "zip_code": {
+                            "type": "string",
+                            "example": "62704"
+                          },
+                          "zip_code_suffix": {
+                            "type": "string",
+                            "example": "6789"
+                          }
+                        }
+                      },
+                      "date_of_birth": {
+                        "type": "string",
+                        "format": "date",
+                        "example": "1980-12-31"
+                      },
+                      "relationship": {
+                        "type": "string",
+                        "example": "Spouse"
+                      },
+                      "phone": {
+                        "type": "string",
+                        "example": "1234567890"
+                      },
+                      "email": {
+                        "type": "string",
+                        "example": "veteran@example.com"
+                      }
+                    }
+                  },
+                  "representative": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "example": "86753",
+                        "description": "This is a Veteran::Service::Representative#representative_id"
+                      },
+                      "organization_id": {
+                        "type": "string",
+                        "example": "B12",
+                        "description": "This is a Veteran::Service::Organization#poa"
                       }
                     }
                   },

--- a/modules/representation_management/spec/requests/representation_management/v0/power_of_attorney_requests_swagger_spec.rb
+++ b/modules/representation_management/spec/requests/representation_management/v0/power_of_attorney_requests_swagger_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+require Rails.root.join('spec', 'rswag_override.rb').to_s
+require_relative '../../../support/swagger_shared_components/v0'
+
+RSpec.describe 'Power of Attorney Requests',
+               openapi_spec: 'modules/representation_management/app/swagger/v0/swagger.json',
+               type: :request do
+  let(:user) { create(:user, :loa3) }
+  let!(:user_verification) { create(:idme_user_verification, idme_uuid: user.idme_uuid) }
+  let!(:organization) do
+    create(:organization, poa: SwaggerSharedComponents::V0.poa_request_representative[:organization_id])
+  end
+  let!(:representative) do
+    create(:representative, representative_id: SwaggerSharedComponents::V0.poa_request_representative[:id])
+  end
+
+  path '/representation_management/v0/power_of_attorney_requests' do
+    post('Submit a Power of Attorney Request (Form 21-22)') do
+      tags 'Power of Attorney Requests'
+      consumes 'application/json'
+      operationId 'createPOARequest'
+      produces 'application/json'
+      parameter SwaggerSharedComponents::V0.body_examples[:poa_request_parameter]
+
+      describe 'Successful submission' do
+        response '201', 'POA Request Submitted Successfully' do
+          let(:poa_request) do
+            SwaggerSharedComponents::V0.body_examples[:poa_request]
+          end
+
+          let(:poa_request_result) do
+            OpenStruct.new(id: 'efd18b43-4421-4539-941a-7397fadfe5dc',
+                           created_at: '2025-02-21T00:00:00.000000000Z'.to_datetime,
+                           expires_at: '2025-04-22T00:00:00.000000000Z'.to_datetime)
+          end
+          before do
+            sign_in_as(user)
+            Flipper.enable(:appoint_a_representative_enable_v2_features)
+            allow_any_instance_of(RepresentationManagement::PowerOfAttorneyRequestService::Orchestrate)
+              .to receive(:call)
+              .and_return({ request: poa_request_result })
+          end
+
+          schema '$ref' => '#/components/schemas/poaRequest'
+          run_test!
+        end
+      end
+
+      describe 'Getting a 422 response' do
+        response '422', 'unprocessable entity response' do
+          produces 'application/json'
+          let(:poa_request) do
+            params = SwaggerSharedComponents::V0.body_examples[:poa_request]
+            params[:veteran][:name].delete(:first)
+            params
+          end
+
+          before do
+            sign_in_as(user)
+            Flipper.enable(:appoint_a_representative_enable_v2_features)
+          end
+
+          schema '$ref' => '#/components/schemas/errors'
+          run_test!
+        end
+      end
+    end
+  end
+end

--- a/modules/representation_management/spec/support/rswag_config.rb
+++ b/modules/representation_management/spec/support/rswag_config.rb
@@ -34,6 +34,10 @@ class RepresentationManagement::RswagConfig
       {
         name: 'Power of Attorney',
         description: 'Retrieves the Power of Attorney for a veteran, if any.'
+      },
+      {
+        name: 'Power of Attorney Requests',
+        description: 'Digital Submission of VA Form 21-22'
       }
     ]
   end
@@ -47,7 +51,8 @@ class RepresentationManagement::RswagConfig
       errorModel: error_model,
       powerOfAttorneyResponse: power_of_attorney_response,
       veteranServiceOrganization: veteran_service_organization_schema,
-      veteranServiceRepresentative: veteran_service_representative_schema
+      veteranServiceRepresentative: veteran_service_representative_schema,
+      poaRequest: poa_request_response
     }
   end
 
@@ -127,6 +132,53 @@ class RepresentationManagement::RswagConfig
           }
         }
       }
+    }
+  end
+
+  def poa_request_response
+    {
+      type: :object,
+      properties: {
+        data: {
+          type: :object,
+          properties: {
+            id: {
+              type: :string,
+              example: '0bfddcc5-fe3c-4ffb-a4c7-70f5e23bde23',
+              description: 'The identifier of the newly created Power of Attorney Request'
+            },
+            type: poa_request_type,
+            attributes: poa_request_attributes
+          }
+        }
+      }
+    }
+  end
+
+  def poa_request_type
+    {
+      type: :string,
+      description: 'The type of resource created',
+      example: 'power_of_attorney_request'
+    }
+  end
+
+  def poa_request_attributes
+    {
+      type: :object,
+      properties: {
+        created_at: {
+          type: :string,
+          description: 'The timestamp of when the resource was created',
+          example: '2020-01-01T12:00:00.000Z'
+        },
+        expires_at: {
+          type: :string,
+          description: 'The timestamp of when the resource expires',
+          example: '2020-03-01T12:00:00.000Z'
+        }
+      },
+      required: %w[created_at expires_at]
     }
   end
 

--- a/modules/representation_management/spec/support/swagger_shared_components/v0.rb
+++ b/modules/representation_management/spec/support/swagger_shared_components/v0.rb
@@ -11,7 +11,9 @@ module SwaggerSharedComponents
         pdf_generator2122:,
         pdf_generator2122_parameter:,
         pdf_generator2122a:,
-        pdf_generator2122a_parameter:
+        pdf_generator2122a_parameter:,
+        poa_request:,
+        poa_request_parameter:
       }
     end
 
@@ -57,6 +59,17 @@ module SwaggerSharedComponents
       }
     end
 
+    def self.poa_request
+      {
+        record_consent: true,
+        consent_address_change: true,
+        consent_limits: [],
+        claimant:,
+        representative: poa_request_representative,
+        veteran:
+      }
+    end
+
     def self.claimant
       {
         date_of_birth: '1980-12-31',
@@ -72,6 +85,13 @@ module SwaggerSharedComponents
       {
         id: '8c3b3b53-02a1-4dbd-bd23-2b556f5ef635',
         organization_id: '6f76b9c2-2a37-4cd7-8a6c-93a0b3a73943'
+      }
+    end
+
+    def self.poa_request_representative
+      {
+        id: '86753',
+        organization_id: 'B12'
       }
     end
 
@@ -161,6 +181,22 @@ module SwaggerSharedComponents
       }
     end
 
+    def self.poa_request_parameter
+      {
+        name: :poa_request,
+        in: :body,
+        schema: {
+          type: :object,
+          properties: appointment_conditions_parameter.merge(
+            claimant: claimant_parameter,
+            representative: poa_request_rep_parameter,
+            veteran: veteran_parameter
+          ),
+          required: %w[record_consent veteran]
+        }
+      }
+    end
+
     def self.appointment_conditions_parameter
       {
         record_consent: { type: :boolean, example: true },
@@ -200,6 +236,24 @@ module SwaggerSharedComponents
             type: :string,
             example: '6f76b9c2-2a37-4cd7-8a6c-93a0b3a73943',
             description: 'This is an AccreditedOrganization#id or a Veteran::Service::Organization#poa'
+          }
+        }
+      }
+    end
+
+    def self.poa_request_rep_parameter
+      {
+        type: :object,
+        properties: {
+          id: {
+            type: :string,
+            example: '86753',
+            description: 'This is a Veteran::Service::Representative#representative_id'
+          },
+          organization_id: {
+            type: :string,
+            example: 'B12',
+            description: 'This is a Veteran::Service::Organization#poa'
           }
         }
       }


### PR DESCRIPTION
## Summary

- This pr adds swagger docs for the new POA Request digital submission endpoint

## Related issue(s)

- [101855](https://github.com/department-of-veterans-affairs/va.gov-team/issues/101855)

## Testing done

- [x] *New code is covered by unit tests*
- looked at generated swagger doc locally

## Screenshots
![image](https://github.com/user-attachments/assets/6c5ee471-381c-466f-8eb1-3c16d8c62884)

## What areas of the site does it impact?
Representation Management swagger docs

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature