### PR TITLE
API-45855-replaces-md5-526-controller

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -67,7 +67,10 @@ module ClaimsApi
           # If it's lacking the ID, that means the create was unsuccessful and an identical claim already exists.
           # Find and return that claim instead.
           unless auto_claim.id
-            existing_auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: auto_claim.md5)
+            existing_auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(header_hash: auto_claim.header_hash)
+            if existing_auto_claim.nil?
+              existing_auto_claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: auto_claim.md5)
+            end
             auto_claim = existing_auto_claim if existing_auto_claim.present?
           end
 

--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/disability_compensation_controller.rb
@@ -228,10 +228,8 @@ module ClaimsApi
         def track_pact_counter(claim)
           return unless valid_pact_act_claim?
 
-          # Fetch the claim by md5 if it doesn't have an ID (given duplicate md5)
-          if claim.id.nil? && claim.errors.find { |e| e.attribute == :md5 }&.type == :taken
-            claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: claim.md5) || claim
-          end
+          find_claim(claim)
+
           if claim.id
             ClaimsApi::ClaimSubmission.create claim:, claim_type: 'PACT',
                                               consumer_label: token.payload['label'] || token.payload['cid']
@@ -285,6 +283,14 @@ module ClaimsApi
 
         def mocking
           Settings.claims_api.benefits_documents.use_mocks
+        end
+
+        def find_claim(claim)
+          # Fetch the claim by md5 if it doesn't have an ID (given duplicate md5)
+          if claim.id.nil? && claim.errors.find { |e| e.attribute == :md5 }&.type == :taken
+            claim = ClaimsApi::AutoEstablishedClaim.find_by(md5: claim.md5) || claim
+          end
+          ClaimsApi::AutoEstablishedClaim.find_by(header_hash: claim.header_hash) || claim if claim.nil?
         end
       end
     end

--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -20,6 +20,7 @@ module ClaimsApi
                   key: :kms_key, **lockbox_options
     validate :validate_service_dates, unless: :skip_validation
     before_validation :set_md5
+    before_validation :set_header_hash
     after_validation :remove_encrypted_fields, on: [:update]
     after_create :log_special_issues
     after_create :log_flashes
@@ -44,6 +45,7 @@ module ClaimsApi
     VALIDATION_METHOD = 'v2'
 
     validates :md5, uniqueness: true, on: :create, unless: :skip_validation
+    validates :header_hash, uniqueness: true, on: :create, unless: :skip_validation
 
     EVSS_CLAIM_ATTRIBUTES.each do |attribute|
       define_method attribute do
@@ -117,6 +119,14 @@ module ClaimsApi
                                     'va_eauth_issueinstant',
                                     'Authorization')
       self.md5 = Digest::MD5.hexdigest form_data.merge(headers).to_json
+    end
+
+    def set_header_hash
+      headers = auth_headers.except('va_eauth_authenticationauthority',
+                                    'va_eauth_service_transaction_id',
+                                    'va_eauth_issueinstant',
+                                    'Authorization')
+      self.header_hash = Digest::SHA256.hexdigest form_data.merge(headers).to_json
     end
 
     def status_from_phase(*)

--- a/modules/claims_api/app/models/claims_api/evss_claim.rb
+++ b/modules/claims_api/app/models/claims_api/evss_claim.rb
@@ -59,6 +59,11 @@ module ClaimsApi
             id: document.id,
             type: 'claim_supporting_document',
             md5: document.file_data['filename'].present? ? Digest::MD5.hexdigest(document.file_data['filename']) : '',
+            header_hash: if document.file_data['filename'].present?
+                           Digest::SHA256.hexdigest(document.file_data['filename'])
+                         else
+                           ''
+                         end,
             filename: document.file_data['filename'],
             uploaded_at: document.created_at
           }

--- a/modules/claims_api/app/serializers/claims_api/claim_detail_serializer.rb
+++ b/modules/claims_api/app/serializers/claims_api/claim_detail_serializer.rb
@@ -30,6 +30,7 @@ module ClaimsApi
           id: document[:id],
           type: 'claim_supporting_document',
           md5: document[:md5],
+          header_hash: document[:header_hash],
           filename: document[:filename],
           uploaded_at: document[:uploaded_at]
         }

--- a/modules/claims_api/spec/serializers/claim_detail_serializer_spec.rb
+++ b/modules/claims_api/spec/serializers/claim_detail_serializer_spec.rb
@@ -13,6 +13,7 @@ describe ClaimsApi::ClaimDetailSerializer, type: :serializer do
         id: claim.supporting_documents.first[:id],
         type: 'claim_supporting_document',
         md5: claim.supporting_documents.first[:md5],
+        header_hash: claim.supporting_documents.first[:header_hash],
         filename: claim.supporting_documents.first[:filename],
         uploaded_at: claim.supporting_documents.first[:uploaded_at]
       }


### PR DESCRIPTION
## Summary

- Replaces md5 with sha256 for disability comp.

## Related issue(s)

- [API-45855](https://jira.devops.va.gov/browse/API-45855)

## Testing done

- [x] *New code is covered by unit tests*


## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
	modified:   modules/claims_api/app/controllers/claims_api/v2/veterans/disability_compensation_controller.rb
	modified:   modules/claims_api/app/models/claims_api/auto_established_claim.rb
	modified:   modules/claims_api/app/models/claims_api/evss_claim.rb
	modified:   modules/claims_api/app/serializers/claims_api/claim_detail_serializer.rb
	modified:   modules/claims_api/spec/serializers/claim_detail_serializer_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature