### PR TITLE
[SIMPLE-FORMS] fix: update send notification email job to account for perform_async args

### DIFF
--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -39,7 +39,7 @@ class FormSubmissionAttempt < ApplicationRecord
                      user_account_uuid: form_submission.user_account_id }
         if should_send_simple_forms_email
           Rails.logger.info('Preparing to send Form Submission Attempt error email', log_info)
-          simple_forms_enqueue_result_email(:error)
+          simple_forms_enqueue_result_email
         elsif form_type == CentralMail::SubmitForm4142Job::FORM4142_FORMSUBMISSION_TYPE
           form526_form4142_email(log_info)
         end
@@ -54,7 +54,7 @@ class FormSubmissionAttempt < ApplicationRecord
 
     event :vbms do
       after do
-        simple_forms_enqueue_result_email(:received) if should_send_simple_forms_email
+        simple_forms_enqueue_result_email if should_send_simple_forms_email
       end
 
       transitions from: :pending, to: :vbms
@@ -137,20 +137,13 @@ class FormSubmissionAttempt < ApplicationRecord
     simple_forms_form_number && Flipper.enabled?(:simple_forms_email_notifications)
   end
 
-  def simple_forms_enqueue_result_email(notification_type)
+  def simple_forms_enqueue_result_email
     form_number = simple_forms_form_number
-    Rails.logger.info('Queuing SimpleFormsAPI notification email to VaNotify', notification_type:, form_number:,
-                                                                               benefits_intake_uuid:)
-    jid = SimpleFormsApi::Notification::SendNotificationEmailJob.perform_async(
-      notification_type:,
-      form_submission_attempt: self,
-      form_number:,
-      user_account:
-    )
+    Rails.logger.info('Queuing SimpleFormsAPI notification email to VaNotify', form_number:, benefits_intake_uuid:)
+    jid = SimpleFormsApi::Notification::SendNotificationEmailJob.perform_async(benefits_intake_uuid, form_number)
     Rails.logger.info(
       'Queuing SimpleFormsAPI notification email to VaNotify completed',
       jid:,
-      notification_type:,
       form_number:,
       benefits_intake_uuid:
     )

--- a/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
+++ b/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
@@ -9,20 +9,17 @@ module SimpleFormsApi
 
       HOUR_TO_SEND_NOTIFICATIONS = 9
 
-      attr_reader :notification_type, :config, :form_number
-
       def perform(args)
+        raise ArgumentError, "Expected a Hash, got #{args.class}" unless args.is_a?(Hash)
+
         @notification_type = args[:notification_type]
         @form_number = args[:form_number]
         @user_account_id = args[:user_account_id]
         @form_submission_attempt_id = args[:form_submission_attempt_id]
-        @config = {
-          form_data: JSON.parse(form_submission_attempt.form_submission.form_data || '{}'),
-          form_number:,
-          confirmation_number: form_submission_attempt.benefits_intake_uuid,
-          date_submitted: form_submission_attempt.created_at.strftime('%B %d, %Y'),
-          lighthouse_updated_at: form_submission_attempt.lighthouse_updated_at&.strftime('%B %d, %Y')
-        }
+
+        return handle_exception(StandardError.new('Missing required arguments')) if missing_required_arguments?
+
+        @config = build_config
 
         return send_form_upload_notification_email if form_supported?
 
@@ -34,46 +31,66 @@ module SimpleFormsApi
       private
 
       def user_account
-        @user_account ||= UserAccount.find(@user_account_id)
+        @user_account ||= UserAccount.find_by(id: @user_account_id) || (raise ActiveRecord::RecordNotFound,
+                                                                              "UserAccount #{@user_account_id} not found")
       end
 
       def form_submission_attempt
-        @form_submission_attempt ||= FormSubmissionAttempt.find(@form_submission_attempt_id)
+        @form_submission_attempt ||= FormSubmissionAttempt.find_by(id: @form_submission_attempt_id) || (raise ActiveRecord::RecordNotFound,
+                                                                                                              "FormSubmissionAttempt #{@form_submission_attempt_id} not found")
       end
 
       def form_supported?
-        SimpleFormsApi::FormUploadNotificationEmail::SUPPORTED_FORMS.include? form_number
+        SimpleFormsApi::FormUploadNotificationEmail::SUPPORTED_FORMS.include?(@form_number)
       end
 
       def send_form_upload_notification_email
-        SimpleFormsApi::FormUploadNotificationEmail.new(config, notification_type:).send(at: time_to_send)
+        SimpleFormsApi::FormUploadNotificationEmail.new(@config,
+                                                        notification_type: @notification_type).send(at: time_to_send)
       end
 
       def send_notification_email
-        SimpleFormsApi::NotificationEmail.new(config, notification_type:, user_account:).send(at: time_to_send)
+        SimpleFormsApi::NotificationEmail.new(@config, notification_type: @notification_type,
+                                                       user_account:).send(at: time_to_send)
       end
 
       def time_to_send
-        now = Time.now.in_time_zone('Eastern Time (US & Canada)')
-        if now.hour < HOUR_TO_SEND_NOTIFICATIONS
-          now.change(hour: HOUR_TO_SEND_NOTIFICATIONS, min: 0)
-        else
-          now.tomorrow.change(hour: HOUR_TO_SEND_NOTIFICATIONS, min: 0)
-        end
+        now = Time.zone.now.in_time_zone('Eastern Time (US & Canada)')
+        target_time = now.change(hour: HOUR_TO_SEND_NOTIFICATIONS, min: 0)
+
+        now.hour < HOUR_TO_SEND_NOTIFICATIONS ? target_time : target_time.tomorrow
       end
 
       def statsd_tags
-        { 'service' => 'veteran-facing-forms', 'function' => "#{form_number} form submission to Lighthouse" }
+        { 'service' => 'veteran-facing-forms', 'function' => "#{@form_number} form submission to Lighthouse" }
       end
 
       def handle_exception(e)
         Rails.logger.error(
-          'Error sending simple forms notification email',
-          message: e.message,
-          notification_type:,
-          confirmation_number: config[:confirmation_number]
+          {
+            error: 'Error sending simple forms notification email',
+            message: e.message,
+            notification_type: @notification_type.to_s,
+            confirmation_number: @config&.dig(:confirmation_number)
+          }.to_json
         )
-        StatsD.increment('silent_failure', tags: statsd_tags) if notification_type == :error
+
+        StatsD.increment('silent_failure', tags: statsd_tags) if @notification_type == :error
+      end
+
+      def missing_required_arguments?
+        [@notification_type, @form_number, @user_account_id, @form_submission_attempt_id].any?(&:nil?)
+      end
+
+      def build_config
+        attempt = form_submission_attempt
+        {
+          form_data: JSON.parse(attempt.form_submission.form_data.presence || '{}'),
+          form_number: @form_number,
+          confirmation_number: attempt.benefits_intake_uuid,
+          date_submitted: attempt.created_at.strftime('%B %d, %Y'),
+          lighthouse_updated_at: attempt.lighthouse_updated_at&.strftime('%B %d, %Y')
+        }
       end
     end
   end

--- a/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
+++ b/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
@@ -15,9 +15,7 @@ module SimpleFormsApi
         @user_account = form_submission_attempt.user_account
         @form_submission = form_submission_attempt.form_submission
 
-        return form_upload_notification_email.send(at: time_to_send) if form_supported?
-
-        notification_email.send(at: time_to_send)
+        send_email
       rescue => e
         handle_exception(e)
       end
@@ -70,6 +68,12 @@ module SimpleFormsApi
         target_time = now.change(hour: HOUR_TO_SEND_NOTIFICATIONS, min: 0)
 
         now.hour < HOUR_TO_SEND_NOTIFICATIONS ? target_time : target_time.tomorrow
+      end
+
+      def send_email
+        email = form_supported? ? form_upload_notification_email : notification_email
+
+        email.send(at: time_to_send)
       end
 
       def statsd_tags

--- a/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
+++ b/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
@@ -78,12 +78,10 @@ module SimpleFormsApi
 
       def handle_exception(e)
         Rails.logger.error(
-          {
-            error: 'Error sending simple forms notification email',
-            message: e.message,
-            notification_type:,
-            confirmation_number: config&.dig(:confirmation_number)
-          }.to_json
+          'Error sending simple forms notification email',
+          message: e.message,
+          notification_type:,
+          confirmation_number: config&.dig(:confirmation_number)
         )
 
         StatsD.increment('silent_failure', tags: statsd_tags) if notification_type == :error

--- a/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
+++ b/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
@@ -58,11 +58,11 @@ module SimpleFormsApi
       end
 
       def form_upload_notification_email
-        SimpleFormsApi::FormUploadNotificationEmail.new(@config, notification_type:)
+        SimpleFormsApi::FormUploadNotificationEmail.new(config, notification_type:)
       end
 
       def notification_email
-        SimpleFormsApi::NotificationEmail.new(@config, notification_type:, user_account:)
+        SimpleFormsApi::NotificationEmail.new(config, notification_type:, user_account:)
       end
 
       def time_to_send
@@ -82,7 +82,7 @@ module SimpleFormsApi
             error: 'Error sending simple forms notification email',
             message: e.message,
             notification_type:,
-            confirmation_number: @config&.dig(:confirmation_number)
+            confirmation_number: config&.dig(:confirmation_number)
           }.to_json
         )
 

--- a/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
+++ b/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
@@ -51,7 +51,7 @@ module SimpleFormsApi
         }
       end
 
-      def form_supported?
+      def form_upload_supported?
         SimpleFormsApi::FormUploadNotificationEmail::SUPPORTED_FORMS.include?(form_number)
       end
 
@@ -71,7 +71,7 @@ module SimpleFormsApi
       end
 
       def send_email
-        email = form_supported? ? form_upload_notification_email : notification_email
+        email = form_upload_supported? ? form_upload_notification_email : notification_email
 
         email.send(at: time_to_send)
       end

--- a/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
+++ b/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
@@ -9,17 +9,11 @@ module SimpleFormsApi
 
       HOUR_TO_SEND_NOTIFICATIONS = 9
 
-      def perform(args)
-        raise ArgumentError, "Expected a Hash, got #{args.class}" unless args.is_a?(Hash)
-
-        @notification_type = args[:notification_type]
-        @form_number = args[:form_number]
-        @user_account_id = args[:user_account_id]
-        @form_submission_attempt_id = args[:form_submission_attempt_id]
-
-        return handle_exception(StandardError.new('Missing required arguments')) if missing_required_arguments?
-
-        @config = build_config
+      def perform(benefits_intake_uuid, form_number)
+        @benefits_intake_uuid = benefits_intake_uuid
+        @form_number = form_number
+        @user_account = form_submission_attempt.user_account
+        @form_submission = form_submission_attempt.form_submission
 
         return form_upload_notification_email.send(at: time_to_send) if form_supported?
 
@@ -30,13 +24,18 @@ module SimpleFormsApi
 
       private
 
-      def user_account
-        @user_account ||= UserAccount.find_by(id: @user_account_id) ||
-                          raise_not_found_error('UserAccount', id)
+      attr_accessor :user_account, :form_number, :form_submission
+
+      def notification_type
+        if form_submission_attempt.failure?
+          :error
+        elsif form_submission_attempt.vbms?
+          :received
+        end
       end
 
       def form_submission_attempt
-        @form_submission_attempt ||= FormSubmissionAttempt.find_by(id: @form_submission_attempt_id) ||
+        @form_submission_attempt ||= FormSubmissionAttempt.find_by(benefits_intake_uuid: @benefits_intake_uuid) ||
                                      raise_not_found_error('FormSubmissionAttempt', id)
       end
 
@@ -44,16 +43,26 @@ module SimpleFormsApi
         raise ActiveRecord::RecordNotFound, "#{resource} #{id} not found"
       end
 
+      def config
+        {
+          form_data: JSON.parse(form_submission.form_data.presence || '{}'),
+          form_number:,
+          confirmation_number: @benefits_intake_uuid,
+          date_submitted: form_submission_attempt.created_at.strftime('%B %d, %Y'),
+          lighthouse_updated_at: form_submission_attempt.lighthouse_updated_at&.strftime('%B %d, %Y')
+        }
+      end
+
       def form_supported?
-        SimpleFormsApi::FormUploadNotificationEmail::SUPPORTED_FORMS.include?(@form_number)
+        SimpleFormsApi::FormUploadNotificationEmail::SUPPORTED_FORMS.include?(form_number)
       end
 
       def form_upload_notification_email
-        SimpleFormsApi::FormUploadNotificationEmail.new(@config, notification_type: @notification_type)
+        SimpleFormsApi::FormUploadNotificationEmail.new(@config, notification_type:)
       end
 
       def notification_email
-        SimpleFormsApi::NotificationEmail.new(@config, notification_type: @notification_type, user_account:)
+        SimpleFormsApi::NotificationEmail.new(@config, notification_type:, user_account:)
       end
 
       def time_to_send
@@ -64,7 +73,7 @@ module SimpleFormsApi
       end
 
       def statsd_tags
-        { 'service' => 'veteran-facing-forms', 'function' => "#{@form_number} form submission to Lighthouse" }
+        { 'service' => 'veteran-facing-forms', 'function' => "#{form_number} form submission to Lighthouse" }
       end
 
       def handle_exception(e)
@@ -72,27 +81,12 @@ module SimpleFormsApi
           {
             error: 'Error sending simple forms notification email',
             message: e.message,
-            notification_type: @notification_type.to_s,
+            notification_type:,
             confirmation_number: @config&.dig(:confirmation_number)
           }.to_json
         )
 
-        StatsD.increment('silent_failure', tags: statsd_tags) if @notification_type == :error
-      end
-
-      def missing_required_arguments?
-        [@notification_type, @form_number, @user_account_id, @form_submission_attempt_id].any?(&:nil?)
-      end
-
-      def build_config
-        attempt = form_submission_attempt
-        {
-          form_data: JSON.parse(attempt.form_submission.form_data.presence || '{}'),
-          form_number: @form_number,
-          confirmation_number: attempt.benefits_intake_uuid,
-          date_submitted: attempt.created_at.strftime('%B %d, %Y'),
-          lighthouse_updated_at: attempt.lighthouse_updated_at&.strftime('%B %d, %Y')
-        }
+        StatsD.increment('silent_failure', tags: statsd_tags) if notification_type == :error
       end
     end
   end

--- a/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
+++ b/app/sidekiq/simple_forms_api/notification/send_notification_email_job.rb
@@ -15,6 +15,8 @@ module SimpleFormsApi
         @user_account = form_submission_attempt.user_account
         @form_submission = form_submission_attempt.form_submission
 
+        return unless valid_notification?
+
         send_email
       rescue => e
         handle_exception(e)
@@ -23,6 +25,10 @@ module SimpleFormsApi
       private
 
       attr_accessor :user_account, :form_number, :form_submission
+
+      def valid_notification?
+        form_submission_attempt.failure? || form_submission_attempt.vbms?
+      end
 
       def notification_type
         if form_submission_attempt.failure?
@@ -34,7 +40,7 @@ module SimpleFormsApi
 
       def form_submission_attempt
         @form_submission_attempt ||= FormSubmissionAttempt.find_by(benefits_intake_uuid: @benefits_intake_uuid) ||
-                                     raise_not_found_error('FormSubmissionAttempt', id)
+                                     raise_not_found_error('FormSubmissionAttempt', @benefits_intake_uuid)
       end
 
       def raise_not_found_error(resource, id)

--- a/spec/models/form_submission_attempt_spec.rb
+++ b/spec/models/form_submission_attempt_spec.rb
@@ -38,10 +38,8 @@ RSpec.describe FormSubmissionAttempt, type: :model do
           form_submission_attempt.fail!
 
           expect(SimpleFormsApi::Notification::SendNotificationEmailJob).to have_received(:perform_async).with(
-            notification_type:,
-            form_submission_attempt:,
-            form_number: 'vba_21_4142',
-            user_account: anything
+            form_submission_attempt.benefits_intake_uuid,
+            'vba_21_4142'
           )
         end
       end
@@ -137,10 +135,8 @@ RSpec.describe FormSubmissionAttempt, type: :model do
         form_submission_attempt.vbms!
 
         expect(SimpleFormsApi::Notification::SendNotificationEmailJob).to have_received(:perform_async).with(
-          notification_type:,
-          form_submission_attempt:,
-          form_number: anything,
-          user_account: anything
+          form_submission_attempt.benefits_intake_uuid,
+          'vba_21_4142'
         )
       end
     end

--- a/spec/sidekiq/simple_forms_api/notification/send_notification_email_job_spec.rb
+++ b/spec/sidekiq/simple_forms_api/notification/send_notification_email_job_spec.rb
@@ -3,84 +3,69 @@
 require 'rails_helper'
 
 RSpec.describe SimpleFormsApi::Notification::SendNotificationEmailJob, type: :worker do
-  let(:notification_email) { instance_double(SimpleFormsApi::NotificationEmail, send: nil) }
-  let(:form_upload_notification_email) { instance_double(SimpleFormsApi::FormUploadNotificationEmail, send: nil) }
-  let(:notification_type) { :confirmation }
-  let(:form_submission_attempt) { create(:form_submission_attempt) }
-  let(:form_number) { '21-0779' }
-  let(:user_account) { create(:user_account) }
-  let(:args) do
-    {
-      notification_type:,
-      form_submission_attempt_id: form_submission_attempt.id,
-      form_number:,
-      user_account_id: user_account.id
-    }
-  end
-
-  before do
-    allow(UserAccount).to receive(:find).with(user_account.id).and_return(user_account)
-    allow(FormSubmissionAttempt).to receive(:find).with(form_submission_attempt.id).and_return(form_submission_attempt)
-    allow(SimpleFormsApi::NotificationEmail).to receive(:new).and_return(notification_email)
-    allow(SimpleFormsApi::FormUploadNotificationEmail).to receive(:new).and_return(form_upload_notification_email)
-    allow(StatsD).to receive(:increment)
-  end
+  let(:form_submission_attempt) { create(:form_submission_attempt, :failure) }
+  let(:form_number) { 'abc-123' }
 
   describe '#perform' do
-    subject(:perform) { described_class.new.perform(args) }
+    context 'form was submitted with a digital form submission tool' do
+      let(:notification_type) { :confirmation }
+      let(:user_account) { build(:user_account) }
+      let(:notification_email) { double(send: nil) }
 
-    context 'when the form is submitted using the digital form submission tool' do
-      before { perform }
+      it 'sends the email' do
+        allow(SimpleFormsApi::NotificationEmail).to receive(:new).and_return(notification_email)
 
-      it 'sends a notification email' do
+        described_class.new.perform(form_submission_attempt.benefits_intake_uuid, form_number)
+
         expect(notification_email).to have_received(:send).with(at: anything)
       end
+
+      context 'SimpleFormsApi::NotificationEmail initialization fails' do
+        it 'increments statsd' do
+          allow(SimpleFormsApi::NotificationEmail).to receive(:new)
+          allow(StatsD).to receive(:increment)
+
+          described_class.new.perform(form_submission_attempt.benefits_intake_uuid, form_number)
+
+          expect(StatsD).to have_received(:increment).with('silent_failure', tags: anything)
+        end
+      end
     end
 
