### PR TITLE
[CST] [ZSF] Resolved edge case bug with turning on ff cst_send_evidence_submission_failure_emails

### DIFF
--- a/app/sidekiq/evss/document_upload.rb
+++ b/app/sidekiq/evss/document_upload.rb
@@ -38,7 +38,7 @@ class EVSS::DocumentUpload
   sidekiq_retries_exhausted do |msg, _ex|
     verify_msg(msg)
 
-    if Flipper.enabled?(:cst_send_evidence_submission_failure_emails)
+    if Flipper.enabled?(:cst_send_evidence_submission_failure_emails) && EvidenceSubmission.find_by(job_id: msg['jid'])
       update_evidence_submission(msg)
     else
       call_failure_notification(msg)

--- a/app/sidekiq/evss/document_upload.rb
+++ b/app/sidekiq/evss/document_upload.rb
@@ -38,8 +38,10 @@ class EVSS::DocumentUpload
   sidekiq_retries_exhausted do |msg, _ex|
     verify_msg(msg)
 
-    if Flipper.enabled?(:cst_send_evidence_submission_failure_emails) && EvidenceSubmission.find_by(job_id: msg['jid'])
-      update_evidence_submission(msg)
+    evidence_submission = EvidenceSubmission.find_by(job_id: msg['jid'])
+
+    if Flipper.enabled?(:cst_send_evidence_submission_failure_emails) && evidence_submission
+      update_evidence_submission(evidence_submission, msg)
     else
       call_failure_notification(msg)
     end
@@ -53,7 +55,11 @@ class EVSS::DocumentUpload
     validate_document!
     pull_file_from_cloud!
     perform_document_upload_to_evss
-    update_evidence_submission_status(jid) if Flipper.enabled?(:cst_send_evidence_submission_failure_emails)
+    evidence_submission = EvidenceSubmission.find_by(job_id: jid)
+
+    if Flipper.enabled?(:cst_send_evidence_submission_failure_emails) && evidence_submission
+      update_evidence_submission_status(evidence_submission)
+    end
     clean_up!
   end
 
@@ -75,8 +81,7 @@ class EVSS::DocumentUpload
     !(%w[evss_claim_id tracked_item_id document_type file_name] - args[2].keys).empty?
   end
 
-  def self.update_evidence_submission(msg)
-    evidence_submission = EvidenceSubmission.find_by(job_id: msg['jid'])
+  def self.update_evidence_submission(evidence_submission, msg)
     current_personalisation = JSON.parse(evidence_submission.template_metadata)['personalisation']
     evidence_submission.update(
       upload_status: BenefitsDocuments::Constants::UPLOAD_STATUS[:FAILED],
@@ -177,8 +182,7 @@ class EVSS::DocumentUpload
     @file_body ||= perform_initial_file_read
   end
 
-  def update_evidence_submission_status(job_id)
-    evidence_submission = EvidenceSubmission.find_by(job_id:)
+  def update_evidence_submission_status(evidence_submission)
     evidence_submission.update!(
       upload_status: BenefitsDocuments::Constants::UPLOAD_STATUS[:SUCCESS],
       delete_date: (DateTime.current + 60.days).utc

--- a/app/sidekiq/lighthouse/evidence_submissions/document_upload.rb
+++ b/app/sidekiq/lighthouse/evidence_submissions/document_upload.rb
@@ -23,8 +23,10 @@ module Lighthouse
       sidekiq_retries_exhausted do |msg, _ex|
         verify_msg(msg)
 
-        if Flipper.enabled?(:cst_send_evidence_submission_failure_emails) && EvidenceSubmission.find_by(job_id: msg['jid'])
-          update_evidence_submission_for_failure(msg)
+        evidence_submission = EvidenceSubmission.find_by(job_id: msg['jid'])
+
+        if Flipper.enabled?(:cst_send_evidence_submission_failure_emails) && evidence_submission
+          update_evidence_submission_for_failure(evidence_submission, msg)
         else
           call_failure_notification(msg)
         end
@@ -53,8 +55,7 @@ module Lighthouse
         !(%w[first_name claim_id document_type file_name tracked_item_id] - args[1].keys).empty?
       end
 
-      def self.update_evidence_submission_for_failure(msg)
-        evidence_submission = EvidenceSubmission.find_by(job_id: msg['jid'])
+      def self.update_evidence_submission_for_failure(evidence_submission, msg)
         current_personalisation = JSON.parse(evidence_submission.template_metadata)['personalisation']
         evidence_submission.update(
           upload_status: BenefitsDocuments::Constants::UPLOAD_STATUS[:FAILED],
@@ -131,10 +132,11 @@ module Lighthouse
       end
 
       def perform_document_upload_to_lighthouse
+        evidence_submission = EvidenceSubmission.find_by(job_id: jid)
         Datadog::Tracing.trace('Sidekiq Upload Document') do |span|
           span.set_tag('Document File Size', file_body.size)
           response = client.upload_document(file_body, document) # returns upload response which includes requestId
-          if Flipper.enabled?(:cst_send_evidence_submission_failure_emails)
+          if Flipper.enabled?(:cst_send_evidence_submission_failure_emails) && evidence_submission
             update_evidence_submission_for_in_progress(jid, response)
           end
         end

--- a/app/sidekiq/lighthouse/evidence_submissions/document_upload.rb
+++ b/app/sidekiq/lighthouse/evidence_submissions/document_upload.rb
@@ -23,7 +23,7 @@ module Lighthouse
       sidekiq_retries_exhausted do |msg, _ex|
         verify_msg(msg)
 
-        if Flipper.enabled?(:cst_send_evidence_submission_failure_emails)
+        if Flipper.enabled?(:cst_send_evidence_submission_failure_emails) && EvidenceSubmission.find_by(job_id: msg['jid'])
           update_evidence_submission_for_failure(msg)
         else
           call_failure_notification(msg)

--- a/spec/sidekiq/evss/document_upload_spec.rb
+++ b/spec/sidekiq/evss/document_upload_spec.rb
@@ -77,10 +77,6 @@ RSpec.describe EVSS::DocumentUpload, type: :job do
     end
 
     context 'when upload succeeds' do
-      before do
-        allow(EVSS::DocumentUpload).to receive(:update_evidence_submission)
-      end
-
       let(:uploader_stub) { instance_double(EVSSClaimDocumentUploader) }
       let(:file) { Rails.root.join('spec', 'fixtures', 'files', file_name).read }
       let(:evidence_submission_pending) do
@@ -110,6 +106,7 @@ RSpec.describe EVSS::DocumentUpload, type: :job do
       end
 
       it 'when there is no EvidenceSubmission' do
+        allow(EVSS::DocumentUpload).to receive(:update_evidence_submission)
         allow(EVSSClaimDocumentUploader).to receive(:new) { uploader_stub }
         allow(EVSS::DocumentsService).to receive(:new) { client_stub }
         allow(uploader_stub).to receive(:retrieve_from_store!).with(file_name) { file }

--- a/spec/sidekiq/evss/document_upload_spec.rb
+++ b/spec/sidekiq/evss/document_upload_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe EVSS::DocumentUpload, type: :job do
       before do
         allow(EVSS::DocumentUpload).to receive(:update_evidence_submission)
       end
+
       let(:uploader_stub) { instance_double(EVSSClaimDocumentUploader) }
       let(:file) { Rails.root.join('spec', 'fixtures', 'files', file_name).read }
       let(:evidence_submission_pending) do
@@ -106,7 +107,7 @@ RSpec.describe EVSS::DocumentUpload, type: :job do
         expect(StatsD)
           .to have_received(:increment)
           .with('cst.evss.document_uploads.evidence_submission_record_updated.success')
-        end
+      end
 
       it 'when there is no EvidenceSubmission' do
         allow(EVSSClaimDocumentUploader).to receive(:new) { uploader_stub }
@@ -172,6 +173,7 @@ RSpec.describe EVSS::DocumentUpload, type: :job do
           allow(EVSS::DocumentUpload).to receive(:update_evidence_submission)
           allow(EVSS::DocumentUpload).to receive(:call_failure_notification)
         end
+
         it 'does not update an evidence submission record' do
           described_class.within_sidekiq_retries_exhausted_block(msg) do
             allow(EvidenceSubmission).to receive(:find_by)

--- a/spec/sidekiq/lighthouse/evidence_submissions/document_upload_spec.rb
+++ b/spec/sidekiq/lighthouse/evidence_submissions/document_upload_spec.rb
@@ -125,12 +125,10 @@ RSpec.describe Lighthouse::EvidenceSubmissions::DocumentUpload, type: :job do
         allow(uploader_stub).to receive(:read_for_upload) { file }
         expect(uploader_stub).to receive(:remove!).once
         expect(client_stub).to receive(:upload_document).with(file, document_data).and_return(success_response)
-        allow(described_class).to receive(:update_evidence_submission_for_failure)
         allow(EvidenceSubmission).to receive(:find_by)
           .with({ job_id: })
           .and_return(nil)
         described_class.drain # runs all queued jobs of this class
-        expect(described_class).not_to have_received(:update_evidence_submission_for_failure)
       end
     end
 
@@ -186,6 +184,28 @@ RSpec.describe Lighthouse::EvidenceSubmissions::DocumentUpload, type: :job do
           expect(evidence_submission.acknowledgement_date).to be_within(1.second).of((current_date_time + 30.days).utc)
         end
         Timecop.unfreeze
+      end
+
+      it 'does not have an EvidenceSubmission record' do
+        allow(Flipper).to receive(:enabled?).with(:cst_send_evidence_failure_emails).and_return(true)
+        allow(described_class).to receive(:update_evidence_submission_for_failure)
+        Lighthouse::EvidenceSubmissions::DocumentUpload.within_sidekiq_retries_exhausted_block(msg) do
+          allow(EvidenceSubmission).to receive(:find_by)
+            .with({ job_id: })
+            .and_return(nil)
+          expect(Lighthouse::FailureNotification).to receive(:perform_async).with(
+            user_account.icn,
+            {
+              first_name: 'Bob',
+              document_type: document_description,
+              filename: BenefitsDocuments::Utilities::Helpers.generate_obscured_file_name(file_name),
+              date_submitted: formatted_submit_date,
+              date_failed: formatted_submit_date
+            }
+          )
+          expect(described_class).not_to receive(:update_evidence_submission_for_failure)
+          expect(EvidenceSubmission.count).to equal(0)
+        end
       end
 
       it 'fails to create a failed evidence submission record when args malformed' do

--- a/spec/sidekiq/lighthouse/evidence_submissions/document_upload_spec.rb
+++ b/spec/sidekiq/lighthouse/evidence_submissions/document_upload_spec.rb
@@ -117,6 +117,21 @@ RSpec.describe Lighthouse::EvidenceSubmissions::DocumentUpload, type: :job do
           .to have_received(:increment)
           .with('cst.lighthouse.document_uploads.evidence_submission_record_updated.added_request_id')
       end
+
+      it 'there is no EvidenceSubmission' do
+        allow(LighthouseDocumentUploader).to receive(:new) { uploader_stub }
+        allow(BenefitsDocuments::WorkerService).to receive(:new) { client_stub }
+        allow(uploader_stub).to receive(:retrieve_from_store!).with(file_name) { file }
+        allow(uploader_stub).to receive(:read_for_upload) { file }
+        expect(uploader_stub).to receive(:remove!).once
+        expect(client_stub).to receive(:upload_document).with(file, document_data).and_return(success_response)
+        allow(described_class).to receive(:update_evidence_submission_for_failure)
+        allow(EvidenceSubmission).to receive(:find_by)
+          .with({ job_id: })
+          .and_return(nil)
+        described_class.drain # runs all queued jobs of this class
+        expect(described_class).not_to have_received(:update_evidence_submission_for_failure)
+      end
     end
 
     context 'when upload fails' do


### PR DESCRIPTION
### Bug
While turning on `cst_send_evidence_submission_failure_emails` on 3/4/25 we noticed that a possible bug was present in the instance where...
- A document was uploaded and queued to upload in the service code with sidekiq (evss_claim_service.rb and service.rb) but the document_upload code (document_upload.rb) was not ran yet. When we turned on the ff `cst_send_evidence_submission_failure_emails` the document upload code was then ran for some document uploads and an error occurred because the code that runs in document_upload.rb expected an evidence_submission record to exist, but no record existed since the service code had not been ran with the ff enabled.

### What we changed:
- We updated `app/sidekiq/evss/document_upload.rb` and `app/sidekiq/lighthouse/evidence_submissions/document_upload.rb` to account for the above bug. Now when we turn the ff on, if there is an upload queued, that then runs in document upload. An error will not be thrown for there not being an evidence_submission record.
- Updated tests and added tests

## Summary

- *This work is behind a feature toggle (flipper): YES*

## Related issue(s)

- [[CST][BUG] Resolve Issue with turning on ff cst_send_evidence_submission_failure_emails](https://github.com/department-of-veterans-affairs/va.gov-team/issues/104394)

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
