### PR TITLE
Remove unused appointments feature toggles - 2

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1514,10 +1514,6 @@ features:
     actor_type: user
     description: Toggle for new vaos service va appointments.
     enable_in_development: true
-  va_online_scheduling_vaos_v2_next:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle for tickets with the label vaos-v2-next will be behind this flag
   va_online_scheduling_vaos_alternate_route:
     actor_type: user
     enable_in_development: false
@@ -1530,14 +1526,6 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle for the breadcrumb and url changes for mhv
-  va_online_scheduling_use_dsot:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle for querying Drupal Source of Truth for Acheron flag
-  va_online_scheduling_poc_type_of_care:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle for proof of concept to help Veteran contact a facility when the type of care is not available
   va_dependents_v2:
     actor_type: user
     description: Allows us to toggle bewteen V1 and V2 of the 686c-674 forms.

--- a/modules/vaos/config/initializers/flipper.rb
+++ b/modules/vaos/config/initializers/flipper.rb
@@ -6,7 +6,6 @@ require 'active_support/notifications'
 module Flipper
   module Instrumentation
     class AppointmentsEventSubscriber
-      # va_online_scheduling_poc_type_of_care used for temporary testing purposes in staging, will be removed
       # va_online_scheduling_subscriber_unit_testing used for unit testing purposes
       CRITICAL_FEATURES_SYMBOLS = %i[
         va_online_scheduling
@@ -14,7 +13,6 @@ module Flipper
         va_online_scheduling_community_care
         va_online_scheduling_direct
         va_online_scheduling_requests
-        va_online_scheduling_poc_type_of_care
         va_online_scheduling_subscriber_unit_testing
       ].freeze
       CRITICAL_FEATURES_NAMES = %w[
@@ -23,7 +21,6 @@ module Flipper
         va_online_scheduling_community_care
         va_online_scheduling_direct
         va_online_scheduling_requests
-        va_online_scheduling_poc_type_of_care
         va_online_scheduling_subscriber_unit_testing
       ].freeze
       RESTRICTED_OPERATIONS_SYMBOLS = %i[disable remove clear].freeze


### PR DESCRIPTION
## Summary

- Removing some of the obsolete feature toggles for features that have been fully released.
- Appointments tools team
- This PR should be merged after https://github.com/department-of-veterans-affairs/vets-website/pull/35106 is merged.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103685

## Testing done

- [x] ~~*New code is covered by unit tests*~~ ensured existing tests pass

## Screenshots
N/A

## What areas of the site does it impact?
Appointments tools

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  ~~Documentation has been updated (link to documentation)~~ Will update documentation after PRs are merged and feature toggles fully deleted from Flipper
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
