### PR TITLE
CVE-2025-30066:  tj-actions/changed-files bump to patched version

### DIFF
--- a/.github/workflows/build_atlas_codeowners.yml
+++ b/.github/workflows/build_atlas_codeowners.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name:  Check codeowner changes
         id: check-codeowner-changes
-        uses: tj-actions/changed-files@v46 # v36.3.0
+        uses: tj-actions/changed-files@v46.0.1 # v46 has a CVE
         with:
           files: |
             .github/CODEOWNERS


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
Due to a CVE issue, `tj-actions/changed-files@v46` was found to have a supply chain vulnerability that could lead to information disclosure of sensitive secrets. This includes, but is not limited to, valid access keys, GitHub Personal Access Tokens (PATs), npm tokens, and private RSA keys.

The vulnerability affected the Action's ability to detect file changes in pull requests and commits, potentially exposing secrets during execution.

🔹 This issue has been patched in v46.0.1. [Upgrading to this version is strongly recommended to mitigate the ris](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-github-action-cve-2025-30066)k

## Related issue(s)
https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-github-action-cve-2025-30066

