### PR TITLE
105513 Add applicants to metadata - form 10-10d

### DIFF
--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
@@ -37,6 +37,7 @@ module IvcChampva
         'primaryContactInfo' => @data['primary_contact_info'],
         'hasApplicantOver65' => @data['has_applicant_over65'].to_s,
         'primaryContactEmail' => @data.dig('primary_contact_info', 'email').to_s
+        # add individual properties for each applicant in the applicants array:
       }.merge(add_applicant_properties)
     end
 

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
@@ -36,8 +36,45 @@ module IvcChampva
         'uuid' => @uuid,
         'primaryContactInfo' => @data['primary_contact_info'],
         'hasApplicantOver65' => @data['has_applicant_over65'].to_s,
-        'primaryContactEmail' => @data.dig('primary_contact_info', 'email').to_s
+        'primaryContactEmail' => @data.dig('primary_contact_info', 'email').to_s,
+        'applicants' => build_applicants_meta_json
       }
+    end
+
+    ##
+    # Creates a JSON object of applicants to be included with the metadata,
+    # ensuring the string does not exceed 1024 bytes in size.
+    # - Only includes SSN, name, and date of birth for each applicant
+    # - Only includes as many applicants as will fit in a 1024 byte string
+    #
+    # @return a stringified JSON array containing applicant objects
+    def build_applicants_meta_json
+      applicants = Marshal.load(Marshal.dump(@data['applicants']))
+      return '[]'.to_json if applicants.blank?
+
+      # Attempt to build JSON and ensure it fits within the 1024-byte limit
+      while applicants.any?
+        json_result = jsonify_applicants_array(applicants)
+        return json_result if json_result.bytesize < 1024
+
+        # If the JSON exceeds the limit, remove the last applicant and retry
+        applicants.pop
+      end
+
+      # If no valid result found within the byte limit, return an empty obj
+      '[]'.to_json
+    end
+
+    ##
+    # Returns the passed in array of applicants as stringified JSON but with
+    # only the specified keys still in place for each applicant.
+    #
+    # @return a stringified JSON array containing applicant objects
+    def jsonify_applicants_array(arr)
+      arr.map do |applicant|
+        # Select only the necessary attributes and symbolize keys
+        applicant.symbolize_keys.slice(:applicant_ssn, :applicant_name, :applicant_dob)
+      end.to_json
     end
 
     def desired_stamps

--- a/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe IvcChampva::VHA1010d do
   end
 
   describe '#add_applicant_properties' do
-    context 'when applicants array is small' do
+    context 'when applicants array is present' do
       let(:applicant_data) do
         data.merge(
           'applicants' => [

--- a/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe IvcChampva::VHA1010d do
     end
   end
 
-  describe '#build_applicants_meta_json' do
+  describe '#add_applicant_properties' do
     context 'when applicants array is small' do
       let(:applicant_data) do
         data.merge(
@@ -162,10 +162,11 @@ RSpec.describe IvcChampva::VHA1010d do
 
       let(:vha1010d_applicants) { described_class.new(applicant_data) }
 
-      it 'returns a valid JSON string within the 1024 byte limit' do
-        json_result = vha1010d_applicants.build_applicants_meta_json
-        expect(json_result.bytesize).to be < 1024
-        expect { JSON.parse(json_result) }.not_to raise_error
+      it 'returns an object with a key for each applicant' do
+        res = vha1010d_applicants.add_applicant_properties
+        expect(res.keys.include?('applicant_0')).to be(true)
+        expect(res.keys.include?('applicant_1')).to be(true)
+        expect(res['applicant_0']['applicant_name']['first'].to_s).to eq('John')
       end
     end
 
@@ -178,31 +179,9 @@ RSpec.describe IvcChampva::VHA1010d do
 
       let(:vha1010d_applicants) { described_class.new(applicant_data) }
 
-      it 'returns an empty JSON array when no applicants are provided' do
-        applicant_data['applicants'] = []
-        json_result = vha1010d.build_applicants_meta_json
-        expect(json_result).to eq('"[]"')
-      end
-    end
-
-    context 'when applicants array is large' do
-      let(:applicant_data) do
-        data.merge(
-          'applicants' => Array.new(25) do |i|
-            { 'applicant_ssn' => '123456789', 'applicant_name' => { 'first' => i.to_s, 'last' => 'Doe' },
-              'applicant_dob' => '1980-01-01' }
-          end
-        )
-      end
-
-      let(:vha1010d_applicants) { described_class.new(applicant_data) }
-
-      it 'returns a valid JSON string within the 1024 byte limit' do
-        expect(vha1010d_applicants.data['applicants'].to_json.bytesize).to be > 1024
-
-        json_result = vha1010d_applicants.build_applicants_meta_json
-        expect(json_result.bytesize).to be < 1024
-        expect { JSON.parse(json_result) }.not_to raise_error
+      it 'returns an empty object' do
+        json_result = vha1010d.add_applicant_properties
+        expect(json_result.empty?).to be(true)
       end
     end
   end

--- a/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
@@ -146,4 +146,64 @@ RSpec.describe IvcChampva::VHA1010d do
       end
     end
   end
+
+  describe '#build_applicants_meta_json' do
+    context 'when applicants array is small' do
+      let(:applicant_data) do
+        data.merge(
+          'applicants' => [
+            { 'applicant_ssn' => '123456789', 'applicant_name' => { 'first' => 'John', 'last' => 'Doe' },
+              'applicant_dob' => '1980-01-01' },
+            { 'applicant_ssn' => '987654321', 'applicant_name' => { 'first' => 'Jane', 'last' => 'Doe' },
+              'applicant_dob' => '1981-02-02' }
+          ]
+        )
+      end
+
+      let(:vha1010d_applicants) { described_class.new(applicant_data) }
+
+      it 'returns a valid JSON string within the 1024 byte limit' do
+        json_result = vha1010d_applicants.build_applicants_meta_json
+        expect(json_result.bytesize).to be < 1024
+        expect { JSON.parse(json_result) }.not_to raise_error
+      end
+    end
+
+    context 'when applicants array is empty' do
+      let(:applicant_data) do
+        data.merge(
+          'applicants' => []
+        )
+      end
+
+      let(:vha1010d_applicants) { described_class.new(applicant_data) }
+
+      it 'returns an empty JSON array when no applicants are provided' do
+        applicant_data['applicants'] = []
+        json_result = vha1010d.build_applicants_meta_json
+        expect(json_result).to eq('"[]"')
+      end
+    end
+
+    context 'when applicants array is large' do
+      let(:applicant_data) do
+        data.merge(
+          'applicants' => Array.new(25) do |i|
+            { 'applicant_ssn' => '123456789', 'applicant_name' => { 'first' => i.to_s, 'last' => 'Doe' },
+              'applicant_dob' => '1980-01-01' }
+          end
+        )
+      end
+
+      let(:vha1010d_applicants) { described_class.new(applicant_data) }
+
+      it 'returns a valid JSON string within the 1024 byte limit' do
+        expect(vha1010d_applicants.data['applicants'].to_json.bytesize).to be > 1024
+
+        json_result = vha1010d_applicants.build_applicants_meta_json
+        expect(json_result.bytesize).to be < 1024
+        expect { JSON.parse(json_result) }.not_to raise_error
+      end
+    end
+  end
 end

--- a/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_10d_spec.rb
@@ -184,5 +184,22 @@ RSpec.describe IvcChampva::VHA1010d do
         expect(json_result.empty?).to be(true)
       end
     end
+
+    context 'when applicants have wrong properties' do
+      let(:applicant_data) do
+        data.merge(
+          'applicants' => [
+            { 'malformed' => '123456789' }
+          ]
+        )
+      end
+
+      let(:vha1010d_applicants) { described_class.new(applicant_data) }
+
+      it 'returns an empty object' do
+        json_result = vha1010d.add_applicant_properties
+        expect(json_result.empty?).to be(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

This PR adds new properties to the 10-10d metadata object. For all applicant objects in the applicants array, we create a new `applicant_x` property that maps to a subset of applicant information. This is so that PEGA can use these metadata values to improve their search functionality after ingesting 10-10d submissions.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/105513

## Testing done

- [X] *New code is covered by unit tests*
- Prior to this change we didn't include all applicants in the metadata
- To verify this change, run vets-api locally, add a byebug after this [line](https://github.com/department-of-veterans-affairs/vets-api/blob/8a338a0380c2893a8a6f96ef61703f6e26591799/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb#L240), and submit a form with one attachment. When the breakpoint is triggered, inspect the `metadata` object.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

IVC CHAMPVA form 10-10d only

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA
