### PR TITLE
Simple Forms Notification Email refactor

### DIFF
--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -152,8 +152,8 @@ class FormSubmissionAttempt < ApplicationRecord
   def simple_forms_form_number
     @simple_forms_form_number ||=
       if (
-        SimpleFormsApi::NotificationEmail::TEMPLATE_IDS.keys +
-        SimpleFormsApi::FormUploadNotificationEmail::SUPPORTED_FORMS
+        SimpleFormsApi::Notification::Email::TEMPLATE_IDS.keys +
+        SimpleFormsApi::Notification::FormUploadEmail::SUPPORTED_FORMS
       ).include? form_submission.form_type
         form_submission.form_type
       else

--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -152,7 +152,7 @@ class FormSubmissionAttempt < ApplicationRecord
   def simple_forms_form_number
     @simple_forms_form_number ||=
       if (
-        SimpleFormsApi::Notification::Email.template_ids.keys +
+        SimpleFormsApi::Notification::Email::TEMPLATE_IDS.keys +
         SimpleFormsApi::Notification::FormUploadEmail::SUPPORTED_FORMS
       ).include? form_submission.form_type
         form_submission.form_type

--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -152,7 +152,7 @@ class FormSubmissionAttempt < ApplicationRecord
   def simple_forms_form_number
     @simple_forms_form_number ||=
       if (
-        SimpleFormsApi::Notification::Email::TEMPLATE_IDS.keys +
+        SimpleFormsApi::Notification::Email.template_ids.keys +
         SimpleFormsApi::Notification::FormUploadEmail::SUPPORTED_FORMS
       ).include? form_submission.form_type
         form_submission.form_type

--- a/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
+++ b/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
@@ -62,11 +62,15 @@ module SimpleFormsApi
       end
 
       def form_upload_notification_email
-        SimpleFormsApi::FormUploadNotificationEmail.new(config, notification_type:)
+        SimpleFormsApi::Notification::FormUploadEmail.new(config, notification_type:)
       end
 
       def notification_email
-        SimpleFormsApi::NotificationEmail.new(config, notification_type:, user_account:)
+        SimpleFormsApi::Notification::Email.new(
+          config,
+          notification_type:,
+          user_account:
+        )
       end
 
       def time_to_send

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/scanned_form_uploads_controller.rb
@@ -126,7 +126,7 @@ module SimpleFormsApi
           date_submitted: Time.zone.today.strftime('%B %d, %Y'),
           confirmation_number:
         }
-        notification_email = SimpleFormsApi::FormUploadNotificationEmail.new(config, notification_type: :confirmation)
+        notification_email = SimpleFormsApi::Notification::FormUploadEmail.new(config, notification_type: :confirmation)
         notification_email.send
       end
     end

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -321,7 +321,7 @@ module SimpleFormsApi
           confirmation_number:,
           date_submitted: Time.zone.today.strftime('%B %d, %Y')
         }
