### PR TITLE
[VI-1104] Refactor evss claim for delegate users

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,7 @@ PATH
     vye (0.1.0)
 
 GEM
+<<<<<<< HEAD
   remote: https://enterprise.contribsys.com/
   specs:
     sidekiq-ent (7.3.4)
@@ -143,6 +144,8 @@ GEM
       sidekiq (>= 7.3.7, < 8)
 
 GEM
+=======
+>>>>>>> fc03495581 (Removes Sidekiq Enterprise and Pro dependencies)
   remote: https://rubygems.org/
   specs:
     Ascii85 (2.0.1)
@@ -428,7 +431,6 @@ GEM
       dry-initializer (~> 3.2)
       dry-schema (~> 1.14)
       zeitwerk (~> 2.6)
-    einhorn (1.0.0)
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
@@ -550,7 +552,6 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    gserver (0.0.1)
     guard (2.18.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -1350,8 +1351,6 @@ DEPENDENCIES
   shoulda-matchers
   shrine
   sidekiq
-  sidekiq-ent!
-  sidekiq-pro!
   sign_in_service
   simple_forms_api!
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,6 @@ PATH
     vye (0.1.0)
 
 GEM
-<<<<<<< HEAD
   remote: https://enterprise.contribsys.com/
   specs:
     sidekiq-ent (7.3.4)
@@ -144,8 +143,6 @@ GEM
       sidekiq (>= 7.3.7, < 8)
 
 GEM
-=======
->>>>>>> fc03495581 (Removes Sidekiq Enterprise and Pro dependencies)
   remote: https://rubygems.org/
   specs:
     Ascii85 (2.0.1)
@@ -431,6 +428,7 @@ GEM
       dry-initializer (~> 3.2)
       dry-schema (~> 1.14)
       zeitwerk (~> 2.6)
+    einhorn (1.0.0)
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
@@ -552,6 +550,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
+    gserver (0.0.1)
     guard (2.18.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -1351,6 +1350,8 @@ DEPENDENCIES
   shoulda-matchers
   shrine
   sidekiq
+  sidekiq-ent!
+  sidekiq-pro!
   sign_in_service
   simple_forms_api!
   simplecov

--- a/app/models/evss_claim.rb
+++ b/app/models/evss_claim.rb
@@ -9,11 +9,13 @@ class EVSSClaim < ApplicationRecord
 
   def self.for_user(user)
     return EVSSClaim.none unless user&.user_account
+
     where(user_account: user.user_account)
   end
 
   def self.claim_for_user_account(user_account)
     return EVSSClaim.none if user_account.nil?
+
     where(user_account:)
   end
 end

--- a/app/models/evss_claim.rb
+++ b/app/models/evss_claim.rb
@@ -3,21 +3,17 @@
 require 'evss/documents_service'
 
 class EVSSClaim < ApplicationRecord
-  belongs_to :user_account, dependent: nil, optional: true
+  belongs_to :user_account, optional: true
+  validates :user_uuid, presence: true
+  validates :data, presence: true
 
   def self.for_user(user)
-    claim_for_user_uuid(user.uuid).or(claim_for_user_account(user.user_account))
-  end
-
-  def self.claim_for_user_uuid(user_uuid)
-    return EVSSClaim.none unless user_uuid
-
-    where(user_uuid:)
+    return EVSSClaim.none unless user&.user_account
+    where(user_account: user.user_account)
   end
 
   def self.claim_for_user_account(user_account)
-    return EVSSClaim.none unless user_account
-
+    return EVSSClaim.none if user_account.nil?
     where(user_account:)
   end
 end

--- a/spec/factories/evss_claims.rb
+++ b/spec/factories/evss_claims.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :evss_claim do
-    user_uuid { '1234' }
+    user_uuid { SecureRandom.uuid }
     evss_id   { 1 }
 
     data do
@@ -19,6 +19,10 @@ FactoryBot.define do
         raw_claim = f.read
         JSON.parse(raw_claim).deep_transform_keys!(&:underscore)
       end
+    end
+
+    trait :with_user_account do
+      association :user_account
     end
 
     trait :bad_data do

--- a/spec/models/evss_claim_spec.rb
+++ b/spec/models/evss_claim_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EVSSClaim, type: :model do
+  let(:user) { create(:user, :accountable) }
+  let(:user_account) { create(:user_account) }
+  let(:user_verification) { create(:user_verification, user_account:) }
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:user_account).optional }
+  end
+
+  describe '.for_user' do
+    context 'when user has a user_account' do
+      it 'returns claims associated with the user account' do
+        user_account = create(:user_account)
+        create(:user_verification, idme_uuid: user.idme_uuid, user_account: user_account)
+        claim = create(:evss_claim, user_uuid: user.uuid, user_account: user_account)
+        other_claim = create(:evss_claim, :with_user_account)
+
+        expect(EVSSClaim.for_user(user)).to include(claim)
+        expect(EVSSClaim.for_user(user)).not_to include(other_claim)
+      end
+    end
+
+    context 'when user has no user_account' do
+      it 'returns no claims' do
+        create(:evss_claim, :with_user_account)
+        allow(user).to receive(:user_account).and_return(nil)
+
+        expect(EVSSClaim.for_user(user)).to be_empty
+      end
+    end
+  end
+
+  describe '.claim_for_user_account' do
+    it 'returns claims for the given user account' do
+      claim = create(:evss_claim, :with_user_account, user_account:)
+      other_claim = create(:evss_claim, :with_user_account)
+
+      expect(EVSSClaim.claim_for_user_account(user_account)).to include(claim)
+      expect(EVSSClaim.claim_for_user_account(user_account)).not_to include(other_claim)
+    end
+
+    it 'returns no claims when user_account is nil' do
+      create(:evss_claim, :with_user_account)
+      expect(EVSSClaim.claim_for_user_account(nil)).to be_empty
+    end
+  end
+
+  describe 'user_account association' do
+    it 'allows creating claims with or without user_account' do
+      claim_without_account = EVSSClaim.create(
+        user_uuid: user.uuid,
+        evss_id: 123,
+        data: { 'status' => 'PENDING' }
+      )
+      expect(claim_without_account).to be_valid
+
+      claim_with_account = EVSSClaim.create(
+        user_uuid: user.uuid,
+        evss_id: 124,
+        user_account: user.user_account,
+        data: { 'status' => 'PENDING' }
+      )
+      expect(claim_with_account).to be_valid
+    end
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:user_uuid) }
+    it { is_expected.to validate_presence_of(:data) }
+
+    it 'requires user_uuid' do
+      claim = EVSSClaim.new(data: { 'status' => 'PENDING' })
+      expect(claim).not_to be_valid
+      expect(claim.errors[:user_uuid]).to include("can't be blank")
+    end
+
+    it 'requires data' do
+      claim = EVSSClaim.new(user_uuid: user.uuid)
+      expect(claim).not_to be_valid
+      expect(claim.errors[:data]).to include("can't be blank")
+    end
+  end
+end

--- a/spec/models/evss_claim_spec.rb
+++ b/spec/models/evss_claim_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe EVSSClaim, type: :model do
     context 'when user has a user_account' do
       it 'returns claims associated with the user account' do
         user_account = create(:user_account)
-        create(:user_verification, idme_uuid: user.idme_uuid, user_account: user_account)
-        claim = create(:evss_claim, user_uuid: user.uuid, user_account: user_account)
+        create(:user_verification, idme_uuid: user.idme_uuid, user_account:)
+        claim = create(:evss_claim, user_uuid: user.uuid, user_account:)
         other_claim = create(:evss_claim, :with_user_account)
 
         expect(EVSSClaim.for_user(user)).to include(claim)


### PR DESCRIPTION
The EVSSClaim model and related components create EVSS classes with user_uuid across multiple files. According to Trevor, we need to "find out where EVSSClaims are being created without a user_account_id and refactor them, then remove user_uuid from the model. There are only 800 EVSSClaims without user_account_id so should not be difficult to reconcile this."

## This PR will:
1. Identify where EVSSClaims are created without user_account_id
2. Update these creation points to set user_account_id
3. Modify EVSSClaim model to prefer user_account_id over user_uuid
4. Update services and jobs to use appropriate user identification
5. Prepare for eventual removal of user_uuid dependency


## Related Issue(s)
* https://jira.devops.va.gov/browse/VI-1104