### PR TITLE
BE | Ask va api: fix inquiries retriever bug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,10 +74,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: d4cd99ae9041e1f1ebce1aae44be80d6693e3908
+  revision: c0f2a9bcf5f6eefd2182732732b1d6e17473db3d
   branch: master
   specs:
-    vets_json_schema (24.11.2)
+    vets_json_schema (24.12.0)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 

--- a/config/form_profile_mappings/0873.yml
+++ b/config/form_profile_mappings/0873.yml
@@ -10,6 +10,7 @@ personalInformation:
 contactInformation:
   email: [contact_information, email]
   phone: [contact_information, us_phone]
+  workPhone: [personal_information, work_phone]
   address: [contact_information, address]
 avaProfile:
   schoolInfo:

--- a/modules/ask_va_api/app/lib/ask_va_api/base_retriever.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/base_retriever.rb
@@ -16,11 +16,6 @@ module AskVAApi
 
       entity_class.new(data)
     rescue => e
-      if e.message.include?('"Message":"Data Validation: No Contact found by ICN"') &&
-         e.instance_of?(AskVAApi::Inquiries::InquiriesRetrieverError)
-        return []
-      end
-
       ::ErrorHandler.handle_service_error(e)
     end
 

--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/inquiry_payload.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/inquiry_payload.rb
@@ -118,9 +118,10 @@ module AskVAApi
         def build_residency_state_data
           {
             Name: fetch_state(inquiry_params.dig(:state_or_residency, :residency_state)) ||
-              inquiry_params[:family_members_location_of_residence],
+              inquiry_params[:family_members_location_of_residence] || inquiry_params[:your_location_of_residence],
             StateCode: inquiry_params.dig(:state_or_residency, :residency_state) ||
-              fetch_state_code(inquiry_params[:family_members_location_of_residence])
+              fetch_state_code(inquiry_params[:family_members_location_of_residence] ||
+              inquiry_params[:your_location_of_residence])
           }
         end
 

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/inquiry_payload_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/inquiry_payload_spec.rb
@@ -66,5 +66,57 @@ RSpec.describe AskVAApi::Inquiries::PayloadBuilder::InquiryPayload do
         )
       end
     end
+
+    context 'when your_location_of_residence is passed' do
+      let(:params) do
+        {
+          category_id: '75524deb-d864-eb11-bb24-000d3a579c45',
+          contact_preference: 'Email',
+          email_address: 'test@test.com',
+          phone_number: '3039751100',
+          question: 'test',
+          relationship_to_veteran: "I'm the Veteran",
+          select_category: 'Education benefits and work study',
+          select_topic: 'Veteran Readiness and Employment (Chapter 31)',
+          subject: 'test',
+          topic_id: 'b18831a7-8276-ef11-a671-001dd8097cca',
+          who_is_your_question_about: 'Myself',
+          your_location_of_residence: 'Colorado',
+          your_vre_information: false,
+          address: {
+            military_address: {
+              military_post_office: nil,
+              military_state: nil
+            }
+          },
+          about_yourself: {
+            date_of_birth: '1950-01-01',
+            first: 'Submitter',
+            last: 'SubVet',
+            social_or_service_num: {
+              ssn: '123456799'
+            }
+          },
+          about_the_veteran: {
+            social_or_service_num: {}
+          },
+          about_the_family_member: {
+            social_or_service_num: {}
+          },
+          state_or_residency: {},
+          files: [
+            {
+              file_name: nil,
+              file_content: nil
+            }
+          ],
+          school_obj: {}
+        }
+      end
+
+      it 'raise an error' do
+        expect(builder.call[:SubmitterStateOfResidency]).to eq({ Name: 'Colorado', StateCode: 'CO' })
+      end
+    end
   end
 end

--- a/modules/ask_va_api/spec/requests/ask_va_api/v0/inquiries_spec.rb
+++ b/modules/ask_va_api/spec/requests/ask_va_api/v0/inquiries_spec.rb
@@ -80,10 +80,10 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
       end
 
       context 'when an error occurs' do
-        context 'when No Contact found by ICN' do
+        context 'when Multiple Contacts found by ICN' do
           let(:service) { instance_double(Crm::Service) }
           let(:body) do
-            '{"Data":null,"Message":"Data Validation: No Contact found by ICN"' \
+            '{"Data":null,"Message":"Data Validation: Multiple Contacts found by ICN"' \
               ',"ExceptionOccurred":true,"ExceptionMessage"' \
               ':"Data Validation: No Contact found by ICN","MessageId":"19d9799c-159f-4901-8672-6bdfc1d4cc0f"}'
           end
@@ -96,9 +96,11 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
             get inquiry_path
           end
 
-          it 'returns an empty array' do
-            expect(JSON.parse(response.body)['data']).to eq([])
-          end
+          it_behaves_like 'common error handling', :unprocessable_entity, 'service_error',
+                          'AskVAApi::Inquiries::InquiriesRetrieverError:' \
+                          ' {"Data":null,"Message":"Data Validation: Multiple Contacts found by ICN"' \
+                          ',"ExceptionOccurred":true,"ExceptionMessage":"Data Validation: No Contact found by ICN",' \
+                          '"MessageId":"19d9799c-159f-4901-8672-6bdfc1d4cc0f"}'
         end
 
         context 'when a standard error' do

--- a/spec/fixtures/pdf_fill/21P-0969/merge_fields.json
+++ b/spec/fixtures/pdf_fill/21P-0969/merge_fields.json
@@ -216,6 +216,61 @@
       "ownedPortionValueOverflow": 12345.67
     }
   ],
+  "assetTransfers": [
+    {
+      "fairMarketValue": 1000000,
+      "saleValue": 8234567.89,
+      "capitalGainValue": 7234567.89,
+      "assetTransferredUnderFairMarketValue": false,
+      "transferDate": "1992-01-01",
+      "newOwnerName": {
+        "first": "John",
+        "last": "Doe",
+        "suffix": "Jr."
+      },
+      "newOwnerRelationship": "Sibling",
+      "saleReportedToIrs": true,
+      "transferMethod": "OTHER",
+      "otherTransferMethod": "Earned",
+      "assetType": "Clothes",
+      "originalOwnerRelationship": "OTHER",
+      "otherOriginalOwnerRelationshipType": "Cousin"
+    },
+    {
+      "fairMarketValue": 123.12,
+      "saleValue": 100,
+      "capitalGainValue": 0,
+      "assetTransferredUnderFairMarketValue": true,
+      "transferDate": "1993-02-02",
+      "newOwnerName": {
+        "first": "Jacob",
+        "last": "Doe",
+        "suffix": "Sr."
+      },
+      "newOwnerRelationship": "Aunt",
+      "saleReportedToIrs": false,
+      "transferMethod": "GIFTED",
+      "assetType": "Artwork",
+      "originalOwnerRelationship": "CHILD"
+    },
+    {
+      "fairMarketValue": 1800.99,
+      "saleValue": 2000,
+      "capitalGainValue": 200.99,
+      "assetTransferredUnderFairMarketValue": false,
+      "transferDate": "1995-05-12",
+      "newOwnerName": {
+        "first": "John",
+        "last": "Doe",
+        "suffix": "Jr."
+      },
+      "newOwnerRelationship": "Brother",
+      "saleReportedToIrs": true,
+      "transferMethod": "TRADED",
+      "assetType": "Bike",
+      "originalOwnerRelationship": "PARENT"
+    }
+  ],
   "unassociatedIncome": "YES",
   "associatedIncome": 0,
   "ownedAsset": 0

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -110,6 +110,14 @@ RSpec.describe FormProfile, type: :model do
   end
 
   let(:v0873_expected) do
+    user_work_phone = user.vet360_contact_info.work_phone
+    work_phone = [
+      user_work_phone.country_code,
+      user_work_phone.area_code,
+      user_work_phone.phone_number,
+      user_work_phone.extension
+    ].compact.join
+
     {
       'personalInformation' => {
         'first' => user.first_name&.capitalize,
@@ -124,7 +132,8 @@ RSpec.describe FormProfile, type: :model do
       'contactInformation' => {
         'email' => user.pciu_email,
         'phone' => us_phone,
-        'address' => address
+        'address' => address,
+        'workPhone' => work_phone
       },
       'avaProfile' => {
         'schoolInfo' => {
@@ -1669,6 +1678,7 @@ RSpec.describe FormProfile, type: :model do
               'contactInformation' => {
                 'email' => user.pciu_email,
                 'phone' => us_phone,
+                'workPhone' => '13035551234',
                 'address' => address
               },
               'avaProfile' => {

--- a/spec/models/form_profile_v2_spec.rb
+++ b/spec/models/form_profile_v2_spec.rb
@@ -100,6 +100,14 @@ RSpec.describe FormProfile, type: :model do
     }
   end
   let(:v0873_expected) do
+    user_work_phone = user.vet360_contact_info.work_phone
+    work_phone = [
+      user_work_phone.country_code,
+      user_work_phone.area_code,
+      user_work_phone.phone_number,
+      user_work_phone.extension
+    ].compact.join
+
     {
       'personalInformation' => {
         'first' => user.first_name&.capitalize,
@@ -114,7 +122,8 @@ RSpec.describe FormProfile, type: :model do
       'contactInformation' => {
         'email' => user.va_profile_email,
         'phone' => us_phone,
-        'address' => address
+        'address' => address,
+        'workPhone' => work_phone
       },
       'avaProfile' => {
         'schoolInfo' => {


### PR DESCRIPTION
## Summary

This PR includes the following enhancements and updates:
	• InquiryPayload Update
	• Added your_location_of_residency to the SubmitterZipCodeOfResidency section to support more accurate residency mapping.
	• BaseRetriever Error Handling
	• Improved error handling logic in BaseRetriever for more consistent and resilient responses across retriever classes.
	• VA0873 Personal Information Enhancement
	• Added work_phone to the personal information payload.
	• Pulled and normalized work_phone data using vet360_contact_info.

## Related issue(s)

- [Ask VA Api: Fix Inquiries retriever bug](https://github.com/department-of-veterans-affairs/ask-va/issues/1707)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
