### PR TITLE
chore: Rename EVSS::ReferenceData::ResponseStrategy class

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -911,8 +911,6 @@ lib/evss/intent_to_file @department-of-veterans-affairs/va-api-engineers @depart
 lib/evss/letters @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-admin
 lib/evss/logged_service_exception.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/evss/ppiu @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-lib/evss/reference_data @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-lib/evss/reference_data/response_strategy.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/evss/response.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/evss/service_exception.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 lib/evss/service.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -966,6 +964,7 @@ lib/lighthouse/benefits_documents/upload_status_updater.rb @department-of-vetera
 lib/lighthouse/benefits_documents/utilities/helpers.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-admin
 lib/lighthouse/benefits_documents/va_notify_email_status_callback.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-admin
 lib/lighthouse/benefits_intake @department-of-veterans-affairs/pension-and-burials @department-of-veterans-affairs/backend-review-group
+lib/lighthouse/benefits_reference_data/response_strategy.rb @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/dbex-trex @department-of-veterans-affairs/backend-review-group
 lib/lighthouse/letters_generator @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-admin
 lib/logging @department-of-veterans-affairs/pension-and-burials @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-api-engineers
 lib/mail_automation @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -4,7 +4,7 @@ require 'evss/common_service'
 require 'evss/disability_compensation_auth_headers'
 require 'evss/disability_compensation_form/form4142'
 require 'evss/disability_compensation_form/service'
-require 'evss/reference_data/response_strategy'
+require 'lighthouse/benefits_reference_data/response_strategy'
 require 'disability_compensation/factories/api_provider_factory'
 
 module V0
@@ -30,7 +30,7 @@ module V0
     end
 
     def separation_locations
-      response = EVSS::ReferenceData::ResponseStrategy.new.cache_by_user_and_type(
+      response = Lighthouse::ReferenceData::ResponseStrategy.new.cache_by_user_and_type(
         :all_users,
         :get_separation_locations
       ) do

--- a/lib/lighthouse/benefits_reference_data/response_strategy.rb
+++ b/lib/lighthouse/benefits_reference_data/response_strategy.rb
@@ -2,7 +2,7 @@
 
 require 'common/models/concerns/cache_aside'
 
-module EVSS
+module Lighthouse
   module ReferenceData
     class ResponseStrategy < Common::RedisStore
       include Common::CacheAside


### PR DESCRIPTION
This PR renames and moves `lib/evss/reference_data/response_strategy.rb` to an appropriate location in the Lighthouse directory.

**Related issue**: https://github.com/department-of-veterans-affairs/va.gov-team/issues/104912