### PR TITLE
[VI-1121] Update identity specific Settings to use IdentitySettings

### DIFF
--- a/app/controllers/concerns/authentication_and_sso_concerns.rb
+++ b/app/controllers/concerns/authentication_and_sso_concerns.rb
@@ -11,7 +11,8 @@ module AuthenticationAndSSOConcerns # rubocop:disable Metrics/ModuleLength
   included do
     before_action :authenticate, :set_session_expiration_header
 
-    validates_access_token_audience [Settings.sign_in.vaweb_client_id, ('vamock' if MockedAuthentication.mockable_env?)]
+    validates_access_token_audience [IdentitySettings.sign_in.vaweb_client_id,
+                                     ('vamock' if MockedAuthentication.mockable_env?)]
   end
 
   protected

--- a/app/controllers/v0/sign_in_controller.rb
+++ b/app/controllers/v0/sign_in_controller.rb
@@ -340,7 +340,7 @@ module V0
       cookies.delete(SignIn::Constants::Auth::ACCESS_TOKEN_COOKIE_NAME, domain: :all)
       cookies.delete(SignIn::Constants::Auth::REFRESH_TOKEN_COOKIE_NAME)
       cookies.delete(SignIn::Constants::Auth::ANTI_CSRF_COOKIE_NAME)
-      cookies.delete(SignIn::Constants::Auth::INFO_COOKIE_NAME, domain: Settings.sign_in.info_cookie_domain)
+      cookies.delete(SignIn::Constants::Auth::INFO_COOKIE_NAME, domain: IdentitySettings.sign_in.info_cookie_domain)
     end
 
     def auth_service(type, client_id = nil)

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -56,9 +56,9 @@ module V1
         url = URI.parse(url_service.ssoe_slo_url)
 
         app_key = if ActiveModel::Type::Boolean.new.cast(params[:agreements_declined])
-                    Settings.saml_ssoe.tou_decline_logout_app_key
+                    IdentitySettings.saml_ssoe.tou_decline_logout_app_key
                   else
-                    Settings.saml_ssoe.logout_app_key
+                    IdentitySettings.saml_ssoe.logout_app_key
                   end
 
         query_strings = { appKey: CGI.escape(app_key), clientId: params[:client_id] }.compact
@@ -201,12 +201,12 @@ module V1
     end
 
     def set_sso_saml_cookie!
-      cookies[Settings.ssoe_eauth_cookie.name] = {
+      cookies[IdentitySettings.ssoe_eauth_cookie.name] = {
         value: saml_cookie_content.to_json,
         expires: nil,
-        secure: Settings.ssoe_eauth_cookie.secure,
+        secure: IdentitySettings.ssoe_eauth_cookie.secure,
         httponly: true,
-        domain: Settings.ssoe_eauth_cookie.domain
+        domain: IdentitySettings.ssoe_eauth_cookie.domain
       }
     end
 

--- a/app/models/terms_of_use_agreement.rb
+++ b/app/models/terms_of_use_agreement.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TermsOfUseAgreement < ApplicationRecord
-  CURRENT_VERSION = Settings.terms_of_use.current_version
+  CURRENT_VERSION = IdentitySettings.terms_of_use.current_version
 
   belongs_to :user_account
 

--- a/app/policies/sign_in/user_info_policy.rb
+++ b/app/policies/sign_in/user_info_policy.rb
@@ -10,7 +10,7 @@ module SignIn
     end
 
     def show?
-      user.present? && client_id.in?(Settings.sign_in.user_info_clients)
+      user.present? && client_id.in?(IdentitySettings.sign_in.user_info_clients)
     end
 
     private

--- a/app/services/sign_in/access_token_jwt_decoder.rb
+++ b/app/services/sign_in/access_token_jwt_decoder.rb
@@ -53,13 +53,13 @@ module SignIn
     end
 
     def public_key
-      OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_encode_key)).public_key
+      OpenSSL::PKey::RSA.new(File.read(IdentitySettings.sign_in.jwt_encode_key)).public_key
     end
 
     def public_key_old
-      return unless Settings.sign_in.jwt_old_encode_key
+      return unless IdentitySettings.sign_in.jwt_old_encode_key
 
-      OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_old_encode_key)).public_key
+      OpenSSL::PKey::RSA.new(File.read(IdentitySettings.sign_in.jwt_old_encode_key)).public_key
     end
   end
 end

--- a/app/services/sign_in/access_token_jwt_encoder.rb
+++ b/app/services/sign_in/access_token_jwt_encoder.rb
@@ -39,7 +39,7 @@ module SignIn
     end
 
     def private_key
-      OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_encode_key))
+      OpenSSL::PKey::RSA.new(File.read(IdentitySettings.sign_in.jwt_encode_key))
     end
   end
 end

--- a/app/services/sign_in/credential_level_creator.rb
+++ b/app/services/sign_in/credential_level_creator.rb
@@ -100,7 +100,7 @@ module SignIn
     end
 
     def previously_verified?(identifier_type)
-      return false unless Settings.sign_in.auto_uplevel && requested_verified_account?
+      return false unless IdentitySettings.sign_in.auto_uplevel && requested_verified_account?
 
       user_verification = UserVerification.find_by(identifier_type => credential_uuid)
       user_verification&.verified?

--- a/app/services/sign_in/openid_connect_certificates_presenter.rb
+++ b/app/services/sign_in/openid_connect_certificates_presenter.rb
@@ -18,12 +18,12 @@ module SignIn
 
     def public_keys
       public_keys = [private_key.public_key]
-      old_key_file_path = Settings.sign_in.jwt_old_encode_key
+      old_key_file_path = IdentitySettings.sign_in.jwt_old_encode_key
       public_keys.push private_key(file_path: old_key_file_path).public_key if old_key_file_path
       public_keys
     end
 
-    def private_key(file_path: Settings.sign_in.jwt_encode_key)
+    def private_key(file_path: IdentitySettings.sign_in.jwt_encode_key)
       OpenSSL::PKey::RSA.new(File.read(file_path))
     end
   end

--- a/app/services/sign_in/service_account_access_token_jwt_decoder.rb
+++ b/app/services/sign_in/service_account_access_token_jwt_decoder.rb
@@ -49,13 +49,13 @@ module SignIn
     end
 
     def public_key
-      OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_encode_key)).public_key
+      OpenSSL::PKey::RSA.new(File.read(IdentitySettings.sign_in.jwt_encode_key)).public_key
     end
 
     def public_key_old
-      return unless Settings.sign_in.jwt_old_encode_key
+      return unless IdentitySettings.sign_in.jwt_old_encode_key
 
-      OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_old_encode_key)).public_key
+      OpenSSL::PKey::RSA.new(File.read(IdentitySettings.sign_in.jwt_old_encode_key)).public_key
     end
   end
 end

--- a/app/services/sign_in/service_account_access_token_jwt_encoder.rb
+++ b/app/services/sign_in/service_account_access_token_jwt_encoder.rb
@@ -35,7 +35,7 @@ module SignIn
     end
 
     def private_key
-      OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_encode_key))
+      OpenSSL::PKey::RSA.new(File.read(IdentitySettings.sign_in.jwt_encode_key))
     end
   end
 end

--- a/app/services/sign_in/state_payload_jwt_decoder.rb
+++ b/app/services/sign_in/state_payload_jwt_decoder.rb
@@ -51,13 +51,13 @@ module SignIn
     end
 
     def public_key
-      OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_encode_key)).public_key
+      OpenSSL::PKey::RSA.new(File.read(IdentitySettings.sign_in.jwt_encode_key)).public_key
     end
 
     def public_key_old
-      return unless Settings.sign_in.jwt_old_encode_key
+      return unless IdentitySettings.sign_in.jwt_old_encode_key
 
-      OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_old_encode_key)).public_key
+      OpenSSL::PKey::RSA.new(File.read(IdentitySettings.sign_in.jwt_old_encode_key)).public_key
     end
   end
 end

--- a/app/services/sign_in/state_payload_jwt_encoder.rb
+++ b/app/services/sign_in/state_payload_jwt_encoder.rb
@@ -99,7 +99,7 @@ module SignIn
     end
 
     def private_key
-      OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_encode_key))
+      OpenSSL::PKey::RSA.new(File.read(IdentitySettings.sign_in.jwt_encode_key))
     end
   end
 end

--- a/app/services/sign_in/token_serializer.rb
+++ b/app/services/sign_in/token_serializer.rb
@@ -37,7 +37,7 @@ module SignIn
       set_cookie!(name: Constants::Auth::INFO_COOKIE_NAME,
                   value: info_cookie_value.to_json,
                   httponly: false,
-                  domain: Settings.sign_in.info_cookie_domain)
+                  domain: IdentitySettings.sign_in.info_cookie_domain)
 
       if anti_csrf_enabled_client?
         set_cookie!(name: Constants::Auth::ANTI_CSRF_COOKIE_NAME,
@@ -50,7 +50,7 @@ module SignIn
       cookies[name] = {
         value:,
         expires: session_expiration,
-        secure: Settings.sign_in.cookies_secure,
+        secure: IdentitySettings.sign_in.cookies_secure,
         httponly:,
         path:,
         domain:

--- a/config/application.rb
+++ b/config/application.rb
@@ -59,7 +59,7 @@ module VetsAPI
     config.middleware.insert_before 0, Rack::Cors, logger: -> { Rails.logger } do
       allow do
         regex = Regexp.new(Settings.web_origin_regex)
-        web_origins = Settings.web_origin.split(',') + Array(Settings.sign_in.web_origins)
+        web_origins = Settings.web_origin.split(',') + Array(IdentitySettings.sign_in.web_origins)
 
         origins { |source, _env| web_origins.include?(source) || source.match?(regex) }
         resource '*', headers: :any,
@@ -122,7 +122,7 @@ module VetsAPI
     config.middleware.insert_after ActionDispatch::Cookies,
                                    ActionDispatch::Session::CookieStore,
                                    key: 'api_session',
-                                   secure: Settings.session_cookie.secure,
+                                   secure: IdentitySettings.session_cookie.secure,
                                    http_only: true
 
     # These files do not contain auto-loaded ruby classes,

--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -146,7 +146,7 @@
       :uid_locator: 'vaapikey'
 
 - :name: 'MHV UserAccount Creation'
-  :base_uri: <%= "#{URI(Settings.mhv.account_creation.host).host}:#{URI(Settings.mhv.account_creation.host).port}" %>
+  :base_uri: <%= "#{URI(IdentitySettings.mhv.account_creation.host).host}:#{URI(IdentitySettings.mhv.account_creation.host).port}" %>
   :endpoints:
   - :method: :post
     :path: '/v1/usermgmt/account-service/account'
@@ -483,87 +483,87 @@
 
 # MVI
 - :name: 'MVI'
-  :base_uri: <%= "#{URI(Settings.mvi.url).host}:#{URI(Settings.mvi.url).port}" %>
+  :base_uri: <%= "#{URI(IdentitySettings.mvi.url).host}:#{URI(IdentitySettings.mvi.url).port}" %>
   :endpoints:
   - :method: :post
-    :path: <%= URI(Settings.mvi.url).path %>
+    :path: <%= URI(IdentitySettings.mvi.url).path %>
     :file_path: "mvi/profile"
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: '(?:root="2.16.840.1.113883.4.1" )?extension="(\d{9})"(?: root="2.16.840.1.113883.4.1")?'
       :optional_code_locator: 'modifyCode code="(MVI\.COMP1\.RMS|MVI\.COMP2)"'
   - :method: :post
-    :path: <%= URI(Settings.mvi.url).path %>
+    :path: <%= URI(IdentitySettings.mvi.url).path %>
     :file_path: "mvi/profile_icn"
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: 'id extension="([V0-9]*)"(?: root="2.16.840.1.113883.4.349")'
       :optional_code_locator: 'modifyCode code="(MVI\.COMP1\.RMS|MVI\.COMP2)"'
   - :method: :post
-    :path: <%= URI(Settings.mvi.url).path %>
+    :path: <%= URI(IdentitySettings.mvi.url).path %>
     :file_path: "mvi/profile_icn"
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: 'id (?:root="2.16.840.1.113883.4.349" )extension="([V0-9]*)"'
       :optional_code_locator: 'modifyCode code="(MVI\.COMP1\.RMS|MVI\.COMP2)"'
   - :method: :post
-    :path: <%= URI(Settings.mvi.url).path %>
+    :path: <%= URI(IdentitySettings.mvi.url).path %>
     :file_path: "mvi/profile_edipi"
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: '(?:root="2.16.840.1.113883.3.42.10001.100001.12" )?extension="(\d{10})"(?: root="2.16.840.1.113883.3.42.10001.100001.12")?'
       :optional_code_locator: 'modifyCode code="(MVI\.COMP1\.RMS|MVI\.COMP2)"'
   - :method: :post
-    :path: <%= URI(Settings.mvi.url).path %>
+    :path: <%= URI(IdentitySettings.mvi.url).path %>
     :file_path: "mvi/profile_idme_uuid"
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: 'id (?:root="2.16.840.1.113883.4.349" )?extension="(.*)\^PN\^200VIDM\^USDVA\^A"(?:root="2.16.840.1.113883.4.349")?'
       :optional_code_locator: 'modifyCode code="(MVI\.COMP1\.RMS|MVI\.COMP2)"'
   - :method: :post
-    :path: <%= URI(Settings.mvi.url).path %>
+    :path: <%= URI(IdentitySettings.mvi.url).path %>
     :file_path: "mvi/profile_logingov_uuid"
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: 'id (?:root="2.16.840.1.113883.4.349" )?extension="(.*)\^PN\^200VLGN\^USDVA\^A"(?:root="2.16.840.1.113883.4.349")?'
       :optional_code_locator: 'modifyCode code="(MVI\.COMP1\.RMS|MVI\.COMP2)"'
   - :method: :post
-    :path: <%= URI(Settings.mvi.url).path %>
+    :path: <%= URI(IdentitySettings.mvi.url).path %>
     :file_path: "mvi/add_person_proxy_icn"
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: 'id (?:root="2.16.840.1.113883.4.349" )extension="([V0-9]*\^NI\^200M\^USVHA\^P)"'
       :optional_code_locator: 'PROXY_ADD'
   - :method: :post
-    :path: <%= URI(Settings.mvi.url).path %>
+    :path: <%= URI(IdentitySettings.mvi.url).path %>
     :file_path: "mvi/add_person_implicit_logingov_uuid"
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: 'id (?:root="2.16.840.1.113883.4.349" )?extension="(.*)\^PN\^200VLGN\^USDVA\^A"(?:root="2.16.840.1.113883.4.349")?'
       :optional_code_locator: 'PRPA_IN201301UV02'
   - :method: :post
-    :path: <%= URI(Settings.mvi.url).path %>
+    :path: <%= URI(IdentitySettings.mvi.url).path %>
     :file_path: "mvi/add_person_implicit_idme_uuid"
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: 'id (?:root="2.16.840.1.113883.4.349" )?extension="(.*)\^PN\^200VIDM\^USDVA\^A"(?:root="2.16.840.1.113883.4.349")?'
       :optional_code_locator: 'PRPA_IN201301UV02'
   - :method: :post
-    :path: <%= URI(Settings.mvi.url).path %>
+    :path: <%= URI(IdentitySettings.mvi.url).path %>
     :file_path: "mvi/update_profile_idme_uuid"
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: 'id (?:root="2.16.840.1.113883.4.349" )?extension="(.*)\^PN\^200VIDM\^USDVA\^A"(?:root="2.16.840.1.113883.4.349")?'
       :optional_code_locator: 'PRPA_IN201302UV02'
   - :method: :post
-    :path: <%= URI(Settings.mvi.url).path %>
+    :path: <%= URI(IdentitySettings.mvi.url).path %>
     :file_path: "mvi/update_profile_logingov_uuid"
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: 'id (?:root="2.16.840.1.113883.4.349" )?extension="(.*)\^PN\^200VLGN\^USDVA\^A"(?:root="2.16.840.1.113883.4.349")?'
       :optional_code_locator: 'PRPA_IN201302UV02'
   - :method: :post
-    :path: <%= URI(Settings.mvi.url).path %>
+    :path: <%= URI(IdentitySettings.mvi.url).path %>
     :file_path: "mvi/update_profile_edipi"
     :cache_multiple_responses:
       :uid_location: body
@@ -943,7 +943,7 @@
 
 # Security Token Service API
 - :name: "MAP STS"
-  :base_uri: <%= "#{URI(Settings.map_services.oauth_url).host}:#{URI(Settings.map_services.oauth_url).port}" %>
+  :base_uri: <%= "#{URI(IdentitySettings.map_services.oauth_url).host}:#{URI(IdentitySettings.map_services.oauth_url).port}" %>
   :endpoints:
     - :method: :post
       :path: "/sts/oauth/v1/token"
@@ -954,7 +954,7 @@
 
 # Sign Up Service Terms API
 - :name: "MAP SUS"
-  :base_uri: <%= "#{URI(Settings.map_services.sign_up_service_url).host}:#{URI(Settings.map_services.sign_up_service_url).port}" %>
+  :base_uri: <%= "#{URI(IdentitySettings.map_services.sign_up_service_url).host}:#{URI(IdentitySettings.map_services.sign_up_service_url).port}" %>
   :endpoints:
     - :method: :get
       :path: "/signup/v1/patients/*/status/summary"

--- a/config/database.yml
+++ b/config/database.yml
@@ -25,6 +25,6 @@ production:
       statement_timeout: <%= ENV["STATEMENT_TIMEOUT"] || "60s" %>
       lock_timeout: 15s
   audit:
-    url: <%= "#{Settings.audit_db.url}" %>
+    url: <%= "#{IdentitySettings.audit_db.url}" %>
     migrations_paths: db/audit_migrate
     database_tasks: false

--- a/config/identity_settings/settings.yml
+++ b/config/identity_settings/settings.yml
@@ -43,14 +43,14 @@ mhv:
       service_account_id: c34b86f2130ff3cd4b1d309bc09d8740
 
 mvi:
-  client_cert_path: /fake/client/cert/path
-  client_key_path: /fake/client/key/path
+  client_cert_path: config/certs/vetsgov-localhost.crt
+  client_key_path: config/certs/vetsgov-localhost.key
   mock: true
   open_timeout: 15
   pii_logging: false
   processing_code: T
   timeout: 30
-  url: http://ps-dev.commserv.healthevet.va.gov:8110/psim_webservice/IdMWebService
+  url: http://www.example.com
 
 saml_ssoe:
   callback_url: http://localhost:3000/v1/sessions/callback

--- a/config/initializers/integration_recorder.rb
+++ b/config/initializers/integration_recorder.rb
@@ -76,7 +76,7 @@ if Rails.env.development? && ENV['DUALDECK_INTERACTION']
     c.filter_sensitive_data('<MHV_HOST>') { Settings.mhv.rx.host }
     c.filter_sensitive_data('<MHV_SM_APP_TOKEN>') { Settings.mhv.sm.app_token }
     c.filter_sensitive_data('<MHV_SM_HOST>') { Settings.mhv.sm.host }
-    c.filter_sensitive_data('<MPI_URL>') { Settings.mvi.url }
+    c.filter_sensitive_data('<MPI_URL>') { IdentitySettings.mvi.url }
     c.filter_sensitive_data('<PRENEEDS_HOST>') { Settings.preneeds.host }
     c.before_record do |i|
       %i[response request].each do |env|

--- a/config/initializers/saml.rb
+++ b/config/initializers/saml.rb
@@ -3,18 +3,18 @@
 # rubocop:disable Layout/LineLength
 
 def saml_ssoe_cert_exists?
-  !Settings.saml_ssoe.cert_path.nil? && File.file?(File.expand_path(Settings.saml_ssoe.cert_path))
+  !IdentitySettings.saml_ssoe.cert_path.nil? && File.file?(File.expand_path(IdentitySettings.saml_ssoe.cert_path))
 end
 
 def saml_ssoe_key_exists?
-  !Settings.saml_ssoe.key_path.nil? && File.file?(File.expand_path(Settings.saml_ssoe.key_path))
+  !IdentitySettings.saml_ssoe.key_path.nil? && File.file?(File.expand_path(IdentitySettings.saml_ssoe.key_path))
 end
 
 def new_saml_ssoe_cert_exists?
-  !Settings.saml_ssoe.cert_new_path.nil? && File.file?(File.expand_path(Settings.saml_ssoe.cert_new_path))
+  !IdentitySettings.saml_ssoe.cert_new_path.nil? && File.file?(File.expand_path(IdentitySettings.saml_ssoe.cert_new_path))
 end
 
-Settings.saml_ssoe.certificate = saml_ssoe_cert_exists? ? File.read(File.expand_path(Settings.saml_ssoe.cert_path)) : nil
-Settings.saml_ssoe.key = saml_ssoe_key_exists? ? File.read(File.expand_path(Settings.saml_ssoe.key_path)) : nil
-Settings.saml_ssoe.certificate_new = new_saml_ssoe_cert_exists? ? File.read(File.expand_path(Settings.saml_ssoe.cert_new_path)) : nil
+IdentitySettings.saml_ssoe.certificate = saml_ssoe_cert_exists? ? File.read(File.expand_path(IdentitySettings.saml_ssoe.cert_path)) : nil
+IdentitySettings.saml_ssoe.key = saml_ssoe_key_exists? ? File.read(File.expand_path(IdentitySettings.saml_ssoe.key_path)) : nil
+IdentitySettings.saml_ssoe.certificate_new = new_saml_ssoe_cert_exists? ? File.read(File.expand_path(IdentitySettings.saml_ssoe.cert_new_path)) : nil
 # rubocop:enable Layout/LineLength

--- a/config/initializers/sign_in_service.rb
+++ b/config/initializers/sign_in_service.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 SignInService::Sts.configure do |config|
-  config.base_url = Settings.sign_in.sts_client.base_url
+  config.base_url = IdentitySettings.sign_in.sts_client.base_url
 end

--- a/config/mpi_schema/IdmWebService_200VGOV.wsdl.erb
+++ b/config/mpi_schema/IdmWebService_200VGOV.wsdl.erb
@@ -139,7 +139,7 @@
 	<service name="VAIdM">
 		<port name="VAIdMPort" binding="tns:VAIdMPort">
 			<soap:address
-				location="<%= Settings.mvi.url %>" />
+				location="<%= IdentitySettings.mvi.url %>" />
 		</port>
 	</service>
 </definitions>

--- a/lib/map/security_token/configuration.rb
+++ b/lib/map/security_token/configuration.rb
@@ -7,31 +7,31 @@ module MAP
   module SecurityToken
     class Configuration < Common::Client::Configuration::REST
       def base_path
-        Settings.map_services.oauth_url
+        IdentitySettings.map_services.oauth_url
       end
 
       def chatbot_client_id
-        Settings.map_services.chatbot_client_id
+        IdentitySettings.map_services.chatbot_client_id
       end
 
       def sign_up_service_client_id
-        Settings.map_services.sign_up_service_client_id
+        IdentitySettings.map_services.sign_up_service_client_id
       end
 
       def check_in_client_id
-        Settings.map_services.check_in_client_id
+        IdentitySettings.map_services.check_in_client_id
       end
 
       def appointments_client_id
-        Settings.map_services.appointments_client_id
+        IdentitySettings.map_services.appointments_client_id
       end
 
       def client_key_path
-        Settings.map_services.client_key_path
+        IdentitySettings.map_services.client_key_path
       end
 
       def client_cert_path
-        Settings.map_services.client_cert_path
+        IdentitySettings.map_services.client_cert_path
       end
 
       def jwks_cache_key
@@ -100,7 +100,7 @@ module MAP
           conn.use Faraday::Response::RaiseError
           conn.adapter Faraday.default_adapter
           conn.response :json, content_type: /\bjson/
-          conn.response :betamocks if Settings.map_services.secure_token_service.mock
+          conn.response :betamocks if IdentitySettings.map_services.secure_token_service.mock
         end
       end
     end

--- a/lib/map/sign_up/configuration.rb
+++ b/lib/map/sign_up/configuration.rb
@@ -7,11 +7,11 @@ module MAP
   module SignUp
     class Configuration < Common::Client::Configuration::REST
       def base_path
-        Settings.map_services.sign_up_service_url
+        IdentitySettings.map_services.sign_up_service_url
       end
 
       def provisioning_api_key
-        Settings.map_services.sign_up_service_provisioning_api_key
+        IdentitySettings.map_services.sign_up_service_provisioning_api_key
       end
 
       def service_name
@@ -66,7 +66,7 @@ module MAP
           conn.use Faraday::Response::RaiseError
           conn.adapter Faraday.default_adapter
           conn.response :json, content_type: /\bjson/
-          conn.response :betamocks if Settings.map_services.sign_up_service.mock
+          conn.response :betamocks if IdentitySettings.map_services.sign_up_service.mock
         end
       end
     end

--- a/lib/mhv/account_creation/configuration.rb
+++ b/lib/mhv/account_creation/configuration.rb
@@ -7,7 +7,7 @@ module MHV
   module AccountCreation
     class Configuration < Common::Client::Configuration::REST
       def base_path
-        Settings.mhv.account_creation.host
+        IdentitySettings.mhv.account_creation.host
       end
 
       def service_name
@@ -39,7 +39,7 @@ module MHV
       end
 
       def access_key
-        Settings.mhv.account_creation.access_key
+        IdentitySettings.mhv.account_creation.access_key
       end
 
       def connection
@@ -48,7 +48,7 @@ module MHV
           conn.use Faraday::Response::RaiseError
           conn.adapter Faraday.default_adapter
           conn.response :json
-          conn.response :betamocks if Settings.mhv.account_creation.mock
+          conn.response :betamocks if IdentitySettings.mhv.account_creation.mock
         end
       end
 
@@ -68,7 +68,7 @@ module MHV
         SignInService::Sts.new(
           service_account_id: mhv_sts_settings.service_account_id,
           issuer: mhv_sts_settings.issuer,
-          private_key_path: Settings.sign_in.sts_client.key_path,
+          private_key_path: IdentitySettings.sign_in.sts_client.key_path,
           scopes: sts_scopes,
           user_identifier:,
           user_attributes: { icn: user_identifier }
@@ -80,7 +80,7 @@ module MHV
       end
 
       def mhv_sts_settings
-        Settings.mhv.account_creation.sts
+        IdentitySettings.mhv.account_creation.sts
       end
     end
   end

--- a/lib/mpi/configuration.rb
+++ b/lib/mpi/configuration.rb
@@ -6,23 +6,23 @@ require 'common/client/middleware/logging'
 module MPI
   class Configuration < Common::Client::Configuration::SOAP
     def self.open_timeout
-      Settings.mvi.open_timeout
+      IdentitySettings.mvi.open_timeout
     end
 
     def self.read_timeout
-      Settings.mvi.timeout
+      IdentitySettings.mvi.timeout
     end
 
     def self.ssl_cert_path
-      Settings.mvi.client_cert_path
+      IdentitySettings.mvi.client_cert_path
     end
 
     def self.ssl_key_path
-      Settings.mvi.client_key_path
+      IdentitySettings.mvi.client_key_path
     end
 
     def base_path
-      Settings.mvi.url
+      IdentitySettings.mvi.url
     end
 
     def service_name
@@ -48,8 +48,8 @@ module MPI
         # conn.response(:logger, ::Logger.new(STDOUT), bodies: true) unless Rails.env.production?
 
         conn.response :soap_parser
-        conn.use :logging, 'MVIRequest' if Settings.mvi.pii_logging # Refactor as response middleware?
-        conn.response :betamocks if Settings.mvi.mock
+        conn.use :logging, 'MVIRequest' if IdentitySettings.mvi.pii_logging # Refactor as response middleware?
+        conn.response :betamocks if IdentitySettings.mvi.mock
         conn.adapter Faraday.default_adapter
       end
     end

--- a/lib/mpi/messages/request_builder.rb
+++ b/lib/mpi/messages/request_builder.rb
@@ -110,7 +110,7 @@ module MPI
       end
 
       def processing_code
-        Settings.mvi.processing_code
+        IdentitySettings.mvi.processing_code
       end
 
       def element(name, attributes = {}, body_text = nil)

--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -47,8 +47,8 @@ module SAML
       auth = 'force-needed' if auth != 'success' && @tracker&.payload_attr(:type) == 'custom'
       set_query_params(auth, code, request_id)
 
-      if Settings.saml_ssoe.relay.present?
-        add_query(Settings.saml_ssoe.relay, query_params)
+      if IdentitySettings.saml_ssoe.relay.present?
+        add_query(IdentitySettings.saml_ssoe.relay, query_params)
       else
         add_query("#{base_redirect_url}#{LOGIN_REDIRECT_PARTIAL}", query_params)
       end
@@ -73,7 +73,7 @@ module SAML
 
     # logout URL for SSOe
     def ssoe_slo_url
-      Settings.saml_ssoe.logout_url
+      IdentitySettings.saml_ssoe.logout_url
     end
 
     private
@@ -147,7 +147,7 @@ module SAML
     end
 
     def enabled_tou_clients
-      Settings.terms_of_use.enabled_clients.split(',').collect(&:strip)
+      IdentitySettings.terms_of_use.enabled_clients.split(',').collect(&:strip)
     end
   end
 end

--- a/lib/saml/ssoe_settings_service.rb
+++ b/lib/saml/ssoe_settings_service.rb
@@ -18,28 +18,28 @@ module SAML
 
       def base_settings
         idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
-        settings = idp_metadata_parser.parse(File.read(Settings.saml_ssoe.idp_metadata_file))
+        settings = idp_metadata_parser.parse(File.read(IdentitySettings.saml_ssoe.idp_metadata_file))
 
         if pki_needed?
-          settings.certificate = Settings.saml_ssoe.certificate
-          settings.private_key = Settings.saml_ssoe.key
-          settings.certificate_new = Settings.saml_ssoe.certificate_new
+          settings.certificate = IdentitySettings.saml_ssoe.certificate
+          settings.private_key = IdentitySettings.saml_ssoe.key
+          settings.certificate_new = IdentitySettings.saml_ssoe.certificate_new
         end
-        settings.sp_entity_id = Settings.saml_ssoe.issuer
-        settings.assertion_consumer_service_url = Settings.saml_ssoe.callback_url
+        settings.sp_entity_id = IdentitySettings.saml_ssoe.issuer
+        settings.assertion_consumer_service_url = IdentitySettings.saml_ssoe.callback_url
         settings.compress_request = false
 
-        settings.idp_sso_service_binding = Settings.saml_ssoe.idp_sso_service_binding
-        settings.security[:authn_requests_signed] = Settings.saml_ssoe.request_signing
-        settings.security[:want_assertions_signed] = Settings.saml_ssoe.response_signing
-        settings.security[:want_assertions_encrypted] = Settings.saml_ssoe.response_encryption
+        settings.idp_sso_service_binding = IdentitySettings.saml_ssoe.idp_sso_service_binding
+        settings.security[:authn_requests_signed] = IdentitySettings.saml_ssoe.request_signing
+        settings.security[:want_assertions_signed] = IdentitySettings.saml_ssoe.response_signing
+        settings.security[:want_assertions_encrypted] = IdentitySettings.saml_ssoe.response_encryption
         settings.security[:digest_method] = XMLSecurity::Document::SHA256
         settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA256
         settings
       end
 
       def pki_needed?
-        Settings.saml_ssoe.request_signing || Settings.saml_ssoe.response_encryption
+        IdentitySettings.saml_ssoe.request_signing || IdentitySettings.saml_ssoe.response_encryption
       end
     end
   end

--- a/lib/saml/url_service.rb
+++ b/lib/saml/url_service.rb
@@ -71,8 +71,8 @@ module SAML
       @query_params[:auth] = auth if auth != 'success'
       @query_params[:code] = code if code
 
-      if Settings.saml_ssoe.relay.present?
-        add_query(Settings.saml_ssoe.relay, query_params)
+      if IdentitySettings.saml_ssoe.relay.present?
+        add_query(IdentitySettings.saml_ssoe.relay, query_params)
       else
         add_query("#{base_redirect_url}#{LOGIN_REDIRECT_PARTIAL}", query_params)
       end
@@ -171,7 +171,7 @@ module SAML
 
     # logout URL for SSOe
     def ssoe_slo_url
-      Settings.saml_ssoe.logout_url
+      IdentitySettings.saml_ssoe.logout_url
     end
 
     private

--- a/lib/sign_in/idme/configuration.rb
+++ b/lib/sign_in/idme/configuration.rb
@@ -7,27 +7,27 @@ module SignIn
   module Idme
     class Configuration < Common::Client::Configuration::REST
       def base_path
-        Settings.idme.oauth_url
+        IdentitySettings.idme.oauth_url
       end
 
       def client_id
-        Settings.idme.client_id
+        IdentitySettings.idme.client_id
       end
 
       def client_secret
-        Settings.idme.client_secret
+        IdentitySettings.idme.client_secret
       end
 
       def redirect_uri
-        Settings.idme.redirect_uri
+        IdentitySettings.idme.redirect_uri
       end
 
       def client_key_path
-        Settings.idme.client_key_path
+        IdentitySettings.idme.client_key_path
       end
 
       def client_cert_path
-        Settings.idme.client_cert_path
+        IdentitySettings.idme.client_cert_path
       end
 
       def service_name

--- a/lib/sign_in/logingov/configuration.rb
+++ b/lib/sign_in/logingov/configuration.rb
@@ -7,31 +7,31 @@ module SignIn
   module Logingov
     class Configuration < Common::Client::Configuration::REST
       def base_path
-        Settings.logingov.oauth_url
+        IdentitySettings.logingov.oauth_url
       end
 
       def client_id
-        Settings.logingov.client_id
+        IdentitySettings.logingov.client_id
       end
 
       def redirect_uri
-        Settings.logingov.redirect_uri
+        IdentitySettings.logingov.redirect_uri
       end
 
       def logout_redirect_uri
-        Settings.logingov.logout_redirect_uri
+        IdentitySettings.logingov.logout_redirect_uri
       end
 
       def client_key_path
-        Settings.logingov.client_key_path
+        IdentitySettings.logingov.client_key_path
       end
 
       def client_cert_path
-        Settings.logingov.client_cert_path
+        IdentitySettings.logingov.client_cert_path
       end
 
       def single_sign_out_uri
-        Settings.logingov.sign_out_uri
+        IdentitySettings.logingov.sign_out_uri
       end
 
       def client_assertion_type

--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/application_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/application_controller.rb
@@ -17,7 +17,7 @@ module AccreditedRepresentativePortal
 
     service_tag 'accredited-representative-portal' # ARP DataDog monitoring: https://bit.ly/arp-datadog-monitoring
 
-    validates_access_token_audience Settings.sign_in.arp_client_id
+    validates_access_token_audience IdentitySettings.sign_in.arp_client_id
 
     before_action :verify_pilot_enabled_for_user
     around_action :handle_exceptions

--- a/modules/claims_api/config/initializers/okcomputer.rb
+++ b/modules/claims_api/config/initializers/okcomputer.rb
@@ -25,7 +25,7 @@ end
 
 class MpiCheck < BaseCheck
   def check
-    Settings.mvi.mock || MPI::Service.service_is_up? ? process_success : process_failure
+    IdentitySettings.mvi.mock || MPI::Service.service_is_up? ? process_success : process_failure
   rescue
     process_failure
   end

--- a/modules/claims_api/spec/requests/metadata_spec.rb
+++ b/modules/claims_api/spec/requests/metadata_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe 'ClaimsApi::Metadata', type: :request do
 
     %w[v1].each do |version|
       context version do
+        before do
+          allow(IdentitySettings.mvi).to receive(:mock).and_return(false)
+        end
+
         it 'returns correct response and status when healthy' do
           allow(MPI::Service).to receive(:service_is_up?).and_return(true)
           allow_any_instance_of(ClaimsApi::LocalBGS).to receive(:healthcheck).and_return(200)

--- a/modules/mobile/app/controllers/mobile/application_controller.rb
+++ b/modules/mobile/app/controllers/mobile/application_controller.rb
@@ -6,7 +6,7 @@ module Mobile
     include SignIn::AudienceValidator
 
     service_tag 'mobile-app'
-    validates_access_token_audience Settings.sign_in.vamobile_client_id
+    validates_access_token_audience IdentitySettings.sign_in.vamobile_client_id
 
     before_action :authenticate
     before_action :set_sentry_tags_and_extra_context

--- a/modules/mocked_authentication/app/controllers/mocked_authentication/mpi/mockdata_controller.rb
+++ b/modules/mocked_authentication/app/controllers/mocked_authentication/mpi/mockdata_controller.rb
@@ -40,7 +40,7 @@ module MockedAuthentication
 
       def mockdata_authorize
         authenticate_or_request_with_http_token do |token|
-          token == Settings.sign_in.mockdata_sync_api_key
+          token == IdentitySettings.sign_in.mockdata_sync_api_key
         end
       end
     end

--- a/modules/mocked_authentication/lib/credential/service.rb
+++ b/modules/mocked_authentication/lib/credential/service.rb
@@ -43,14 +43,14 @@ module MockedAuthentication
         {
           type:,
           acr_values: acr,
-          mock_redirect_uri: Settings.sign_in.mock_redirect_uri,
+          mock_redirect_uri: IdentitySettings.sign_in.mock_redirect_uri,
           state:,
           operation:
         }.compact
       end
 
       def redirect_uri
-        Settings.sign_in.mock_auth_url
+        IdentitySettings.sign_in.mock_auth_url
       end
 
       def logingov_acr(code)

--- a/modules/mocked_authentication/lib/mockdata/mpi/find.rb
+++ b/modules/mocked_authentication/lib/mockdata/mpi/find.rb
@@ -29,7 +29,7 @@ module MockedAuthentication
 
         def mpi_response
           @mpi_response ||= begin
-            uri = URI.parse(Settings.mvi.url)
+            uri = URI.parse(IdentitySettings.mvi.url)
             request = Net::HTTP::Post.new(uri)
             request.content_type = CONTENT_TYPE
             request['Connection'] = CONNECTION

--- a/modules/mocked_authentication/spec/lib/credential/service_spec.rb
+++ b/modules/mocked_authentication/spec/lib/credential/service_spec.rb
@@ -16,7 +16,7 @@ describe MockedAuthentication::Credential::Service do
     let(:acr) { 'some-acr' }
     let(:type) { 'some-type' }
     let(:operation) { 'some-operation' }
-    let(:expected_redirect_url) { Settings.sign_in.mock_auth_url }
+    let(:expected_redirect_url) { IdentitySettings.sign_in.mock_auth_url }
     let(:meta_refresh_tag) { '<meta http-equiv="refresh" content="0;' }
 
     it 'renders the oauth_get_form template with meta refresh tag' do

--- a/modules/mocked_authentication/spec/requests/mocked_authentication/mpi/mockdata_request_spec.rb
+++ b/modules/mocked_authentication/spec/requests/mocked_authentication/mpi/mockdata_request_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'MockedAuthentication::MPI::Mockdata', type: :request do
 
   describe 'GET #show' do
     before do
-      allow(Settings.sign_in).to receive(:mockdata_sync_api_key).and_return(api_key)
+      allow(IdentitySettings.sign_in).to receive(:mockdata_sync_api_key).and_return(api_key)
     end
 
     context 'when icn is present and api_key is valid' do

--- a/modules/travel_pay/app/services/travel_pay/token_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/token_client.rb
@@ -53,7 +53,7 @@ module TravelPay
     end
 
     def request_sts_token(user)
-      private_key_file = Settings.sign_in.sts_client.key_path
+      private_key_file = IdentitySettings.sign_in.sts_client.key_path
       private_key = OpenSSL::PKey::RSA.new(File.read(private_key_file))
 
       assertion = build_sts_assertion(user)

--- a/modules/travel_pay/spec/services/token_client_spec.rb
+++ b/modules/travel_pay/spec/services/token_client_spec.rb
@@ -94,7 +94,7 @@ describe TravelPay::TokenClient do
     after { Timecop.return }
 
     it 'builds sts assertion and requests sts token' do
-      private_key_file = Settings.sign_in.sts_client.key_path
+      private_key_file = IdentitySettings.sign_in.sts_client.key_path
       private_key = OpenSSL::PKey::RSA.new(File.read(private_key_file))
       jwt = JWT.encode(assertion, private_key, 'RS256')
       @stubs.post("http:/v0/sign_in/token?assertion=#{jwt}&grant_type=#{grant_type}") do

--- a/rakelib/connectivity.rake
+++ b/rakelib/connectivity.rake
@@ -83,7 +83,7 @@ namespace :connectivity do
 
   desc 'Check MVI'
   task mvi: :environment do
-    check 'MVI', Settings.mvi.url do
+    check 'MVI', IdentitySettings.mvi.url do
       user = User.new(
         first_name: 'John',
         last_name: 'Smith',

--- a/rakelib/mockdata_synchronize.rake
+++ b/rakelib/mockdata_synchronize.rake
@@ -28,7 +28,7 @@ namespace :mockdata_synchronize do
     end
 
     def create_curl(icn)
-      uri = URI.parse(Settings.mvi.url)
+      uri = URI.parse(IdentitySettings.mvi.url)
       request = Net::HTTP::Post.new(uri)
       request.content_type = 'text/xml;charset=UTF-8'
       request['Connection'] = 'close'

--- a/spec/controllers/sign_in/openid_connect_certificates_controller_spec.rb
+++ b/spec/controllers/sign_in/openid_connect_certificates_controller_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe SignIn::OpenidConnectCertificatesController, type: :controller do
     subject { get(:index) }
 
     let(:public_key_jwk) { JWT::JWK.new(public_key, { alg: 'RS256', use: 'sig' }).export }
-    let(:public_key) { OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_encode_key)).public_key }
+    let(:public_key) { OpenSSL::PKey::RSA.new(File.read(IdentitySettings.sign_in.jwt_encode_key)).public_key }
     let(:old_encode_key_setting) { nil }
     let(:expected_status) { :ok }
 
-    before { Settings.sign_in.jwt_old_encode_key = old_encode_key_setting }
+    before { IdentitySettings.sign_in.jwt_old_encode_key = old_encode_key_setting }
 
     context 'without an old Sign in Service access token encode setting' do
       let(:expected_public_key_jwks) { { keys: [public_key_jwk] } }
@@ -24,8 +24,10 @@ RSpec.describe SignIn::OpenidConnectCertificatesController, type: :controller do
     context 'with an old Sign in Service access token encode setting' do
       let(:expected_public_key_jwks) { { keys: [public_key_jwk, old_public_key_jwk] } }
       let(:old_public_key_jwk) { JWT::JWK.new(old_public_key, { alg: 'RS256', use: 'sig' }).export }
-      let(:old_public_key) { OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_old_encode_key)) }
-      let(:old_encode_key_setting) { Settings.sign_in.jwt_old_encode_key || Settings.sign_in.jwt_encode_key }
+      let(:old_public_key) { OpenSSL::PKey::RSA.new(File.read(IdentitySettings.sign_in.jwt_old_encode_key)) }
+      let(:old_encode_key_setting) do
+        IdentitySettings.sign_in.jwt_old_encode_key || IdentitySettings.sign_in.jwt_encode_key
+      end
 
       it 'renders the current & previous public keys' do
         expect(JSON.parse(subject.body)).to eq(expected_public_key_jwks.as_json)

--- a/spec/controllers/sign_in/user_info_controller_spec.rb
+++ b/spec/controllers/sign_in/user_info_controller_spec.rb
@@ -25,7 +25,7 @@ describe SignIn::UserInfoController do
   let(:encoded_access_token) { SignIn::AccessTokenJwtEncoder.new(access_token:).perform }
 
   before do
-    allow(Settings.sign_in).to receive(:user_info_clients).and_return(user_info_clients)
+    allow(IdentitySettings.sign_in).to receive(:user_info_clients).and_return(user_info_clients)
     request.headers['Authorization'] = "Bearer #{encoded_access_token}"
   end
 

--- a/spec/controllers/v0/sign_in_controller_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_spec.rb
@@ -378,7 +378,7 @@ RSpec.describe V0::SignInController, type: :controller do
 
       context 'when type param is logingov' do
         let(:type_value) { SignIn::Constants::Auth::LOGINGOV }
-        let(:expected_redirect_uri) { Settings.logingov.redirect_uri }
+        let(:expected_redirect_uri) { IdentitySettings.logingov.redirect_uri }
 
         context 'and operation param is not given' do
           let(:operation) { {} }
@@ -447,7 +447,7 @@ RSpec.describe V0::SignInController, type: :controller do
       end
 
       shared_context 'an idme service interface with appropriate operation' do
