### PR TITLE
Vets::SharedLogging example

### DIFF
--- a/app/models/form_attachment.rb
+++ b/app/models/form_attachment.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require 'vets/shared_logging'
+
 class FormAttachment < ApplicationRecord
   include SetGuid
-  include SentryLogging
+  include Vets::SharedLogging
 
   has_kms_key
   has_encrypted :file_data, key: :kms_key, **lockbox_options
@@ -18,6 +20,7 @@ class FormAttachment < ApplicationRecord
     self.file_data = { filename: attachment_uploader.filename }.to_json
   rescue CarrierWave::IntegrityError => e
     log_exception_to_sentry(e, nil, nil, 'warn')
+    log_exception_to_rails(e, 'warn')
     raise Common::Exceptions::UnprocessableEntity.new(detail: e.message, source: 'FormAttachment.set_file_data')
   end
 
@@ -46,6 +49,7 @@ class FormAttachment < ApplicationRecord
       password_regex = /(input_pw).*?(output)/
       sanitized_message = e.message.gsub(file_regex, '[FILTERED FILENAME]').gsub(password_regex, '\1 [FILTERED] \2')
       log_message_to_sentry(sanitized_message, 'warn')
+      log_message_to_rails(sanitized_message, 'warn')
       raise Common::Exceptions::UnprocessableEntity.new(
         detail: I18n.t('errors.messages.uploads.pdf.incorrect_password'),
         source: 'FormAttachment.unlock_pdf'

--- a/lib/sentry_logging.rb
+++ b/lib/sentry_logging.rb
@@ -3,6 +3,10 @@
 require 'sentry_logging'
 
 module SentryLogging
+  # WARNING: This module is deprecated, and will be removed in June 2025. Please use Vets::SharedLogging instead.
+  # If your team currently uses this module, please see documentation for migrating to Vets::SharedLogging: TODO
+  ActiveSupport::Deprecation
+    .new.warn('SentryLogging is deprecated and will be removed in June 2025. Use Vets::SharedLogging instead.')
   extend self
 
   def log_message_to_sentry(message, level, extra_context = {}, tags_context = {})

--- a/lib/vets/shared_logging.rb
+++ b/lib/vets/shared_logging.rb
@@ -36,7 +36,7 @@ module Vets
       level = normalize_level(level, exception)
       if exception.is_a? Common::Exceptions::BackendServiceException
         error_details = exception.errors.first.attributes.compact.reject { |_k, v| v.try(:empty?) }
-        log_message_to_rails(exception.message, level, error_details.merge(exception.backtrace))
+        log_message_to_rails(exception.message, level, error_details.merge(backtrace: exception.backtrace))
       else
         log_message_to_rails("#{exception.message}.", level)
       end

--- a/lib/vets/shared_logging.rb
+++ b/lib/vets/shared_logging.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Vets
+  module SharedLogging
+    extend ActiveSupport::Concern
+
+    def log_message_to_sentry(message, level, extra_context = {}, tags_context = {})
+      level = normalize_level(level, nil)
+      # https://docs.sentry.io/platforms/ruby/usage/set-level/
+      # valid sentry levels: log, debug, info, warning, error, fatal
+      level = 'warning' if level == 'warn'
+
+      if Settings.sentry.dsn.present?
+        set_sentry_metadata(extra_context, tags_context)
+        Sentry.capture_message(message, level:)
+      end
+    end
+
+    def log_exception_to_sentry(exception, extra_context = {}, tags_context = {}, level = 'error')
+      level = normalize_level(level, exception)
+
+      if Settings.sentry.dsn.present?
+        set_sentry_metadata(extra_context, tags_context)
+        Sentry.capture_exception(exception.cause.presence || exception, level:)
+      end
+    end
+
+    def log_message_to_rails(message, level, extra_context = {})
+      # this can be a drop-in replacement for now, but maybe suggest teams
+      # handle extra context on their own and move to a direct Rails.logger call?
+      formatted_message = extra_context.empty? ? message : "#{message} : #{extra_context}"
+      Rails.logger.send(level, formatted_message)
+    end
+
+    def log_exception_to_rails(exception, level = 'error')
+      level = normalize_level(level, exception)
+      if exception.is_a? Common::Exceptions::BackendServiceException
+        error_details = exception.errors.first.attributes.compact.reject { |_k, v| v.try(:empty?) }
+        log_message_to_rails(exception.message, level, error_details.merge(exception.backtrace))
+      else
+        log_message_to_rails("#{exception.message}.", level)
+      end
+
+      log_message_to_rails(exception.backtrace.join("\n"), level) unless exception.backtrace.nil?
+    end
+
+    def normalize_level(level, exception)
+      case exception
+      when Pundit::NotAuthorizedError
+        'info'
+      when Common::Exceptions::BaseError
+        # could change this attribute to log_level
+        # to make clear it is not just a Sentry concern
+        exception.sentry_type.to_s
+      else
+        level.to_s
+      end
+    end
+
+    def non_nil_hash?(h)
+      h.is_a?(Hash) && !h.empty?
+    end
+
+    private
+
+    def set_sentry_metadata(extra_context, tags_context)
+      Sentry.set_extras(extra_context) if non_nil_hash?(extra_context)
+      Sentry.set_tags(tags_context) if non_nil_hash?(tags_context)
+    end
+  end
+end

--- a/modules/decision_reviews/spec/requests/v1/notice_of_disagreements_spec.rb
+++ b/modules/decision_reviews/spec/requests/v1/notice_of_disagreements_spec.rb
@@ -120,7 +120,9 @@ RSpec.describe 'DecisionReviews::V1::NoticeOfDisagreements', type: :request do
           message: "Exception occurred while submitting Notice Of Disagreement: #{extra_error_log_message}",
           backtrace: anything
         )
