### PR TITLE
remove add_local_config.rb

### DIFF
--- a/config/initializers/add_local_config.rb
+++ b/config/initializers/add_local_config.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-vsp_environment = ENV.fetch('VSP_ENVIRONMENT', nil)
-
-if vsp_environment
-  source = Rails.root.join("config/settings/#{vsp_environment}.local.yml").to_s
-  Settings.prepend_source!(source)
-  Settings.reload!
-end


### PR DESCRIPTION
## Summary

- remove add_local_config.rb no longer being used

## Related issue(s)

- n/a

## Testing done

- [ ] not used

## Acceptance criteria

- [ ]  init file is removed