### PR TITLE
[ARP] pending sort order & processed only shows decisioned

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
@@ -59,11 +59,11 @@ module AccreditedRepresentativePortal
       def pending(relation)
         relation
           .not_processed
-          .order(created_at: :asc)
+          .order(created_at: :desc)
       end
 
       def processed(relation)
-        relation.processed.not_expired.order(
+        relation.processed.decisioned.order(
           resolution: { created_at: :desc }
         )
       end

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request.rb
@@ -99,10 +99,10 @@ module AccreditedRepresentativePortal
     scope :unresolved, -> { where.missing(:resolution) }
     scope :resolved, -> { joins(:resolution) }
 
-    scope :not_expired, lambda {
-      where.not(
+    scope :decisioned, lambda {
+      where(
         resolution: {
-          resolving_type: PowerOfAttorneyRequestExpiration.to_s
+          resolving_type: PowerOfAttorneyRequestDecision.to_s
         }
       )
     }

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec.rb
@@ -254,6 +254,9 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
         create(:power_of_attorney_request, :with_acceptance, :with_form_submission,
                resolution_created_at: time_plus_one_day, poa_code:)
       end
+      let!(:replaced_request) do
+        create(:power_of_attorney_request, :with_replacement, resolution_created_at: time, poa_code:)
+      end
       let!(:expired_request) do
         create(:power_of_attorney_request, :with_expiration, resolution_created_at: time_plus_one_day, poa_code:)
       end
@@ -269,7 +272,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
         expect(parsed_response.map { |poa| poa['id'] }).to include(accepted_failed_request.id)
         expect(parsed_response.map { |poa| poa['id'] }).not_to include(expired_request.id)
         expect(parsed_response.map { |h| h['createdAt'] }).to eq(
-          [time, time, time, time_plus_one_day]
+          [time_plus_one_day, time, time, time]
         )
       end
 


### PR DESCRIPTION
Bugfix for fixing processed POA requests 500 in API overlapped w/ excluding "withdrawn" POA requests from search results. (In fact logic changed to "return resolved that are decisioned", previously was "return resolved that are not expired").

Also threw in pending sort order fix because it just involved changing 2 characters.