-        expect(Rails.logger).to receive(:error).with(extra_error_log_message, anything)
+        expect(Rails.logger).to receive(:error) do |message|
+          expect(message).to include(extra_error_log_message)
+        end
         allow(StatsD).to receive(:increment)
         expect(StatsD).to receive(:increment).with('decision_review.form_10182.overall_claim_submission.failure')
         expect(personal_information_logs.count).to be 0

--- a/modules/decision_reviews/spec/requests/v1/supplemental_claims_spec.rb
+++ b/modules/decision_reviews/spec/requests/v1/supplemental_claims_spec.rb
@@ -106,7 +106,9 @@ RSpec.describe 'DecisionReviews::V1::SupplementalClaims', type: :request do
           message: "Exception occurred while submitting Supplemental Claim: #{extra_error_log_message}",
           backtrace: anything
         )
-        expect(Rails.logger).to receive(:error).with(extra_error_log_message, anything)
+        expect(Rails.logger).to receive(:error) do |message|
+          expect(message).to include(extra_error_log_message)
+        end
         allow(StatsD).to receive(:increment)
         expect(StatsD).to receive(:increment).with('decision_review.form_995.overall_claim_submission.failure')
 

--- a/modules/decision_reviews/spec/requests/v2/higher_level_reviews_spec.rb
+++ b/modules/decision_reviews/spec/requests/v2/higher_level_reviews_spec.rb
@@ -107,7 +107,9 @@ RSpec.describe 'DecisionReviews::V2::HigherLevelReviews', type: :request do
             message: "Exception occurred while submitting Higher Level Review: #{extra_error_log_message}",
             backtrace: anything
           )
-          expect(Rails.logger).to receive(:error).with(extra_error_log_message, anything)
+          expect(Rails.logger).to receive(:error) do |message|
+            expect(message).to include(extra_error_log_message)
+          end
           allow(StatsD).to receive(:increment)
           expect(StatsD).to receive(:increment).with('decision_review.form_996.overall_claim_submission.failure')
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -93,11 +93,6 @@ RSpec.describe ApplicationController, type: :controller do
       before { allow(Settings.sentry).to receive(:dsn).and_return('asdf') }
 
       describe '#log_message_to_sentry' do
-        it 'error logs to Rails logger' do
-          expect(Rails.logger).to receive(:error).with(/blah/).with(/context/)
-          subject.log_message_to_sentry('blah', :error, { extra: 'context' }, tags: 'tagging')
-        end
-
         it 'logs to Sentry' do
           expect(Sentry).to receive(:set_tags)
           expect(Sentry).to receive(:set_extras)
@@ -106,15 +101,24 @@ RSpec.describe ApplicationController, type: :controller do
         end
       end
 
-      describe '#log_exception_to_sentry' do
-        it 'warn logs to Rails logger' do
-          expect(Rails.logger).to receive(:error).with("#{exception.message}.")
-          subject.log_exception_to_sentry(exception)
+      describe '#log_message_to_rails' do
+        it 'error logs to Rails logger' do
+          expect(Rails.logger).to receive(:error).with(/blah/).with(/context/)
+          subject.log_message_to_rails('blah', :error, { extra: 'context' })
         end
+      end
 
+      describe '#log_exception_to_sentry' do
         it 'logs to Sentry' do
           expect(Sentry).to receive(:capture_exception).with(exception, level: 'error').once
           subject.log_exception_to_sentry(exception)
+        end
+      end
+
+      describe '#log_exception_to_rails' do
+        it 'warn logs to Rails logger' do
+          expect(Rails.logger).to receive(:error).with("#{exception.message}.")
+          subject.log_exception_to_rails(exception)
         end
       end
     end

--- a/spec/models/form_attachment_spec.rb
+++ b/spec/models/form_attachment_spec.rb
@@ -15,11 +15,12 @@ RSpec.describe FormAttachment do
       let(:bad_password) { 'bad_pw' }
 
       context 'when provided password is incorrect' do
-        it 'logs a sanitized message to Sentry' do
+        it 'logs a sanitized message to Sentry and Rails' do
           error_message = nil
           allow_any_instance_of(FormAttachment).to receive(:log_message_to_sentry) do |_, message, _level|
             error_message = message
           end
+          allow(Rails.logger).to receive(:warn)
 
           tempfile = Tempfile.new(['', "-#{file_name}"])
           file = ActionDispatch::Http::UploadedFile.new(original_filename: file_name, type: 'application/pdf',
@@ -30,6 +31,7 @@ RSpec.describe FormAttachment do
           end.to raise_error(Common::Exceptions::UnprocessableEntity)
           expect(error_message).not_to include(file_name)
           expect(error_message).not_to include(bad_password)
+          expect(Rails.logger).to have_received(:warn)
         end
       end
     end


### PR DESCRIPTION
## Logging Refactor Option 1
This is a spike showing one option for separating logging to Sentry and Rails in `vets-api`. A new module inside the `vets` folder has different methods for logging to Sentry and Rails, and an example of the new usage is shown in `form_attachment.rb`. If this path is chosen, `Vets::SharedLogging` would replace `SentryLogging` entirely.




## Summary

- *This work is behind a feature toggle (flipper): NO*
- *(Summarize the changes that have been made to the platform)*
Created a new module Vets::SharedLogging to replace SentryLogging. Using it only in ExceptionHandling, and as an example in `form_attachment.rb`
- *(Which team do you work for, does your team own the maintenance of this component?)*
Decision Reviews. We own some of this code, but most is shared across teams.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103363


## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
SentryLogging mixed logging to Rails and Sentry.
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
Ensure exceptions are being logged as expected in DataDog and Sentry, via testing in staging

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
Exception logging in controllers that inherit from ApplicationController. The behavior is basically identical, except that some additional backtrace info is logged to Rails for exceptions.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
