### PR TITLE
feat: enable deploys to named mock-data branches, when enabled

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -116,7 +116,8 @@ type: application
 # 0.15.12  - Discard ImageMagick k8s changes
 # 0.15.13  - Add external secret that removes SETTINGS__ prefix for env var injection
 # 0.15.14  - remove secret with SETTINGS__ prefix, as no longer used
-version: 0.15.14
+# 0.15.15  - Add branch selector to mockData 
+version: 0.15.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/server-deployment.yaml
+++ b/chart/templates/server-deployment.yaml
@@ -51,12 +51,14 @@ spec:
             path: /var/run/datadog
 {{ toYaml $root.Values.common.volumes | indent 8 }}
       {{- if $root.Values.mockData.enabled }}
+      {{- if $root.Values.mockData.branch | default "master" }}
       initContainers:
         - name: vets-api-mockdata
           image: "{{ $root.Values.git_container_repo }}:{{ $root.Values.git_container_version }}"
           args:
             - clone
             - --single-branch
+            - --branch {{ $root.Values.mockData.branch }}
             - --
             - https://$(GITHUB_TOKEN)@github.com/department-of-veterans-affairs/vets-api-mockdata.git
             - /data

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -17,6 +17,7 @@ vsp_environment:
 affinityWeight:
 mockData:
   enabled: false
+  branch: master
 matchExpressions:
   key: app
   operator: In


### PR DESCRIPTION

## Summary

This change is to help facilitate PR environments. We want to add the ability to specify and mock-data branch so that the correct dataset may be used. 

## Related issue(s)

Relates to https://github.com/department-of-veterans-affairs/va.gov-team/issues/105592

## Testing done

- Testing will commence after merge


