### PR TITLE
Fix args for SendNotificationEmailJob

### DIFF
--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -39,7 +39,7 @@ class FormSubmissionAttempt < ApplicationRecord
                      user_account_uuid: form_submission.user_account_id }
         if should_send_simple_forms_email
           Rails.logger.info('Preparing to send Form Submission Attempt error email', log_info)
-          simple_forms_enqueue_result_email(:error)
+          simple_forms_enqueue_result_email
         elsif form_type == CentralMail::SubmitForm4142Job::FORM4142_FORMSUBMISSION_TYPE
           form526_form4142_email(log_info)
         end
@@ -54,7 +54,7 @@ class FormSubmissionAttempt < ApplicationRecord
 
     event :vbms do
       after do
-        simple_forms_enqueue_result_email(:received) if should_send_simple_forms_email
+        simple_forms_enqueue_result_email if should_send_simple_forms_email
       end
 
       transitions from: :pending, to: :vbms
@@ -137,20 +137,13 @@ class FormSubmissionAttempt < ApplicationRecord
     simple_forms_form_number && Flipper.enabled?(:simple_forms_email_notifications)
   end
 
-  def simple_forms_enqueue_result_email(notification_type)
+  def simple_forms_enqueue_result_email
     form_number = simple_forms_form_number
-    Rails.logger.info('Queuing SimpleFormsAPI notification email to VaNotify', notification_type:, form_number:,
-                                                                               benefits_intake_uuid:)
-    jid = SimpleFormsApi::Notification::SendNotificationEmailJob.perform_async(
-      notification_type:,
-      form_submission_attempt: self,
-      form_number:,
-      user_account:
-    )
+    Rails.logger.info('Queuing SimpleFormsAPI notification email to VaNotify', form_number:, benefits_intake_uuid:)
+    jid = SimpleFormsApi::Notification::SendNotificationEmailJob.perform_async(benefits_intake_uuid, form_number)
     Rails.logger.info(
       'Queuing SimpleFormsAPI notification email to VaNotify completed',
       jid:,
-      notification_type:,
       form_number:,
       benefits_intake_uuid:
     )

--- a/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
+++ b/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
@@ -5,7 +5,7 @@ module SimpleFormsApi
     class SendNotificationEmailJob
       include Sidekiq::Job
 
-      sidekiq_options retry: 10
+      sidekiq_options retry: 10, backtrace: true
 
       HOUR_TO_SEND_NOTIFICATIONS = 9
 

--- a/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
+++ b/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
@@ -58,7 +58,7 @@ module SimpleFormsApi
       end
 
       def get_notification_type
-        if form_submission_attempt.fail?
+        if form_submission_attempt.failure?
           :error
         elsif form_submission_attempt.vbms?
           :received
@@ -70,6 +70,7 @@ module SimpleFormsApi
       end
 
       def handle_exception(e)
+        notification_type = get_notification_type
         Rails.logger.error(
           'Error sending simple forms notification email',
           message: e.message,

--- a/spec/models/form_submission_attempt_spec.rb
+++ b/spec/models/form_submission_attempt_spec.rb
@@ -38,10 +38,8 @@ RSpec.describe FormSubmissionAttempt, type: :model do
           form_submission_attempt.fail!
 
           expect(SimpleFormsApi::Notification::SendNotificationEmailJob).to have_received(:perform_async).with(
-            notification_type:,
-            form_submission_attempt:,
-            form_number: 'vba_21_4142',
-            user_account: anything
+            form_submission_attempt.benefits_intake_uuid,
+            '21-4142'
           )
         end
       end
@@ -137,10 +135,8 @@ RSpec.describe FormSubmissionAttempt, type: :model do
         form_submission_attempt.vbms!
 
         expect(SimpleFormsApi::Notification::SendNotificationEmailJob).to have_received(:perform_async).with(
-          notification_type:,
-          form_submission_attempt:,
-          form_number: anything,
-          user_account: anything
+          form_submission_attempt.benefits_intake_uuid,
+          form_submission_attempt.form_submission.form_type
         )
       end
     end

--- a/spec/models/form_submission_attempt_spec.rb
+++ b/spec/models/form_submission_attempt_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe FormSubmissionAttempt, type: :model do
 
           expect(SimpleFormsApi::Notification::SendNotificationEmailJob).to have_received(:perform_async).with(
             form_submission_attempt.benefits_intake_uuid,
-            '21-4142'
+            'vba_21_4142'
           )
         end
       end
@@ -136,7 +136,7 @@ RSpec.describe FormSubmissionAttempt, type: :model do
 
         expect(SimpleFormsApi::Notification::SendNotificationEmailJob).to have_received(:perform_async).with(
           form_submission_attempt.benefits_intake_uuid,
-          form_submission_attempt.form_submission.form_type
+          'vba_21_4142'
         )
       end
     end

--- a/spec/sidekiq/simple_forms_api/notification/send_notification_email_job_spec.rb
+++ b/spec/sidekiq/simple_forms_api/notification/send_notification_email_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SimpleFormsApi::Notification::SendNotificationEmailJob, type: :wo
   describe '#perform' do
     context 'form was submitted with a digital form submission tool' do
       let(:notification_type) { :confirmation }
-      let(:form_submission_attempt) { build(:form_submission_attempt) }
+      let(:form_submission_attempt) { create(:form_submission_attempt, :failure) }
       let(:form_number) { 'abc-123' }
       let(:user_account) { build(:user_account) }
       let(:notification_email) { double(send: nil) }
@@ -33,7 +33,7 @@ RSpec.describe SimpleFormsApi::Notification::SendNotificationEmailJob, type: :wo
 
     context 'form was submitted with Form Upload tool' do
       let(:notification_type) { :confirmation }
-      let(:form_submission_attempt) { build(:form_submission_attempt) }
+      let(:form_submission_attempt) { create(:form_submission_attempt, :failure) }
       let(:form_number) { '21-0779' }
       let(:user_account) { build(:user_account) }
       let(:form_upload_notification_email) { double(send: nil) }

--- a/spec/sidekiq/simple_forms_api/notification/send_notification_email_job_spec.rb
+++ b/spec/sidekiq/simple_forms_api/notification/send_notification_email_job_spec.rb
@@ -14,12 +14,7 @@ RSpec.describe SimpleFormsApi::Notification::SendNotificationEmailJob, type: :wo
       it 'sends the email' do
         allow(SimpleFormsApi::NotificationEmail).to receive(:new).and_return(notification_email)
 
-        described_class.new.perform(
-          notification_type:,
-          form_submission_attempt:,
-          form_number:,
-          user_account:
-        )
+        described_class.new.perform(form_submission_attempt.benefits_intake_uuid, form_number)
 
         expect(notification_email).to have_received(:send).with(at: anything)
       end
@@ -29,12 +24,7 @@ RSpec.describe SimpleFormsApi::Notification::SendNotificationEmailJob, type: :wo
           allow(SimpleFormsApi::NotificationEmail).to receive(:new)
           allow(StatsD).to receive(:increment)
 
-          described_class.new.perform(
-            notification_type: :error,
-            form_submission_attempt:,
-            form_number:,
-            user_account:
-          )
+          described_class.new.perform(form_submission_attempt.benefits_intake_uuid, form_number)
 
           expect(StatsD).to have_received(:increment).with('silent_failure', tags: anything)
         end
@@ -51,12 +41,7 @@ RSpec.describe SimpleFormsApi::Notification::SendNotificationEmailJob, type: :wo
       it 'sends the email' do
         allow(SimpleFormsApi::FormUploadNotificationEmail).to receive(:new).and_return(form_upload_notification_email)
 
-        described_class.new.perform(
-          notification_type:,
-          form_submission_attempt:,
-          form_number:,
-          user_account:
-        )
+        described_class.new.perform(form_submission_attempt.benefits_intake_uuid, form_number)
 
         expect(form_upload_notification_email).to have_received(:send).with(at: anything)
       end
@@ -66,12 +51,8 @@ RSpec.describe SimpleFormsApi::Notification::SendNotificationEmailJob, type: :wo
           allow(SimpleFormsApi::FormUploadNotificationEmail).to receive(:new).and_raise(ArgumentError)
           allow(StatsD).to receive(:increment)
 
-          described_class.new.perform(
-            notification_type: :error,
-            form_submission_attempt:,
-            form_number:,
-            user_account:
-          )
+          described_class.new.perform(form_submission_attempt.benefits_intake_uuid, form_number)
+
           expect(StatsD).to have_received(:increment).with('silent_failure', tags: anything)
         end
       end


### PR DESCRIPTION
## Summary
This PR replaces keyword args with positional args for the `SendNotificationEmailJob`. It turns out Sidekiq doesn't play nicely with keyword args.
