### PR TITLE
Remove remnants of mhv_account_creation_after_login flipper

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -931,10 +931,6 @@ features:
     actor_type: user
     description: Enables notifications to be sent for new copay statements
     enable_in_development: true
-  mhv_account_creation_after_login:
-    actor_type: user
-    descriptiom: Enables access to MHV Account Creation API
-    enable_in_development: true
   mhv_accelerated_delivery_enabled:
     actor_type: user
     description: Control whether vets-api allows fetching MR data from LightHouse

--- a/spec/services/sign_in/user_loader_spec.rb
+++ b/spec/services/sign_in/user_loader_spec.rb
@@ -151,8 +151,6 @@ RSpec.describe SignIn::UserLoader do
 
           before do
             allow(MHV::AccountCreatorJob).to receive(:perform_async)
-            allow(Flipper).to receive(:enabled?).with(:mhv_account_creation_after_login,
-                                                      user_account).and_return(enabled)
           end
 
           it 'enqueues an MHV::AccountCreatorJob' do


### PR DESCRIPTION
## Summary

- Remove flipper `:mhv_account_creation_after_login` no longer being used