### PR TITLE
1492: do not retry 1095b ingestion job

### DIFF
--- a/app/sidekiq/form1095/new1095_bs_job.rb
+++ b/app/sidekiq/form1095/new1095_bs_job.rb
@@ -7,7 +7,7 @@ module Form1095
     include Sidekiq::Job
     include SentryLogging
 
-    sidekiq_options(unique_for: 4.hours)
+    sidekiq_options(retry: false)
 
     def bucket
       @bucket ||= Aws::S3::Resource.new(


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- Changes the 1095b ingestion job to not retry. Based on logs, it looks as though it spawns two or occasionally three retry processes simultaneously, which results in a race condition wherein both jobs attempt to create the same record at once, which kills the job and forces more retries. Given the sheer number of records per ingestion file, this is extremely inefficient. There is no need to retry this job.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-iir/issues/1492

## Testing done

No testing needed because it just changes the sidekiq options for the job. 

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
1095b ingestion job

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

