### PR TITLE
Fix retry loop in AccreditedRepresentativePortal::PowerOfAttorneyRequestEmailJob

### DIFF
--- a/modules/accredited_representative_portal/app/sidekiq/accredited_representative_portal/power_of_attorney_request_email_job.rb
+++ b/modules/accredited_representative_portal/app/sidekiq/accredited_representative_portal/power_of_attorney_request_email_job.rb
@@ -31,7 +31,7 @@ module AccreditedRepresentativePortal
           personalisation: personalisation || poa_request_notification.personalisation
         }.compact
       )
-      poa_request_notification.update!(notification_id: response['id'])
+      poa_request_notification.update!(notification_id: response.id)
     rescue VANotify::Error => e
       handle_backend_exception(e, template_id)
     end

--- a/modules/accredited_representative_portal/spec/sidekiq/accredited_representative_portal/power_of_attorney_request_email_job_spec.rb
+++ b/modules/accredited_representative_portal/spec/sidekiq/accredited_representative_portal/power_of_attorney_request_email_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestEmailJob, t
   let(:type) { 'declined' }
   let(:personalisation) { { 'name' => 'Test User' } }
   let(:api_key) { 'test-api-key' }
-  let(:response) { { 'id' => Faker::Internet.uuid } }
+  let(:response) { Struct.new(:id).new(Faker::Internet.uuid) }
   let(:client) { instance_double(VaNotify::Service) }
 
   before do
@@ -31,7 +31,7 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequestEmailJob, t
                                   api_key)
 
       power_of_attorney_request_notification.reload
-      expect(power_of_attorney_request_notification.notification_id).to eq(response['id'])
+      expect(power_of_attorney_request_notification.notification_id).to eq(response.id)
     end
 
     it 'handles VANotify::Error with status code 400 and does not update the poa_request_notification record' do


### PR DESCRIPTION
The VA Notify team pointed out to us that the response is a ruby object, not a hash.  The hash code here was causing the email job to error and retry, resending the email every time.

## Summary

- *This work is behind a feature toggle (flipper): YES*
- *(Summarize the changes that have been made to the platform)*: This PR just changes the method of accessing the response object from a hash to an object.  `.id` vs `['id']`.
- *(If bug, how to reproduce)* Triggering the digital submit confirmation or declination email now will cause the email job to get stuck in a retry loop.
- *(What is the solution, why is this the solution?)*: We were advised by the VA Notify team that the response will be a ruby object.  I had previously thought it was a hash, but I couldn't find the documentation that caused me to take that leap in the first place.
- *(Which team do you work for, does your team own the maintenance of this component?)*: FAR/ARM, yes we own the maintenance.
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/105296
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*: Triggering an email would cause a retry loop in the email job.
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*: Trigger a digital submit confirmation or declination email, you should only receive it once.
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*: This only touches the `AccreditedRepresentativePortal` module.

## Acceptance criteria

- [x]  I updated unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
