### PR TITLE
[SIMPLE-FORMS] fix: add new form upload forms to the form upload flow notification email configuration

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/notification/form_upload_email.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/notification/form_upload_email.rb
@@ -12,7 +12,14 @@ module SimpleFormsApi
         error: template_root.form_upload_error_email,
         received: template_root.form_upload_received_email
       }.freeze
-      SUPPORTED_FORMS = %w[21-0779 21-509 21P-0518-1 21P-0516-1].freeze
+      SUPPORTED_FORMS = %w[
+        21-0779
+        21-4192
+        21-509
+        21-8940
+        21P-0516-1
+        21P-0518-1
+      ].freeze
 
       def initialize(config, notification_type:)
         @notification_type = notification_type

--- a/modules/simple_forms_api/docs/form_upload_tool_README.md
+++ b/modules/simple_forms_api/docs/form_upload_tool_README.md
@@ -6,37 +6,37 @@ The Form Upload tool was developed by the Veteran Facing Forms team to provide a
 
 The Form Upload tool launched with support for four forms: `21-0779`, `21-509`, `21P-0518-1`, and `21P-0516-1`. If you'd like to add support for additional forms, follow the steps below.
 
-### 1. Add the form to the prefill configuration.
+### 1. Add the form to the prefill configuration
 
-- Add an entry to [this array](https://github.com/department-of-veterans-affairs/vets-api/blob/863dba2808abdca9b5484b5cd5e94dbdc3a124a4/app/models/form_profile.rb#L101), appending `-UPLOAD` to the form id.
+- Add an entry to [this array](https://github.com/department-of-veterans-affairs/vets-api/blob/f6a74d680753f5abb6ba8458d9a6173a95933577/app/models/form_profile.rb#L101), appending `-UPLOAD` to the form id.
 
-  **Why?**  
+  **Why?**
   This enables prefill functionality for the form.
 
-- Add a corresponding entry to [this hash](https://github.com/department-of-veterans-affairs/vets-api/blob/863dba2808abdca9b5484b5cd5e94dbdc3a124a4/app/models/form_profile.rb#L120), similar to the existing configuration for `21-0779`.
+- Add a corresponding entry to [this hash](https://github.com/department-of-veterans-affairs/vets-api/blob/f6a74d680753f5abb6ba8458d9a6173a95933577/app/models/form_profile.rb#L120), similar to the existing configuration for `21-0779`.
 
-  **Why?**  
+  **Why?**
   This ensures the form is recognized for prefill.
-  
+
 ### 2. Define the form’s expected page limits
 
-- Add an entry to [this hash](https://github.com/department-of-veterans-affairs/vets-api/blob/863dba2808abdca9b5484b5cd5e94dbdc3a124a4/app/models/persistent_attachments/va_form.rb#L11-L16), specifying:
+- Add an entry to [this hash](https://github.com/department-of-veterans-affairs/vets-api/blob/f6a74d680753f5abb6ba8458d9a6173a95933577/app/models/persistent_attachments/va_form.rb#L11-L16), specifying:
   - The maximum expected number of pages.
   - The minimum number required for a valid submission.
 
-  **Why?**  
+  **Why?**
   This applies a **soft validation** which won’t block submission if incorrect, but it will display a confirmation alert prompting users to verify their uploaded file.
 
 ### 3. Integrate with VANotify to send notification emails (not required, but highly recommended)
 
-- Add your form id to [this array](https://github.com/department-of-veterans-affairs/vets-api/blob/863dba2808abdca9b5484b5cd5e94dbdc3a124a4/modules/simple_forms_api/app/services/simple_forms_api/form_upload_notification_email.rb#L14).
+- Add your form id to [this array](https://github.com/department-of-veterans-affairs/vets-api/blob/f6a74d680753f5abb6ba8458d9a6173a95933577/modules/simple_forms_api/app/services/simple_forms_api/notification/form_upload_email.rb#L15).
 
-  **Why?**  
+  **Why?**
   This allows VANotify to send emails about the form submission. Three emails potentially get sent: once upon **submission**, and once each upon **error** or **receipt/final success**.
 
-### 4. Follow the instructions in the `vets-website` repo.
+### 4. Follow the instructions in the `vets-website` repo
 
 - [Follow the instructions here](https://github.com/department-of-veterans-affairs/vets-website/blob/56ef89fee0e645df5c39e1285df295cd9eed8818/src/applications/simple-forms/form-upload/README.md) to enable the form on the front-end.
 
-  **Why?**  
+  **Why?**
   The front end needs a few pieces of data to be able to accurately render the tool for additional forms.


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- *Updated `SUPPORTED_FORMS` in Simple Forms API notification service to include additional form IDs.*
- *Updated documentation (`form_upload_tool_README.md`) with changes to form support and updated links.*
- *Which team do you work for, does your team own the maintenance of this component?* **Veteran Facing Forms Team**
- *No new flipper introduced.*

## Testing done

- Unit and E2E tests pass

## Acceptance criteria

- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution.
- [x] Documentation has been updated (link to documentation).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs.
- [x] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected.

## Requested Feedback

Any