### PR TITLE
Update iam_ssoe_oauth/service spec

### DIFF
--- a/lib/iam_ssoe_oauth/configuration.rb
+++ b/lib/iam_ssoe_oauth/configuration.rb
@@ -33,7 +33,7 @@ module IAMSSOeOAuth
     # @return Faraday::Connection connection to make http calls
     #
     def connection
-      @connection ||= Faraday.new(
+      Faraday.new(
         base_path, headers: base_request_headers, request: request_options, ssl: ssl_options
       ) do |conn|
         conn.use :breakers

--- a/spec/lib/iam_ssoe_oauth/service_spec.rb
+++ b/spec/lib/iam_ssoe_oauth/service_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'iam_ssoe_oauth/service'
 
 describe 'IAMSSOeOAuth::Service' do
-  let(:service) { IAMSSOeOAuth::Service.new }
+  subject(:service) { IAMSSOeOAuth::Service.new }
 
   describe '#post_introspect' do
     context 'with an active user response' do


### PR DESCRIPTION
## Summary

- Don't memoize `connection`. This only gets called once per instance so there is no benefit. The cert and key are loaded in the `connection.ssl` and leaked across tests causing intermittent failures: 
  - <img width="828" alt="Screenshot 2025-03-27 at 9 02 44 AM" src="https://github.com/user-attachments/assets/a72d738b-abeb-4726-af0c-7f7daf92aa37" />




