### PR TITLE
[103953] Update POA Request creation to use poa holder types

### DIFF
--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request.rb
@@ -33,6 +33,8 @@ module AccreditedRepresentativePortal
     before_validation :set_claimant_type
 
     validates :claimant_type, inclusion: { in: ClaimantTypes::ALL }
+    validates :power_of_attorney_holder_type, inclusion: { in: PowerOfAttorneyHolder::Types::ALL }
+
     accepts_nested_attributes_for :power_of_attorney_form
 
     def expires_at

--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/power_of_attorney_request_service/create.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/power_of_attorney_request_service/create.rb
@@ -3,7 +3,7 @@
 module AccreditedRepresentativePortal
   module PowerOfAttorneyRequestService
     class Create
-      ORGANIZATION = 'AccreditedOrganization'
+      ORGANIZATION = PowerOfAttorneyHolder::Types::VETERAN_SERVICE_ORGANIZATION
       ACCREDITED_ENTITY_ERROR = 'poa_code can not be blank'
 
       # @note For the 21-22 pilot:

--- a/modules/accredited_representative_portal/spec/models/accredited_representative_portal/power_of_attorney_request_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representative_portal/power_of_attorney_request_spec.rb
@@ -10,15 +10,15 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequest, type: :mo
         power_of_attorney_form: build(
           :power_of_attorney_form,
           data: {}.to_json
-        )
+        ),
+        power_of_attorney_holder_type: 'abc'
       )
 
     expect(poa_request).not_to be_valid
-    expect(poa_request.errors.full_messages).to eq(
-      [
-        'Claimant type is not included in the list',
-        'Power of attorney form data does not comply with schema'
-      ]
+    expect(poa_request.errors.full_messages).to contain_exactly(
+      'Claimant type is not included in the list',
+      'Power of attorney holder type is not included in the list',
+      'Power of attorney form data does not comply with schema'
     )
   end
 end

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/power_of_attorney_request_service/create_spec.rb
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/power_of_attorney_request_service/create_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestService::Cr
     it 'sets the power_of_attorney_holder_type' do
       result = subject.call
 
-      expect(result[:request].power_of_attorney_holder_type).to eq('AccreditedOrganization')
+      expect(result[:request].power_of_attorney_holder_type).to eq('veteran_service_organization')
     end
 
     context 'when only poa_code is provided' do


### PR DESCRIPTION
## Summary

- This pr updates the POA Request Create service to use the poa holder type constant instead of hard coding the type as `AccreditedOrganization`
- This pr adds model validation to the POA Request to check the holder type against the allowed list

## Related issue(s)

- [103953](https://github.com/department-of-veterans-affairs/va.gov-team/issues/103953)

## Testing done

- [x] *New code is covered by unit tests*
- Created new poa requests locally running through the appoint front end

## What areas of the site does it impact?
Appoint a Rep Form 21-22 and ARP

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature