### PR TITLE
Bump ruby-saml to 1.18.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -915,7 +915,7 @@ GEM
       hashie (>= 1.2.0, < 6.0)
       jwt (>= 1.5.6)
     retriable (3.1.2)
-    rexml (3.4.0)
+    rexml (3.4.1)
     rgeo (3.0.1)
     rgeo-activerecord (8.0.0)
       activerecord (>= 7.0)
@@ -1004,7 +1004,7 @@ GEM
       rubocop (~> 1.72, >= 1.72.1)
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
-    ruby-saml (1.17.0)
+    ruby-saml (1.18.0)
       nokogiri (>= 1.13.10)
       rexml
     ruby-vips (2.2.2)


### PR DESCRIPTION
## Summary

- Bump ruby-saml to 1.18.0
```
Name: ruby-saml
Version: 1.17.0
CVE: CVE-2025-25292
GHSA: GHSA-754f-8gm6-c4r2
Criticality: Unknown
URL: https://github.com/SAML-Toolkits/ruby-saml/security/advisories/GHSA-754f-8gm6-c4r2
Title: Ruby SAML allows a SAML authentication bypass due to namespace handling (parser differential)
Solution: update to '~> 1.12.4', '>= 1.18.0'
```
## Related issue(s)

- n/a

## Testing done

- [x] n/a

## Acceptance criteria

- [ ] All CI tests pass 
- [ ] the gem is v1.18.0