### PR TITLE
Return empty array when BGS uploaded_document is null

### DIFF
--- a/app/services/bgs/uploaded_document_service.rb
+++ b/app/services/bgs/uploaded_document_service.rb
@@ -14,7 +14,7 @@ module BGS
     end
 
     def get_documents
-      service.uploaded_document.find_by_participant_id(participant_id) # rubocop:disable Rails/DynamicFindBy
+      service.uploaded_document.find_by_participant_id(participant_id) || [] # rubocop:disable Rails/DynamicFindBy
     rescue => e
       log_exception_to_sentry(e, { icn: }, { team: Constants::SENTRY_REPORTING_TEAM })
       []

--- a/app/services/bgs/uploaded_document_service.rb
+++ b/app/services/bgs/uploaded_document_service.rb
@@ -14,7 +14,7 @@ module BGS
     end
 
     def get_documents
-      service.uploaded_document.find_by_participant_id(participant_id) || [] # rubocop:disable Rails/DynamicFindBy
+      service.uploaded_document.find_by(participant_id:) || []
     rescue => e
       log_exception_to_sentry(e, { icn: }, { team: Constants::SENTRY_REPORTING_TEAM })
       []

--- a/app/services/bgs/uploaded_document_service.rb
+++ b/app/services/bgs/uploaded_document_service.rb
@@ -14,7 +14,7 @@ module BGS
     end
 
     def get_documents
-      service.uploaded_document.find_by(participant_id:) || []
+      service.uploaded_document.find_by_participant_id(participant_id) || [] # rubocop:disable Rails/DynamicFindBy
     rescue => e
       log_exception_to_sentry(e, { icn: }, { team: Constants::SENTRY_REPORTING_TEAM })
       []


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary


Attempting to fix the high yielding[ efolder error](https://vagov.ddog-gov.com/error-tracking?query=service%3Avets-api%20env%3Aeks-prod&fromUser=true&issueId=bd619772-b170-11ef-80c2-da7ad0900007&refresh_mode=sliding&source=all&from_ts=1741880342338&to_ts=1742485142338&live=true). Return empty array when BGS uploaded_document is null. [Slack thread](https://dsva.slack.com/archives/C07VBGW29CZ/p1741963709097769)

## Related issue(s)
- department-of-veterans-affairs/octo_watchofficer/issues/461

## Testing done
Behavir

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
This does not impact Vets API. This will return an empty array instead of nil.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
