### PR TITLE
Add feature toggles for displaying past cancelled appointments

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -37,19 +37,19 @@ features:
   ask_va_announcement_banner:
     actor_type: cookie_id
     description: >
-      The Ask VA announcement banner displays message(s) to visitors 
-      from the CRM-managed, expirable notifications - as retrieved 
+      The Ask VA announcement banner displays message(s) to visitors
+      from the CRM-managed, expirable notifications - as retrieved
       from the /ask_va_api/v0/announcements endpoint.
     enable_in_development: true
   ask_va_canary_release:
     actor_type: cookie_id
-    description: > 
-      Percent of visitors to keep in the updated Ask VA experience on VA.gov. 
+    description: >
+      Percent of visitors to keep in the updated Ask VA experience on VA.gov.
       All other users are redirected to the legacy experience.
-      To route or retain all users, set to 0% for legacy or 100% for the 
+      To route or retain all users, set to 0% for legacy or 100% for the
       updated experience on VA.gov.
-      NOTE: When ready for all users to be in the updated experience on 
-      VA.gov, set this toggle to "Enabled", rather than specifying 100% 
+      NOTE: When ready for all users to be in the updated experience on
+      VA.gov, set this toggle to "Enabled", rather than specifying 100%
       in the percentage.
     enable_in_development: true
   ask_va_mock_api_for_testing:
@@ -1638,6 +1638,10 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle for warning user of appointment conflicts on the direct scheduling calendar during booking.
+  va_online_scheduling_display_past_cancelled_appointments:
+    actor_type: user
+    enable_in_development: true
+    description: Toggle for displaying past cancelled appointments.
   veteran_onboarding_beta_flow:
     actor_type: user
     description: Conditionally display the new veteran onboarding flow to user
@@ -1965,7 +1969,7 @@ features:
     actor_type: user
     enable_in_development: true
     description: >-
-      A switch that toggles new claims management functionality. 
+      A switch that toggles new claims management functionality.
   yellow_ribbon_automated_date_on_school_search:
     actor_type: user
     description: Enable the automated date displayed in the Find a Yellow Ribbon school search results
@@ -2070,7 +2074,7 @@ features:
     description: Hides sort by in POA Request Search page
   accredited_representative_portal_help:
     actor_type: user
-    description: Hides Get Help link on navigation  
+    description: Hides Get Help link on navigation
   accredited_representative_portal_profile:
     actor_type: user
     description: Hides Profile link on navigation dropdown


### PR DESCRIPTION
## Summary

- Adding `va_online_scheduling_display_past_cancelled_appointments`
- Appointments Tool Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/105404

## Testing done

N/A

## Screenshots

N/A

## What areas of the site does it impact?

Appointments Tool

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

