### PR TITLE
Updates-test-expecations-to-match-vcr-dates-in-rated-dis-controller

### DIFF
--- a/spec/controllers/v0/rated_disabilities_controller_spec.rb
+++ b/spec/controllers/v0/rated_disabilities_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe V0::RatedDisabilitiesController, type: :controller do
         expect(response).to have_http_status(:ok)
       end
 
-      it 'only returns active ratings' do
+      it 'only returns active ratings', run_at: '2025-02-01T18:48:27Z' do
         VCR.use_cassette('lighthouse/veteran_verification/disability_rating/200_inactives_response') do
           get(:show)
         end


### PR DESCRIPTION
## Summary
* Currently there is a failing test in `spec/controllers/v0/rated_disabilities_controller_spec.rb` due to a date of 3-16-2025 having an expectation of being in the future
* This fix just sets a time for the test to run in order to make sure the hard coded dates are always returning as expected.

## Related issue(s)


## Testing done
- [x] *Updated existing test*

## Screenshots
![Screenshot 2025-03-17 at 10 16 35 AM](https://github.com/user-attachments/assets/3e289a95-36b6-40a2-87be-eeb16355d33e)


## What areas of the site does it impact?
modified:   spec/controllers/v0/rated_disabilities_controller_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
