### PR TITLE
VEBT Add feature toggle for forms 10215, 10216 release

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2074,4 +2074,7 @@ features:
   accredited_representative_portal_profile:
     actor_type: user
     description: Hides Profile link on navigation dropdown
+  forms_10215_10216_release:
+    actor_type: user
+    description: If enabled, show links to new forms instead of download links on SCO page
 


### PR DESCRIPTION
## Summary

- New feature toggle for linking to our react apps for forms 10215 and 10216 when we release them instead of the paper form download links

## Related issue(s)

- [VEBT-1250](https://jira.devops.va.gov/browse/VEBT-1250)
- [VEBT-1251](https://jira.devops.va.gov/browse/VEBT-1251)

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
