### PR TITLE
104036 - Update unit tests for Missing Form Status Job - IVC CHAMPVA forms

### DIFF
--- a/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
+++ b/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
@@ -12,7 +12,7 @@ module IvcChampva
     def perform # rubocop:disable Metrics/MethodLength
       return unless Settings.ivc_forms.sidekiq.missing_form_status_job.enabled
 
-      forms = IvcChampvaForm.where(pega_status: nil)
+      forms = IvcChampvaForm.where(pega_status: nil).where('created_at < ?', 1.minute.ago)
 
       return unless forms.any?
 

--- a/modules/ivc_champva/spec/jobs/missing_form_status_job_spec.rb
+++ b/modules/ivc_champva/spec/jobs/missing_form_status_job_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'IvcChampva::MissingFormStatusJob', type: :job do
     allow(Settings.vanotify.services.ivc_champva).to receive(:failure_email_threshold_days).and_return(threshold)
 
     # verify that the forms are approaching threshold w/ no PEGA status:
-    forms.each_key do |form|
+    forms.each do |form|
       expect(form.pega_status).to be_nil
       expect(days_since_now(form.created_at) < threshold).to be true
       expect(days_since_now(form.created_at) > threshold - 2).to be true

--- a/modules/ivc_champva/spec/jobs/missing_form_status_job_spec.rb
+++ b/modules/ivc_champva/spec/jobs/missing_form_status_job_spec.rb
@@ -2,6 +2,13 @@
 
 require 'rails_helper'
 
+# Returns the number of days from `created_at` until now.
+#
+# @param [ActiveSupport::TimeWithZone] created_at property of IvcChampvaForm
+def days_since_now(created_at)
+  (Time.now.utc - created_at).to_i / 1.day
+end
+
 RSpec.describe 'IvcChampva::MissingFormStatusJob', type: :job do
   let!(:one_week_ago) { 1.week.ago.utc }
   let!(:forms) { create_list(:ivc_champva_form, 3, pega_status: nil, created_at: one_week_ago) }
@@ -15,6 +22,87 @@ RSpec.describe 'IvcChampva::MissingFormStatusJob', type: :job do
     allow(IvcChampva::Email).to receive(:new).and_return(double(send_email: true))
     allow(job).to receive(:monitor).and_return(double(track_send_zsf_notification_to_pega: nil,
                                                       track_failed_send_zsf_notification_to_pega: nil))
+    # Save the original form creation times so we can restore them later
+    @original_creation_times = forms.map(&:created_at)
+  end
+
+  after do
+    # Restore original form creation times for time sensitive tests
+    forms.each_with_index do |form, index|
+      form.update(created_at: @original_creation_times[index])
+    end
+  end
+
+  it 'does not run the job when it is disabled in settings' do
+    allow(Settings.ivc_forms.sidekiq.missing_form_status_job).to receive(:enabled).and_return(false)
+
+    expect(IvcChampva::MissingFormStatusJob.new.perform).to be_nil
+    expect(StatsD).not_to have_received(:gauge)
+    expect(StatsD).not_to have_received(:increment)
+  end
+
+  it 'attempts to send failure email to user if the elapsed days w/out PEGA status exceed the threshold' do
+    threshold = 5 # using 5 since dummy forms have `created_at` set to 1 week ago
+    allow(Settings.vanotify.services.ivc_champva).to receive(:failure_email_threshold_days).and_return(threshold)
+
+    # Verify that the form is past threshold and has no email sent:
+    expect(days_since_now(forms[0].created_at) > threshold).to be true
+    expect(forms[0].reload.email_sent).to be false
+
+    # Perform should identify the form as lapsed and send a failure email:
+    job.perform
+
+    # Verify that an email has now been sent for the target form:
+    expect(forms[0].reload.email_sent).to be true
+  end
+
+  it 'identifies forms nearing expiration threshold and attempts to notify PEGA' do
+    threshold = 8
+    allow(Settings.vanotify.services.ivc_champva).to receive(:failure_email_threshold_days).and_return(threshold)
+
+    # verify that the forms are approaching threshold w/ no PEGA status:
+    forms.each_key do |form|
+      expect(form.pega_status).to be_nil
+      expect(days_since_now(form.created_at) < threshold).to be true
+      expect(days_since_now(form.created_at) > threshold - 2).to be true
+    end
+
+    # `perform` should identify the form as nearing a lapse and send a notice to PEGA:
+    job.perform
+
+    # Verify that we attempted to notify PEGA:
+    expect(job.monitor).to have_received(:track_send_zsf_notification_to_pega).exactly(forms.count).times
+
+    # email_sent should not be true for this form since we only attempted to notify PEGA:
+    expect(forms[0].reload.email_sent).to be false
+  end
+
+  it 'does not mark email_sent true when email fails to send' do
+    threshold = 5
+    allow(Settings.vanotify.services.ivc_champva).to receive(:failure_email_threshold_days).and_return(threshold)
+    allow(IvcChampva::Email).to receive(:new).and_return(double(send_email: false))
+    allow(job.monitor).to receive(:log_silent_failure).and_return(nil)
+
+    # Verify that we SHOULD send an email to user for this form
+    expect(forms[0].email_sent).to be false
+    expect(forms[0].pega_status).to be_nil
+    expect(days_since_now(forms[0].created_at) > threshold).to be true
+
+    job.perform
+
+    # Should have no change since `send_email` didn't return true
+    expect(forms[0].reload.email_sent).to be false
+  end
+
+  it 'ignores forms created within the last 1 minute' do
+    forms[0].update(created_at: Time.zone.now) # Created within the last minute
+    forms[1].update(created_at: 1.minute.ago) # Created more than 1 minute ago
+
+    # Perform the job that checks form statuses
+    IvcChampva::MissingFormStatusJob.new.perform
+
+    # Check that forms created in the last minute are ignored
+    expect(StatsD).to have_received(:gauge).with('ivc_champva.forms_missing_status.count', forms.count - 1)
   end
 
   it 'sends the count of forms to DataDog' do


### PR DESCRIPTION
## Summary

This PR adds new unit tests to the `MissingFormStatusJob` and updates the job to ignore form submissions that are < 1 minute old when determining if alerts should be sent.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/104036

## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots

NA

## What areas of the site does it impact?

`MissingFormStatusJob` periodic job only

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA