### PR TITLE
API-45666 Move VANotify job, save harder, and log more

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/poa_updater.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/poa_updater.rb
@@ -29,9 +29,7 @@ module ClaimsApi
 
         ClaimsApi::Logger.log('poa', poa_id: poa_form.id, detail: 'BIRLS Success')
 
-        ClaimsApi::VANotifyAcceptedJob.perform_async(poa_form.id, rep_id) if vanotify?(poa_form.auth_headers, rep_id)
-
-        ClaimsApi::PoaVBMSUpdater.perform_async(poa_form.id)
+        ClaimsApi::PoaVBMSUpdater.perform_async(poa_form.id, rep_id)
       else
         poa_form.status = ClaimsApi::PowerOfAttorney::ERRORED
         poa_form.vbms_error_message = "BGS Error: update_birls_record failed with code #{response[:return_code]}"

--- a/modules/claims_api/app/sidekiq/claims_api/poa_vbms_updater.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/poa_vbms_updater.rb
@@ -8,7 +8,7 @@ module ClaimsApi
     LOG_TAG = 'poa_vbms_updater'
     sidekiq_options retry_for: 48.hours
 
-    def perform(power_of_attorney_id) # rubocop:disable Metrics/MethodLength
+    def perform(power_of_attorney_id, rep_id = nil) # rubocop:disable Metrics/MethodLength
       poa_form = ClaimsApi::PowerOfAttorney.find(power_of_attorney_id)
       process = ClaimsApi::Process.find_or_create_by(processable: poa_form, step_type: 'POA_ACCESS_UPDATE')
       process.update!(step_status: 'IN_PROGRESS')
@@ -32,20 +32,26 @@ module ClaimsApi
         poa_form.status = ClaimsApi::PowerOfAttorney::UPDATED
         process.update!(step_status: 'SUCCESS', error_messages: [], completed_at: Time.zone.now)
         poa_form.vbms_error_message = nil if poa_form.vbms_error_message.present?
-        ClaimsApi::Logger.log('poa_vbms_updater', poa_id: power_of_attorney_id, detail: 'VBMS Success')
+        ClaimsApi::Logger.log(LOG_TAG, poa_id: power_of_attorney_id, detail: 'VBMS Success')
       else
         poa_form.status = ClaimsApi::PowerOfAttorney::ERRORED
         poa_form.vbms_error_message = 'update_poa_access failed with code ' \
                                       "#{response[:return_code]}: #{response[:return_message]}"
         process.update!(step_status: 'FAILED', error_messages: [{ title: 'BGS Error',
                                                                   detail: poa_form.vbms_error_message }])
-        ClaimsApi::Logger.log('poa_vbms_updater',
+        ClaimsApi::Logger.log(LOG_TAG,
                               poa_id: power_of_attorney_id,
                               detail: 'VBMS Failed',
                               error: response[:return_message])
       end
 
-      poa_form.save
+      poa_form.save!
+      ClaimsApi::Logger.log(LOG_TAG, poa_id: poa_form.id, detail: 'POA Saved successfully')
+
+      if vanotify?(poa_form.auth_headers, rep_id)
+        ClaimsApi::Logger.log(LOG_TAG, poa_id: poa_form.id, detail: 'Sending Email')
+        ClaimsApi::VANotifyAcceptedJob.perform_async(poa_form.id, rep_id)
+      end
     rescue BGS::ShareError => e
       poa_form.status = ClaimsApi::PowerOfAttorney::ERRORED
       poa_form.vbms_error_message = e.respond_to?(:message) ? e.message : 'BGS::ShareError'
@@ -53,7 +59,10 @@ module ClaimsApi
       process.update!(step_status: 'FAILED',
                       error_messages: [{ title: 'BGS Error',
                                          detail: poa_form.vbms_error_message }])
-      ClaimsApi::Logger.log('poa', poa_id: poa_form.id, detail: 'BGS Error', error: e)
+      ClaimsApi::Logger.log(LOG_TAG, poa_id: poa_form.id, detail: 'BGS Error', error: e)
+    rescue => e
+      ClaimsApi::Logger.log(LOG_TAG, poa_id: poa_form.id, detail: 'Re-raising Error', error: get_error_message(e))
+      raise e
     end
 
     def update_poa_access(poa_form:, participant_id:, poa_code:)

--- a/modules/claims_api/spec/sidekiq/poa_updater_spec.rb
+++ b/modules/claims_api/spec/sidekiq/poa_updater_spec.rb
@@ -102,65 +102,6 @@ RSpec.describe ClaimsApi::PoaUpdater, type: :job, vcr: 'bgs/person_web_service/f
     end
   end
 
-  context 'deciding to send a VA Notify email' do
-    before do
-      create_mock_lighthouse_service
-      allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_v2_poa_va_notify).and_return true
-    end
-
-    let(:poa) { create_poa }
-    let(:header_key) { ClaimsApi::V2::Veterans::PowerOfAttorney::BaseController::VA_NOTIFY_KEY }
-
-    context 'when the header key and rep are present' do
-      it 'sends the vanotify job' do
-        poa.auth_headers.merge!({
-                                  header_key => 'this_value'
-                                })
-        poa.save!
-
-        allow_any_instance_of(ClaimsApi::ServiceBase).to receive(:vanotify?).and_return true
-        expect(ClaimsApi::VANotifyAcceptedJob).to receive(:perform_async)
-
-        subject.new.perform(poa.id, 'Rep Data')
-      end
-    end
-
-    context 'when the flipper is off' do
-      it 'does not send the vanotify job' do
-        allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_v2_poa_va_notify).and_return false
-        Flipper.disable(:lighthouse_claims_api_v2_poa_va_notify)
-
-        poa.auth_headers.merge!({
-                                  header_key => 'this_value'
-                                })
-        poa.save!
-
-        expect(ClaimsApi::VANotifyAcceptedJob).not_to receive(:perform_async)
-
-        subject.new.perform(poa.id, 'Rep Data')
-      end
-    end
-
-    context 'does not send the va notify job' do
-      it 'when the rep is not present' do
-        poa.auth_headers.merge!({
-                                  header_key => 'this_value'
-                                })
-        poa.save!
-
-        expect(ClaimsApi::VANotifyAcceptedJob).not_to receive(:perform_async)
-
-        subject.new.perform(poa.id, nil)
-      end
-
-      it 'when the header key is not present' do
-        expect(ClaimsApi::VANotifyAcceptedJob).not_to receive(:perform_async)
-
-        subject.new.perform(poa.id, 'Rep data')
-      end
-    end
-  end
-
   context 'when an errored job has exhausted its retries' do
     it 'logs to the ClaimsApi Logger' do
       poa = create_poa

--- a/modules/claims_api/spec/sidekiq/poa_vbms_updater_spec.rb
+++ b/modules/claims_api/spec/sidekiq/poa_vbms_updater_spec.rb
@@ -110,6 +110,90 @@ RSpec.describe ClaimsApi::PoaVBMSUpdater, type: :job do
       end
     end
 
+    context 'deciding to send a VA Notify email' do
+      let(:allow_poa_c_add) { 'Y' }
+      let(:consent_address_change) { true }
+
+      before do
+        create_mock_lighthouse_service
+        allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_v2_poa_va_notify).and_return true
+      end
+
+      let(:poa) { create_poa }
+      let(:header_key) { ClaimsApi::V2::Veterans::PowerOfAttorney::BaseController::VA_NOTIFY_KEY }
+
+      context 'when the header key and rep are present' do
+        it 'sends the vanotify job' do
+          poa.auth_headers.merge!({
+                                    header_key => 'this_value'
+                                  })
+          poa.save!
+
+          allow_any_instance_of(ClaimsApi::ServiceBase).to receive(:vanotify?).and_return true
+          expect(ClaimsApi::VANotifyAcceptedJob).to receive(:perform_async)
+
+          subject.new.perform(poa.id, 'Rep Data')
+        end
+      end
+
+      context 'when the flipper is off' do
+        it 'does not send the vanotify job' do
+          allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_v2_poa_va_notify).and_return false
+          Flipper.disable(:lighthouse_claims_api_v2_poa_va_notify)
+
+          poa.auth_headers.merge!({
+                                    header_key => 'this_value'
+                                  })
+          poa.save!
+
+          expect(ClaimsApi::VANotifyAcceptedJob).not_to receive(:perform_async)
+
+          subject.new.perform(poa.id, 'Rep Data')
+        end
+      end
+
+      context 'does not send the va notify job' do
+        it 'when the rep is not present' do
+          poa.auth_headers.merge!({
+                                    header_key => 'this_value'
+                                  })
+          poa.save!
+
+          expect(ClaimsApi::VANotifyAcceptedJob).not_to receive(:perform_async)
+
+          subject.new.perform(poa.id, nil)
+        end
+
+        it 'when the header key is not present' do
+          expect(ClaimsApi::VANotifyAcceptedJob).not_to receive(:perform_async)
+
+          subject.new.perform(poa.id, 'Rep data')
+        end
+      end
+    end
+
+    context 'inability to save the poa form' do
+      let(:allow_poa_c_add) { 'Y' }
+      let(:consent_address_change) { true }
+
+      it 'logs to the ClaimsApi logger & re-raises' do
+        err_msg = Faker::Lorem.sentence
+        Sidekiq::Testing.inline! do
+          poa = create_poa(allow_poa_access: true)
+          create_mock_lighthouse_service
+          allow_any_instance_of(ClaimsApi::PowerOfAttorney).to receive(:save!).and_raise StandardError.new(err_msg)
+          allow(ClaimsApi::Logger).to receive(:log) # Ignore other logger calls we're not testing for, if they exist
+          expect(ClaimsApi::Logger).to receive(:log).with(
+            'poa_vbms_updater',
+            poa_id: poa.id,
+            detail: 'Re-raising Error',
+            error: err_msg
+          )
+          expect { subject.new.perform(poa.id) }.to raise_error StandardError
+        end
+      end
+    end
+
     context 'when an errored job has exhausted its retries' do
       let(:allow_poa_c_add) { 'Y' }
       let(:consent_address_change) { true }


### PR DESCRIPTION
## Summary
* Move VANotify to after saving the POA record in PoaVBMSUpdater
* Should let the record save successfully before trying to send email, hopefully allowing the status to move into UPDATED as expected even when the email fails.

## Related issue(s)
[API-45666](https://jira.devops.va.gov/browse/API-45666)

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
Background jobs & process order

## Acceptance criteria

- x ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
