### PR TITLE
Re-add Kafka producer shutdown

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,7 +9,7 @@ require 'sidekiq/set_request_id'
 require 'sidekiq/set_request_attributes'
 require 'datadog/statsd' # gem 'dogstatsd-ruby'
 require 'admin/redis_health_checker'
-# require 'kafka/producer_manager'
+require 'kafka/producer_manager'
 
 Rails.application.reloader.to_prepare do
   Sidekiq::Enterprise.unique! if Rails.env.production?
@@ -51,9 +51,9 @@ Rails.application.reloader.to_prepare do
       Rails.logger.error "#{job['class']} #{job['jid']} died with error #{ex.message}."
     end
 
-    # config.on(:shutdown) do
-    #   Kafka::ProducerManager.instance.producer&.close
-    # end
+    config.on(:shutdown) do
+      Kafka::ProducerManager.instance.producer&.close
+    end
   end
 
   Sidekiq.configure_client do |config|

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# require 'kafka/producer_manager'
-
 workers Integer(ENV.fetch('WEB_CONCURRENCY', 0))
 threads_count_min = Integer(ENV.fetch('RAILS_MIN_THREADS', 5))
 threads_count_max = Integer(ENV.fetch('RAILS_MAX_THREADS', 5))
@@ -15,6 +13,7 @@ on_worker_boot do
   ActiveRecord::Base.establish_connection
 end
 
-# on_worker_shutdown do
-#   Kafka::ProducerManager.instance.producer&.close
-# end
+on_worker_shutdown do
+  require 'kafka/producer_manager'
+  Kafka::ProducerManager.instance.producer&.close
+end


### PR DESCRIPTION
Re-adding Kafka shutdown behavior with correct require statements. In the `config/initializer/sidekiq.rb` file, the path to `kafka/producer_manager` can be found. In `config/puma.rb`, the `$LOAD_PATH` does not contain the lib directory in local environments, but does contain it in VSP environments. I added the `require` statement to the `on_worker_shutdown` hook that won't run locally anyway:

> Warning: You specified code to run in a `on_worker_shutdown` block, but Puma is not configured to run in cluster mode (worker count > 0), so your `on_worker_shutdown` block will not run