### PR TITLE
104641d2 - Remove champva_pdf_decrypt flipper from features.yml - IVC CHAMPVA forms

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -203,9 +203,6 @@ features:
   champva_log_all_s3_uploads:
     actor_type: user
     description: Enables logging for all s3 uploads using UUID or keys for monitoring
-  champva_pdf_decrypt:
-    actor_type: user
-    description: Enables unlocking password protected file submissions in IVC CHAMPVA forms.
   champva_require_all_s3_success:
     actor_type: user
     description: Enables raising a StandardError if any supporting documents fail to upload to S3 in IVC CHAMPVA forms.


### PR DESCRIPTION
## Summary

This PR removes the `champva_pdf_decrypt` flipper from features.yml. It is a follow-on to this [PR](https://github.com/department-of-veterans-affairs/vets-api/pull/21325) that removed all logic dependent on the flipper's presence.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/104641

## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA