### PR TITLE
[SIMPLE-FORMS] fix: add logic and supporting tests for user email support

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/notification/email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification/email.rb
@@ -309,25 +309,30 @@ module SimpleFormsApi
 
       # email and first name for form 20-10207
       def form20_10207_contact_info
-        preparer_types = %w[veteran third-party-veteran non-veteran third-party-non-veteran]
+        return unless form_data
 
-        return unless preparer_types.include?(@form_data['preparer_type'])
+        preparer_type = form_data['preparer_type']
 
-        email_and_first_name = [@user&.va_profile_email]
-        # veteran
-        email_and_first_name << if @form_data['preparer_type'] == 'veteran'
-                                  @form_data['veteran_full_name']['first']
+        return unless %w[veteran third-party-veteran non-veteran third-party-non-veteran].include?(preparer_type)
 
-                                # non-veteran
-                                elsif @form_data['preparer_type'] == 'non-veteran'
-                                  @form_data['non_veteran_full_name']['first']
+        email = if preparer_type.include?('non-veteran')
+                  form_data['non_veteran_email_address']
+                else
+                  form_data['veteran_email_address']
+                end
 
-                                  # third-party
-                                else
-                                  @form_data['third_party_full_name']['first']
-                                end
+        first_name = case preparer_type
+                     when 'veteran'
+                       form_data.dig('veteran_full_name', 'first')
+                     when 'non-veteran'
+                       form_data.dig('non_veteran_full_name', 'first')
+                     when /third-party/
+                       form_data.dig('third_party_full_name', 'first')
+                     end
 
-        email_and_first_name
+        email ||= user&.va_profile_email
+
+        [email, first_name]
       end
 
       # email and first name for form 21-0845

--- a/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification_email.rb
@@ -315,25 +315,30 @@ module SimpleFormsApi
 
     # email and first name for form 20-10207
     def form20_10207_contact_info
-      preparer_types = %w[veteran third-party-veteran non-veteran third-party-non-veteran]
+      return unless form_data
 
-      return unless preparer_types.include?(@form_data['preparer_type'])
+      preparer_type = form_data['preparer_type']
 
-      email_and_first_name = [@user&.va_profile_email]
-      # veteran
-      email_and_first_name << if @form_data['preparer_type'] == 'veteran'
-                                @form_data['veteran_full_name']['first']
+      return unless %w[veteran third-party-veteran non-veteran third-party-non-veteran].include?(preparer_type)
 
-                              # non-veteran
-                              elsif @form_data['preparer_type'] == 'non-veteran'
-                                @form_data['non_veteran_full_name']['first']
+      email = if preparer_type.include?('non-veteran')
+                form_data['non_veteran_email_address']
+              else
+                form_data['veteran_email_address']
+              end
 
-                                # third-party
-                              else
-                                @form_data['third_party_full_name']['first']
-                              end
+      first_name = case preparer_type
+                   when 'veteran'
+                     form_data.dig('veteran_full_name', 'first')
+                   when 'non-veteran'
+                     form_data.dig('non_veteran_full_name', 'first')
+                   when /third-party/
+                     form_data.dig('third_party_full_name', 'first')
+                   end
 
-      email_and_first_name
+      email ||= user&.va_profile_email
+
+      [email, first_name]
     end
 
     # email and first name for form 21-0845

--- a/modules/simple_forms_api/spec/fixtures/form_json/vba_20_10207-third-party-non-veteran.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/vba_20_10207-third-party-non-veteran.json
@@ -5,6 +5,7 @@
     "last": "Third-Pty-Non-Vet"
   },
   "third_party_type": "power-of-attorney",
+  "non_veteran_email_address": "john.non-veteran@example.com",
   "non_veteran_full_name": {
     "first": "John",
     "last": "Non-Veteran"

--- a/modules/simple_forms_api/spec/fixtures/form_json/vba_20_10207-third-party-veteran.json
+++ b/modules/simple_forms_api/spec/fixtures/form_json/vba_20_10207-third-party-veteran.json
@@ -5,6 +5,7 @@
     "last": "Rep-Veteran"
   },
   "third_party_type": "representative",
+  "veteran_email_address": "john.veteran@example.com",
   "veteran_full_name": {
     "first": "John",
     "last": "Veteran"


### PR DESCRIPTION
## Summary

- This work adds logic which properly uses the user's email address when sending a notification email
- This work also refactors the existing logic for determining form 20-10207's first name and email
- This work also refines and extends the existing RSpec coverage
- The logic is currently being duplicated because a separate refactor is still underway which will move this logic to a new location within the codebase.
- I'm on the Veteran Facing Forms team who own this code.

## Related issue(s)

- [[Bug] 10207 emails are reverting to email address in Profile](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/2036)

## Testing done

- [x] New code is covered by unit tests

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

Any
