### PR TITLE
API-45658-fix-bug-with-page-params

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -320,7 +320,8 @@ module ClaimsApi
         end
 
         def valid_page_param?(key)
-          return true if params[:page][:"#{key}"].is_a?(Integer) && params[:page][:"#{key}"]
+          param_val = params[:page][:"#{key}"]
+          return true if param_val.is_a?(String) && param_val.match?(/^\d+?/) && param_val
 
           raise ::Common::Exceptions::BadRequest.new(
             detail: "The page[#{key}] param value #{params[:page][:"#{key}"]} is invalid"

--- a/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
+++ b/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
@@ -8,7 +8,7 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
 
   describe '#index' do
     let(:scopes) { %w[claim.read] }
-    let(:page_params) { { page: { size: 10, number: 2 } } }
+    let(:page_params) { { page: { size: '10', number: '2' } } }
 
     context 'when poaCodes is not present' do
       before do
@@ -70,7 +70,7 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
         context 'and page size is present' do
           context 'and exceeds the max value allowed' do
             it 'raises a 422' do
-              page_params[:page][:size] = 101
+              page_params[:page][:size] = '101'
               mock_ccg(scopes) do |auth_header|
                 VCR.use_cassette('claims_api/bgs/manage_representative_service/read_poa_request_valid') do
                   index_request_with(poa_codes:, page_params:, auth_header:)
@@ -86,8 +86,8 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
 
           context 'and exceeds the max value allowed along with page number' do
             it 'raises a 422' do
-              page_params[:page][:size] = 101
-              page_params[:page][:number] = 120
+              page_params[:page][:size] = '101'
+              page_params[:page][:number] = '120'
               mock_ccg(scopes) do |auth_header|
                 VCR.use_cassette('claims_api/bgs/manage_representative_service/read_poa_request_valid') do
                   index_request_with(poa_codes:, page_params:, auth_header:)
@@ -677,7 +677,7 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
         context 'when only one param is sent' do
           context 'sets the param value and uses the default for the other' do
             it 'sets default page number when page size is sent in' do
-              page_params = { page: { size: 5 } }
+              page_params = { page: { size: '5' } }
               allow(subject).to receive(:params).and_return(page_params)
 
               subject.send(:validate_page_size_and_number_params)
@@ -689,7 +689,7 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
             end
 
             it 'sets default page size when page number is sent in' do
-              page_params = { page: { number: 2 } }
+              page_params = { page: { number: '2' } }
               allow(subject).to receive(:params).and_return(page_params)
 
               subject.send(:validate_page_size_and_number_params)


### PR DESCRIPTION
## Summary
* The current check first looks to see if it isan integer, which it never will be
* This updates the check to use regex to verify it is an nteger value
* Updates related tests to use the correct data type

## Related issue(s)
[API-45658](https://jira.devops.va.gov/browse/API-45658)

## Testing done

- [x] *Fixes related tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
	modified:   modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
