### PR TITLE
Removing Kafka shutdown behavior b/c of broken require statements

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,7 +9,7 @@ require 'sidekiq/set_request_id'
 require 'sidekiq/set_request_attributes'
 require 'datadog/statsd' # gem 'dogstatsd-ruby'
 require 'admin/redis_health_checker'
-require 'kafka/producer_manager'
+# require 'kafka/producer_manager'
 
 Rails.application.reloader.to_prepare do
   Sidekiq::Enterprise.unique! if Rails.env.production?
@@ -51,9 +51,9 @@ Rails.application.reloader.to_prepare do
       Rails.logger.error "#{job['class']} #{job['jid']} died with error #{ex.message}."
     end
 
-    config.on(:shutdown) do
-      Kafka::ProducerManager.instance.producer&.close
-    end
+    # config.on(:shutdown) do
+    #   Kafka::ProducerManager.instance.producer&.close
+    # end
   end
 
   Sidekiq.configure_client do |config|

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'kafka/producer_manager'
+# require 'kafka/producer_manager'
 
 workers Integer(ENV.fetch('WEB_CONCURRENCY', 0))
 threads_count_min = Integer(ENV.fetch('RAILS_MIN_THREADS', 5))
@@ -15,6 +15,6 @@ on_worker_boot do
   ActiveRecord::Base.establish_connection
 end
 
-on_worker_shutdown do
-  Kafka::ProducerManager.instance.producer&.close
-end
+# on_worker_shutdown do
+#   Kafka::ProducerManager.instance.producer&.close
+# end


### PR DESCRIPTION
Emergency fix to a broken require statement that could prevent Puma from starting.