### PR TITLE
add https to schema registry dynamic call

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -655,7 +655,7 @@ kafka_producer:
   aws_role_arn: "arn:aws:iam::123456789012:role/role-name" # this is an example
   broker_urls: ["localhost:19092"] # for local Kafka cluster in Docker
   sasl_mechanisms: 'GSSAPI'
-  schema_registry_url: "http://localhost:8081" # for local Schema Registry in Docker
+  schema_registry_url: "localhost:8081" # for local Schema Registry in Docker
   security_protocol: 'plaintext'
 kms_key_id: ~
 lgy:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -649,7 +649,7 @@ kafka_producer:
   aws_role_arn: 'arn:aws:iam::123456789012:role/role-name' # this is an example
   broker_urls: ['localhost:19092'] # for local Kafka cluster in Docker
   sasl_mechanisms: 'GSSAPI'
-  schema_registry_url: "http://localhost:8081" # for local Schema Registry in Docker
+  schema_registry_url: "localhost:8081" # for local Schema Registry in Docker
   security_protocol: 'plaintext'
 kms_key_id: ~
 lgy:

--- a/lib/kafka/schema_registry/configuration.rb
+++ b/lib/kafka/schema_registry/configuration.rb
@@ -14,7 +14,7 @@ module Kafka
       end
 
       def connection
-        Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
+        Faraday.new("https://#{base_path}", headers: base_request_headers, request: request_options) do |conn|
           conn.use :breakers
           conn.use Faraday::Response::RaiseError
           conn.adapter Faraday.default_adapter

--- a/spec/support/vcr_cassettes/kafka/topics.yml
+++ b/spec/support/vcr_cassettes/kafka/topics.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:8081/subjects/topic-1-value/versions/latest
+    uri: https://localhost:8081/subjects/topic-1-value/versions/latest
     body:
       encoding: US-ASCII
       string: ''
@@ -63,7 +63,7 @@ http_interactions:
   recorded_at: Tue, 10 Aug 2021 15:55:41 GMT
 - request:
     method: get
-    uri: http://localhost:8081/subjects/topic-2-value/versions/latest
+    uri: https://localhost:8081/subjects/topic-2-value/versions/latest
     body:
       encoding: US-ASCII
       string: ''
@@ -124,7 +124,7 @@ http_interactions:
   recorded_at: Tue, 10 Aug 2021 15:55:41 GMT
 - request:
     method: get
-    uri: http://localhost:8081/subjects/topic-1-value/versions/1
+    uri: https://localhost:8081/subjects/topic-1-value/versions/1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/kafka/topics404.yml
+++ b/spec/support/vcr_cassettes/kafka/topics404.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:8081/subjects/topic-999-value/versions/latest
+    uri: https://localhost:8081/subjects/topic-999-value/versions/latest
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
## Summary
when testing schema registry dynamic call, it failed. We think this is because it was hitting http and not https

## Related issue(s)
https://github.com/department-of-veterans-affairs/VES/issues/4567

## Testing done
specs and curling the schema url manually with https 

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
