### PR TITLE
Restored the count parameter used for logging to statsd which records got deleted

### DIFF
--- a/app/sidekiq/lighthouse/evidence_submissions/delete_evidence_submission_records_job.rb
+++ b/app/sidekiq/lighthouse/evidence_submissions/delete_evidence_submission_records_job.rb
@@ -20,7 +20,7 @@ module Lighthouse
           upload_status: BenefitsDocuments::Constants::UPLOAD_STATUS[:SUCCESS]
         ).destroy_all
 
-        StatsD.increment("#{STATSD_KEY_PREFIX}.count")
+        StatsD.increment("#{STATSD_KEY_PREFIX}.count", deleted_records.size)
         Rails.logger.info("#{self.class} deleted #{deleted_records.size} of #{record_count} EvidenceSubmission records")
 
         nil

--- a/spec/sidekiq/lighthouse/evidence_submissions/delete_evidence_submission_records_job_spec.rb
+++ b/spec/sidekiq/lighthouse/evidence_submissions/delete_evidence_submission_records_job_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Lighthouse::EvidenceSubmissions::DeleteEvidenceSubmissionRecordsJ
     context 'when EvidenceSubmission records have a delete_date set' do
       it 'deletes only the records with a past or current delete_time' do
         expect(StatsD).to receive(:increment)
-          .with('worker.cst.delete_evidence_submission_records.count').exactly(1).time
+          .with('worker.cst.delete_evidence_submission_records.count', 2).exactly(1).time
         expect(Rails.logger)
           .to receive(:info)
           .with("#{subject} deleted 2 of 3 EvidenceSubmission records")


### PR DESCRIPTION
This reverses this PR, which was incorrect: https://github.com/department-of-veterans-affairs/vets-api/commit/8e6c548f45e69d727310c49ad05e05e8817c2a74

## Summary

- Restores the second parameter in `StatsD.increment` used for tracking amount of records deleted
- After speaking with Molly Trombley-McCann and Derek Fong, it was confirmed that the StatsD gem we use does implement that second parameter to store counts (unlike the official docs on DataDog's website say)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-api/commit/8e6c548f45e69d727310c49ad05e05e8817c2a74

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
