### PR TITLE
Fix endpoint filter for StatD Breakers metrics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1027,6 +1027,7 @@ lib/simple_forms_api_submission @department-of-veterans-affairs/platform-va-prod
 lib/slack @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/sm @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/stats_d_metric.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+lib/statsd_endpoint_tag_filter.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/source_app_middleware.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/statsd_middleware.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/string_helpers.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1584,6 +1585,7 @@ spec/lib/simple_forms_api_submission @department-of-veterans-affairs/platform-va
 spec/lib/slack/service_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/sm @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/string_helpers_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/lib/statsd_endpoint_tag_filter_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/tasks/support/schema_camelizer_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/token_validation @department-of-veterans-affairs/lighthouse-dash @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/user_profile_attribute_service_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/octo-identity

--- a/lib/breakers/statsd_plugin.rb
+++ b/lib/breakers/statsd_plugin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'string_helpers'
+require 'statsd_endpoint_tag_filter'
 
 module Breakers
   class StatsdPlugin
@@ -10,7 +10,7 @@ module Breakers
       tags = []
       if upstream_request
         if upstream_request.url&.path
-          tags.append("endpoint:#{StringHelpers.filtered_endpoint_tag(upstream_request.url.path)}")
+          tags.append("endpoint:#{StatsdEndpointTagFilter.redact(upstream_request.url.path)}")
         end
         tags.append("method:#{upstream_request.method}") if upstream_request.method
         tags.append("source:#{source_app}") if source_app

--- a/lib/statsd_endpoint_tag_filter.rb
+++ b/lib/statsd_endpoint_tag_filter.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class StatsdEndpointTagFilter
+
+  def self.redact(endpoint)
+    # Regex for OIDs (excluding version numbers)
+    oid_regex = /(\b\d+(\.\d+)+\b)/
+    uuid_regex = /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/
+    encoded_segment_regex = %r{[^/]*_5eusd(?:va|od)[^/]*}
+    id_regex = /\b[a-f0-9]{5,}\b/
+    institution_ids = /[\dA-Z]{8}/
+    provider_ids = /Providers\(\d{10}\)/
+    okta_users = %r{(?<user_path>api/v1/users/)\w*}
+    digit = /(?<![a-zA-Z])(?<!v)-?\d+/  # Avoid matching numbers with preceding letters or 'v'
+    contact_id = /\d{10}V\d{6}(%5ENI%5E200M%5EUSVHA)*/  # institution id's of form 111A2222 or 11A22222
+
+    # Combined regex (OIDs OR UUIDs)
+    redact_regex = Regexp.union(
+      oid_regex,
+      id_regex,
+      uuid_regex,
+      encoded_segment_regex,
+      institution_ids,
+      provider_ids,
+      okta_users,
+      digit,
+      contact_id
+    )
+    # replace identifiers with 'xxx'
+    endpoint.gsub(redact_regex, 'xxx').gsub(/x{4,}/, 'xxx')
+  end
+end

--- a/lib/statsd_endpoint_tag_filter.rb
+++ b/lib/statsd_endpoint_tag_filter.rb
@@ -1,32 +1,31 @@
 # frozen_string_literal: true
 
 class StatsdEndpointTagFilter
+  OID_REGEX = /(\b\d+(\.\d+)+\b)/
+  UUID_REGEX = /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/
+  ENCODED_SEGMENT_REGEX = %r{[^/]*_5eusd(?:va|od)[^/]*}
+  ID_REGEX = /\b[a-f0-9]{5,}\b/
+  INSTITUTION_IDS = /[\dA-Z]{8}/
+  PROVIDER_IDS = /Providers\(\d{10}\)/
+  OKTA_USERS = %r{(?<user_path>api/v1/users/)\w*}
+  DIGIT = /(?<![a-zA-Z])(?<!v)-?\d+/ # Avoid matching numbers with preceding letters or 'v'
+  CONTACT_ID = /\d{10}V\d{6}(%5ENI%5E200M%5EUSVHA)*/ # institution id's of form 111A2222 or 11A22222
+
+  # Combined regex (OIDs OR UUIDs)
+  REDACT_REGEX = Regexp.union(
+    OID_REGEX,
+    ID_REGEX,
+    UUID_REGEX,
+    ENCODED_SEGMENT_REGEX,
+    INSTITUTION_IDS,
+    PROVIDER_IDS,
+    OKTA_USERS,
+    DIGIT,
+    CONTACT_ID
+  )
 
   def self.redact(endpoint)
-    # Regex for OIDs (excluding version numbers)
-    oid_regex = /(\b\d+(\.\d+)+\b)/
-    uuid_regex = /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/
-    encoded_segment_regex = %r{[^/]*_5eusd(?:va|od)[^/]*}
-    id_regex = /\b[a-f0-9]{5,}\b/
-    institution_ids = /[\dA-Z]{8}/
-    provider_ids = /Providers\(\d{10}\)/
-    okta_users = %r{(?<user_path>api/v1/users/)\w*}
-    digit = /(?<![a-zA-Z])(?<!v)-?\d+/  # Avoid matching numbers with preceding letters or 'v'
-    contact_id = /\d{10}V\d{6}(%5ENI%5E200M%5EUSVHA)*/  # institution id's of form 111A2222 or 11A22222
-
-    # Combined regex (OIDs OR UUIDs)
-    redact_regex = Regexp.union(
-      oid_regex,
-      id_regex,
-      uuid_regex,
-      encoded_segment_regex,
-      institution_ids,
-      provider_ids,
-      okta_users,
-      digit,
-      contact_id
-    )
-    # replace identifiers with 'xxx'
-    endpoint.gsub(redact_regex, 'xxx').gsub(/x{4,}/, 'xxx')
+    # Replace identifiers with 'xxx'
+    endpoint.gsub(REDACT_REGEX, 'xxx').gsub(/x{4,}/, 'xxx')
   end
 end

--- a/spec/lib/statsd_endpoint_tag_filter_spec.rb
+++ b/spec/lib/statsd_endpoint_tag_filter_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'statsd_endpoint_tag_filter'
+
+RSpec.describe StatsdEndpointTagFilter do
+  describe ".redact" do
+
+    it 'does not redact versions' do
+      endpoint = "/demographics/demographics/v1"
+      expected_result = "/demographics/demographics/v1"
+      expect(StatsdEndpointTagFilter.redact(endpoint)).to eq(expected_result)
+    end
+
+    it "redacts 1.12.123.1.123456.1.123" do
+      endpoint = "/demographics/demographics/v1/1.12.123.1.123456.1.123"
+      expected_result = "/demographics/demographics/v1/xxx"
+      expect(StatsdEndpointTagFilter.redact(endpoint)).to eq(expected_result)
+    end
+
+    it "redacts hexidecimal path segments" do
+      endpoint = "/api/vetext/pub/mobile/push/preferences/client/12ab123414f9191d4817409427447978862"
+      expected_result = "/api/vetext/pub/mobile/push/preferences/client/xxx"
+      expect(StatsdEndpointTagFilter.redact(endpoint)).to eq(expected_result)
+    end
+
+    it "redacts encodings " do
+      endpoint = "/communication-hub/communication/v1/12345678_5epi_5e200vets_5eusdva/communication-permissions"
+      expected_result = "/communication-hub/communication/v1/xxx/communication-permissions"
+      expect(StatsdEndpointTagFilter.redact(endpoint)).to eq(expected_result)
+    end
+
+    it 'it keeps end paths' do
+      endpoint = "/communication-hub/communication/v1/123456789abcdef/communication-permissions"
+      expected_result = "/communication-hub/communication/v1/xxx/communication-permissions"
+      expect(StatsdEndpointTagFilter.redact(endpoint)).to eq(expected_result)
+    end
+
+    it "redacts UUIDs" do
+      endpoint = "/demographics/demographics/v1/d12a1234-12a0-4f65-bc1d-4ab1cd89551d_5epn_5e200vlgn_5eusdva"
+      expected_result = "/communication-hub/communication/v1/xxx/communication-permissions"
+      expect(StatsdEndpointTagFilter.redact(endpoint)).to eq(expected_result)
+    end
+
+    it 'combines redacted xxx' do
+      endpoint = '/profile-service/profile/v3/1.12.123.1.123456.1.123/12345678_5epi_5e200vets_5eusdva'
+      expected_result = "/profile-service/profile/v3/xxx"
+      expect(StatsdEndpointTagFilter.redact(endpoint)).to eq(expected_result)
+    end
+
+    it "redacts multiple match" do
+      endpoint = "/profile-service/profile/v3/1.12.123.1.123456.1.123/123456789_5eni_5e200dod_5eusdod"
+      expected_result = "/profile-service/profile/v3/xxx"
+      expect(StatsdEndpointTagFilter.redact(endpoint)).to eq(expected_result)
+    end
+  end
+end

--- a/spec/lib/statsd_endpoint_tag_filter_spec.rb
+++ b/spec/lib/statsd_endpoint_tag_filter_spec.rb
@@ -4,53 +4,52 @@ require 'rails_helper'
 require 'statsd_endpoint_tag_filter'
 
 RSpec.describe StatsdEndpointTagFilter do
-  describe ".redact" do
-
+  describe '.redact' do
     it 'does not redact versions' do
-      endpoint = "/demographics/demographics/v1"
-      expected_result = "/demographics/demographics/v1"
+      endpoint = '/demographics/demographics/v1'
+      expected_result = '/demographics/demographics/v1'
       expect(StatsdEndpointTagFilter.redact(endpoint)).to eq(expected_result)
     end
 
-    it "redacts 1.12.123.1.123456.1.123" do
-      endpoint = "/demographics/demographics/v1/1.12.123.1.123456.1.123"
-      expected_result = "/demographics/demographics/v1/xxx"
+    it 'redacts 1.12.123.1.123456.1.123' do
+      endpoint = '/demographics/demographics/v1/1.12.123.1.123456.1.123'
+      expected_result = '/demographics/demographics/v1/xxx'
       expect(StatsdEndpointTagFilter.redact(endpoint)).to eq(expected_result)
     end
 
-    it "redacts hexidecimal path segments" do
-      endpoint = "/api/vetext/pub/mobile/push/preferences/client/12ab123414f9191d4817409427447978862"
-      expected_result = "/api/vetext/pub/mobile/push/preferences/client/xxx"
+    it 'redacts hexidecimal path segments' do
+      endpoint = '/api/vetext/pub/mobile/push/preferences/client/12ab123414f9191d4817409427447978862'
+      expected_result = '/api/vetext/pub/mobile/push/preferences/client/xxx'
       expect(StatsdEndpointTagFilter.redact(endpoint)).to eq(expected_result)
     end
 
-    it "redacts encodings " do
-      endpoint = "/communication-hub/communication/v1/12345678_5epi_5e200vets_5eusdva/communication-permissions"
-      expected_result = "/communication-hub/communication/v1/xxx/communication-permissions"
+    it 'redacts encodings' do
+      endpoint = '/communication-hub/communication/v1/12345678_5epi_5e200vets_5eusdva/communication-permissions'
+      expected_result = '/communication-hub/communication/v1/xxx/communication-permissions'
       expect(StatsdEndpointTagFilter.redact(endpoint)).to eq(expected_result)
     end
 
-    it 'it keeps end paths' do
-      endpoint = "/communication-hub/communication/v1/123456789abcdef/communication-permissions"
-      expected_result = "/communication-hub/communication/v1/xxx/communication-permissions"
+    it 'keeps end paths' do
+      endpoint = '/communication-hub/communication/v1/123456789abcdef/communication-permissions'
+      expected_result = '/communication-hub/communication/v1/xxx/communication-permissions'
       expect(StatsdEndpointTagFilter.redact(endpoint)).to eq(expected_result)
     end
 
-    it "redacts UUIDs" do
-      endpoint = "/demographics/demographics/v1/d12a1234-12a0-4f65-bc1d-4ab1cd89551d_5epn_5e200vlgn_5eusdva"
-      expected_result = "/communication-hub/communication/v1/xxx/communication-permissions"
+    it 'redacts UUIDs' do
+      endpoint = '/demographics/demographics/v1/d12a1234-12a0-4f65-bc1d-4ab1cd89551d_5epn_5e200vlgn_5eusdva'
+      expected_result = '/communication-hub/communication/v1/xxx/communication-permissions'
       expect(StatsdEndpointTagFilter.redact(endpoint)).to eq(expected_result)
     end
 
     it 'combines redacted xxx' do
       endpoint = '/profile-service/profile/v3/1.12.123.1.123456.1.123/12345678_5epi_5e200vets_5eusdva'
-      expected_result = "/profile-service/profile/v3/xxx"
+      expected_result = '/profile-service/profile/v3/xxx'
       expect(StatsdEndpointTagFilter.redact(endpoint)).to eq(expected_result)
     end
 
-    it "redacts multiple match" do
-      endpoint = "/profile-service/profile/v3/1.12.123.1.123456.1.123/123456789_5eni_5e200dod_5eusdod"
-      expected_result = "/profile-service/profile/v3/xxx"
+    it 'redacts multiple match' do
+      endpoint = '/profile-service/profile/v3/1.12.123.1.123456.1.123/123456789_5eni_5e200dod_5eusdod'
+      expected_result = '/profile-service/profile/v3/xxx'
       expect(StatsdEndpointTagFilter.redact(endpoint)).to eq(expected_result)
     end
   end


### PR DESCRIPTION
## Summary

- Create endpoint filter for StatsD `external_http_request` metric

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/81352

## Testing done

- [ ] new spec created
- [ ] manual testing

## Acceptance criteria

- [ ]  Filters endpoints for IDs in various forms