### PR TITLE
104641a - Remove `champva_confirmation_email_bugfix` flipper - IVC CHAMPVA forms

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -200,9 +200,6 @@ features:
   champva_failure_email_job_enabled:
     actor_type: user
     description: Enables sending failure notification emails for IVC CHAMPVA form submissions that lack a Pega status
-  champva_confirmation_email_bugfix:
-    actor_type: user
-    description: Enables fix for a bug where confirmation emails may get sent when Pega reports a status of 'Not Processed'
   champva_enhanced_monitor_logging:
     actor_type: user
     description: Enables using the new IVC CHAMPVA Monitoring logging class for enhanced Stats D info.

--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
@@ -46,15 +46,8 @@ module IvcChampva
           # We only need the first form, outside of the file_names field, the data is the same.
           form = ivc_forms.first
 
-          # rubocop:disable Style/IfInsideElse
-          # Temporarily disabling rubocop because of flipper
-          if Flipper.enabled?(:champva_confirmation_email_bugfix, @user)
-            send_email(form_uuid, ivc_forms.first) if form.email.present? && status == 'Processed'
-            # Possible values for form.pega_status are 'Processed', 'Not Processed'
-          else
-            send_email(form_uuid, ivc_forms.first) if form.email.present?
-          end
-          # rubocop:enable Style/IfInsideElse
+          # Possible values for form.pega_status are 'Processed', 'Not Processed'
+          send_email(form_uuid, ivc_forms.first) if form.email.present? && status == 'Processed'
 
           if Flipper.enabled?(:champva_enhanced_monitor_logging, @current_user)
             monitor.track_update_status(form_uuid, status)

--- a/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/status_updates_spec.rb
+++ b/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/status_updates_spec.rb
@@ -146,164 +146,82 @@ RSpec.describe 'IvcChampva::V1::Forms::StatusUpdates', type: :request do
       end
     end
 
-    context 'Feature champva_confirmation_email_bugfix=true' do
+    context 'with valid payload and status of Not Processed' do
+      let(:valid_payload_with_status_of_not_processed) do
+        {
+          form_uuid: '12345678-1234-5678-1234-567812345678',
+          file_names: ['12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
+                        '12345678-1234-5678-1234-567812345678_vha_10_10d1.pdf'],
+          case_id: 'ABC-1234',
+          status: 'Not Processed'
+        }
+      end
+
+      let(:email_instance) { instance_double(IvcChampva::Email) }
+
       before do
-        allow(Flipper).to receive(:enabled?).with(:champva_confirmation_email_bugfix, @current_user).and_return(true)
         allow(Flipper).to receive(:enabled?).with(:champva_enhanced_monitor_logging, @current_user).and_return(false)
+        allow_any_instance_of(IvcChampva::Email).to receive(:valid_environment?).and_return(true)
+        allow(IvcChampva::Email).to receive(:new).and_return(email_instance)
+        allow(email_instance).to receive(:send_email).and_return(true)
       end
 
-      let(:valid_payload_with_status_of_not_processed) do
-        {
+      it 'returns HTTP status 200 with same form_uuid but not all files and sends no email' do
+        IvcChampvaForm.delete_all
+        IvcChampvaForm.create!(
           form_uuid: '12345678-1234-5678-1234-567812345678',
-          file_names: ['12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
-                       '12345678-1234-5678-1234-567812345678_vha_10_10d1.pdf'],
-          case_id: 'ABC-1234',
-          status: 'Not Processed'
-        }
-      end
+          email: 'test@email.com',
+          first_name: 'Veteran',
+          last_name: 'Surname',
+          form_number: '10-10D',
+          file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
+          s3_status: 'Submitted',
+          pega_status: nil,
+          case_id: nil,
+          email_sent: false
+        )
 
-      let(:email_instance) { instance_double(IvcChampva::Email) }
-
-      context 'with valid payload and status of Not Processed' do
-        before do
-          allow_any_instance_of(IvcChampva::Email).to receive(:valid_environment?).and_return(true)
-          allow(IvcChampva::Email).to receive(:new).and_return(email_instance)
-          allow(email_instance).to receive(:send_email).and_return(true)
-        end
-
-        it 'returns HTTP status 200 with same form_uuid but not all files and sends no email' do
-          IvcChampvaForm.delete_all
-          IvcChampvaForm.create!(
-            form_uuid: '12345678-1234-5678-1234-567812345678',
-            email: 'test@email.com',
-            first_name: 'Veteran',
-            last_name: 'Surname',
-            form_number: '10-10D',
-            file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
-            s3_status: 'Submitted',
-            pega_status: nil,
-            case_id: nil,
-            email_sent: false
-          )
-
-          IvcChampvaForm.create!(
-            form_uuid: '12345678-1234-5678-1234-567812345678',
-            email: 'test@email.com',
-            first_name: 'Veteran',
-            last_name: 'Surname',
-            form_number: '10-10D',
-            file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d1.pdf',
-            s3_status: 'Submitted',
-            pega_status: nil,
-            case_id: nil,
-            email_sent: false
-          )
-
-          IvcChampvaForm.create!(
-            form_uuid: '12345678-1234-5678-1234-567812345678',
-            email: 'test@email.com',
-            first_name: 'Veteran',
-            last_name: 'Surname',
-            form_number: '10-10D',
-            file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d2.pdf',
-            s3_status: 'Submitted',
-            pega_status: nil,
-            case_id: nil,
-            email_sent: false
-          )
-
-          post '/ivc_champva/v1/forms/status_updates', params: valid_payload_with_status_of_not_processed
-
-          # an email should not be sent
-          expect(email_instance).not_to have_received(:send_email)
-
-          ivc_forms = [IvcChampvaForm.all]
-          status_array = ivc_forms.map { |form| form.pluck(:pega_status) }
-          case_id_array = ivc_forms.map { |form| form.pluck(:case_id) }
-          email_sent_array = ivc_forms.map { |form| form.pluck(:email_sent) }
-
-          # only 2/3 should be updated
-          expect(status_array.flatten.compact!).to eq(['Not Processed', 'Not Processed'])
-          expect(case_id_array.flatten.compact!).to eq(%w[ABC-1234 ABC-1234])
-          expect(email_sent_array.flatten).to eq([false, false, false])
-          expect(response).to have_http_status(:ok)
-        end
-      end
-    end
-
-    context 'Feature champva_confirmation_email_bugfix=false' do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:champva_confirmation_email_bugfix, @current_user).and_return(false)
-        allow(Flipper).to receive(:enabled?).with(
-          :champva_vanotify_custom_confirmation_callback, @current_user
-        ).and_return(false)
-      end
-
-      let(:valid_payload_with_status_of_not_processed) do
-        {
+        IvcChampvaForm.create!(
           form_uuid: '12345678-1234-5678-1234-567812345678',
-          file_names: ['12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
-                       '12345678-1234-5678-1234-567812345678_vha_10_10d1.pdf'],
-          case_id: 'ABC-1234',
-          status: 'Not Processed'
-        }
-      end
+          email: 'test@email.com',
+          first_name: 'Veteran',
+          last_name: 'Surname',
+          form_number: '10-10D',
+          file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d1.pdf',
+          s3_status: 'Submitted',
+          pega_status: nil,
+          case_id: nil,
+          email_sent: false
+        )
 
-      let(:email_instance) { instance_double(IvcChampva::Email) }
+        IvcChampvaForm.create!(
+          form_uuid: '12345678-1234-5678-1234-567812345678',
+          email: 'test@email.com',
+          first_name: 'Veteran',
+          last_name: 'Surname',
+          form_number: '10-10D',
+          file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d2.pdf',
+          s3_status: 'Submitted',
+          pega_status: nil,
+          case_id: nil,
+          email_sent: false
+        )
 
-      context 'with valid payload and status of Not Processed' do
-        before do
-          allow_any_instance_of(IvcChampva::Email).to receive(:valid_environment?).and_return(true)
-          allow(IvcChampva::Email).to receive(:new).and_return(email_instance)
-          allow(email_instance).to receive(:send_email).and_return(true)
-        end
+        post '/ivc_champva/v1/forms/status_updates', params: valid_payload_with_status_of_not_processed
 
-        it 'returns HTTP status 200 with same form_uuid but not all files and incorrectly sends success email' do
-          IvcChampvaForm.delete_all
-          IvcChampvaForm.create!(
-            form_uuid: '12345678-1234-5678-1234-567812345678',
-            email: 'test@email.com',
-            first_name: 'Veteran',
-            last_name: 'Surname',
-            form_number: '10-10D',
-            file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
-            s3_status: 'Submitted',
-            pega_status: nil,
-            case_id: nil,
-            email_sent: false
-          )
+        # an email should not be sent
+        expect(email_instance).not_to have_received(:send_email)
 
-          IvcChampvaForm.create!(
-            form_uuid: '12345678-1234-5678-1234-567812345678',
-            email: 'test@email.com',
-            first_name: 'Veteran',
-            last_name: 'Surname',
-            form_number: '10-10D',
-            file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d1.pdf',
-            s3_status: 'Submitted',
-            pega_status: nil,
-            case_id: nil,
-            email_sent: false
-          )
+        ivc_forms = [IvcChampvaForm.all]
+        status_array = ivc_forms.map { |form| form.pluck(:pega_status) }
+        case_id_array = ivc_forms.map { |form| form.pluck(:case_id) }
+        email_sent_array = ivc_forms.map { |form| form.pluck(:email_sent) }
 
-          IvcChampvaForm.create!(
-            form_uuid: '12345678-1234-5678-1234-567812345678',
-            email: 'test@email.com',
-            first_name: 'Veteran',
-            last_name: 'Surname',
-            form_number: '10-10D',
-            file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d2.pdf',
-            s3_status: 'Submitted',
-            pega_status: nil,
-            case_id: nil,
-            email_sent: false
-          )
-
-          # with the toggle disabled, we should see an email sent
-          expect(IvcChampva::Email).to receive(:new).once
-
-          post '/ivc_champva/v1/forms/status_updates', params: valid_payload_with_status_of_not_processed
-        end
+        # only 2/3 should be updated
+        expect(status_array.flatten.compact!).to eq(['Not Processed', 'Not Processed'])
+        expect(case_id_array.flatten.compact!).to eq(%w[ABC-1234 ABC-1234])
+        expect(email_sent_array.flatten).to eq([false, false, false])
+        expect(response).to have_http_status(:ok)
       end
     end
 

--- a/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/status_updates_spec.rb
+++ b/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/status_updates_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe 'IvcChampva::V1::Forms::StatusUpdates', type: :request do
         {
           form_uuid: '12345678-1234-5678-1234-567812345678',
           file_names: ['12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
-                        '12345678-1234-5678-1234-567812345678_vha_10_10d1.pdf'],
+                       '12345678-1234-5678-1234-567812345678_vha_10_10d1.pdf'],
           case_id: 'ABC-1234',
           status: 'Not Processed'
         }


### PR DESCRIPTION
## Summary

This PR removes the `champva_confirmation_email_bugfix` flipper that has been fully enabled in production for some months now.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/104641

## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA