### PR TITLE
[ARP] Fix POA signature

### DIFF
--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/representative_user_account.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/representative_user_account.rb
@@ -14,7 +14,7 @@ module AccreditedRepresentativePortal
         .select(&:accepts_digital_power_of_attorney_requests?)
     end
 
-    def registration_number(power_of_attorney_holder_type)
+    def get_registration_number(power_of_attorney_holder_type)
       registrations.each do |registration|
         next unless registration.power_of_attorney_holder_type == power_of_attorney_holder_type
 

--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/power_of_attorney_request_service/accept.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/power_of_attorney_request_service/accept.rb
@@ -92,10 +92,14 @@ module AccreditedRepresentativePortal
       end
 
       def organization_data
+        registration_number =
+          creator.get_registration_number(
+            poa_request.power_of_attorney_holder_type
+          )
+
         {
           poaCode: poa_request.power_of_attorney_holder_poa_code,
-          # TODO: update when allowing non-veteran claimant submissions
-          registrationNumber: poa_request.accredited_individual_registration_number
+          registrationNumber: registration_number
         }
       end
 

--- a/modules/accredited_representative_portal/spec/models/accredited_representative_portal/representative_user_account_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representative_portal/representative_user_account_spec.rb
@@ -94,8 +94,8 @@ module AccreditedRepresentativePortal
       end
     end
 
-    describe '#registration_number' do
-      subject { user_account.registration_number(power_of_attorney_holder_type) }
+    describe '#get_registration_number' do
+      subject { user_account.get_registration_number(power_of_attorney_holder_type) }
 
       context 'without a user email set' do
         let(:user_email) { nil }

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_request_decisions_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_request_decisions_spec.rb
@@ -29,7 +29,12 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestDecisio
   let!(:other_vso) { create(:organization, poa: other_poa_code, can_accept_digital_poa_requests: true) }
 
   let!(:poa_request) do
-    create(:power_of_attorney_request, :with_veteran_claimant, poa_code:)
+    create(
+      :power_of_attorney_request,
+      :with_veteran_claimant,
+      accredited_individual_registration_number: nil,
+      poa_code:
+    )
   end
   let!(:other_poa_request) { create(:power_of_attorney_request, poa_code: other_poa_code) }
 
@@ -41,7 +46,6 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestDecisio
       :accredited_representative_portal_pilot,
       instance_of(AccreditedRepresentativePortal::RepresentativeUser)
     ).and_return(true)
-    poa_request.update(accredited_individual_registration_number: '357458')
     poa_request.claimant.update(icn: '1012666183V089914')
 
     login_as(test_user)


### PR DESCRIPTION
Use the signature of the accepting representative rather than the requested representative on the POA form.