### PR TITLE
[VI-1119] - Create IdentitySettings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -744,6 +744,7 @@ config/form_profile_mappings/FORM-MOCK-AE-DESIGN-PATTERNS.yml @department-of-vet
 config/form_profile_mappings/MDOT.yml @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/backend-review-group
 config/freshclam.conf @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/health_care_application @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+config/identity_settings @department-of-veterans-affairs/octo-identity
 config/imagemagick/policies/new-policy.xml @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/01_redis.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/aal.rb @department-of-veterans-affairs/octo-identity
@@ -769,6 +770,7 @@ config/initializers/flipper.rb @department-of-veterans-affairs/va-api-engineers 
 config/initializers/freeze_schemas.rb @department-of-veterans-affairs/vfs-10-10 @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/httpi.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/ial.rb @department-of-veterans-affairs/octo-identity
+config/initializers/identity_config.rb @department-of-veterans-affairs/octo-identity
 config/initializers/inflections.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/integration_recorder.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/jsonapi_serializer_blank_id_patch.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/.gitignore
+++ b/.gitignore
@@ -93,7 +93,7 @@ test_users.csv
 **/.DS_STORE
 
 # Ignore VIM/vscode artifact files
-.ignore 
+.ignore
 *.swp
 .vscode
 
@@ -116,3 +116,6 @@ staging.benefits_claims.pem
 
 # ignore Yardoc generation
 .yardoc/
