### PR TITLE
EDM/maintenance window lighthouse education benefits

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -836,10 +836,10 @@ maintenance:
     hcq: PWGA814
     idme: <%= ENV['maintenance__services__idme'] %>
     lighthouse_benefits_claims: <%= ENV['maintenance__services__lighthouse_benefits_claims'] %>
+    lighthouse_benefits_education: <%= ENV['maintenance__services__lighthouse_benefits_education'] %>
     lighthouse_benefits_intake: <%= ENV['maintenance__services__lighthouse_benefits_intake'] %>
     lighthouse_direct_deposit: <%= ENV['maintenance__services__lighthouse_direct_deposit'] %>
     lighthouse_vshe: <%= ENV['maintenance__services__lighthouse_vshe'] %>
-    lighthouse_benefits_education: <%= ENV['maintenance__services__lighthouse_benefits_education'] %>
     logingov: P2SHMM9
     mdot: PEOIHN1
     mhv: <%= ENV['maintenance__services__mhv'] %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -839,6 +839,7 @@ maintenance:
     lighthouse_benefits_intake: <%= ENV['maintenance__services__lighthouse_benefits_intake'] %>
     lighthouse_direct_deposit: <%= ENV['maintenance__services__lighthouse_direct_deposit'] %>
     lighthouse_vshe: <%= ENV['maintenance__services__lighthouse_vshe'] %>
+    lighthouse_benefits_education: <%= ENV['maintenance__services__lighthouse_benefits_education'] %>
     logingov: P2SHMM9
     mdot: PEOIHN1
     mhv: <%= ENV['maintenance__services__mhv'] %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -844,6 +844,7 @@ maintenance:
     hcq: PWGA814
     idme: PVWB4R8
     lighthouse_benefits_claims: ~
+    lighthouse_benefits_education: ~
     lighthouse_benefits_intake: ~
     lighthouse_direct_deposit: ~
     lighthouse_vshe: ~

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -838,6 +838,7 @@ maintenance:
     hcq: PWGA814
     idme: PVWB4R8
     lighthouse_benefits_claims: ~
+    lighthouse_benefits_education: ~
     lighthouse_benefits_intake: ~
     lighthouse_direct_deposit: ~
     lighthouse_vshe: ~


### PR DESCRIPTION
Expediting creation of downtime notification/maintenance window for lighthouse benefits education API after learning upstream service LTS will be down for this weekend [here](https://lighthouseva.slack.com/archives/C03LWCPSYQ2/p1742505848600629)

Slack ticket: https://dsva.slack.com/archives/CBU0KDSB1/p1742566437320389

downtime notification on frontend: https://github.com/department-of-veterans-affairs/vets-website/pull/35420

Created pager duty maintenance window here: https://dsva.pagerduty.com/service-directory/PL6F0K1/