### PR TITLE
Ask va api fix veteran profile dup bug

### DIFF
--- a/modules/ask_va_api/app/lib/ask_va_api/base_retriever.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/base_retriever.rb
@@ -12,12 +12,15 @@ module AskVAApi
     def call
       data = fetch_data
 
-      if data.is_a?(Array)
-        data.map { |item| entity_class.new(item) }
-      else
-        entity_class.new(data)
-      end
+      return data.map { |item| entity_class.new(item) } if data.is_a?(Array)
+
+      entity_class.new(data)
     rescue => e
+      if e.message.include?('"Message":"Data Validation: No Contact found by ICN"') &&
+         e.instance_of?(AskVAApi::Inquiries::InquiriesRetrieverError)
+        return []
+      end
+
       ::ErrorHandler.handle_service_error(e)
     end
 

--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/inquiry_details.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/inquiry_details.rb
@@ -88,7 +88,7 @@ module AskVAApi
 
         def education_benefits?
           category == 'Education benefits and work study' &&
-            topic != 'Veteran Readiness and Employment'
+            topic != 'Veteran Readiness and Employment (Chapter 31)'
         end
 
         def benefits_outside_us_edu?

--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/profile_builder_base.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/profile_builder_base.rb
@@ -31,12 +31,12 @@ module AskVAApi
           }
         end
 
-        def address_data(address, postal_code, location_of_residence = nil)
+        def address_data(address, postal_code = nil, location_of_residence = nil)
           {
             Street: address[:street],
             City: address[:city],
             State: state_data(address[:state], location_of_residence),
-            ZipCode: postal_code
+            ZipCode: address[:postal_code] || postal_code
           }
         end
       end

--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/submitter_profile.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/submitter_profile.rb
@@ -33,7 +33,7 @@ module AskVAApi
             Suffix: @translator.call(:suffix, submitter_info[:suffix]),
             Pronouns: formatted_pronouns(inquiry_params[:pronouns]) || inquiry_params[:pronouns_not_listed_text],
             Country: country_data(inquiry_params[:country]),
-            **address_data(submitter_address, inquiry_params[:postal_code]),
+            **address_data(submitter_address, inquiry_params[:your_postal_code]),
             DateOfBirth: submitter_info[:date_of_birth]
           }
         end

--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/veteran_profile.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/veteran_profile.rb
@@ -9,10 +9,13 @@ module AskVAApi
         def call
           if inquiry_details[:inquiry_about] == 'A general question'
             base_profile
-          else
+          elsif i_am_the_veteran?
             base_profile
               .merge(contact_info)
               .merge(school_info)
+              .merge(service_info(veteran_info))
+          else
+            base_profile
               .merge(service_info(veteran_info))
           end
         end
@@ -23,12 +26,9 @@ module AskVAApi
           {
             BranchOfService: info[:branch_of_service],
             SSN: info.dig(:social_or_service_num, :ssn) || info[:social_num],
-            EDIPI: about_me_veteran? ? user&.edipi : nil,
-            ICN: about_me_veteran? ? user&.icn : nil,
-            ServiceNumber: info.dig(:social_or_service_num, :service_number),
-            ClaimNumber: nil,
-            VeteranServiceStateDate: nil,
-            VeteranServiceEndDate: nil
+            EDIPI: i_am_the_veteran? ? user&.edipi : nil,
+            ICN: i_am_the_veteran? ? user&.icn : nil,
+            ServiceNumber: info.dig(:social_or_service_num, :service_number)
           }
         end
 
@@ -40,7 +40,6 @@ module AskVAApi
             LastName: veteran_info[:last],
             PreferredName: preferred_name,
             Suffix: @translator.call(:suffix, veteran_info[:suffix]),
-            Pronouns: veteran_pronouns,
             Country: country_data_or_default,
             **address_data(veteran_address, postal_code, inquiry_params[:veterans_location_of_residence]),
             DateOfBirth: veteran_info[:date_of_birth]
@@ -48,40 +47,33 @@ module AskVAApi
         end
 
         # Determines if the inquiry is about the veteran
-        def about_me_veteran?
-          inquiry_details[:inquiry_about] == 'About Me, the Veteran'
+        def i_am_the_veteran?
+          inquiry_params[:relationship_to_veteran] == "I'm the Veteran"
         end
 
         # Returns veteran info based on inquiry context
         def veteran_info
-          about_me_veteran? ? inquiry_params[:about_yourself] : inquiry_params[:about_the_veteran] || {}
+          i_am_the_veteran? ? inquiry_params[:about_yourself] : inquiry_params[:about_the_veteran] || {}
         end
 
         # Returns the veteran's address based on inquiry context
         def veteran_address
-          about_me_veteran? ? inquiry_params[:address] : {}
+          i_am_the_veteran? ? (inquiry_params[:address] || {}) : {}
         end
 
         # Returns the postal code based on inquiry context
         def postal_code
-          about_me_veteran? ? inquiry_params[:postal_code] : inquiry_params[:veteran_postal_code]
+          i_am_the_veteran? ? inquiry_params[:your_postal_code] : inquiry_params[:veterans_postal_code]
         end
 
         # Returns the preferred name based on inquiry context
         def preferred_name
-          about_me_veteran? ? inquiry_params[:preferred_name] : veteran_info[:preferred_name]
+          i_am_the_veteran? ? inquiry_params[:preferred_name] : veteran_info[:preferred_name]
         end
 
         # Returns country data or default values
         def country_data_or_default
-          about_me_veteran? ? country_data(inquiry_params[:country]) : { Name: nil, CountryCode: nil }
-        end
-
-        def veteran_pronouns
-          if about_me_veteran?
-            formatted_pronouns(inquiry_params[:pronouns]) ||
-              inquiry_params[:pronouns_not_listed_text]
-          end
+          i_am_the_veteran? ? country_data(inquiry_params[:country]) : { Name: nil, CountryCode: nil }
         end
       end
     end

--- a/modules/ask_va_api/config/locales/en.yml
+++ b/modules/ask_va_api/config/locales/en.yml
@@ -64,6 +64,7 @@ en:
           - :date_of_death
           - :email_address
           - :family_members_location_of_residence
+          - :family_member_postal_code
           - :is_military_base
           - :is_question_about_veteran_or_someone_else
           - :military_base_post_office
@@ -71,7 +72,6 @@ en:
           - :more_about_your_relationship_to_veteran
           - :on_base_outside_us
           - :phone_number
-          - :postal_code
           - :preferred_name
           - :pronouns_not_listed_text
           - :question
@@ -80,6 +80,7 @@ en:
           - :select_category
           - :select_subtopic
           - :select_topic
+          - :state_of_property
           - :subject
           - :subtopic_id
           - :their_vre_information
@@ -89,9 +90,10 @@ en:
           - :topic_id
           - :use_school
           - :use_school_in_profile
-          - :veteran_postal_code
+          - :veterans_postal_code
           - :veterans_location_of_residence
           - :who_is_your_question_about
+          - :your_postal_code
           - :your_health_facility
           - :your_location_of_residence
           - :your_role

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/submitter_profile_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/submitter_profile_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::SubmitterProfile do
         country: 'USA',
         email_address: 'test@example.com',
         phone_number: '987-654-3210',
-        postal_code: '12345',
         preferred_name: 'Test User',
         pronouns:,
         school_obj: {
@@ -80,7 +79,7 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::SubmitterProfile do
           Name: 'California',
           StateCode: 'CA'
         },
-        ZipCode: '12345',
+        ZipCode: '90001',
         DateOfBirth: '1980-05-15',
         BusinessPhone: nil,
         PersonalPhone: '987-654-3210',

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/veteran_profile_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/veteran_profile_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::VeteranProfile do
             },
             suffix: 'Sr.'
           },
-          veteran_postal_code: '54321',
+          veterans_postal_code: '54321',
           veterans_location_of_residence: 'Texas'
         }
       end
@@ -57,28 +57,17 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::VeteranProfile do
           LastName: params[:about_the_veteran][:last],
           PreferredName: params[:about_the_veteran][:preferred_name],
           Suffix: 722_310_001,
-          Pronouns: nil,
           Country: { Name: nil, CountryCode: nil },
           Street: nil,
           City: nil,
           State: { Name: 'Texas', StateCode: 'TX' },
-          ZipCode: params[:veteran_postal_code],
+          ZipCode: params[:veterans_postal_code],
           DateOfBirth: params[:about_the_veteran][:date_of_birth],
-          BusinessPhone: nil,
-          PersonalPhone: nil,
-          BusinessEmail: nil,
-          PersonalEmail: nil,
-          SchoolState: nil,
-          SchoolFacilityCode: nil,
-          SchoolId: nil,
           BranchOfService: params[:about_the_veteran][:branch_of_service],
           SSN: params[:about_the_veteran][:social_or_service_num][:ssn],
           EDIPI: nil,
           ICN: nil,
-          ServiceNumber: params[:about_the_veteran][:social_or_service_num][:service_number],
-          ClaimNumber: nil,
-          VeteranServiceStateDate: nil,
-          VeteranServiceEndDate: nil }
+          ServiceNumber: params[:about_the_veteran][:social_or_service_num][:service_number] }
       end
 
       context 'when PERSONAL inquiry_params is received' do
@@ -89,9 +78,6 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::VeteranProfile do
     end
 
     context 'when the submitter IS the veteran' do
-      let(:pronouns) do
-        { he_him_his: 'true' }
-      end
       let(:params) do
         {
           about_yourself: {
@@ -115,14 +101,13 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::VeteranProfile do
             street3: 'Building 5',
             unit_number: 'Unit 10'
           },
+          relationship_to_veteran: "I'm the Veteran",
           business_email: 'business@example.com',
           business_phone: '123-456-7890',
           country: 'USA',
           email_address: 'test@example.com',
           phone_number: '987-654-3210',
-          postal_code: '12345',
           preferred_name: 'Test User',
-          pronouns:,
           school_obj: {
             institution_name: 'University of California',
             school_facility_code: '123456',
@@ -147,7 +132,6 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::VeteranProfile do
           LastName: 'User',
           PreferredName: 'Test User',
           Suffix: 722_310_000,
-          Pronouns: 'he/him/his',
           Country: {
             Name: 'United States',
             CountryCode: 'USA'
@@ -158,7 +142,7 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::VeteranProfile do
             Name: 'California',
             StateCode: 'CA'
           },
-          ZipCode: '12345',
+          ZipCode: '90001',
           DateOfBirth: '1980-05-15',
           BusinessPhone: nil,
           PersonalPhone: '987-654-3210',
@@ -171,10 +155,7 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::VeteranProfile do
           SSN: '123456799',
           EDIPI: '123',
           ICN: '234',
-          ServiceNumber: nil,
-          ClaimNumber: nil,
-          VeteranServiceStateDate: nil,
-          VeteranServiceEndDate: nil
+          ServiceNumber: nil
         }
       end
 
@@ -198,7 +179,6 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::VeteranProfile do
           email_address: 'test@test.com',
           on_base_outside_us: false,
           phone_number: '3039751100',
-          pronouns_not_listed_text: 'zem/zis/zat',
           question: 'test',
           select_category: 'Health care',
           select_topic: 'Audiology and hearing aids',
@@ -206,7 +186,6 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::VeteranProfile do
           topic_id: 'c0da1728-d91f-ed11-b83c-001dd8069009',
           who_is_your_question_about: "It's a general question",
           your_health_facility: 'vba_349b',
-          pronouns: { use_my_preferred_name: true, ze_zir_zirs: false },
           address: { military_address: {} },
           about_yourself: {
             first: 'Yourself',
@@ -227,7 +206,6 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::VeteranProfile do
           LastName: nil,
           PreferredName: nil,
           Suffix: nil,
-          Pronouns: nil,
           Country: { Name: nil, CountryCode: nil },
           Street: nil,
           City: nil,

--- a/modules/ask_va_api/spec/requests/ask_va_api/v0/inquiries_spec.rb
+++ b/modules/ask_va_api/spec/requests/ask_va_api/v0/inquiries_spec.rb
@@ -76,21 +76,25 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
       end
 
       context 'when an error occurs' do
-        context 'when a service error' do
-          let(:error_message) do
-            'AskVAApi::Inquiries::InquiriesRetrieverError: Data Validation: No Contact found by ICN'
+        context 'when No Contact found by ICN' do
+          let(:service) { instance_double(Crm::Service) }
+          let(:body) do
+            '{"Data":null,"Message":"Data Validation: No Contact found by ICN"' \
+              ',"ExceptionOccurred":true,"ExceptionMessage"' \
+              ':"Data Validation: No Contact found by ICN","MessageId":"19d9799c-159f-4901-8672-6bdfc1d4cc0f"}'
           end
+          let(:failure) { Faraday::Response.new(response_body: body, status: 400) }
 
           before do
-            allow_any_instance_of(Crm::Service)
-              .to receive(:call)
-              .and_raise(Crm::ErrorHandler::ServiceError.new(error_message))
+            allow(Crm::Service).to receive(:new).and_return(service)
+            allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('Token')
+            allow(service).to receive(:call).and_return(failure)
             get inquiry_path
           end
 
-          it_behaves_like 'common error handling', :unprocessable_entity, 'service_error',
-                          'Crm::ErrorHandler::ServiceError: ' \
-                          'AskVAApi::Inquiries::InquiriesRetrieverError: Data Validation: No Contact found by ICN'
+          it 'returns an empty array' do
+            expect(JSON.parse(response.body)['data']).to eq([])
+          end
         end
 
         context 'when a standard error' do

--- a/modules/ask_va_api/spec/support/shared_contexts.rb
+++ b/modules/ask_va_api/spec/support/shared_contexts.rb
@@ -21,7 +21,7 @@ RSpec.shared_context 'shared data' do
         },
         their_vre_information: 'false',
         is_military_base: 'false',
-        postal_code: '80122',
+        veterans_postal_code: '80122',
         family_members_location_of_residence: 'Alabama',
         about_the_family_member: {
           first: 'James',
@@ -89,8 +89,8 @@ RSpec.shared_context 'shared data' do
       SubmitterQuestion: 'fasfdas',
       SubmitterStateOfSchool: { Name: nil, StateCode: nil },
       SubmitterStateOfProperty: { Name: nil, StateCode: nil },
-      SubmitterStateOfResidency: { Name: nil, StateCode: nil },
-      SubmitterZipCodeOfResidency: '80122',
+      SubmitterStateOfResidency: { Name: 'Alabama', StateCode: 'AL' },
+      SubmitterZipCodeOfResidency: nil,
       UntrustedFlag: false,
       VeteranDateOfDeath: nil,
       VeteranRelationship: 722_310_007,
@@ -106,7 +106,7 @@ RSpec.shared_context 'shared data' do
                           Street: nil,
                           City: nil,
                           State: { Name: nil, StateCode: nil },
-                          ZipCode: '80122',
+                          ZipCode: nil,
                           DateOfBirth: nil,
                           BusinessPhone: nil,
                           PersonalPhone: '3039751100',
@@ -128,27 +128,551 @@ RSpec.shared_context 'shared data' do
                         LastName: 'New',
                         PreferredName: nil,
                         Suffix: 722_310_001,
-                        Pronouns: nil,
                         Country: { Name: nil, CountryCode: nil },
                         Street: nil,
                         City: nil,
                         State: { Name: nil, StateCode: nil },
-                        ZipCode: nil,
+                        ZipCode: '80122',
                         DateOfBirth: '2000-01-01',
-                        BusinessPhone: nil,
-                        PersonalPhone: '3039751100',
-                        BusinessEmail: nil,
-                        PersonalEmail: 'test@test.com',
-                        SchoolState: nil,
-                        SchoolFacilityCode: nil,
-                        SchoolId: nil,
                         BranchOfService: nil,
                         SSN: '123456799',
                         EDIPI: nil,
                         ICN: nil,
-                        ServiceNumber: nil,
-                        ClaimNumber: nil,
-                        VeteranServiceStateDate: nil,
-                        VeteranServiceEndDate: nil } }
+                        ServiceNumber: nil } }
+  end
+  let(:veteran_spouse_edu_vrae_flow) do
+    {
+      inquiry: { category_id: '75524deb-d864-eb11-bb24-000d3a579c45',
+                 contact_preference: 'Email',
+                 date_of_death: '1999-02-01',
+                 email_address: 'test@test.com',
+                 family_members_location_of_residence: 'Alabama',
+                 is_question_about_veteran_or_someone_else: 'Someone else',
+                 on_base_outside_us: false,
+                 phone_number: '3039751100',
+                 preferred_name: 'Glenny',
+                 question: 'test edu and vrae flow',
+                 relationship_to_veteran: "I'm a family member of a Veteran",
+                 select_category: 'Education benefits and work study',
+                 select_topic: 'Veteran Readiness and Employment (Chapter 31)',
+                 subject: 'Test',
+                 subtopic_id: '',
+                 their_vre_information: true,
+                 their_vre_counselor: 'Joe Smith',
+                 their_relationship_to_veteran: "They're the Veteran's spouse",
+                 topic_id: 'b18831a7-8276-ef11-a671-001dd8097cca',
+                 who_is_your_question_about: 'Someone else',
+                 pronouns: { they_them_theirs: true },
+                 address: { military_address: {} },
+                 about_yourself: { first: 'Yourself', last: 'Member', social_or_service_num: {} },
+                 about_the_veteran: {
+                   date_of_birth: '1950-01-01',
+                   first: 'Veteran',
+                   last: 'Member',
+                   is_veteran_deceased: true,
+                   social_or_service_num: { ssn: '997654321' }
+                 },
+                 about_the_family_member: {
+                   first: 'Family',
+                   last: 'Member',
+                   social_or_service_num: { ssn: '123456799' },
+                   date_of_birth: '2000-01-01'
+                 },
+                 state_or_residency: {},
+                 files: [{ file_name: nil, file_content: nil }],
+                 school_obj: {} }
+    }
+  end
+  let(:i_am_the_veteran_health_care) do
+    {
+      inquiry: {
+        category_id: '73524deb-d864-eb11-bb24-000d3a579c45',
+        email_address: 'test@test.com',
+        on_base_outside_us: false,
+        phone_number: '3039751100',
+        question: 'test',
+        relationship_to_veteran: "I'm the Veteran",
+        select_category: 'Health care',
+        select_topic: 'Audiology and hearing aids',
+        subtopic_id: '',
+        topic_id: 'c0da1728-d91f-ed11-b83c-001dd8069009',
+        who_is_your_question_about: 'Myself',
+        your_health_facility: 'vba_349b',
+        pronouns: {},
+        address: { military_address: {} },
+        about_yourself: {
+          date_of_birth: '1950-01-01',
+          first: 'test',
+          last: 'test',
+          social_or_service_num: { ssn: '123456799' }
+        },
+        about_the_veteran: { social_or_service_num: {} },
+        about_the_family_member: { social_or_service_num: {} },
+        state_or_residency: {},
+        files: [{ file_name: nil, file_content: nil }],
+        school_obj: {}
+      }
+    }
+  end
+  let(:i_am_veteran_spouse_center_for_minority) do
+    {
+      inquiry: { question: 'Testing with User 160 - second submission',
+                 on_base_outside_us: false,
+                 country: 'USA',
+                 address: {
+                   street: '8820 Covey Rise Ct',
+                   city: 'Charlotte',
+                   state: 'NC',
+                   postal_code: '28226',
+                   country: 'USA'
+                 },
+                 phone_number: '9898989898',
+                 email_address: 'myemail54800658@unattended.com',
+                 contact_preference: 'U.S. mail',
+                 pronouns: {},
+                 date_of_death: '2024-05-01',
+                 about_the_veteran: {
+                   first: 'VETFirst',
+                   last: 'VETLast',
+                   is_veteran_deceased: true,
+                   social_or_service_num: {
+                     ssn: '796127674'
+                   },
+                   date_of_birth: '1940-02-01'
+                 },
+                 more_about_your_relationship_to_veteran: "I'm the Veteran's spouse",
+                 relationship_to_veteran: "I'm a family member of a Veteran",
+                 about_yourself: {
+                   first: 'Leslie',
+                   middle: 'M',
+                   last: 'Rogers',
+                   social_or_service_num: {
+                     ssn: '796075869'
+                   },
+                   date_of_birth: '1978-07-06',
+                   social_security_number: '796075869'
+                 },
+                 about_the_family_member: {
+                   social_or_service_num: {}
+                 },
+                 state_or_residency: {},
+                 email: 'myemail54800658@unattended.com',
+                 phone: '9898989898',
+                 select_category: 'Center for Minority Veterans',
+                 allow_attachments: false,
+                 select_topic: 'Programs and policies',
+                 who_is_your_question_about: 'Myself',
+                 category_id: '5a524deb-d864-eb11-bb24-000d3a579c45',
+                 topic_id: '852a8586-e764-eb11-bb23-000d3a579c3f',
+                 subtopic_id: '',
+                 updated_in_review: '',
+                 search_location_input: '',
+                 get_location_in_progress: false,
+                 current_user_location: '',
+                 get_location_error: false,
+                 selected_facility: nil,
+                 files: [
+                   {
+                     file_name: nil,
+                     file_content: nil
+                   }
+                 ],
+                 school_obj: {} }
+    }
+  end
+  let(:i_am_veteran_edu) do
+    {
+      inquiry: {
+        subject: 'edu personl 4',
+        question: "I'm the veteran",
+        relationship_to_veteran: "I'm the Veteran",
+        about_yourself: {
+          first: 'Theodore',
+          middle: 'Matthew',
+          last: 'Roberts',
+          social_or_service_num: {
+            ssn: '796019724'
+          },
+          date_of_birth: '1986-02-28',
+          preferred_name: 'DEMETER',
+          social_security_number: '796019724'
+        },
+        state_of_the_school: nil,
+        phone_number: '2507963268',
+        email_address: 'valid@somedomain.com',
+        business_phone: '2507963268',
+        on_base_outside_us: false,
+        address: {
+          street: '19 S Fremont Ave',
+          street2: 'Apt 23',
+          city: 'Alhambra',
+          state: 'CA',
+          military_address: {},
+          postal_code: '91801',
+          country: 'USA'
+        },
+        about_the_veteran: {
+          social_or_service_num: {}
+        },
+        about_the_family_member: {
+          social_or_service_num: {}
+        },
+        state_or_residency: {
+          school_state: 'AK'
+        },
+        email: 'valid@somedomain.com',
+        phone: '2507963268',
+        category_id: '75524deb-d864-eb11-bb24-000d3a579c45',
+        select_category: 'Education benefits and work study',
+        allow_attachments: true,
+        select_topic: 'Transfer of benefits',
+        topic_id: '8085b967-8276-ef11-a671-001dd8097cca',
+        select_subtopic: 'Transferring benefits to dependents',
+        subtopic_id: 'bba71e82-8276-ef11-a671-001dd8097cca',
+        files: [
+          {
+            file_name: nil,
+            file_content: nil
+          }
+        ],
+        school_obj: {}
+      }
+    }
+  end
+  let(:healthcare_veteran_child) do
+    {
+      question: 'Testing',
+      phone_number: '3039751100',
+      email_address: 'test@test.com',
+      about_yourself: {
+        first: 'Submitter',
+        last: 'SubLast',
+        suffix: 'II',
+        social_or_service_num: {
+          ssn: '997654321'
+        },
+        date_of_birth: '2000-01-01'
+      },
+      about_the_veteran: {
+        first: 'Veteran',
+        last: 'VetLast',
+        suffix: 'II',
+        is_veteran_deceased: false,
+        social_or_service_num: {
+          ssn: '123456799'
+        },
+        date_of_birth: '1950-01-01'
+      },
+      more_about_your_relationship_to_veteran: "I'm the Veteran's child",
+      is_question_about_veteran_or_someone_else: 'Veteran',
+      relationship_to_veteran: "I'm a family member of a Veteran",
+      on_base_outside_us: false,
+      address: {
+        military_address: {}
+      },
+      about_the_family_member: {
+        social_or_service_num: {}
+      },
+      state_or_residency: {},
+      category_id: '73524deb-d864-eb11-bb24-000d3a579c45',
+      select_category: 'Health care',
+      allow_attachments: false,
+      contact_preferences: ['Email'],
+      category_requires_sign_in: false,
+      select_topic: 'Audiology and hearing aids',
+      topic_id: 'c0da1728-d91f-ed11-b83c-001dd8069009',
+      topic_requires_sign_in: false,
+      who_is_your_question_about: 'Someone else',
+      your_question_requires_sign_in: false,
+      your_health_facility: 'vha_674BY',
+      files: [
+        {
+          file_name: nil,
+          file_content: nil
+        }
+      ],
+      school_obj: {},
+      controller: 'ask_va_api/v0/inquiries',
+      action: 'create',
+      inquiry: {
+        question: 'Testing',
+        phone_number: '3039751100',
+        email_address: 'test@test.com',
+        about_yourself: {
+          first: 'Submitter',
+          last: 'SubLast',
+          suffix: 'II',
+          social_or_service_num: {
+            ssn: '997654321'
+          },
+          date_of_birth: '2000-01-01'
+        },
+        about_the_veteran: {
+          first: 'Veteran',
+          last: 'VetLast',
+          suffix: 'II',
+          is_veteran_deceased: false,
+          social_or_service_num: {
+            ssn: '123456799'
+          },
+          date_of_birth: '1950-01-01'
+        },
+        more_about_your_relationship_to_veteran: "I'm the Veteran's child",
+        is_question_about_veteran_or_someone_else: 'Veteran',
+        relationship_to_veteran: "I'm a family member of a Veteran",
+        on_base_outside_us: false,
+        address: {
+          military_address: {}
+        },
+        about_the_family_member: {
+          social_or_service_num: {}
+        },
+        state_or_residency: {},
+        category_id: '73524deb-d864-eb11-bb24-000d3a579c45',
+        select_category: 'Health care',
+        allow_attachments: false,
+        contact_preferences: ['Email'],
+        category_requires_sign_in: false,
+        select_topic: 'Audiology and hearing aids',
+        topic_id: 'c0da1728-d91f-ed11-b83c-001dd8069009',
+        topic_requires_sign_in: false,
+        who_is_your_question_about: 'Someone else',
+        your_question_requires_sign_in: false,
+        your_health_facility: 'vha_674BY',
+        files: [
+          {
+            file_name: nil,
+            file_content: nil
+          }
+        ],
+        school_obj: {}
+      }
+    }
+  end
+  let(:edu_address) do
+    {
+      subject: 'test',
+      question: 'testing address',
+      on_base_outside_us: false,
+      country: 'USA',
+      address: {
+        street: '9092 Rio Blanco ST',
+        city: 'Littleton',
+        state: 'CO',
+        postal_code: '80125'
+      },
+      phone_number: '3039751100',
+      email_address: 'test@test.com',
+      contact_preference: 'U.S. mail',
+      about_yourself: {
+        first: 'Submitter',
+        last: 'SubLast',
+        suffix: 'III',
+        social_or_service_num: {
+          ssn: '997654321'
+        },
+        date_of_birth: '2000-03-01'
+      },
+      family_member_postal_code: '80112',
+      family_members_location_of_residence: 'California',
+      their_vre_information: false,
+      about_the_family_member: {
+        first: 'Family',
+        last: 'FamLast',
+        suffix: 'II',
+        social_or_service_num: {
+          ssn: '123456799'
+        },
+        date_of_birth: '1950-01-01'
+      },
+      about_your_relationship_to_family_member: "They're my parent",
+      relationship_to_veteran: "I'm the Veteran",
+      address_validation: {
+        city: 'Littleton',
+        province: '',
+        street2: ''
+      },
+      about_the_veteran: {
+        social_or_service_num: {}
+      },
+      state_or_residency: {},
+      category_id: '75524deb-d864-eb11-bb24-000d3a579c45',
+      select_category: 'Education benefits and work study',
+      allow_attachments: true,
+      contact_preferences: %w[Email Phone USMail],
+      category_requires_sign_in: false,
+      select_topic: 'Veteran Readiness and Employment (Chapter 31)',
+      topic_id: 'b18831a7-8276-ef11-a671-001dd8097cca',
+      topic_requires_sign_in: false,
+      who_is_your_question_about: 'Someone else',
+      your_question_requires_sign_in: false,
+      files: [
+        {
+          file_name: nil,
+          file_content: nil
+        }
+      ],
+      school_obj: {},
+      controller: 'ask_va_api/v0/inquiries',
+      action: 'create',
+      inquiry: {
+        subject: 'test',
+        question: 'testing address',
+        on_base_outside_us: false,
+        country: 'USA',
+        address: {
+          street: '9092 Rio Blanco ST',
+          city: 'Littleton',
+          state: 'CO',
+          postal_code: '80125'
+        },
+        phone_number: '3039751100',
+        email_address: 'test@test.com',
+        contact_preference: 'U.S. mail',
+        about_yourself: {
+          first: 'Submitter',
+          last: 'SubLast',
+          suffix: 'III',
+          social_or_service_num: {
+            ssn: '997654321'
+          },
+          date_of_birth: '2000-03-01'
+        },
+        family_member_postal_code: '80112',
+        family_members_location_of_residence: 'California',
+        their_vre_information: false,
+        about_the_family_member: {
+          first: 'Family',
+          last: 'FamLast',
+          suffix: 'II',
+          social_or_service_num: {
+            ssn: '123456799'
+          },
+          date_of_birth: '1950-01-01'
+        },
+        about_your_relationship_to_family_member: "They're my parent",
+        relationship_to_veteran: "I'm the Veteran",
+        address_validation: {
+          city: 'Littleton',
+          province: '',
+          street2: ''
+        },
+        about_the_veteran: {
+          social_or_service_num: {}
+        },
+        state_or_residency: {},
+        category_id: '75524deb-d864-eb11-bb24-000d3a579c45',
+        select_category: 'Education benefits and work study',
+        allow_attachments: true,
+        contact_preferences: %w[Email Phone USMail],
+        category_requires_sign_in: false,
+        select_topic: 'Veteran Readiness and Employment (Chapter 31)',
+        topic_id: 'b18831a7-8276-ef11-a671-001dd8097cca',
+        topic_requires_sign_in: false,
+        who_is_your_question_about: 'Someone else',
+        your_question_requires_sign_in: false,
+        files: [
+          {
+            file_name: nil,
+            file_content: nil
+          }
+        ],
+        school_obj: {}
+      }
+    }
+  end
+  let(:housing_assistance) do
+    {
+      question: 'testing state of property',
+      phone_number: '3039751100',
+      email_address: 'test@test.com',
+      contact_preference: 'Email',
+      state_of_property: 'Colorado',
+      about_yourself: {
+        first: 'Veteran',
+        last: 'VetLast',
+        suffix: 'Sr.',
+        social_or_service_num: {
+          ssn: '123456799'
+        },
+        date_of_birth: '1950-01-01'
+      },
+      relationship_to_veteran: "I'm the Veteran",
+      on_base_outside_us: false,
+      address: {
+        military_address: {}
+      },
+      about_the_veteran: {
+        social_or_service_num: {}
+      },
+      about_the_family_member: {
+        social_or_service_num: {}
+      },
+      state_or_residency: {},
+      category_id: '64524deb-d864-eb11-bb24-000d3a579c45',
+      select_category: 'Housing assistance and home loans',
+      allow_attachments: false,
+      contact_preferences: %w[Email Phone],
+      category_requires_sign_in: false,
+      select_topic: 'Specially Adapted Housing (SAH) and Special Home Adaptation (SHA) grants',
+      topic_id: 'b32a8586-e764-eb11-bb23-000d3a579c3f',
+      topic_requires_sign_in: false,
+      who_is_your_question_about: 'Myself',
+      your_question_requires_sign_in: false,
+      files: [
+        {
+          file_name: nil,
+          file_content: nil
+        }
+      ],
+      school_obj: {},
+      controller: 'ask_va_api/v0/inquiries',
+      action: 'create',
+      inquiry: {
+        question: 'testing state of property',
+        phone_number: '3039751100',
+        email_address: 'test@test.com',
+        contact_preference: 'Email',
+        state_of_property: 'Colorado',
+        about_yourself: {
+          first: 'Veteran',
+          last: 'VetLast',
+          suffix: 'Sr.',
+          social_or_service_num: {
+            ssn: '123456799'
+          },
+          date_of_birth: '1950-01-01'
+        },
+        relationship_to_veteran: "I'm the Veteran",
+        on_base_outside_us: false,
+        address: {
+          military_address: {}
+        },
+        about_the_veteran: {
+          social_or_service_num: {}
+        },
+        about_the_family_member: {
+          social_or_service_num: {}
+        },
+        state_or_residency: {},
+        category_id: '64524deb-d864-eb11-bb24-000d3a579c45',
+        select_category: 'Housing assistance and home loans',
+        allow_attachments: false,
+        contact_preferences: %w[Email Phone],
+        category_requires_sign_in: false,
+        select_topic: 'Specially Adapted Housing (SAH) and Special Home Adaptation (SHA) grants',
+        topic_id: 'b32a8586-e764-eb11-bb23-000d3a579c3f',
+        topic_requires_sign_in: false,
+        who_is_your_question_about: 'Myself',
+        your_question_requires_sign_in: false,
+        files: [
+          {
+            file_name: nil,
+            file_content: nil
+          }
+        ],
+        school_obj: {}
+      }
+    }
   end
 end


### PR DESCRIPTION
## Summary

This PR introduces several improvements across multiple components, focusing on profile duplication, address handling, inquiry retrieval, and localization updates.

Key Changes
	• VeteranProfile & Profile Duplication
	• Updated VeteranProfile to check “I’m the Veteran”, ensuring it correctly duplicates VeteranProfile with SubmitterProfile.
	• Expanded SharedContext with additional payload data for improved handling.
	• Added new translation keys to en.yml for better localization support.
	• Profile & Address Handling
	• Enhanced InquiryPayload, ProfileBuilderBase, and SubmitterProfile to properly handle StateOfProperty, ZipCodeOfResidency, and other address-related data.
	• Ensured consistent processing and integration of these fields across the system.
	• Inquiry Retrieval Improvements
	• Updated BaseRetriever to return an empty array when no inquiries are found by ICN, preventing errors.
	• Refactored inquiries_spec to handle ICN-related errors appropriately.
	• General Improvements
	• Updated wording for VRAE to enhance clarity and readability.

Impact

## Related issue(s)

- https://github.com/orgs/department-of-veterans-affairs/projects/1033/views/1?filterQuery=Khoa&pane=issue&itemId=100154796&issue=department-of-veterans-affairs%7Cask-va%7C1648
- https://github.com/orgs/department-of-veterans-affairs/projects/1033/views/1?filterQuery=Khoa&pane=issue&itemId=100708310&issue=department-of-veterans-affairs%7Cask-va%7C1655

## Testing done

- [x] *New code is covered by unit tests*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected