### PR TITLE
[ARP] Disable non-POA request routes outside development and test

### DIFF
--- a/modules/accredited_representative_portal/config/routes.rb
+++ b/modules/accredited_representative_portal/config/routes.rb
@@ -19,7 +19,7 @@ AccreditedRepresentativePortal::Engine.routes.draw do
       resources :in_progress_forms, only: %i[update show destroy]
     end
 
-    resources :power_of_attorney_requests, only: %i[index show create] do
+    resources :power_of_attorney_requests, only: %i[index show] do
       resource :decision, only: :create, controller: 'power_of_attorney_request_decisions'
     end
   end

--- a/modules/accredited_representative_portal/config/routes.rb
+++ b/modules/accredited_representative_portal/config/routes.rb
@@ -4,9 +4,21 @@ AccreditedRepresentativePortal::Engine.routes.draw do
   namespace :v0, defaults: { format: :json } do
     get 'user', to: 'representative_users#show'
 
-    post 'form21a', to: 'form21a#submit'
+    ##
+    # While these endpoints are still under development, they should be
+    # inaccessible in production. For now, this check is extra stringent, and
+    # makes these endpoints inaccessible anywhere outside development and test.
+    # But once development on these features picks back up, we want them to be
+    # accessible in staging too.
+    #
+    # TODO: Carry out this per-environment guard of these endpoints by using
+    # Flipper feature toggling and controller before actions instead.
+    #
+    if Rails.env.development? || Rails.env.test?
+      post 'form21a', to: 'form21a#submit'
+      resources :in_progress_forms, only: %i[update show destroy]
+    end
 
-    resources :in_progress_forms, only: %i[update show destroy]
     resources :power_of_attorney_requests, only: %i[index show create] do
       resource :decision, only: :create, controller: 'power_of_attorney_request_decisions'
     end


### PR DESCRIPTION
While these endpoints are still under development, they should be inaccessible in production. For now, this check is extra stringent, and makes these endpoints inaccessible anywhere outside development and test. But once development on these features picks back up, we want them to be accessible in staging too.

TODO: Carry out this per-environment guard of these endpoints by using Flipper feature toggling and controller before actions instead.