### PR TITLE
Added more failure email template params - IVC CHAMPVA forms

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1475,9 +1475,9 @@ vanotify:
         form_10_10d_email: <%= ENV['vanotify__services__ivc_champva__template_id__form_10_10d_email'] %>
         form_10_10d_failure_email: <%= ENV['vanotify__services__ivc_champva__template_id__form_10_10d_failure_email'] %>
         form_10_7959a_email: <%= ENV['vanotify__services__ivc_champva__template_id__form_10_7959a_email'] %>
-        form_10_7959a_failure_email: form_10_7959a_failure_email
+        form_10_7959a_failure_email: <%= ENV['vanotify__services__ivc_champva__template_id__form_10_7959a_failure_email'] %>
         form_10_7959c_email: <%= ENV['vanotify__services__ivc_champva__template_id__form_10_7959c_email'] %>
-        form_10_7959c_failure_email: form_10_7959c_failure_email
+        form_10_7959c_failure_email: <%= ENV['vanotify__services__ivc_champva__template_id__form_10_7959c_failure_email'] %>
         form_10_7959f_1_email: <%= ENV['vanotify__services__ivc_champva__template_id__form_10_7959f_1_email'] %>
         form_10_7959f_1_failure_email: <%= ENV['vanotify__services__ivc_champva__template_id__form_10_7959f_1_failure_email'] %>
         form_10_7959f_2_email: <%= ENV['vanotify__services__ivc_champva__template_id__form_10_7959f_2_email'] %>


### PR DESCRIPTION
## Summary

Adds two more IVC failure email template values to the settings file. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/104386

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots

NA

## What areas of the site does it impact?

IVC forms 10-7959a/c

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA