### PR TITLE
feat: SearchTypehead: Handle 500, 502, & 504

### DIFF
--- a/spec/requests/v0/search_typeahead_spec.rb
+++ b/spec/requests/v0/search_typeahead_spec.rb
@@ -39,5 +39,51 @@ Rspec.describe 'V0::SearchTypeahead', type: :request do
         end
       end
     end
+
+    context 'when a timeout error occurs' do
+      before do
+        allow_any_instance_of(SearchTypeahead::Service).to receive(:suggestions).and_return(
+          OpenStruct.new(body: { error: 'The request timed out. Please try again.' }.to_json, status: 504)
+        )
+      end
+
+      it 'returns a 504 status with a timeout error message' do
+        get '/v0/search_typeahead', params: { query: 'ebenefits' }
+        expect(response).to have_http_status(:gateway_timeout)
+        parsed = JSON.parse(response.body)
+        expect(parsed['error']).to eq 'The request timed out. Please try again.'
+      end
+    end
+
+    context 'when a connection error occurs' do
+      before do
+        allow_any_instance_of(SearchTypeahead::Service).to receive(:suggestions).and_return(
+          OpenStruct.new(body: { error: 'Unable to connect to the search service. Please try again later.' }.to_json,
+                         status: 502)
+        )
+      end
+
+      it 'returns a 502 status with a connection error message' do
+        get '/v0/search_typeahead', params: { query: 'ebenefits' }
+        expect(response).to have_http_status(:bad_gateway)
+        parsed = JSON.parse(response.body)
+        expect(parsed['error']).to eq 'Unable to connect to the search service. Please try again later.'
+      end
+    end
+
+    context 'when an unexpected error occurs' do
+      before do
+        allow_any_instance_of(SearchTypeahead::Service).to receive(:suggestions).and_return(
+          OpenStruct.new(body: { error: 'An unexpected error occurred.' }.to_json, status: 500)
+        )
+      end
+
+      it 'returns a 500 status with an unexpected error message' do
+        get '/v0/search_typeahead', params: { query: 'ebenefits' }
+        expect(response).to have_http_status(:internal_server_error)
+        parsed = JSON.parse(response.body)
+        expect(parsed['error']).to eq 'An unexpected error occurred.'
+      end
+    end
   end
 end


### PR DESCRIPTION
This is to address `NoMethodError`s we see when search.gov is slow.

> NoMethodError: undefined method `body' for an instance of Faraday::TimeoutError

https://dsva.slack.com/archives/C0460N83Y9G/p1741889358811859