-        notification_email = SimpleFormsApi::NotificationEmail.new(
+        notification_email = SimpleFormsApi::Notification::Email.new(
           config,
           notification_type: :confirmation,
           user: @current_user
@@ -337,7 +337,7 @@ module SimpleFormsApi
           date_submitted: Time.zone.today.strftime('%B %d, %Y'),
           expiration_date: Time.zone.parse(expiration_date).strftime('%B %d, %Y')
         }
-        notification_email = SimpleFormsApi::NotificationEmail.new(
+        notification_email = SimpleFormsApi::Notification::Email.new(
           config,
           notification_type: :received,
           user: @current_user
@@ -352,7 +352,7 @@ module SimpleFormsApi
           confirmation_number:,
           date_submitted: Time.zone.today.strftime('%B %d, %Y')
         }
-        notification_email = SimpleFormsApi::NotificationEmail.new(
+        notification_email = SimpleFormsApi::Notification::Email.new(
           config,
           notification_type:,
           user: @current_user

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification/email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification/email.rb
@@ -4,71 +4,11 @@ module SimpleFormsApi
   module Notification
     class Email
       attr_reader :form_number, :confirmation_number, :date_submitted, :expiration_date, :lighthouse_updated_at,
-                  :notification_type, :user, :user_account, :form_data
-
-      TEMPLATE_IDS = {
-        'vba_21_0845' => {
-          confirmation: Settings.vanotify.services.va_gov.template_id.form21_0845_confirmation_email,
-          error: Settings.vanotify.services.va_gov.template_id.form21_0845_error_email,
-          received: Settings.vanotify.services.va_gov.template_id.form21_0845_received_email
-        },
-        'vba_21p_0847' => {
-          confirmation: Settings.vanotify.services.va_gov.template_id.form21p_0847_confirmation_email,
-          error: Settings.vanotify.services.va_gov.template_id.form21p_0847_error_email,
-          received: Settings.vanotify.services.va_gov.template_id.form21p_0847_received_email
-        },
-        'vba_21_0966' => {
-          confirmation: Settings.vanotify.services.va_gov.template_id.form21_0966_confirmation_email,
-          error: Settings.vanotify.services.va_gov.template_id.form21_0966_error_email,
-          received: Settings.vanotify.services.va_gov.template_id.form21_0966_received_email
-        },
-        'vba_21_0966_intent_api' => {
-          received: Settings.vanotify.services.va_gov.template_id.form21_0966_itf_api_received_email
-        },
-        'vba_21_0972' => {
-          confirmation: Settings.vanotify.services.va_gov.template_id.form21_0972_confirmation_email,
-          error: Settings.vanotify.services.va_gov.template_id.form21_0972_error_email,
-          received: Settings.vanotify.services.va_gov.template_id.form21_0972_received_email
-        },
-        'vba_21_4142' => {
-          confirmation: Settings.vanotify.services.va_gov.template_id.form21_4142_confirmation_email,
-          error: Settings.vanotify.services.va_gov.template_id.form21_4142_error_email,
-          received: Settings.vanotify.services.va_gov.template_id.form21_4142_received_email
-        },
-        'vba_21_10210' => {
-          confirmation: Settings.vanotify.services.va_gov.template_id.form21_10210_confirmation_email,
-          error: Settings.vanotify.services.va_gov.template_id.form21_10210_error_email,
-          received: Settings.vanotify.services.va_gov.template_id.form21_10210_received_email
-        },
-        'vba_20_10206' => {
-          confirmation: Settings.vanotify.services.va_gov.template_id.form20_10206_confirmation_email,
-          error: Settings.vanotify.services.va_gov.template_id.form20_10206_error_email,
-          received: Settings.vanotify.services.va_gov.template_id.form20_10206_received_email
-        },
-        'vba_20_10207' => {
-          confirmation: Settings.vanotify.services.va_gov.template_id.form20_10207_confirmation_email,
-          error: Settings.vanotify.services.va_gov.template_id.form20_10207_error_email,
-          received: Settings.vanotify.services.va_gov.template_id.form20_10207_received_email
-        },
-        'vba_40_0247' => {
-          confirmation: Settings.vanotify.services.va_gov.template_id.form40_0247_confirmation_email,
-          error: Settings.vanotify.services.va_gov.template_id.form40_0247_error_email,
-          received: nil
-        },
-        'vba_40_10007' => {
-          confirmation: nil,
-          error: Settings.vanotify.services.va_gov.template_id.form40_10007_error_email,
-          received: nil
-        },
-        'vba_26_4555' => {
-          confirmation: Settings.vanotify.services.va_gov.template_id.form26_4555_confirmation_email,
-          rejected: Settings.vanotify.services.va_gov.template_id.form26_4555_rejected_email,
-          duplicate: Settings.vanotify.services.va_gov.template_id.form26_4555_duplicate_email
-        }
-      }.freeze
-      SUPPORTED_FORMS = TEMPLATE_IDS.keys
+                  :notification_type, :user, :user_account, :form_data, :template_ids
 
       def initialize(config, notification_type: :confirmation, user: nil, user_account: nil)
+        filepath = 'modules/simple_forms_api/app/services/simple_forms_api/notification/template_ids.yml'
+        @template_ids = YAML.load_file(filepath)
         @notification_type = notification_type
 
         check_missing_keys(config)
@@ -87,7 +27,7 @@ module SimpleFormsApi
       def send(at: nil)
         return unless flipper?
 
-        template_id = TEMPLATE_IDS[form_number][notification_type]
+        template_id = template_ids[form_number][notification_type]
         return unless template_id
 
         sent_to_va_notify = if at

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification/email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification/email.rb
@@ -4,11 +4,14 @@ module SimpleFormsApi
   module Notification
     class Email
       attr_reader :form_number, :confirmation_number, :date_submitted, :expiration_date, :lighthouse_updated_at,
-                  :notification_type, :user, :user_account, :form_data, :template_ids
+                  :notification_type, :user, :user_account, :form_data
+
+      TEMPLATE_IDS = YAML.load_file(
+        'modules/simple_forms_api/app/services/simple_forms_api/notification/template_ids.yml'
+      )
+      SUPPORTED_FORMS = TEMPLATE_IDS.keys
 
       def initialize(config, notification_type: :confirmation, user: nil, user_account: nil)
-        filepath = 'modules/simple_forms_api/app/services/simple_forms_api/notification/template_ids.yml'
-        @template_ids = YAML.load_file(filepath)
         @notification_type = notification_type
 
         check_missing_keys(config)
@@ -27,7 +30,7 @@ module SimpleFormsApi
       def send(at: nil)
         return unless flipper?
 
-        template_id = template_ids[form_number][notification_type]
+        template_id = TEMPLATE_IDS[form_number][notification_type.to_s]
         return unless template_id
 
         sent_to_va_notify = if at

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification/template_ids.yml
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification/template_ids.yml
@@ -1,0 +1,46 @@
+vba_21_0845:
+  confirmation: form21_0845_confirmation_email_template_id
+  error: form21_0845_error_email_template_id
+  received: form21_0845_received_email_template_id
+vba_21p_0847:
+  confirmation: form21p_0847_confirmation_email_template_id
+  error: form21p_0847_error_email_template_id
+  received: form21p_0847_received_email_template_id
+vba_21_0966:
+  confirmation: form21_0966_confirmation_email_template_id
+  error: form21_0966_error_email_template_id
+  received: form21_0966_received_email_template_id
+vba_21_0966_intent_api:
+  received: form21_0966_itf_api_received_email_template_id
+vba_21_0972:
+  confirmation: form21_0972_confirmation_email_template_id
+  error: form21_0972_error_email_template_id
+  received: form21_0972_received_email_template_id
+vba_21_4142:
+  confirmation: form21_4142_confirmation_email_template_id
+  error: form21_4142_error_email_template_id
+  received: form21_4142_received_email_template_id
+vba_21_10210:
+  confirmation: form21_10210_confirmation_email_template_id
+  error: form21_10210_error_email_template_id
+  received: form21_10210_received_email_template_id
+vba_20_10206:
+  confirmation: form20_10206_confirmation_email_template_id
+  error: form20_10206_error_email_template_id
+  received: form20_10206_received_email_template_id
+vba_20_10207:
+  confirmation: form20_10207_confirmation_email_template_id
+  error: form20_10207_error_email_template_id
+  received: form20_10207_received_email_template_id
+vba_40_0247:
+  confirmation: form40_0247_confirmation_email_template_id
+  error: form40_0247_error_email_template_id
+  received:
+vba_40_10007:
+  confirmation:
+  error: form40_10007_error_email_template_id
+  received:
+vba_26_4555:
+  confirmation: form26_4555_confirmation_email_template_id
+  rejected: form26_4555_rejected_email_template_id
+  duplicate: form26_4555_duplicate_email_template_id

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification/template_ids.yml
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification/template_ids.yml
@@ -1,11 +1,15 @@
+vba_20_10206:
+  confirmation: form20_10206_confirmation_email_template_id
+  error: form20_10206_error_email_template_id
+  received: form20_10206_received_email_template_id
+vba_20_10207:
+  confirmation: form20_10207_confirmation_email_template_id
+  error: form20_10207_error_email_template_id
+  received: form20_10207_received_email_template_id
 vba_21_0845:
   confirmation: form21_0845_confirmation_email_template_id
   error: form21_0845_error_email_template_id
   received: form21_0845_received_email_template_id
-vba_21p_0847:
-  confirmation: form21p_0847_confirmation_email_template_id
-  error: form21p_0847_error_email_template_id
-  received: form21p_0847_received_email_template_id
 vba_21_0966:
   confirmation: form21_0966_confirmation_email_template_id
   error: form21_0966_error_email_template_id
@@ -16,22 +20,22 @@ vba_21_0972:
   confirmation: form21_0972_confirmation_email_template_id
   error: form21_0972_error_email_template_id
   received: form21_0972_received_email_template_id
-vba_21_4142:
-  confirmation: form21_4142_confirmation_email_template_id
-  error: form21_4142_error_email_template_id
-  received: form21_4142_received_email_template_id
 vba_21_10210:
   confirmation: form21_10210_confirmation_email_template_id
   error: form21_10210_error_email_template_id
   received: form21_10210_received_email_template_id
-vba_20_10206:
-  confirmation: form20_10206_confirmation_email_template_id
-  error: form20_10206_error_email_template_id
-  received: form20_10206_received_email_template_id
-vba_20_10207:
-  confirmation: form20_10207_confirmation_email_template_id
-  error: form20_10207_error_email_template_id
-  received: form20_10207_received_email_template_id
+vba_21_4142:
+  confirmation: form21_4142_confirmation_email_template_id
+  error: form21_4142_error_email_template_id
+  received: form21_4142_received_email_template_id
+vba_21p_0847:
+  confirmation: form21p_0847_confirmation_email_template_id
+  error: form21p_0847_error_email_template_id
+  received: form21p_0847_received_email_template_id
+vba_26_4555:
+  confirmation: form26_4555_confirmation_email_template_id
+  rejected: form26_4555_rejected_email_template_id
+  duplicate: form26_4555_duplicate_email_template_id
 vba_40_0247:
   confirmation: form40_0247_confirmation_email_template_id
   error: form40_0247_error_email_template_id
@@ -40,7 +44,3 @@ vba_40_10007:
   confirmation:
   error: form40_10007_error_email_template_id
   received:
-vba_26_4555:
-  confirmation: form26_4555_confirmation_email_template_id
-  rejected: form26_4555_rejected_email_template_id
-  duplicate: form26_4555_duplicate_email_template_id

--- a/spec/lib/lighthouse/benefits_intake/sidekiq/submission_status_job_spec.rb
+++ b/spec/lib/lighthouse/benefits_intake/sidekiq/submission_status_job_spec.rb
@@ -98,7 +98,7 @@ Rspec.describe BenefitsIntake::SubmissionStatusJob, type: :job do
       let(:form_id) { pending.form_submission.form_type }
 
       before do
-        allow_any_instance_of(SimpleFormsApi::NotificationEmail).to receive(:send)
+        allow_any_instance_of(SimpleFormsApi::Notification::Email).to receive(:send)
       end
 
       it 'skips non present uuid' do

--- a/spec/models/form_submission_attempt_spec.rb
+++ b/spec/models/form_submission_attempt_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe FormSubmissionAttempt, type: :model do
   end
 
   describe 'state machine' do
-    before { allow_any_instance_of(SimpleFormsApi::NotificationEmail).to receive(:send) }
+    before { allow_any_instance_of(SimpleFormsApi::Notification::Email).to receive(:send) }
 
     let(:config) do
       {
@@ -48,12 +48,12 @@ RSpec.describe FormSubmissionAttempt, type: :model do
         let(:form_submission) { build(:form_submission, form_type: 'some-other-form') }
 
         it 'does not send an error email' do
-          allow(SimpleFormsApi::NotificationEmail).to receive(:new)
+          allow(SimpleFormsApi::Notification::Email).to receive(:new)
           form_submission_attempt = create(:form_submission_attempt, form_submission:)
 
           form_submission_attempt.fail!
 
-          expect(SimpleFormsApi::NotificationEmail).not_to have_received(:new)
+          expect(SimpleFormsApi::Notification::Email).not_to have_received(:new)
         end
 
         context 'is a form526_form4142 form' do

--- a/spec/sidekiq/benefits_intake_status_job_spec.rb
+++ b/spec/sidekiq/benefits_intake_status_job_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe BenefitsIntakeStatusJob, type: :job do
     end
 
     describe 'updating the form submission status' do
-      before { allow_any_instance_of(SimpleFormsApi::NotificationEmail).to receive(:send) }
+      before { allow_any_instance_of(SimpleFormsApi::Notification::Email).to receive(:send) }
 
       it 'updates the status with vbms from the bulk status report endpoint' do
         pending_form_submission_attempts = create_list(:form_submission_attempt, 1, :pending)

--- a/spec/sidekiq/simple_forms_api/notification/send_notification_email_job_spec.rb
+++ b/spec/sidekiq/simple_forms_api/notification/send_notification_email_job_spec.rb
@@ -38,13 +38,13 @@ RSpec.describe SimpleFormsApi::Notification::SendNotificationEmailJob, type: :wo
     context 'when submitted with digital form submission tool' do
       let(:form_number) { 'abc-123' }
 
-      it_behaves_like 'sends notification email', SimpleFormsApi::NotificationEmail
+      it_behaves_like 'sends notification email', SimpleFormsApi::Notification::Email
     end
 
     context 'when submitted with Form Upload tool' do
       let(:form_number) { '21-0779' }
 
-      it_behaves_like 'sends notification email', SimpleFormsApi::FormUploadNotificationEmail
+      it_behaves_like 'sends notification email', SimpleFormsApi::Notification::FormUploadEmail
     end
   end
 


### PR DESCRIPTION
## Summary
This PR continues the work begun in these [two](https://github.com/department-of-veterans-affairs/vets-api/pull/20923) [PRs](https://github.com/department-of-veterans-affairs/vets-api/pull/20926). In the prior PRs we created new files in the right directory structure and this PR uses these new files.

This PR also makes use of a YAML file for template_ids, instead of having them inline in the code.
