### PR TITLE
Add missing require statements to initializers

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,6 +9,7 @@ require 'sidekiq/set_request_id'
 require 'sidekiq/set_request_attributes'
 require 'datadog/statsd' # gem 'dogstatsd-ruby'
 require 'admin/redis_health_checker'
+require 'kafka/producer_manager'
 
 Rails.application.reloader.to_prepare do
   Sidekiq::Enterprise.unique! if Rails.env.production?

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'kafka/producer_manager'
 
 workers Integer(ENV.fetch('WEB_CONCURRENCY', 0))

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'kafka/producer_manager'
 
 workers Integer(ENV.fetch('WEB_CONCURRENCY', 0))
 threads_count_min = Integer(ENV.fetch('RAILS_MIN_THREADS', 5))


### PR DESCRIPTION
## Summary

Adding missing require statements for safely closing down Kafka producer instance when the Puma and Sidekiq processes shut down.
