### PR TITLE
SharedRailsLogging with example

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1009,6 +1009,7 @@ lib/search_typeahead @department-of-veterans-affairs/va-api-engineers @departmen
 lib/sentry @department-of-veterans-affairs/backend-review-group
 lib/sentry_logging.rb @department-of-veterans-affairs/backend-review-group
 lib/sftp_writer @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
+lib/shared_rails_logging @department-of-veterans-affairs/backend-review-group
 lib/shrine @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 lib/sidekiq/attr_package.rb @department-of-veterans-affairs/octo-identity @department-of-veterans-affairs/backend-review-group
 lib/sidekiq/error_tag.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers

--- a/lib/shared_rails_logging.rb
+++ b/lib/shared_rails_logging.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module SharedRailsLogging
+  extend ActiveSupport::Concern
+
+  def log_message_to_rails(message, level, extra_context = {})
+    # this can be a drop-in replacement for now, but maybe suggest teams
+    # handle extra context on their own and move to a direct Rails.logger call?
+    formatted_message = extra_context.empty? ? message : "#{message} : #{extra_context}"
+    Rails.logger.send(level, formatted_message)
+  end
+
+  def log_exception_to_rails(exception, level = 'error')
+    level = normalize_level(level, exception)
+    if exception.is_a? Common::Exceptions::BackendServiceException
+      error_details = exception.errors.first.attributes.compact.reject { |_k, v| v.try(:empty?) }
+      log_message_to_rails(exception.message, level, error_details.merge(exception.backtrace))
+    else
+      log_message_to_rails("#{exception.message}.", level)
+    end
+
+    log_message_to_rails(exception.backtrace.join("\n"), level) unless exception.backtrace.nil?
+  end
+
+  def normalize_level(level, exception)
+    case exception
+    when Pundit::NotAuthorizedError
+      'info'
+    when Common::Exceptions::BaseError
+      # could change this attribute to log_level
+      # to make clear it is not just a Sentry concern
+      exception.sentry_type.to_s
+    else
+      level.to_s
+    end
+  end
+end


### PR DESCRIPTION
## Logging Refactor Option 2
This is a spike showing one option for separating logging to Sentry and Rails in `vets-api`. A new module at `lib/shared_rails_logging.rb` has methods for logging to Rails. This module would be included alongside SentryLogging and an example of the new usage is in `form_attachment.rb`. If this approach is chosen, the Rails logging behavior would be removed from SentryLogging when the refactor is complete.


## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
- *(Summarize the changes that have been made to the platform)*
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)*
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
