### PR TITLE
dbex/103148: [0781 PS] Spike - Test the Backup path for new 0781

### DIFF
--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -44,7 +44,7 @@ FactoryBot.define do
     end
   end
 
-  trait :with_0781 do
+  trait :with_0781 do # rubocop:disable Naming/VariableNumber
     form_json do
       File.read("#{submissions_path}/with_0781.json")
     end

--- a/spec/factories/form526_submissions.rb
+++ b/spec/factories/form526_submissions.rb
@@ -44,6 +44,12 @@ FactoryBot.define do
     end
   end
 
+  trait :with_0781 do
+    form_json do
+      File.read("#{submissions_path}/with_0781.json")
+    end
+  end
+
   trait :with_0781v2 do
     form_json do
       File.read("#{submissions_path}/with_0781v2.json")

--- a/spec/lib/sidekiq/form526_backup_submission_process/processor_spec.rb
+++ b/spec/lib/sidekiq/form526_backup_submission_process/processor_spec.rb
@@ -69,4 +69,31 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Processor do
         .get_form526_pdf
     end
   end
+
+  describe '#get_form0781_pdf' do
+    context 'generates a 0781 version 1 pdf' do
+      let(:submission) { create(:form526_submission, :with_0781, submit_endpoint: 'benefits_intake_api') } # rubocop:disable Naming/VariableNumber
+
+      it 'generates a 0781 v1 pdf and a 0781a pdf' do
+        form0781_pdfs = subject
+                        .new(submission.id, get_upload_location_on_instantiation: false)
+                        .get_form0781_pdf
+        expect(form0781_pdfs.count).to eq(2)
+        expect(form0781_pdfs.first[:type]).to eq('21-0781')
+        expect(form0781_pdfs.last[:type]).to eq('21-0781a')
+      end
+    end
+
+    context 'generates a 0781 version 2 pdf' do
+      let(:submission) { create(:form526_submission, :with_0781v2, submit_endpoint: 'benefits_intake_api') }
+
+      it 'generates a 0781 v2 pdf' do
+        form0781_pdfs = subject
+                        .new(submission.id, get_upload_location_on_instantiation: false)
+                        .get_form0781_pdf
+        expect(form0781_pdfs.count).to eq(1)
+        expect(form0781_pdfs.first[:type]).to eq('21-0781V2')
+      end
+    end
+  end
 end


### PR DESCRIPTION
- add unit test for generating 0781 and 0781a pdfs
- add unit test for generating 0781v2 pdf

## Summary

- *This work is behind a feature toggle (flipper): YES*
- adds 2 unit tests checking the correct 0781 pdf is generated with the expected dataset in the Form526Submission record

## Related issue(s)

- [#103148](https://github.com/department-of-veterans-affairs/va.gov-team/issues/103148)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
n/a

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
