### PR TITLE
Simple forms send emails by date range rake task

### DIFF
--- a/modules/simple_forms_api/lib/tasks/send_emails_by_date_range.rake
+++ b/modules/simple_forms_api/lib/tasks/send_emails_by_date_range.rake
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Invoke this as follows (tested on ZShell):
+#   rails "simple_forms_api:send_emails_by_date_range[1 January 2025,2 January 2025]"
+namespace :simple_forms_api do
+  task :send_emails_by_date_range, %i[start_date end_date] => :environment do |_, args|
+    start_date = Time.zone.parse(args[:start_date])
+    end_date = Time.zone.parse(args[:end_date])
+    date_range = (start_date..end_date)
+    form_submission_attempts = FormSubmissionAttempt.where(updated_at: date_range).where.not(aasm_state: :pending)
+    successful_uuids = []
+
+    form_submission_attempts.map do |form_submission_attempt|
+      confirmation_number = form_submission_attempt.benefits_intake_uuid
+      Rails.logger.info "Attempting to enqueue email for: #{confirmation_number}"
+
+      now = Time.now.in_time_zone('Eastern Time (US & Canada)')
+      time_to_send = now.tomorrow.change(hour: 9, min: 0)
+
+      form_submission = form_submission_attempt.form_submission
+      form_number = SimpleFormsApi::V1::UploadsController::FORM_NUMBER_MAP[form_submission.form_type]
+      notification_type = if form_submission_attempt.failure?
+                            :error
+                          elsif form_submission_attempt.vbms?
+                            :received
+                          else
+                            Rails.logger.error(
+                              'Invalid notification_type for FormSubmissionAttempt with benefits_intake_uuid: ' \
+                              "#{confirmation_number}"
+                            )
+                            raise
+                          end
+      config = {
+        form_data: JSON.parse(form_submission.form_data),
+        form_number:,
+        confirmation_number:,
+        date_submitted: form_submission_attempt.created_at.strftime('%B %d, %Y'),
+        lighthouse_updated_at: form_submission_attempt.lighthouse_updated_at&.strftime('%B %d, %Y')
+      }
+
+      SimpleFormsApi::Notification::Email.new(
+        config,
+        notification_type:,
+        user_account: form_submission.user_account
+      ).send(at: time_to_send)
+
+      successful_uuids << [confirmation_number, notification_type]
+      Rails.logger.info "Successfully enqueued email for: #{confirmation_number}"
+    end
+
+    Rails.logger.info 'Successful UUIDS & notification types:'
+    Rails.logger.info successful_uuids
+  rescue => e
+    Rails.logger.error(e)
+    raise e
+  end
+end

--- a/modules/simple_forms_api/lib/tasks/send_emails_by_date_range.rake
+++ b/modules/simple_forms_api/lib/tasks/send_emails_by_date_range.rake
@@ -10,6 +10,7 @@ namespace :simple_forms_api do
     form_submission_attempts = FormSubmissionAttempt.where(updated_at: date_range).where.not(aasm_state: :pending)
     successful_uuids = []
 
+    Rails.logger.info "Total FormSubmissionAttempts found: #{form_submission_attempts.count}"
     form_submission_attempts.map do |form_submission_attempt|
       confirmation_number = form_submission_attempt.benefits_intake_uuid
       Rails.logger.info "Attempting to enqueue email for: #{confirmation_number}"

--- a/modules/simple_forms_api/lib/tasks/send_emails_by_date_range.rake
+++ b/modules/simple_forms_api/lib/tasks/send_emails_by_date_range.rake
@@ -4,55 +4,73 @@
 #   rails "simple_forms_api:send_emails_by_date_range[1 January 2025,2 January 2025]"
 namespace :simple_forms_api do
   task :send_emails_by_date_range, %i[start_date end_date] => :environment do |_, args|
-    start_date = Time.zone.parse(args[:start_date])
-    end_date = Time.zone.parse(args[:end_date])
-    date_range = (start_date..end_date)
-    form_submission_attempts = FormSubmissionAttempt.where(updated_at: date_range).where.not(aasm_state: :pending)
-    successful_uuids = []
-
+    start_date, end_date = parse_date_args(args)
+    form_submission_attempts = fetch_form_submission_attempts(start_date, end_date)
     Rails.logger.info "Total FormSubmissionAttempts found: #{form_submission_attempts.count}"
+    successful_uuids = process_form_submission_attempts(form_submission_attempts)
+    log_successful_attempts(successful_uuids)
+  rescue => e
+    Rails.logger.error("Error in send_emails_by_date_range: #{e.message}")
+    Rails.logger.error(e.backtrace.join("\n"))
+    raise e
+  end
+
+  def parse_date_args(args)
+    [Time.zone.parse(args[:start_date]), Time.zone.parse(args[:end_date])]
+  end
+
+  def fetch_form_submission_attempts(start_date, end_date)
+    date_range = (start_date..end_date)
+    FormSubmissionAttempt.where(updated_at: date_range).where.not(aasm_state: :pending)
+  end
+
+  def process_form_submission_attempts(form_submission_attempts)
     form_submission_attempts.map do |form_submission_attempt|
       confirmation_number = form_submission_attempt.benefits_intake_uuid
       Rails.logger.info "Attempting to enqueue email for: #{confirmation_number}"
-
       now = Time.now.in_time_zone('Eastern Time (US & Canada)')
       time_to_send = now.tomorrow.change(hour: 9, min: 0)
-
       form_submission = form_submission_attempt.form_submission
-      form_number = SimpleFormsApi::V1::UploadsController::FORM_NUMBER_MAP[form_submission.form_type]
-      notification_type = if form_submission_attempt.failure?
-                            :error
-                          elsif form_submission_attempt.vbms?
-                            :received
-                          else
-                            Rails.logger.error(
-                              'Invalid notification_type for FormSubmissionAttempt with benefits_intake_uuid: ' \
-                              "#{confirmation_number}"
-                            )
-                            raise
-                          end
-      config = {
-        form_data: JSON.parse(form_submission.form_data),
-        form_number:,
-        confirmation_number:,
-        date_submitted: form_submission_attempt.created_at.strftime('%B %d, %Y'),
-        lighthouse_updated_at: form_submission_attempt.lighthouse_updated_at&.strftime('%B %d, %Y')
-      }
+      notification_type = get_notification_type(form_submission_attempt)
 
       SimpleFormsApi::Notification::Email.new(
-        config,
+        config(form_submission_attempt, form_submission, confirmation_number),
         notification_type:,
         user_account: form_submission.user_account
       ).send(at: time_to_send)
 
-      successful_uuids << [confirmation_number, notification_type]
       Rails.logger.info "Successfully enqueued email for: #{confirmation_number}"
+      [confirmation_number, notification_type]
     end
+  end
 
+  def log_successful_attempts(successful_uuids)
     Rails.logger.info 'Successful UUIDS & notification types:'
     Rails.logger.info successful_uuids
-  rescue => e
-    Rails.logger.error(e)
-    raise e
+  end
+
+  def get_notification_type(form_submission_attempt)
+    if form_submission_attempt.failure?
+      :error
+    elsif form_submission_attempt.vbms?
+      :received
+    else
+      Rails.logger.error(
+        'Invalid notification_type for FormSubmissionAttempt with benefits_intake_uuid: ' \
+        "#{confirmation_number}"
+      )
+      raise
+    end
+  end
+
+  def config(form_submission_attempt, form_submission, confirmation_number)
+    form_number = SimpleFormsApi::V1::UploadsController::FORM_NUMBER_MAP[form_submission.form_type]
+    {
+      form_data: JSON.parse(form_submission.form_data),
+      form_number:,
+      confirmation_number:,
+      date_submitted: form_submission_attempt.created_at.strftime('%B %d, %Y'),
+      lighthouse_updated_at: form_submission_attempt.lighthouse_updated_at&.strftime('%B %d, %Y')
+    }
   end
 end

--- a/modules/simple_forms_api/spec/tasks/send_emails_by_date_range_spec.rb
+++ b/modules/simple_forms_api/spec/tasks/send_emails_by_date_range_spec.rb
@@ -5,15 +5,13 @@ require 'rake'
 require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
 
 RSpec.describe 'simple_forms_api:send_emails_by_date_range', type: :task do
+  load File.expand_path('../../lib/tasks/send_emails_by_date_range.rake', __dir__)
+
   let(:task) { Rake::Task['simple_forms_api:send_emails_by_date_range'] }
   let(:notification_email) { double(send: nil) }
 
   before do
-    load File.expand_path('../../lib/tasks/send_emails_by_date_range.rake', __dir__)
     Rake::Task.define_task(:environment)
-
-    allow(Rails.logger).to receive(:info)
-    allow(Rails.logger).to receive(:error)
   end
 
   after { task.reenable }
@@ -33,12 +31,12 @@ RSpec.describe 'simple_forms_api:send_emails_by_date_range', type: :task do
           anything,
           notification_type: :received,
           user_account: anything
-        ).and_return(notification_email)
+        ).once.and_return(notification_email)
         expect(SimpleFormsApi::Notification::Email).to receive(:new).with(
           anything,
           notification_type: :error,
           user_account: anything
-        ).and_return(notification_email)
+        ).once.and_return(notification_email)
 
         task.invoke(start_date, end_date)
       end

--- a/modules/simple_forms_api/spec/tasks/send_emails_by_date_range_spec.rb
+++ b/modules/simple_forms_api/spec/tasks/send_emails_by_date_range_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
+
+RSpec.describe 'simple_forms_api:send_emails_by_date_range', type: :task do
+  let(:task) { Rake::Task['simple_forms_api:send_emails_by_date_range'] }
+  let(:notification_email) { double(send: nil) }
+
+  before do
+    load File.expand_path('../../lib/tasks/send_emails_by_date_range.rake', __dir__)
+    Rake::Task.define_task(:environment)
+
+    allow(Rails.logger).to receive(:info)
+    allow(Rails.logger).to receive(:error)
+  end
+
+  after { task.reenable }
+
+  context 'when valid dates are provided' do
+    let(:start_date) { '1 January 2025' }
+    let(:end_date) { '3 January 2025' }
+
+    context 'FormSubmissionAttempts are in an end-state and updated in the right time period' do
+      before do
+        create(:form_submission_attempt, :vbms, updated_at: Time.zone.parse('2 January 2025'))
+        create(:form_submission_attempt, :failure, updated_at: Time.zone.parse('2 January 2025'))
+      end
+
+      it 'sends Notification::Emails' do
+        expect(SimpleFormsApi::Notification::Email).to receive(:new).with(
+          anything,
+          notification_type: :received,
+          user_account: anything
+        ).and_return(notification_email)
+        expect(SimpleFormsApi::Notification::Email).to receive(:new).with(
+          anything,
+          notification_type: :error,
+          user_account: anything
+        ).and_return(notification_email)
+
+        task.invoke(start_date, end_date)
+      end
+    end
+
+    context 'FormSubmissionAttempts are in an end-state but not updated in the right time period' do
+      before do
+        create(:form_submission_attempt, :vbms, updated_at: Time.zone.parse('5 January 2025'))
+        create(:form_submission_attempt, :failure, updated_at: Time.zone.parse('5 January 2025'))
+      end
+
+      it 'does not send Notification::Emails' do
+        expect(SimpleFormsApi::Notification::Email).not_to receive(:new)
+
+        task.invoke(start_date, end_date)
+      end
+    end
+
+    context 'FormSubmissionAttempts are not in an end-state but were updated in the right time period' do
+      before do
+        create(:form_submission_attempt, :pending, updated_at: Time.zone.parse('2 January 2025'))
+      end
+
+      it 'does not send Notification::Emails' do
+        expect(SimpleFormsApi::Notification::Email).not_to receive(:new)
+
+        task.invoke(start_date, end_date)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
This PR introduces a rake task whose goal is to send `:received` and `:error` emails for form submissions that advanced to their final status but emails failed.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&visibleFields=%5B%22Title%22%2C%22Assignees%22%2C%22Status%22%2C%22Labels%22%2C139765646%5D&pane=issue&itemId=100860483&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C2070
