### PR TITLE
Include cancelled past appointments in fetch results

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_presentation_filter.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_presentation_filter.rb
@@ -9,27 +9,12 @@ module VAOS
       end
 
       def user_facing?(appointment)
-        return true if valid_appointment?(appointment) &&
-                       (presentable_upcoming_appointment?(appointment) ||
-                         presentable_past_appointment?(appointment) ||
-                         presentable_cancelled_appointment?(appointment))
+        return true if valid_appointment?(appointment)
 
         presentable_requested_appointment?(appointment)
       end
 
       private
-
-      def presentable_upcoming_appointment?(appointment)
-        appointment[:start] >= @now
-      end
-
-      def presentable_past_appointment?(appointment)
-        appointment[:start] < @now && appointment[:status] != 'cancelled'
-      end
-
-      def presentable_cancelled_appointment?(appointment)
-        appointment[:status] == 'cancelled' && appointment[:start] >= 30.days.ago.beginning_of_day
-      end
 
       def presentable_requested_appointment?(appointment)
         created_at = appointment[:created]

--- a/modules/vaos/spec/requests/vaos/v2/appointments_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/appointments_spec.rb
@@ -579,9 +579,9 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
               data = JSON.parse(response.body)['data']
               expect(response).to have_http_status(:ok)
               expect(response.body).to be_a(String)
-              expect(data.size).to eq(10)
+              expect(data.size).to eq(18)
               expect(data[0]['attributes']['location']).to eq(facility_error_msg)
-              expect(data[9]['attributes']['location']).not_to eq(facility_error_msg)
+              expect(data[17]['attributes']['location']).not_to eq(facility_error_msg)
               expect(response).to match_camelized_response_schema('vaos/v2/appointments', { strict: false })
             end
           end
@@ -594,8 +594,9 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
               data = JSON.parse(response.body)['data']
               expect(response).to have_http_status(:ok)
               expect(response.body).to be_a(String)
+              expect(data.size).to eq(18)
               expect(data[0]['attributes']['location']).to eq(facility_error_msg)
-              expect(data[9]['attributes']['location']).not_to eq(facility_error_msg)
+              expect(data[17]['attributes']['location']).not_to eq(facility_error_msg)
               expect(Rails.logger).not_to have_received(:info).with("Details for Cerner 'COL OR 1' Appointment",
                                                                     any_args)
               expect(response).to match_camelized_response_schema('vaos/v2/appointments', { strict: false })

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -2292,6 +2292,21 @@ describe VAOS::V2::AppointmentsService do
   end
 
   describe '#future' do
+    it 'sets future to true if the appointment is not a request and occurs within the past 60 minutes' do
+      appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text).attributes
+      appt[:type] = 'VA'
+      appt[:start] = Time.now.utc - 30.minutes
+      expect(subject.send(:future?, appt)).to be(true)
+    end
+
+    it 'sets future to true if the appointment is telehealth and occurs within the past 240 minutes' do
+      appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text).attributes
+      appt[:type] = 'VA'
+      appt[:kind] = 'telehealth'
+      appt[:start] = Time.now.utc - 210.minutes
+      expect(subject.send(:future?, appt)).to be(true)
+    end
+
     it 'sets future to true if the appointment is not a request and occurs after the beginning of the current day' do
       appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text).attributes
       appt[:type] = 'VA'

--- a/modules/vaos/spec/services/v2/appointments_presentation_filter_spec.rb
+++ b/modules/vaos/spec/services/v2/appointments_presentation_filter_spec.rb
@@ -39,15 +39,8 @@ describe VAOS::V2::AppointmentsPresentationFilter do
       expect(filterer.user_facing?(past)).to be true
     end
 
-    describe 'cancelled appointments' do
-      it 'returns true for a cancelled appointment with a valid start time 30 days ago or after' do
-        expect(filterer.user_facing?(cancelled)).to be true
-      end
-
-      it 'returns false if start time is more than 30 days ago' do
-        cancelled[:start] = 31.days.ago
-        expect(filterer.user_facing?(cancelled)).to be false
-      end
+    it 'returns true for cancelled appointments' do
+      expect(filterer.user_facing?(cancelled)).to be true
     end
 
     describe 'appointment requests' do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This updates the determination of future appointments by allowing a grace period of 240 minutes for telehealth appointments and 60 minutes for all other appointments. This ensures that for valid appointments exactly one of `past` or `future` is set to true.
- We are also updating the presentation filter to allow all past cancelled appointments to be retrieved.
- Appointments tool team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/105466

## Testing done

- [x] *New code is covered by existing and new unit tests*

## Screenshots
N/A

## What areas of the site does it impact?

Appointments tool

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
