### PR TITLE
Remove unused appointments feature toggles - 5

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1562,10 +1562,6 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle for routing slots search requests to the VetsAPI Gateway Service(VPG) instead of vaos-service
-  va_online_scheduling_datadog_RUM:
-    actor_type: user
-    description: Enables datadog Real User Monitoring.
-    enable_in_development: true
   va_online_scheduling_cc_direct_scheduling:
     actor_type: user
     description: Enables CC direct scheduling.


### PR DESCRIPTION
## Summary

- Removing some of the obsolete feature toggles for features that have been fully released.
- Appointments tools team
- This PR can only be merged after https://github.com/department-of-veterans-affairs/vets-website/pull/35081 is merged.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103882

## Testing done

- [x] ~~*New code is covered by unit tests*~~ ensured existing tests pass

## Screenshots
N/A

## What areas of the site does it impact?
Appointments tools

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  ~~Documentation has been updated (link to documentation)~~ Will update documentation after PRs are merged and feature toggles fully deleted from Flipper
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
