### PR TITLE
API-45558: Reenable Decision Reviews Specs After Testing for Flakiness

### DIFF
--- a/modules/appeals_api/spec/requests/appeals_api/v1/notice_of_disagreements_spec.rb
+++ b/modules/appeals_api/spec/requests/appeals_api/v1/notice_of_disagreements_spec.rb
@@ -56,29 +56,29 @@ Rspec.describe 'AppealsApi::V1::DecisionReviews::NoticeOfDisagreements', type: :
       expect(parsed['errors'][0]['source']['pointer']).to eq '/included/0/attributes/issue'
     end
 
-    # it 'create the job to build the PDF' do
-    #   client_stub = instance_double(CentralMail::Service)
-    #   faraday_response = instance_double(Faraday::Response)
+    it 'create the job to build the PDF' do
+      client_stub = instance_double(CentralMail::Service)
+      faraday_response = instance_double(Faraday::Response)
 
-    #   allow(CentralMail::Service).to receive(:new) { client_stub }
-    #   allow(client_stub).to receive(:upload).and_return(faraday_response)
-    #   allow(faraday_response).to receive(:success?).and_return(true)
+      allow(CentralMail::Service).to receive(:new) { client_stub }
+      allow(client_stub).to receive(:upload).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
 
-    #   with_settings(Settings.vanotify.services.lighthouse.template_id,
-    #                 notice_of_disagreement_received: 'veteran_template',
-    #                 notice_of_disagreement_received_claimant: 'claimant_template') do
-    #     client = instance_double(VaNotify::Service)
-    #     allow(VaNotify::Service).to receive(:new).and_return(client)
-    #     allow(client).to receive(:send_email)
+      with_settings(Settings.vanotify.services.lighthouse.template_id,
+                    notice_of_disagreement_received: 'veteran_template',
+                    notice_of_disagreement_received_claimant: 'claimant_template') do
+        client = instance_double(VaNotify::Service)
+        allow(VaNotify::Service).to receive(:new).and_return(client)
+        allow(client).to receive(:send_email)
 
-    #     Sidekiq::Testing.inline! do
-    #       post(path, params: data, headers:)
-    #     end
+        Sidekiq::Testing.inline! do
+          post(path, params: data, headers:)
+        end
 
-    #     nod = AppealsApi::NoticeOfDisagreement.find_by(id: parsed['data']['id'])
-    #     expect(nod.status).to eq('submitted')
-    #   end
-    # end
+        nod = AppealsApi::NoticeOfDisagreement.find_by(id: parsed['data']['id'])
+        expect(nod.status).to eq('submitted')
+      end
+    end
 
     context 'keeps track of board_review_option' do
       let(:path) { base_path('notice_of_disagreements') }

--- a/modules/appeals_api/spec/requests/appeals_api/v2/decision_reviews/higher_level_reviews_spec.rb
+++ b/modules/appeals_api/spec/requests/appeals_api/v2/decision_reviews/higher_level_reviews_spec.rb
@@ -220,29 +220,29 @@ describe 'AppealsApi::V2::DecisionReviews::HigherLevelReviews', type: :request d
       end
     end
 
-    # it 'updates the appeal status once submitted to central mail' do
-    #   client_stub = instance_double(CentralMail::Service)
-    #   faraday_response = instance_double(Faraday::Response)
+    it 'updates the appeal status once submitted to central mail' do
+      client_stub = instance_double(CentralMail::Service)
+      faraday_response = instance_double(Faraday::Response)
 
-    #   allow(CentralMail::Service).to receive(:new) { client_stub }
-    #   allow(client_stub).to receive(:upload).and_return(faraday_response)
-    #   allow(faraday_response).to receive(:success?).and_return(true)
+      allow(CentralMail::Service).to receive(:new) { client_stub }
+      allow(client_stub).to receive(:upload).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
 
-    #   with_settings(Settings.vanotify.services.lighthouse.template_id,
-    #                 higher_level_review_received: 'veteran_template',
-    #                 higher_level_review_received_claimant: 'claimant_template') do
-    #     client = instance_double(VaNotify::Service)
-    #     allow(VaNotify::Service).to receive(:new).and_return(client)
-    #     allow(client).to receive(:send_email)
+      with_settings(Settings.vanotify.services.lighthouse.template_id,
+                    higher_level_review_received: 'veteran_template',
+                    higher_level_review_received_claimant: 'claimant_template') do
+        client = instance_double(VaNotify::Service)
+        allow(VaNotify::Service).to receive(:new).and_return(client)
+        allow(client).to receive(:send_email)
 
-    #     Sidekiq::Testing.inline! do
-    #       post(path, params: data_default, headers: headers_default)
-    #     end
+        Sidekiq::Testing.inline! do
+          post(path, params: data_default, headers: headers_default)
+        end
 
-    #     hlr = AppealsApi::HigherLevelReview.find_by(id: parsed['data']['id'])
-    #     expect(hlr.status).to eq('submitted')
-    #   end
-    # end
+        hlr = AppealsApi::HigherLevelReview.find_by(id: parsed['data']['id'])
+        expect(hlr.status).to eq('submitted')
+      end
+    end
 
     context 'when invalid headers supplied' do
       it 'returns an error' do

--- a/modules/appeals_api/spec/requests/appeals_api/v2/decision_reviews/supplemental_claims_spec.rb
+++ b/modules/appeals_api/spec/requests/appeals_api/v2/decision_reviews/supplemental_claims_spec.rb
@@ -387,29 +387,29 @@ Rspec.describe 'AppealsApi::V2::DecisionReviews::SupplementalClaims', type: :req
       end
     end
 
-    # it 'updates the appeal status once submitted to central mail' do
-    #   client_stub = instance_double(CentralMail::Service)
-    #   faraday_response = instance_double(Faraday::Response)
+    it 'updates the appeal status once submitted to central mail' do
+      client_stub = instance_double(CentralMail::Service)
+      faraday_response = instance_double(Faraday::Response)
 
-    #   allow(CentralMail::Service).to receive(:new) { client_stub }
-    #   allow(client_stub).to receive(:upload).and_return(faraday_response)
-    #   allow(faraday_response).to receive(:success?).and_return(true)
+      allow(CentralMail::Service).to receive(:new) { client_stub }
+      allow(client_stub).to receive(:upload).and_return(faraday_response)
+      allow(faraday_response).to receive(:success?).and_return(true)
 
-    #   with_settings(Settings.vanotify.services.lighthouse.template_id,
-    #                 supplemental_claim_received: 'veteran_template',
-    #                 supplemental_claim_received_claimant: 'claimant_template') do
-    #     client = instance_double(VaNotify::Service)
-    #     allow(VaNotify::Service).to receive(:new).and_return(client)
-    #     allow(client).to receive(:send_email)
+      with_settings(Settings.vanotify.services.lighthouse.template_id,
+                    supplemental_claim_received: 'veteran_template',
+                    supplemental_claim_received_claimant: 'claimant_template') do
+        client = instance_double(VaNotify::Service)
+        allow(VaNotify::Service).to receive(:new).and_return(client)
+        allow(client).to receive(:send_email)
 
-    #     Sidekiq::Testing.inline! do
-    #       post(path, params: data, headers:)
-    #     end
+        Sidekiq::Testing.inline! do
+          post(path, params: data, headers:)
+        end
 
-    #     sc = AppealsApi::SupplementalClaim.find_by(id: parsed['data']['id'])
-    #     expect(sc.status).to eq('submitted')
-    #   end
-    # end
+        sc = AppealsApi::SupplementalClaim.find_by(id: parsed['data']['id'])
+        expect(sc.status).to eq('submitted')
+      end
+    end
 
     it_behaves_like 'an endpoint requiring gateway origin headers',
                     headers: {


### PR DESCRIPTION
## Summary
This work is behind a feature toggle (flipper): *NO*

On 2/21, our team was notified by the Platform Team that a few of our `AppealsAPI` specs had been temporarily disabled in #20902 due to reported flakiness. However, on closer look at that PR, its description, and the failed job runs linked from it, we couldn't find any evidence that these specs were the ones causing a problem. (The description mentioned instance doubles for `OpenSSL::X509::Certificate`, which these specs don't utilize, and the failed Test job runs from the linked PR showed failed `V0::SignInController` specs but no failed `AppealsApi` specs.)

I also attempted to reproduce the flakiness locally by running the specs in parallel using the exact command we use in CI, but was not able to reproduce any failures after half a dozen tries. Therefore, this PR reenables the Appeals API specs as-is.

My team (Lighthouse Banana Peels) owns the `appeals_api` module.

## Related issue(s)
- [API-45558](https://jira.devops.va.gov/browse/API-45558)

<img width="821" alt="Jira Screenshot" src="https://github.com/user-attachments/assets/08c1857c-3d49-4f2e-9227-c06796d67c2c" />

## Testing done
- [ ] *New code is covered by unit tests* – N/A
- Prior to this change, the specs were not enabled.

## Screenshots
None

## What areas of the site does it impact?
This PR impacts the `appeals_api` module specs only.

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable) – N/A
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested for this PR.
