### PR TITLE
[104070] Migration for new poa withdrawals - Part 1

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -317,9 +317,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_27_192104) do
 
   create_table "ar_power_of_attorney_request_withdrawals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "superseding_power_of_attorney_request_id"
-    t.uuid "creator_id", null: false
     t.string "type", null: false
-    t.index ["creator_id"], name: "index_ar_power_of_attorney_request_withdrawals_on_creator_id"
     t.index ["superseding_power_of_attorney_request_id"], name: "idx_on_superseding_power_of_attorney_request_id_7318c79fef"
   end
 
@@ -1816,7 +1814,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_27_192104) do
   add_foreign_key "ar_power_of_attorney_request_decisions", "user_accounts", column: "creator_id"
   add_foreign_key "ar_power_of_attorney_request_resolutions", "ar_power_of_attorney_requests", column: "power_of_attorney_request_id"
   add_foreign_key "ar_power_of_attorney_request_withdrawals", "ar_power_of_attorney_requests", column: "superseding_power_of_attorney_request_id"
-  add_foreign_key "ar_power_of_attorney_request_withdrawals", "user_accounts", column: "creator_id"
   add_foreign_key "ar_power_of_attorney_requests", "user_accounts", column: "claimant_id"
   add_foreign_key "async_transactions", "user_accounts"
   add_foreign_key "claim_va_notifications", "saved_claims"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_19_232344) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_27_192104) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -313,6 +313,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_19_232344) do
     t.datetime "created_at", null: false
     t.index ["power_of_attorney_request_id"], name: "idx_on_power_of_attorney_request_id_fd7d2d11b1", unique: true
     t.index ["resolving_type", "resolving_id"], name: "unique_resolving_type_and_id", unique: true
+  end
+
+  create_table "ar_power_of_attorney_request_withdrawals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "superseding_power_of_attorney_request_id"
+    t.uuid "creator_id", null: false
+    t.string "type", null: false
+    t.index ["creator_id"], name: "index_ar_power_of_attorney_request_withdrawals_on_creator_id"
+    t.index ["superseding_power_of_attorney_request_id"], name: "idx_on_superseding_power_of_attorney_request_id_7318c79fef"
   end
 
   create_table "ar_power_of_attorney_requests", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1807,6 +1815,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_19_232344) do
   add_foreign_key "ar_power_of_attorney_forms", "ar_power_of_attorney_requests", column: "power_of_attorney_request_id"
   add_foreign_key "ar_power_of_attorney_request_decisions", "user_accounts", column: "creator_id"
   add_foreign_key "ar_power_of_attorney_request_resolutions", "ar_power_of_attorney_requests", column: "power_of_attorney_request_id"
+  add_foreign_key "ar_power_of_attorney_request_withdrawals", "ar_power_of_attorney_requests", column: "superseding_power_of_attorney_request_id"
+  add_foreign_key "ar_power_of_attorney_request_withdrawals", "user_accounts", column: "creator_id"
   add_foreign_key "ar_power_of_attorney_requests", "user_accounts", column: "claimant_id"
   add_foreign_key "async_transactions", "user_accounts"
   add_foreign_key "claim_va_notifications", "saved_claims"

--- a/modules/accredited_representative_portal/db/migrate/20250227192104_create_ar_power_of_attorney_request_withdrawals.rb
+++ b/modules/accredited_representative_portal/db/migrate/20250227192104_create_ar_power_of_attorney_request_withdrawals.rb
@@ -8,7 +8,6 @@ class CreateArPowerOfAttorneyRequestWithdrawals < ActiveRecord::Migration[7.2]
       t.references 'superseding_power_of_attorney_request',
                    type: :uuid,
                    foreign_key: { to_table: :ar_power_of_attorney_requests }
-      t.references 'creator', type: :uuid, foreign_key: { to_table: :user_accounts }, null: false
       t.string 'type', null: false
     end
   end

--- a/modules/accredited_representative_portal/db/migrate/20250227192104_create_ar_power_of_attorney_request_withdrawals.rb
+++ b/modules/accredited_representative_portal/db/migrate/20250227192104_create_ar_power_of_attorney_request_withdrawals.rb
@@ -1,0 +1,15 @@
+class CreateArPowerOfAttorneyRequestWithdrawals < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction! # Required for concurrent index creation
+
+  def change
+    # Withdrawals act as a delegated subtype of Resolutions
+    # This table stores specific withdrawal data for PowerOfAttorneyRequestResolutions
+    create_table :ar_power_of_attorney_request_withdrawals, id: :uuid do |t|
+      t.references 'superseding_power_of_attorney_request',
+                   type: :uuid,
+                   foreign_key: { to_table: :ar_power_of_attorney_requests }
+      t.references 'creator', type: :uuid, foreign_key: { to_table: :user_accounts }, null: false
+      t.string 'type', null: false
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- This is part 1 of work to introduce a new concept for POA Request Resolutions - Withdrawals
  - for example, replacing an active request with a new one to enforce the business rule that a claimant can only have one active poa request
- This pr is the migration to create the new resolution type table

## Related issue(s)

- [104070](https://github.com/department-of-veterans-affairs/va.gov-team/issues/104070)

## Testing done

- No unit tests because it's only a migration
- Ran migration locally

## What areas of the site does it impact?
Will impact Appoint a Rep 21-22 and ARP once the table is in use

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature