### PR TITLE
Write to log before sending to slack

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/va_notify_accepted_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/va_notify_accepted_job.rb
@@ -42,13 +42,8 @@ module ClaimsApi
       msg = "VA Notify email notification failed to send for #{poa_id} with error #{error}"
       process.update!(step_status: 'FAILED', error_messages: [{ title: 'VA Notify Error',
                                                                 detail: msg }])
+      ClaimsApi::Logger.log(LOG_TAG, detail: msg)
       slack_alert_on_failure(job_name, msg)
-
-      ClaimsApi::Logger.log(
-        LOG_TAG,
-        detail: msg
-      )
-      # retry job
       raise error
     end
 

--- a/modules/claims_api/app/sidekiq/claims_api/va_notify_declined_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/va_notify_declined_job.rb
@@ -21,10 +21,8 @@ module ClaimsApi
       ClaimsApi::VANotifyFollowUpJob.perform_async(res.id) if res.present?
     rescue => e
       msg = "VA Notify email notification failed to send with error #{e}"
-      slack_alert_on_failure('ClaimsApi::VANotifyDeclinedJob', msg)
-
       ClaimsApi::Logger.log(LOG_TAG, detail: msg)
-
+      slack_alert_on_failure('ClaimsApi::VANotifyDeclinedJob', msg)
       raise e
     end
 

--- a/modules/claims_api/app/sidekiq/claims_api/va_notify_follow_up_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/va_notify_follow_up_job.rb
@@ -44,12 +44,8 @@ module ClaimsApi
 
     def handle_failure(msg)
       job_name = 'ClaimsApi::VANotifyFollowUpJob'
+      ClaimsApi::Logger.log(LOG_TAG, detail: msg)
       slack_alert_on_failure(job_name, msg)
-
-      ClaimsApi::Logger.log(
-        LOG_TAG,
-        detail: msg
-      )
     end
 
     def notification_response_status(notification_id)


### PR DESCRIPTION
## Summary

What it says on the tin. Make sure to log _before_ trying to reach out to a 3rd party for error alerting. That way if its call errors, we'll at least still have our log to fall back on.

## Related issue(s)
[API-40902](https://jira.devops.va.gov/browse/API-40902)

## Testing done
- Ran existing specs w/ no failures.

## What areas of the site does it impact?
Background job processing w/in ClaimsAPI - nothing consume facing.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature