### PR TITLE
Proof of Concept - Alphamocks

### DIFF
--- a/config/initializers/faraday_middleware.rb
+++ b/config/initializers/faraday_middleware.rb
@@ -2,11 +2,13 @@
 
 require 'common/client/middleware/request/remove_cookies'
 require 'common/client/middleware/request/immutable_headers'
+require 'common/client/middleware/mock'
 require 'hca/soap_parser'
 
 Rails.application.reloader.to_prepare do
   Faraday::Middleware.register_middleware remove_cookies: Common::Client::Middleware::Request::RemoveCookies
   Faraday::Middleware.register_middleware immutable_headers: Common::Client::Middleware::Request::ImmutableHeaders
+  Faraday::Middleware.register_middleware mock: Common::Client::Middleware::Mock
 
   Faraday::Response.register_middleware hca_soap_parser: HCA::SOAPParser
 end

--- a/lib/common/client/middleware/mock.rb
+++ b/lib/common/client/middleware/mock.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'faraday'
+require 'vcr'
+require Rails.root.join('spec/support/vcr')
+
+module Common
+  module Client
+    module Middleware
+      class Mock < Faraday::Middleware
+        def initialize(app, options = {})
+          super(app)
+          @cassette_dir = options[:cassette_dir]
+          @record_mode = options[:record] || :none
+        end
+
+        def call(env)
+          return @app.call(env) unless Settings.vsp_environment != 'production'
+
+          cassette_name = find_matching_cassette(env)
+          puts "Mock using VCR cassette: #{cassette_name}"
+
+          VCR.use_cassette(cassette_name, record: @record_mode, match_requests_on: [:method, :uri]) do
+            @app.call(env)
+          end
+        end
+
+        private
+
+        def find_matching_cassette(env)
+          request_uri = env.url.to_s
+
+          Dir.glob("spec/support/vcr_cassettes/#{@cassette_dir}/*.yml").each do |file|
+            yaml_data = YAML.load_file(file)
+            interactions = yaml_data['http_interactions']
+
+            next unless interactions
+
+            interactions.each do |interaction|
+
+              request_match = interaction.dig('request', 'uri').gsub(/<.*?>/, '') == URI(request_uri).path
+              ok_response = interaction.dig('response','status','code') == 200
+
+              if request_match && ok_response
+                return file.gsub("spec/support/vcr_cassettes/", '').gsub('.yml', '')
+              end
+            end
+          end
+
+          nil
+        end
+      end
+    end
+  end
+end
+
+=begin
+
+Usage
+
+Mock using VCR cassette: va_profile/v2/contact_information/person
+ =>
+#<VAProfile::V2::ContactInformation::PersonResponse:0x0000000300e1b9e8
+ @errors_hash={},
+ @metadata={},
+ @original_attributes=
+  {:status=>nil,
+   :person=>
+    #<VAProfile::Models::V3::Person:0x0000000300e54b08
+     @addresses=
+      [#<VAProfile::Models::V3::Address:0x00000003006d5878
+        @address_line1="1495 Martin Luther King Rd",
+        @address_line2=nil,
+        @address_line3=nil,
+        @address_pou="RESIDENCE",
+        @address_type="DOMESTIC",
+
+=end

--- a/lib/va_profile/v2/contact_information/configuration.rb
+++ b/lib/va_profile/v2/contact_information/configuration.rb
@@ -19,6 +19,20 @@ module VAProfile
         def mock_enabled?
           VAProfile::Configuration::SETTINGS.contact_information.mock || false
         end
+
+        def connection
+          ssl_enabled = Rails.env.production?
+          @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options,
+                                           ssl: { verify: ssl_enabled }) do |faraday|
+            faraday.use      :breakers
+            faraday.use      Faraday::Response::RaiseError
+            faraday.use :mock, cassette_dir: 'va_profile/v2/contact_information'
+            faraday.response :snakecase, symbolize: false
+            faraday.response :json, content_type: /\bjson/ # ensures only json content types parsed
+            # faraday.response :betamocks if mock_enabled?
+            faraday.adapter Faraday.default_adapter
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

- Alphamocks are an alternative to Betamocks
- Uses VCR cassettes instead of custom yml files

## Related issue(s)

- n/a

## Testing done

- [ ] manual testing with `rails console`

## Screenshots
```
Mock using VCR cassette: va_profile/v2/contact_information/person
 =>
#<VAProfile::V2::ContactInformation::PersonResponse:0x0000000300e1b9e8
 @errors_hash={},
 @metadata={},
 @original_attributes=
  {:status=>nil,
   :person=>
    #<VAProfile::Models::V3::Person:0x0000000300e54b08
     @addresses=
      [#<VAProfile::Models::V3::Address:0x00000003006d5878
        @address_line1="1495 Martin Luther King Rd",
```

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x] A response was mocked
- [x] No UnhandledHTTPRequestError