### PR TITLE
Add CarrierWave upload directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,11 @@ public/assets/**
 public/disability_compensation_supporting_form/**
 public/hca_attachments/**
 public/preneed_attachments/**
+public/decision_review/**
+public/evss_claim_documents/**
+public/lighthouse_documents/**
+public/submissions/**
+public/remediation/**
 spec/support/uploads/
 
 # Ignore local config


### PR DESCRIPTION
## Summary

- The public directory was but is not currently ignored
- CarrierWave likes to store uploads in the public folder when it isn't using s3 (Local development)
- All CarrierWave store_dir values are added to .gitignore

## Related issue(s)

- n/a

## Testing done

- [ ] n/a

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  All values from `def store_dir` are added to gitignore