### PR TITLE
API-45585-add-logging-to-add-person-proxy-response-on-failure

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/target_veteran.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/target_veteran.rb
@@ -45,7 +45,8 @@ module ClaimsApi
             add_person_proxy_response = target_veteran.recache_mpi_data.add_person_proxy
             unless add_person_proxy_response.ok?
               claims_logging('unable_to_locate_participant_id',
-                             message: 'unable_to_locate_participant_id on request in target veteran (Flipper on).')
+                             message: 'unable_to_locate_participant_id on request in target veteran (Flipper on).' \
+                                      "Failed call to add_person_proxy returned: #{add_person_proxy_response&.error}")
 
               raise ::Common::Exceptions::UnprocessableEntity.new(
                 detail: "Unable to locate Veteran's Participant ID in Master Person Index (MPI). " \

--- a/modules/claims_api/spec/requests/v2/veterans/claims_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/claims_spec.rb
@@ -551,6 +551,8 @@ RSpec.describe 'ClaimsApi::V2::Veterans::Claims', type: :request do
                 .to receive(:mvi_response).and_return(profile)
               allow_any_instance_of(MPIData)
                 .to receive(:add_person_proxy).and_return(add_person_proxy_response)
+              allow(add_person_proxy_response)
+                .to receive(:error)
 
               get all_claims_path, headers: auth_header
 


### PR DESCRIPTION
## Summary
* Updates target veteran `add_person_proxy` check to log out response when it fails.
* updates a related to test

## Related issue(s)
[API-45585](https://jira.devops.va.gov/browse/API-45585)

## Testing done

- [x] *Adjusted related test*

## Screenshots
<img width="1046" alt="Screenshot 2025-03-12 at 10 15 13 AM" src="https://github.com/user-attachments/assets/18d07a54-f282-44d8-8811-9d8e094975fb" />


## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/concerns/claims_api/target_veteran.rb
	modified:   modules/claims_api/spec/requests/v2/veterans/claims_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
