### PR TITLE
API-45550-changes-422-to-400-bad-request

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -322,7 +322,7 @@ module ClaimsApi
         def valid_page_param?(key)
           return true if params[:page][:"#{key}"].is_a?(Integer) && params[:page][:"#{key}"]
 
-          raise ::Common::Exceptions::UnprocessableEntity.new(
+          raise ::Common::Exceptions::BadRequest.new(
             detail: "The page[#{key}] param value #{params[:page][:"#{key}"]} is invalid"
           )
         end
@@ -337,7 +337,7 @@ module ClaimsApi
             msg = "The maximum page number param value of #{MAX_PAGE_NUMBER} has been exceeded."
           end
 
-          raise ::Common::Exceptions::UnprocessableEntity.new(
+          raise ::Common::Exceptions::BadRequest.new(
             detail: msg
           )
         end

--- a/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
+++ b/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
@@ -75,7 +75,7 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
                 VCR.use_cassette('claims_api/bgs/manage_representative_service/read_poa_request_valid') do
                   index_request_with(poa_codes:, page_params:, auth_header:)
 
-                  expect(response).to have_http_status(:unprocessable_entity)
+                  expect(response).to have_http_status(:bad_request)
                   expect(response.parsed_body['errors'][0]['detail']).to eq(
                     'The maximum page size param value of 100 has been exceeded.'
                   )
@@ -92,7 +92,7 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
                 VCR.use_cassette('claims_api/bgs/manage_representative_service/read_poa_request_valid') do
                   index_request_with(poa_codes:, page_params:, auth_header:)
 
-                  expect(response).to have_http_status(:unprocessable_entity)
+                  expect(response).to have_http_status(:bad_request)
                   expect(response.parsed_body['errors'][0]['detail']).to eq(
                     'Both the maximum page size param value of 100 has been exceeded ' \
                     'and the maximum page number param value of 100 has been exceeded.'
@@ -643,7 +643,7 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
             expect do
               subject.send(:validate_page_size_and_number_params)
             end.to(raise_error do |error|
-              expect(error.message).to eq('Unprocessable Entity')
+              expect(error.message).to eq('Bad request')
               expect(error.errors[0].detail).to eq("The page[number] param value #{param_val} is invalid")
             end)
           end
@@ -656,7 +656,7 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
             expect do
               subject.send(:validate_page_size_and_number_params)
             end.to(raise_error do |error|
-              expect(error.message).to eq('Unprocessable Entity')
+              expect(error.message).to eq('Bad request')
               expect(error.errors[0].detail).to eq("The page[size] param value #{param_val} is invalid")
             end)
           end
@@ -669,7 +669,7 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
             expect do
               subject.send(:validate_page_size_and_number_params)
             end.to(raise_error do |error|
-              expect(error.message).to eq('Unprocessable Entity')
+              expect(error.message).to eq('Bad request')
             end)
           end
         end


### PR DESCRIPTION
## Summary
* When params are sent to the power-of-attorney-requests endpoint we want a 400 status returned not a 422
* Adjusts the error status returned and adjusts the related tests

## Related issue(s)
[API-45550](https://jira.devops.va.gov/browse/API-45550)
[API-45362](https://jira.devops.va.gov/browse/API-45362)

## Testing done

- [x] *Adjusts existing code for change code is covered by unit tests*

## Screenshots
<img width="513" alt="Screenshot 2025-03-10 at 8 47 43 AM" src="https://github.com/user-attachments/assets/8178de18-e1e4-4870-8b85-2d455b1b0632" />

## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
	modified:   modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
