### PR TITLE
1421 enable 1095b log monitoring

### DIFF
--- a/app/sidekiq/form1095/delete_old1095_bs_job.rb
+++ b/app/sidekiq/form1095/delete_old1095_bs_job.rb
@@ -10,15 +10,21 @@ module Form1095
     def perform(limit = 100_000)
       forms_to_delete = Form1095B.where('tax_year < ?', Form1095B.current_tax_year).limit(limit)
       if forms_to_delete.none?
-        Rails.logger.info('No old Form1095B records to delete')
+        log_message('No old Form1095B records to delete')
         return
       end
 
-      Rails.logger.info("Begin deleting #{forms_to_delete.count} old Form1095B files")
+      log_message("Begin deleting #{forms_to_delete.count} old Form1095B files")
       start_time = Time.now.to_f
       forms_to_delete.in_batches(&:delete_all)
       duration = Time.now.to_f - start_time
-      Rails.logger.info("Finished deleting old Form1095B files in #{duration} seconds")
+      log_message("Finished deleting old Form1095B files in #{duration} seconds")
     end
+
+    private
+
+      def log_message(message)
+        Rails.logger.info("Form1095B Deletion Job: #{message}")
+      end
   end
 end

--- a/app/sidekiq/form1095/delete_old1095_bs_job.rb
+++ b/app/sidekiq/form1095/delete_old1095_bs_job.rb
@@ -23,8 +23,8 @@ module Form1095
 
     private
 
-      def log_message(message)
-        Rails.logger.info("Form1095B Deletion Job: #{message}")
-      end
+    def log_message(message)
+      Rails.logger.info("Form1095B Deletion Job: #{message}")
+    end
   end
 end

--- a/app/sidekiq/form1095/new1095_bs_job.rb
+++ b/app/sidekiq/form1095/new1095_bs_job.rb
@@ -172,7 +172,7 @@ module Form1095
 
       all_succeeded
     rescue => e
-      message = "Error processing file: #{file_details}, on line #{lines};"\
+      message = "Error processing file: #{file_details[:name]}, on line #{lines}; "\
                 "#{e.message}"
       log_error(message)
       false

--- a/app/sidekiq/form1095/new1095_bs_job.rb
+++ b/app/sidekiq/form1095/new1095_bs_job.rb
@@ -36,7 +36,7 @@ module Form1095
 
     private
 
-    # this method adds a prefix to the log message to enable datadog monitoring
+    # used to enable datadog monitoring
     def log_message(level, message)
       Rails.logger.send(level, "Form1095B Creation Job #{level.capitalize}: #{message}")
     end

--- a/app/sidekiq/form1095/new1095_bs_job.rb
+++ b/app/sidekiq/form1095/new1095_bs_job.rb
@@ -9,20 +9,20 @@ module Form1095
     sidekiq_options(retry: false)
 
     def perform
-      Rails.logger.info 'Checking for new 1095-B data'
+      log_message(:info, 'Checking for new 1095-B data')
 
       file_names = get_bucket_files
       if file_names.empty?
-        Rails.logger.info 'No new 1095 files found'
+        log_message(:info, 'No new 1095 files found')
       else
-        Rails.logger.info "#{file_names.size} files found"
+        log_message(:info, "#{file_names.size} files found")
       end
 
       files_read_count = 0
       file_names.each do |file_name|
         if download_and_process_file?(file_name)
           files_read_count += 1
-          Rails.logger.info "Successfully read #{@form_count} 1095B forms from #{file_name}, deleting file from S3"
+          log_message(:info, "Successfully read #{@form_count} 1095B forms from #{file_name}, deleting file from S3")
           bucket.delete_objects(delete: { objects: [{ key: file_name }] })
         else
           message = "failed to save #{@error_count} forms from file: #{file_name}; " \
@@ -31,7 +31,7 @@ module Form1095
         end
       end
 
-      Rails.logger.info "#{files_read_count}/#{file_names.size} files read successfully"
+      log_message(:info, "#{files_read_count}/#{file_names.size} files read successfully")
     end
 
     private
@@ -200,8 +200,7 @@ module Form1095
 
       all_succeeded
     rescue => e
-      message = "Error processing file: #{file_details[:name]}, on line #{lines}; "\
-                "#{e.message}"
+      message = "Error processing file: #{file_details[:name]}, on line #{lines}; #{e.message}"
       log_message(:error, message)
       false
     end

--- a/spec/sidekiq/form1095/delete_old1095_bs_job_spec.rb
+++ b/spec/sidekiq/form1095/delete_old1095_bs_job_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe Form1095::DeleteOld1095BsJob, type: :job do
       create(:form1095_b, tax_year: Form1095B.current_tax_year - 1)
 
       expect(Rails.logger).to receive(:info).with('Form1095B Deletion Job: Begin deleting 3 old Form1095B files')
-      expect(Rails.logger).to receive(:info).with(/Form1095B Deletion Job: Finished deleting old Form1095B files in \d+\.\d+ seconds/)
+      expect(Rails.logger).to receive(:info).with(
+        /Form1095B Deletion Job: Finished deleting old Form1095B files in \d+\.\d+ seconds/
+      )
 
       subject.perform
 
@@ -26,7 +28,9 @@ RSpec.describe Form1095::DeleteOld1095BsJob, type: :job do
       old_form = create(:form1095_b, tax_year: Form1095B.current_tax_year - 1)
 
       expect(Rails.logger).to receive(:info).with('Form1095B Deletion Job: Begin deleting 2 old Form1095B files')
-      expect(Rails.logger).to receive(:info).with(/Form1095B Deletion Job: Finished deleting old Form1095B files in \d+\.\d+ seconds/)
+      expect(Rails.logger).to receive(:info).with(
+        /Form1095B Deletion Job: Finished deleting old Form1095B files in \d+\.\d+ seconds/
+      )
 
       subject.perform(2)
 

--- a/spec/sidekiq/form1095/delete_old1095_bs_job_spec.rb
+++ b/spec/sidekiq/form1095/delete_old1095_bs_job_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Form1095::DeleteOld1095BsJob, type: :job do
       create(:form1095_b, tax_year: Form1095B.current_tax_year - 3)
       create(:form1095_b, tax_year: Form1095B.current_tax_year - 1)
 
-      expect(Rails.logger).to receive(:info).with('Begin deleting 3 old Form1095B files')
-      expect(Rails.logger).to receive(:info).with(/Finished deleting old Form1095B files in \d+\.\d+ seconds/)
+      expect(Rails.logger).to receive(:info).with('Form1095B Deletion Job: Begin deleting 3 old Form1095B files')
+      expect(Rails.logger).to receive(:info).with(/Form1095B Deletion Job: Finished deleting old Form1095B files in \d+\.\d+ seconds/)
 
       subject.perform
 
@@ -25,8 +25,8 @@ RSpec.describe Form1095::DeleteOld1095BsJob, type: :job do
       older_form = create(:form1095_b, tax_year: Form1095B.current_tax_year - 3)
       old_form = create(:form1095_b, tax_year: Form1095B.current_tax_year - 1)
 
-      expect(Rails.logger).to receive(:info).with('Begin deleting 2 old Form1095B files')
-      expect(Rails.logger).to receive(:info).with(/Finished deleting old Form1095B files in \d+\.\d+ seconds/)
+      expect(Rails.logger).to receive(:info).with('Form1095B Deletion Job: Begin deleting 2 old Form1095B files')
+      expect(Rails.logger).to receive(:info).with(/Form1095B Deletion Job: Finished deleting old Form1095B files in \d+\.\d+ seconds/)
 
       subject.perform(2)
 
@@ -35,7 +35,7 @@ RSpec.describe Form1095::DeleteOld1095BsJob, type: :job do
     end
 
     it 'logs a message and deletes nothing if there are no forms to delete' do
-      expect(Rails.logger).to receive(:info).with('No old Form1095B records to delete')
+      expect(Rails.logger).to receive(:info).with('Form1095B Deletion Job: No old Form1095B records to delete')
 
       subject.perform
 

--- a/spec/sidekiq/form1095/new1095_bs_job_spec.rb
+++ b/spec/sidekiq/form1095/new1095_bs_job_spec.rb
@@ -111,10 +111,11 @@ RSpec.describe Form1095::New1095BsJob, type: :job do
           allow(Tempfile).to receive(:new).and_return(tempfile3)
           allow(tempfile3).to receive(:each_line).and_raise(RuntimeError, 'Bad file')
 
-          expect(Rails.logger).to receive(:error).once.with("Form1095B Creation Job Error: Error processing file: "\
-            "#{file_names3.first}, on line 0; Bad file")
+          expect(Rails.logger).to receive(:error).once.with('Form1095B Creation Job Error: Error processing file: ' \
+                                                            "#{file_names3.first}, on line 0; Bad file")
           expect(Rails.logger).to receive(:error).once.with(
-            /Form1095B Creation Job Error: failed to save 0 forms from file: #{file_names3.first}; successfully saved 0 forms/
+            "Form1095B Creation Job Error: failed to save 0 forms from file: #{file_names3.first}; " \
+            'successfully saved 0 forms'
           )
           expect(bucket).not_to receive(:delete_objects)
 

--- a/spec/sidekiq/form1095/new1095_bs_job_spec.rb
+++ b/spec/sidekiq/form1095/new1095_bs_job_spec.rb
@@ -111,10 +111,10 @@ RSpec.describe Form1095::New1095BsJob, type: :job do
           allow(Tempfile).to receive(:new).and_return(tempfile3)
           allow(tempfile3).to receive(:each_line).and_raise(RuntimeError, 'Bad file')
 
-          expect(Rails.logger).to receive(:error).once.with("Form1095B Job Error: Error processing file: "\
+          expect(Rails.logger).to receive(:error).once.with("Form1095B Creation Job Error: Error processing file: "\
             "#{file_names3.first}, on line 0; Bad file")
           expect(Rails.logger).to receive(:error).once.with(
-            /Form1095B Job Error: failed to save 0 forms from file: #{file_names3.first}; successfully saved 0 forms/
+            /Form1095B Creation Job Error: failed to save 0 forms from file: #{file_names3.first}; successfully saved 0 forms/
           )
           expect(bucket).not_to receive(:delete_objects)
 

--- a/spec/sidekiq/form1095/new1095_bs_job_spec.rb
+++ b/spec/sidekiq/form1095/new1095_bs_job_spec.rb
@@ -111,10 +111,10 @@ RSpec.describe Form1095::New1095BsJob, type: :job do
           allow(Tempfile).to receive(:new).and_return(tempfile3)
           allow(tempfile3).to receive(:each_line).and_raise(RuntimeError, 'Bad file')
 
-          expect(Rails.logger).to receive(:error).once.with('Bad file.')
-          expect(Rails.logger).to receive(:error).once # log_exception_to_sentry stacktrace error
+          expect(Rails.logger).to receive(:error).once.with("Form1095B Job Error: Error processing file: "\
+            "#{file_names3.first}, on line 0; Bad file")
           expect(Rails.logger).to receive(:error).once.with(
-            "failed to save 0 forms from file: #{file_names3.first}; successfully saved 0 forms"
+            /Form1095B Job Error: failed to save 0 forms from file: #{file_names3.first}; successfully saved 0 forms/
           )
           expect(bucket).not_to receive(:delete_objects)
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES
- Adds a prefix to 1095b logging to simplify log monitoring

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-iir/issues/1424

## Testing done

- specs

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
1095b ingestion and deletion logs

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
