### PR TITLE
Handle missing allergy fields gracefully

### DIFF
--- a/modules/mobile/app/models/mobile/v0/adapters/legacy_allergy_intolerance.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/legacy_allergy_intolerance.rb
@@ -13,7 +13,7 @@ module Mobile
               type: allergy_info['type'],
               clinicalStatus: clinical_status(allergy_info['clinicalStatus']),
               code: code(allergy_info['code']),
-              recordedDate: allergy_info['recordedDate'],
+              recordedDate: allergy_info&.dig('recordedDate'),
               patient: patient(allergy_info['patient']),
               recorder: recorder(allergy_info['recorder']),
               notes: notes(allergy_info['note']),
@@ -26,6 +26,8 @@ module Mobile
         private
 
         def clinical_status(attributes)
+          return { 'coding' => [] } if attributes.blank?
+
           values = Array.wrap(attributes['coding'])
           coding_hash = values.map do |code|
             {
@@ -55,19 +57,21 @@ module Mobile
 
         def patient(attributes)
           {
-            'reference' => attributes['reference'],
-            'display' => attributes['display']
+            'reference' => attributes&.dig('reference'),
+            'display' => attributes&.dig('display')
           }
         end
 
         def recorder(attributes)
           {
-            'reference' => attributes['reference'],
-            'display' => attributes['display']
+            'reference' => attributes&.dig('reference'),
+            'display' => attributes&.dig('display')
           }
         end
 
         def notes(attributes)
+          return [] if attributes.blank?
+
           Array.wrap(attributes).map do |note|
             {
               'authorReference' => {
@@ -81,6 +85,8 @@ module Mobile
         end
 
         def reactions(attributes)
+          return [] if attributes.blank?
+
           Array.wrap(attributes).map do |reaction|
             substance = Array.wrap(reaction.dig('substance', 'coding'))
 

--- a/spec/support/vcr_cassettes/rrd/lighthouse_allergy_intolerances_empty_fields.yml
+++ b/spec/support/vcr_cassettes/rrd/lighthouse_allergy_intolerances_empty_fields.yml
@@ -134,14 +134,6 @@ http_interactions:
       "resource": {
         "resourceType": "AllergyIntolerance",
         "id": "I2-FY4N5GUAQ4IZQVQZUPDFN43S4A000000",
-        "clinicalStatus": {
-          "coding": [
-            {
-              "system": "http://hl7.org/fhir/ValueSet/allergyintolerance-clinical",
-              "code": "active"
-            }
-          ]
-        },
         "type": "allergy",
         "category": [
           "environment"
@@ -155,52 +147,7 @@ http_interactions:
             }
           ],
           "text": "Latex allergy"
-        },
-        "patient": {
-          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/43000199",
-          "display": "Ms. Carlita746 Kautzer186"
-        },
-        "recordedDate": "1999-01-07T01:43:31Z",
-        "recorder": {
-          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-4ZXYC2SQAZCHMOWPPFNLOY65GE000000",
-          "display": "DR. THOMAS359 REYNOLDS206 PHD"
-        },
-        "note": [
-          {
-            "authorReference": {
-              "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-HRJI2MVST2IQSPR7U5SACWIWZA000000",
-              "display": "DR. JANE460 DOE922 MD"
-            },
-            "time": "1999-01-07T01:43:31Z",
-            "text": "Latex allergy"
-          }
-        ],
-        "reaction": [
-          {
-            "substance": {
-              "coding": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "300916003",
-                  "display": "Latex allergy"
-                }
-              ],
-              "text": "Latex allergy"
-            },
-            "manifestation": [
-              {
-                "coding": [
-                  {
-                    "system": "urn:oid:2.16.840.1.113883.6.233",
-                    "code": "43000006",
-                    "display": "Itchy Watery Eyes"
-                  }
-                ],
-                "text": "Itchy Watery Eyes"
-              }
-            ]
-          }
-        ]
+        }
       },
       "search": {
         "mode": "match"


### PR DESCRIPTION
## Summary

We are seeing some allergy requests fail with `adapters/legacy_allergy_intolerance.rb:65:in 'recorder': undefined method '[]' for nil (NoMethodError)` ([datadog link](https://vagov.ddog-gov.com/logs?query=service%3Avets-api%20env%3Aeks-prod%20%40payload.controller%3A%28%22Mobile%3A%3AV0%3A%3AAllergyIntolerancesController%22%29%20%40http.status_code%3A500&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=3507310816979748981&storage=hot&stream_sort=desc&viz=stream&from_ts=1742916718354&to_ts=1742931118354&live=true))

We investigated with @stephenBarrs and he was able to confirm that some results are returned from Lighthouse with a missing `recorder` field. This PR updates the adapter to allow nil values for non-core fields (type, text, id).

## Related issue(s)

- https://dsva.slack.com/archives/C018V2JCWRJ/p1742932149150149

## Testing done

- [x] *New code is covered by unit tests*
