### PR TITLE
Fix audit_log enum value

### DIFF
--- a/db/audit_migrate/20250320151836_rename_audit_user_identifier_type_enum_option.rb
+++ b/db/audit_migrate/20250320151836_rename_audit_user_identifier_type_enum_option.rb
@@ -1,0 +1,17 @@
+class RenameAuditUserIdentifierTypeEnumOption < ActiveRecord::Migration[7.2]
+  def up
+    safety_assured do
+      execute <<-SQL
+        ALTER TYPE audit_user_identifier_types RENAME VALUE 'system_hostmame' TO 'system_hostname';
+      SQL
+    end
+  end
+
+  def down
+    safety_assured do
+      execute <<-SQL
+        ALTER TYPE audit_user_identifier_types RENAME VALUE 'system_hostname' TO 'system_hostmame';
+      SQL
+    end
+  end
+end

--- a/db/audit_schema.rb
+++ b/db/audit_schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_29_172450) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_20_151836) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
-  create_enum "audit_user_identifier_types", ["icn", "login_uuid", "idme_uuid", "mhv_id", "dslogon_id", "system_hostmame"]
+  create_enum "audit_user_identifier_types", ["icn", "login_uuid", "idme_uuid", "mhv_id", "dslogon_id", "system_hostname"]
 
   create_table "logs", force: :cascade do |t|
     t.string "subject_user_identifier", null: false


### PR DESCRIPTION
## Summary

- Fix audit log enum `audit_user_identifier_types`. `system_hostmame` -> `system_hostname`


## Testing
- Run migrations:
   ```bash
    rails db:migrate:audit
   ```

## What areas of the site does it impact?
Audit Log

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

