### PR TITLE
cookie_id for show_yellow_ribbon_table

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2006,7 +2006,7 @@ features:
     actor_type: user
     description: If enabled, VA Profile is used to populate contact information with PCIU backup calls
   show_yellow_ribbon_table:
-    actor_type: user
+    actor_type: cookie_id
     description: Used to show yellow ribbon table in Comparison Tool
   banner_update_alternative_banners:
     actor_type: user


### PR DESCRIPTION
Switching show_yellow_ribbon_table from user to cookie_id, the comparison tool is not an authenticated service.