### PR TITLE
Refactor ExtrasGenerator redesign code into ExtrasGeneratorV2

### DIFF
--- a/lib/pdf_fill/extras_generator.rb
+++ b/lib/pdf_fill/extras_generator.rb
@@ -2,18 +2,8 @@
 
 module PdfFill
   class ExtrasGenerator
-    HEADER_FONT_SIZE = 14.5
-    SUBHEADER_FONT_SIZE = 10.5
-
-    attr_reader :extras_redesign
-
-    def initialize(extras_redesign: false, form_name: nil, submit_date: nil, start_page: 1, sections: nil)
+    def initialize
       @generate_blocks = []
-      @extras_redesign = extras_redesign
-      @form_name = form_name
-      @submit_date = format_date(submit_date)
-      @start_page = start_page
-      @sections = sections
     end
 
     def create_block(value, metadata)
@@ -25,13 +15,13 @@ module PdfFill
         i = metadata[:i]
         prefix += " Line #{i + 1}" if i.present?
 
-        pdf.text("#{prefix}:", { style: extras_redesign ? :normal : :bold })
-        pdf.text(value.to_s, { style: extras_redesign ? :bold : :normal })
+        pdf.text("#{prefix}:", { style: :bold })
+        pdf.text(value.to_s, { style: :normal })
       end
     end
 
     def add_text(value, metadata)
-      unless text? || extras_redesign
+      unless text?
         @generate_blocks << {
           metadata: {},
           block: lambda do |pdf|
@@ -48,17 +38,6 @@ module PdfFill
 
     def text?
       @generate_blocks.size.positive?
-    end
-
-    def populate_section_indices!
-      return if @sections.blank?
-
-      @generate_blocks.each do |generate_block|
-        metadata = generate_block[:metadata]
-        if metadata[:top_level_key].present?
-          metadata[:section_index] = @sections.index { |sec| sec[:top_level_keys].include?(metadata[:top_level_key]) }
-        end
-      end
     end
 
     def sort_generate_blocks
@@ -84,42 +63,13 @@ module PdfFill
       pdf.font('Roboto')
     end
 
-    def set_header(pdf)
-      pdf.repeat :all do
-        bound_width = pdf.bounds.width / 2
-        location = [pdf.bounds.left, pdf.bounds.top]
-        write_header_main(pdf, location, bound_width, HEADER_FONT_SIZE)
-        if @submit_date.present?
-          location[0] += bound_width
-          write_header_submit_date(pdf, location, bound_width, HEADER_FONT_SIZE)
-        end
-        pdf.pad_top(2) { pdf.stroke_horizontal_rule }
-      end
-    end
-
-    def add_page_numbers(pdf)
-      pdf.number_pages('Page <page>',
-                       start_count_at: @start_page,
-                       at: [pdf.bounds.right - 50, 0],
-                       align: :right,
-                       size: 9)
-    end
-
-    def generate_pdf(file_path, generate_blocks)
+    def generate_pdf(file_path)
+      generate_blocks = sort_generate_blocks
       Prawn::Document.generate(file_path) do |pdf|
         set_font(pdf)
-        set_header(pdf) if extras_redesign
 
         render_pdf_content(pdf, generate_blocks)
-        add_page_numbers(pdf) if extras_redesign
       end
-    end
-
-    def render_new_section(pdf, section_index)
-      return unless @extras_redesign && @sections.present?
-
-      pdf.move_down(20)
-      pdf.text(@sections[section_index][:label], { size: 14 })
     end
 
     def render_pdf_content(pdf, generate_blocks)
@@ -145,42 +95,8 @@ module PdfFill
       folder = 'tmp/pdfs'
       FileUtils.mkdir_p(folder)
       file_path = "#{folder}/extras_#{SecureRandom.uuid}.pdf"
-      populate_section_indices!
-      generate_blocks = sort_generate_blocks
-      generate_pdf(file_path, generate_blocks)
+      generate_pdf(file_path)
       file_path
-    end
-
-    def write_header_main(pdf, location, bound_width, bound_height)
-      pdf.bounding_box(location, width: bound_width, height: bound_height) do
-        pdf.text("<b>ATTACHMENT</b> to VA Form #{@form_name}",
-                 align: :left,
-                 valign: :bottom,
-                 size: bound_height,
-                 inline_format: true)
-      end
-    end
-
-    def write_header_submit_date(pdf, location, bound_width, bound_height)
-      pdf.bounding_box(location, width: bound_width, height: bound_height) do
-        pdf.text("Submitted on VA.gov on #{@submit_date}",
-                 align: :right,
-                 valign: :bottom,
-                 size: SUBHEADER_FONT_SIZE)
-      end
-    end
-
-    # Formats the submit_date for the PDF header
-    def format_date(date)
-      return nil if date.blank?
-
-      return "#{date['month']}-#{date['day']}-#{date['year']}" if date.is_a?(Hash)
-      return date.strftime('%m-%d-%Y') if date.is_a?(Date)
-
-      Date.parse(date).strftime('%m-%d-%Y')
-    rescue
-      Rails.logger.error("Error formatting submit date for PdfFill: #{date}")
-      nil
     end
   end
 end

--- a/lib/pdf_fill/extras_generator_v2.rb
+++ b/lib/pdf_fill/extras_generator_v2.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+module PdfFill
+  class ExtrasGeneratorV2 < ExtrasGenerator
+    HEADER_FONT_SIZE = 14.5
+    SUBHEADER_FONT_SIZE = 10.5
+
+    def initialize(form_name: nil, submit_date: nil, start_page: 1, sections: nil)
+      super()
+      @form_name = form_name
+      @submit_date = format_date(submit_date)
+      @start_page = start_page
+      @sections = sections
+    end
+
+    def create_block(value, metadata)
+      lambda do |pdf|
+        pdf.move_down(10)
+        prefix = metadata[:question_num].to_s
+        prefix += metadata[:question_suffix] if metadata[:question_suffix].present?
+        prefix = "#{prefix}. #{metadata[:question_text].humanize}"
+        i = metadata[:i]
+        prefix += " Line #{i + 1}" if i.present?
+
+        pdf.text("#{prefix}:", { style: :normal })
+        pdf.text(value.to_s, { style: :bold })
+      end
+    end
+
+    def add_text(value, metadata)
+      @generate_blocks << {
+        metadata:,
+        block: create_block(value, metadata)
+      }
+    end
+
+    def populate_section_indices!
+      return if @sections.blank?
+
+      @generate_blocks.each do |generate_block|
+        metadata = generate_block[:metadata]
+        if metadata[:top_level_key].present?
+          metadata[:section_index] = @sections.index { |sec| sec[:top_level_keys].include?(metadata[:top_level_key]) }
+        end
+      end
+    end
+
+    def generate_pdf(file_path)
+      populate_section_indices!
+      generate_blocks = sort_generate_blocks
+      Prawn::Document.generate(file_path) do |pdf|
+        set_font(pdf)
+        set_header(pdf)
+
+        render_pdf_content(pdf, generate_blocks)
+        add_page_numbers(pdf)
+      end
+    end
+
+    def render_new_section(pdf, section_index)
+      return if @sections.blank?
+
+      pdf.move_down(20)
+      pdf.text(@sections[section_index][:label], { size: 14 })
+    end
+
+    def set_header(pdf)
+      pdf.repeat :all do
+        bound_width = pdf.bounds.width / 2
+        location = [pdf.bounds.left, pdf.bounds.top]
+        write_header_main(pdf, location, bound_width, HEADER_FONT_SIZE)
+        if @submit_date.present?
+          location[0] += bound_width
+          write_header_submit_date(pdf, location, bound_width, HEADER_FONT_SIZE)
+        end
+        pdf.pad_top(2) { pdf.stroke_horizontal_rule }
+      end
+    end
+
+    def add_page_numbers(pdf)
+      pdf.number_pages('Page <page>',
+                       start_count_at: @start_page,
+                       at: [pdf.bounds.right - 50, 0],
+                       align: :right,
+                       size: 9)
+    end
+
+    def write_header_main(pdf, location, bound_width, bound_height)
+      pdf.bounding_box(location, width: bound_width, height: bound_height) do
+        pdf.text("<b>ATTACHMENT</b> to VA Form #{@form_name}",
+                 align: :left,
+                 valign: :bottom,
+                 size: bound_height,
+                 inline_format: true)
+      end
+    end
+
+    def write_header_submit_date(pdf, location, bound_width, bound_height)
+      pdf.bounding_box(location, width: bound_width, height: bound_height) do
+        pdf.text("Submitted on VA.gov on #{@submit_date}",
+                 align: :right,
+                 valign: :bottom,
+                 size: SUBHEADER_FONT_SIZE)
+      end
+    end
+
+    # Formats the submit_date for the PDF header
+    def format_date(date)
+      return nil if date.blank?
+
+      return "#{date['month']}-#{date['day']}-#{date['year']}" if date.is_a?(Hash)
+      return date.strftime('%m-%d-%Y') if date.is_a?(Date)
+
+      Date.parse(date).strftime('%m-%d-%Y')
+    rescue
+      Rails.logger.error("Error formatting submit date for PdfFill: #{date}")
+      nil
+    end
+  end
+end

--- a/lib/pdf_fill/hash_converter.rb
+++ b/lib/pdf_fill/hash_converter.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'pdf_fill/extras_generator'
 require 'pdf_fill/form_value'
 
 # frozen_string_literal: true

--- a/spec/lib/pdf_fill/extras_generator_spec.rb
+++ b/spec/lib/pdf_fill/extras_generator_spec.rb
@@ -4,34 +4,7 @@ require 'rails_helper'
 require 'pdf_fill/extras_generator'
 
 describe PdfFill::ExtrasGenerator do
-  subject { described_class.new(sections:) }
-
-  let(:sections) { nil }
-
-  describe '#populate_section_indices!' do
-    let(:sections) do
-      [
-        {
-          label: 'Section I',
-          top_level_keys: %w[veteranFullName vaFileNumber veteranDateOfBirth]
-        },
-        {
-          label: 'Section II',
-          top_level_keys: ['events']
-        }
-      ]
-    end
-
-    it 'populates section indices correctly' do
-      blocks = %w[veteranFullName events evidence vaFileNumber].map do |top_level_key|
-        { metadata: { top_level_key: } }
-      end
-      subject.instance_variable_set(:@generate_blocks, blocks)
-      subject.populate_section_indices!
-      indices = subject.instance_variable_get(:@generate_blocks).map { |block| block[:metadata][:section_index] }
-      expect(indices).to eq([0, 1, nil, 0])
-    end
-  end
+  subject { described_class.new }
 
   describe '#sort_generate_blocks' do
     let(:metadatas) do
@@ -128,96 +101,6 @@ describe PdfFill::ExtrasGenerator do
       ).to be(true)
 
       File.delete(file_path)
-    end
-  end
-
-  describe '#add_page_numbers' do
-    subject { described_class.new(start_page: 8, extras_redesign: true) }
-
-    let(:pdf) { instance_double(Prawn::Document, bounds: double('Bounds', right: 400)) }
-
-    it 'adds page numbers starting at @start_page' do
-      expect(pdf).to receive(:number_pages).with(
-        'Page <page>',
-        start_count_at: 8,
-        at: [400 - 50, 0],
-        align: :right,
-        size: 9
-      )
-
-      subject.add_page_numbers(pdf)
-    end
-  end
-
-  # frozen_string_literal: true
-  describe '#set_header' do
-    subject { described_class.new(form_name:, submit_date:, extras_redesign: true) }
-
-    let(:form_name) { 'TEST' }
-    let(:submit_date) { nil }
-    let(:pdf) { instance_double(Prawn::Document, bounds: double('Bounds', width: 500, top: 700, left: 0, right: 500)) }
-    let(:header_font_size) { described_class::HEADER_FONT_SIZE }
-    let(:subheader_font_size) { described_class::SUBHEADER_FONT_SIZE }
-
-    before do
-      allow(pdf).to receive(:repeat).and_yield
-      allow(pdf).to receive(:bounding_box).and_yield
-      allow(pdf).to receive(:text)
-      allow(pdf).to receive(:pad_top).and_yield
-      allow(pdf).to receive(:stroke_horizontal_rule)
-    end
-
-    context 'when submit_date is not present' do
-      it 'adds the header text correctly' do
-        subject.set_header(pdf)
-        expect(pdf).to have_received(:text).with("<b>ATTACHMENT</b> to VA Form #{form_name}",
-                                                 align: :left, valign: :bottom, size: header_font_size,
-                                                 inline_format: true)
-        expect(pdf).not_to have_received(:text).with('Submitted on VA.gov on 12-25-2020',
-                                                     align: :right, valign: :bottom, size: subheader_font_size)
-        expect(pdf).to have_received(:stroke_horizontal_rule)
-      end
-    end
-
-    context 'when submit_date is present' do
-      let(:submit_date) { { 'month' => '12', 'day' => '25', 'year' => '2020' } }
-
-      it 'adds the header text correctly' do
-        subject.set_header(pdf)
-        expect(pdf).to have_received(:text).with("<b>ATTACHMENT</b> to VA Form #{form_name}",
-                                                 align: :left, valign: :bottom, size: header_font_size,
-                                                 inline_format: true)
-        expect(pdf).to have_received(:text).with('Submitted on VA.gov on 12-25-2020',
-                                                 align: :right, valign: :bottom, size: subheader_font_size)
-        expect(pdf).to have_received(:stroke_horizontal_rule)
-      end
-    end
-  end
-
-  describe '#format_date' do
-    it 'returns nil for blank date' do
-      expect(subject.send(:format_date, nil)).to be_nil
-      expect(subject.send(:format_date, '')).to be_nil
-    end
-
-    it 'formats date from hash' do
-      date_hash = { 'month' => '12', 'day' => '25', 'year' => '2020' }
-      expect(subject.send(:format_date, date_hash)).to eq('12-25-2020')
-    end
-
-    it 'formats date from Date object' do
-      date_obj = Date.new(2020, 12, 25)
-      expect(subject.send(:format_date, date_obj)).to eq('12-25-2020')
-    end
-
-    it 'formats date from string' do
-      date_str = '2020-12-25'
-      expect(subject.send(:format_date, date_str)).to eq('12-25-2020')
-    end
-
-    it 'returns nil for invalid date string' do
-      invalid_date_str = 'invalid-date'
-      expect(subject.send(:format_date, invalid_date_str)).to be_nil
     end
   end
 end

--- a/spec/lib/pdf_fill/extras_generator_spec.rb
+++ b/spec/lib/pdf_fill/extras_generator_spec.rb
@@ -52,26 +52,6 @@ describe PdfFill::ExtrasGenerator do
         expect(generate_block[:metadata]).to eq(metadatas[i])
       end
     end
-
-    context 'when section metadata is provided' do
-      let(:metadatas) do
-        [
-          { section_index: 0, question_num: 2, question_suffix: 'A', question_text: 'First Name' },
-          { section_index: 0, question_num: 2, question_suffix: 'B', question_text: 'Last Name' },
-          { section_index: 0, question_num: 3, question_text: 'Email Address' },
-          { section_index: 1, question_num: 1, question_text: 'Remarks' },
-          { section_index: 1, question_num: 4, question_text: 'Additional Remarks' }
-        ]
-      end
-
-      it 'sorts the blocks correctly, even if question numbers are jumbled' do
-        subject.instance_variable_set(:@generate_blocks, metadatas.reverse.map { |metadata| { metadata: } })
-
-        subject.sort_generate_blocks.each_with_index do |generate_block, i|
-          expect(generate_block[:metadata]).to eq(metadatas[i])
-        end
-      end
-    end
   end
 
   describe '#generate' do

--- a/spec/lib/pdf_fill/extras_generator_v2_spec.rb
+++ b/spec/lib/pdf_fill/extras_generator_v2_spec.rb
@@ -33,6 +33,28 @@ describe PdfFill::ExtrasGeneratorV2 do
     end
   end
 
+  describe '#sort_generate_blocks' do
+    context 'when section metadata is provided' do
+      let(:metadatas) do
+        [
+          { section_index: 0, question_num: 2, question_suffix: 'A', question_text: 'First Name' },
+          { section_index: 0, question_num: 2, question_suffix: 'B', question_text: 'Last Name' },
+          { section_index: 0, question_num: 3, question_text: 'Email Address' },
+          { section_index: 1, question_num: 1, question_text: 'Remarks' },
+          { section_index: 1, question_num: 4, question_text: 'Additional Remarks' }
+        ]
+      end
+
+      it 'sorts the blocks correctly, even if question numbers are jumbled' do
+        subject.instance_variable_set(:@generate_blocks, metadatas.reverse.map { |metadata| { metadata: } })
+
+        subject.sort_generate_blocks.each_with_index do |generate_block, i|
+          expect(generate_block[:metadata]).to eq(metadatas[i])
+        end
+      end
+    end
+  end
+
   describe '#add_page_numbers' do
     subject { described_class.new(start_page: 8) }
 

--- a/spec/lib/pdf_fill/extras_generator_v2_spec.rb
+++ b/spec/lib/pdf_fill/extras_generator_v2_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'pdf_fill/extras_generator_v2'
+
+describe PdfFill::ExtrasGeneratorV2 do
+  subject { described_class.new(sections:) }
+
+  let(:sections) { nil }
+
+  describe '#populate_section_indices!' do
+    let(:sections) do
+      [
+        {
+          label: 'Section I',
+          top_level_keys: %w[veteranFullName vaFileNumber veteranDateOfBirth]
+        },
+        {
+          label: 'Section II',
+          top_level_keys: ['events']
+        }
+      ]
+    end
+
+    it 'populates section indices correctly' do
+      blocks = %w[veteranFullName events evidence vaFileNumber].map do |top_level_key|
+        { metadata: { top_level_key: } }
+      end
+      subject.instance_variable_set(:@generate_blocks, blocks)
+      subject.populate_section_indices!
+      indices = subject.instance_variable_get(:@generate_blocks).map { |block| block[:metadata][:section_index] }
+      expect(indices).to eq([0, 1, nil, 0])
+    end
+  end
+
+  describe '#add_page_numbers' do
+    subject { described_class.new(start_page: 8) }
+
+    let(:pdf) { instance_double(Prawn::Document, bounds: double('Bounds', right: 400)) }
+
+    it 'adds page numbers starting at @start_page' do
+      expect(pdf).to receive(:number_pages).with(
+        'Page <page>',
+        start_count_at: 8,
+        at: [400 - 50, 0],
+        align: :right,
+        size: 9
+      )
+
+      subject.add_page_numbers(pdf)
+    end
+  end
+
+  describe '#set_header' do
+    subject { described_class.new(form_name:, submit_date:) }
+
+    let(:form_name) { 'TEST' }
+    let(:submit_date) { nil }
+    let(:pdf) { instance_double(Prawn::Document, bounds: double('Bounds', width: 500, top: 700, left: 0, right: 500)) }
+    let(:header_font_size) { described_class::HEADER_FONT_SIZE }
+    let(:subheader_font_size) { described_class::SUBHEADER_FONT_SIZE }
+
+    before do
+      allow(pdf).to receive(:repeat).and_yield
+      allow(pdf).to receive(:bounding_box).and_yield
+      allow(pdf).to receive(:text)
+      allow(pdf).to receive(:pad_top).and_yield
+      allow(pdf).to receive(:stroke_horizontal_rule)
+    end
+
+    context 'when submit_date is not present' do
+      it 'adds the header text correctly' do
+        subject.set_header(pdf)
+        expect(pdf).to have_received(:text).with("<b>ATTACHMENT</b> to VA Form #{form_name}",
+                                                 align: :left, valign: :bottom, size: header_font_size,
+                                                 inline_format: true)
+        expect(pdf).not_to have_received(:text).with('Submitted on VA.gov on 12-25-2020',
+                                                     align: :right, valign: :bottom, size: subheader_font_size)
+        expect(pdf).to have_received(:stroke_horizontal_rule)
+      end
+    end
+
+    context 'when submit_date is present' do
+      let(:submit_date) { { 'month' => '12', 'day' => '25', 'year' => '2020' } }
+
+      it 'adds the header text correctly' do
+        subject.set_header(pdf)
+        expect(pdf).to have_received(:text).with("<b>ATTACHMENT</b> to VA Form #{form_name}",
+                                                 align: :left, valign: :bottom, size: header_font_size,
+                                                 inline_format: true)
+        expect(pdf).to have_received(:text).with('Submitted on VA.gov on 12-25-2020',
+                                                 align: :right, valign: :bottom, size: subheader_font_size)
+        expect(pdf).to have_received(:stroke_horizontal_rule)
+      end
+    end
+  end
+
+  describe '#format_date' do
+    it 'returns nil for blank date' do
+      expect(subject.send(:format_date, nil)).to be_nil
+      expect(subject.send(:format_date, '')).to be_nil
+    end
+
+    it 'formats date from hash' do
+      date_hash = { 'month' => '12', 'day' => '25', 'year' => '2020' }
+      expect(subject.send(:format_date, date_hash)).to eq('12-25-2020')
+    end
+
+    it 'formats date from Date object' do
+      date_obj = Date.new(2020, 12, 25)
+      expect(subject.send(:format_date, date_obj)).to eq('12-25-2020')
+    end
+
+    it 'formats date from string' do
+      date_str = '2020-12-25'
+      expect(subject.send(:format_date, date_str)).to eq('12-25-2020')
+    end
+
+    it 'returns nil for invalid date string' do
+      invalid_date_str = 'invalid-date'
+      expect(subject.send(:format_date, invalid_date_str)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO* -- this work is not hooked up to live code paths; when it is, it will be behind a feature toggle.

This PR is a refactor that moves all PDF overflow redesign code in ExtrasGenerator into a new subclass ExtrasGeneratorV2. This effectively reverts ExtrasGenerator to the existing overflow code using the `prawn` PDF renderer, while allowing ExtrasGeneratorV2 to switch to the extended renderer `prawn-markup`. No change to behavior or underlying renderer is introduced here.

I am on the Employee Experience team. The PdfFill codebase is shared library code maintained by Platform.

## Code review notes

The diff is pretty big, but most of it is moving code from ExtrasGenerator to ExtrasGeneratorV2, and the corresponding move in RSpecs. The resulting ExtrasGenerator is very close to its historical state from before any overflow redesign logic was added (in #20628, whose parent commit was 7b04bec). To verify this, use `git` to generate a single-path diff:

```bash
$ git checkout nanotone/extras-generator-refactor
$ git diff -w 7b04bec lib/pdf_fill/extras_generator.rb
# something like +5 lines, -3 lines
```

The difference is essentially an aggregation of all the recent [changes to extras_generator.rb](https://github.com/department-of-veterans-affairs/vets-api/commits/master/lib/pdf_fill/extras_generator.rb), gathered into `extras_generator_v2.rb`.

## Related issue(s)

- department-of-veterans-affairs/abd-vro#4194

## Testing done

- [x] *New code is covered by unit tests*
- All unit tests are preserved and continue to pass after the refactor. In particular, the test fixtures [overflow_extras.pdf](https://github.com/department-of-veterans-affairs/vets-api/blob/master/spec/fixtures/pdf_fill/21-0781V2/overflow_extras.pdf) and [overflow_redesign_extras.pdf](https://github.com/department-of-veterans-affairs/vets-api/blob/master/spec/fixtures/pdf_fill/21-0781V2/overflow_redesign_extras.pdf), used for binary PDF checks, are unchanged.
- In the same vein as the **Code review notes** above, we can verify that `extras_generator_spec.rb` has reverted close to its pre-redesign state:
```bash
$ git checkout nanotone/extras-generator-refactor
$ git diff -w 7b04bec spec/lib/pdf_fill/extras_generator_spec.rb
# something like +5 lines, -5 lines
```

## What areas of the site does it impact?
No behavior change

## Acceptance criteria
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs