### PR TITLE
104641d - Remove `champva_pdf_decrypt` flipper - IVC CHAMPVA forms

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -197,9 +197,6 @@ features:
   champva_log_all_s3_uploads:
     actor_type: user
     description: Enables logging for all s3 uploads using UUID or keys for monitoring
-  champva_pdf_decrypt:
-    actor_type: user
-    description: Enables unlocking password protected file submissions in IVC CHAMPVA forms.
   champva_require_all_s3_success:
     actor_type: user
     description: Enables raising a StandardError if any supporting documents fail to upload to S3 in IVC CHAMPVA forms.

--- a/config/features.yml
+++ b/config/features.yml
@@ -200,9 +200,6 @@ features:
   champva_failure_email_job_enabled:
     actor_type: user
     description: Enables sending failure notification emails for IVC CHAMPVA form submissions that lack a Pega status
-  champva_enhanced_monitor_logging:
-    actor_type: user
-    description: Enables using the new IVC CHAMPVA Monitoring logging class for enhanced Stats D info.
   champva_pdf_decrypt:
     actor_type: user
     description: Enables unlocking password protected file submissions in IVC CHAMPVA forms.

--- a/config/features.yml
+++ b/config/features.yml
@@ -200,9 +200,6 @@ features:
   champva_failure_email_job_enabled:
     actor_type: user
     description: Enables sending failure notification emails for IVC CHAMPVA form submissions that lack a Pega status
-  champva_confirmation_email_bugfix:
-    actor_type: user
-    description: Enables fix for a bug where confirmation emails may get sent when Pega reports a status of 'Not Processed'
   champva_enhanced_monitor_logging:
     actor_type: user
     description: Enables using the new IVC CHAMPVA Monitoring logging class for enhanced Stats D info.

--- a/config/features.yml
+++ b/config/features.yml
@@ -197,9 +197,6 @@ features:
   champva_log_all_s3_uploads:
     actor_type: user
     description: Enables logging for all s3 uploads using UUID or keys for monitoring
-  champva_failure_email_job_enabled:
-    actor_type: user
-    description: Enables sending failure notification emails for IVC CHAMPVA form submissions that lack a Pega status
   champva_pdf_decrypt:
     actor_type: user
     description: Enables unlocking password protected file submissions in IVC CHAMPVA forms.

--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
@@ -46,15 +46,8 @@ module IvcChampva
           # We only need the first form, outside of the file_names field, the data is the same.
           form = ivc_forms.first
 
-          # rubocop:disable Style/IfInsideElse
-          # Temporarily disabling rubocop because of flipper
-          if Flipper.enabled?(:champva_confirmation_email_bugfix, @user)
-            send_email(form_uuid, ivc_forms.first) if form.email.present? && status == 'Processed'
-            # Possible values for form.pega_status are 'Processed', 'Not Processed'
-          else
-            send_email(form_uuid, ivc_forms.first) if form.email.present?
-          end
-          # rubocop:enable Style/IfInsideElse
+          # Possible values for form.pega_status are 'Processed', 'Not Processed'
+          send_email(form_uuid, ivc_forms.first) if form.email.present? && status == 'Processed'
 
           if Flipper.enabled?(:champva_enhanced_monitor_logging, @current_user)
             monitor.track_update_status(form_uuid, status)

--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
@@ -49,9 +49,7 @@ module IvcChampva
           # Possible values for form.pega_status are 'Processed', 'Not Processed'
           send_email(form_uuid, ivc_forms.first) if form.email.present? && status == 'Processed'
 
-          if Flipper.enabled?(:champva_enhanced_monitor_logging, @current_user)
-            monitor.track_update_status(form_uuid, status)
-          end
+          monitor.track_update_status(form_uuid, status)
 
           { json: {}, status: :ok }
         else

--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
@@ -77,13 +77,8 @@ module IvcChampva
         if %w[10-10D 10-7959C 10-7959F-2 10-7959A].include?(params[:form_id])
           attachment = PersistentAttachments::MilitaryRecords.new(form_id: params[:form_id])
 
-          if Flipper.enabled?(:champva_pdf_decrypt, @current_user)
-            unlocked = unlock_file(params['file'], params['password'])
-            attachment.file = params['password'] ? unlocked : params['file']
-          else
-            attachment.file = params['file']
-          end
-
+          unlocked = unlock_file(params['file'], params['password'])
+          attachment.file = params['password'] ? unlocked : params['file']
           raise Common::Exceptions::ValidationErrors, attachment unless attachment.valid?
 
           attachment.save

--- a/modules/ivc_champva/app/services/ivc_champva/attachments.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/attachments.rb
@@ -22,23 +22,12 @@ module IvcChampva
                           "#{uuid}_#{form_id}_supporting_doc-#{index}.pdf"
                         end
 
-        new_file_path = if Flipper.enabled?(:champva_pdf_decrypt, @current_user)
-                          Rails.logger.info("IVC ChampVA Forms - Attachment #{index} is using decrypt path")
-                          File.join('tmp', new_file_name)
-                        else
-                          Rails.logger.info("IVC ChampVA Forms - Attachment #{index} is using original path")
-                          File.join(File.dirname(attachment), new_file_name)
-                        end
+        new_file_path = File.join('tmp', new_file_name)
 
-        if Flipper.enabled?(:champva_pdf_decrypt, @current_user)
-          # Use FileUtils.mv to handle `Errno::EXDEV` error since encrypted PDFs
-          # get stashed in the clamav_tmp dir which is a different device on staging, apparently
-          Rails.logger.info("IVC ChampVA Forms - Handling attachment #{index} via mv")
-          FileUtils.mv(attachment, new_file_path) # Performs a copy automatically if mv fails
-        else
-          Rails.logger.info("IVC ChampVA Forms - Handling attachment #{index} via rename")
-          File.rename(attachment, new_file_path)
-        end
+        # Use FileUtils.mv to handle `Errno::EXDEV` error since encrypted PDFs
+        # get stashed in the clamav_tmp dir which is a different device on staging, apparently
+        Rails.logger.info("IVC ChampVA Forms - Handling attachment #{index} via mv")
+        FileUtils.mv(attachment, new_file_path) # Performs a copy automatically if mv fails
 
         file_paths << new_file_path
       rescue Errno::ENOENT # File.rename and FileUtils.mv throw this error when a file is not found

--- a/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
@@ -100,9 +100,7 @@ module IvcChampva
         pega_status:
       )
 
-      if Flipper.enabled?(:champva_enhanced_monitor_logging, @current_user)
-        monitor.track_insert_form(@metadata['uuid'], @form_id)
-      end
+      monitor.track_insert_form(@metadata['uuid'], @form_id)
     rescue ActiveRecord::RecordInvalid => e
       Rails.logger.error("Database Insertion Error for #{@metadata['uuid']}: #{e.message}")
     end

--- a/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/status_updates_spec.rb
+++ b/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/status_updates_spec.rb
@@ -146,164 +146,82 @@ RSpec.describe 'IvcChampva::V1::Forms::StatusUpdates', type: :request do
       end
     end
 
-    context 'Feature champva_confirmation_email_bugfix=true' do
+    context 'with valid payload and status of Not Processed' do
+      let(:valid_payload_with_status_of_not_processed) do
+        {
+          form_uuid: '12345678-1234-5678-1234-567812345678',
+          file_names: ['12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
+                        '12345678-1234-5678-1234-567812345678_vha_10_10d1.pdf'],
+          case_id: 'ABC-1234',
+          status: 'Not Processed'
+        }
+      end
+
+      let(:email_instance) { instance_double(IvcChampva::Email) }
+
       before do
-        allow(Flipper).to receive(:enabled?).with(:champva_confirmation_email_bugfix, @current_user).and_return(true)
         allow(Flipper).to receive(:enabled?).with(:champva_enhanced_monitor_logging, @current_user).and_return(false)
+        allow_any_instance_of(IvcChampva::Email).to receive(:valid_environment?).and_return(true)
+        allow(IvcChampva::Email).to receive(:new).and_return(email_instance)
+        allow(email_instance).to receive(:send_email).and_return(true)
       end
 
-      let(:valid_payload_with_status_of_not_processed) do
-        {
+      it 'returns HTTP status 200 with same form_uuid but not all files and sends no email' do
+        IvcChampvaForm.delete_all
+        IvcChampvaForm.create!(
           form_uuid: '12345678-1234-5678-1234-567812345678',
-          file_names: ['12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
-                       '12345678-1234-5678-1234-567812345678_vha_10_10d1.pdf'],
-          case_id: 'ABC-1234',
-          status: 'Not Processed'
-        }
-      end
+          email: 'test@email.com',
+          first_name: 'Veteran',
+          last_name: 'Surname',
+          form_number: '10-10D',
+          file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
+          s3_status: 'Submitted',
+          pega_status: nil,
+          case_id: nil,
+          email_sent: false
+        )
 
-      let(:email_instance) { instance_double(IvcChampva::Email) }
-
-      context 'with valid payload and status of Not Processed' do
-        before do
-          allow_any_instance_of(IvcChampva::Email).to receive(:valid_environment?).and_return(true)
-          allow(IvcChampva::Email).to receive(:new).and_return(email_instance)
-          allow(email_instance).to receive(:send_email).and_return(true)
-        end
-
-        it 'returns HTTP status 200 with same form_uuid but not all files and sends no email' do
-          IvcChampvaForm.delete_all
-          IvcChampvaForm.create!(
-            form_uuid: '12345678-1234-5678-1234-567812345678',
-            email: 'test@email.com',
-            first_name: 'Veteran',
-            last_name: 'Surname',
-            form_number: '10-10D',
-            file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
-            s3_status: 'Submitted',
-            pega_status: nil,
-            case_id: nil,
-            email_sent: false
-          )
-
-          IvcChampvaForm.create!(
-            form_uuid: '12345678-1234-5678-1234-567812345678',
-            email: 'test@email.com',
-            first_name: 'Veteran',
-            last_name: 'Surname',
-            form_number: '10-10D',
-            file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d1.pdf',
-            s3_status: 'Submitted',
-            pega_status: nil,
-            case_id: nil,
-            email_sent: false
-          )
-
-          IvcChampvaForm.create!(
-            form_uuid: '12345678-1234-5678-1234-567812345678',
-            email: 'test@email.com',
-            first_name: 'Veteran',
-            last_name: 'Surname',
-            form_number: '10-10D',
-            file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d2.pdf',
-            s3_status: 'Submitted',
-            pega_status: nil,
-            case_id: nil,
-            email_sent: false
-          )
-
-          post '/ivc_champva/v1/forms/status_updates', params: valid_payload_with_status_of_not_processed
-
-          # an email should not be sent
-          expect(email_instance).not_to have_received(:send_email)
-
-          ivc_forms = [IvcChampvaForm.all]
-          status_array = ivc_forms.map { |form| form.pluck(:pega_status) }
-          case_id_array = ivc_forms.map { |form| form.pluck(:case_id) }
-          email_sent_array = ivc_forms.map { |form| form.pluck(:email_sent) }
-
-          # only 2/3 should be updated
-          expect(status_array.flatten.compact!).to eq(['Not Processed', 'Not Processed'])
-          expect(case_id_array.flatten.compact!).to eq(%w[ABC-1234 ABC-1234])
-          expect(email_sent_array.flatten).to eq([false, false, false])
-          expect(response).to have_http_status(:ok)
-        end
-      end
-    end
-
-    context 'Feature champva_confirmation_email_bugfix=false' do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:champva_confirmation_email_bugfix, @current_user).and_return(false)
-        allow(Flipper).to receive(:enabled?).with(
-          :champva_vanotify_custom_confirmation_callback, @current_user
-        ).and_return(false)
-      end
-
-      let(:valid_payload_with_status_of_not_processed) do
-        {
+        IvcChampvaForm.create!(
           form_uuid: '12345678-1234-5678-1234-567812345678',
-          file_names: ['12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
-                       '12345678-1234-5678-1234-567812345678_vha_10_10d1.pdf'],
-          case_id: 'ABC-1234',
-          status: 'Not Processed'
-        }
-      end
+          email: 'test@email.com',
+          first_name: 'Veteran',
+          last_name: 'Surname',
+          form_number: '10-10D',
+          file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d1.pdf',
+          s3_status: 'Submitted',
+          pega_status: nil,
+          case_id: nil,
+          email_sent: false
+        )
 
