### PR TITLE
Stub the entire instance method of IAMSSOeOAuth::Configuration in the IAMSSOeOAuth::SessionManager

### DIFF
--- a/spec/lib/iam_ssoe_oauth/session_manager_spec.rb
+++ b/spec/lib/iam_ssoe_oauth/session_manager_spec.rb
@@ -8,12 +8,13 @@ describe 'IAMSSOeOAuth::SessionManager' do
   let(:session_manager) { IAMSSOeOAuth::SessionManager.new(access_token) }
 
   before do
-    allow(IAMSSOeOAuth::Configuration.instance).to receive(:ssl_cert)
-      .and_return(instance_double('OpenSSL::X509::Certificate'))
-    allow(IAMSSOeOAuth::Configuration.instance).to receive(:ssl_key)
-      .and_return(instance_double('OpenSSL::PKey::RSA'))
+    allow(IAMSSOeOAuth::Configuration).to receive(:instance).and_return(
+      instance_double('IAMSSOeOAuth::Configuration',
+        ssl_cert: instance_double('OpenSSL::X509::Certificate'),
+        ssl_key: instance_double('OpenSSL::PKey::RSA')
+      )
+    )
   end
-
 
   describe '#find_or_create_user' do
     context 'with a valid access token' do

--- a/spec/lib/iam_ssoe_oauth/session_manager_spec.rb
+++ b/spec/lib/iam_ssoe_oauth/session_manager_spec.rb
@@ -9,10 +9,9 @@ describe 'IAMSSOeOAuth::SessionManager' do
 
   before do
     allow(IAMSSOeOAuth::Configuration).to receive(:instance).and_return(
-      instance_double('IAMSSOeOAuth::Configuration',
-        ssl_cert: instance_double('OpenSSL::X509::Certificate'),
-        ssl_key: instance_double('OpenSSL::PKey::RSA')
-      )
+      instance_double(IAMSSOeOAuth::Configuration,
+                      ssl_cert: instance_double(OpenSSL::X509::Certificate),
+                      ssl_key: instance_double(OpenSSL::PKey::RSA))
     )
   end
 

--- a/spec/lib/iam_ssoe_oauth/session_manager_spec.rb
+++ b/spec/lib/iam_ssoe_oauth/session_manager_spec.rb
@@ -7,6 +7,14 @@ describe 'IAMSSOeOAuth::SessionManager' do
   let(:access_token) { 'ypXeAwQedpmAy5xFD2u5' }
   let(:session_manager) { IAMSSOeOAuth::SessionManager.new(access_token) }
 
+  before do
+    allow(IAMSSOeOAuth::Configuration.instance).to receive(:ssl_cert)
+      .and_return(instance_double('OpenSSL::X509::Certificate'))
+    allow(IAMSSOeOAuth::Configuration.instance).to receive(:ssl_key)
+      .and_return(instance_double('OpenSSL::PKey::RSA'))
+  end
+
+
   describe '#find_or_create_user' do
     context 'with a valid access token' do
       before do


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

Fixing the IAMSSOeOAuth::SessionManager flakey spec by stubbing the entire IAMSSOeOAuth::Configuration instance. The configuration used to be stubbed but was taken out, I believe on accident, when fixing a dependabot issue. The error can be found in this [CI run ](https://github.com/department-of-veterans-affairs/vets-api/runs/38972950446).

## Related issue(s)
- N/A 
## Testing done

- N/A - spec fix

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Improving CI specs

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
