### PR TITLE
feat: test Flipper feature flag in ApplicationController

### DIFF
--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/application_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/application_spec.rb
@@ -29,32 +29,43 @@ RSpec.describe AccreditedRepresentativePortal::ApplicationController, type: :req
       Rails.application.reload_routes!
     end
 
-    context 'when authenticated' do
-      context 'with a valid audience' do
-        it 'allows access' do
-          expect(subject).to have_http_status(:ok)
+    context 'when feature flag is enabled' do
+      before { Flipper.enable(:accredited_representative_portal_pilot) }
+
+      context 'when authenticated' do
+        context 'with a valid audience' do
+          it 'allows access' do
+            expect(subject).to have_http_status(:ok)
+          end
+        end
+
+        context 'with an invalid audience' do
+          let(:access_token_cookie) { SignIn::AccessTokenJwtEncoder.new(access_token: invalid_access_token).perform }
+          let(:expected_log_message) { '[SignIn][AudienceValidator] Invalid audience' }
+          let(:expected_log_payload) do
+            { invalid_audience: invalid_access_token.audience, valid_audience: valid_access_token.audience }
+          end
+          let(:expected_response_body) do
+            { errors: 'Invalid audience' }.to_json
+          end
+
+          before { allow(Rails.logger).to receive(:error) }
+
+          it 'denies access' do
+            expect(subject).to have_http_status(:unauthorized)
+            expect(subject.body).to eq(expected_response_body)
+            expect(Rails.logger).to have_received(:error).with(expected_log_message, expected_log_payload)
+          end
         end
       end
+    end
 
-      context 'with an invalid audience' do
-        let(:access_token_cookie) { SignIn::AccessTokenJwtEncoder.new(access_token: invalid_access_token).perform }
-        let(:expected_log_message) { '[SignIn][AudienceValidator] Invalid audience' }
-        let(:expected_log_payload) do
-          { invalid_audience: invalid_access_token.audience, valid_audience: valid_access_token.audience }
-        end
-        let(:expected_response_body) do
-          { errors: 'Invalid audience' }.to_json
-        end
+    context 'when feature flag is disabled' do
+      before { Flipper.disable(:accredited_representative_portal_pilot) }
 
-        before do
-          allow(Rails.logger).to receive(:error)
-        end
-
-        it 'denies access' do
-          expect(subject).to have_http_status(:unauthorized)
-          expect(subject.body).to eq(expected_response_body)
-          expect(Rails.logger).to have_received(:error).with(expected_log_message, expected_log_payload)
-        end
+      it 'returns 403 Forbidden regardless of authentication' do
+        expect(subject).to have_http_status(:forbidden)
+        expect(subject.body).to match(/flag is disabled/)
       end
     end
   end


### PR DESCRIPTION
This PR ensures that all routes in the Accredited Representative Portal are properly gated behind the :accredited_representative_portal_pilot feature flag. If the flag is disabled, the API will immediately return 403 Forbidden, regardless of authentication.
