### PR TITLE
Add Transaction ID datadog link to va.gov-specific alerts

### DIFF
--- a/modules/claims_api/app/services/claims_api/slack/failed_submissions_messenger.rb
+++ b/modules/claims_api/app/services/claims_api/slack/failed_submissions_messenger.rb
@@ -6,11 +6,11 @@ module ClaimsApi
   module Slack
     class FailedSubmissionsMessenger
       def initialize(options = {})
-        @errored_disability_claims = options[:errored_disability_claims]
-        @errored_va_gov_claims = options[:errored_va_gov_claims]
-        @errored_poa = options[:errored_poa]
-        @errored_itf = options[:errored_itf]
-        @errored_ews = options[:errored_ews]
+        @errored_disability_claims = options[:errored_disability_claims] # Array of id
+        @errored_va_gov_claims = options[:errored_va_gov_claims] # Array of [id, transaction_id]
+        @errored_poa = options[:errored_poa] # Array of id
+        @errored_itf = options[:errored_itf] # Array of id
+        @errored_ews = options[:errored_ews] # Array of id
         @from = options[:from]
         @to = options[:to]
         @environment = options[:environment]
@@ -79,7 +79,7 @@ module ClaimsApi
 
       def build_error_block(title, errors)
         text = if title == 'Va Gov Disability Compensation'
-                 errors.map { |eid| link_value(eid) }.join("\n")
+                 errors.map { |eid, tid| "CID: #{link_value(eid)} / TID: #{link_value(tid)}" }.join("\n")
                else
                  errors.join("\n")
                end

--- a/modules/claims_api/app/services/claims_api/slack/failed_submissions_messenger.rb
+++ b/modules/claims_api/app/services/claims_api/slack/failed_submissions_messenger.rb
@@ -94,6 +94,8 @@ module ClaimsApi
       end
 
       def link_value(id)
+        return 'N/A' if id.blank?
+
         time_stamps = datadog_timestamps
 
         "<https://vagov.ddog-gov.com/logs?query='#{id}'&agg_m=count&agg_m_source=base&agg_t=count&cols=" \

--- a/modules/claims_api/app/sidekiq/claims_api/report_hourly_unsuccessful_submissions.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/report_hourly_unsuccessful_submissions.rb
@@ -61,7 +61,7 @@ module ClaimsApi
       filtered_error_ids = []
 
       unique_errors.each do |ue|
-        filtered_error_ids << [ue[:id], ue[:transaction_id]] unless NO_INVESTIGATION_ERROR_TEXT.any? do |text|
+        filtered_error_ids << [ue[:id], ue[:transaction_id].presence] unless NO_INVESTIGATION_ERROR_TEXT.any? do |text|
           ue[:evss_response].to_s&.include?(text)
         end
       end

--- a/modules/claims_api/app/sidekiq/claims_api/report_hourly_unsuccessful_submissions.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/report_hourly_unsuccessful_submissions.rb
@@ -21,7 +21,7 @@ module ClaimsApi
         'status = ? AND created_at BETWEEN ? AND ? AND cid <> ?',
         'errored', @search_from, @search_to, '0oagdm49ygCSJTp8X297'
       ).pluck(:id).uniq
-      @va_gov_errored_claims = get_filtered_unique_errors
+      @va_gov_errored_claims = get_filtered_unique_errors # Array of [id, transaction_id]
       @errored_poa = ClaimsApi::PowerOfAttorney.where(created_at: @search_from..@search_to,
                                                       status: 'errored').pluck(:id).uniq
       @errored_itf = ClaimsApi::IntentToFile.where(created_at: @search_from..@search_to,
@@ -61,11 +61,12 @@ module ClaimsApi
       filtered_error_ids = []
 
       unique_errors.each do |ue|
-        filtered_error_ids << ue[:id] unless NO_INVESTIGATION_ERROR_TEXT.any? do |text|
+        filtered_error_ids << [ue[:id], ue[:transaction_id]] unless NO_INVESTIGATION_ERROR_TEXT.any? do |text|
           ue[:evss_response].to_s&.include?(text)
         end
       end
 
+      # return signature: [[id, transaction_id],...]
       filtered_error_ids
     end
 

--- a/modules/claims_api/spec/services/failed_submissions_messenger_spec.rb
+++ b/modules/claims_api/spec/services/failed_submissions_messenger_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ClaimsApi::Slack::FailedSubmissionsMessenger do
 
   context 'when there is one type of each error' do
     let(:errored_disability_claims) { Array.new(1) { SecureRandom.uuid } }
-    let(:errored_va_gov_claims) { Array.new(1) { SecureRandom.uuid } }
+    let(:errored_va_gov_claims) { Array.new(1) { [SecureRandom.uuid, SecureRandom.uuid] } }
     let(:errored_poa) { Array.new(1) { SecureRandom.uuid } }
     let(:errored_itf) { Array.new(1) { SecureRandom.uuid } }
     let(:errored_ews) { Array.new(1) { SecureRandom.uuid } }
@@ -96,12 +96,15 @@ RSpec.describe ClaimsApi::Slack::FailedSubmissionsMessenger do
 
   context 'when there are more than 10 failed va.gov submissions' do
     let(:num_errors) { 12 }
-    let(:errored_va_gov_claims) { Array.new(num_errors) { SecureRandom.uuid } }
+    let(:errored_va_gov_claims) { Array.new(num_errors) { [SecureRandom.uuid, SecureRandom.uuid] } }
     let(:from) { '03:59PM EST' }
     let(:to) { '04:59PM EST' }
     let(:environment) { 'production' }
 
     it 'sends error ids with links to logs' do
+      first_cid = errored_va_gov_claims.first[0]
+      first_tid = errored_va_gov_claims.first[1]
+
       messenger = described_class.new(
         errored_va_gov_claims:,
         from:,
@@ -133,7 +136,7 @@ RSpec.describe ClaimsApi::Slack::FailedSubmissionsMessenger do
             text: {
               type: 'mrkdwn',
               text: a_string_including('```', '<https://vagov.ddog-gov.com/logs?query=',
-                                       "|#{errored_va_gov_claims.first}>", '```')
+                                       'CID', "|#{first_cid}>", 'TID', "|#{first_tid}", '```')
             }
           )
         )

--- a/modules/claims_api/spec/sidekiq/report_hourly_unsuccessful_submissions_spec.rb
+++ b/modules/claims_api/spec/sidekiq/report_hourly_unsuccessful_submissions_spec.rb
@@ -72,7 +72,10 @@ describe ClaimsApi::ReportHourlyUnsuccessfulSubmissions, type: :job do
                                                                       transaction_id: 'transaction_3',
                                                                       id: '4')
 
-        expected_vagov_claims = [claim_three.id, claim_four.id]
+        expected_vagov_claims = [
+          [claim_three.id, claim_three.transaction_id],
+          [claim_four.id, claim_four.transaction_id]
+        ]
 
         expect(ClaimsApi::Slack::FailedSubmissionsMessenger).to receive(:new).with(
           errored_disability_claims: [],
@@ -136,7 +139,10 @@ describe ClaimsApi::ReportHourlyUnsuccessfulSubmissions, type: :job do
                                              'Retries will fail.' }],
                transaction_id: 'transaction_5')
 
-        expected_vagov_claims = [claim_three.id, claim_four.id]
+        expected_vagov_claims = [
+          [claim_three.id, claim_three.transaction_id],
+          [claim_four.id, claim_four.transaction_id]
+        ]
 
         expect(ClaimsApi::Slack::FailedSubmissionsMessenger).to receive(:new).with(
           errored_disability_claims: [],


### PR DESCRIPTION

## Summary

Workflow from taking a claim ID datadog link, copying a transaction id from the detail, then pasting it back into the search felt not-great. In the cases of va.gov autoestablish claim errors, add a link to the transaction id log search directly to ease some suffering.

## Related issue(s)

- [API-44632](https://jira.devops.va.gov/browse/API-44632)

## Testing done

- [x] *New code is covered by unit tests*

Before, only the claim ID would have a link to datadog. 

Now, both the claim ID and its associated Transaction ID both have links to datadog.

## What areas of the site does it impact?
Claims API slack alerting. Nothing consumer-facing.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature