### PR TITLE
Resolve bundle audit error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -159,6 +159,7 @@ gem 'swagger-blocks'
 # Include the IANA Time Zone Database on Windows, where Windows doesn't ship with a timezone database.
 # POSIX systems should have this already, so we're not going to bring it in on other platforms
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'uri', '>= 1.0.3'
 gem 'utf8-cleaner'
 gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', branch: 'master'
 gem 'virtus'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1087,7 +1087,7 @@ GEM
       tzinfo (>= 1.0.0)
     uber (0.1.0)
     unicode-display_width (2.6.0)
-    uri (1.0.2)
+    uri (1.0.3)
     useragent (0.16.11)
     utf8-cleaner (1.0.0)
       activesupport
@@ -1338,6 +1338,7 @@ DEPENDENCIES
   timecop
   travel_pay!
   tzinfo-data
+  uri (>= 1.0.3)
   utf8-cleaner
   va_notify!
   vaos!


### PR DESCRIPTION
From the following Backend Support issue -> https://dsva.slack.com/archives/CBU0KDSB1/p1741023083130489

Run bundle-audit CI check is failing on all PRs with the following message
```
Run bundle exec bundle-audit check --update --ignore CVE-2024-27456
Download ruby-advisory-db ...
Cloning into '/home/runner/.local/share/ruby-advisory-db'...
ruby-advisory-db:
  advisories:	963 advisories
  last updated:	2025-03-03 08:44:49 -0800
  commit:	4b6766fe26a9f2590732bca3b563bf37d3aeacc9
Name: uri
Version: 1.0.2
CVE: CVE-2025-27221
Criticality: Unknown
URL: https://www.cve.org/CVERecord?id=CVE-2025-27221
Title: CVE-2025-27221 - userinfo leakage in URI#join, URI#merge and URI#+.
Solution: update to '~> 0.11.3', '~> 0.12.4', '~> 0.13.2', '>= 1.0.3'

Vulnerabilities found!
Error: Process completed with exit code 1.
```

This PR updates the uri gem as recommended in the solution above.