-    context 'when the form is submitted with the Form Upload tool' do
-      before do
-        allow(SimpleFormsApi::FormUploadNotificationEmail).to receive(:SUPPORTED_FORMS).and_return([form_number])
-        perform
-      end
+    context 'form was submitted with Form Upload tool' do
+      let(:notification_type) { :confirmation }
+      let(:form_submission_attempt) { create(:form_submission_attempt, :failure) }
+      let(:form_number) { '21-0779' }
+      let(:user_account) { build(:user_account) }
+      let(:form_upload_notification_email) { double(send: nil) }
 
-      it 'sends a form upload notification email' do
+      it 'sends the email' do
+        allow(SimpleFormsApi::FormUploadNotificationEmail).to receive(:new).and_return(form_upload_notification_email)
+
+        described_class.new.perform(form_submission_attempt.benefits_intake_uuid, form_number)
+
         expect(form_upload_notification_email).to have_received(:send).with(at: anything)
       end
-    end
 
-    context 'when an error occurs during email sending' do
-      let(:error_message) { 'Test error' }
+      context 'SimpleFormsApi::FormUploadNotificationEmail initialization fails' do
+        it 'increments statsd' do
+          allow(SimpleFormsApi::FormUploadNotificationEmail).to receive(:new).and_raise(ArgumentError)
+          allow(StatsD).to receive(:increment)
 
-      before do
-        allow(notification_email).to receive(:send).and_raise(StandardError, error_message)
-        allow(Rails.logger).to receive(:error)
-      end
+          described_class.new.perform(form_submission_attempt.benefits_intake_uuid, form_number)
 
-      it 'logs an error' do
-        expect { perform }.to raise_error(StandardError, error_message)
-        expect(Rails.logger).to have_received(:error).with(
-          hash_including(message: error_message)
-        )
-      end
-
-      it 'increments StatsD for silent failures' do
-        expect { perform }.to raise_error(StandardError)
-        expect(StatsD).to have_received(:increment).with('silent_failure', tags: anything)
-      end
-    end
-
-    context 'when required arguments are missing' do
-      let(:args) { {} }
-
-      it 'raises an ArgumentError' do
-        expect { perform }.to raise_error(ArgumentError, /Expected a Hash, got/)
+          expect(StatsD).to have_received(:increment).with('silent_failure', tags: anything)
+        end
       end
     end
   end
 
-  describe '#perform_async' do
+  describe '.perform_async' do
     it 'enqueues the job' do
-      expect { described_class.perform_async(args) }.to change(described_class.jobs, :size).by(1)
+      expect do
+        described_class.perform_async(form_submission_attempt.benefits_intake_uuid,
+                                      form_number)
+      end.to change(described_class.jobs, :size).by(1)
     end
   end
 end

--- a/spec/sidekiq/simple_forms_api/notification/send_notification_email_job_spec.rb
+++ b/spec/sidekiq/simple_forms_api/notification/send_notification_email_job_spec.rb
@@ -3,69 +3,56 @@
 require 'rails_helper'
 
 RSpec.describe SimpleFormsApi::Notification::SendNotificationEmailJob, type: :worker do
+  subject(:perform) { described_class.new.perform(benefits_intake_uuid, form_number) }
+
   let(:form_submission_attempt) { create(:form_submission_attempt, :failure) }
   let(:form_number) { 'abc-123' }
+  let(:benefits_intake_uuid) { form_submission_attempt.benefits_intake_uuid }
 
   describe '#perform' do
-    context 'form was submitted with a digital form submission tool' do
-      let(:notification_type) { :confirmation }
-      let(:user_account) { build(:user_account) }
-      let(:notification_email) { double(send: nil) }
+    shared_examples 'sends notification email' do |email_class|
+      let(:notification_email) { instance_double(email_class, send: nil) }
+
+      before do
+        allow(email_class).to receive(:new).and_return(notification_email)
+      end
 
       it 'sends the email' do
-        allow(SimpleFormsApi::NotificationEmail).to receive(:new).and_return(notification_email)
-
-        described_class.new.perform(form_submission_attempt.benefits_intake_uuid, form_number)
-
+        perform
         expect(notification_email).to have_received(:send).with(at: anything)
       end
 
-      context 'SimpleFormsApi::NotificationEmail initialization fails' do
-        it 'increments statsd' do
-          allow(SimpleFormsApi::NotificationEmail).to receive(:new)
+      context 'when email initialization fails' do
+        before do
+          allow(email_class).to receive(:new).and_raise(ArgumentError)
           allow(StatsD).to receive(:increment)
+        end
 
-          described_class.new.perform(form_submission_attempt.benefits_intake_uuid, form_number)
-
+        it 'increments StatsD' do
+          perform
           expect(StatsD).to have_received(:increment).with('silent_failure', tags: anything)
         end
       end
     end
 
-    context 'form was submitted with Form Upload tool' do
-      let(:notification_type) { :confirmation }
-      let(:form_submission_attempt) { create(:form_submission_attempt, :failure) }
+    context 'when submitted with digital form submission tool' do
+      let(:form_number) { 'abc-123' }
+
+      it_behaves_like 'sends notification email', SimpleFormsApi::NotificationEmail
+    end
+
+    context 'when submitted with Form Upload tool' do
       let(:form_number) { '21-0779' }
-      let(:user_account) { build(:user_account) }
-      let(:form_upload_notification_email) { double(send: nil) }
 
-      it 'sends the email' do
-        allow(SimpleFormsApi::FormUploadNotificationEmail).to receive(:new).and_return(form_upload_notification_email)
-
-        described_class.new.perform(form_submission_attempt.benefits_intake_uuid, form_number)
-
-        expect(form_upload_notification_email).to have_received(:send).with(at: anything)
-      end
-
-      context 'SimpleFormsApi::FormUploadNotificationEmail initialization fails' do
-        it 'increments statsd' do
-          allow(SimpleFormsApi::FormUploadNotificationEmail).to receive(:new).and_raise(ArgumentError)
-          allow(StatsD).to receive(:increment)
-
-          described_class.new.perform(form_submission_attempt.benefits_intake_uuid, form_number)
-
-          expect(StatsD).to have_received(:increment).with('silent_failure', tags: anything)
-        end
-      end
+      it_behaves_like 'sends notification email', SimpleFormsApi::FormUploadNotificationEmail
     end
   end
 
   describe '.perform_async' do
+    subject(:perform_async) { described_class.perform_async(benefits_intake_uuid, form_number) }
+
     it 'enqueues the job' do
-      expect do
-        described_class.perform_async(form_submission_attempt.benefits_intake_uuid,
-                                      form_number)
-      end.to change(described_class.jobs, :size).by(1)
+      expect { perform_async }.to change(described_class.jobs, :size).by(1)
     end
   end
 end

--- a/spec/sidekiq/simple_forms_api/notification/send_notification_email_job_spec.rb
+++ b/spec/sidekiq/simple_forms_api/notification/send_notification_email_job_spec.rb
@@ -3,78 +3,84 @@
 require 'rails_helper'
 
 RSpec.describe SimpleFormsApi::Notification::SendNotificationEmailJob, type: :worker do
+  let(:notification_email) { double(send: nil) }
+  let(:form_upload_notification_email) { double(send: nil) }
+  let(:notification_type) { :confirmation }
+  let(:form_submission_attempt) { build(:form_submission_attempt) }
+  let(:form_number) { '21-0779' }
+  let(:user_account) { build(:user_account) }
+  let(:args) do
+    {
+      notification_type:,
+      form_submission_attempt_id: form_submission_attempt.id,
+      form_number:,
+      user_account_id: user_account.id
+    }
+  end
+
+  before do
+    allow(UserAccount).to receive(:find).and_return(user_account)
+    allow(FormSubmissionAttempt).to receive(:find).and_return(form_submission_attempt)
+    allow(SimpleFormsApi::NotificationEmail).to receive(:new).and_return(notification_email)
+    allow(SimpleFormsApi::FormUploadNotificationEmail).to receive(:new).and_return(form_upload_notification_email)
+    allow(StatsD).to receive(:increment)
+  end
+
   describe '#perform' do
+    subject(:perform) { described_class.new.perform(args) }
+
+    before { perform }
+
     context 'form was submitted with a digital form submission tool' do
-      let(:notification_type) { :confirmation }
-      let(:form_submission_attempt) { build(:form_submission_attempt) }
-      let(:form_number) { 'abc-123' }
-      let(:user_account) { build(:user_account) }
-      let(:notification_email) { double(send: nil) }
-
       it 'sends the email' do
-        allow(SimpleFormsApi::NotificationEmail).to receive(:new).and_return(notification_email)
-
-        described_class.new.perform(
-          notification_type:,
-          form_submission_attempt:,
-          form_number:,
-          user_account:
-        )
-
         expect(notification_email).to have_received(:send).with(at: anything)
       end
 
       context 'SimpleFormsApi::NotificationEmail initialization fails' do
         it 'increments statsd' do
-          allow(SimpleFormsApi::NotificationEmail).to receive(:new)
-          allow(StatsD).to receive(:increment)
-
-          described_class.new.perform(
-            notification_type: :error,
-            form_submission_attempt:,
-            form_number:,
-            user_account:
-          )
-
           expect(StatsD).to have_received(:increment).with('silent_failure', tags: anything)
         end
       end
     end
 
     context 'form was submitted with Form Upload tool' do
-      let(:notification_type) { :confirmation }
-      let(:form_submission_attempt) { build(:form_submission_attempt) }
-      let(:form_number) { '21-0779' }
-      let(:user_account) { build(:user_account) }
-      let(:form_upload_notification_email) { double(send: nil) }
-
       it 'sends the email' do
-        allow(SimpleFormsApi::FormUploadNotificationEmail).to receive(:new).and_return(form_upload_notification_email)
-
-        described_class.new.perform(
-          notification_type:,
-          form_submission_attempt:,
-          form_number:,
-          user_account:
-        )
-
         expect(form_upload_notification_email).to have_received(:send).with(at: anything)
       end
 
       context 'SimpleFormsApi::FormUploadNotificationEmail initialization fails' do
-        it 'increments statsd' do
+        before do
           allow(SimpleFormsApi::FormUploadNotificationEmail).to receive(:new).and_raise(ArgumentError)
-          allow(StatsD).to receive(:increment)
+        end
 
-          described_class.new.perform(
-            notification_type: :error,
-            form_submission_attempt:,
-            form_number:,
-            user_account:
-          )
+        it 'increments statsd' do
           expect(StatsD).to have_received(:increment).with('silent_failure', tags: anything)
         end
       end
+    end
+  end
+
+  describe '#perform_async' do
+    subject(:perform_async) { described_class.perform_async(args) }
+
+    before do
+      perform_async
+    end
+
+    it 'enqueues the job' do
+      expect(described_class).to respond_to(:perform_async)
+    end
+
+    it 'finds the user account' do
+      expect(UserAccount).to have_received(:find).with(user_account.id)
+    end
+
+    it 'finds the form submission attempt' do
+      expect(FormSubmissionAttempt).to have_received(:find).with(form_submission_attempt.id)
+    end
+
+    it 'initializes the notification email' do
+      expect(SimpleFormsApi::NotificationEmail).to have_received(:new)
     end
   end
 end


### PR DESCRIPTION
## Summary

- This work refactors the SendNotificationEmailJob to use a simplified parameter scheme in order to avoid any Sidekiq related state/data drops.
- This work also updates the FormSubmissionAttempt to call this job in the proper way
- This work also updates code coverage around the updated logic to be more streamlined and ensure full test coverage is met.
- I work on the Veteran Facing Forms team which owns this logic.

## Related issue(s)

- [[Zero Silent Failures] - Failure email notification job is failing to queue](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/2062)

## Testing done

- [x] *New code is covered by unit tests*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

Any
