### PR TITLE
API-45733 Add-VANotify-settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -222,8 +222,8 @@ claims_api:
     services:
       lighthouse:
         api_key: <%= ENV['claims_api__vanotify__services__lighthouse__api_key'] %>
-        notify_service_id: <%= ENV['claims_api__vanotify__services__lighthouse__notify_service_id'] %>
         notification_client_secret: <%= ENV['claims_api__vanotify__services__lighthouse__notification_client_secret'] %>
+        notify_service_id: <%= ENV['claims_api__vanotify__services__lighthouse__notify_service_id'] %>
 clamav:
   host: clamav
   mock: <%= ENV['clamav__mock'] %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -222,6 +222,8 @@ claims_api:
     services:
       lighthouse:
         api_key: <%= ENV['claims_api__vanotify__services__lighthouse__api_key'] %>
+        notify_service_id: <%= ENV['claims_api__vanotify__services__lighthouse__notify_service_id'] %>
+        notification_client_secret: <%= ENV['claims_api__vanotify__services__lighthouse__notification_client_secret'] %>
 clamav:
   host: clamav
   mock: <%= ENV['clamav__mock'] %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -222,6 +222,8 @@ claims_api:
     services:
       lighthouse:
         api_key: ~
+        notify_service_id: ~
+        notification_client_secret: ~
 clamav:
   host: 0.0.0.0
   mock: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -222,8 +222,8 @@ claims_api:
     services:
       lighthouse:
         api_key: ~
-        notify_service_id: ~
         notification_client_secret: ~
+        notify_service_id: ~
 clamav:
   host: 0.0.0.0
   mock: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -221,8 +221,8 @@ claims_api:
     services:
       lighthouse:
         api_key: fake-xxxxxx-zzzz-aaaa-bbbb-cccccccc-xxxxxx-zzzz-aaaa-bbbb-cccccccc
-        notify_service_id: xxxxxxxx-aaaa-bbbb-cccc-dddddddddddd
         notification_client_secret: xxxxxxxx-zzzz-xxxx-yyyy-vvvvvvvvvvvv
+        notify_service_id: xxxxxxxx-aaaa-bbbb-cccc-dddddddddddd
 clamav:
   host: 0.0.0.0
   mock: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -221,6 +221,8 @@ claims_api:
     services:
       lighthouse:
         api_key: fake-xxxxxx-zzzz-aaaa-bbbb-cccccccc-xxxxxx-zzzz-aaaa-bbbb-cccccccc
+        notify_service_id: xxxxxxxx-aaaa-bbbb-cccc-dddddddddddd
+        notification_client_secret: xxxxxxxx-zzzz-xxxx-yyyy-vvvvvvvvvvvv
 clamav:
   host: 0.0.0.0
   mock: true


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Adds settings entries for VANotify poller to production configuration file.
- Note that corresponding entries have been made in AWS parameter store to populate the values for the added settings:
/dsva-vagov/vets-api/prod/env_vars/claims_api/vanotify/services/lighthouse/notify_service_id
/dsva-vagov/vets-api/prod/env_vars/claims_api/vanotify/services/lighthouse/notification_client_secret

## Related issue(s)

[API-45733](https://jira.devops.va.gov/browse/API-45733)

## Testing done

- [ ] *New code is covered by unit tests*
- VANotify polling is currently failing with auth errors in production, so once these settings are deployed we should no longer see these errors.


## What areas of the site does it impact?
VANotifyFollowUpJob configuration

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

