### PR TITLE
Only show TIDs if whitelisted

### DIFF
--- a/modules/claims_api/app/services/claims_api/slack/failed_submissions_messenger.rb
+++ b/modules/claims_api/app/services/claims_api/slack/failed_submissions_messenger.rb
@@ -5,6 +5,13 @@ require 'common/client/base'
 module ClaimsApi
   module Slack
     class FailedSubmissionsMessenger
+
+      # Transaction IDs, despite the name, can have some pretty wild stuff in them. Whitelist values we find useful.
+      # Assumes comparison string is upcase'd for matching
+      TID_SUBSTRING_WHITELIST = %w[
+        FORM526SUBMISSION
+      ].freeze
+
       def initialize(options = {})
         @errored_disability_claims = options[:errored_disability_claims] # Array of id
         @errored_va_gov_claims = options[:errored_va_gov_claims] # Array of [id, transaction_id]

--- a/modules/claims_api/app/services/claims_api/slack/failed_submissions_messenger.rb
+++ b/modules/claims_api/app/services/claims_api/slack/failed_submissions_messenger.rb
@@ -123,7 +123,7 @@ module ClaimsApi
       # 'Form526Submission_3443656, user_uuid: [filtered], service_provider: lighthouse'
       # The KV-looking stuff isn't useful in a DD link, so extract the "tag" at the beginning of the string
       def extract_tag_from_whitelist(id)
-        return nil if TID_SUBSTRING_WHITELIST.none? { |s| id.upcase.include? s }
+        return nil if TID_SUBSTRING_WHITELIST.none? { |s| id&.upcase&.include? s }
 
         # Not scanning for beginning single quote in case it's not there
         id.split(',').first.scan(/[a-zA-Z0-9_-]+/)[0]

--- a/modules/claims_api/app/services/claims_api/slack/failed_submissions_messenger.rb
+++ b/modules/claims_api/app/services/claims_api/slack/failed_submissions_messenger.rb
@@ -79,7 +79,7 @@ module ClaimsApi
 
       def build_error_block(title, errors)
         text = if title == 'Va Gov Disability Compensation'
-                 errors.map { |eid, tid| "CID: #{link_value(eid)} / TID: #{link_value(tid)}" }.join("\n")
+                 errors.map { |eid, tid| "CID: #{link_value(eid, :eid)} / TID: #{link_value(tid, :tid)}" }.join("\n")
                else
                  errors.join("\n")
                end
@@ -93,8 +93,10 @@ module ClaimsApi
         }
       end
 
-      def link_value(id)
+      def link_value(id, type = :eid)
         return 'N/A' if id.blank?
+
+        return 'N/A' if type == :tid && TID_SUBSTRING_WHITELIST.none? { |substr| id.upcase.include? substr }
 
         time_stamps = datadog_timestamps
 

--- a/modules/claims_api/spec/services/failed_submissions_messenger_spec.rb
+++ b/modules/claims_api/spec/services/failed_submissions_messenger_spec.rb
@@ -154,13 +154,12 @@ RSpec.describe ClaimsApi::Slack::FailedSubmissionsMessenger do
     end
 
     context 'if transaction ids are not in the substring whitelist' do
-      [nil, SecureRandom.uuid].each do |tid|
-        let(:errored_va_gov_claims) { Array.new(num_errors) { [SecureRandom.uuid, tid] } }
+      let(:num_errors) { 1 }
 
+      [nil, SecureRandom.uuid, 'NOT_WHITELISTED_TAG'].each do |tid|
         it 'avoids linking to logs that are not there' do
+          errored_va_gov_claims = Array.new(num_errors) { [SecureRandom.uuid, tid] }
           first_cid = errored_va_gov_claims.first[0]
-          first_tid = errored_va_gov_claims.first[1]
-          puts first_tid
           messenger = described_class.new(
             errored_va_gov_claims:,
             from:,

--- a/modules/claims_api/spec/services/failed_submissions_messenger_spec.rb
+++ b/modules/claims_api/spec/services/failed_submissions_messenger_spec.rb
@@ -96,7 +96,8 @@ RSpec.describe ClaimsApi::Slack::FailedSubmissionsMessenger do
 
   context 'when there are more than 10 failed va.gov submissions' do
     let(:num_errors) { 12 }
-    let(:errored_va_gov_claims) { Array.new(num_errors) { [SecureRandom.uuid, SecureRandom.uuid] } }
+    let(:tid_prefix) { 'FORM526SUBMISSION' }
+    let(:errored_va_gov_claims) { Array.new(num_errors) { [SecureRandom.uuid, "#{tid_prefix}#{SecureRandom.uuid}"] } }
     let(:from) { '03:59PM EST' }
     let(:to) { '04:59PM EST' }
     let(:environment) { 'production' }
@@ -150,35 +151,37 @@ RSpec.describe ClaimsApi::Slack::FailedSubmissionsMessenger do
       messenger.notify!
     end
 
-    context 'if transaction ids are missing' do
-      let(:errored_va_gov_claims) { Array.new(num_errors) { [SecureRandom.uuid, nil] } }
+    context 'if transaction ids are not in the substring whitelist' do
+      [nil, SecureRandom.uuid].each do |tid|
+        let(:errored_va_gov_claims) { Array.new(num_errors) { [SecureRandom.uuid, tid] } }
 
-      it 'avoids linking to logs that are not there' do
-        first_cid = errored_va_gov_claims.first[0]
-        first_tid = errored_va_gov_claims.first[1]
-        puts first_tid
-        messenger = described_class.new(
-          errored_va_gov_claims:,
-          from:,
-          to:,
-          environment:
-        )
-
-        expect(notifier).to receive(:notify) do |_text, args|
-          expect(args[:blocks]).to include(
-            a_hash_including(
-              text: {
-                type: 'mrkdwn',
-                text: a_string_including('```',
-                                         'CID', '<https://vagov.ddog-gov.com/logs?query=', "|#{first_cid}>",
-                                         'TID', 'N/A',
-                                         '```')
-              }
-            )
+        it 'avoids linking to logs that are not there' do
+          first_cid = errored_va_gov_claims.first[0]
+          first_tid = errored_va_gov_claims.first[1]
+          puts first_tid
+          messenger = described_class.new(
+            errored_va_gov_claims:,
+            from:,
+            to:,
+            environment:
           )
-        end
 
-        messenger.notify!
+          expect(notifier).to receive(:notify) do |_text, args|
+            expect(args[:blocks]).to include(
+              a_hash_including(
+                text: {
+                  type: 'mrkdwn',
+                  text: a_string_including('```',
+                                           'CID', '<https://vagov.ddog-gov.com/logs?query=', "|#{first_cid}>",
+                                           'TID', 'N/A',
+                                           '```')
+                }
+              )
+            )
+          end
+
+          messenger.notify!
+        end
       end
     end
 


### PR DESCRIPTION
## Summary
TIDs could be filled with things not very ID-like, so this whitelists what we link to in DataDog.

## Related issue(s)

* [API-44632](https://jira.devops.va.gov/browse/API-44632)
* #21094

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
* ClaimsAPI alerting, nothing consumer/veteran facing.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
