### PR TITLE
1529 1095b statsd

### DIFF
--- a/app/controllers/v0/form1095_bs_controller.rb
+++ b/app/controllers/v0/form1095_bs_controller.rb
@@ -9,7 +9,7 @@ module V0
     def available_forms
       form = Form1095B.find_by(veteran_icn: current_user.icn, tax_year: Form1095B.current_tax_year)
       forms = form.nil? ? [] : [{ year: form.tax_year, last_updated: form.updated_at }]
-      StatsD.increment('user_has_no_1095b') if forms.empty?
+      StatsD.increment('api.user_has_no_1095b') if forms.empty?
       render json: { available_forms: forms }
     end
 

--- a/app/controllers/v0/form1095_bs_controller.rb
+++ b/app/controllers/v0/form1095_bs_controller.rb
@@ -9,6 +9,7 @@ module V0
     def available_forms
       form = Form1095B.find_by(veteran_icn: current_user.icn, tax_year: Form1095B.current_tax_year)
       forms = form.nil? ? [] : [{ year: form.tax_year, last_updated: form.updated_at }]
+      StatsD.increment('user_has_no_1095b') if forms.empty?
       render json: { available_forms: forms }
     end
 

--- a/spec/requests/v0/form1095_bs_spec.rb
+++ b/spec/requests/v0/form1095_bs_spec.rb
@@ -87,8 +87,10 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
   describe 'GET /available_forms' do
     before do
       sign_in_as(user)
-      # this occurs automatically as part of our datadog metrics. allowing in order to test the explicit statsd call in the controller
-      allow(StatsD).to receive(:increment).with("api.rack.request", { tags: ["controller:v0/form1095_bs", "action:available_forms", "source_app:not_provided", "status:200"] })
+      # allow endpoint increment in order to test user_has_no_1095b increment
+      allow(StatsD).to receive(:increment).with('api.rack.request',
+                                                { tags: ['controller:v0/form1095_bs', 'action:available_forms',
+                                                         'source_app:not_provided', 'status:200'] })
     end
 
     it 'returns success with only the most recent tax year form data' do
@@ -97,7 +99,7 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
       create(:form1095_b, tax_year: this_year)
       create(:form1095_b, tax_year: this_year - 2)
 
-      expect(StatsD).not_to receive(:increment).with('user_has_no_1095b')
+      expect(StatsD).not_to receive(:increment).with('api.user_has_no_1095b')
       get '/v0/form1095_bs/available_forms'
       expect(response).to have_http_status(:success)
       expect(response.parsed_body.deep_symbolize_keys).to eq(
@@ -107,7 +109,7 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
     end
 
     it 'returns success with no available forms and increments statsd when user has no form data' do
-      expect(StatsD).to receive(:increment).with('user_has_no_1095b')
+      expect(StatsD).to receive(:increment).with('api.user_has_no_1095b')
       get '/v0/form1095_bs/available_forms'
       expect(response).to have_http_status(:success)
       expect(response.parsed_body.symbolize_keys).to eq(

--- a/spec/requests/v0/form1095_bs_spec.rb
+++ b/spec/requests/v0/form1095_bs_spec.rb
@@ -87,6 +87,8 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
   describe 'GET /available_forms' do
     before do
       sign_in_as(user)
+      # this occurs automatically as part of our datadog metrics. allowing in order to test the explicit statsd call in the controller
+      allow(StatsD).to receive(:increment).with("api.rack.request", { tags: ["controller:v0/form1095_bs", "action:available_forms", "source_app:not_provided", "status:200"] })
     end
 
     it 'returns success with only the most recent tax year form data' do
@@ -94,6 +96,8 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
       last_year_form = create(:form1095_b, tax_year: this_year - 1)
       create(:form1095_b, tax_year: this_year)
       create(:form1095_b, tax_year: this_year - 2)
+
+      expect(StatsD).not_to receive(:increment).with('user_has_no_1095b')
       get '/v0/form1095_bs/available_forms'
       expect(response).to have_http_status(:success)
       expect(response.parsed_body.deep_symbolize_keys).to eq(
@@ -102,7 +106,8 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
       )
     end
 
-    it 'returns success with no available forms when user has no form data' do
+    it 'returns success with no available forms and increments statsd when user has no form data' do
+      expect(StatsD).to receive(:increment).with('user_has_no_1095b')
       get '/v0/form1095_bs/available_forms'
       expect(response).to have_http_status(:success)
       expect(response.parsed_body.symbolize_keys).to eq(


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES (on front end)
- adds statsd increment when user does not have a current 1095b for download. This is intended to help us better understand the user experience. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va-iir/issues/1529

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
It only increments a counter when the user requests whether they have 1095b forms and they don't have any. It's just a metrics change.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