-      let(:email_instance) { instance_double(IvcChampva::Email) }
+        IvcChampvaForm.create!(
+          form_uuid: '12345678-1234-5678-1234-567812345678',
+          email: 'test@email.com',
+          first_name: 'Veteran',
+          last_name: 'Surname',
+          form_number: '10-10D',
+          file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d2.pdf',
+          s3_status: 'Submitted',
+          pega_status: nil,
+          case_id: nil,
+          email_sent: false
+        )
 
-      context 'with valid payload and status of Not Processed' do
-        before do
-          allow_any_instance_of(IvcChampva::Email).to receive(:valid_environment?).and_return(true)
-          allow(IvcChampva::Email).to receive(:new).and_return(email_instance)
-          allow(email_instance).to receive(:send_email).and_return(true)
-        end
+        post '/ivc_champva/v1/forms/status_updates', params: valid_payload_with_status_of_not_processed
 
-        it 'returns HTTP status 200 with same form_uuid but not all files and incorrectly sends success email' do
-          IvcChampvaForm.delete_all
-          IvcChampvaForm.create!(
-            form_uuid: '12345678-1234-5678-1234-567812345678',
-            email: 'test@email.com',
-            first_name: 'Veteran',
-            last_name: 'Surname',
-            form_number: '10-10D',
-            file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
-            s3_status: 'Submitted',
-            pega_status: nil,
-            case_id: nil,
-            email_sent: false
-          )
+        # an email should not be sent
+        expect(email_instance).not_to have_received(:send_email)
 
-          IvcChampvaForm.create!(
-            form_uuid: '12345678-1234-5678-1234-567812345678',
-            email: 'test@email.com',
-            first_name: 'Veteran',
-            last_name: 'Surname',
-            form_number: '10-10D',
-            file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d1.pdf',
-            s3_status: 'Submitted',
-            pega_status: nil,
-            case_id: nil,
-            email_sent: false
-          )
+        ivc_forms = [IvcChampvaForm.all]
+        status_array = ivc_forms.map { |form| form.pluck(:pega_status) }
+        case_id_array = ivc_forms.map { |form| form.pluck(:case_id) }
+        email_sent_array = ivc_forms.map { |form| form.pluck(:email_sent) }
 
-          IvcChampvaForm.create!(
-            form_uuid: '12345678-1234-5678-1234-567812345678',
-            email: 'test@email.com',
-            first_name: 'Veteran',
-            last_name: 'Surname',
-            form_number: '10-10D',
-            file_name: '12345678-1234-5678-1234-567812345678_vha_10_10d2.pdf',
-            s3_status: 'Submitted',
-            pega_status: nil,
-            case_id: nil,
-            email_sent: false
-          )
-
-          # with the toggle disabled, we should see an email sent
-          expect(IvcChampva::Email).to receive(:new).once
-
-          post '/ivc_champva/v1/forms/status_updates', params: valid_payload_with_status_of_not_processed
-        end
+        # only 2/3 should be updated
+        expect(status_array.flatten.compact!).to eq(['Not Processed', 'Not Processed'])
+        expect(case_id_array.flatten.compact!).to eq(%w[ABC-1234 ABC-1234])
+        expect(email_sent_array.flatten).to eq([false, false, false])
+        expect(response).to have_http_status(:ok)
       end
     end
 

--- a/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/status_updates_spec.rb
+++ b/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/status_updates_spec.rb
@@ -160,7 +160,6 @@ RSpec.describe 'IvcChampva::V1::Forms::StatusUpdates', type: :request do
       let(:email_instance) { instance_double(IvcChampva::Email) }
 
       before do
-        allow(Flipper).to receive(:enabled?).with(:champva_enhanced_monitor_logging, @current_user).and_return(false)
         allow_any_instance_of(IvcChampva::Email).to receive(:valid_environment?).and_return(true)
         allow(IvcChampva::Email).to receive(:new).and_return(email_instance)
         allow(email_instance).to receive(:send_email).and_return(true)

--- a/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/status_updates_spec.rb
+++ b/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/status_updates_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe 'IvcChampva::V1::Forms::StatusUpdates', type: :request do
         {
           form_uuid: '12345678-1234-5678-1234-567812345678',
           file_names: ['12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
-                        '12345678-1234-5678-1234-567812345678_vha_10_10d1.pdf'],
+                       '12345678-1234-5678-1234-567812345678_vha_10_10d1.pdf'],
           case_id: 'ABC-1234',
           status: 'Not Processed'
         }

--- a/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/uploads_spec.rb
+++ b/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/uploads_spec.rb
@@ -113,12 +113,6 @@ RSpec.describe 'IvcChampva::V1::Forms::Uploads', type: :request do
     let(:controller) { IvcChampva::V1::UploadsController.new }
     let(:file) { fixture_file_upload('locked_pdf_password_is_test.pdf') }
 
-    before do
-      allow(Flipper).to receive(:enabled?)
-        .with(:champva_pdf_decrypt, @current_user)
-        .and_return(true)
-    end
-
     context 'with locked PDF and no provided password' do
       let(:locked_file) { fixture_file_upload('locked_pdf_password_is_test.pdf', 'application/pdf') }
 

--- a/modules/ivc_champva/spec/services/attachments_spec.rb
+++ b/modules/ivc_champva/spec/services/attachments_spec.rb
@@ -14,12 +14,6 @@ class TestClass
 end
 
 RSpec.describe IvcChampva::Attachments do
-  before do
-    allow(Flipper).to receive(:enabled?)
-      .with(:champva_pdf_decrypt, @current_user)
-      .and_return(false)
-  end
-
   # Mocking a class to include the Attachments module
   let(:form_id) { 'vha_10_7959c' }
   let(:uuid) { 'f4ae6102-7f05-485a-948c-c0d9ef028983' }
@@ -127,26 +121,6 @@ RSpec.describe IvcChampva::Attachments do
     end
 
     context 'when a file is not found' do
-      it 'throws an error with hard coded details' do
-        expect(test_instance).to receive(:get_attachments).and_return(['attachmentA.pdf'])
-        expect(File).to receive(:rename).with('attachmentA.pdf', "./#{uuid}_#{form_id}_supporting_doc-0.pdf")
-                                        .and_raise(Errno::ENOENT.new)
-
-        expected_error_message = 'Unable to process all attachments: '
-        expected_error_message += 'Error processing attachment at index 0: ENOENT No such file or directory'
-        expect do
-          test_instance.handle_attachments(file_path)
-        end.to raise_error(StandardError, expected_error_message)
-      end
-    end
-
-    context 'when a file is not found and champva_pdf_decrypt is enabled' do
-      before do
-        allow(Flipper).to receive(:enabled?)
-          .with(:champva_pdf_decrypt, @current_user)
-          .and_return(true)
-      end
-
       it 'throws an error with hard coded details' do
         expect(test_instance).to receive(:get_attachments).and_return(['attachmentA.pdf'])
         expect(FileUtils).to receive(:mv).with('attachmentA.pdf', "tmp/#{uuid}_#{form_id}_supporting_doc-0.pdf")

--- a/modules/ivc_champva/spec/services/monitor_spec.rb
+++ b/modules/ivc_champva/spec/services/monitor_spec.rb
@@ -6,12 +6,6 @@ require_relative '../../lib/ivc_champva/monitor'
 RSpec.describe IvcChampva::Monitor do
   let(:monitor) { described_class.new }
 
-  before do
-    allow(Flipper).to receive(:enabled?)
-      .with(:champva_enhanced_monitor_logging, @current_user)
-      .and_return(true)
-  end
-
   context 'with params supplied' do
     describe '#track_update_status' do
       it 'logs sidekiq success' do


### PR DESCRIPTION
## Summary

This PR removes the `champva_pdf_decrypt` flipper that has been fully enabled in production for some months now.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/104641

## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA