### PR TITLE
Fix settings typo

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -656,7 +656,7 @@ kafka_producer:
   aws_role_arn: <%= ENV['kafka_producer__aws_role_arn'] %>
   broker_urls: <%= ENV['kafka_producer__broker_urls'] %>
   sasl_mechanisms: 'OAUTHBEARER'
-  schema_registry_url: <%= ENV['kafka_proudcer__schema_registry_url'] %>
+  schema_registry_url: <%= ENV['kafka_producer__schema_registry_url'] %>
   security_protocol: 'sasl_ssl'
 kms_key_id: <%= ENV['kms_key_id'] %>
 lgy:


### PR DESCRIPTION
`kafka_producer` was misspelled in settings.yml file