### PR TITLE
Switch VA Profile Settings back to Settings.vet360 for local and test 

### DIFF
--- a/lib/va_profile/configuration.rb
+++ b/lib/va_profile/configuration.rb
@@ -5,7 +5,7 @@ require_relative 'models/base'
 
 module VAProfile
   class Configuration < Common::Client::Configuration::REST
-    SETTINGS = Settings.va_profile || Settings.vet360
+    SETTINGS = Rails.env.production? ? Settings.va_profile : Settings.vet360
 
     def self.base_request_headers
       super.merge('cufSystemName' => VAProfile::Models::Base::SOURCE_SYSTEM)


### PR DESCRIPTION
## Summary

- Cannot determine the nature of the issue with local testing and data needed for prefill
- Switch back to local & test using `Settings.vet360` and deployed env using `Settings.va_profile`
    - Settings for va_profile didn't exist in local development or test

## Related issue(s)

- n/a

## Testing done

- [ ] n/a

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  Settings in VAProfile::Configuration use vet360 for local & test
- [ ]  Settings in VAProfile::Configuration use va_profile for Rails production