### PR TITLE
fix: require IntentToFilesResponse to resolve error

### DIFF
--- a/spec/serializers/intent_to_file_serializer_spec.rb
+++ b/spec/serializers/intent_to_file_serializer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'evss/intent_to_file/intent_to_files_response'
 
 describe IntentToFileSerializer, type: :serializer do
   # TODO: remove this file or update with LH response


### PR DESCRIPTION
The uninitialized constant error was due to missing the require statement for `IntentToFilesResponse`. Adding this resolves the issue in the serializer spec.

When running `rspec spec/serializers/intent_to_file_serializer_spec.rb` alone, this error occured:

```
uninitialized constant EVSS::IntentToFile::IntentToFilesResponse
```
