### PR TITLE
chore: Update Rack to 2.2.13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -829,7 +829,7 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     racc (1.8.1-java)
-    rack (2.2.12)
+    rack (2.2.13)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
     rack-cors (2.0.2)


### PR DESCRIPTION
Resolves CVE

```
Name: rack
Version: 2.2.12
CVE: CVE-2025-27610
GHSA: GHSA-7wqh-767x-r66v
Criticality: High
URL: https://github.com/rack/rack/security/advisories/GHSA-7wqh-767x-r66v
Title: Local File Inclusion in Rack::Static
Solution: update to '~> 2.2.13', '~> 3.0.14', '>= 3.1.12'
```