### PR TITLE
Add logging for Simple Forms emails

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/notification/email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification/email.rb
@@ -34,8 +34,9 @@ module SimpleFormsApi
         template_id = Settings.vanotify.services.va_gov.template_id[template_id_suffix]
         return unless template_id
 
-        email_job_id = if at
-                         enqueue_email(at, template_id)
+        scheduled_at = at
+        email_job_id = if scheduled_at
+                         enqueue_email(scheduled_at, template_id)
                        else
                          send_email_now(template_id)
                        end


### PR DESCRIPTION
## Summary
This PR does not affect behavior except to add some logging when we send Simple Forms emails. This is part of an effort to debug 26-4555 emails not sending.

## Related issue(s)
https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/2077
