### PR TITLE
API-45553 - POA v2 - Update CLAIMANT_NOTIFICATION status

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/va_notify_accepted_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/va_notify_accepted_job.rb
@@ -19,8 +19,7 @@ module ClaimsApi
         poa_code_from_form('2122a', poa)
         res = send_representative_notification(poa, rep)
       end
-      process.update!(step_status: 'SUCCESS', error_messages: [], completed_at: Time.zone.now)
-      schedule_follow_up_check(res.id) if res.present?
+      schedule_follow_up_check(res.id, poa_id) if res.present?
     rescue => e
       handle_failure(poa_id, e, process)
     end
@@ -187,8 +186,8 @@ module ClaimsApi
       poa.form_data.dig(base, 'poaCode')
     end
 
-    def schedule_follow_up_check(notification_id)
-      ClaimsApi::VANotifyFollowUpJob.perform_async(notification_id)
+    def schedule_follow_up_check(notification_id, poa_id)
+      ClaimsApi::VANotifyFollowUpJob.perform_async(notification_id, poa_id)
     end
 
     def skip_notification_email?

--- a/modules/claims_api/app/sidekiq/claims_api/va_notify_follow_up_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/va_notify_follow_up_job.rb
@@ -33,7 +33,11 @@ module ClaimsApi
       # Update the POA process step with latest status
       poa = ClaimsApi::PowerOfAttorney.find(poa_id)
       process = ClaimsApi::Process.find_or_create_by(processable: poa, step_type: 'CLAIMANT_NOTIFICATION')
-      process.update!(step_status:, error_messages: [], completed_at: Time.zone.now)
+      if step_status == 'IN_PROGRESS'
+        process.update!(step_status:, error_messages: [])
+      else
+        process.update!(step_status:, error_messages: [], completed_at: Time.zone.now)
+      end
 
       handle_failure(detail) if status == 'permanent-failure'
 

--- a/modules/claims_api/app/sidekiq/claims_api/va_notify_follow_up_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/va_notify_follow_up_job.rb
@@ -24,7 +24,7 @@ module ClaimsApi
       slack_client.notify(msg)
     end
 
-    def perform(notification_id, poa_id)
+    def perform(notification_id, poa_id) # rubocop:disable Metrics/MethodLength
       status = notification_response_status(notification_id)
       detail = "Status for notification #{notification_id} was '#{status}'"
 

--- a/modules/claims_api/app/sidekiq/claims_api/va_notify_follow_up_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/va_notify_follow_up_job.rb
@@ -7,8 +7,8 @@ module ClaimsApi
     sidekiq_options retry: 14
 
     LOG_TAG = 'va_notify_follow_up_job'
-    NON_RETRY_STATUSES = %w[cancelled delivered permanent-failure validation-failed].freeze
-    RETRY_STATUSES = %w[created failed pending sending sent temporary-failure].freeze
+    NON_RETRY_STATUSES = %w[cancelled delivered failed permanent-failure validation-failed].freeze
+    RETRY_STATUSES = %w[created pending sending sent temporary-failure].freeze
     NOTIFY_STATUS_DICTIONARY = {
       IN_PROGRESS: %w[created pending sending sent temporary-failure],
       SUCCESS: ['delivered'],

--- a/modules/claims_api/spec/sidekiq/va_notify_accepted_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/va_notify_accepted_job_spec.rb
@@ -111,7 +111,7 @@ describe ClaimsApi::VANotifyAcceptedJob, type: :job do
           )
           instance.perform(rep_poa.id, va_notify_rep.id)
           process = ClaimsApi::Process.find_by(processable: rep_poa, step_type: 'CLAIMANT_NOTIFICATION')
-          expect(process.step_status).to eq('SUCCESS')
+          expect(process.step_status).to eq('IN_PROGRESS')
         end
       end
     end
@@ -154,7 +154,7 @@ describe ClaimsApi::VANotifyAcceptedJob, type: :job do
           )
           instance.perform(rep_dep_poa.id, va_notify_rep.id)
           process = ClaimsApi::Process.find_by(processable: rep_dep_poa, step_type: 'CLAIMANT_NOTIFICATION')
-          expect(process.step_status).to eq('SUCCESS')
+          expect(process.step_status).to eq('IN_PROGRESS')
         end
       end
     end
@@ -194,7 +194,7 @@ describe ClaimsApi::VANotifyAcceptedJob, type: :job do
           )
           instance.perform(organization_poa.id, va_notify_org.id)
           process = ClaimsApi::Process.find_by(processable: organization_poa, step_type: 'CLAIMANT_NOTIFICATION')
-          expect(process.step_status).to eq('SUCCESS')
+          expect(process.step_status).to eq('IN_PROGRESS')
         end
       end
     end

--- a/modules/claims_api/spec/sidekiq/va_notify_follow_up_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/va_notify_follow_up_job_spec.rb
@@ -11,14 +11,17 @@ describe ClaimsApi::VANotifyFollowUpJob, type: :job do
     end
 
     let(:notification_id) { '111111-1111-1111-11111111' }
+    let(:temp) { create(:power_of_attorney, :with_full_headers) }
 
     context 'no retry statues' do
       shared_examples 'does not requeue the job' do |status|
         it "when the status is #{status}" do
+          power_of_attorney = ClaimsApi::PowerOfAttorney.find(temp.id)
+          allow(ClaimsApi::PowerOfAttorney).to receive(:find).with(temp.id).and_return(power_of_attorney)
           allow(described_class).to receive(:perform_async)
           allow_any_instance_of(described_class).to receive(:notification_response_status).and_return(status)
 
-          subject.perform(notification_id)
+          subject.perform(notification_id, power_of_attorney.id)
 
           expect(described_class).not_to have_received(:perform_async)
         end
@@ -32,9 +35,11 @@ describe ClaimsApi::VANotifyFollowUpJob, type: :job do
     context 'retry statues' do
       shared_examples 'requeues the job' do |status|
         it "when the status is #{status}" do
+          power_of_attorney = ClaimsApi::PowerOfAttorney.find(temp.id)
+          allow(ClaimsApi::PowerOfAttorney).to receive(:find).with(temp.id).and_return(power_of_attorney)
           allow_any_instance_of(described_class).to receive(:notification_response_status).and_return(status)
           expect do
-            subject.perform(notification_id)
+            subject.perform(notification_id, power_of_attorney.id)
           end.to raise_error(RuntimeError, "Status for notification #{notification_id} was '#{status}'")
         end
       end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Updates VANotifyFollowUpJob so that it sets the status of the CLAIMANT_NOTIFICATION step of POA submissions.

## Related issue(s)

[API-45553](https://jira.devops.va.gov/browse/API-45553)

## Testing done

- [x] *New code is covered by unit tests*
- Formerly the VANotifyAcceptedJob set the status of the CLAIMANT_NOTIFICATION to "SUCCESS" after kicking of the asynchronous call to send the VANotify email.
- VANotifyAcceptedJob now sets the step status to "IN_PROGRESS", and the VANotifyFollowUpJob sets the step status to the correct mapped status value based on the status returned from VANotify for the email job.


## What areas of the site does it impact?
- POA v2 submissions notification step.
- VANotifyFollowUpJob

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
