### PR TITLE
[VI-1097] - Add mhv_exception operation type to sessions#new

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -31,6 +31,7 @@ module V1
     OPERATION_TYPES = [AUTHORIZE = 'authorize',
                        INTERSTITIAL_VERIFY = 'interstitial_verify',
                        INTERSTITIAL_SIGNUP = 'interstitial_signup',
+                       MHV_EXCEPTION = 'mhv_exception',
                        MYHEALTHEVET_TEST_ACCOUNT = 'myhealthevet_test_account'].freeze
 
     # Collection Action: auth is required for certain types of requests

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -458,6 +458,31 @@ RSpec.describe V1::SessionsController, type: :controller do
             end
           end
         end
+
+        context 'when type is mhv' do
+          let(:params) { { type:, operation: } }
+          let(:type) { 'mhv' }
+          let(:expected_tags) do
+            [
+              "type:#{type}",
+              'version:v1',
+              'client_id:vaweb',
+              "operation:#{operation}"
+            ]
+          end
+
+          context 'when operation is mhv_exception' do
+            let(:operation) { 'mhv_exception' }
+
+            it 'increments statsd with the expected tags' do
+              expect do
+                call_endpoint
+              end.to trigger_statsd_increment(described_class::STATSD_SSO_NEW_KEY, tags: expected_tags, **once)
+
+              expect(response).to have_http_status(:ok)
+            end
+          end
+        end
       end
 
       context 'routes requiring auth' do


### PR DESCRIPTION
## Summary
- Accept `operation=mhv_exception` param in Sessions#new

## Related issue(s)
- https://jira.devops.va.gov/browse/VI-1097
- https://github.com/department-of-veterans-affairs/vets-website/pull/34938

## Testing 
- Check out vets-website branch - https://github.com/department-of-veterans-affairs/vets-website/pull/34938
- start website and api
- got to http://localhost:3001/sign-in/mhv
- Click MHV button
- you should be redirected to http://localhost:3000/v1/sessions/mhv/new?operation=mhv_exception

## What areas of the site does it impact?
Sessions

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
