### PR TITLE
Update swagger docs for decision review endpoints

### DIFF
--- a/app/swagger/swagger/v1/requests/appeals/appeals.rb
+++ b/app/swagger/swagger/v1/requests/appeals/appeals.rb
@@ -5,7 +5,7 @@ require 'decision_review/schemas'
 class Swagger::V1::Requests::Appeals::Appeals
   include Swagger::Blocks
 
-  swagger_path '/v1/higher_level_reviews' do
+  swagger_path '/decision_reviews/v1/higher_level_reviews' do
     operation :post do
       key :tags, %w[higher_level_reviews]
       key :summary, 'Creates a higher level review'
@@ -34,7 +34,7 @@ class Swagger::V1::Requests::Appeals::Appeals
     end
   end
 
-  swagger_path '/v1/higher_level_reviews/{uuid}' do
+  swagger_path '/decision_reviews/v1/higher_level_reviews/{uuid}' do
     operation :get do
       key :description, 'This endpoint returns the details of a specific Higher Level Review'
       key :operationId, 'showHigherLevelReview'
@@ -62,7 +62,7 @@ class Swagger::V1::Requests::Appeals::Appeals
     end
   end
 
-  swagger_path '/v1/higher_level_reviews/contestable_issues/{benefit_type}' do
+  swagger_path '/decision_reviews/v1/higher_level_reviews/contestable_issues/{benefit_type}' do
     operation :get do
       description =
         'For the logged-in veteran, returns a list of issues that could be contested in a Higher-Level Review ' \
@@ -96,7 +96,7 @@ class Swagger::V1::Requests::Appeals::Appeals
     end
   end
 
-  swagger_path '/v1/notice_of_disagreements' do
+  swagger_path '/decision_reviews/v1/notice_of_disagreements' do
     operation :post do
       key :tags, %w[notice_of_disagreements]
       key :summary, 'Creates a notice of disagreement'
@@ -125,7 +125,7 @@ class Swagger::V1::Requests::Appeals::Appeals
     end
   end
 
-  swagger_path '/v1/notice_of_disagreements/{uuid}' do
+  swagger_path '/decision_reviews/v1/notice_of_disagreements/{uuid}' do
     operation :get do
       key :description, 'This endpoint returns the details of a specific notice of disagreement'
       key :operationId, 'showNoticeOfDisagreement'
@@ -153,7 +153,7 @@ class Swagger::V1::Requests::Appeals::Appeals
     end
   end
 
-  swagger_path '/v1/notice_of_disagreements/contestable_issues' do
+  swagger_path '/decision_reviews/v1/notice_of_disagreements/contestable_issues' do
     operation :get do
       description =
         'For the logged-in veteran, returns a list of issues that could be contested in a Notice of Disagreement'
@@ -173,7 +173,7 @@ class Swagger::V1::Requests::Appeals::Appeals
     end
   end
 
-  swagger_path '/v1/supplemental_claims' do
+  swagger_path '/decision_reviews/v1/supplemental_claims' do
     operation :post do
       key :tags, %w[supplemental_claims]
       key :summary, 'Creates a supplemental claim'
@@ -202,7 +202,7 @@ class Swagger::V1::Requests::Appeals::Appeals
     end
   end
 
-  swagger_path '/v1/supplemental_claims/{uuid}' do
+  swagger_path '/decision_reviews/v1/supplemental_claims/{uuid}' do
     operation :get do
       key :description, 'Returns all of the data associated with a specific \
       Supplemental Claim.'
@@ -231,7 +231,7 @@ class Swagger::V1::Requests::Appeals::Appeals
     end
   end
 
-  swagger_path '/v1/supplemental_claims/contestable_issues/{benefit_type}' do
+  swagger_path '/decision_reviews/v1/supplemental_claims/contestable_issues/{benefit_type}' do
     operation :get do
       description =
         'For the logged-in veteran, returns a list of issues that could be \
@@ -260,7 +260,7 @@ class Swagger::V1::Requests::Appeals::Appeals
     end
   end
 
-  swagger_path '/v1/decision_review_evidence' do
+  swagger_path '/decision_reviews/v1/decision_review_evidence' do
     operation :post do
       extend Swagger::Responses::BadRequestError
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- *(Summarize the changes that have been made to the platform)*
Update the urls for decision review endpoints in the swagger docs, to reflect the new module prefix
- *(Which team do you work for, does your team own the maintenance of this component?)*
Decision Reviews, we own the urls being documented

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/105843

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
Swagger docs still showed the old urls without the `decision_reviews` prefix
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
Check swagger docs page

## What areas of the site does it impact?
Swagger docs

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
