### PR TITLE
Remove max ratings api switch ff

### DIFF
--- a/app/models/form_profiles/va_526ez.rb
+++ b/app/models/form_profiles/va_526ez.rb
@@ -135,7 +135,7 @@ class FormProfiles::VA526ez < FormProfile
     )
     invoker = 'FormProfiles::VA526ez#initialize_rated_disabilities_information'
     response = api_provider.get_rated_disabilities(nil, nil, { invoker: })
-    ClaimFastTracking::MaxRatingAnnotator.annotate_disabilities(response, user)
+    ClaimFastTracking::MaxRatingAnnotator.annotate_disabilities(response)
 
     # Remap response object to schema fields
     VA526ez::FormRatedDisabilities.new(

--- a/app/services/claim_fast_tracking/max_rating_annotator.rb
+++ b/app/services/claim_fast_tracking/max_rating_annotator.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
-require 'virtual_regional_office/client'
 require 'disability_max_ratings/client'
 
 module ClaimFastTracking
   class MaxRatingAnnotator
     EXCLUDED_DIGESTIVE_CODES = [7318, 7319, 7327, 7336, 7346].freeze
 
-    def self.annotate_disabilities(rated_disabilities_response, user)
+    def self.annotate_disabilities(rated_disabilities_response)
       return if rated_disabilities_response.rated_disabilities.blank?
 
       log_hyphenated_diagnostic_codes(rated_disabilities_response.rated_disabilities)
@@ -18,7 +17,7 @@ module ClaimFastTracking
                                                     .map(&:diagnostic_code) # map to diagnostic_code field in rating
       return rated_disabilities_response if diagnostic_codes.empty?
 
-      ratings = get_ratings(diagnostic_codes, user)
+      ratings = get_ratings(diagnostic_codes)
       return rated_disabilities_response unless ratings
 
       ratings_hash = ratings.to_h { |rating| [rating['diagnostic_code'], rating['max_rating']] }
@@ -57,14 +56,9 @@ module ClaimFastTracking
       end
     end
 
-    def self.get_ratings(diagnostic_codes, user)
-      if Flipper.enabled?(:disability_526_max_cfi_service_switch, user)
-        disability_max_ratings_client = DisabilityMaxRatings::Client.new
-        response = disability_max_ratings_client.post_for_max_ratings(diagnostic_codes)
-      else
-        vro_client = VirtualRegionalOffice::Client.new
-        response = vro_client.get_max_rating_for_diagnostic_codes(diagnostic_codes)
-      end
+    def self.get_ratings(diagnostic_codes)
+      disability_max_ratings_client = DisabilityMaxRatings::Client.new
+      response = disability_max_ratings_client.post_for_max_ratings(diagnostic_codes)
       response.body['ratings']
     rescue Faraday::TimeoutError
       Rails.logger.error 'Get Max Ratings Failed: Request timed out.'

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe FormProfile, type: :model do
     described_class.instance_variable_set(:@mappings, nil)
     allow(Flipper).to receive(:enabled?).and_call_original
     allow(Flipper).to receive(:enabled?).with(:remove_pciu, anything).and_return(false)
-    allow(Flipper).to receive(:enabled?).with(:disability_526_max_cfi_service_switch, anything).and_return(false)
     allow(Flipper).to receive(:enabled?).with(:va_v3_contact_information_service, anything)
                                         .and_return(false)
   end
@@ -1874,25 +1873,6 @@ RSpec.describe FormProfile, type: :model do
                   VCR.use_cassette('lighthouse/direct_deposit/show/200_valid_new_icn') do
                     VCR.use_cassette('va_profile/military_personnel/service_history_200_many_episodes',
                                      allow_playback_repeats: true, match_requests_on: %i[uri method body]) do
-                      VCR.use_cassette('virtual_regional_office/max_ratings') do
-                        expect_prefilled('21-526EZ')
-                      end
-                    end
-                  end
-                end
-              end
-            end
-
-            it 'returns prefilled 21-526EZ when disability_526_max_cfi_service_switch is enabled' do
-              allow(Flipper).to receive(:enabled?).with(:disability_compensation_remove_pciu,
-                                                        anything).and_return(false)
-              allow(Flipper).to receive(:enabled?).with(:disability_526_max_cfi_service_switch,
-                                                        anything).and_return(true)
-              VCR.use_cassette('evss/pciu_address/address_domestic') do
-                VCR.use_cassette('lighthouse/veteran_verification/disability_rating/200_response') do
-                  VCR.use_cassette('lighthouse/direct_deposit/show/200_valid_new_icn') do
-                    VCR.use_cassette('va_profile/military_personnel/service_history_200_many_episodes',
-                                     allow_playback_repeats: true, match_requests_on: %i[uri method body]) do
                       VCR.use_cassette('disability_max_ratings/max_ratings') do
                         expect_prefilled('21-526EZ')
                       end
@@ -1924,26 +1904,6 @@ RSpec.describe FormProfile, type: :model do
             end
 
             it 'returns prefilled 21-526EZ' do
-              expect(user).to receive(:authorize).with(:ppiu, :access?).and_return(true).at_least(:once)
-              expect(user).to receive(:authorize).with(:evss, :access?).and_return(true).at_least(:once)
-              expect(user).to receive(:authorize).with(:va_profile, :access_to_v2?).and_return(true).at_least(:once)
-              VCR.use_cassette('evss/pciu_address/address_domestic') do
-                VCR.use_cassette('lighthouse/veteran_verification/disability_rating/200_response') do
-                  VCR.use_cassette('lighthouse/direct_deposit/show/200_valid_new_icn') do
-                    VCR.use_cassette('va_profile/military_personnel/service_history_200_many_episodes',
-                                     allow_playback_repeats: true, match_requests_on: %i[uri method body]) do
-                      VCR.use_cassette('virtual_regional_office/max_ratings') do
-                        expect_prefilled('21-526EZ')
-                      end
-                    end
-                  end
-                end
-              end
-            end
-
-            it 'returns prefilled 21-526EZ when disability_526_max_cfi_service_switch is enabled' do
-              allow(Flipper).to receive(:enabled?).with(:disability_526_max_cfi_service_switch,
-                                                        anything).and_return(true)
               expect(user).to receive(:authorize).with(:ppiu, :access?).and_return(true).at_least(:once)
               expect(user).to receive(:authorize).with(:evss, :access?).and_return(true).at_least(:once)
               expect(user).to receive(:authorize).with(:va_profile, :access_to_v2?).and_return(true).at_least(:once)

--- a/spec/models/form_profile_v2_spec.rb
+++ b/spec/models/form_profile_v2_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe FormProfile, type: :model do
   before do
     allow(Flipper).to receive(:enabled?).and_call_original
     allow(Flipper).to receive(:enabled?).with(:remove_pciu, anything).and_return(true)
-    allow(Flipper).to receive(:enabled?).with(:disability_526_max_cfi_service_switch, anything).and_return(false)
     allow(Flipper).to receive(:enabled?).with(:va_v3_contact_information_service, anything).and_return(true)
     allow(Flipper).to receive(:enabled?).with(:disability_compensation_remove_pciu, anything).and_return(true)
     described_class.instance_variable_set(:@mappings, nil)
@@ -1576,27 +1575,7 @@ RSpec.describe FormProfile, type: :model do
             VAProfile::Configuration::SETTINGS.prefill = false
           end
 
-          it 'returns prefilled 21-526EZ when disability_526_max_cfi_service_switch is disabled' do
-            expect(user).to receive(:authorize).with(:ppiu, :access?).and_return(true).at_least(:once)
-            expect(user).to receive(:authorize).with(:evss, :access?).and_return(true).at_least(:once)
-            expect(user).to receive(:authorize).with(:va_profile, :access_to_v2?).and_return(true).at_least(:once)
-            VCR.use_cassette('va_profile/v2/contact_information/get_address') do
-              VCR.use_cassette('lighthouse/veteran_verification/disability_rating/200_response') do
-                VCR.use_cassette('lighthouse/direct_deposit/show/200_valid_new_icn') do
-                  VCR.use_cassette('va_profile/military_personnel/service_history_200_many_episodes',
-                                   allow_playback_repeats: true, match_requests_on: %i[uri method body]) do
-                    VCR.use_cassette('virtual_regional_office/max_ratings') do
-                      expect_prefilled('21-526EZ')
-                    end
-                  end
-                end
-              end
-            end
-          end
-
-          it 'returns prefilled 21-526EZ when disability_526_max_cfi_service_switch is enabled' do
-            allow(Flipper).to receive(:enabled?).with(:disability_526_max_cfi_service_switch, anything).and_return(true)
-
+          it 'returns prefilled 21-526EZ' do
             expect(user).to receive(:authorize).with(:ppiu, :access?).and_return(true).at_least(:once)
             expect(user).to receive(:authorize).with(:evss, :access?).and_return(true).at_least(:once)
             expect(user).to receive(:authorize).with(:va_profile, :access_to_v2?).and_return(true).at_least(:once)

--- a/spec/requests/v0/disability_compensation_in_progress_forms_controller_spec.rb
+++ b/spec/requests/v0/disability_compensation_in_progress_forms_controller_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe V0::DisabilityCompensationInProgressFormsController do
         allow(Flipper).to receive(:enabled?).with(:disability_compensation_sync_modern_0781_flow, instance_of(User))
         allow(Flipper).to receive(:enabled?).with(:disability_compensation_remove_pciu, instance_of(User))
         allow(Flipper).to receive(:enabled?).with(:remove_pciu, instance_of(User))
-        allow(Flipper).to receive(:enabled?).with(:disability_526_max_cfi_service_switch, instance_of(User))
         allow(Flipper).to receive(:enabled?).with(:intent_to_file_lighthouse_enabled, instance_of(User))
       end
 
@@ -64,7 +63,7 @@ RSpec.describe V0::DisabilityCompensationInProgressFormsController do
             in_progress_form_lighthouse.update(form_data: fd)
 
             VCR.use_cassette('lighthouse/veteran_verification/disability_rating/200_response') do
-              VCR.use_cassette('virtual_regional_office/max_ratings') do
+              VCR.use_cassette('disability_max_ratings/max_ratings') do
                 get v0_disability_compensation_in_progress_form_url(in_progress_form_lighthouse.form_id), params: nil
               end
             end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
Removes the feature flag `disability_526_max_cfi_service_switch`. 

## Related issue(s)
- https://github.com/department-of-veterans-affairs/abd-vro/issues/4164

Follow On Ticket to Remove the Feature Flag from features.yml:
- https://github.com/department-of-veterans-affairs/vets-api/pull/21080

## Testing done
- unit tests were updated 
- old behavior: feature flag indicated where to send traffic `max-cfi-api` within VRO **OR** to `disability-max-ratings-api`
- new behavior: API in VRO is being turned off, all traffic needs to always point to `disability-max-ratings-api`

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
