### PR TITLE
[104070] Enforce only one active poa request

### DIFF
--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request.rb
@@ -63,6 +63,11 @@ module AccreditedRepresentativePortal
       resolved? && resolution.resolving.is_a?(PowerOfAttorneyRequestExpiration)
     end
 
+    def replaced?
+      resolved? && resolution.resolving.is_a?(PowerOfAttorneyRequestWithdrawal) &&
+        resolution.resolving.type == PowerOfAttorneyRequestWithdrawal::Types::REPLACEMENT
+    end
+
     def mark_accepted!(creator, reason)
       PowerOfAttorneyRequestDecision.create_acceptance!(
         creator:, power_of_attorney_request: self, reason:
@@ -72,6 +77,13 @@ module AccreditedRepresentativePortal
     def mark_declined!(creator, reason)
       PowerOfAttorneyRequestDecision.create_declination!(
         creator:, power_of_attorney_request: self, reason:
+      )
+    end
+
+    def mark_replaced!(superseding_power_of_attorney_request)
+      PowerOfAttorneyRequestWithdrawal.create_replacement!(
+        power_of_attorney_request: self,
+        superseding_power_of_attorney_request:
       )
     end
 

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_resolution.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_resolution.rb
@@ -9,6 +9,7 @@ module AccreditedRepresentativePortal
     RESOLVING_TYPES = %w[
       PowerOfAttorneyRequestExpiration
       PowerOfAttorneyRequestDecision
+      PowerOfAttorneyRequestWithdrawal
     ].freeze
 
     delegated_type :resolving,

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_withdrawal.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_withdrawal.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class PowerOfAttorneyRequestWithdrawal < ApplicationRecord
+    include PowerOfAttorneyRequestResolution::Resolving
+
+    self.inheritance_column = nil
+
+    module Types
+      ALL = [
+        REPLACEMENT = 'PowerOfAttorneyRequestReplacement'
+      ].freeze
+    end
+
+    belongs_to :superseding_power_of_attorney_request,
+               class_name: 'PowerOfAttorneyRequest',
+               optional: true
+
+    validates :type, inclusion: { in: Types::ALL }
+
+    class << self
+      def create_replacement!(**attrs)
+        create_with_resolution!(type: Types::REPLACEMENT, **attrs)
+      end
+
+      private
+
+      def create_with_resolution!(type:, superseding_power_of_attorney_request:, **resolution_attrs)
+        PowerOfAttorneyRequestResolution.create_with_resolving!(
+          resolving: new(type:, superseding_power_of_attorney_request:),
+          **resolution_attrs
+        )
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/power_of_attorney_request_service/create.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/power_of_attorney_request_service/create.rb
@@ -54,10 +54,20 @@ module AccreditedRepresentativePortal
           # PowerOfAttorneyForm expects the incoming data to be json, not a hash
           request.build_power_of_attorney_form(data: @form_data.to_json)
 
+          if unresolved_requests.any?
+            unresolved_requests.each do |unresolved|
+              unresolved.mark_replaced!(request)
+            end
+          end
+
           request.save!
         end
 
         request
+      end
+
+      def unresolved_requests
+        @unresolved_requests ||= PowerOfAttorneyRequest.unresolved.where(claimant: @claimant)
       end
     end
   end

--- a/modules/accredited_representative_portal/spec/factories/power_of_attorney_request.rb
+++ b/modules/accredited_representative_portal/spec/factories/power_of_attorney_request.rb
@@ -65,6 +65,17 @@ FactoryBot.define do
       end
     end
 
+    trait :with_replacement do
+      after(:build) do |poa_request, evaluator|
+        poa_request.resolution = build(
+          :power_of_attorney_request_resolution,
+          :replacement,
+          power_of_attorney_request: poa_request,
+          resolution_created_at: evaluator.resolution_created_at
+        )
+      end
+    end
+
     trait :with_veteran_claimant do
       association :power_of_attorney_form, :with_veteran_claimant, strategy: :build
     end

--- a/modules/accredited_representative_portal/spec/factories/power_of_attorney_request_resolution.rb
+++ b/modules/accredited_representative_portal/spec/factories/power_of_attorney_request_resolution.rb
@@ -73,5 +73,16 @@ FactoryBot.define do
         resolution.created_at = evaluator.resolution_created_at if evaluator.resolution_created_at
       end
     end
+
+    trait :replacement do
+      after(:build) do |resolution, evaluator|
+        resolution.resolving =
+          build(
+            :power_of_attorney_request_withdrawal, :replacement,
+            resolution:
+          )
+        resolution.created_at = evaluator.resolution_created_at if evaluator.resolution_created_at
+      end
+    end
   end
 end

--- a/modules/accredited_representative_portal/spec/factories/power_of_attorney_request_withdrawal.rb
+++ b/modules/accredited_representative_portal/spec/factories/power_of_attorney_request_withdrawal.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :power_of_attorney_request_withdrawal,
+          class: 'AccreditedRepresentativePortal::PowerOfAttorneyRequestWithdrawal' do
+    association :resolution, factory: :power_of_attorney_request_resolution
+
+    trait :replacement do
+      transient do
+        claimant { resolution.power_of_attorney_request.claimant }
+      end
+
+      superseding_power_of_attorney_request { build(:power_of_attorney_request, claimant:) }
+      type { AccreditedRepresentativePortal::PowerOfAttorneyRequestWithdrawal::Types::REPLACEMENT }
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/models/accredited_representative_portal/power_of_attorney_request_withdrawal_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representative_portal/power_of_attorney_request_withdrawal_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestWithdrawal, type: :model do
+  it 'validates inclusion of type in (replacement)' do
+    withdrawal = build(:power_of_attorney_request_withdrawal, type: 'invalid')
+    withdrawal.valid?
+
+    expect(withdrawal).not_to be_valid
+    expect(withdrawal.errors.full_messages).to eq(
+      [
+        'Type is not included in the list'
+      ]
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- This pr introduces a new `PowerOfAttorneyRequestResolution` type of `Withdrawal`
- This pr withdraws, as a replacement, all unresolved poa requests when creating a new request

## Related issue(s)

- [104070](https://github.com/department-of-veterans-affairs/va.gov-team/issues/104070)

## Testing done

- [x] *New code is covered by unit tests*
- Went through the Appoint a Rep flow locally and confirmed previous active requests were withdrawn

## What areas of the site does it impact?
Appoint a Rep and Accredited Representative Portal

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature