### PR TITLE
Use new JSON fixture to test form4142 actions

### DIFF
--- a/modules/decision_reviews/spec/sidekiq/form4142_submit_spec.rb
+++ b/modules/decision_reviews/spec/sidekiq/form4142_submit_spec.rb
@@ -51,7 +51,9 @@ RSpec.describe DecisionReviews::Form4142Submit, type: :job do
       create(:appeal_submission_module, :with_one_upload_module, submitted_appeal_uuid:, type_of_appeal: 'SC')
     end
     let(:user) { build(:user, :loa3) }
-    let(:request_body) { VetsJsonSchema::EXAMPLES.fetch('SC-CREATE-REQUEST-BODY-FOR-VA-GOV') }
+    let(:request_body) do
+      JSON.parse(File.read('modules/decision_reviews/spec/support/schema_examples/sc_create_with_4142_v1.json'))
+    end
 
     context 'when form4142 data exists' do
       it '#decrypt_form properly decrypts encrypted payloads' do

--- a/modules/decision_reviews/spec/support/schema_examples/sc_create_with_4142_v1.json
+++ b/modules/decision_reviews/spec/support/schema_examples/sc_create_with_4142_v1.json
@@ -1,0 +1,35 @@
+{"form4142":
+{"privacyAgreementAccepted":true,
+   "limitedConsent":"Please limit to only non-psych records",
+   "providerFacility":
+    [{"providerFacilityName":"provider 1",
+      "treatmentDateRange":[{"from":"1980-01-01", "to":"1985-01-01"}, {"from":"1986-01-01", "to":"1987-01-01"}],
+      "providerFacilityAddress":{"street":"123 Main Street", "street2":"1B", "city":"Baltimore", "state":"MD", "country":"USA", "postalCode":"21200-1111"}},
+     {"providerFacilityName":"provider 2",
+      "treatmentDateRange":[{"from":"1980-02-01", "to":"1985-02-01"}, {"from":"1986-02-01", "to":"1987-02-01"}],
+      "providerFacilityAddress":{"street":"456 Main Street", "street2":"1B", "city":"Baltimore", "state":"MD", "country":"USA", "postalCode":"21200-1111"}},
+     {"providerFacilityName":"provider 3",
+      "treatmentDateRange":[{"from":"1980-03-01", "to":"1985-03-01"}, {"from":"1986-03-01", "to":"1987-03-01"}],
+      "providerFacilityAddress":{"street":"789 Main Street", "street2":"1B", "city":"Baltimore", "state":"MD", "country":"USA", "postalCode":"21200-1111"}},
+     {"providerFacilityName":"provider 4",
+      "treatmentDateRange":[{"from":"1980-04-01", "to":"1985-04-01"}, {"from":"1986-04-01", "to":"1987-04-01"}],
+      "providerFacilityAddress":{"street":"101 Main Street", "street2":"1B", "city":"Baltimore", "state":"MD", "country":"USA", "postalCode":"21200-1111"}},
+     {"providerFacilityName":"provider 5",
+      "treatmentDateRange":[{"from":"1980-05-01", "to":"1985-05-01"}, {"from":"1986-05-01", "to":"1987-05-01"}],
+      "providerFacilityAddress":{"street":"102 Main Street", "street2":"1B", "city":"Baltimore", "state":"MD", "country":"USA", "postalCode":"21200-1111"}}]},
+ "data":
+  {"type":"supplementalClaim",
+   "attributes":
+    {"benefitType":"fiduciary",
+     "claimantType":"veteran",
+     "veteran":
+      {"address":{"addressLine1":"123  Main St", "city":"New York", "countryCodeISO2":"US", "zipCode5":"30012"},
+       "phone":{"areaCode":"555", "phoneNumber":"8001111"},
+       "email":"josie@example.com",
+       "timezone":"America/Chicago"},
+     "socOptIn":false,
+     "evidenceSubmission":{"evidenceType":["upload"]}}},
+ "additionalDocuments":
+  [{"name":"buddy-statement.pdf", "confirmationCode":"kkkkkkkk-llll-mmmm-nnnn-oooooooooooo", "attachmentId":"L015", "size":40000, "isEncrypted":false},
+   {"name":"photos.pdf", "confirmationCode":"pppppppp-qqqql-rrrr-ssss-ttttttttttt", "attachmentId":"L070", "size":40000, "isEncrypted":false}],
+ "included":[{"type":"contestableIssue", "attributes":{"issue":"right  shoulder", "decisionDate":"1900-01-06"}}]}


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- *(Summarize the changes that have been made to the platform)*
Add a new json fixture for supplemental claim request testing in the decision_reviews module
- *(If bug, how to reproduce)*
Some tests in this module are currently red due to changes in `vets-json-schema` that did not get reflected in the example schemas
- *(What is the solution, why is this the solution?)*
Don't rely on example schemas from `vets-json-schema` until this is resolved
- *(Which team do you work for, does your team own the maintenance of this component?)*
Decision Reviews, yes

## Related issue(s)

- No ticket or issue, noticed test failures while working on an unrelated feature

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
Relied on example schemas from `vets-json-schema` for form 4142 testing
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
In this case, the problem was red tests due to incorrect fixtures, not broken behavior

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
Tests for form 4142 creation as part of submitting a supplemental claim

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature