### PR TITLE
EDM-852/update LCPE characters for etag and enriched id

### DIFF
--- a/app/controllers/v1/gids/lcpe_controller.rb
+++ b/app/controllers/v1/gids/lcpe_controller.rb
@@ -25,20 +25,20 @@ module V1
         preload_from_enriched_id || preload_from_etag
       end
 
-      # '<record id>@<preload version>'
+      # '<record id>v<preload version>'
       def preload_from_enriched_id
-        params[:id]&.split('@')&.last
+        params[:id]&.split('v')&.last
       end
 
       def preload_from_etag
-        request.headers['If-None-Match']&.match(%r{W/'(\d+)'})&.captures&.first
+        request.headers['If-None-Match']&.match(%r{W/"(\d+)"})&.captures&.first
       end
 
       def set_headers(version)
-        response.set_header('Cache-Control', 'private, max-age=0')
+        response.headers.delete('Cache-Control')
         response.headers.delete('Pragma')
         response.set_header('Expires', 1.week.since.to_s)
-        response.set_header('ETag', "W/'#{version}'")
+        response.set_header('ETag', "W/\"#{version}\"")
       end
 
       # If additional filter params present, bypass versioning

--- a/app/models/lcpe_redis.rb
+++ b/app/models/lcpe_redis.rb
@@ -32,7 +32,7 @@ class LCPERedis < Common::RedisStore
   end
 
   def force_client_refresh_and_cache(gids_response)
-    v_fresh = gids_response.response_headers['Etag'].match(%r{W/'(\d+)'})[1]
+    v_fresh = gids_response.response_headers['Etag'].match(%r{W/"(\d+)"})[1]
     # no need to cache if vets-api cache already has fresh version
     cache(lcpe_type, GI::LCPE::Response.from(gids_response)) unless v_fresh == cached_version
     raise ClientCacheStaleError

--- a/lib/gi/lcpe/configuration.rb
+++ b/lib/gi/lcpe/configuration.rb
@@ -9,7 +9,7 @@ module GI
       attr_accessor :etag
 
       def set_etag(version)
-        self.etag = "W/'#{version}'"
+        self.etag = "W/\"#{version}\""
       end
 
       private

--- a/lib/gi/lcpe/response.rb
+++ b/lib/gi/lcpe/response.rb
@@ -10,7 +10,7 @@ module GI
       # @param response returned from the rest call
       # @return [GI::LCPE::Response]
       def self.from(response)
-        version = response.response_headers['Etag'].match(%r{W/'(\d+)'})[1]
+        version = response.response_headers['Etag'].match(%r{W/"(\d+)"})[1]
         new(status: response.status, body: response.body.merge(version:))
       end
 

--- a/spec/lib/gi/lcpe/client_spec.rb
+++ b/spec/lib/gi/lcpe/client_spec.rb
@@ -8,7 +8,7 @@ describe GI::LCPE::Client do
   let(:client) { described_class.new(v_client:, lcpe_type:) }
   let(:v_fresh) { '3' }
   let(:v_stale) { '2' }
-  let(:enriched_id) { "1@#{v_client}" }
+  let(:enriched_id) { "1v#{v_client}" }
 
   describe '#get_licenses_and_certs_v1' do
     context 'when versioning disabled' do

--- a/spec/requests/v1/gi/lcpe/exams_spec.rb
+++ b/spec/requests/v1/gi/lcpe/exams_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'V1::GI::LCPE::Exams', type: :request do
           get v1_gi_lcpe_exams_url, params: { state: 'MT' }
           expect(response).to have_http_status(:ok)
           expect(response).to match_response_schema('gi/lcpe/exams')
-          expect(response.headers['Etag']).not_to match(%r{W/'\d+'})
+          expect(response.headers['Etag']).not_to match(%r{W/"\d+"})
         end
       end
     end
@@ -34,7 +34,7 @@ RSpec.describe 'V1::GI::LCPE::Exams', type: :request do
             get v1_gi_lcpe_exams_url
             expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('gi/lcpe/exams_with_version')
-            expect(response.headers['Etag']).to eq("W/'#{v_fresh}'")
+            expect(response.headers['Etag']).to eq("W/\"#{v_fresh}\"")
           end
         end
       end
@@ -53,10 +53,10 @@ RSpec.describe 'V1::GI::LCPE::Exams', type: :request do
 
         it 'returns 200 response with fresh version' do
           VCR.use_cassette('gi/lcpe/get_exams_cache_stale') do
-            get v1_gi_lcpe_exams_url, headers: { 'If-None-Match' => "W/'#{v_client}'" }
+            get v1_gi_lcpe_exams_url, headers: { 'If-None-Match' => "W/\"#{v_client}\"" }
             expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('gi/lcpe/exams_with_version')
-            expect(response.headers['Etag']).to eq("W/'#{v_fresh}'")
+            expect(response.headers['Etag']).to eq("W/\"#{v_fresh}\"")
           end
         end
       end
@@ -73,10 +73,10 @@ RSpec.describe 'V1::GI::LCPE::Exams', type: :request do
 
         it 'returns 200 response with fresh version' do
           VCR.use_cassette('gi/lcpe/get_exams_cache_fresh') do
-            get v1_gi_lcpe_exams_url, headers: { 'If-None-Match' => "W/'#{v_client}'" }
+            get v1_gi_lcpe_exams_url, headers: { 'If-None-Match' => "W/\"#{v_client}\"" }
             expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('gi/lcpe/exams_with_version')
-            expect(response.headers['Etag']).to eq("W/'#{v_fresh}'")
+            expect(response.headers['Etag']).to eq("W/\"#{v_fresh}\"")
           end
         end
       end
@@ -93,9 +93,9 @@ RSpec.describe 'V1::GI::LCPE::Exams', type: :request do
 
         it 'returns 304 response with fresh version' do
           VCR.use_cassette('gi/lcpe/get_exams_cache_fresh') do
-            get v1_gi_lcpe_exams_url, headers: { 'If-None-Match' => "W/'#{v_client}'" }
+            get v1_gi_lcpe_exams_url, headers: { 'If-None-Match' => "W/\"#{v_client}\"" }
             expect(response).to have_http_status(:not_modified)
-            expect(response.headers['Etag']).to eq("W/'#{v_client}'")
+            expect(response.headers['Etag']).to eq("W/\"#{v_client}\"")
           end
         end
       end

--- a/spec/requests/v1/gi/lcpe/exams_spec.rb
+++ b/spec/requests/v1/gi/lcpe/exams_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'V1::GI::LCPE::Exams', type: :request do
 
   let(:v_fresh) { '3' }
   let(:v_stale) { '2' }
-  let(:enriched_id) { "1@#{v_client}" }
+  let(:enriched_id) { "1v#{v_client}" }
 
   describe 'GET v1/gi/lcpe/exams' do
     let(:lcpe_type) { 'exams' }

--- a/spec/requests/v1/gi/lcpe/lacs_spec.rb
+++ b/spec/requests/v1/gi/lcpe/lacs_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'V1::GI::LCPE::Lacs', type: :request do
           get v1_gi_lcpe_lacs_url, params: { state: 'MT' }
           expect(response).to have_http_status(:ok)
           expect(response).to match_response_schema('gi/lcpe/lacs')
-          expect(response.headers['Etag']).not_to match(%r{W/'\d+'})
+          expect(response.headers['Etag']).not_to match(%r{W/"\d+"})
         end
       end
     end
@@ -34,7 +34,7 @@ RSpec.describe 'V1::GI::LCPE::Lacs', type: :request do
             get v1_gi_lcpe_lacs_url
             expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('gi/lcpe/lacs_with_version')
-            expect(response.headers['Etag']).to eq("W/'#{v_fresh}'")
+            expect(response.headers['Etag']).to eq("W/\"#{v_fresh}\"")
           end
         end
       end
@@ -53,10 +53,10 @@ RSpec.describe 'V1::GI::LCPE::Lacs', type: :request do
 
         it 'returns 200 response with fresh version' do
           VCR.use_cassette('gi/lcpe/get_lacs_cache_stale') do
-            get v1_gi_lcpe_lacs_url, headers: { 'If-None-Match' => "W/'#{v_client}'" }
+            get v1_gi_lcpe_lacs_url, headers: { 'If-None-Match' => "W/\"#{v_client}\"" }
             expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('gi/lcpe/lacs_with_version')
-            expect(response.headers['Etag']).to eq("W/'#{v_fresh}'")
+            expect(response.headers['Etag']).to eq("W/\"#{v_fresh}\"")
           end
         end
       end
@@ -76,7 +76,7 @@ RSpec.describe 'V1::GI::LCPE::Lacs', type: :request do
             get v1_gi_lcpe_lacs_url, headers: { 'If-None-Match' => "W/'#{v_client}'" }
             expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('gi/lcpe/lacs_with_version')
-            expect(response.headers['Etag']).to eq("W/'#{v_fresh}'")
+            expect(response.headers['Etag']).to eq("W/\"#{v_fresh}\"")
           end
         end
       end
@@ -93,9 +93,9 @@ RSpec.describe 'V1::GI::LCPE::Lacs', type: :request do
 
         it 'returns 304 response with fresh version' do
           VCR.use_cassette('gi/lcpe/get_lacs_cache_fresh') do
-            get v1_gi_lcpe_lacs_url, headers: { 'If-None-Match' => "W/'#{v_client}'" }
+            get v1_gi_lcpe_lacs_url, headers: { 'If-None-Match' => "W/\"#{v_client}\"" }
             expect(response).to have_http_status(:not_modified)
-            expect(response.headers['Etag']).to eq("W/'#{v_client}'")
+            expect(response.headers['Etag']).to eq("W/\"#{v_client}\"")
           end
         end
       end

--- a/spec/requests/v1/gi/lcpe/lacs_spec.rb
+++ b/spec/requests/v1/gi/lcpe/lacs_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'V1::GI::LCPE::Lacs', type: :request do
 
   let(:v_fresh) { '3' }
   let(:v_stale) { '2' }
-  let(:enriched_id) { "1@#{v_client}" }
+  let(:enriched_id) { "1v#{v_client}" }
 
   describe 'GET v1/gi/lcpe/lacs' do
     let(:lcpe_type) { 'lacs' }

--- a/spec/support/vcr_cassettes/gi/lcpe/get_exam_details.yml
+++ b/spec/support/vcr_cassettes/gi/lcpe/get_exam_details.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<GIDS_URL>/v1/lcpe/exams/1@3"
+    uri: "<GIDS_URL>/v1/lcpe/exams/1v3"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/gi/lcpe/get_exams_cache_fresh.yml
+++ b/spec/support/vcr_cassettes/gi/lcpe/get_exams_cache_fresh.yml
@@ -16,7 +16,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       If-None-Match:
-      - W/'3'
+      - W/"3"
   response:
     status:
       code: 304
@@ -35,7 +35,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/'3'
+      - W/"3"
       X-Request-Id:
       - 582e7f03-6e42-4e4b-b809-a40cd2a4f2ab
       X-Runtime:

--- a/spec/support/vcr_cassettes/gi/lcpe/get_exams_cache_nil.yml
+++ b/spec/support/vcr_cassettes/gi/lcpe/get_exams_cache_nil.yml
@@ -33,7 +33,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/'3'
+      - W/"3"
       X-Request-Id:
       - 582e7f03-6e42-4e4b-b809-a40cd2a4f2ab
       X-Runtime:

--- a/spec/support/vcr_cassettes/gi/lcpe/get_exams_cache_stale.yml
+++ b/spec/support/vcr_cassettes/gi/lcpe/get_exams_cache_stale.yml
@@ -16,7 +16,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       If-None-Match:
-      - W/'2'
+      - W/"2"
   response:
     status:
       code: 200
@@ -35,7 +35,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/'3'
+      - W/"3"
       X-Request-Id:
       - 582e7f03-6e42-4e4b-b809-a40cd2a4f2ab
       X-Runtime:

--- a/spec/support/vcr_cassettes/gi/lcpe/get_lac_details.yml
+++ b/spec/support/vcr_cassettes/gi/lcpe/get_lac_details.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<GIDS_URL>/v1/lcpe/lacs/1@3"
+    uri: "<GIDS_URL>/v1/lcpe/lacs/1v3"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/gi/lcpe/get_lacs_cache_fresh.yml
+++ b/spec/support/vcr_cassettes/gi/lcpe/get_lacs_cache_fresh.yml
@@ -16,7 +16,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       If-None-Match:
-      - W/'3'
+      - W/"3"
   response:
     status:
       code: 304
@@ -35,7 +35,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/'3'
+      - W/"3"
       X-Request-Id:
       - 42eda17d-ee1b-41bc-852a-f326c5d47915
       X-Runtime:

--- a/spec/support/vcr_cassettes/gi/lcpe/get_lacs_cache_nil.yml
+++ b/spec/support/vcr_cassettes/gi/lcpe/get_lacs_cache_nil.yml
@@ -33,7 +33,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/'3'
+      - W/"3"
       X-Request-Id:
       - 42eda17d-ee1b-41bc-852a-f326c5d47915
       X-Runtime:

--- a/spec/support/vcr_cassettes/gi/lcpe/get_lacs_cache_stale.yml
+++ b/spec/support/vcr_cassettes/gi/lcpe/get_lacs_cache_stale.yml
@@ -16,7 +16,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       If-None-Match:
-      - W/'2'
+      - W/"2"
   response:
     status:
       code: 200
@@ -35,7 +35,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/'3'
+      - W/"3"
       X-Request-Id:
       - 42eda17d-ee1b-41bc-852a-f326c5d47915
       X-Runtime:


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- *(Summarize the changes that have been made to the platform)* Staging review required removing '@' delimiter from enriched id for lcpe lacs and exams. Replacing with a 'v' for version. Also updating ETAG to use double instead of single quotes.
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)* Replace special character with accepted character
- *(Which team do you work for, does your team own the maintenance of this component?)* Education Data Migration (EDM), yes
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/105704
- https://jira.devops.va.gov/browse/EDM-852

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing* Run gids and vets-api locally and test get request for lacs and exams
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
GI Comparison Tool (feature to be released)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature