### PR TITLE
21p_527ez setting hardcoded to ENV

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1388,7 +1388,7 @@ vanotify:
           template_id: <%= ENV['vanotify__services__21p_527ez__email__error__template_id'] %>
         received:
           flipper_id: pension_received_email_notification
-          template_id: 54140052-af03-4d2b-9903-cd33f21dc422
+          template_id: <%= ENV['vanotify__services__21p_527ez__email__received__template_id'] %>
         submitted:
           flipper_id: pension_submitted_email_notification
           template_id: <%= ENV['vanotify__services__21p_527ez__email__submitted__template_id'] %>


### PR DESCRIPTION
## Summary

- Setting for `vanotify/services/21p_527ez/email/received/template_id` was hardcoded but should now be ENV
- All Parameters exist
- SETTINGS__ override parameters should be removed just before deploy

## Related issue(s)

- n/a

## Testing done

- [ ] 

## Acceptance criteria

- [x] setting uses ENV
- [x] all parameters exists 