-        let(:expected_redirect_uri) { Settings.idme.redirect_uri }
+        let(:expected_redirect_uri) { IdentitySettings.idme.redirect_uri }
 
         context 'and acr param is not given' do
           let(:acr) { {} }
@@ -800,7 +800,7 @@ RSpec.describe V0::SignInController, type: :controller do
               context 'and credential should be uplevelled' do
                 let(:acr) { 'min' }
                 let(:logingov_acr) { IAL::LOGIN_GOV_IAL1 }
-                let(:expected_redirect_uri) { Settings.logingov.redirect_uri }
+                let(:expected_redirect_uri) { IdentitySettings.logingov.redirect_uri }
                 let(:expected_redirect_uri_param) { { redirect_uri: expected_redirect_uri }.to_query }
 
                 before do
@@ -971,7 +971,7 @@ RSpec.describe V0::SignInController, type: :controller do
               context 'and credential should be uplevelled' do
                 let(:acr) { 'min' }
                 let(:credential_ial) { LOA::ONE }
-                let(:expected_redirect_uri) { Settings.idme.redirect_uri }
+                let(:expected_redirect_uri) { IdentitySettings.idme.redirect_uri }
                 let(:expected_redirect_uri_param) { { redirect_uri: expected_redirect_uri }.to_query }
 
                 before do
@@ -2815,9 +2815,9 @@ RSpec.describe V0::SignInController, type: :controller do
         end
 
         context 'and client configuration has configured a logout redirect uri' do
-          let(:logingov_client_id) { Settings.logingov.client_id }
+          let(:logingov_client_id) { IdentitySettings.logingov.client_id }
           let(:logout_redirect_uri) { 'some-logout-redirect-uri' }
-          let(:logingov_logout_redirect_uri) { Settings.logingov.logout_redirect_uri }
+          let(:logingov_logout_redirect_uri) { IdentitySettings.logingov.logout_redirect_uri }
           let(:random_seed) { 'some-random-seed' }
           let(:logout_state_payload) do
             {
@@ -2833,7 +2833,7 @@ RSpec.describe V0::SignInController, type: :controller do
               state:
             }
           end
-          let(:expected_url_host) { Settings.logingov.oauth_url }
+          let(:expected_url_host) { IdentitySettings.logingov.oauth_url }
           let(:expected_url_path) { 'openid_connect/logout' }
           let(:expected_url) { "#{expected_url_host}/#{expected_url_path}?#{expected_url_params.to_query}" }
           let(:expected_status) { :redirect }

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -638,9 +638,9 @@ RSpec.describe V1::SessionsController, type: :controller do
           SAMLRequestTracker.create(uuid: login_uuid, payload: { type: 'idme', application: })
         end
 
-        context 'and authentication occurred with a application in Settings.terms_of_use.enabled_clients' do
+        context 'and authentication occurred with a application in IdentitySettings.terms_of_use.enabled_clients' do
           before do
-            allow(Settings.terms_of_use).to receive(:enabled_clients).and_return(application)
+            allow(IdentitySettings.terms_of_use).to receive(:enabled_clients).and_return(application)
           end
 
           context 'when the application is not in SKIP_MHV_ACCOUNT_CREATION_CLIENTS' do
@@ -660,9 +660,9 @@ RSpec.describe V1::SessionsController, type: :controller do
           end
         end
 
-        context 'and authentication occurred with an application not in Settings.terms_of_use.enabled_clients' do
+        context 'and auth occurred with an application not in IdentitySettings.terms_of_use.enabled_clients' do
           before do
-            allow(Settings.terms_of_use).to receive(:enabled_clients).and_return('')
+            allow(IdentitySettings.terms_of_use).to receive(:enabled_clients).and_return('')
           end
 
           it 'redirects to expected auth page' do
@@ -691,9 +691,9 @@ RSpec.describe V1::SessionsController, type: :controller do
           SAMLRequestTracker.create(uuid: login_uuid, payload: { type: 'idme', application: })
         end
 
-        context 'and authentication occurred with a application in Settings.terms_of_use.enabled_clients' do
+        context 'and authentication occurred with a application in IdentitySettings.terms_of_use.enabled_clients' do
           before do
-            allow(Settings.terms_of_use).to receive(:enabled_clients).and_return(application)
+            allow(IdentitySettings.terms_of_use).to receive(:enabled_clients).and_return(application)
           end
 
           context 'when the application is not in SKIP_MHV_ACCOUNT_CREATION_CLIENTS' do
@@ -713,9 +713,9 @@ RSpec.describe V1::SessionsController, type: :controller do
           end
         end
 
-        context 'and authentication occurred with an application not in Settings.terms_of_use.enabled_clients' do
+        context 'and auth occurred with an application not in IdentitySettings.terms_of_use.enabled_clients' do
           before do
-            allow(Settings.terms_of_use).to receive(:enabled_clients).and_return('')
+            allow(IdentitySettings.terms_of_use).to receive(:enabled_clients).and_return('')
           end
 
           it 'redirects to expected auth page' do

--- a/spec/factories/rubysaml_settings.rb
+++ b/spec/factories/rubysaml_settings.rb
@@ -2,10 +2,10 @@
 
 FactoryBot.define do
   factory :rubysaml_settings, class: 'OneLogin::RubySaml::Settings' do
-    certificate                     { Settings.saml_ssoe.certificate }
-    private_key                     { Settings.saml_ssoe.key }
-    sp_entity_id                    { Settings.saml_ssoe.issuer }
-    assertion_consumer_service_url  { Settings.saml_ssoe.callback_url }
+    certificate                     { IdentitySettings.saml_ssoe.certificate }
+    private_key                     { IdentitySettings.saml_ssoe.key }
+    sp_entity_id                    { IdentitySettings.saml_ssoe.issuer }
+    assertion_consumer_service_url  { IdentitySettings.saml_ssoe.callback_url }
     idp_cert                        {
       File.read(Rails.root.join(*'/spec/fixtures/files/idme_cert.crt'.split('/'))
                             .to_s)
@@ -18,10 +18,10 @@ FactoryBot.define do
   end
 
   factory :settings_no_context, class: 'OneLogin::RubySaml::Settings' do
-    certificate                     { Settings.saml_ssoe.certificate }
-    private_key                     { Settings.saml_ssoe.key }
-    sp_entity_id                    { Settings.saml_ssoe.issuer }
-    assertion_consumer_service_url  { Settings.saml_ssoe.callback_url }
+    certificate                     { IdentitySettings.saml_ssoe.certificate }
+    private_key                     { IdentitySettings.saml_ssoe.key }
+    sp_entity_id                    { IdentitySettings.saml_ssoe.issuer }
+    assertion_consumer_service_url  { IdentitySettings.saml_ssoe.callback_url }
     idp_cert                        {
       File.read(Rails.root.join(*'/spec/fixtures/files/idme_cert.crt'.split('/'))
                             .to_s)

--- a/spec/lib/mpi/configuration_spec.rb
+++ b/spec/lib/mpi/configuration_spec.rb
@@ -35,7 +35,7 @@ describe MPI::Configuration do
   end
 
   describe '.open_timeout' do
-    context 'when Settings.mvi.open_timeout is set' do
+    context 'when IdentitySettings.mvi.open_timeout is set' do
       it 'uses the setting' do
         expect(MPI::Configuration.instance.open_timeout).to eq(15)
       end
@@ -43,7 +43,7 @@ describe MPI::Configuration do
   end
 
   describe '.read_timeout' do
-    context 'when Settings.mvi.timeout is set' do
+    context 'when IdentitySettings.mvi.timeout is set' do
       it 'uses the setting' do
         expect(MPI::Configuration.instance.read_timeout).to eq(30)
       end

--- a/spec/lib/mpi/messages/request_builder_spec.rb
+++ b/spec/lib/mpi/messages/request_builder_spec.rb
@@ -9,7 +9,7 @@ describe MPI::Messages::RequestBuilder do
 
     before do
       allow(SecureRandom).to receive(:uuid).and_return(random_number)
-      allow(Settings.mvi).to receive(:processing_code).and_return(processing_code)
+      allow(IdentitySettings.mvi).to receive(:processing_code).and_return(processing_code)
       Timecop.freeze
     end
 

--- a/spec/lib/saml/post_url_service_spec.rb
+++ b/spec/lib/saml/post_url_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SAML::PostURLService do
     SAML::URLService::VIRTUAL_HOST_MAPPINGS.each_key do |vhost_url|
       context "virtual host: #{vhost_url}" do
         let(:saml_settings) do
-          callback_path = URI.parse(Settings.saml_ssoe.callback_url).path
+          callback_path = URI.parse(IdentitySettings.saml_ssoe.callback_url).path
           build(:settings_no_context, assertion_consumer_service_url: "#{vhost_url}#{callback_path}")
         end
         let(:params) { { action: 'new' } }
@@ -99,7 +99,7 @@ RSpec.describe SAML::PostURLService do
     SAML::URLService::VIRTUAL_HOST_MAPPINGS.each do |vhost_url, values|
       context "virtual host: #{vhost_url}" do
         let(:saml_settings) do
-          callback_path = URI.parse(Settings.saml_ssoe.callback_url).path
+          callback_path = URI.parse(IdentitySettings.saml_ssoe.callback_url).path
           build(:settings_no_context, assertion_consumer_service_url: "#{vhost_url}#{callback_path}")
         end
 
@@ -386,7 +386,7 @@ RSpec.describe SAML::PostURLService do
     SAML::URLService::VIRTUAL_HOST_MAPPINGS.each do |vhost_url, values|
       context "virtual host: #{vhost_url}" do
         let(:saml_settings) do
-          callback_path = URI.parse(Settings.saml_ssoe.callback_url).path
+          callback_path = URI.parse(IdentitySettings.saml_ssoe.callback_url).path
           build(:settings_no_context, assertion_consumer_service_url: "#{vhost_url}#{callback_path}")
         end
 
@@ -641,11 +641,11 @@ RSpec.describe SAML::PostURLService do
               let(:cache_expiration) { 5.minutes }
 
               before do
-                allow(Settings.terms_of_use).to receive(:enabled_clients).and_return(enabled_clients)
+                allow(IdentitySettings.terms_of_use).to receive(:enabled_clients).and_return(enabled_clients)
                 allow(Rails.cache).to receive(:read).with(cache_key).and_return(application)
               end
 
-              context 'and application is within Settings.terms_of_use.enabled_clients' do
+              context 'and application is within IdentitySettings.terms_of_use.enabled_clients' do
                 let(:enabled_clients) { application }
 
                 context 'and authentication is occuring on a review instance' do
@@ -664,7 +664,7 @@ RSpec.describe SAML::PostURLService do
                 end
               end
 
-              context 'and stored application is not within Settings.terms_of_use.enabled_clients' do
+              context 'and stored application is not within IdentitySettings.terms_of_use.enabled_clients' do
                 let(:enabled_clients) { '' }
 
                 it 'has a login redirect url with success not embedded in a terms of use page' do
@@ -679,9 +679,9 @@ RSpec.describe SAML::PostURLService do
             end
 
             context 'when associated terms of use redirect user cache object does not exist' do
-              context 'when tracker application is within Settings.terms_of_use.enabled_clients' do
+              context 'when tracker application is within IdentitySettings.terms_of_use.enabled_clients' do
                 before do
-                  allow(Settings.terms_of_use).to receive(:enabled_clients).and_return(application)
+                  allow(IdentitySettings.terms_of_use).to receive(:enabled_clients).and_return(application)
                 end
 
                 context 'and authentication is occuring on a review instance' do
@@ -707,9 +707,9 @@ RSpec.describe SAML::PostURLService do
                 it_behaves_like 'terms of use redirected url'
               end
 
-              context 'when tracker application is not within Settings.terms_of_use.enabled_clients' do
+              context 'when tracker application is not within IdentitySettings.terms_of_use.enabled_clients' do
                 before do
-                  allow(Settings.terms_of_use).to receive(:enabled_clients).and_return('')
+                  allow(IdentitySettings.terms_of_use).to receive(:enabled_clients).and_return('')
                 end
 
                 it 'has a login redirect url with success not embedded in a terms of use page' do
@@ -745,7 +745,8 @@ RSpec.describe SAML::PostURLService do
     around do |example|
       Timecop.freeze('2018-04-09T17:52:03Z')
       RequestStore.store['request_id'] = request_id
-      with_settings(Settings.saml_ssoe, relay: "http://#{slug_id}.review.vetsgov-internal/auth/login/callback") do
+      with_settings(IdentitySettings.saml_ssoe,
+                    relay: "http://#{slug_id}.review.vetsgov-internal/auth/login/callback") do
         with_settings(Settings, review_instance_slug: slug_id) do
           example.run
         end

--- a/spec/lib/saml/ssoe_settings_service_spec.rb
+++ b/spec/lib/saml/ssoe_settings_service_spec.rb
@@ -5,7 +5,7 @@ require 'saml/ssoe_settings_service'
 
 RSpec.describe SAML::SSOeSettingsService do
   before do
-    allow(Settings.saml_ssoe)
+    allow(IdentitySettings.saml_ssoe)
       .to receive(:idp_metadata_file).and_return(Rails.root.join('spec', 'support', 'saml', 'test_idp_metadata.xml'))
   end
 
@@ -21,9 +21,9 @@ RSpec.describe SAML::SSOeSettingsService do
 
     context 'with no signing or encryption configured' do
       it 'omits certificate from settings' do
-        with_settings(Settings.saml_ssoe, certificate: 'foobar',
-                                          request_signing: false, response_signing: false,
-                                          response_encryption: false) do
+        with_settings(IdentitySettings.saml_ssoe, certificate: 'foobar',
+                                                  request_signing: false, response_signing: false,
+                                                  response_encryption: false) do
           expect(SAML::SSOeSettingsService.saml_settings.certificate).to be_nil
         end
       end
@@ -31,9 +31,9 @@ RSpec.describe SAML::SSOeSettingsService do
 
     context 'with signing configured' do
       it 'includes certificate in settings' do
-        with_settings(Settings.saml_ssoe, certificate: 'foobar',
-                                          request_signing: true, response_signing: false,
-                                          response_encryption: false) do
+        with_settings(IdentitySettings.saml_ssoe, certificate: 'foobar',
+                                                  request_signing: true, response_signing: false,
+                                                  response_encryption: false) do
           expect(SAML::SSOeSettingsService.saml_settings.certificate).to eq('foobar')
         end
       end
@@ -41,9 +41,9 @@ RSpec.describe SAML::SSOeSettingsService do
 
     context 'with encryption configured' do
       it 'includes certificate in settings' do
-        with_settings(Settings.saml_ssoe, certificate: 'foobar',
-                                          request_signing: false, response_signing: false,
-                                          response_encryption: true) do
+        with_settings(IdentitySettings.saml_ssoe, certificate: 'foobar',
+                                                  request_signing: false, response_signing: false,
+                                                  response_encryption: true) do
           expect(SAML::SSOeSettingsService.saml_settings.certificate).to eq('foobar')
         end
       end

--- a/spec/lib/saml/url_service_spec.rb
+++ b/spec/lib/saml/url_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SAML::URLService do
     SAML::URLService::VIRTUAL_HOST_MAPPINGS.each do |vhost_url, values|
       context "virtual host: #{vhost_url}" do
         let(:saml_settings) do
-          callback_path = URI.parse(Settings.saml_ssoe.callback_url).path
+          callback_path = URI.parse(IdentitySettings.saml_ssoe.callback_url).path
           build(:settings_no_context, assertion_consumer_service_url: "#{vhost_url}#{callback_path}")
         end
         let(:expected_saml_url) { "#{saml_settings.idp_sso_target_url}?SAMLRequest=" }
@@ -345,7 +345,7 @@ RSpec.describe SAML::URLService do
     SAML::URLService::VIRTUAL_HOST_MAPPINGS.each do |vhost_url, values|
       context "virtual host: #{vhost_url}" do
         let(:saml_settings) do
-          callback_path = URI.parse(Settings.saml_ssoe.callback_url).path
+          callback_path = URI.parse(IdentitySettings.saml_ssoe.callback_url).path
           build(:settings_no_context, assertion_consumer_service_url: "#{vhost_url}#{callback_path}")
         end
         let(:expected_saml_url) { "#{saml_settings.idp_sso_target_url}?SAMLRequest=" }
@@ -593,7 +593,8 @@ RSpec.describe SAML::URLService do
     around do |example|
       Timecop.freeze('2018-04-09T17:52:03Z')
       RequestStore.store['request_id'] = '123'
-      with_settings(Settings.saml_ssoe, relay: "http://#{slug_id}.review.vetsgov-internal/auth/login/callback") do
+      with_settings(IdentitySettings.saml_ssoe,
+                    relay: "http://#{slug_id}.review.vetsgov-internal/auth/login/callback") do
         with_settings(Settings, review_instance_slug: slug_id) do
           example.run
         end

--- a/spec/lib/sign_in/idme/service_spec.rb
+++ b/spec/lib/sign_in/idme/service_spec.rb
@@ -83,7 +83,7 @@ describe SignIn::Idme::Service do
     end
 
     before do
-      allow(Settings.idme).to receive(:oauth_url).and_return(base_path)
+      allow(IdentitySettings.idme).to receive(:oauth_url).and_return(base_path)
     end
 
     it 'logs information to rails logger' do
@@ -157,8 +157,8 @@ describe SignIn::Idme::Service do
     let(:expected_jwks_fetch_log) { '[SignIn][Idme][Service] Get Public JWKs Success' }
 
     before do
-      allow(Settings.idme).to receive_messages(client_cert_path: test_client_cert_path,
-                                               client_key_path: test_client_key_path)
+      allow(IdentitySettings.idme).to receive_messages(client_cert_path: test_client_cert_path,
+                                                       client_key_path: test_client_key_path)
     end
 
     it 'returns user attributes', vcr: { cassette_name: 'identity/idme_200_responses' } do

--- a/spec/lib/sign_in/logingov/service_spec.rb
+++ b/spec/lib/sign_in/logingov/service_spec.rb
@@ -123,8 +123,8 @@ describe SignIn::Logingov::Service do
   end
 
   describe '#render_logout' do
-    let(:client_id) { Settings.logingov.client_id }
-    let(:logout_redirect_uri) { Settings.logingov.logout_redirect_uri }
+    let(:client_id) { IdentitySettings.logingov.client_id }
+    let(:logout_redirect_uri) { IdentitySettings.logingov.logout_redirect_uri }
     let(:expected_url_params) do
       {
         client_id:,
@@ -140,7 +140,7 @@ describe SignIn::Logingov::Service do
       }
     end
     let(:seed) { 'some-seed' }
-    let(:expected_url_host) { Settings.logingov.oauth_url }
+    let(:expected_url_host) { IdentitySettings.logingov.oauth_url }
     let(:expected_url_path) { 'openid_connect/logout' }
     let(:expected_url) { "#{expected_url_host}/#{expected_url_path}?#{expected_url_params.to_query}" }
     let(:client_logout_redirect_uri) { 'some-client-logout-redirect-uri' }

--- a/spec/policies/sign_in/user_info_policy_spec.rb
+++ b/spec/policies/sign_in/user_info_policy_spec.rb
@@ -11,7 +11,7 @@ describe SignIn::UserInfoPolicy do
   let(:user_info_clients) { [client_id] }
 
   before do
-    allow(Settings.sign_in).to receive(:user_info_clients).and_return(user_info_clients)
+    allow(IdentitySettings.sign_in).to receive(:user_info_clients).and_return(user_info_clients)
   end
 
   permissions :show? do

--- a/spec/requests/v0/user_spec.rb
+++ b/spec/requests/v0/user_spec.rb
@@ -405,7 +405,7 @@ RSpec.describe 'V0::User', type: :request do
   end
 
   def stub_mpi_external_request(file)
-    stub_request(:post, Settings.mvi.url)
+    stub_request(:post, IdentitySettings.mvi.url)
       .to_return(status: 200, headers: { 'Content-Type' => 'text/xml' }, body: file)
   end
 end

--- a/spec/services/sign_in/credential_level_creator_spec.rb
+++ b/spec/services/sign_in/credential_level_creator_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe SignIn::CredentialLevelCreator do
     end
     let(:auto_uplevel) { false }
 
-    before { allow(Settings.sign_in).to receive(:auto_uplevel).and_return(auto_uplevel) }
+    before { allow(IdentitySettings.sign_in).to receive(:auto_uplevel).and_return(auto_uplevel) }
 
     shared_examples 'invalid credential level error' do
       let(:expected_error) { SignIn::Errors::InvalidCredentialLevelError }

--- a/spec/services/sign_in/logout_redirect_generator_spec.rb
+++ b/spec/services/sign_in/logout_redirect_generator_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe SignIn::LogoutRedirectGenerator do
         let(:logout_redirect_uri) { 'some-logout-redirect-uri' }
 
         context 'and the user is authenticated with login.gov credential' do
-          let(:logingov_client_id) { Settings.logingov.client_id }
-          let(:logingov_logout_redirect_uri) { Settings.logingov.logout_redirect_uri }
+          let(:logingov_client_id) { IdentitySettings.logingov.client_id }
+          let(:logingov_logout_redirect_uri) { IdentitySettings.logingov.logout_redirect_uri }
           let(:random_seed) { 'some-random-seed' }
           let(:logout_state_payload) do
             {
@@ -34,7 +34,7 @@ RSpec.describe SignIn::LogoutRedirectGenerator do
               state:
             }
           end
-          let(:expected_url_host) { Settings.logingov.oauth_url }
+          let(:expected_url_host) { IdentitySettings.logingov.oauth_url }
           let(:expected_url_path) { 'openid_connect/logout' }
           let(:expected_url) { "#{expected_url_host}/#{expected_url_path}?#{expected_url_params.to_query}" }
 

--- a/spec/services/sign_in/openid_connect_certificates_presenter_spec.rb
+++ b/spec/services/sign_in/openid_connect_certificates_presenter_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe SignIn::OpenidConnectCertificatesPresenter do
     subject { SignIn::OpenidConnectCertificatesPresenter.new.perform }
 
     let(:public_key_jwk) { JWT::JWK.new(public_key, { alg: 'RS256', use: 'sig' }).export }
-    let(:public_key) { OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_encode_key)).public_key }
+    let(:public_key) { OpenSSL::PKey::RSA.new(File.read(IdentitySettings.sign_in.jwt_encode_key)).public_key }
 
-    before { allow(Settings.sign_in).to receive(:jwt_old_encode_key).and_return(old_encode_key_setting) }
+    before { allow(IdentitySettings.sign_in).to receive(:jwt_old_encode_key).and_return(old_encode_key_setting) }
 
     shared_examples 'certificates return' do
       it 'returns a JWK representation of Sign in Service public keys' do
@@ -27,8 +27,8 @@ RSpec.describe SignIn::OpenidConnectCertificatesPresenter do
     context 'with an old Sign in Service access token encode setting' do
       let(:expected_public_keys_jwks) { { keys: [public_key_jwk, old_public_key_jwk] } }
       let(:old_public_key_jwk) { JWT::JWK.new(old_public_key, { alg: 'RS256', use: 'sig' }).export }
-      let(:old_public_key) { OpenSSL::PKey::RSA.new(File.read(Settings.sign_in.jwt_old_encode_key)) }
-      let(:old_encode_key_setting) { Settings.sign_in.jwt_encode_key }
+      let(:old_public_key) { OpenSSL::PKey::RSA.new(File.read(IdentitySettings.sign_in.jwt_old_encode_key)) }
+      let(:old_encode_key_setting) { IdentitySettings.sign_in.jwt_encode_key }
 
       it_behaves_like 'certificates return'
     end

--- a/spec/services/sign_in/token_serializer_spec.rb
+++ b/spec/services/sign_in/token_serializer_spec.rb
@@ -48,10 +48,10 @@ RSpec.describe SignIn::TokenSerializer do
         }
       end
       let(:path) { '/' }
-      let(:secure) { Settings.sign_in.cookies_secure }
+      let(:secure) { IdentitySettings.sign_in.cookies_secure }
       let(:httponly) { true }
       let(:httponly_info_cookie) { false }
-      let(:domain) { Settings.sign_in.info_cookie_domain }
+      let(:domain) { IdentitySettings.sign_in.info_cookie_domain }
       let(:refresh_path) { SignIn::Constants::Auth::REFRESH_ROUTE_PATH }
       let(:expected_access_token_cookie) do
         {
@@ -230,10 +230,10 @@ RSpec.describe SignIn::TokenSerializer do
         }
       end
       let(:path) { '/' }
-      let(:secure) { Settings.sign_in.cookies_secure }
+      let(:secure) { IdentitySettings.sign_in.cookies_secure }
       let(:httponly) { true }
       let(:httponly_info_cookie) { false }
-      let(:domain) { Settings.sign_in.info_cookie_domain }
+      let(:domain) { IdentitySettings.sign_in.info_cookie_domain }
       let(:refresh_path) { SignIn::Constants::Auth::REFRESH_ROUTE_PATH }
       let(:expected_access_token_cookie) do
         {

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -32,7 +32,7 @@ VCR.configure do |c|
   c.filter_sensitive_data('<MHV_X_API_KEY>') { Settings.mhv.medical_records.mhv_x_api_key }
   c.filter_sensitive_data('<MHV_SM_APP_TOKEN>') { Settings.mhv.sm.app_token }
   c.filter_sensitive_data('<MHV_SM_HOST>') { Settings.mhv.sm.host }
-  c.filter_sensitive_data('<MPI_URL>') { Settings.mvi.url }
+  c.filter_sensitive_data('<MPI_URL>') { IdentitySettings.mvi.url }
   c.filter_sensitive_data('<PD_TOKEN>') { Settings.maintenance.pagerduty_api_token }
   c.filter_sensitive_data('<CENTRAL_MAIL_TOKEN>') { Settings.central_mail.upload.token }
   c.filter_sensitive_data('<PPMS_API_KEY>') { Settings.ppms.api_keys }


### PR DESCRIPTION
## Summary

- `IdentitySettings` was created for better maintainability of identity specific settings. 
- non-secret IdentitySettings are stored in environment specific settings files instead of the anti-pattern of storing everything in parameter store

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-1120

## Testing
- Check that IdentitySettings match existing Settings in all environments
- Test authentication

## What areas of the site does it impact?
Settings

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
