### PR TITLE
Added poa_policy to verify loa3, icn, and participant id 

### DIFF
--- a/app/policies/poa_policy.rb
+++ b/app/policies/poa_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+POARequestPolicy = Struct.new(:user, :power_of_attorney) do
+  def access?
+    user.loa3? && user.icn.present? && user.participant_id.present?
+  end
+end

--- a/modules/representation_management/app/controllers/representation_management/v0/power_of_attorney_controller.rb
+++ b/modules/representation_management/app/controllers/representation_management/v0/power_of_attorney_controller.rb
@@ -6,6 +6,7 @@ module RepresentationManagement
   module V0
     class PowerOfAttorneyController < ApplicationController
       service_tag 'representation-management'
+      before_action :authorize_access
 
       def index
         @active_poa = lighthouse_service.get_power_of_attorney
@@ -18,6 +19,10 @@ module RepresentationManagement
       end
 
       private
+
+      def authorize_access
+        authorize(current_user, :access?, policy_class: POARequestPolicy)
+      end
 
       def lighthouse_service
         BenefitsClaims::Service.new(icn)

--- a/spec/policies/poa_policy_spec.rb
+++ b/spec/policies/poa_policy_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+describe POAPolicy do
+  subject { described_class }
+
+  permissions :access? do
+    context 'when user has an ICN and is LOA3' do
+      let(:user) { build(:user, :loa3) }
+
+      it 'grants access' do
+        expect(subject).to permit(user, :power_of_attorney)
+      end
+
+
+    end
+
+    context 'when user does not have an ICN nor LOA3' do
+      let(:user) { build(:user, :loa1) }
+
+      before do
+        user.identity.attributes = {
+          icn: nil,
+        }
+      end
+
+      it 'denies access' do
+        expect(subject).not_to permit(user, :power_of_attorney)
+      end
+
+
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Added a pundit policy to authorize loa3 users with and icn and participant id
- Accredited Representative Management team

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85092

## Testing done

- [x] *New code is covered by unit tests*
- Non-LOA3 users without icns or participant ids were able to call lighthouse, resulting in one of several different error
- Testing policy that only grants access to loa3 users with an icn and participant id

