### PR TITLE
Add additional feature toggles for source of truth updates

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1605,7 +1605,23 @@ features:
   va_online_scheduling_fe_source_of_truth:
     actor_type: user
     enable_in_development: true
-    description: Toggle for changes made in the FE based on API source of truth changes.
+    description: Toggle to use API response as the source of truth in FE for upcoming/past/pending appointments.
+  va_online_scheduling_fe_source_of_truth_va:
+    actor_type: user
+    enable_in_development: true
+    description: Toggle to use API response as the source of truth in FE for VA appointment and request types.
+  va_online_scheduling_fe_source_of_truth_cc:
+    actor_type: user
+    enable_in_development: true
+    description: Toggle to use API response as the source of truth in FE for CC appointment and request types.
+  va_online_scheduling_fe_source_of_truth_modality:
+    actor_type: user
+    enable_in_development: true
+    description: Toggle to use API response as the source of truth in FE for in person, phone, claims exam, covid vaccine modalities.
+  va_online_scheduling_fe_source_of_truth_telehealth:
+    actor_type: user
+    enable_in_development: true
+    description: Toggle to use API response as the source of truth in FE for Video at VA, Video at ATLAS, Video at Home modalities.
   va_online_scheduling_past_appt_date_range:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
## Summary

- Adding 4 new feature toggles:
  - `va_online_scheduling_fe_source_of_truth_va`
  - `va_online_scheduling_fe_source_of_truth_cc`
  - `va_online_scheduling_fe_source_of_truth_modality`
  - `va_online_scheduling_fe_source_of_truth_telehealth`
- Updating description of the existing feature toggle `va_online_scheduling_fe_source_of_truth`
- Appointments Tool Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/104288

## Testing done

N/A

## Screenshots

N/A

## What areas of the site does it impact?

Appointments Tool

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

