### PR TITLE
[CST] - 104179 Remove setting of the acknowledgement_date for type 1 errors

### DIFF
--- a/app/sidekiq/evss/document_upload.rb
+++ b/app/sidekiq/evss/document_upload.rb
@@ -81,7 +81,6 @@ class EVSS::DocumentUpload
     evidence_submission.update(
       upload_status: BenefitsDocuments::Constants::UPLOAD_STATUS[:FAILED],
       failed_date: DateTime.now.utc,
-      acknowledgement_date: (DateTime.current + 30.days).utc,
       error_message: 'EVSS::DocumentUpload document upload failure',
       template_metadata: {
         personalisation: update_personalisation(current_personalisation, msg['failed_at'])

--- a/app/sidekiq/lighthouse/evidence_submissions/document_upload.rb
+++ b/app/sidekiq/lighthouse/evidence_submissions/document_upload.rb
@@ -59,7 +59,6 @@ module Lighthouse
         evidence_submission.update(
           upload_status: BenefitsDocuments::Constants::UPLOAD_STATUS[:FAILED],
           failed_date: DateTime.now.utc,
-          acknowledgement_date: (DateTime.current + 30.days).utc,
           error_message: 'Lighthouse::EvidenceSubmissions::DocumentUpload document upload failure',
           template_metadata: {
             personalisation: update_personalisation(current_personalisation, msg['failed_at'])

--- a/spec/factories/lighthouse/benefits_documents/evidence_submission.rb
+++ b/spec/factories/lighthouse/benefits_documents/evidence_submission.rb
@@ -52,7 +52,6 @@ FactoryBot.define do
     job_class { 'Lighthouse::BenefitsDocuments::Service' }
     upload_status { BenefitsDocuments::Constants::UPLOAD_STATUS[:FAILED] }
     failed_date { DateTime.now.utc }
-    acknowledgement_date { DateTime.now.utc + 30.days }
     error_message { 'Lighthouse::EvidenceSubmissions::DocumentUpload document upload failure' }
     template_metadata do
       { 'personalisation' => {
@@ -97,7 +96,6 @@ FactoryBot.define do
     job_class { 'EVSS::DocumentUpload' }
     upload_status { BenefitsDocuments::Constants::UPLOAD_STATUS[:FAILED] }
     failed_date { DateTime.now.utc }
-    acknowledgement_date { DateTime.now.utc + 30.days }
     error_message { 'EVSS::DocumentUpload document upload failure' }
     template_metadata do
       { 'personalisation' => {

--- a/spec/sidekiq/evss/document_upload_spec.rb
+++ b/spec/sidekiq/evss/document_upload_spec.rb
@@ -137,10 +137,10 @@ RSpec.describe EVSS::DocumentUpload, type: :job do
         expect(evidence_submission.upload_status).to eql(BenefitsDocuments::Constants::UPLOAD_STATUS[:FAILED])
         expect(evidence_submission.error_message).to eql('EVSS::DocumentUpload document upload failure')
         expect(current_personalisation['date_failed']).to eql(failed_date)
+        expect(evidence_submission.acknowledgement_date).to be_nil
 
         Timecop.freeze(current_date_time) do
           expect(evidence_submission.failed_date).to be_within(1.second).of(current_date_time.utc)
-          expect(evidence_submission.acknowledgement_date).to be_within(1.second).of((current_date_time + 30.days).utc)
         end
         Timecop.unfreeze
       end

--- a/spec/sidekiq/lighthouse/evidence_submissions/document_upload_spec.rb
+++ b/spec/sidekiq/lighthouse/evidence_submissions/document_upload_spec.rb
@@ -161,10 +161,10 @@ RSpec.describe Lighthouse::EvidenceSubmissions::DocumentUpload, type: :job do
         expect(evidence_submission.error_message)
           .to eql('Lighthouse::EvidenceSubmissions::DocumentUpload document upload failure')
         expect(current_personalisation['date_failed']).to eql(failed_date)
+        expect(evidence_submission.acknowledgement_date).to be_nil
 
         Timecop.freeze(current_date_time) do
           expect(evidence_submission.failed_date).to be_within(1.second).of(current_date_time.utc)
-          expect(evidence_submission.acknowledgement_date).to be_within(1.second).of((current_date_time + 30.days).utc)
         end
         Timecop.unfreeze
       end


### PR DESCRIPTION
## Summary

- Removed setting of the `acknowledgement_date` in `app/sidekiq/evss/document_upload.rb`, `app/sidekiq/lighthouse/evidence_submissions/document_upload.rb`, and`spec/factories/lighthouse/benefits_documents/evidence_submission.rb`
- Updated the tests `spec/sidekiq/evss/document_upload_spec.rb` and `spec/sidekiq/lighthouse/evidence_submissions/document_upload_spec.rb`

## Related issue(s)

- *Link to ticket created in va.gov-team repo https://github.com/department-of-veterans-affairs/va.gov-team/issues/104179

## Testing done

- [ x] *New code is covered by unit tests*

*Describe what the old behavior was prior to the change*
- we were setting the field acknowledgement_date for type 1 errors

*Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
-

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
CST

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
