### PR TITLE
API-45836-replace-md5-poa-v1

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
@@ -35,15 +35,15 @@ module ClaimsApi
           file_number = check_file_number_exists!
           claimant_information = validate_dependent_claimant!(poa_code:)
 
-          power_of_attorney = ClaimsApi::PowerOfAttorney.find_using_identifier_and_source(header_md5:,
-                                                                                          source_name:)
+          power_of_attorney = find_poa_record
+
           unless power_of_attorney&.status&.in?(%w[submitted pending])
             attributes = {
               status: ClaimsApi::PowerOfAttorney::PENDING,
               auth_headers:,
               form_data: form_attributes,
               current_poa: power_of_attorney_verifier.current_poa_code,
-              header_md5:,
+              header_md5: header_sha256,
               cid: token.payload['cid']
             }
             attributes.merge!({ source_data: }) unless token.client_credentials_token?
@@ -210,6 +210,20 @@ module ClaimsApi
                                                                     'va_eauth_service_transaction_id',
                                                                     'va_eauth_issueinstant',
                                                                     'Authorization').to_json)
+        end
+
+        def header_sha256
+          @header_sha256 ||= Digest::SHA256.hexdigest(auth_headers.except('va_eauth_authenticationauthority',
+                                                                          'va_eauth_service_transaction_id',
+                                                                          'va_eauth_issueinstant',
+                                                                          'Authorization').to_json)
+        end
+
+        def find_poa_record
+          ClaimsApi::PowerOfAttorney.find_using_identifier_and_source(header_md5:,
+                                                                      source_name:) ||
+            ClaimsApi::PowerOfAttorney.find_using_identifier_and_source(header_md5: header_sha256,
+                                                                        source_name:)
         end
 
         def source_data

--- a/modules/claims_api/app/models/claims_api/power_of_attorney.rb
+++ b/modules/claims_api/app/models/claims_api/power_of_attorney.rb
@@ -65,8 +65,8 @@ module ClaimsApi
                                     'va_eauth_issueinstant',
                                     'Authorization')
       headers['status'] = status
-      self.header_md5 = Digest::MD5.hexdigest headers.to_json
-      self.md5 = Digest::MD5.hexdigest form_data.merge(headers).to_json
+      self.header_md5 = Digest::SHA256.hexdigest headers.to_json
+      self.md5 = Digest::SHA256.hexdigest form_data.merge(headers).to_json
     end
 
     def processes


### PR DESCRIPTION
## Summary

- Replaces md5 with sha256 in v1 poa

## Related issue(s)

- [API-45836](https://jira.devops.va.gov/browse/API-45836)

## Testing done

- [x] *New code is covered by unit tests*


## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
	modified:   modules/claims_api/app/models/claims_api/power_of_attorney.rb
	modified:   modules/claims_api/spec/models/power_of_attorney_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature