### PR TITLE
Pass service_name to breakers middleware for all services

### DIFF
--- a/app/services/medical_copays/request.rb
+++ b/app/services/medical_copays/request.rb
@@ -92,7 +92,7 @@ module MedicalCopays
     def connection
       Faraday.new(url:, headers:, request: request_options) do |conn|
         conn.request :json
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.use Faraday::Response::RaiseError
         conn.response :raise_custom_error, error_prefix: service_name
         conn.response :json

--- a/lib/apps/configuration.rb
+++ b/lib/apps/configuration.rb
@@ -12,7 +12,7 @@ module Apps
 
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use      :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use      Faraday::Response::RaiseError
 
         faraday.response :snakecase, symbolize: false

--- a/lib/bb/configuration.rb
+++ b/lib/bb/configuration.rb
@@ -51,7 +51,7 @@ module BB
     #
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.request :camelcase
         conn.request :json
 

--- a/lib/benefits_intake_service/configuration.rb
+++ b/lib/benefits_intake_service/configuration.rb
@@ -41,7 +41,7 @@ module BenefitsIntakeService
     #
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use      :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use      Faraday::Response::RaiseError
 
         faraday.request :multipart

--- a/lib/benefits_intake_service/configuration.rb
+++ b/lib/benefits_intake_service/configuration.rb
@@ -42,7 +42,7 @@ module BenefitsIntakeService
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
         faraday.use(:breakers, service_name:)
-        faraday.use      Faraday::Response::RaiseError
+        faraday.use Faraday::Response::RaiseError
 
         faraday.request :multipart
         faraday.request :json

--- a/lib/bid/configuration.rb
+++ b/lib/bid/configuration.rb
@@ -6,7 +6,7 @@ module BID
   class Configuration < Common::Client::Configuration::REST
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use Faraday::Response::RaiseError
         faraday.response :betamocks if mock_enabled?
         faraday.response :snakecase, symbolize: false

--- a/lib/bip_claims/configuration.rb
+++ b/lib/bip_claims/configuration.rb
@@ -17,7 +17,7 @@ module BipClaims
     #
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use :breakers
+        faraday.use(:breakers, service_name:)
         faraday.request :json
 
         faraday.response :raise_custom_error, error_prefix: service_name

--- a/lib/bpds/configuration.rb
+++ b/lib/bpds/configuration.rb
@@ -34,8 +34,8 @@ module BPDS
     # @return [Faraday::Connection] a Faraday connection instance.
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use      :breakers
-        faraday.use      Faraday::Response::RaiseError
+        faraday.use(:breakers, service_name:)
+        faraday.use Faraday::Response::RaiseError
 
         faraday.request :multipart
         faraday.request :json

--- a/lib/carma/client/mule_soft_auth_token_configuration.rb
+++ b/lib/carma/client/mule_soft_auth_token_configuration.rb
@@ -5,7 +5,7 @@ module CARMA
     class MuleSoftAuthTokenConfiguration < Common::Client::Configuration::REST
       def connection
         Faraday.new(base_path) do |conn|
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.request :instrumentation, name: service_name
           conn.adapter Faraday.default_adapter
         end

--- a/lib/carma/client/mule_soft_configuration.rb
+++ b/lib/carma/client/mule_soft_configuration.rb
@@ -12,7 +12,7 @@ module CARMA
 
       def connection
         Faraday.new(base_path) do |conn|
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.request :instrumentation, name: service_name
           conn.adapter Faraday.default_adapter
         end

--- a/lib/caseflow/configuration.rb
+++ b/lib/caseflow/configuration.rb
@@ -39,7 +39,7 @@ module Caseflow
     #
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use :breakers
+        faraday.use(:breakers, service_name:)
         faraday.request :json
 
         faraday.response :raise_custom_error, error_prefix: service_name

--- a/lib/central_mail/configuration.rb
+++ b/lib/central_mail/configuration.rb
@@ -14,7 +14,7 @@ module CentralMail
 
     def connection
       Faraday.new(base_path) do |faraday|
-        faraday.use     :breakers
+        faraday.use(:breakers, service_name:)
 
         faraday.request :multipart
         faraday.request :url_encoded

--- a/lib/chip/configuration.rb
+++ b/lib/chip/configuration.rb
@@ -36,7 +36,7 @@ module Chip
     #
     def connection
       @conn ||= Faraday.new(url:) do |faraday|
-        faraday.use :breakers
+        faraday.use(:breakers, service_name:)
         faraday.request :json
 
         faraday.response :chip_error

--- a/lib/contention_classification/configuration.rb
+++ b/lib/contention_classification/configuration.rb
@@ -18,7 +18,7 @@ module ContentionClassification
 
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use Faraday::Response::RaiseError
         faraday.response :json, content_type: /\bjson/
         faraday.adapter Faraday.default_adapter

--- a/lib/debt_management_center/debts_configuration.rb
+++ b/lib/debt_management_center/debts_configuration.rb
@@ -19,7 +19,7 @@ module DebtManagementCenter
 
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |f|
-        f.use :breakers
+        f.use(:breakers, service_name:)
         f.use Faraday::Response::RaiseError
         f.request :json
         f.response :betamocks if Settings.dmc.mock_debts

--- a/lib/debt_management_center/sharepoint/request.rb
+++ b/lib/debt_management_center/sharepoint/request.rb
@@ -170,7 +170,7 @@ module DebtManagementCenter
       def auth_connection
         Faraday.new(url: authentication_url, headers: auth_headers) do |conn|
           conn.request :url_encoded
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.use Faraday::Response::RaiseError
           conn.response :raise_custom_error, error_prefix: service_name
           conn.response :json
@@ -182,7 +182,7 @@ module DebtManagementCenter
       def sharepoint_connection
         Faraday.new(url: "https://#{sharepoint_url}", headers: sharepoint_headers) do |conn|
           conn.request :json
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.use Faraday::Response::RaiseError
           if Flipper.enabled?(:debts_sharepoint_error_logging)
             conn.response :sharepoint_errors, error_prefix: service_name
@@ -199,7 +199,7 @@ module DebtManagementCenter
         Faraday.new(url: "https://#{sharepoint_url}", headers: sharepoint_headers) do |conn|
           conn.request :multipart
           conn.request :url_encoded
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.use Faraday::Response::RaiseError
           if Flipper.enabled?(:debts_sharepoint_error_logging)
             conn.response :sharepoint_pdf_errors, error_prefix: service_name

--- a/lib/debt_management_center/vbs/request.rb
+++ b/lib/debt_management_center/vbs/request.rb
@@ -60,7 +60,7 @@ module DebtManagementCenter
       def connection
         Faraday.new(url:, headers:) do |conn|
           conn.request :json
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.use Faraday::Response::RaiseError
           conn.response :raise_custom_error, error_prefix: service_name
           conn.response :json

--- a/lib/decision_review/configuration.rb
+++ b/lib/decision_review/configuration.rb
@@ -40,7 +40,7 @@ module DecisionReview
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
         faraday.use(:breakers, service_name:)
-        faraday.use      Faraday::Response::RaiseError
+        faraday.use Faraday::Response::RaiseError
 
         faraday.request :multipart
         faraday.request :json

--- a/lib/decision_review/configuration.rb
+++ b/lib/decision_review/configuration.rb
@@ -39,7 +39,7 @@ module DecisionReview
     #
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use      :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use      Faraday::Response::RaiseError
 
         faraday.request :multipart

--- a/lib/decision_review/utilities/pdf_validation/configuration.rb
+++ b/lib/decision_review/utilities/pdf_validation/configuration.rb
@@ -37,7 +37,7 @@ module DecisionReview
       #
       def connection
         @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-          faraday.use      :breakers
+          faraday.use(:breakers, service_name:)
           faraday.use      Faraday::Response::RaiseError
 
           faraday.response :betamocks if mock_enabled?

--- a/lib/disability_max_ratings/configuration.rb
+++ b/lib/disability_max_ratings/configuration.rb
@@ -18,7 +18,7 @@ module DisabilityMaxRatings
 
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use Faraday::Response::RaiseError
         faraday.response :json, content_type: /\bjson/
         faraday.adapter Faraday.default_adapter

--- a/lib/evss/base_service.rb
+++ b/lib/evss/base_service.rb
@@ -57,7 +57,7 @@ module EVSS
     # Net/HTTP capitalizes headers
     def conn
       @conn ||= Faraday.new(base_url, headers: @headers, ssl: ssl_options, request: timeout) do |faraday|
-        faraday.use      :breakers
+        faraday.use :breakers
         faraday.use      Faraday::Response::RaiseError
         faraday.use      EVSS::ErrorMiddleware
         faraday.response :betamocks if @use_mock

--- a/lib/evss/configuration.rb
+++ b/lib/evss/configuration.rb
@@ -43,7 +43,7 @@ module EVSS
     end
 
     def set_evss_middlewares(faraday, snakecase: true)
-      faraday.use      :breakers
+      faraday.use(:breakers, service_name:)
       faraday.use      EVSS::ErrorMiddleware
       faraday.use      Faraday::Response::RaiseError
       faraday.response :betamocks if mock_enabled?

--- a/lib/evss/letters/download_configuration.rb
+++ b/lib/evss/letters/download_configuration.rb
@@ -14,7 +14,7 @@ module EVSS
       #
       def connection
         @conn ||= Faraday.new(base_path, request: request_options, ssl: ssl_options) do |faraday|
-          faraday.use :breakers
+          faraday.use(:breakers, service_name:)
           faraday.use EVSS::ErrorMiddleware
           faraday.use :immutable_headers
 

--- a/lib/form526_backup_submission/configuration.rb
+++ b/lib/form526_backup_submission/configuration.rb
@@ -36,7 +36,7 @@ module Form526BackupSubmission
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
         faraday.use(:breakers, service_name:)
-        faraday.use      Faraday::Response::RaiseError
+        faraday.use Faraday::Response::RaiseError
 
         faraday.request :multipart
         faraday.request :json

--- a/lib/form526_backup_submission/configuration.rb
+++ b/lib/form526_backup_submission/configuration.rb
@@ -35,7 +35,7 @@ module Form526BackupSubmission
     #
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use      :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use      Faraday::Response::RaiseError
 
         faraday.request :multipart

--- a/lib/forms/configuration.rb
+++ b/lib/forms/configuration.rb
@@ -12,7 +12,7 @@ module Forms
 
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use      :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use      Faraday::Response::RaiseError
 
         faraday.response :betamocks if mock_enabled?

--- a/lib/generators/module_component/templates/app/services/configuration.rb.erb
+++ b/lib/generators/module_component/templates/app/services/configuration.rb.erb
@@ -13,7 +13,7 @@ module <%= class_name %>
 
       def connection
         @connection ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-          faraday.use :breakers
+          faraday.use(:breakers, service_name:)
           faraday.use Faraday::Response::RaiseError
 
           faraday.request :json

--- a/lib/gi/configuration.rb
+++ b/lib/gi/configuration.rb
@@ -21,7 +21,7 @@ module GI
 
     def connection
       Faraday.new(base_path, headers: request_headers, request: request_options) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.request :json
         # Uncomment this out for generating curl output
         # conn.request :curl, ::Logger.new(STDOUT), :warn

--- a/lib/hca/configuration.rb
+++ b/lib/hca/configuration.rb
@@ -19,7 +19,7 @@ module HCA
 
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.options.open_timeout = 10
         conn.options.timeout = Settings.hca.timeout
         conn.request :soap_headers

--- a/lib/hca/enrollment_eligibility/configuration.rb
+++ b/lib/hca/enrollment_eligibility/configuration.rb
@@ -13,7 +13,7 @@ module HCA
 
       def connection
         Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.request :soap_headers
           conn.response :soap_parser
           conn.adapter Faraday.default_adapter

--- a/lib/iam_ssoe_oauth/configuration.rb
+++ b/lib/iam_ssoe_oauth/configuration.rb
@@ -36,7 +36,7 @@ module IAMSSOeOAuth
       @connection ||= Faraday.new(
         base_path, headers: base_request_headers, request: request_options, ssl: ssl_options
       ) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.use Faraday::Response::RaiseError
         conn.response :snakecase
         conn.response :json, content_type: /\bjson$/

--- a/lib/ihub/configuration.rb
+++ b/lib/ihub/configuration.rb
@@ -6,7 +6,7 @@ module IHub
   class Configuration < Common::Client::Configuration::REST
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use      :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use      Faraday::Response::RaiseError
 
         faraday.response :betamocks if mock_enabled?

--- a/lib/kafka/schema_registry/configuration.rb
+++ b/lib/kafka/schema_registry/configuration.rb
@@ -19,7 +19,7 @@ module Kafka
 
       def connection
         Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.use Faraday::Response::RaiseError
           conn.adapter Faraday.default_adapter
         end

--- a/lib/lgy/configuration.rb
+++ b/lib/lgy/configuration.rb
@@ -6,7 +6,7 @@ module LGY
   class Configuration < Common::Client::Configuration::REST
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use Faraday::Response::RaiseError
         faraday.response :betamocks if mock_enabled?
         faraday.response :snakecase, symbolize: false

--- a/lib/lighthouse/benefits_claims/configuration.rb
+++ b/lib/lighthouse/benefits_claims/configuration.rb
@@ -90,8 +90,8 @@ module BenefitsClaims
     #
     def connection
       @conn ||= Faraday.new(base_api_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use      :breakers
-        faraday.use      Faraday::Response::RaiseError
+        faraday.use(:breakers, service_name:)
+        faraday.use Faraday::Response::RaiseError
 
         faraday.request :multipart
         faraday.request :json

--- a/lib/lighthouse/benefits_documents/configuration.rb
+++ b/lib/lighthouse/benefits_documents/configuration.rb
@@ -120,7 +120,7 @@ module BenefitsDocuments
     #
     def connection(api_path = base_api_path)
       @conn ||= Faraday.new(api_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use Faraday::Response::RaiseError
 
         faraday.request :multipart

--- a/lib/lighthouse/benefits_education/configuration.rb
+++ b/lib/lighthouse/benefits_education/configuration.rb
@@ -52,7 +52,7 @@ module BenefitsEducation
     #
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use Faraday::Response::RaiseError
 
         faraday.request :multipart

--- a/lib/lighthouse/benefits_intake/configuration.rb
+++ b/lib/lighthouse/benefits_intake/configuration.rb
@@ -51,7 +51,7 @@ module BenefitsIntake
     def connection
       @conn ||= Faraday.new(service_path, headers: base_request_headers, request: request_options) do |faraday|
         faraday.use(:breakers, service_name:)
-        faraday.use      Faraday::Response::RaiseError
+        faraday.use Faraday::Response::RaiseError
 
         faraday.request :multipart
         faraday.request :json

--- a/lib/lighthouse/benefits_intake/configuration.rb
+++ b/lib/lighthouse/benefits_intake/configuration.rb
@@ -50,7 +50,7 @@ module BenefitsIntake
     #
     def connection
       @conn ||= Faraday.new(service_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use      :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use      Faraday::Response::RaiseError
 
         faraday.request :multipart

--- a/lib/lighthouse/benefits_reference_data/configuration.rb
+++ b/lib/lighthouse/benefits_reference_data/configuration.rb
@@ -46,7 +46,7 @@ module BenefitsReferenceData
     #
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use      :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use      Faraday::Response::RaiseError
 
         faraday.request :multipart

--- a/lib/lighthouse/benefits_reference_data/configuration.rb
+++ b/lib/lighthouse/benefits_reference_data/configuration.rb
@@ -47,7 +47,7 @@ module BenefitsReferenceData
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
         faraday.use(:breakers, service_name:)
-        faraday.use      Faraday::Response::RaiseError
+        faraday.use Faraday::Response::RaiseError
 
         faraday.request :multipart
         faraday.request :json

--- a/lib/lighthouse/benefits_reference_data_staging/configuration.rb
+++ b/lib/lighthouse/benefits_reference_data_staging/configuration.rb
@@ -49,7 +49,7 @@ module BenefitsReferenceData
       def connection
         @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
           faraday.use(:breakers, service_name:)
-          faraday.use      Faraday::Response::RaiseError
+          faraday.use Faraday::Response::RaiseError
 
           faraday.request :multipart
           faraday.request :json

--- a/lib/lighthouse/benefits_reference_data_staging/configuration.rb
+++ b/lib/lighthouse/benefits_reference_data_staging/configuration.rb
@@ -48,7 +48,7 @@ module BenefitsReferenceData
       #
       def connection
         @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-          faraday.use      :breakers
+          faraday.use(:breakers, service_name:)
           faraday.use      Faraday::Response::RaiseError
 
           faraday.request :multipart

--- a/lib/lighthouse/direct_deposit/configuration.rb
+++ b/lib/lighthouse/direct_deposit/configuration.rb
@@ -58,7 +58,7 @@ module DirectDeposit
     #
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use Faraday::Response::RaiseError
         faraday.request :json
 

--- a/lib/lighthouse/facilities/configuration.rb
+++ b/lib/lighthouse/facilities/configuration.rb
@@ -21,7 +21,7 @@ module Lighthouse
 
       def connection
         Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.request :instrumentation, name: 'lighthouse.facilities.request.faraday'
 
           # Uncomment this if you want curl command equivalent or response output to log

--- a/lib/lighthouse/letters_generator/configuration.rb
+++ b/lib/lighthouse/letters_generator/configuration.rb
@@ -28,8 +28,8 @@ module Lighthouse
 
       def connection
         @conn ||= Faraday.new(generator_url, headers: base_request_headers, request: request_options) do |faraday|
-          faraday.use      :breakers
-          faraday.use      Faraday::Response::RaiseError
+          faraday.use(:breakers, service_name:)
+          faraday.use Faraday::Response::RaiseError
 
           faraday.request :json
 

--- a/lib/lighthouse/veteran_verification/configuration.rb
+++ b/lib/lighthouse/veteran_verification/configuration.rb
@@ -74,7 +74,7 @@ module VeteranVerification
     #
     def connection
       @conn ||= Faraday.new(base_api_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use Faraday::Response::RaiseError
 
         faraday.request :multipart

--- a/lib/lighthouse/veterans_health/configuration.rb
+++ b/lib/lighthouse/veterans_health/configuration.rb
@@ -20,7 +20,7 @@ module Lighthouse
 
       def connection
         Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-          faraday.use :breakers
+          faraday.use(:breakers, service_name:)
           faraday.use Faraday::Response::RaiseError
 
           # This is necessary to pass multiple date query params to Lighthouse

--- a/lib/mail_automation/configuration.rb
+++ b/lib/mail_automation/configuration.rb
@@ -18,7 +18,7 @@ module MailAutomation
 
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use Faraday::Response::RaiseError
 
         # Uncomment this if you want curl command equivalent or response output to log

--- a/lib/map/security_token/configuration.rb
+++ b/lib/map/security_token/configuration.rb
@@ -96,7 +96,7 @@ module MAP
           headers: base_request_headers,
           request: request_options
         ) do |conn|
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.use Faraday::Response::RaiseError
           conn.adapter Faraday.default_adapter
           conn.response :json, content_type: /\bjson/

--- a/lib/map/sign_up/configuration.rb
+++ b/lib/map/sign_up/configuration.rb
@@ -62,7 +62,7 @@ module MAP
           headers: base_request_headers,
           request: request_options
         ) do |conn|
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.use Faraday::Response::RaiseError
           conn.adapter Faraday.default_adapter
           conn.response :json, content_type: /\bjson/

--- a/lib/mdot/configuration.rb
+++ b/lib/mdot/configuration.rb
@@ -14,7 +14,7 @@ module MDOT
 
     def connection
       @connection = Faraday.new(base_path, headers: base_request_headers, request: request_options) do |f|
-        f.use :breakers
+        f.use(:breakers, service_name:)
         f.request :json
         f.use Faraday::Response::RaiseError
         f.response :betamocks if mock_enabled?

--- a/lib/medical_records/bb_internal/configuration.rb
+++ b/lib/medical_records/bb_internal/configuration.rb
@@ -45,7 +45,7 @@ module BBInternal
     #
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.request :multipart_request
         conn.request :multipart
         conn.request :json

--- a/lib/medical_records/configuration.rb
+++ b/lib/medical_records/configuration.rb
@@ -43,7 +43,7 @@ module MedicalRecords
     #
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.request :multipart_request
         conn.request :multipart
         conn.request :json

--- a/lib/medical_records/phr_mgr/configuration.rb
+++ b/lib/medical_records/phr_mgr/configuration.rb
@@ -43,7 +43,7 @@ module PHRMgr
     #
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.request :multipart_request
         conn.request :multipart
         conn.request :json

--- a/lib/medical_records/user_eligibility/configuration.rb
+++ b/lib/medical_records/user_eligibility/configuration.rb
@@ -46,7 +46,7 @@ module UserEligibility
     #
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.request :multipart_request
         conn.request :multipart
         conn.request :json

--- a/lib/mhv/account_creation/configuration.rb
+++ b/lib/mhv/account_creation/configuration.rb
@@ -44,7 +44,7 @@ module MHV
 
       def connection
         Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.use Faraday::Response::RaiseError
           conn.adapter Faraday.default_adapter
           conn.response :json

--- a/lib/mhv_ac/configuration.rb
+++ b/lib/mhv_ac/configuration.rb
@@ -43,7 +43,7 @@ module MHVAC
     #
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.request :camelcase
         conn.request :json
 

--- a/lib/mpi/configuration.rb
+++ b/lib/mpi/configuration.rb
@@ -40,7 +40,7 @@ module MPI
 
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options, ssl: ssl_options) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.request :soap_headers
 
         # Uncomment this if you want curl command equivalent or response output to log

--- a/lib/pagerduty/configuration.rb
+++ b/lib/pagerduty/configuration.rb
@@ -8,7 +8,7 @@ module PagerDuty
   class Configuration < Common::Client::Configuration::REST
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.request :json
 
         conn.response :raise_custom_error, error_prefix: service_name

--- a/lib/post911_sob/dgib/configuration.rb
+++ b/lib/post911_sob/dgib/configuration.rb
@@ -19,7 +19,7 @@ module Post911SOB
 
       def connection
         @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-          faraday.use :breakers
+          faraday.use(:breakers, service_name:)
           faraday.use Faraday::Response::RaiseError
           faraday.request :json
 

--- a/lib/preneeds/configuration.rb
+++ b/lib/preneeds/configuration.rb
@@ -44,7 +44,7 @@ module Preneeds
       @faraday ||= Faraday.new(
         path, headers: base_request_headers, request: request_options, ssl: { verify: false }
       ) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
 
         conn.options.timeout = TIMEOUT
 

--- a/lib/res/configuration.rb
+++ b/lib/res/configuration.rb
@@ -6,7 +6,7 @@ module RES
   class Configuration < Common::Client::Configuration::REST
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use Faraday::Response::RaiseError
         faraday.response :betamocks if mock_enabled?
         faraday.response :snakecase, symbolize: false

--- a/lib/rx/configuration.rb
+++ b/lib/rx/configuration.rb
@@ -81,7 +81,7 @@ module Rx
 
     def parallel_connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.request :camelcase
         conn.request :json
 

--- a/lib/rx/configuration.rb
+++ b/lib/rx/configuration.rb
@@ -59,7 +59,7 @@ module Rx
     #
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.request :json
 
         # Uncomment this if you want curl command equivalent or response output to log

--- a/lib/search/configuration.rb
+++ b/lib/search/configuration.rb
@@ -8,7 +8,7 @@ module Search
 
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use      :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use      Faraday::Response::RaiseError
 
         faraday.response :betamocks if mock_enabled?

--- a/lib/search_gsa/configuration.rb
+++ b/lib/search_gsa/configuration.rb
@@ -8,8 +8,8 @@ module SearchGsa
 
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use      :breakers
-        faraday.use      Faraday::Response::RaiseError
+        faraday.use(:breakers, service_name:)
+        faraday.use Faraday::Response::RaiseError
 
         faraday.response :betamocks if mock_enabled?
         faraday.response :snakecase, symbolize: false

--- a/lib/sign_in/idme/configuration.rb
+++ b/lib/sign_in/idme/configuration.rb
@@ -113,7 +113,7 @@ module SignIn
           ssl: { client_cert: ssl_cert,
                  client_key: ssl_key }
         ) do |conn|
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.use Faraday::Response::RaiseError
           conn.response :snakecase
           conn.response :json, content_type: /\bjson$/

--- a/lib/sign_in/logingov/configuration.rb
+++ b/lib/sign_in/logingov/configuration.rb
@@ -114,7 +114,7 @@ module SignIn
           ssl: { client_cert: ssl_cert,
                  client_key: ssl_key }
         ) do |conn|
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.use Faraday::Response::RaiseError
           conn.response :snakecase
           conn.response :json, content_type: /\bjson$/

--- a/lib/sm/configuration.rb
+++ b/lib/sm/configuration.rb
@@ -45,7 +45,7 @@ module SM
     #
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.request :camelcase
         conn.request :multipart_request
         conn.request :multipart

--- a/lib/token_validation/v2/configuration.rb
+++ b/lib/token_validation/v2/configuration.rb
@@ -15,7 +15,7 @@ module TokenValidation
 
       def connection
         Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.request :json
           conn.response :snakecase
           conn.adapter Faraday.default_adapter

--- a/lib/va_profile/configuration.rb
+++ b/lib/va_profile/configuration.rb
@@ -15,7 +15,7 @@ module VAProfile
       ssl_enabled = Rails.env.production?
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options,
                                        ssl: { verify: ssl_enabled }) do |faraday|
-        faraday.use      :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use      Faraday::Response::RaiseError
 
         faraday.response :snakecase, symbolize: false

--- a/lib/va_profile/profile/v3/configuration.rb
+++ b/lib/va_profile/profile/v3/configuration.rb
@@ -44,7 +44,7 @@ module VAProfile
         #
         def connection
           @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-            faraday.use :breakers
+            faraday.use(:breakers, service_name:)
             faraday.request :json
 
             faraday.response :betamocks if use_mocks?

--- a/lib/vetext/configuration.rb
+++ b/lib/vetext/configuration.rb
@@ -17,7 +17,7 @@ module VEText
       @connection ||= Faraday.new(
         base_path, headers: base_request_headers, request: request_options
       ) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.request :authorization, :basic, Settings.vetext_push.user, Settings.vetext_push.pass
         conn.request :json
         conn.use Faraday::Response::RaiseError

--- a/lib/virtual_regional_office/configuration.rb
+++ b/lib/virtual_regional_office/configuration.rb
@@ -20,7 +20,7 @@ module VirtualRegionalOffice
 
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use Faraday::Response::RaiseError
 
         # Uncomment this if you want curl command equivalent or response output to log

--- a/lib/vye/dgib/configuration.rb
+++ b/lib/vye/dgib/configuration.rb
@@ -5,10 +5,10 @@ module Vye
     class Configuration < Common::Client::Configuration::REST
       def connection
         @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-          faraday.use :breakers
+          faraday.use(:breakers, service_name:)
           faraday.ssl[:ca_file] = Settings.dgi.vye.jwt.public_ica11_rca2_key_path
           faraday.request :json
-          faraday.use      Faraday::Response::RaiseError
+          faraday.use Faraday::Response::RaiseError
           faraday.response :betamocks if mock_enabled?
           faraday.response :snakecase, symbolize: false
           faraday.response :json, content_type: /\bjson$/ # ensures only json content types parsed

--- a/modules/appeals_api/lib/appeals_api/token_validation_client.rb
+++ b/modules/appeals_api/lib/appeals_api/token_validation_client.rb
@@ -13,7 +13,7 @@ module AppealsApi
   class Configuration < ::TokenValidation::V2::Configuration
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.request :url_encoded # required for token validation service v3 (v2 accepted json)
         conn.response :snakecase
         conn.adapter Faraday.default_adapter

--- a/modules/ask_va_api/app/services/crm/crm_token.rb
+++ b/modules/ask_va_api/app/services/crm/crm_token.rb
@@ -51,7 +51,7 @@ module Crm
 
     def conn(url:)
       Faraday.new(url:) do |f|
-        f.use :breakers
+        f.use(:breakers, service_name:)
         f.response :raise_custom_error, error_prefix: service_name
         f.adapter Faraday.default_adapter
       end

--- a/modules/ask_va_api/app/services/crm/service.rb
+++ b/modules/ask_va_api/app/services/crm/service.rb
@@ -52,7 +52,7 @@ module Crm
 
     def conn(url:)
       Faraday.new(url:) do |f|
-        f.use :breakers
+        f.use(:breakers, service_name:)
         f.response :raise_custom_error, error_prefix: service_name
         f.adapter Faraday.default_adapter
       end

--- a/modules/avs/app/services/avs/configuration.rb
+++ b/modules/avs/app/services/avs/configuration.rb
@@ -16,7 +16,7 @@ module Avs
 
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.request :camelcase
         conn.request :json
 

--- a/modules/check_in/app/services/check_in/map/client.rb
+++ b/modules/check_in/app/services/check_in/map/client.rb
@@ -74,7 +74,7 @@ module CheckIn
       #
       def connection
         Faraday.new(url:) do |conn|
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.response :raise_custom_error, error_prefix: service_name
           conn.response :betamocks if mock_enabled?
 

--- a/modules/check_in/app/services/check_in/vaos/configuration.rb
+++ b/modules/check_in/app/services/check_in/vaos/configuration.rb
@@ -21,7 +21,7 @@ module CheckIn
 
       def connection
         Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.request :camelcase
           conn.request :json
 

--- a/modules/check_in/app/services/travel_claim/client.rb
+++ b/modules/check_in/app/services/travel_claim/client.rb
@@ -136,7 +136,7 @@ module TravelClaim
     #
     def connection(server_url:)
       Faraday.new(url: server_url) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.response :raise_custom_error, error_prefix: service_name
         conn.response :betamocks if mock_enabled?
 

--- a/modules/check_in/app/services/v2/chip/client.rb
+++ b/modules/check_in/app/services/v2/chip/client.rb
@@ -205,7 +205,7 @@ module V2
       #
       def connection
         Faraday.new(url:) do |conn|
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.response :raise_custom_error, error_prefix: service_name
           conn.response :betamocks if mock_enabled?
 

--- a/modules/check_in/app/services/v2/lorota/client.rb
+++ b/modules/check_in/app/services/v2/lorota/client.rb
@@ -77,7 +77,7 @@ module V2
 
       def connection
         Faraday.new(url:) do |conn|
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           conn.response :raise_custom_error, error_prefix: 'LOROTA-API'
           conn.response :betamocks if mock_enabled?
 

--- a/modules/debts_api/lib/debts_api/v0/financial_status_report_configuration.rb
+++ b/modules/debts_api/lib/debts_api/v0/financial_status_report_configuration.rb
@@ -19,7 +19,7 @@ module DebtsApi
 
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |f|
-        f.use :breakers
+        f.use(:breakers, service_name:)
         f.use Faraday::Response::RaiseError
         f.request :json
         f.response :betamocks if Settings.dmc.mock_fsr

--- a/modules/decision_reviews/lib/decision_reviews/v1/configuration.rb
+++ b/modules/decision_reviews/lib/decision_reviews/v1/configuration.rb
@@ -41,7 +41,7 @@ module DecisionReviews
       def connection
         @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
           faraday.use(:breakers, service_name:)
-          faraday.use      Faraday::Response::RaiseError
+          faraday.use Faraday::Response::RaiseError
 
           faraday.request :multipart
           faraday.request :json

--- a/modules/decision_reviews/lib/decision_reviews/v1/configuration.rb
+++ b/modules/decision_reviews/lib/decision_reviews/v1/configuration.rb
@@ -40,7 +40,7 @@ module DecisionReviews
       #
       def connection
         @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-          faraday.use      :breakers
+          faraday.use(:breakers, service_name:)
           faraday.use      Faraday::Response::RaiseError
 
           faraday.request :multipart

--- a/modules/dhp_connected_devices/lib/fitbit/configuration.rb
+++ b/modules/dhp_connected_devices/lib/fitbit/configuration.rb
@@ -20,7 +20,7 @@ module DhpConnectedDevices
 
       def connection
         Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           # conn.use :instrumentation, name: 'dhp.fitbit.request.faraday'
 
           # Uncomment this if you want curlggg command equivalent or response output to log

--- a/modules/facilities_api/app/services/facilities_api/v2/lighthouse/configuration.rb
+++ b/modules/facilities_api/app/services/facilities_api/v2/lighthouse/configuration.rb
@@ -22,7 +22,7 @@ module FacilitiesApi
 
         def connection
           Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-            conn.use :breakers
+            conn.use(:breakers, service_name:)
             conn.request :instrumentation, name: 'lighthouse.facilities.v2.request.faraday'
 
             # Uncomment this if you want curl command equivalent or response output to log

--- a/modules/facilities_api/app/services/facilities_api/v2/mobile_covid/configuration.rb
+++ b/modules/facilities_api/app/services/facilities_api/v2/mobile_covid/configuration.rb
@@ -16,7 +16,7 @@ module FacilitiesApi
 
         def connection
           Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-            conn.use :breakers
+            conn.use(:breakers, service_name:)
             conn.request :instrumentation, name: 'facilities.mobile_covid.v2.request.faraday'
 
             # Uncomment this if you want curlggg command equivalent or response output to log

--- a/modules/facilities_api/app/services/facilities_api/v2/ppms/configuration.rb
+++ b/modules/facilities_api/app/services/facilities_api/v2/ppms/configuration.rb
@@ -24,7 +24,7 @@ module FacilitiesApi
 
         def connection
           Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-            conn.use :breakers
+            conn.use(:breakers, service_name:)
             conn.request :instrumentation, name: 'facilities.ppms.v2.request.faraday'
 
             # Uncomment this if you want curl command equivalent or response output to log

--- a/modules/ivc_champva/lib/pega_api/configuration.rb
+++ b/modules/ivc_champva/lib/pega_api/configuration.rb
@@ -16,7 +16,7 @@ module IvcChampva
 
       def connection
         Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-          conn.use :breakers
+          conn.use(:breakers, service_name:)
           # conn.use :instrumentation, name: 'dhp.fitbit.request.faraday'
 
           # Uncomment this if you want curlggg command equivalent or response output to log

--- a/modules/meb_api/lib/dgi/configuration.rb
+++ b/modules/meb_api/lib/dgi/configuration.rb
@@ -5,7 +5,7 @@ module MebApi
     class Configuration < Common::Client::Configuration::REST
       def connection
         @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-          faraday.use :breakers
+          faraday.use(:breakers, service_name:)
           faraday.request :json
           faraday.use      Faraday::Response::RaiseError
           faraday.response :betamocks if mock_enabled?

--- a/modules/meb_api/lib/dgi/fry_dea/configuration.rb
+++ b/modules/meb_api/lib/dgi/fry_dea/configuration.rb
@@ -13,7 +13,7 @@ module MebApi
 
         def connection
           @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-            faraday.use :breakers
+            faraday.use(:breakers, service_name:)
             faraday.use Faraday::Response::RaiseError
 
             faraday.request :multipart

--- a/modules/meb_api/lib/dgi/letters/configuration.rb
+++ b/modules/meb_api/lib/dgi/letters/configuration.rb
@@ -13,7 +13,7 @@ module MebApi
 
         def connection
           @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-            faraday.use :breakers
+            faraday.use(:breakers, service_name:)
             faraday.use Faraday::Response::RaiseError
 
             faraday.request :multipart

--- a/modules/meb_api/lib/dgi/toe/configuration.rb
+++ b/modules/meb_api/lib/dgi/toe/configuration.rb
@@ -13,7 +13,7 @@ module MebApi
 
         def connection
           @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-            faraday.use :breakers
+            faraday.use(:breakers, service_name:)
             faraday.use Faraday::Response::RaiseError
 
             faraday.request :multipart

--- a/modules/mobile/app/services/mobile/v0/lighthouse_health/configuration.rb
+++ b/modules/mobile/app/services/mobile/v0/lighthouse_health/configuration.rb
@@ -50,7 +50,7 @@ module Mobile
         #
         def connection
           Faraday.new(api_url) do |conn|
-            conn.use :breakers
+            conn.use(:breakers, service_name:)
             conn.response :snakecase
             conn.response :json, content_type: /\bjson$/
             conn.adapter Faraday.default_adapter

--- a/modules/mobile/app/services/mobile/v0/lighthouse_health/configuration.rb
+++ b/modules/mobile/app/services/mobile/v0/lighthouse_health/configuration.rb
@@ -37,7 +37,7 @@ module Mobile
         #
         def access_token_connection
           Faraday.new(access_token_url) do |conn|
-            conn.use :breakers
+            conn.use(:breakers, service_name:)
             conn.use Faraday::Response::RaiseError
             conn.response :json, content_type: /\bjson$/
             conn.adapter Faraday.default_adapter

--- a/modules/travel_pay/app/services/travel_pay/base_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/base_client.rb
@@ -27,7 +27,7 @@ module TravelPay
       service_name = Settings.travel_pay.service_name
 
       Faraday.new(url: server_url) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.response :raise_custom_error, error_prefix: service_name, include_request: true
         conn.response :betamocks if mock_enabled?
         conn.response :json

--- a/modules/va_notify/lib/va_notify/configuration.rb
+++ b/modules/va_notify/lib/va_notify/configuration.rb
@@ -8,7 +8,7 @@ module VaNotify
 
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use      :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use      Faraday::Response::RaiseError
 
         faraday.response :betamocks if mock_enabled?

--- a/modules/vaos/app/services/ccra/configuration.rb
+++ b/modules/vaos/app/services/ccra/configuration.rb
@@ -42,7 +42,7 @@ module Ccra
     # @return [Faraday::Connection] A configured Faraday connection object.
     def connection
       Faraday.new(api_url, headers: base_request_headers, request: request_options) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.request :camelcase
         conn.request :json
 

--- a/modules/vaos/app/services/eps/configuration.rb
+++ b/modules/vaos/app/services/eps/configuration.rb
@@ -22,7 +22,7 @@ module Eps
 
     def connection
       Faraday.new(api_url, headers: base_request_headers, request: request_options) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.request :camelcase
         conn.request :json
 

--- a/modules/vaos/app/services/vaos/configuration.rb
+++ b/modules/vaos/app/services/vaos/configuration.rb
@@ -23,7 +23,7 @@ module VAOS
 
     def connection
       Faraday.new(base_path, headers: base_request_headers, request: request_options) do |conn|
-        conn.use :breakers
+        conn.use(:breakers, service_name:)
         conn.request :camelcase
         conn.request :json
 

--- a/modules/vre/app/services/vre/configuration.rb
+++ b/modules/vre/app/services/vre/configuration.rb
@@ -4,7 +4,7 @@ module VRE
   class Configuration < ::Common::Client::Configuration::REST
     def connection
       @conn ||= Faraday.new(base_path, headers: base_request_headers, request: request_options) do |faraday|
-        faraday.use :breakers
+        faraday.use(:breakers, service_name:)
         faraday.use Faraday::Response::RaiseError
         faraday.response :betamocks if mock_enabled?
         faraday.response :snakecase, symbolize: false

--- a/spec/lib/carma/client/mule_soft_auth_token_configuration_spec.rb
+++ b/spec/lib/carma/client/mule_soft_auth_token_configuration_spec.rb
@@ -23,7 +23,7 @@ describe CARMA::Client::MuleSoftAuthTokenConfiguration do
     it 'creates the connection' do
       allow(Faraday).to receive(:new).and_yield(faraday)
 
-      expect(faraday).to receive(:use).once.with(:breakers)
+      expect(faraday).to receive(:use).once.with(:breakers, { service_name: subject.service_name })
       expect(faraday).to receive(:request).once.with(:instrumentation,
                                                      { name: 'CARMA::Client::MuleSoftAuthTokenConfiguration' })
       expect(faraday).to receive(:adapter).once.with(Faraday.default_adapter)

--- a/spec/lib/carma/client/mule_soft_configuration_spec.rb
+++ b/spec/lib/carma/client/mule_soft_configuration_spec.rb
@@ -20,7 +20,7 @@ describe CARMA::Client::MuleSoftConfiguration do
     it 'creates the connection' do
       allow(Faraday).to receive(:new).and_yield(faraday)
 
-      expect(faraday).to receive(:use).once.with(:breakers)
+      expect(faraday).to receive(:use).once.with(:breakers, { service_name: subject.service_name })
       expect(faraday).to receive(:request).once.with(:instrumentation, { name: 'CARMA::Client::MuleSoftConfiguration' })
       expect(faraday).to receive(:adapter).once.with(Faraday.default_adapter)
 

--- a/spec/lib/lighthouse/benefits_intake/configuration_spec.rb
+++ b/spec/lib/lighthouse/benefits_intake/configuration_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe BenefitsIntake::Configuration do
     it 'creates the connection' do
       expect(Faraday).to receive(:new).with('service_path', headers: 'base_request_headers', request: 'request_options')
 
-      expect(faraday).to receive(:use).once.with(:breakers)
+      expect(faraday).to receive(:use).once.with(:breakers, { service_name: config.service_name })
       expect(faraday).to receive(:use).once.with(Faraday::Response::RaiseError)
 
       expect(faraday).to receive(:request).once.with(:multipart)

--- a/spec/support/default_configuration_helper.rb
+++ b/spec/support/default_configuration_helper.rb
@@ -9,7 +9,7 @@ module Specs
         def connection
           @conn ||= Faraday.new(base_path) do |faraday|
             unless adapter_only
-              faraday.use     :breakers
+              faraday.use(:breakers, service_name:)
               faraday.use     Faraday::Response::RaiseError
               faraday.use     :remove_cookies
             end


### PR DESCRIPTION
## Summary

This is a follow-on to #21368, sending the `service_name` param for all integrated services. This allows breakers to match on the service in use rather than the URL, port and path of the request being made, and avoids breakers tripping for different services that share the same fwd proxy port and don't specify a unique base_path.

Slack thread: https://dsva.slack.com/archives/C0460N83Y9G/p1742325203299699