+
+# ignore all local settings files
+**/*.local.yml

--- a/config/identity_settings/environments/dev.yml
+++ b/config/identity_settings/environments/dev.yml
@@ -1,0 +1,58 @@
+idme:
+  client_cert_path: /srv/vets-api/secret/sign-in-service-oauth-lowers.pem
+  client_id: dde0b5b8bfc023a093830e64ef83f148
+  client_key_path: /srv/vets-api/secret/sign-in-service-oauth-lowers-key.pem
+  redirect_uri: https://dev-api.va.gov/v0/sign_in/callback
+
+logingov:
+  client_cert_path: /srv/vets-api/secret/sign-in-service-oauth-lowers.pem
+  client_key_path: /srv/vets-api/secret/sign-in-service-oauth-lowers-key.pem
+  logout_redirect_uri: https://dev-api.va.gov/v0/sign_in/logingov_logout_proxy
+  oauth_public_key: /srv/vets-api/secret/logingov_oauth_pub.pem
+  redirect_uri: https://dev-api.va.gov/v0/sign_in/callback
+
+map_services:
+  client_cert_path: /srv/vets-api/secret/mobile-application-platform-lowers.pem
+  client_key_path: /srv/vets-api/secret/mobile-application-platform-lowers-key.pem
+
+mhv:
+  account_creation:
+    sts:
+      issuer: https://dev-api.va.gov
+      service_account_id: e2386c6ec816c44ddcb82e21fe730cb2
+
+mvi:
+  client_cert_path: /etc/pki/tls/certs/vetsgov-mvi-cert.pem
+  client_key_path: /etc/pki/tls/private/vetsgov-mvi.key
+  url: https://fwdproxy-dev.vfs.va.gov:4434/psim_webservice/dev/IdMWebService
+
+saml_ssoe:
+  callback_url: https://dev-api.va.gov/v1/sessions/callback
+  cert_path: /srv/vets-api/secret/vagov-ssoe-saml-dev-cert.pem
+  idp_metadata_file: /app/config/ssoe_idp_int_metadata_isam.xml
+  issuer: https://ssoe-sp-dev.va.gov
+  key_path: /srv/vets-api/secret/vagov-ssoe-saml-dev-key.pem
+  logout_url: https://int.eauth.va.gov/slo/globallogout?appKey=https%253A%252F%252Fssoe-sp-dev.va.gov
+  request_signing: true
+  response_encryption: true
+  response_signing: true
+  tou_decline_logout_app_key: https://ssoe-sp-dev.va.gov/agreements_declined
+
+session_cookie:
+  secure: true
+
+sign_in:
+  cookies_secure: true
+  info_cookie_domain: va.gov
+  jwt_encode_key: /srv/vets-api/secret/sign-in-service-token-signing-lowers-key.pem
+  jwt_old_encode_key: /srv/vets-api/secret/sign-in-service-token-signing-lowers-key-old.pem
+  mock_auth_url: https://dev-api.va.gov/mocked_authentication/profiles
+  mock_redirect_uri: https://dev-api.va.gov/v0/sign_in/callback
+  sts_client:
+    base_url: https://dev-api.va.gov
+    key_path: /srv/vets-api/secret/sign-in-service-sts-client.pem
+
+ssoe_eauth_cookie:
+  domain: .va.gov
+  name: vagov_saml_request_dev
+  secure: true

--- a/config/identity_settings/environments/localhost.yml
+++ b/config/identity_settings/environments/localhost.yml
@@ -1,0 +1,2 @@
+idme:
+  client_secret: ae657fd2b253d17be7b48ecdb39d7b34

--- a/config/identity_settings/environments/production.yml
+++ b/config/identity_settings/environments/production.yml
@@ -1,0 +1,78 @@
+idme:
+  client_cert_path: /srv/vets-api/secret/sign-in-service-oauth-prod.pem
+  client_id: 4b0e5276cea986f6cd2525be1ab788f7
+  client_key_path: /srv/vets-api/secret/sign-in-service-oauth-prod-key.pem
+  oauth_url: https://api.id.me
+  redirect_uri: https://api.va.gov/v0/sign_in/callback
+
+logingov:
+  client_cert_path: /srv/vets-api/secret/sign-in-service-oauth-prod.pem
+  client_id: https://eauth.va.gov/isam/sps/saml20sp/saml20
+  client_key_path: /srv/vets-api/secret/sign-in-service-oauth-prod-key.pem
+  logout_redirect_uri: https://api.va.gov/v0/sign_in/logingov_logout_proxy
+  oauth_public_key: /srv/vets-api/secret/logingov_oauth_prod_pub.pem
+  oauth_url: https://secure.login.gov
+  redirect_uri: https://api.va.gov/v0/sign_in/callback
+
+map_services:
+  appointments_client_id: 3cf08c719c8c69eb
+  chatbot_client_id: 2bb9803acfc3
+  check_in_client_id: bc75b71c7e67
+  client_cert_path: /srv/vets-api/secret/mobile-application-platform-prod.pem
+  client_key_path: /srv/vets-api/secret/mobile-application-platform-prod-key.pem
+  oauth_url: https://veteran.apps.va.gov
+  secure_token_service:
+    mock: false
+  sign_up_service:
+    mock: false
+  sign_up_service_client_id: c7d6e0fc9a39
+  sign_up_service_url: https://staff.apps.va.gov
+
+mhv:
+  account_creation:
+    host: https://apigw.myhealth.va.gov
+    mock: false
+    sts:
+      issuer: https://api.va.gov
+      service_account_id: e23aebb01255a8a157691d43ab7d5bcd
+
+mvi:
+  client_cert_path: /etc/pki/tls/certs/vetsgov-mvi-prod-cert.pem
+  client_key_path: /etc/pki/tls/private/vetsgov-mvi.key
+  processing_code: P
+  url: https://fwdproxy-prod.vfs.va.gov:4434/psim_webservice/IdMWebService
+
+saml_ssoe:
+  callback_url: https://api.va.gov/v1/sessions/callback
+  cert_path: /srv/vets-api/secret/vagov-ssoe-saml-prod-cert.pem
+  idp_metadata_file: /app/config/ssoe_idp_prod_metadata_isam.xml
+  issuer: https://ssoe-sp-prod.va.gov
+  key_path: /srv/vets-api/secret/vagov-ssoe-saml-prod-key.pem
+  logout_url: https://eauth.va.gov/slo/globallogout?appKey=https%253A%252F%252Fssoe-sp-prod.va.gov
+  request_signing: true
+  response_encryption: true
+  response_signing: true
+  tou_decline_logout_app_key: https://ssoe-sp-prod.va.gov/agreements_declined
+
+session_cookie:
+  secure: true
+
+sign_in:
+  arp_client_id: fe0d4b2cac7935e7eec5946b8ee31643
+  cookies_secure: true
+  info_cookie_domain: va.gov
+  jwt_encode_key: /srv/vets-api/secret/sign-in-service-token-signing-prod-key.pem
+  jwt_old_encode_key: /srv/vets-api/secret/sign-in-service-token-signing-prod-key-old.pem
+  sts_client:
+    base_url: https://api.va.gov
+    key_path: /srv/vets-api/secret/sign-in-service-sts-client.pem
+  web_origins:
+    - https://identity.va.gov
+    - https://staging.identity.va.gov
+    - https://sandbox.identity.va.gov
+    - https://dev.identity.va.gov
+
+ssoe_eauth_cookie:
+  domain: .va.gov
+  name: vagov_saml_request_prod
+  secure: true

--- a/config/identity_settings/environments/staging.yml
+++ b/config/identity_settings/environments/staging.yml
@@ -1,0 +1,64 @@
+idme:
+  client_cert_path: /srv/vets-api/secret/sign-in-service-oauth-lowers.pem
+  client_id: dde0b5b8bfc023a093830e64ef83f148
+  client_key_path: /srv/vets-api/secret/sign-in-service-oauth-lowers-key.pem
+  redirect_uri: https://staging-api.va.gov/v0/sign_in/callback
+
+logingov:
+  client_cert_path: /srv/vets-api/secret/sign-in-service-oauth-lowers.pem
+  client_key_path: /srv/vets-api/secret/sign-in-service-oauth-lowers-key.pem
+  logout_redirect_uri: https://staging-api.va.gov/v0/sign_in/logingov_logout_proxy
+  oauth_public_key: /srv/vets-api/secret/logingov_oauth_pub.pem
+  redirect_uri: https://staging-api.va.gov/v0/sign_in/callback
+
+map_services:
+  client_cert_path: /srv/vets-api/secret/mobile-application-platform-lowers.pem
+  client_key_path: /srv/vets-api/secret/mobile-application-platform-lowers-key.pem
+  secure_token_service:
+    mock: false
+  sign_up_service:
+    mock: false
+
+mhv:
+  account_creation:
+    mock: false
+    sts:
+      issuer: https://staging-api.va.gov
+      service_account_id: 59d4a3199f42179e510e867cc786d8ac
+
+mvi:
+  client_cert_path: /etc/pki/tls/certs/vetsgov-mvi-cert.pem
+  client_key_path: /etc/pki/tls/private/vetsgov-mvi.key
+  url: https://fwdproxy-staging.vfs.va.gov:4434/psim_webservice/stage1a/IdMWebService
+
+saml_ssoe:
+  callback_url: https://staging-api.va.gov/v1/sessions/callback
+  cert_path: /srv/vets-api/secret/vagov-ssoe-saml-staging-cert.pem
+  idp_metadata_file: /app/config/ssoe_idp_int_metadata_isam.xml
+  issuer: https://ssoe-sp-staging.va.gov
+  key_path: /srv/vets-api/secret/vagov-ssoe-saml-staging-key.pem
+  logout_url: https://sqa.eauth.va.gov/slo/globallogout?appKey=https%253A%252F%252Fssoe-sp-staging.va.gov
+  request_signing: true
+  response_encryption: true
+  response_signing: true
+  tou_decline_logout_app_key: https://ssoe-sp-staging.va.gov/agreements_declined
+
+session_cookie:
+  secure: true
+
+sign_in:
+  arp_client_id: ce6db4d7974daf061dccdd21ba9add14
+  cookies_secure: true
+  info_cookie_domain: va.gov
+  jwt_encode_key: /srv/vets-api/secret/sign-in-service-token-signing-lowers-key.pem
+  sts_client:
+    base_url: https://staging-api.va.gov
+    key_path: /srv/vets-api/secret/sign-in-service-sts-client.pem
+  vamobile_client_id:
+    - vamobile
+    - vamobile_test
+
+ssoe_eauth_cookie:
+  domain: .va.gov
+  name: vagov_saml_request_staging
+  secure: true

--- a/config/identity_settings/settings.yml
+++ b/config/identity_settings/settings.yml
@@ -1,0 +1,99 @@
+audit_db:
+  url: ~
+
+idme:
+  client_cert_path: spec/fixtures/sign_in/oauth.crt
+  client_id: ef7f1237ed3c396e4b4a2b04b608a7b1
+  client_key_path: spec/fixtures/sign_in/oauth.key
+  client_secret: ~
+  oauth_url: https://api.idmelabs.com
+  redirect_uri: http://localhost:3000/v0/sign_in/callback
+
+logingov:
+  client_cert_path: spec/fixtures/sign_in/oauth.crt
+  client_id: https://sqa.eauth.va.gov/isam/sps/saml20sp/saml20
+  client_key_path: spec/fixtures/sign_in/oauth.key
+  logout_redirect_uri: http://localhost:3000/v0/sign_in/logingov_logout_proxy
+  oauth_public_key: spec/fixtures/logingov/logingov_oauth_pub.pem
+  oauth_url: https://idp.int.identitysandbox.gov
+  redirect_uri: http://localhost:3000/v0/sign_in/callback
+
+map_services:
+  appointments_client_id: 74b3145e1354555e
+  chatbot_client_id: 2bb9803acfc3
+  check_in_client_id: bc75b71c7e67
+  client_cert_path: spec/fixtures/map/oauth.crt
+  client_key_path: spec/fixtures/map/oauth.key
+  oauth_url: https://veteran.apps-staging.va.gov
+  secure_token_service:
+    mock: true
+  sign_up_service:
+    mock: true
+  sign_up_service_client_id: c7d6e0fc9a39
+  sign_up_service_provisioning_api_key: ~
+  sign_up_service_url: https://cerner.apps-staging.va.gov
+
+mhv:
+  account_creation:
+    access_key: ~
+    host: https://apigw-intb.aws.myhealth.va.gov
+    mock: true
+    sts:
+      issuer: http://localhost:3000
+      service_account_id: c34b86f2130ff3cd4b1d309bc09d8740
+
+mvi:
+  client_cert_path: /fake/client/cert/path
+  client_key_path: /fake/client/key/path
+  mock: false
+  open_timeout: 15
+  pii_logging: false
+  processing_code: T
+  timeout: 30
+  url: http://ps-dev.commserv.healthevet.va.gov:8110/psim_webservice/IdMWebService
+
+saml_ssoe:
+  callback_url: http://localhost:3000/v1/sessions/callback
+  cert_path: spec/support/certificates/ruby-saml.crt
+  idp_metadata_file: config/ssoe_idp_int_metadata_isam.xml
+  idp_sso_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
+  issuer: https://ssoe-sp-localhost.va.gov
+  key_path: spec/support/certificates/ruby-saml.key
+  logout_app_key: https://ssoe-sp-dev.va.gov
+  logout_url: https://int.eauth.va.gov/slo/globallogout
+  request_signing: false
+  response_encryption: false
+  response_signing: false
+  tou_decline_logout_app_key: https://dev-api.va.gov/agreements_declined
+
+session_cookie:
+  secure: false
+
+sign_in:
+  arp_client_id: arp
+  auto_uplevel: true
+  cookies_secure: false
+  info_cookie_domain: localhost
+  jwt_encode_key: spec/fixtures/sign_in/privatekey.pem
+  jwt_old_encode_key: spec/fixtures/sign_in/privatekey_old.pem
+  mock_auth_url: http://localhost:3000/mocked_authentication/profiles
+  mock_redirect_uri: http://localhost:3000/v0/sign_in/callback
+  mockdata_sync_api_key: ~
+  sts_client:
+    base_url: http://localhost:3000
+    key_path: spec/fixtures/sign_in/sts_client.pem
+  user_info_clients:
+    - okta_test
+  vaweb_client_id: vaweb
+  vamobile_client_id: vamobile
+  web_origins:
+    - http://localhost:4000
+
+ssoe_eauth_cookie:
+  domain: localhost
+  name: vagov_saml_request_localhost
+  secure: false
+
+terms_of_use:
+  current_version: v1
+  enabled_clients: vaweb, mhv, myvahealth

--- a/config/initializers/identity_config.rb
+++ b/config/initializers/identity_config.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+identity_settings_files = Config.setting_files(Rails.root.join('config', 'identity_settings'), Settings.vsp_environment)
+
+IdentitySettings = Config.load_files(identity_settings_files)


### PR DESCRIPTION
## Summary

- Create `IdentitySettings` for identity owned config. 
- `settings.yml` contains defaults
- each environment overrides or uses the default value
- a `~` is a secret value that will be injected from parameter store

## Related issue(s)
- https://jira.devops.va.gov/browse/VI-1119

## Testing 
- Check `IdentitySettings` in console

## What areas of the site does it impact?
Settings

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
