### PR TITLE
Revise Simple Forms email rake task

### DIFF
--- a/modules/simple_forms_api/lib/tasks/send_emails_by_date_range.rake
+++ b/modules/simple_forms_api/lib/tasks/send_emails_by_date_range.rake
@@ -4,22 +4,12 @@
 #   rails "simple_forms_api:send_emails_by_date_range[1 January 2025,2 January 2025]"
 namespace :simple_forms_api do
   task :send_emails_by_date_range, %i[start_date end_date] => :environment do |_, args|
-    errors = []
-    start_date, end_date = parse_date_args(args)
+    start_date = Time.zone.parse(args[:start_date])
+    end_date = Time.zone.parse(args[:end_date])
     form_submission_attempts = fetch_form_submission_attempts(start_date, end_date)
     Rails.logger.info "Total FormSubmissionAttempts found: #{form_submission_attempts.count}"
-    successful_uuids = process_form_submission_attempts(form_submission_attempts)
-    log_successful_attempts(successful_uuids)
-    log_errors(errors)
-    log_counts(successful_uuids.count, errors.count)
-  rescue => e
-    Rails.logger.error("Error in send_emails_by_date_range: #{e.message}")
-    Rails.logger.error(e.backtrace.join("\n"))
-    errors << e
-  end
-
-  def parse_date_args(args)
-    [Time.zone.parse(args[:start_date]), Time.zone.parse(args[:end_date])]
+    successful_uuids, failure_notifications_sent = process_form_submission_attempts(form_submission_attempts)
+    log_results(successful_uuids, failure_notifications_sent)
   end
 
   def fetch_form_submission_attempts(start_date, end_date)
@@ -32,27 +22,42 @@ namespace :simple_forms_api do
   end
 
   def process_form_submission_attempts(form_submission_attempts)
-    error_notifications_sent = []
-    form_submission_attempts.map do |form_submission_attempt|
+    failure_notifications_sent = []
+    errors = []
+
+    confirmation_numbers = form_submission_attempts.map do |form_submission_attempt|
       confirmation_number = form_submission_attempt.benefits_intake_uuid
-      Rails.logger.info "Attempting to enqueue email for: #{confirmation_number}"
-      now = Time.now.in_time_zone('Eastern Time (US & Canada)')
-      time_to_send = now.tomorrow.change(hour: 9, min: 0)
-      form_submission = form_submission_attempt.form_submission
-      notification_type = get_notification_type(form_submission_attempt)
-      error_notifications_sent << confirmation_number if notification_type == :error
-
-      SimpleFormsApi::Notification::Email.new(
-        config(form_submission_attempt, form_submission, confirmation_number),
-        notification_type:,
-        user_account: form_submission.user_account
-      ).send(at: time_to_send)
-
+      send_email(form_submission_attempt, failure_notifications_sent)
       Rails.logger.info "Successfully enqueued email for: #{confirmation_number}"
-      [confirmation_number, notification_type]
+      confirmation_number
+    rescue => e
+      errors << { message: e.message, backtrace: e.backtrace, confirmation_number: }
     end
-    Rails.logger.info 'Successful error notifications sent:'
-    Rails.logger.info error_notifications_sent
+
+    log_errors(errors)
+    [confirmation_numbers, failure_notifications_sent]
+  end
+
+  def send_email(form_submission_attempt, error_notifications_sent)
+    Rails.logger.info "Attempting to enqueue email for: #{confirmation_number}"
+    now = Time.now.in_time_zone('Eastern Time (US & Canada)')
+    time_to_send = now.tomorrow.change(hour: 9, min: 0)
+    form_submission = form_submission_attempt.form_submission
+    notification_type = get_notification_type(form_submission_attempt)
+    error_notifications_sent << confirmation_number if notification_type == :error
+
+    SimpleFormsApi::Notification::Email.new(
+      config(form_submission_attempt, form_submission, confirmation_number),
+      notification_type:,
+      user_account: form_submission.user_account
+    ).send(at: time_to_send)
+  end
+
+  def log_results(successful_uuids, failure_notifications_sent)
+    log_successful_attempts(successful_uuids)
+    Rails.logger.info('Total successful', successful_count: successful_uuids.count)
+    Rails.logger.info('Failure notifications successfully sent:',
+                      failure_notifications_sent_count: failure_notifications_sent.count)
   end
 
   def log_successful_attempts(successful_uuids)
@@ -62,12 +67,11 @@ namespace :simple_forms_api do
 
   def log_errors(errors)
     Rails.logger.error 'Errors:'
-    Rails.logger.error errors
-  end
-
-  def log_counts(successful_count, error_count)
-    Rails.logger.info "Total successful: #{successful_count}"
-    Rails.logger.info "Total errors: #{error_count}"
+    errors.each do |error|
+      Rails.logger.error error.confirmation_number
+      Rails.logger.error error.message
+      Rails.logger.error error.backtrace.join("\n")
+    end
   end
 
   def get_notification_type(form_submission_attempt)
@@ -77,8 +81,7 @@ namespace :simple_forms_api do
       :received
     else
       Rails.logger.error(
-        'Invalid notification_type for FormSubmissionAttempt with benefits_intake_uuid: ' \
-        "#{confirmation_number}"
+        "Invalid notification_type for FormSubmissionAttempt with benefits_intake_uuid: #{confirmation_number}"
       )
       raise
     end

--- a/modules/simple_forms_api/lib/tasks/send_emails_by_date_range.rake
+++ b/modules/simple_forms_api/lib/tasks/send_emails_by_date_range.rake
@@ -68,9 +68,8 @@ namespace :simple_forms_api do
   def log_errors(errors)
     Rails.logger.error 'Errors:'
     errors.each do |error|
-      Rails.logger.error error.confirmation_number
-      Rails.logger.error error.message
-      Rails.logger.error error.backtrace.join("\n")
+      Rails.logger.error('SendEmailsByDateRange error.', confirmation_number: error.confirmation_number,
+                                                         message: error.message, backtrace: error.backtrace.join('\n'))
     end
   end
 

--- a/modules/simple_forms_api/lib/tasks/send_emails_by_date_range.rake
+++ b/modules/simple_forms_api/lib/tasks/send_emails_by_date_range.rake
@@ -27,7 +27,7 @@ namespace :simple_forms_api do
 
     confirmation_numbers = form_submission_attempts.map do |form_submission_attempt|
       confirmation_number = form_submission_attempt.benefits_intake_uuid
-      send_email(form_submission_attempt, failure_notifications_sent)
+      send_email(form_submission_attempt, failure_notifications_sent, confirmation_number)
       Rails.logger.info "Successfully enqueued email for: #{confirmation_number}"
       confirmation_number
     rescue => e
@@ -38,7 +38,7 @@ namespace :simple_forms_api do
     [confirmation_numbers, failure_notifications_sent]
   end
 
-  def send_email(form_submission_attempt, error_notifications_sent)
+  def send_email(form_submission_attempt, error_notifications_sent, confirmation_number)
     Rails.logger.info "Attempting to enqueue email for: #{confirmation_number}"
     now = Time.now.in_time_zone('Eastern Time (US & Canada)')
     time_to_send = now.tomorrow.change(hour: 9, min: 0)
@@ -68,8 +68,8 @@ namespace :simple_forms_api do
   def log_errors(errors)
     Rails.logger.error 'Errors:'
     errors.each do |error|
-      Rails.logger.error('SendEmailsByDateRange error.', confirmation_number: error.confirmation_number,
-                                                         message: error.message, backtrace: error.backtrace.join('\n'))
+      Rails.logger.error('SendEmailsByDateRange error.', confirmation_number: error[:confirmation_number],
+                                                         message: error[:message], backtrace: error[:backtrace])
     end
   end
 

--- a/modules/simple_forms_api/spec/tasks/send_emails_by_date_range_spec.rb
+++ b/modules/simple_forms_api/spec/tasks/send_emails_by_date_range_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'simple_forms_api:send_emails_by_date_range', type: :task do
     let(:start_date) { '1 January 2025' }
     let(:end_date) { '3 January 2025' }
 
-    context 'FormSubmissionAttempts are a VFF-form, in an end-state and updated in the right time period' do
+    context 'FormSubmissionAttempts are a Simple Form, in an end-state and updated in the right time period' do
       before do
         create(:form_submission_attempt, :vbms, updated_at: Time.zone.parse('2 January 2025'))
         create(:form_submission_attempt, :failure, updated_at: Time.zone.parse('2 January 2025'))

--- a/modules/simple_forms_api/spec/tasks/send_emails_by_date_range_spec.rb
+++ b/modules/simple_forms_api/spec/tasks/send_emails_by_date_range_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'simple_forms_api:send_emails_by_date_range', type: :task do
     let(:start_date) { '1 January 2025' }
     let(:end_date) { '3 January 2025' }
 
-    context 'FormSubmissionAttempts are in an end-state and updated in the right time period' do
+    context 'FormSubmissionAttempts are a VFF-form, in an end-state and updated in the right time period' do
       before do
         create(:form_submission_attempt, :vbms, updated_at: Time.zone.parse('2 January 2025'))
         create(:form_submission_attempt, :failure, updated_at: Time.zone.parse('2 January 2025'))
@@ -37,6 +37,21 @@ RSpec.describe 'simple_forms_api:send_emails_by_date_range', type: :task do
           notification_type: :error,
           user_account: anything
         ).once.and_return(notification_email)
+
+        task.invoke(start_date, end_date)
+      end
+    end
+
+    context 'FormSubmissionAttempts are not a Simple Form' do
+      let(:form_submission) { build(:form_submission, form_type: 'something-else') }
+
+      before do
+        create(:form_submission_attempt, :vbms, form_submission:, updated_at: Time.zone.parse('2 January 2025'))
+        create(:form_submission_attempt, :failure, form_submission:, updated_at: Time.zone.parse('2 January 2025'))
+      end
+
+      it 'does not send a Notification::Email' do
+        expect(SimpleFormsApi::Notification::Email).not_to receive(:new)
 
         task.invoke(start_date, end_date)
       end


### PR DESCRIPTION
## Summary
This PR makes two improvements to [the previously-merged rake task](https://github.com/department-of-veterans-affairs/vets-api/pull/21177):
1. Don't `raise` in case of error. Instead we will keep processing emails and output all errors at the end for further remediation. We also will keep extra track of error notifications to be sure all of those get sent.
2. Only send emails for Simple Forms. Other forms handle their own emails.

## Related issue(s)
https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/2070
