### PR TITLE
[ARP] Derive `recordDisclosure`

### DIFF
--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_form.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_form.rb
@@ -83,10 +83,6 @@ module AccreditedRepresentativePortal
           "authorizations": {
             "type": "object",
             "properties": {
-              "recordDisclosure": {
-                "type": "boolean",
-                "example": true
-              },
               "recordDisclosureLimitations": {
                 "type": "array",
                 "items": {
@@ -111,7 +107,6 @@ module AccreditedRepresentativePortal
               }
             },
             "required": [
-              "recordDisclosure",
               "recordDisclosureLimitations",
               "addressChange"
             ]

--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/power_of_attorney_request_service/accept.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/power_of_attorney_request_service/accept.rb
@@ -91,7 +91,7 @@ module AccreditedRepresentativePortal
       def form_payload
         {}.tap do |a|
           limits = form_data.dig('authorizations', 'recordDisclosureLimitations').to_a
-          
+
           a[:veteran] = veteran_data
           a[:serviceOrganization] = organization_data
           a[:recordConsent] = limits.empty?

--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/power_of_attorney_request_service/accept.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/power_of_attorney_request_service/accept.rb
@@ -90,10 +90,12 @@ module AccreditedRepresentativePortal
 
       def form_payload
         {}.tap do |a|
+          limits = form_data.dig('authorizations', 'recordDisclosureLimitations').to_a
+          
           a[:veteran] = veteran_data
           a[:serviceOrganization] = organization_data
-          a[:recordConsent] = form_data.dig('authorizations', 'recordDisclosure')
-          a[:consentLimits] = form_data.dig('authorizations', 'recordDisclosureLimitations')
+          a[:recordConsent] = limits.empty?
+          a[:consentLimits] = limits
           a[:consentAddressChange] = form_data.dig('authorizations', 'addressChange')
         end
       end

--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/power_of_attorney_request_service/create/form_data_adapter.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/power_of_attorney_request_service/create/form_data_adapter.rb
@@ -31,7 +31,6 @@ module AccreditedRepresentativePortal
 
         def authorizations
           {
-            'recordDisclosure' => @data[:record_consent],
             'recordDisclosureLimitations' => @data[:consent_limits] || [],
             'addressChange' => @data[:consent_address_change]
           }

--- a/modules/accredited_representative_portal/spec/factories/power_of_attorney_form.rb
+++ b/modules/accredited_representative_portal/spec/factories/power_of_attorney_form.rb
@@ -2,7 +2,6 @@
 
 dependent_claimant_data_hash = {
   authorizations: {
-    recordDisclosure: true,
     recordDisclosureLimitations: [],
     addressChange: true
   },
@@ -53,7 +52,6 @@ dependent_claimant_data_hash = {
 
 veteran_claimant_data_hash = {
   authorizations: {
-    recordDisclosure: true,
     recordDisclosureLimitations: %w[
       HIV
       DRUG_ABUSE
@@ -94,7 +92,6 @@ FactoryBot.define do
       data_hash do
         {
           authorizations: {
-            recordDisclosure: Faker::Boolean.boolean,
             recordDisclosureLimitations: %w[
               ALCOHOLISM
               DRUG_ABUSE

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec/responses/dependent_claimant_power_of_attorney_form.json
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec/responses/dependent_claimant_power_of_attorney_form.json
@@ -1,6 +1,5 @@
 {
   "authorizations": {
-    "recordDisclosure": true,
     "recordDisclosureLimitations": [],
     "addressChange": true
   },

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec/responses/veteran_claimant_power_of_attorney_form.json
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec/responses/veteran_claimant_power_of_attorney_form.json
@@ -1,6 +1,5 @@
 {
   "authorizations": {
-    "recordDisclosure": true,
     "recordDisclosureLimitations": [
       "HIV",
       "DRUG_ABUSE"

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/power_of_attorney_request_service/create/form_data_adapter_spec.rb
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/power_of_attorney_request_service/create/form_data_adapter_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestService::Cr
       expected_result = {
         data: {
           'authorizations' => {
-            'recordDisclosure' => true,
             'recordDisclosureLimitations' => ['HIV'],
             'addressChange' => true
           },

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/power_of_attorney_request_service/create_spec.rb
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/power_of_attorney_request_service/create_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestService::Cr
     let(:form_data) do
       {
         'authorizations' => {
-          'recordDisclosure' => true,
           'recordDisclosureLimitations' => ['HIV'],
           'addressChange' => true
         },

--- a/spec/support/vcr_cassettes/accredited_representative_portal/requests/accredited_representative_portal/v0/power_of_attorney_request_decisions_spec/202_response.yml
+++ b/spec/support/vcr_cassettes/accredited_representative_portal/requests/accredited_representative_portal/v0/power_of_attorney_request_decisions_spec/202_response.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<LIGHTHOUSE_DIRECT_DEPOSIT_HOST>/services/claims/v2/veterans/1012666183V089914/2122"
     body:
       encoding: UTF-8
-      string: '{"data":{"attributes":{"veteran":{"address":{"addressLine1":"123 Main St","addressLine2":"Apt 1","city":"Springfield","stateCode":"IL","countryCode":"US","zipCode":"62704","zipCodeSuffix":"6789"},"phone":{"areaCode":"123","phoneNumber":"4567890"},"email":"veteran@example.com","serviceNumber":"123456789"},"serviceOrganization":{"poaCode":"x23","registrationNumber":"357458"},"recordConsent":true,"consentLimits":["HIV","DRUG_ABUSE"],"consentAddressChange":true}}}'
+      string: '{"data":{"attributes":{"veteran":{"address":{"addressLine1":"123 Main St","addressLine2":"Apt 1","city":"Springfield","stateCode":"IL","countryCode":"US","zipCode":"62704","zipCodeSuffix":"6789"},"phone":{"areaCode":"123","phoneNumber":"4567890"},"email":"veteran@example.com","serviceNumber":"123456789"},"serviceOrganization":{"poaCode":"x23","registrationNumber":"357458"},"recordConsent":false,"consentLimits":["HIV","DRUG_ABUSE"],"consentAddressChange":true}}}'
     headers:
       Accept:
       - application/json

--- a/spec/support/vcr_cassettes/accredited_representative_portal/requests/accredited_representative_portal/v0/power_of_attorney_request_decisions_spec/404_response.yml
+++ b/spec/support/vcr_cassettes/accredited_representative_portal/requests/accredited_representative_portal/v0/power_of_attorney_request_decisions_spec/404_response.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<LIGHTHOUSE_DIRECT_DEPOSIT_HOST>/services/claims/v2/veterans/1012666183V089914/2122"
     body:
       encoding: UTF-8
-      string: '{"data":{"attributes":{"veteran":{"address":{"addressLine1":"123 Main St","addressLine2":"Apt 1","city":"Springfield","stateCode":"IL","countryCode":"US","zipCode":"62704","zipCodeSuffix":"6789"},"phone":{"areaCode":"123","phoneNumber":"4567890"},"email":"veteran@example.com","serviceNumber":"123456789"},"serviceOrganization":{"poaCode":"x23","registrationNumber":"357458"},"recordConsent":true,"consentLimits":["HIV","DRUG_ABUSE"],"consentAddressChange":true}}}'
+      string: '{"data":{"attributes":{"veteran":{"address":{"addressLine1":"123 Main St","addressLine2":"Apt 1","city":"Springfield","stateCode":"IL","countryCode":"US","zipCode":"62704","zipCodeSuffix":"6789"},"phone":{"areaCode":"123","phoneNumber":"4567890"},"email":"veteran@example.com","serviceNumber":"123456789"},"serviceOrganization":{"poaCode":"x23","registrationNumber":"357458"},"recordConsent":false,"consentLimits":["HIV","DRUG_ABUSE"],"consentAddressChange":true}}}'
     headers:
       Accept:
       - application/json


### PR DESCRIPTION
Rather than store it redundantly, since it is a function of _only_ the `recordDisclosureLimitations` array.

[ARP frontend already derives](https://github.com/department-of-veterans-affairs/vets-website/blob/485b20089beab3cf5e7da200566cca4e93fd2c8f/src/applications/accredited-representative-portal/containers/POARequestDetailsPage.jsx#L369-L375) the display convenience for `Protected medical records` which can be one of `(Authorized, AccessToSome, NoAccess)` as a function of only the `recordDisclosureLimitations`. This matches the meaning evident in the paper form 21-22 for field 19:
> 19. AUTHORIZATION FOR REPRESENTATIVE'S ACCESS TO RECORDS PROTECTED BY SECTION 7332, TITLE 38, U.S.C.

Presumably it is also the correct meaning for the `recordConsent` field in LH's digital POA form; snippet from LH POA form mapping code:
```ruby
limits = form_data.dig('authorizations', 'recordDisclosureLimitations').to_a
a[:recordConsent] = limits.empty?
```