### PR TITLE
[VI-1104] updates Form526 user_account lookup

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -643,12 +643,22 @@ class Form526Submission < ApplicationRecord
   end
 
   def get_user_verifications
-    UserVerification.where(idme_uuid: user&.idme_uuid)
-                    .or(UserVerification.where(backing_idme_uuid: user&.idme_uuid))
-                    .or(UserVerification.where(logingov_uuid: user&.logingov_uuid))
-                    .or(UserVerification.where(mhv_uuid: user&.mhv_credential_uuid))
-                    .or(UserVerification.where(dslogon_uuid: user&.edipi))
-                    .where.not(user_account_id:)
+    user_verifications = []
+    if (idme_uuid = user&.idme_uuid).present?
+      user_verifications = UserVerification.where(idme_uuid:)
+                                           .or(UserVerification.where(backing_idme_uuid: idme_uuid))
+                                           .where.not(user_account_id:)
+    end
+    if (user_verifications.empty? && logingov_uuid = user&.logingov_uuid).present?
+      user_verifications = UserVerification.where(logingov_uuid:).where.not(user_account_id:)
+    end
+    if (user_verifications.empty? && mhv_uuid = user&.mhv_credential_uuid).present?
+      user_verifications = UserVerification.where(mhv_uuid:).where.not(user_account_id:)
+    end
+    if (user_verifications.empty? && dslogon_uuid = user&.edipi).present?
+      user_verifications = UserVerification.where(dslogon_uuid:).where.not(user_account_id:)
+    end
+    user_verifications
   end
 
   def user

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -645,7 +645,7 @@ class Form526Submission < ApplicationRecord
   end
 
   def log_payload
-    @log_payload ||= { user_uuid:, submission_id: }
+    @log_payload ||= { user_uuid:, submission_id: id }
   end
 
   def mpi_service

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -466,13 +466,11 @@ class Form526Submission < ApplicationRecord
   end
 
   def account
-    # first, check for an ICN on the UserAccount associated to the submission, return it if found
-    account = user_account
-    return account if account&.icn.present?
+    return user_account if user_account.icn.present?
 
-    # next, check MPI for profile information using the saved EDIPI
+    # check MPI for profile information using the saved EDIPI
     mpi_response = MPI::Service.new.find_profile_by_edipi(edipi: auth_headers['va_eauth_dodedipnid'])
-    OpenStruct.new(icn: mpi_response.profile.icn) if mpi_response && mpi_response.profile.icn.present?
+    OpenStruct.new(icn: mpi_response.profile.icn) if mpi_response.ok? && mpi_response.profile.icn.present?
   end
 
   # Send the Submitted Email - when the Veteran has clicked the "submit" button in va.gov

--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -691,14 +691,14 @@ namespace :form526 do
       edipi = submission.auth_headers['va_eauth_dodedipnid']
       raise Error, 'no edipi' unless edipi
 
-      ids = { edipi:, icn: submission.user_account&.icn || fetch_mpi_icn(edipi:) }
+      ids = { edipi:, icn: submission.user_account&.icn }
 
       pp mpi_profile(user_identity(**ids)).as_json
     end
 
     def mpi_profile(user_identity)
-      if user_identity.mhv_icn
-        find_profile_response = MPI::Service.new.find_profile_by_identifier(identifier: user_identity.mhv_icn,
+      if user_identity.icn
+        find_profile_response = MPI::Service.new.find_profile_by_identifier(identifier: user_identity.icn,
                                                                             identifier_type: MPI::Constants::ICN)
       else
         find_profile_response = MPI::Service.new.find_profile_by_edipi(edipi: user_identity.edipi)
@@ -710,11 +710,6 @@ namespace :form526 do
 
     def user_identity(icn:, edipi:)
       OpenStruct.new mhv_icn: icn, edipi:
-    end
-
-    def fetch_mpi_icn(edipi:)
-      mpi_response = MPI::Service.new.find_profile_by_edipi(edipi:)
-      mpi_response.profile.icn if mpi_response.ok? && mpi_response.profile.icn.present?
     end
 
     Form526Submission.where(id: args.extras).find_each { |sub| puts_mpi_profile sub }

--- a/rakelib/form526.rake
+++ b/rakelib/form526.rake
@@ -693,23 +693,19 @@ namespace :form526 do
 
       ids = { edipi:, icn: submission.user_account&.icn }
 
-      pp mpi_profile(user_identity(**ids)).as_json
+      pp mpi_profile(ids).as_json
     end
 
-    def mpi_profile(user_identity)
-      if user_identity.icn
-        find_profile_response = MPI::Service.new.find_profile_by_identifier(identifier: user_identity.icn,
+    def mpi_profile(ids)
+      if ids[:icn]
+        find_profile_response = MPI::Service.new.find_profile_by_identifier(identifier: ids[:icn],
                                                                             identifier_type: MPI::Constants::ICN)
       else
-        find_profile_response = MPI::Service.new.find_profile_by_edipi(edipi: user_identity.edipi)
+        find_profile_response = MPI::Service.new.find_profile_by_edipi(edipi: ids[:edipi])
       end
       raise find_profile_response.error if find_profile_response.error
 
       find_profile_response.profile
-    end
-
-    def user_identity(icn:, edipi:)
-      OpenStruct.new mhv_icn: icn, edipi:
     end
 
     Form526Submission.where(id: args.extras).find_each { |sub| puts_mpi_profile sub }

--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -3,9 +3,11 @@
 FactoryBot.define do
   factory :form526_submission do
     transient do
-      user { create(:disabilities_compensation_user) }
+      user_verification { create(:idme_user_verification) }
+      user { create(:disabilities_compensation_user, idme_uuid: user_verification.idme_uuid) }
       submissions_path { Rails.root.join(*'/spec/support/disability_compensation_form/submissions'.split('/')).to_s }
     end
+    user_account { user_verification.user_account }
     user_uuid { user.uuid }
     saved_claim { create(:va526ez) }
     submitted_claim_id { nil }

--- a/spec/lib/sidekiq/form526_backup_submission_process/processor_spec.rb
+++ b/spec/lib/sidekiq/form526_backup_submission_process/processor_spec.rb
@@ -28,8 +28,10 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Processor do
   end
 
   describe '#choose_provider' do
-    let(:account) { create(:account) }
-    let(:submission) { create(:form526_submission, user_uuid: account.idme_uuid, submit_endpoint: 'claims_api') }
+    let(:user) { create(:user, :loa3) }
+    let(:icn) { user.icn }
+    let(:user_account) { create(:user_account, icn:, id: user.user_account_uuid) }
+    let(:submission) { create(:form526_submission, user_account:, submit_endpoint: 'claims_api') }
 
     it 'delegates to the ApiProviderFactory with the correct data' do
       auth_headers = {}
@@ -38,7 +40,7 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Processor do
           type: ApiProviderFactory::FACTORIES[:generate_pdf],
           provider: ApiProviderFactory::API_PROVIDER[:lighthouse],
           options: { auth_headers:, breakered: true },
-          current_user: OpenStruct.new({ flipper_id: submission.user_uuid, icn: account.icn }),
+          current_user: OpenStruct.new({ flipper_id: submission.user_uuid, icn: }),
           feature_toggle: nil
         }
       )
@@ -59,7 +61,7 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Processor do
           type: ApiProviderFactory::FACTORIES[:generate_pdf],
           provider: ApiProviderFactory::API_PROVIDER[:lighthouse],
           options: { auth_headers: submission.auth_headers, breakered: true },
-          current_user: OpenStruct.new({ flipper_id: submission.user_uuid, icn: account.icn }),
+          current_user: OpenStruct.new({ flipper_id: submission.user_uuid, icn: }),
           feature_toggle: nil
         }
       ).and_call_original

--- a/spec/lib/sidekiq/form526_backup_submission_process/processor_spec.rb
+++ b/spec/lib/sidekiq/form526_backup_submission_process/processor_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Processor do
   end
 
   describe '#choose_provider' do
-    let(:user) { create(:user, :loa3) }
-    let(:icn) { user.icn }
-    let(:user_account) { create(:user_account, icn:, id: user.user_account_uuid) }
+    let(:user) { create(:user, :loa3, :with_terms_of_use_agreement) }
+    let(:user_account) { user.user_account }
+    let(:icn) { user_account.icn }
     let(:submission) { create(:form526_submission, user_account:, submit_endpoint: 'claims_api') }
 
     it 'delegates to the ApiProviderFactory with the correct data' do

--- a/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
+++ b/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
       .and_return('access_token')
   end
 
-  let(:user_account) { create(:user_account) }
+  let(:user_account) { create(:user_account, icn: '123498767V234859') }
   let(:user) { create(:user, :loa3, icn: user_account.icn) }
   let(:auth_headers) do
     EVSS::DisabilityCompensationAuthHeaders.new(user).add_headers(EVSS::AuthHeaders.new(user).to_h)
@@ -112,7 +112,7 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
         allow(Settings.form526_backup).to receive_messages(submission_method: payload_method, enabled: true)
       end
 
-      let!(:submission) { create(:form526_submission, :with_everything) }
+      let!(:submission) { create(:form526_submission, :with_everything, user_account:) }
       let!(:upload_data) { submission.form[Form526Submission::FORM_526_UPLOADS] }
 
       context 'successfully' do
@@ -223,7 +223,7 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
       allow(Settings.form526_backup).to receive_messages(submission_method: 'single', enabled: true)
     end
 
-    let!(:submission) { create(:form526_submission, :with_non_pdf_uploads) }
+    let!(:submission) { create(:form526_submission, :with_non_pdf_uploads, user_account:) }
     let!(:upload_data) { submission.form[Form526Submission::FORM_526_UPLOADS] }
 
     context 'converts non-pdf files to pdf' do

--- a/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
+++ b/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
@@ -16,9 +16,8 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
       .and_return('access_token')
   end
 
-  let(:user) { create(:user, :loa3) }
-  let(:icn) { user.icn }
-  let(:user_account) { create(:user_account, icn:, id: user.user_account_uuid) }
+  let(:user_account) { create(:user_account) }
+  let(:user) { create(:user, :loa3, icn: user_account.icn) }
   let(:auth_headers) do
     EVSS::DisabilityCompensationAuthHeaders.new(user).add_headers(EVSS::AuthHeaders.new(user).to_h)
   end

--- a/spec/lib/sidekiq/form526_job_status_tracker/job_tracker_spec.rb
+++ b/spec/lib/sidekiq/form526_job_status_tracker/job_tracker_spec.rb
@@ -19,7 +19,7 @@ describe Sidekiq::Form526JobStatusTracker::JobTracker do
 
   context 'with an exhausted callback message' do
     let(:user_account) { create(:user_account, icn: '123498767V234859') }
-    let!(:form526_submission) { create(:form526_submission) }
+    let!(:form526_submission) { create(:form526_submission, user_account:) }
     let!(:form526_job_status) do
       create(:form526_job_status, job_id: msg['jid'], form526_submission:)
     end

--- a/spec/lib/sidekiq/form526_job_status_tracker/job_tracker_spec.rb
+++ b/spec/lib/sidekiq/form526_job_status_tracker/job_tracker_spec.rb
@@ -18,6 +18,7 @@ describe Sidekiq::Form526JobStatusTracker::JobTracker do
   end
 
   context 'with an exhausted callback message' do
+    let(:user_account) { create(:user_account, icn: '123498767V234859') }
     let!(:form526_submission) { create(:form526_submission) }
     let!(:form526_job_status) do
       create(:form526_job_status, job_id: msg['jid'], form526_submission:)

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe Form526Submission do
 
   let(:user_account) { create(:user_account) }
   let(:user) do
-    create(:user, :loa3, first_name: 'Beyonce', last_name: 'Knowles', icn: user_account.icn,
+    create(:user, :loa3, first_name: 'Beyonce',
+                         last_name: 'Knowles',
+                         icn: user_account.icn,
                          idme_uuid: SecureRandom.uuid)
   end
   let(:auth_headers) do

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Form526Submission do
     )
   end
 
-  let(:user) { create(:user, :loa3, first_name: 'Beyonce', last_name: 'Knowles', user_account_uuid: SecureRandom.uuid) }
-  let(:user_account) { create(:user_account, icn: user.icn, id: user.user_account_uuid) }
+  let(:user_account) { create(:user_account) }
+  let(:user) { create(:user, :loa3, first_name: 'Beyonce', last_name: 'Knowles', icn: user_account.icn) }
   let(:auth_headers) do
     EVSS::DisabilityCompensationAuthHeaders.new(user).add_headers(EVSS::AuthHeaders.new(user).to_h)
   end

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -1582,17 +1582,6 @@ RSpec.describe Form526Submission do
         expect(account.icn).to eq('123498767V222222')
       end
 
-      it 'submissions user account has no ICN, default to Account lookup' do
-        submission.user_account = UserAccount.new(icn: nil)
-        account = submission.account
-        expect(account.icn).to eq('123498767V234859')
-      end
-
-      it 'submission has NO user account, default to Account lookup' do
-        account = submission.account
-        expect(account.icn).to eq('123498767V234859')
-      end
-
       it 'submissions user account has no ICN, lookup from past submissions' do
         user_account_with_icn = UserAccount.create!(icn: '123498767V111111')
         create(:form526_submission, user_uuid: submission.user_uuid, user_account: user_account_with_icn)
@@ -1602,18 +1591,18 @@ RSpec.describe Form526Submission do
         expect(account.icn).to eq('123498767V111111')
       end
 
-      it 'lookup ICN from user verifications, idme_uuid defined' do
+      it 'lookup ICN from User model csp_uuid-sourced UserVerifications, idme_uuid defined' do
         user_account_with_icn = UserAccount.create!(icn: '123498767V333333')
-        UserVerification.create!(idme_uuid: submission.user_uuid, user_account_id: user_account_with_icn.id)
+        UserVerification.create!(idme_uuid: user.idme_uuid, user_account_id: user_account_with_icn.id)
         submission.user_account = UserAccount.create!(icn: nil)
         submission.save!
         account = submission.account
         expect(account.icn).to eq('123498767V333333')
       end
 
-      it 'lookup ICN from user verifications, backing_idme_uuid defined' do
+      it 'lookup ICN from User model csp_uuid-sourced UserVerifications, backing_idme_uuid defined' do
         user_account_with_icn = UserAccount.create!(icn: '123498767V444444')
-        UserVerification.create!(dslogon_uuid: Faker::Internet.uuid, backing_idme_uuid: submission.user_uuid,
+        UserVerification.create!(dslogon_uuid: Faker::Internet.uuid, backing_idme_uuid: user.idme_uuid,
                                  user_account_id: user_account_with_icn.id)
         submission.user_account = UserAccount.create!(icn: nil)
         submission.save!
@@ -1623,12 +1612,17 @@ RSpec.describe Form526Submission do
 
       it 'lookup ICN from user verifications, alternate provider id defined' do
         user_account_with_icn = UserAccount.create!(icn: '123498767V555555')
-        UserVerification.create!(dslogon_uuid: submission.user_uuid, backing_idme_uuid: Faker::Internet.uuid,
+        UserVerification.create!(dslogon_uuid: user.edipi, backing_idme_uuid: Faker::Internet.uuid,
                                  user_account_id: user_account_with_icn.id)
         submission.user_account = UserAccount.create!(icn: nil)
         submission.save!
         account = submission.account
         expect(account.icn).to eq('123498767V555555')
+      end
+
+      it 'submission has NO user account & NO linked user verifications, default to Account lookup' do
+        account = submission.account
+        expect(account.icn).to eq('123498767V234859')
       end
     end
   end

--- a/spec/requests/v0/disability_compensation_form_spec.rb
+++ b/spec/requests/v0/disability_compensation_form_spec.rb
@@ -8,8 +8,7 @@ require 'disability_compensation/factories/api_provider_factory'
 RSpec.describe 'V0::DisabilityCompensationForm', type: :request do
   include SchemaMatchers
 
-  let(:user_account) { create(:user_account) }
-  let(:user) { build(:disabilities_compensation_user) }
+  let(:user) { build(:disabilities_compensation_user, :with_terms_of_use_agreement) }
   let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
   let(:headers_with_camel) { headers.merge('X-Key-Inflection' => 'camel') }
 

--- a/spec/requests/v0/disability_compensation_form_spec.rb
+++ b/spec/requests/v0/disability_compensation_form_spec.rb
@@ -8,6 +8,7 @@ require 'disability_compensation/factories/api_provider_factory'
 RSpec.describe 'V0::DisabilityCompensationForm', type: :request do
   include SchemaMatchers
 
+  let(:user_account) { create(:user_account) }
   let(:user) { build(:disabilities_compensation_user) }
   let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
   let(:headers_with_camel) { headers.merge('X-Key-Inflection' => 'camel') }
@@ -289,7 +290,10 @@ RSpec.describe 'V0::DisabilityCompensationForm', type: :request do
 
       context 'with an `bdd` claim' do
         let(:bdd_form) { File.read 'spec/support/disability_compensation_form/bdd_fe_submission.json' }
-        let(:user) { build(:disabilities_compensation_user, icn: '1012666073V986297') }
+        let(:user) do
+          build(:disabilities_compensation_user, :with_terms_of_use_agreement, icn: '1012666073V986297',
+                                                                               idme_uuid: SecureRandom.uuid)
+        end
 
         before do
           allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_token')

--- a/spec/sidekiq/central_mail/submit_form4142_job_spec.rb
+++ b/spec/sidekiq/central_mail/submit_form4142_job_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
       Flipper.disable(:disability_compensation_form4142_supplemental)
     end
 
-    let(:user_account) { create(:user_account) }
-    let(:user) { create(:user, :loa3, icn: user_account.icn) }
+    let(:user_account) { user.user_account }
+    let(:user) { create(:user, :loa3, :with_terms_of_use_agreement) }
     let(:auth_headers) do
       EVSS::DisabilityCompensationAuthHeaders.new(user).add_headers(EVSS::AuthHeaders.new(user).to_h)
     end
@@ -141,7 +141,7 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
 
     context 'catastrophic failure state' do
       describe 'when all retries are exhausted' do
-        let!(:form526_submission) { create(:form526_submission) }
+        let!(:form526_submission) { create(:form526_submission, user_account:) }
         let!(:form526_job_status) { create(:form526_job_status, :retryable_error, form526_submission:, job_id: 1) }
 
         it 'updates a StatsD counter and updates the status on an exhaustion event' do
@@ -175,7 +175,7 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
                 timestamp: instance_of(Time),
                 form526_submission_id: form526_submission.id
               },
-              nil,
+              user_account.id,
               call_location: instance_of(Logging::CallLocation)
             )
 
@@ -204,8 +204,8 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
       Flipper.enable(:disability_compensation_form4142_supplemental)
     end
 
-    let(:user_account) { create(:user_account) }
-    let(:user) { create(:user, :loa3, icn: user_account.icn) }
+    let(:user_account) { user.user_account }
+    let(:user) { create(:user, :loa3, :with_terms_of_use_agreement) }
     let(:auth_headers) do
       EVSS::DisabilityCompensationAuthHeaders.new(user).add_headers(EVSS::AuthHeaders.new(user).to_h)
     end

--- a/spec/sidekiq/central_mail/submit_form4142_job_spec.rb
+++ b/spec/sidekiq/central_mail/submit_form4142_job_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
       Flipper.disable(:disability_compensation_form4142_supplemental)
     end
 
-    let(:user) { create(:user, :loa3) }
+    let(:user_account) { create(:user_account) }
+    let(:user) { create(:user, :loa3, icn: user_account.icn) }
     let(:auth_headers) do
       EVSS::DisabilityCompensationAuthHeaders.new(user).add_headers(EVSS::AuthHeaders.new(user).to_h)
     end
@@ -35,6 +36,7 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
       end
       let(:submission) do
         Form526Submission.create(user_uuid: user.uuid,
+                                 user_account:,
                                  auth_headers_json: auth_headers.to_json,
                                  saved_claim_id: saved_claim.id,
                                  form_json:,
@@ -120,6 +122,7 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
       end
       let(:submission) do
         Form526Submission.create(user_uuid: user.uuid,
+                                 user_account:,
                                  auth_headers_json: auth_headers.to_json,
                                  saved_claim_id: saved_claim.id,
                                  form_json: missing_postalcode_form_json,
@@ -201,7 +204,8 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
       Flipper.enable(:disability_compensation_form4142_supplemental)
     end
 
-    let(:user) { create(:user, :loa3) }
+    let(:user_account) { create(:user_account) }
+    let(:user) { create(:user, :loa3, icn: user_account.icn) }
     let(:auth_headers) do
       EVSS::DisabilityCompensationAuthHeaders.new(user).add_headers(EVSS::AuthHeaders.new(user).to_h)
     end
@@ -214,6 +218,7 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
       end
       let(:submission) do
         Form526Submission.create(user_uuid: user.uuid,
+                                 user_account:,
                                  auth_headers_json: auth_headers.to_json,
                                  saved_claim_id: saved_claim.id,
                                  form_json:,
@@ -349,6 +354,7 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
       end
       let(:submission) do
         Form526Submission.create(user_uuid: user.uuid,
+                                 user_account:,
                                  auth_headers_json: auth_headers.to_json,
                                  saved_claim_id: saved_claim.id,
                                  form_json: missing_postalcode_form_json,

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form0781_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form0781_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
                                               anything).and_return(false)
   end
 
-  let(:user_account) { create(:user_account) }
-  let(:user) { create(:user, :loa3, icn: user_account.icn) }
+  let(:user) { create(:user, :loa3, :with_terms_of_use_agreement) }
+  let(:user_account) { user.user_account }
   let(:auth_headers) do
     EVSS::DisabilityCompensationAuthHeaders.new(user).add_headers(EVSS::AuthHeaders.new(user).to_h)
   end
@@ -151,7 +151,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
 
   context 'catastrophic failure state' do
     describe 'when all retries are exhausted' do
-      let!(:form526_submission) { create(:form526_submission) }
+      let!(:form526_submission) { create(:form526_submission, user_account:) }
       let!(:form526_job_status) { create(:form526_job_status, :retryable_error, form526_submission:, job_id: 1) }
 
       it 'updates a StatsD counter and updates the status on an exhaustion event' do
@@ -187,7 +187,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
               timestamp: instance_of(Time),
               form526_submission_id: form526_submission.id
             },
-            nil,
+            user_account.id,
             call_location: instance_of(Logging::CallLocation)
           )
 

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form0781_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form0781_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
                                               anything).and_return(false)
   end
 
-  let(:user) { create(:user, :loa3) }
+  let(:user_account) { create(:user_account) }
+  let(:user) { create(:user, :loa3, icn: user_account.icn) }
   let(:auth_headers) do
     EVSS::DisabilityCompensationAuthHeaders.new(user).add_headers(EVSS::AuthHeaders.new(user).to_h)
   end
@@ -50,6 +51,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
     context 'when a submission has both 0781 and 0781a' do
       let(:submission) do
         Form526Submission.create(user_uuid: user.uuid,
+                                 user_account:,
                                  auth_headers_json: auth_headers.to_json,
                                  saved_claim_id: saved_claim.id,
                                  form_json: form0781,
@@ -99,6 +101,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
     context 'when a submission has 0781v2' do
       let(:submission) do
         Form526Submission.create(user_uuid: user.uuid,
+                                 user_account:,
                                  auth_headers_json: auth_headers.to_json,
                                  saved_claim_id: saved_claim.id,
                                  form_json: form0781v2,
@@ -307,6 +310,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
 
       let(:submission) do
         Form526Submission.create(user_uuid: user.uuid,
+                                 user_account:,
                                  auth_headers_json: auth_headers.to_json,
                                  saved_claim_id: saved_claim.id,
                                  form_json: form0781, # contains 0781 and 0781a
@@ -701,6 +705,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm0781, type: :job do
 
       let(:submission) do
         Form526Submission.create(user_uuid: user.uuid,
+                                 user_account:,
                                  auth_headers_json: auth_headers.to_json,
                                  saved_claim_id: saved_claim.id,
                                  form_json: form0781v2,

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_all_claim_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
       .and_return('fake_access_token')
   end
 
-  let(:user) { create(:user, :loa3) }
+  let(:user) { create(:user, :loa3, icn: '123498767V234859') }
+  let(:user_account) { create(:user_account, icn: user.icn, id: user.user_account_uuid) }
   let(:auth_headers) do
     EVSS::DisabilityCompensationAuthHeaders.new(user).add_headers(EVSS::AuthHeaders.new(user).to_h)
   end
@@ -35,10 +36,9 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
 
     let(:saved_claim) { create(:va526ez) }
     let(:submitted_claim_id) { 600_130_094 }
-    let(:user_account) { create(:user_account, icn: '123498767V234859') }
     let(:submission) do
       create(:form526_submission,
-             user_account_id: user_account.id,
+             user_account:,
              user_uuid: user.uuid,
              auth_headers_json: auth_headers.to_json,
              saved_claim_id: saved_claim.id)
@@ -107,6 +107,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
           create(:form526_submission,
                  :asthma_claim_for_increase,
                  user_uuid: user.uuid,
+                 user_account:,
                  auth_headers_json: auth_headers.to_json,
                  saved_claim_id: saved_claim.id)
         end
@@ -124,6 +125,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
           create(:form526_submission,
                  :without_diagnostic_code,
                  user_uuid: user.uuid,
+                 user_account:,
                  auth_headers_json: auth_headers.to_json,
                  saved_claim_id: saved_claim.id)
         end
@@ -144,6 +146,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
           create(:form526_submission,
                  :als_claim_for_increase,
                  user_uuid: user.uuid,
+                 user_account:,
                  auth_headers_json: auth_headers.to_json,
                  saved_claim_id: saved_claim.id)
         end
@@ -167,6 +170,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
           create(:form526_submission,
                  :als_claim_for_increase_terminally_ill,
                  user_uuid: user.uuid,
+                 user_account:,
                  auth_headers_json: auth_headers.to_json,
                  saved_claim_id: saved_claim.id)
         end
@@ -195,6 +199,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
         create(:form526_submission,
                :with_mixed_action_disabilities_and_free_text,
                user_uuid: user.uuid,
+               user_account:,
                auth_headers_json: auth_headers.to_json,
                saved_claim_id: saved_claim.id)
       end
@@ -214,6 +219,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
             create(:form526_submission,
                    :without_diagnostic_code,
                    user_uuid: user.uuid,
+                   user_account:,
                    auth_headers_json: auth_headers.to_json,
                    saved_claim_id: saved_claim.id)
           end
@@ -296,6 +302,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
           create(:form526_submission,
                  :with_empty_disabilities,
                  user_uuid: user.uuid,
+                 user_account:,
                  auth_headers_json: auth_headers.to_json,
                  saved_claim_id: saved_claim.id)
         end
@@ -350,6 +357,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
           create(:form526_submission,
                  :non_rrd_with_mas_diagnostic_code,
                  user_uuid: user.uuid,
+                 user_account:,
                  auth_headers_json: auth_headers.to_json,
                  saved_claim_id: saved_claim.id)
         end
@@ -396,6 +404,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
             create(:form526_submission,
                    :mas_diagnostic_code_with_classification,
                    user_uuid: user.uuid,
+                   user_account:,
                    auth_headers_json: auth_headers.to_json,
                    saved_claim_id: saved_claim.id)
           end
@@ -429,6 +438,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
           create(:form526_submission,
                  :with_multiple_mas_diagnostic_code,
                  user_uuid: user.uuid,
+                 user_account:,
                  auth_headers_json: auth_headers.to_json,
                  saved_claim_id: saved_claim.id)
         end
@@ -450,6 +460,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
           create(:form526_submission,
                  :with_everything,
                  user_uuid: user.uuid,
+                 user_account:,
                  auth_headers_json: auth_headers.to_json,
                  saved_claim_id: saved_claim.id,
                  submit_endpoint: 'claims_api')
@@ -560,6 +571,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526AllClaim, type: :j
         create(:form526_submission,
                :with_uploads,
                user_uuid: user.uuid,
+               user_account:,
                auth_headers_json: auth_headers.to_json,
                saved_claim_id: saved_claim.id)
       end

--- a/spec/sidekiq/evss/disability_compensation_form/submit_uploads_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_uploads_spec.rb
@@ -425,7 +425,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
             timestamp: instance_of(Time),
             form526_submission_id: submission.id
           },
-          nil,
+          user_account.id,
           call_location: instance_of(Logging::CallLocation)
         )
 

--- a/spec/sidekiq/evss/disability_compensation_form/submit_uploads_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_uploads_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
     Flipper.disable(:form526_send_document_upload_failure_notification)
   end
 
-  let(:user_account) { create(:user_account) }
-  let(:user) { create(:user, :loa3, icn: user_account.icn) }
+  let(:user) { create(:user, :loa3, :with_terms_of_use_agreement) }
+  let(:user_account) { user.user_account }
   let(:auth_headers) do
     EVSS::DisabilityCompensationAuthHeaders.new(user).add_headers(EVSS::AuthHeaders.new(user).to_h)
   end
@@ -355,7 +355,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
 
   context 'catastrophic failure state' do
     describe 'when all retries are exhausted' do
-      let!(:form526_submission) { create(:form526_submission, :with_uploads) }
+      let!(:form526_submission) { create(:form526_submission, :with_uploads, user_account:) }
       let!(:form526_job_status) { create(:form526_job_status, :retryable_error, form526_submission:, job_id: 1) }
 
       it 'updates a StatsD counter and updates the status on an exhaustion event' do

--- a/spec/sidekiq/evss/disability_compensation_form/submit_uploads_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_uploads_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
     Flipper.disable(:form526_send_document_upload_failure_notification)
   end
 
-  let(:user) { create(:user, :loa3) }
+  let(:user_account) { create(:user_account) }
+  let(:user) { create(:user, :loa3, icn: user_account.icn) }
   let(:auth_headers) do
     EVSS::DisabilityCompensationAuthHeaders.new(user).add_headers(EVSS::AuthHeaders.new(user).to_h)
   end
@@ -20,6 +21,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitUploads, type: :job do
   let(:submission) do
     create(:form526_submission, :with_uploads,
            user_uuid: user.uuid,
+           user_account:,
            auth_headers_json: auth_headers.to_json,
            saved_claim_id: saved_claim.id,
            submitted_claim_id: '600130094')

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/disability_rating/200_Not_Connected_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/disability_rating/200_Not_Connected_response.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://sandbox-api.va.gov/services/veteran_verification/v2/disability_rating/123498767V234859
+    uri: https://staging-api.va.gov/services/veteran_verification/v2/disability_rating/123498767V234859
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/lighthouse/veteran_verification/disability_rating/200_Not_Connected_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/veteran_verification/disability_rating/200_Not_Connected_response.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://staging-api.va.gov/services/veteran_verification/v2/disability_rating/123498767V234859
+    uri: https://sandbox-api.va.gov/services/veteran_verification/v2/disability_rating/123498767V234859
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
## Summary

- Updates `Form526Submission` model's `account` methods backup lookup behavior
  - Past behavior for backup querying when `UserAccount` sourced ICN failed:
    1. Use past submissions to find alternative `UserAccount` with an ICN
    2. `user_uuid` lookups of `UserVerification` & `Account` records to find  an ICN
  - Updated backup query behavior calls MPI for a profile with an ICN
    1. first query made using EDIPI -  `auth_headers['va_eauth_dodedipnid']`
    2. second query made using user name/DOB/SSN  as saved in submission auth_headers
- enforces a `UserAccount` association on `Form526Submission` records in validations
- updates `form526.rake` to rely on `UserAccount` over `Account` for ICN sourcing & adds similar MPI backup querying for ICN values

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-1104
- https://dsva.slack.com/archives/C04KW0B46N5/p1741623491445729
