### PR TITLE
Implement VAOS referral controller

### DIFF
--- a/modules/vaos/app/controllers/vaos/v2/referrals_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/referrals_controller.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module VAOS
+  module V2
+    # ReferralsController provides endpoints for fetching CCRA referrals
+    # It uses the Ccra::ReferralService to interact with the underlying CCRA API
+    class ReferralsController < VAOS::BaseController
+      # GET /v2/referrals
+      # Fetches a list of referrals for the current user
+      def index
+        response = referral_service.get_vaos_referral_list(
+          current_user.icn,
+          referral_status_param
+        )
+
+        render json: Ccra::ReferralListSerializer.new(response)
+      end
+
+      # GET /v2/referrals/:id
+      # Fetches a specific referral by ID
+      def show
+        response = referral_service.get_referral(
+          referral_id,
+          referral_mode_param
+        )
+
+        render json: Ccra::ReferralDetailSerializer.new(response)
+      end
+
+      private
+
+      # The referral ID from request parameters
+      # @return [String] the referral ID
+      def referral_id
+        params.require(:id)
+      end
+
+      # The referral mode parameter (defaults to 'C' if not provided)
+      # @return [String] the referral mode
+      def referral_mode_param
+        # TODO: Need to verify what modes we can allow. API spec is not clear.
+        params.fetch(:mode, 'C')
+      end
+
+      # The referral status parameter for filtering referrals
+      # @return [String] the referral status
+      def referral_status_param
+        # TODO: Need to verify what statuses we can allow. API spec is not clear.
+        params.fetch(:status, "'S','BP','AP','AC','A','I'")
+      end
+
+      # Memoized referral service instance
+      # @return [Ccra::ReferralService] the referral service
+      def referral_service
+        @referral_service ||= Ccra::ReferralService.new(current_user)
+      end
+    end
+  end
+end

--- a/modules/vaos/app/controllers/vaos/v2/referrals_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/referrals_controller.rb
@@ -13,7 +13,7 @@ module VAOS
           referral_status_param
         )
 
-        render json: Ccra::ReferralListSerializer.new(response)
+        render json: Ccra::ReferralListSerializer.new(response).serializable_hash
       end
 
       # GET /v2/referrals/:id
@@ -24,7 +24,7 @@ module VAOS
           referral_mode_param
         )
 
-        render json: Ccra::ReferralDetailSerializer.new(response)
+        render json: Ccra::ReferralDetailSerializer.new(response).serializable_hash
       end
 
       private

--- a/modules/vaos/app/serializers/ccra/referral_detail_serializer.rb
+++ b/modules/vaos/app/serializers/ccra/referral_detail_serializer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Ccra
+  # Serializer for detailed referral information
+  # Used by the ReferralsController to serialize a single referral's details
+  class ReferralDetailSerializer
+    include JSONAPI::Serializer
+
+    set_type :referral
+
+    # Serializes the referral detail
+    def initialize(referral)
+      @referral = referral
+    end
+
+    def as_json(*)
+      {
+        id: @referral.referral_number,
+        type_of_care: @referral.type_of_care,
+        provider_name: @referral.provider_name,
+        location: @referral.location,
+        expiration_date: @referral.expiration_date
+      }.compact
+    end
+  end
+end

--- a/modules/vaos/app/serializers/ccra/referral_detail_serializer.rb
+++ b/modules/vaos/app/serializers/ccra/referral_detail_serializer.rb
@@ -6,21 +6,12 @@ module Ccra
   class ReferralDetailSerializer
     include JSONAPI::Serializer
 
+    set_id :referral_number
     set_type :referral
 
-    # Serializes the referral detail
-    def initialize(referral)
-      @referral = referral
-    end
-
-    def as_json(*)
-      {
-        id: @referral.referral_number,
-        type_of_care: @referral.type_of_care,
-        provider_name: @referral.provider_name,
-        location: @referral.location,
-        expiration_date: @referral.expiration_date
-      }.compact
-    end
+    attribute :type_of_care
+    attribute :provider_name
+    attribute :location
+    attribute :expiration_date
   end
 end

--- a/modules/vaos/app/serializers/ccra/referral_list_serializer.rb
+++ b/modules/vaos/app/serializers/ccra/referral_list_serializer.rb
@@ -6,21 +6,20 @@ module Ccra
   class ReferralListSerializer
     include JSONAPI::Serializer
 
+    set_id :referral_id
     set_type :referrals
 
-    # Serialize each referral list entry as an array
-    def initialize(referrals)
-      @referrals = referrals || []
+    attribute :type_of_care
+
+    attribute :expiration_date do |referral|
+      referral.expiration_date&.strftime('%Y-%m-%d')
     end
 
-    def as_json(*)
-      @referrals.map do |referral|
-        {
-          id: referral.referral_id,
-          type_of_care: referral.type_of_care,
-          expiration_date: referral.expiration_date&.strftime('%Y-%m-%d')
-        }.compact
-      end
+    # Override to handle nil collection
+    def serializable_hash(...)
+      return { data: [] } unless @resource.is_a?(Array)
+
+      super
     end
   end
 end

--- a/modules/vaos/app/serializers/ccra/referral_list_serializer.rb
+++ b/modules/vaos/app/serializers/ccra/referral_list_serializer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Ccra
+  # Serializer for referral list entries
+  # Used by the ReferralsController to serialize lists of referrals
+  class ReferralListSerializer
+    include JSONAPI::Serializer
+
+    set_type :referrals
+
+    # Serialize each referral list entry as an array
+    def initialize(referrals)
+      @referrals = referrals || []
+    end
+
+    def as_json(*)
+      @referrals.map do |referral|
+        {
+          id: referral.referral_id,
+          type_of_care: referral.type_of_care,
+          expiration_date: referral.expiration_date&.strftime('%Y-%m-%d')
+        }.compact
+      end
+    end
+  end
+end

--- a/modules/vaos/config/routes.rb
+++ b/modules/vaos/config/routes.rb
@@ -22,5 +22,9 @@ VAOS::Engine.routes.draw do
     post '/appointments', to: 'appointments#create'
     post '/appointments/draft', to: 'appointments#create_draft'
     post '/appointments/submit', to: 'appointments#submit_referral_appointment'
+
+    # Referrals routes
+    get '/referrals', to: 'referrals#index'
+    get '/referrals/:id', to: 'referrals#show'
   end
 end

--- a/modules/vaos/spec/controllers/v2/referrals_controller_spec.rb
+++ b/modules/vaos/spec/controllers/v2/referrals_controller_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe VAOS::V2::ReferralsController, type: :request do
+  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+  let(:referral_id) { '5682' }
+  let(:inflection_header) { { 'X-Key-Inflection' => 'camel' } }
+  let(:referral_statuses) { "'S','BP','AP','AC','A','I'" }
+  let(:referral_mode) { 'C' }
+
+  before do
+    allow(Rails).to receive(:cache).and_return(memory_store)
+    Rails.cache.clear
+  end
+
+  describe 'GET index' do
+    context 'when called without authorization' do
+      let(:resp) do
+        {
+          'errors' => [
+            {
+              'title' => 'Not authorized',
+              'detail' => 'Not authorized',
+              'code' => '401',
+              'status' => '401'
+            }
+          ]
+        }
+      end
+
+      it 'throws unauthorized exception' do
+        get '/vaos/v2/referrals'
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)).to eq(resp)
+      end
+    end
+
+    context 'when called with authorization' do
+      let(:icn) { '1012845331V153043' }
+      let(:user) { build(:user, :vaos, :loa3, icn:) }
+      let(:referral_list_entries) { build_list(:ccra_referral_list_entry, 3) }
+
+      before do
+        sign_in_as(user)
+        allow_any_instance_of(Ccra::ReferralService).to receive(:get_vaos_referral_list)
+          .with(icn, referral_statuses)
+          .and_return(referral_list_entries)
+      end
+
+      it 'returns a list of referrals' do
+        get '/vaos/v2/referrals'
+
+        expect(response).to have_http_status(:ok)
+
+        response_data = JSON.parse(response.body)
+        expect(response_data).to be_a(Array)
+        expect(response_data.size).to eq(3)
+
+        # Verify first referral entry structure
+        first_referral = response_data.first
+        expect(first_referral['id']).to eq('5682')
+        expect(first_referral['type_of_care']).to eq('CARDIOLOGY')
+        expect(first_referral['expiration_date']).to eq('2024-05-27')
+      end
+
+      context 'with a custom status parameter' do
+        let(:custom_statuses) { "'A','I'" }
+
+        before do
+          allow_any_instance_of(Ccra::ReferralService).to receive(:get_vaos_referral_list)
+            .with(icn, custom_statuses)
+            .and_return(referral_list_entries)
+        end
+
+        it 'passes the correct status to the service' do
+          get '/vaos/v2/referrals', params: { status: custom_statuses }
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+
+  describe 'GET show' do
+    context 'when called without authorization' do
+      let(:resp) do
+        {
+          'errors' => [
+            {
+              'title' => 'Not authorized',
+              'detail' => 'Not authorized',
+              'code' => '401',
+              'status' => '401'
+            }
+          ]
+        }
+      end
+
+      it 'throws unauthorized exception' do
+        get "/vaos/v2/referrals/#{referral_id}"
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)).to eq(resp)
+      end
+    end
+
+    context 'when called with authorization' do
+      let(:user) { build(:user, :vaos, :loa3) }
+      let(:referral_detail) { build(:ccra_referral_detail, referral_number: referral_id) }
+
+      before do
+        sign_in_as(user)
+        allow_any_instance_of(Ccra::ReferralService).to receive(:get_referral)
+          .with(referral_id, referral_mode)
+          .and_return(referral_detail)
+      end
+
+      it 'returns a referral detail' do
+        get "/vaos/v2/referrals/#{referral_id}"
+
+        expect(response).to have_http_status(:ok)
+
+        response_data = JSON.parse(response.body)
+        expect(response_data['id']).to eq(referral_id)
+        expect(response_data['type_of_care']).to eq('CARDIOLOGY')
+        expect(response_data['provider_name']).to eq('Dr. Smith')
+        expect(response_data['location']).to eq('VA Medical Center')
+        expect(response_data['expiration_date']).to eq('2024-05-27')
+      end
+
+      context 'with a custom mode parameter' do
+        let(:custom_mode) { 'A' }
+
+        before do
+          allow_any_instance_of(Ccra::ReferralService).to receive(:get_referral)
+            .with(referral_id, custom_mode)
+            .and_return(referral_detail)
+        end
+
+        it 'passes the correct mode to the service' do
+          get "/vaos/v2/referrals/#{referral_id}", params: { mode: custom_mode }
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+end

--- a/modules/vaos/spec/controllers/v2/referrals_controller_spec.rb
+++ b/modules/vaos/spec/controllers/v2/referrals_controller_spec.rb
@@ -49,20 +49,22 @@ RSpec.describe VAOS::V2::ReferralsController, type: :request do
           .and_return(referral_list_entries)
       end
 
-      it 'returns a list of referrals' do
+      it 'returns a list of referrals in JSON:API format' do
         get '/vaos/v2/referrals'
 
         expect(response).to have_http_status(:ok)
 
         response_data = JSON.parse(response.body)
-        expect(response_data).to be_a(Array)
-        expect(response_data.size).to eq(3)
+        expect(response_data).to have_key('data')
+        expect(response_data['data']).to be_an(Array)
+        expect(response_data['data'].size).to eq(3)
 
         # Verify first referral entry structure
-        first_referral = response_data.first
+        first_referral = response_data['data'].first
         expect(first_referral['id']).to eq('5682')
-        expect(first_referral['type_of_care']).to eq('CARDIOLOGY')
-        expect(first_referral['expiration_date']).to eq('2024-05-27')
+        expect(first_referral['type']).to eq('referrals')
+        expect(first_referral['attributes']['type_of_care']).to eq('CARDIOLOGY')
+        expect(first_referral['attributes']['expiration_date']).to eq('2024-05-27')
       end
 
       context 'with a custom status parameter' do
@@ -117,17 +119,19 @@ RSpec.describe VAOS::V2::ReferralsController, type: :request do
           .and_return(referral_detail)
       end
 
-      it 'returns a referral detail' do
+      it 'returns a referral detail in JSON:API format' do
         get "/vaos/v2/referrals/#{referral_id}"
 
         expect(response).to have_http_status(:ok)
 
         response_data = JSON.parse(response.body)
-        expect(response_data['id']).to eq(referral_id)
-        expect(response_data['type_of_care']).to eq('CARDIOLOGY')
-        expect(response_data['provider_name']).to eq('Dr. Smith')
-        expect(response_data['location']).to eq('VA Medical Center')
-        expect(response_data['expiration_date']).to eq('2024-05-27')
+        expect(response_data).to have_key('data')
+        expect(response_data['data']['id']).to eq(referral_id)
+        expect(response_data['data']['type']).to eq('referral')
+        expect(response_data['data']['attributes']['type_of_care']).to eq('CARDIOLOGY')
+        expect(response_data['data']['attributes']['provider_name']).to eq('Dr. Smith')
+        expect(response_data['data']['attributes']['location']).to eq('VA Medical Center')
+        expect(response_data['data']['attributes']['expiration_date']).to eq('2024-05-27')
       end
 
       context 'with a custom mode parameter' do

--- a/modules/vaos/spec/factories/ccra/referrals.rb
+++ b/modules/vaos/spec/factories/ccra/referrals.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ccra_referral_list_entry, class: 'Ccra::ReferralListEntry' do
+    type_of_care { 'CARDIOLOGY' }
+    referral_id { '5682' }
+    start_date { '2024-03-28' }
+    seoc_days { '60' }
+
+    initialize_with do
+      attributes = {
+        'CategoryOfCare' => type_of_care,
+        'ID' => referral_id,
+        'StartDate' => start_date,
+        'SEOCNumberOfDays' => seoc_days
+      }
+      Ccra::ReferralListEntry.new(attributes)
+    end
+  end
+
+  factory :ccra_referral_detail, class: 'Ccra::ReferralDetail' do
+    type_of_care { 'CARDIOLOGY' }
+    provider_name { 'Dr. Smith' }
+    location { 'VA Medical Center' }
+    referral_number { 'VA0000005681' }
+    expiration_date { '2024-05-27' }
+
+    initialize_with do
+      attributes = {
+        'Referral' => {
+          'CategoryOfCare' => type_of_care,
+          'TreatingProvider' => provider_name,
+          'TreatingFacility' => location,
+          'ReferralNumber' => referral_number,
+          'ReferralExpirationDate' => expiration_date
+        }
+      }
+      Ccra::ReferralDetail.new(attributes)
+    end
+  end
+end

--- a/modules/vaos/spec/requests/v2/referrals_spec.rb
+++ b/modules/vaos/spec/requests/v2/referrals_spec.rb
@@ -31,12 +31,21 @@ RSpec.describe 'VAOS V2 Referrals', type: :request do
         sign_in_as(user)
       end
 
-      it 'returns referrals list' do
+      it 'returns referrals list in JSON:API format' do
         get '/vaos/v2/referrals'
 
         expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)).to be_an(Array)
-        expect(JSON.parse(response.body).length).to eq(3)
+        response_data = JSON.parse(response.body)
+
+        expect(response_data).to have_key('data')
+        expect(response_data['data']).to be_an(Array)
+        expect(response_data['data'].length).to eq(3)
+
+        first_referral = response_data['data'].first
+        expect(first_referral).to have_key('id')
+        expect(first_referral).to have_key('type')
+        expect(first_referral).to have_key('attributes')
+        expect(first_referral['attributes']).to have_key('type_of_care')
       end
     end
   end
@@ -70,11 +79,21 @@ RSpec.describe 'VAOS V2 Referrals', type: :request do
         sign_in_as(user)
       end
 
-      it 'returns referral detail' do
+      it 'returns referral detail in JSON:API format' do
         get "/vaos/v2/referrals/#{referral_id}"
 
         expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)['id']).to eq(referral_id)
+        response_data = JSON.parse(response.body)
+
+        expect(response_data).to have_key('data')
+        expect(response_data['data']).to have_key('id')
+        expect(response_data['data']['id']).to eq(referral_id)
+        expect(response_data['data']).to have_key('type')
+        expect(response_data['data']['type']).to eq('referral')
+        expect(response_data['data']).to have_key('attributes')
+        expect(response_data['data']['attributes']).to have_key('type_of_care')
+        expect(response_data['data']['attributes']).to have_key('provider_name')
+        expect(response_data['data']['attributes']).to have_key('location')
       end
     end
 

--- a/modules/vaos/spec/requests/v2/referrals_spec.rb
+++ b/modules/vaos/spec/requests/v2/referrals_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'VAOS V2 Referrals', type: :request do
+  describe 'GET /vaos/v2/referrals' do
+    let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+    let(:icn) { '1012845331V153043' }
+    let(:user) { build(:user, :vaos, :loa3, icn:) }
+    let(:referrals) { build_list(:ccra_referral_list_entry, 3) }
+    let(:service_double) { instance_double(Ccra::ReferralService) }
+
+    before do
+      allow(Rails).to receive(:cache).and_return(memory_store)
+      Rails.cache.clear
+
+      allow(Ccra::ReferralService).to receive(:new).and_return(service_double)
+      allow(service_double).to receive(:get_vaos_referral_list).and_return(referrals)
+    end
+
+    context 'when user is not authenticated' do
+      it 'returns 401 unauthorized' do
+        get '/vaos/v2/referrals'
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when user is authenticated' do
+      before do
+        sign_in_as(user)
+      end
+
+      it 'returns referrals list' do
+        get '/vaos/v2/referrals'
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to be_an(Array)
+        expect(JSON.parse(response.body).length).to eq(3)
+      end
+    end
+  end
+
+  describe 'GET /vaos/v2/referrals/:id' do
+    let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+    let(:icn) { '1012845331V153043' }
+    let(:referral_id) { '5682' }
+    let(:user) { build(:user, :vaos, :loa3, icn:) }
+    let(:referral) { build(:ccra_referral_detail, referral_number: referral_id) }
+    let(:service_double) { instance_double(Ccra::ReferralService) }
+
+    before do
+      allow(Rails).to receive(:cache).and_return(memory_store)
+      Rails.cache.clear
+
+      allow(Ccra::ReferralService).to receive(:new).and_return(service_double)
+      allow(service_double).to receive(:get_referral).and_return(referral)
+    end
+
+    context 'when user is not authenticated' do
+      it 'returns 401 unauthorized' do
+        get "/vaos/v2/referrals/#{referral_id}"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when user is authenticated' do
+      before do
+        sign_in_as(user)
+      end
+
+      it 'returns referral detail' do
+        get "/vaos/v2/referrals/#{referral_id}"
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['id']).to eq(referral_id)
+      end
+    end
+
+    context 'when using invalid referral id' do
+      let(:invalid_id) { 'invalid' }
+
+      before do
+        sign_in_as(user)
+        allow(service_double).to receive(:get_referral)
+          .with(invalid_id, anything)
+          .and_raise(Common::Exceptions::ParameterMissing.new('id'))
+      end
+
+      it 'returns appropriate error status' do
+        get "/vaos/v2/referrals/#{invalid_id}"
+
+        # Expecting bad request based on how the controller likely handles missing parameters
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+  end
+end

--- a/modules/vaos/spec/serializers/ccra/referral_detail_serializer_spec.rb
+++ b/modules/vaos/spec/serializers/ccra/referral_detail_serializer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Ccra::ReferralDetailSerializer do
-  describe '#as_json' do
+  describe 'serialization' do
     context 'with a valid referral detail' do
       let(:referral_number) { 'VA0000005681' }
       let(:type_of_care) { 'CARDIOLOGY' }
@@ -23,14 +23,19 @@ RSpec.describe Ccra::ReferralDetailSerializer do
       end
 
       let(:serializer) { described_class.new(referral) }
-      let(:serialized_data) { serializer.as_json }
+      let(:serialized_data) { serializer.serializable_hash }
+
+      it 'returns a hash with data' do
+        expect(serialized_data).to have_key(:data)
+      end
 
       it 'serializes the referral detail correctly' do
-        expect(serialized_data[:id]).to eq(referral_number)
-        expect(serialized_data[:type_of_care]).to eq(type_of_care)
-        expect(serialized_data[:provider_name]).to eq(provider_name)
-        expect(serialized_data[:location]).to eq(location)
-        expect(serialized_data[:expiration_date]).to eq(expiration_date)
+        expect(serialized_data[:data][:id]).to eq(referral_number)
+        expect(serialized_data[:data][:type]).to eq(:referral)
+        expect(serialized_data[:data][:attributes][:type_of_care]).to eq(type_of_care)
+        expect(serialized_data[:data][:attributes][:provider_name]).to eq(provider_name)
+        expect(serialized_data[:data][:attributes][:location]).to eq(location)
+        expect(serialized_data[:data][:attributes][:expiration_date]).to eq(expiration_date)
       end
     end
 
@@ -53,14 +58,15 @@ RSpec.describe Ccra::ReferralDetailSerializer do
       end
 
       let(:serializer) { described_class.new(referral) }
-      let(:serialized_data) { serializer.as_json }
+      let(:serialized_data) { serializer.serializable_hash }
 
-      it 'omits nil attributes' do
-        expect(serialized_data[:id]).to eq(referral_number)
-        expect(serialized_data[:type_of_care]).to eq(type_of_care)
-        expect(serialized_data).not_to have_key(:provider_name)
-        expect(serialized_data).not_to have_key(:location)
-        expect(serialized_data).not_to have_key(:expiration_date)
+      it 'includes nil attributes in JSON:API format' do
+        expect(serialized_data[:data][:id]).to eq(referral_number)
+        expect(serialized_data[:data][:type]).to eq(:referral)
+        expect(serialized_data[:data][:attributes][:type_of_care]).to eq(type_of_care)
+        expect(serialized_data[:data][:attributes][:provider_name]).to be_nil
+        expect(serialized_data[:data][:attributes][:location]).to be_nil
+        expect(serialized_data[:data][:attributes][:expiration_date]).to be_nil
       end
     end
 
@@ -71,11 +77,15 @@ RSpec.describe Ccra::ReferralDetailSerializer do
       end
 
       let(:serializer) { described_class.new(referral) }
-      let(:serialized_data) { serializer.as_json }
+      let(:serialized_data) { serializer.serializable_hash }
 
-      it 'returns an empty hash' do
-        expect(serialized_data).to be_a(Hash)
-        expect(serialized_data).to be_empty
+      it 'returns a hash with data containing null attributes' do
+        expect(serialized_data).to have_key(:data)
+        expect(serialized_data[:data][:attributes]).to be_a(Hash)
+        # All attributes should be nil
+        serialized_data[:data][:attributes].each_value do |value|
+          expect(value).to be_nil
+        end
       end
     end
   end

--- a/modules/vaos/spec/serializers/ccra/referral_detail_serializer_spec.rb
+++ b/modules/vaos/spec/serializers/ccra/referral_detail_serializer_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Ccra::ReferralDetailSerializer do
+  describe '#as_json' do
+    context 'with a valid referral detail' do
+      let(:referral_number) { 'VA0000005681' }
+      let(:type_of_care) { 'CARDIOLOGY' }
+      let(:provider_name) { 'Dr. Smith' }
+      let(:location) { 'VA Medical Center' }
+      let(:expiration_date) { '2024-05-27' }
+
+      let(:referral) do
+        build(
+          :ccra_referral_detail,
+          referral_number:,
+          type_of_care:,
+          provider_name:,
+          location:,
+          expiration_date:
+        )
+      end
+
+      let(:serializer) { described_class.new(referral) }
+      let(:serialized_data) { serializer.as_json }
+
+      it 'serializes the referral detail correctly' do
+        expect(serialized_data[:id]).to eq(referral_number)
+        expect(serialized_data[:type_of_care]).to eq(type_of_care)
+        expect(serialized_data[:provider_name]).to eq(provider_name)
+        expect(serialized_data[:location]).to eq(location)
+        expect(serialized_data[:expiration_date]).to eq(expiration_date)
+      end
+    end
+
+    context 'with a referral missing some attributes' do
+      let(:referral_number) { 'VA0000005681' }
+      let(:type_of_care) { 'CARDIOLOGY' }
+      let(:provider_name) { nil }
+      let(:location) { nil }
+      let(:expiration_date) { nil }
+
+      let(:referral) do
+        build(
+          :ccra_referral_detail,
+          referral_number:,
+          type_of_care:,
+          provider_name:,
+          location:,
+          expiration_date:
+        )
+      end
+
+      let(:serializer) { described_class.new(referral) }
+      let(:serialized_data) { serializer.as_json }
+
+      it 'omits nil attributes' do
+        expect(serialized_data[:id]).to eq(referral_number)
+        expect(serialized_data[:type_of_care]).to eq(type_of_care)
+        expect(serialized_data).not_to have_key(:provider_name)
+        expect(serialized_data).not_to have_key(:location)
+        expect(serialized_data).not_to have_key(:expiration_date)
+      end
+    end
+
+    context 'with a nil referral' do
+      # Create an empty ReferralDetail object that would result from a nil response
+      let(:referral) do
+        Ccra::ReferralDetail.new({})
+      end
+
+      let(:serializer) { described_class.new(referral) }
+      let(:serialized_data) { serializer.as_json }
+
+      it 'returns an empty hash' do
+        expect(serialized_data).to be_a(Hash)
+        expect(serialized_data).to be_empty
+      end
+    end
+  end
+end

--- a/modules/vaos/spec/serializers/ccra/referral_list_serializer_spec.rb
+++ b/modules/vaos/spec/serializers/ccra/referral_list_serializer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Ccra::ReferralListSerializer do
-  describe '#as_json' do
+  describe 'serialization' do
     context 'with a list of referrals' do
       # These values should calculate to May 27, 2024
       let(:cardiology_referral) do
@@ -20,47 +20,53 @@ RSpec.describe Ccra::ReferralListSerializer do
       end
       let(:referrals) { [cardiology_referral, podiatry_referral, optometry_referral] }
       let(:serializer) { described_class.new(referrals) }
-      let(:serialized_data) { serializer.as_json }
+      let(:serialized_data) { serializer.serializable_hash }
 
-      it 'returns an array of serialized referrals' do
-        expect(serialized_data).to be_an(Array)
-        expect(serialized_data.size).to eq(3)
+      it 'returns a hash with data array' do
+        expect(serialized_data).to have_key(:data)
+        expect(serialized_data[:data]).to be_an(Array)
+        expect(serialized_data[:data].size).to eq(3)
       end
 
       it 'serializes each referral correctly' do
-        expect(serialized_data[0][:id]).to eq('5682')
-        expect(serialized_data[0][:type_of_care]).to eq('CARDIOLOGY')
-        expect(serialized_data[0][:expiration_date]).to eq('2024-05-27')
+        expect(serialized_data[:data][0][:id]).to eq('5682')
+        expect(serialized_data[:data][0][:type]).to eq(:referrals)
+        expect(serialized_data[:data][0][:attributes][:type_of_care]).to eq('CARDIOLOGY')
+        expect(serialized_data[:data][0][:attributes][:expiration_date]).to eq('2024-05-27')
 
-        expect(serialized_data[1][:id]).to eq('5683')
-        expect(serialized_data[1][:type_of_care]).to eq('PODIATRY')
-        expect(serialized_data[1][:expiration_date]).to eq('2024-05-27')
+        expect(serialized_data[:data][1][:id]).to eq('5683')
+        expect(serialized_data[:data][1][:type]).to eq(:referrals)
+        expect(serialized_data[:data][1][:attributes][:type_of_care]).to eq('PODIATRY')
+        expect(serialized_data[:data][1][:attributes][:expiration_date]).to eq('2024-05-27')
 
-        expect(serialized_data[2][:id]).to eq('5684')
-        expect(serialized_data[2][:type_of_care]).to eq('OPTOMETRY')
-        expect(serialized_data[2][:expiration_date]).to eq('2024-05-27')
+        expect(serialized_data[:data][2][:id]).to eq('5684')
+        expect(serialized_data[:data][2][:type]).to eq(:referrals)
+        expect(serialized_data[:data][2][:attributes][:type_of_care]).to eq('OPTOMETRY')
+        expect(serialized_data[:data][2][:attributes][:expiration_date]).to eq('2024-05-27')
       end
     end
 
     context 'with an empty list' do
       let(:referrals) { [] }
       let(:serializer) { described_class.new(referrals) }
-      let(:serialized_data) { serializer.as_json }
+      let(:serialized_data) { serializer.serializable_hash }
 
-      it 'returns an empty array' do
-        expect(serialized_data).to be_an(Array)
-        expect(serialized_data).to be_empty
+      it 'returns a hash with empty data array' do
+        expect(serialized_data).to have_key(:data)
+        expect(serialized_data[:data]).to be_an(Array)
+        expect(serialized_data[:data]).to be_empty
       end
     end
 
     context 'with a nil list' do
       let(:referrals) { nil }
       let(:serializer) { described_class.new(referrals) }
-      let(:serialized_data) { serializer.as_json }
+      let(:serialized_data) { serializer.serializable_hash }
 
-      it 'returns an empty array' do
-        expect(serialized_data).to be_an(Array)
-        expect(serialized_data).to be_empty
+      it 'returns a hash with empty data array' do
+        expect(serialized_data).to have_key(:data)
+        expect(serialized_data[:data]).to be_an(Array)
+        expect(serialized_data[:data]).to be_empty
       end
     end
   end

--- a/modules/vaos/spec/serializers/ccra/referral_list_serializer_spec.rb
+++ b/modules/vaos/spec/serializers/ccra/referral_list_serializer_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Ccra::ReferralListSerializer do
+  describe '#as_json' do
+    context 'with a list of referrals' do
+      # These values should calculate to May 27, 2024
+      let(:cardiology_referral) do
+        build(:ccra_referral_list_entry, referral_id: '5682', type_of_care: 'CARDIOLOGY', start_date: '2024-03-28',
+                                         seoc_days: '60')
+      end
+      let(:podiatry_referral) do
+        build(:ccra_referral_list_entry, referral_id: '5683', type_of_care: 'PODIATRY', start_date: '2024-03-28',
+                                         seoc_days: '60')
+      end
+      let(:optometry_referral) do
+        build(:ccra_referral_list_entry, referral_id: '5684', type_of_care: 'OPTOMETRY', start_date: '2024-03-28',
+                                         seoc_days: '60')
+      end
+      let(:referrals) { [cardiology_referral, podiatry_referral, optometry_referral] }
+      let(:serializer) { described_class.new(referrals) }
+      let(:serialized_data) { serializer.as_json }
+
+      it 'returns an array of serialized referrals' do
+        expect(serialized_data).to be_an(Array)
+        expect(serialized_data.size).to eq(3)
+      end
+
+      it 'serializes each referral correctly' do
+        expect(serialized_data[0][:id]).to eq('5682')
+        expect(serialized_data[0][:type_of_care]).to eq('CARDIOLOGY')
+        expect(serialized_data[0][:expiration_date]).to eq('2024-05-27')
+
+        expect(serialized_data[1][:id]).to eq('5683')
+        expect(serialized_data[1][:type_of_care]).to eq('PODIATRY')
+        expect(serialized_data[1][:expiration_date]).to eq('2024-05-27')
+
+        expect(serialized_data[2][:id]).to eq('5684')
+        expect(serialized_data[2][:type_of_care]).to eq('OPTOMETRY')
+        expect(serialized_data[2][:expiration_date]).to eq('2024-05-27')
+      end
+    end
+
+    context 'with an empty list' do
+      let(:referrals) { [] }
+      let(:serializer) { described_class.new(referrals) }
+      let(:serialized_data) { serializer.as_json }
+
+      it 'returns an empty array' do
+        expect(serialized_data).to be_an(Array)
+        expect(serialized_data).to be_empty
+      end
+    end
+
+    context 'with a nil list' do
+      let(:referrals) { nil }
+      let(:serializer) { described_class.new(referrals) }
+      let(:serialized_data) { serializer.as_json }
+
+      it 'returns an empty array' do
+        expect(serialized_data).to be_an(Array)
+        expect(serialized_data).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO* - This adds a new controller that is not currently used.
- Implement VAOS referral controller that uses the CCRA referral service.
- Team and owned by: UAE Check-in team

Tasks outstanding:
1. Betamocks - separate PR not yet opened
2. Swagger updates - separate ticket

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/98256

## Testing done
- [x] *New code is covered by unit tests*

No Betamocks yet. That is a separate PR as mocks reside in `vets-api-mockdata`

## Screenshots
N/A

## What areas of the site does it impact?
N/A - not integrated yet

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

