### PR TITLE
[SIMPLE-FORMS] fix: update logic to handle form 4138 and handle errors gracefully

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -155,13 +155,13 @@ module SimpleFormsApi
         )
 
         if status == 200
-          if Flipper.enabled?(:simple_forms_email_confirmations)
+          begin
             send_confirmation_email(parsed_form_data, confirmation_number)
+          rescue => e
+            Rails.logger.error('Simple forms api - error sending confirmation email', error: e)
           end
 
-          presigned_s3_url = if Flipper.enabled?(:submission_pdf_s3_upload)
-                               upload_pdf_to_s3(confirmation_number, file_path, metadata, submission, form)
-                             end
+          presigned_s3_url = upload_pdf_to_s3(confirmation_number, file_path, metadata, submission, form)
         end
 
         build_response(confirmation_number, presigned_s3_url, status)

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -251,6 +251,8 @@ module SimpleFormsApi
       end
 
       def upload_pdf_to_s3(id, file_path, metadata, submission, form)
+        return unless Flipper.enabled?(:simple_forms_s3_upload)
+
         config = SimpleFormsApi::FormRemediation::Configuration::VffConfig.new
         attachments = form_id == 'vba_20_10207' ? form.get_attachments : []
         s3_client = config.s3_client.new(
@@ -311,6 +313,8 @@ module SimpleFormsApi
       end
 
       def send_confirmation_email(parsed_form_data, confirmation_number)
+        return unless Flipper.enabled?(:simple_forms_email_confirmations)
+
         config = {
           form_data: parsed_form_data,
           form_number: form_id,

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -6,64 +6,70 @@ module SimpleFormsApi
     attr_reader :form_number, :confirmation_number, :date_submitted, :expiration_date, :lighthouse_updated_at,
                 :notification_type, :user, :user_account, :form_data
 
+    TEMPLATE_ROOT = Settings.vanotify.services.va_gov.template_id
     TEMPLATE_IDS = {
-      'vba_21_0845' => {
-        confirmation: Settings.vanotify.services.va_gov.template_id.form21_0845_confirmation_email,
-        error: Settings.vanotify.services.va_gov.template_id.form21_0845_error_email,
-        received: Settings.vanotify.services.va_gov.template_id.form21_0845_received_email
-      },
-      'vba_21p_0847' => {
-        confirmation: Settings.vanotify.services.va_gov.template_id.form21p_0847_confirmation_email,
-        error: Settings.vanotify.services.va_gov.template_id.form21p_0847_error_email,
-        received: Settings.vanotify.services.va_gov.template_id.form21p_0847_received_email
-      },
-      'vba_21_0966' => {
-        confirmation: Settings.vanotify.services.va_gov.template_id.form21_0966_confirmation_email,
-        error: Settings.vanotify.services.va_gov.template_id.form21_0966_error_email,
-        received: Settings.vanotify.services.va_gov.template_id.form21_0966_received_email
-      },
-      'vba_21_0966_intent_api' => {
-        received: Settings.vanotify.services.va_gov.template_id.form21_0966_itf_api_received_email
-      },
-      'vba_21_0972' => {
-        confirmation: Settings.vanotify.services.va_gov.template_id.form21_0972_confirmation_email,
-        error: Settings.vanotify.services.va_gov.template_id.form21_0972_error_email,
-        received: Settings.vanotify.services.va_gov.template_id.form21_0972_received_email
-      },
-      'vba_21_4142' => {
-        confirmation: Settings.vanotify.services.va_gov.template_id.form21_4142_confirmation_email,
-        error: Settings.vanotify.services.va_gov.template_id.form21_4142_error_email,
-        received: Settings.vanotify.services.va_gov.template_id.form21_4142_received_email
-      },
-      'vba_21_10210' => {
-        confirmation: Settings.vanotify.services.va_gov.template_id.form21_10210_confirmation_email,
-        error: Settings.vanotify.services.va_gov.template_id.form21_10210_error_email,
-        received: Settings.vanotify.services.va_gov.template_id.form21_10210_received_email
-      },
       'vba_20_10206' => {
-        confirmation: Settings.vanotify.services.va_gov.template_id.form20_10206_confirmation_email,
-        error: Settings.vanotify.services.va_gov.template_id.form20_10206_error_email,
-        received: Settings.vanotify.services.va_gov.template_id.form20_10206_received_email
+        confirmation: TEMPLATE_ROOT.form20_10206_confirmation_email,
+        error: TEMPLATE_ROOT.form20_10206_error_email,
+        received: TEMPLATE_ROOT.form20_10206_received_email
       },
       'vba_20_10207' => {
-        confirmation: Settings.vanotify.services.va_gov.template_id.form20_10207_confirmation_email,
-        error: Settings.vanotify.services.va_gov.template_id.form20_10207_error_email,
-        received: Settings.vanotify.services.va_gov.template_id.form20_10207_received_email
+        confirmation: TEMPLATE_ROOT.form20_10207_confirmation_email,
+        error: TEMPLATE_ROOT.form20_10207_error_email,
+        received: TEMPLATE_ROOT.form20_10207_received_email
+      },
+      'vba_21_0845' => {
+        confirmation: TEMPLATE_ROOT.form21_0845_confirmation_email,
+        error: TEMPLATE_ROOT.form21_0845_error_email,
+        received: TEMPLATE_ROOT.form21_0845_received_email
+      },
+      'vba_21_0966' => {
+        confirmation: TEMPLATE_ROOT.form21_0966_confirmation_email,
+        error: TEMPLATE_ROOT.form21_0966_error_email,
+        received: TEMPLATE_ROOT.form21_0966_received_email
+      },
+      'vba_21_0966_intent_api' => {
+        received: TEMPLATE_ROOT.form21_0966_itf_api_received_email
+      },
+      'vba_21_0972' => {
+        confirmation: TEMPLATE_ROOT.form21_0972_confirmation_email,
+        error: TEMPLATE_ROOT.form21_0972_error_email,
+        received: TEMPLATE_ROOT.form21_0972_received_email
+      },
+      'vba_21_10210' => {
+        confirmation: TEMPLATE_ROOT.form21_10210_confirmation_email,
+        error: TEMPLATE_ROOT.form21_10210_error_email,
+        received: TEMPLATE_ROOT.form21_10210_received_email
+      },
+      'vba_21_4138' => {
+        confirmation: TEMPLATE_ROOT.form21_4138_confirmation_email,
+        error: TEMPLATE_ROOT.form21_4138_error_email,
+        received: TEMPLATE_ROOT.form21_4138_received_email
+      },
+      'vba_21_4142' => {
+        confirmation: TEMPLATE_ROOT.form21_4142_confirmation_email,
+        error: TEMPLATE_ROOT.form21_4142_error_email,
+        received: TEMPLATE_ROOT.form21_4142_received_email
+      },
+      'vba_21p_0847' => {
+        confirmation: TEMPLATE_ROOT.form21p_0847_confirmation_email,
+        error: TEMPLATE_ROOT.form21p_0847_error_email,
+        received: TEMPLATE_ROOT.form21p_0847_received_email
+      },
+      'vba_26_4555' => {
+        confirmation: TEMPLATE_ROOT.form26_4555_confirmation_email,
+        rejected: TEMPLATE_ROOT.form26_4555_rejected_email,
+        duplicate: TEMPLATE_ROOT.form26_4555_duplicate_email
       },
       'vba_40_0247' => {
-        confirmation: Settings.vanotify.services.va_gov.template_id.form40_0247_confirmation_email,
-        error: Settings.vanotify.services.va_gov.template_id.form40_0247_error_email,
+        confirmation: TEMPLATE_ROOT.form40_0247_confirmation_email,
+        error: TEMPLATE_ROOT.form40_0247_error_email,
         received: nil
       },
       'vba_40_10007' => {
         confirmation: nil,
-        error: Settings.vanotify.services.va_gov.template_id.form40_10007_error_email,
+        error: TEMPLATE_ROOT.form40_10007_error_email,
         received: nil
-      },
-      'vba_26_4555' => {
-        confirmation: Settings.vanotify.services.va_gov.template_id.form26_4555_confirmation_email,
-        rejected: Settings.vanotify.services.va_gov.template_id.form26_4555_rejected_email,
-        duplicate: Settings.vanotify.services.va_gov.template_id.form26_4555_duplicate_email
       }
     }.freeze
     SUPPORTED_FORMS = TEMPLATE_IDS.keys


### PR DESCRIPTION
## Summary

- This work updates the accepted forms check to include form 21-4138
- This work also updates the logic calling notification email to fail gracefully
- This bug is stopping the user from successfully submitting form 21-4138

## Related issue(s)

- [21-4138 - Error when submitting the form](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/2034)

## Testing done

- All tests pass and form submits successfully locally.

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

Any
