### PR TITLE
Bump gha runner image to ubuntu-22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     name: Build and Push
     env:
       BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   prepare-values:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       environments: ${{ steps.set-environments.outputs.environments }}
     steps:
@@ -38,7 +38,7 @@ jobs:
   release:
     needs: [prepare-values]
     if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,7 +5,7 @@ permissions:
   pull-requests: write
 jobs:
   label:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/labeler@v5


### PR DESCRIPTION
## Summary

- Scheduled brownout today for Ubuntu 20.04 Actions runner image
- Bump to 22.04
- Source: https://github.com/actions/runner-images/issues/11101 

## Related issue(s)

- n/a

## Testing done

- [ ] Testing in CI

## Acceptance criteria

- [ ]  the workflows pass