### PR TITLE
Fixing add_person_proxy bug that doesn't properly search with a family name

### DIFF
--- a/app/models/mpi_data.rb
+++ b/app/models/mpi_data.rb
@@ -200,7 +200,7 @@ class MPIData < Common::RedisStore
   def perform_orchestrated_search(search_response)
     mpi_service.find_profile_by_attributes_with_orch_search(
       first_name: search_response.profile.given_names.first,
-      last_name: search_response.profile.given_names.last,
+      last_name: search_response.profile.family_name,
       birth_date: search_response.profile.birth_date,
       ssn: search_response.profile.ssn,
       edipi: search_response.profile.edipi


### PR DESCRIPTION


## Summary

- Add person proxy MPI call requires an MPI orchestrated 'search by attributes', returning a search token, before it can update the record. This search by attributes is incorrectly searching with the first and last given names, instead of family name


## What areas of the site does it impact?
MPI integration