### PR TITLE
[CST] - Updated code to no longer use `.utc` and to use `DateTime.current `

### DIFF
--- a/app/sidekiq/evss/document_upload.rb
+++ b/app/sidekiq/evss/document_upload.rb
@@ -85,7 +85,7 @@ class EVSS::DocumentUpload
     current_personalisation = JSON.parse(evidence_submission.template_metadata)['personalisation']
     evidence_submission.update(
       upload_status: BenefitsDocuments::Constants::UPLOAD_STATUS[:FAILED],
-      failed_date: DateTime.now.utc,
+      failed_date: DateTime.current,
       acknowledgement_date: (DateTime.current + 30.days).utc,
       error_message: 'EVSS::DocumentUpload document upload failure',
       template_metadata: {
@@ -185,7 +185,7 @@ class EVSS::DocumentUpload
   def update_evidence_submission_status(evidence_submission)
     evidence_submission.update!(
       upload_status: BenefitsDocuments::Constants::UPLOAD_STATUS[:SUCCESS],
-      delete_date: (DateTime.current + 60.days).utc
+      delete_date: (DateTime.current + 60.days)
     )
     StatsD.increment('cst.evss.document_uploads.evidence_submission_record_updated.success')
   end

--- a/app/sidekiq/lighthouse/evidence_submissions/delete_evidence_submission_records_job.rb
+++ b/app/sidekiq/lighthouse/evidence_submissions/delete_evidence_submission_records_job.rb
@@ -16,7 +16,7 @@ module Lighthouse
       def perform
         record_count = EvidenceSubmission.all.count
         deleted_records = EvidenceSubmission.where(
-          delete_date: ..DateTime.now,
+          delete_date: ..DateTime.current,
           upload_status: BenefitsDocuments::Constants::UPLOAD_STATUS[:SUCCESS]
         ).destroy_all
 

--- a/app/sidekiq/lighthouse/evidence_submissions/document_upload.rb
+++ b/app/sidekiq/lighthouse/evidence_submissions/document_upload.rb
@@ -59,8 +59,8 @@ module Lighthouse
         current_personalisation = JSON.parse(evidence_submission.template_metadata)['personalisation']
         evidence_submission.update(
           upload_status: BenefitsDocuments::Constants::UPLOAD_STATUS[:FAILED],
-          failed_date: DateTime.now.utc,
-          acknowledgement_date: (DateTime.current + 30.days).utc,
+          failed_date: DateTime.current,
+          acknowledgement_date: (DateTime.current + 30.days),
           error_message: 'Lighthouse::EvidenceSubmissions::DocumentUpload document upload failure',
           template_metadata: {
             personalisation: update_personalisation(current_personalisation, msg['failed_at'])

--- a/app/sidekiq/lighthouse/evidence_submissions/failure_notification_email_job.rb
+++ b/app/sidekiq/lighthouse/evidence_submissions/failure_notification_email_job.rb
@@ -55,7 +55,7 @@ module Lighthouse
 
       def record_email_send_success(upload, response)
         # Update evidence_submissions table record with the va_notify_id and va_notify_date
-        upload.update(va_notify_id: response.id, va_notify_date: DateTime.now)
+        upload.update(va_notify_id: response.id, va_notify_date: DateTime.current)
         message = "#{upload.job_class} va notify failure email queued"
         ::Rails.logger.info(message)
         StatsD.increment('silent_failure_avoided_no_confirmation',

--- a/lib/lighthouse/benefits_documents/upload_status_updater.rb
+++ b/lib/lighthouse/benefits_documents/upload_status_updater.rb
@@ -95,7 +95,7 @@ module BenefitsDocuments
       @pending_evidence_submission.update!(
         upload_status: BenefitsDocuments::Constants::UPLOAD_STATUS[:FAILED],
         failed_date: DateTime.now.utc,
-        acknowledgement_date: (DateTime.current + 30.days).utc,
+        acknowledgement_date: (DateTime.current + 30.days),
         error_message: @lighthouse_document_status_response['error'],
         template_metadata: {
           personalisation: update_personalisation
@@ -113,7 +113,7 @@ module BenefitsDocuments
     def process_upload
       @pending_evidence_submission.update!(
         upload_status: BenefitsDocuments::Constants::UPLOAD_STATUS[:SUCCESS],
-        delete_date: (DateTime.current + 60.days).utc
+        delete_date: (DateTime.current + 60.days)
       )
     end
   end

--- a/spec/lib/lighthouse/benefits_documents/service_spec.rb
+++ b/spec/lib/lighthouse/benefits_documents/service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe BenefitsDocuments::Service do
         }
       end
 
-      let(:issue_instant) { Time.now.to_i }
+      let(:issue_instant) { Time.current.to_i }
       let(:submitted_date) do
         BenefitsDocuments::Utilities::Helpers.format_date_for_mailers(issue_instant)
       end

--- a/spec/lib/lighthouse/benefits_documents/upload_status_updater_spec.rb
+++ b/spec/lib/lighthouse/benefits_documents/upload_status_updater_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe BenefitsDocuments::UploadStatusUpdater do
   let(:lighthouse_document_upload) { create(:bd_evidence_submission_pending, job_class: 'BenefitsDocuments::Service') }
   let(:lighthouse_document_upload_timeout) { create(:bd_evidence_submission_timeout) }
   let(:past_date_time) { DateTime.new(1985, 10, 26) }
-  let(:current_date_time) { DateTime.now.utc }
+  let(:current_date_time) { DateTime.current }
   let(:issue_instant) { Time.now.to_i }
 
   describe '#update_status' do
@@ -64,10 +64,10 @@ RSpec.describe BenefitsDocuments::UploadStatusUpdater do
               expect { status_updater.update_status }
                 .to change(lighthouse_document_upload, :acknowledgement_date)
                 .from(nil)
-                .to(be_within(1.second).of((current_date_time + 30.days).utc))
+                .to(be_within(1.second).of((current_date_time + 30.days)))
                 .and change(lighthouse_document_upload, :failed_date)
                 .from(nil)
-                .to(be_within(1.second).of(current_date_time.utc))
+                .to(be_within(1.second).of(current_date_time))
                 .and change(lighthouse_document_upload, :upload_status)
                 .from(BenefitsDocuments::Constants::UPLOAD_STATUS[:PENDING])
                 .to(BenefitsDocuments::Constants::UPLOAD_STATUS[:FAILED])
@@ -85,7 +85,7 @@ RSpec.describe BenefitsDocuments::UploadStatusUpdater do
               expect { status_updater.update_status }
                 .to change(lighthouse_document_upload, :delete_date)
                 .from(nil)
-                .to(be_within(1.second).of((current_date_time + 60.days).utc))
+                .to(be_within(1.second).of((current_date_time + 60.days)))
                 .and change(lighthouse_document_upload, :upload_status)
                 .from(BenefitsDocuments::Constants::UPLOAD_STATUS[:PENDING])
                 .to(BenefitsDocuments::Constants::UPLOAD_STATUS[:SUCCESS])

--- a/spec/services/evss_claim_service_spec.rb
+++ b/spec/services/evss_claim_service_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe EVSSClaimService do
       user.save!
     end
 
-    let(:issue_instant) { Time.now.to_i }
+    let(:issue_instant) { Time.current.to_i }
     let(:submitted_date) do
       BenefitsDocuments::Utilities::Helpers.format_date_for_mailers(issue_instant)
     end

--- a/spec/sidekiq/evss/document_upload_spec.rb
+++ b/spec/sidekiq/evss/document_upload_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe EVSS::DocumentUpload, type: :job do
   let(:client_stub) { instance_double(EVSS::DocumentsService) }
   let(:notify_client_stub) { instance_double(VaNotify::Service) }
   let(:issue_instant) { Time.now.to_i }
-  let(:current_date_time) { DateTime.now.utc }
+  let(:current_date_time) { DateTime.current }
   let(:msg) do
     {
       'jid' => job_id,
@@ -158,8 +158,8 @@ RSpec.describe EVSS::DocumentUpload, type: :job do
         expect(current_personalisation['date_failed']).to eql(failed_date)
 
         Timecop.freeze(current_date_time) do
-          expect(evidence_submission.failed_date).to be_within(1.second).of(current_date_time.utc)
-          expect(evidence_submission.acknowledgement_date).to be_within(1.second).of((current_date_time + 30.days).utc)
+          expect(evidence_submission.failed_date).to be_within(1.second).of(current_date_time)
+          expect(evidence_submission.acknowledgement_date).to be_within(1.second).of((current_date_time + 30.days))
         end
         Timecop.unfreeze
       end

--- a/spec/sidekiq/lighthouse/evidence_submissions/document_upload_spec.rb
+++ b/spec/sidekiq/lighthouse/evidence_submissions/document_upload_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe Lighthouse::EvidenceSubmissions::DocumentUpload, type: :job do
   let(:job_id) { job }
   let(:client_stub) { instance_double(BenefitsDocuments::WorkerService) }
   let(:job_class) { 'Lighthouse::EvidenceSubmissions::DocumentUpload' }
-  let(:issue_instant) { Time.now.to_i }
-  let(:current_date_time) { DateTime.now.utc }
+  let(:issue_instant) { Time.current.to_i }
+  let(:current_date_time) { DateTime.current }
   let(:msg) do
     {
       'jid' => job_id,
@@ -180,8 +180,8 @@ RSpec.describe Lighthouse::EvidenceSubmissions::DocumentUpload, type: :job do
         expect(current_personalisation['date_failed']).to eql(failed_date)
 
         Timecop.freeze(current_date_time) do
-          expect(evidence_submission.failed_date).to be_within(1.second).of(current_date_time.utc)
-          expect(evidence_submission.acknowledgement_date).to be_within(1.second).of((current_date_time + 30.days).utc)
+          expect(evidence_submission.failed_date).to be_within(1.second).of(current_date_time)
+          expect(evidence_submission.acknowledgement_date).to be_within(1.second).of((current_date_time + 30.days))
         end
         Timecop.unfreeze
       end

--- a/spec/sidekiq/lighthouse/evidence_submissions/evidence_submission_document_upload_polling_job_spec.rb
+++ b/spec/sidekiq/lighthouse/evidence_submissions/evidence_submission_document_upload_polling_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Lighthouse::EvidenceSubmissions::EvidenceSubmissionDocumentUpload
   let(:job) { described_class.perform_async }
   let(:user_account) { create(:user_account) }
   let(:user_account_uuid) { user_account.id }
-  let(:current_date_time) { DateTime.current.utc }
+  let(:current_date_time) { DateTime.current }
   let!(:pending_lighthouse_document_upload1) do
     create(:bd_evidence_submission_pending, job_class: 'BenefitsDocuments::Service', request_id: 1)
   end
@@ -22,7 +22,7 @@ RSpec.describe Lighthouse::EvidenceSubmissions::EvidenceSubmissionDocumentUpload
       'step' => 'BENEFITS_GATEWAY_SERVICE'
     }
   end
-  let(:issue_instant) { Time.now.to_i }
+  let(:issue_instant) { Time.current.to_i }
   let(:date_failed) do
     BenefitsDocuments::Utilities::Helpers.format_date_for_mailers(issue_instant)
   end
@@ -45,10 +45,10 @@ RSpec.describe Lighthouse::EvidenceSubmissions::EvidenceSubmissionDocumentUpload
       pending_es = EvidenceSubmission.where(request_id: 1).first
       pending_es2 = EvidenceSubmission.where(request_id: 2).first
       expect(pending_es.completed?).to be(true)
-      expect(pending_es.delete_date).to be_within(1.second).of((current_date_time + 60.days).utc)
+      expect(pending_es.delete_date).to be_within(1.second).of((current_date_time + 60.days))
 
       expect(pending_es2.completed?).to be(true)
-      expect(pending_es2.delete_date).to be_within(1.second).of((current_date_time + 60.days).utc)
+      expect(pending_es2.delete_date).to be_within(1.second).of((current_date_time + 60.days))
 
       expect(StatsD).to have_received(:increment).with(
         'worker.lighthouse.cst_document_uploads.pending_documents_polled', 2
@@ -71,14 +71,14 @@ RSpec.describe Lighthouse::EvidenceSubmissions::EvidenceSubmissionDocumentUpload
       pending_es = EvidenceSubmission.where(request_id: 1).first
       pending_es2 = EvidenceSubmission.where(request_id: 2).first
       expect(pending_es.failed?).to be(true)
-      expect(pending_es.acknowledgement_date).to be_within(1.second).of((current_date_time + 30.days).utc)
-      expect(pending_es.failed_date).to be_within(1.second).of(current_date_time.utc)
+      expect(pending_es.acknowledgement_date).to be_within(1.second).of((current_date_time + 30.days))
+      expect(pending_es.failed_date).to be_within(1.second).of(current_date_time)
       expect(pending_es.error_message).to eq(error_message.to_s)
       expect(JSON.parse(pending_es.template_metadata)['personalisation']['date_failed']).to eq(date_failed)
 
       expect(pending_es2.failed?).to be(true)
-      expect(pending_es2.acknowledgement_date).to be_within(1.second).of((current_date_time + 30.days).utc)
-      expect(pending_es2.failed_date).to be_within(1.second).of(current_date_time.utc)
+      expect(pending_es2.acknowledgement_date).to be_within(1.second).of((current_date_time + 30.days))
+      expect(pending_es2.failed_date).to be_within(1.second).of(current_date_time)
       expect(pending_es2.error_message).to eq(error_message.to_s)
       expect(JSON.parse(pending_es2.template_metadata)['personalisation']['date_failed']).to eq(date_failed)
 

--- a/spec/sidekiq/lighthouse/evidence_submissions/failure_notification_email_job_spec.rb
+++ b/spec/sidekiq/lighthouse/evidence_submissions/failure_notification_email_job_spec.rb
@@ -165,6 +165,8 @@ RSpec.describe Lighthouse::EvidenceSubmissions::FailureNotificationEmailJob, typ
         expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation', tags:)
         subject.new.perform
         expect(EvidenceSubmission.va_notify_email_queued.length).to eq(1)
+        evidence_submission = EvidenceSubmission.find_by(id: evidence_submission_failed.id)
+        expect(evidence_submission.va_notify_date).not_to be_nil
       end
     end
   end
@@ -229,6 +231,8 @@ RSpec.describe Lighthouse::EvidenceSubmissions::FailureNotificationEmailJob, typ
         expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation', tags:)
         subject.new.perform
         expect(EvidenceSubmission.va_notify_email_queued.length).to eq(1)
+        evidence_submission = EvidenceSubmission.find_by(id: evidence_submission_failed.id)
+        expect(evidence_submission.va_notify_date).not_to be_nil
       end
     end
   end


### PR DESCRIPTION
## Summary

- Found that we were setting `.utc` to the evidence submission date fields and we didn't need to since the date fields are saved as utc when saved to the database
- Also found that in the evidence submission code and tests we are using `DateTime.now` or `Time.now` when we should use `DateTime.current` or `Time.current` which uses what the Rails environment is set to. If it's not set, then .current will be same as .now and use the servers timezone.

Updated the following files: 

- app/sidekiq/evss/document_upload.rb
- app/sidekiq/lighthouse/evidence_submissions/delete_evidence_submission_records_job.rb
- app/sidekiq/lighthouse/evidence_submissions/document_upload.rb
- app/sidekiq/lighthouse/evidence_submissions/failure_notification_email_job.rb
- lib/lighthouse/benefits_documents/upload_status_updater.rb
- spec/lib/lighthouse/benefits_documents/service_spec.rb
- spec/lib/lighthouse/benefits_documents/upload_status_updater_spec.rb
- spec/services/evss_claim_service_spec.rb
- spec/sidekiq/evss/document_upload_spec.rb
- spec/sidekiq/lighthouse/evidence_submissions/document_upload_spec.rb
- spec/sidekiq/lighthouse/evidence_submissions/evidence_submission_document_upload_polling_job_spec.rb
- spec/sidekiq/lighthouse/evidence_submissions/failure_notification_email_job_spec.rb

## Related issue(s)

- *Link to ticket created in va.gov-team repo https://github.com/department-of-veterans-affairs/va.gov-team/issues/104360

## Testing done

- [x ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
Tested lighthouse upload success. Evidence Submission record shows dates with utc.
![Screenshot 2025-03-10 at 2 47 50 PM](https://github.com/user-attachments/assets/00e1719e-2cf9-48c4-8427-9189fc7467da)

Tested lighthouse upload failure. Evidence Submission record shows dates with utc.
![Screenshot 2025-03-10 at 3 19 47 PM](https://github.com/user-attachments/assets/4210dbdb-af5a-4030-a792-2330c7049b12)

## What areas of the site does it impact?
CST
## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

