### PR TITLE
1421: add form-1095b service tag for datadog monitoring

### DIFF
--- a/app/controllers/v0/form1095_bs_controller.rb
+++ b/app/controllers/v0/form1095_bs_controller.rb
@@ -2,7 +2,7 @@
 
 module V0
   class Form1095BsController < ApplicationController
-    service_tag 'deprecated'
+    service_tag 'form-1095b'
     before_action { authorize :form1095, :access? }
     before_action :set_form, only: %i[download_pdf download_txt]
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO (but these endpoints are not currently in use)
- Adds a service tag for use on datadog. AFAIK no additional steps are necessary to make this service appear on DD.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-iir/issues/1424

## Testing done

I don't think this needs to be tested, but I'm open to suggestion if anyone has ideas.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
It should create a new service on DD that can be used for monitoring this feature.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
