### PR TITLE
105455 add gclaws client

### DIFF
--- a/app/models/accredited_individual.rb
+++ b/app/models/accredited_individual.rb
@@ -3,7 +3,7 @@
 require 'accredited_representation/constants'
 
 class AccreditedIndividual < ApplicationRecord
-  # Represents an accredited individual (attorney, claims agent, representative) as defined by he OGC accreditation
+  # Represents an accredited individual (attorney, claims agent, representative) as defined by the OGC accreditation
   # APIs. Until a form of soft deletion is implemented, these records will only reflect individuals with active
   # accreditation.
   #

--- a/app/models/accredited_organization.rb
+++ b/app/models/accredited_organization.rb
@@ -3,7 +3,7 @@
 require 'accredited_representation/constants'
 
 class AccreditedOrganization < ApplicationRecord
-  # Represents an accredited organization as defined by he OGC accreditation APIs. Until a form of soft deletion is
+  # Represents an accredited organization as defined by the OGC accreditation APIs. Until a form of soft deletion is
   # implemented, these records will only reflect organization with active accreditation.
   #
   # Key notes:

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -12,6 +12,7 @@ ActiveSupport::Inflector.inflections do |inflect|
   inflect.acronym 'DGI' # Digital GI
   inflect.acronym 'EVSS'
   inflect.acronym 'FHIR'
+  inflect.acronym 'GCLAWS' # General Counsel Automated Workload System
   inflect.acronym 'GIDS'
   inflect.acronym 'GI'
   inflect.acronym 'HCA'

--- a/modules/representation_management/app/services/representation_management/gclaws/client.rb
+++ b/modules/representation_management/app/services/representation_management/gclaws/client.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# This client is responsible for retrieving accreditation data from the GCLAWS API.
+
+module RepresentationManagement
+  module GCLAWS
+    class Client
+      DEFAULT_PAGE = 1
+      DEFAULT_PAGE_SIZE = 100
+      def get_agents(page: DEFAULT_PAGE, page_size: DEFAULT_PAGE_SIZE)
+        configuration = GCLAWS::Configuration.new(type: 'agents', page:, page_size:)
+
+        configuration.connection.get
+      end
+
+      # self.submit_form21a(parsed_body): Submits the given parsed body as JSON to the gclaws service.
+      #   - Parameters:
+      #     - parsed_body: A Hash representing the parsed form data.
+      #     - user_uuid: A String representing the user's UUID, which is also stored in the in_progress_forms DB entry.
+      #   - Returns: A Faraday::Response object containing the service response.
+      def self.submit_form21a(parsed_body, user_uuid)
+        Rails.logger.info("Accreditation Service attempting submit_form21a with service_url: #{service_url}")
+        connection.post do |req|
+          req.headers['x-api-key'] = Settings.ogc.form21a_service_url.api_key
+          req.body = parsed_body.to_json
+        end
+      rescue Faraday::ConnectionFailed => e
+        Rails.logger.error(
+          "Accreditation Service connection failed for user with user_uuid=#{user_uuid}: #{e.message}, URL: #{service_url}"
+        )
+        Faraday::Response.new(status: :service_unavailable,
+                              body: { errors: 'Accreditation Service unavailable' }.to_json)
+      rescue Faraday::TimeoutError => e
+        Rails.logger.error("Accreditation Service request timed out for user with user_uuid=#{user_uuid}: #{e.message}")
+        Faraday::Response.new(status: :request_timeout,
+                              body: { errors: 'Accreditation Service request timed out' }.to_json)
+      end
+    end
+  end
+end

--- a/modules/representation_management/app/services/representation_management/gclaws/client.rb
+++ b/modules/representation_management/app/services/representation_management/gclaws/client.rb
@@ -5,35 +5,26 @@
 module RepresentationManagement
   module GCLAWS
     class Client
+      ALLOWED_TYPES = %w[agents attorneys representatives veteran_service_organizations].freeze
       DEFAULT_PAGE = 1
       DEFAULT_PAGE_SIZE = 100
-      def get_agents(page: DEFAULT_PAGE, page_size: DEFAULT_PAGE_SIZE)
-        configuration = GCLAWS::Configuration.new(type: 'agents', page:, page_size:)
+
+      def self.get_accredited_entities(type:, page: DEFAULT_PAGE, page_size: DEFAULT_PAGE_SIZE)
+        return {} unless ALLOWED_TYPES.include?(type)
+
+        configuration = GCLAWS::Configuration.new(type:, page:, page_size:)
 
         configuration.connection.get
-      end
-
-      # self.submit_form21a(parsed_body): Submits the given parsed body as JSON to the gclaws service.
-      #   - Parameters:
-      #     - parsed_body: A Hash representing the parsed form data.
-      #     - user_uuid: A String representing the user's UUID, which is also stored in the in_progress_forms DB entry.
-      #   - Returns: A Faraday::Response object containing the service response.
-      def self.submit_form21a(parsed_body, user_uuid)
-        Rails.logger.info("Accreditation Service attempting submit_form21a with service_url: #{service_url}")
-        connection.post do |req|
-          req.headers['x-api-key'] = Settings.ogc.form21a_service_url.api_key
-          req.body = parsed_body.to_json
-        end
-      rescue Faraday::ConnectionFailed => e
+      rescue Faraday::ConnectionFailed
         Rails.logger.error(
-          "Accreditation Service connection failed for user with user_uuid=#{user_uuid}: #{e.message}, URL: #{service_url}"
+          "GCLAWS Accreditation connection failed for #{type}"
         )
         Faraday::Response.new(status: :service_unavailable,
-                              body: { errors: 'Accreditation Service unavailable' }.to_json)
-      rescue Faraday::TimeoutError => e
-        Rails.logger.error("Accreditation Service request timed out for user with user_uuid=#{user_uuid}: #{e.message}")
+                              body: { errors: 'GCLAWS Accreditation unavailable' }.to_json)
+      rescue Faraday::TimeoutError
+        Rails.logger.error("GCLAWS Accreditation request timed out for #{type}")
         Faraday::Response.new(status: :request_timeout,
-                              body: { errors: 'Accreditation Service request timed out' }.to_json)
+                              body: { errors: 'GCLAWS Accreditation request timed out' }.to_json)
       end
     end
   end

--- a/modules/representation_management/app/services/representation_management/gclaws/configuration.rb
+++ b/modules/representation_management/app/services/representation_management/gclaws/configuration.rb
@@ -9,11 +9,26 @@ module RepresentationManagement
         'agents' => {
           'sortColumn' => 'LastName',
           'sortOrder' => 'ASC'
+        },
+        'attorneys' => {
+          'sortColumn' => 'LastName',
+          'sortOrder' => 'ASC'
+        },
+        'representatives' => {
+          'sortColumn' => 'LastName',
+          'sortOrder' => 'ASC'
+        },
+        'veteran_service_organizations' => {
+          'sortColumn' => 'Organization.OrganizationName',
+          'sortOrder' => 'ASC'
         }
       }.freeze
 
       URL_MAPPING = {
-        'agents' => Settings.gclaws.accreditation.agents.url
+        'agents' => Settings.gclaws.accreditation.agents.url,
+        'attorneys' => Settings.gclaws.accreditation.attorneys.url,
+        'representatives' => Settings.gclaws.accreditation.representatives.url,
+        'veteran_service_organizations' => Settings.gclaws.accreditation.veteran_service_organizations.url
       }.freeze
 
       def initialize(type:, page:, page_size:)

--- a/modules/representation_management/app/services/representation_management/gclaws/configuration.rb
+++ b/modules/representation_management/app/services/representation_management/gclaws/configuration.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# HTTP client configuration for the RepresentationManagement::GCLAWS::Client
+#
+module RepresentationManagement
+  module GCLAWS
+    class Configuration
+      DEFAULT_SORT_PARAMS = {
+        'agents' => {
+          'sortColumn' => 'LastName',
+          'sortOrder' => 'ASC'
+        }
+      }.freeze
+
+      URL_MAPPING = {
+        'agents' => Settings.gclaws.accreditation.agents.url
+      }.freeze
+
+      def initialize(type:, page:, page_size:)
+        @type = type
+        @page = page
+        @page_size = page_size
+      end
+
+      def connection
+        Faraday.new(url:, params:, headers:) do |conn|
+          conn.request :json
+          conn.response :json, content_type: /\bjson$/
+          conn.adapter Faraday.default_adapter
+        end
+      end
+
+      private
+
+      def api_key
+        Settings.gclaws.accreditation.api_key
+      end
+
+      def headers
+        {
+          'x-api-key' => api_key
+        }
+      end
+
+      def params
+        DEFAULT_SORT_PARAMS[@type].merge({ 'page' => @page, 'pageSize' => @page_size })
+      end
+
+      def url
+        URL_MAPPING[@type]
+      end
+    end
+  end
+end

--- a/modules/representation_management/spec/models/representation_management/form_2122_digital_submission_spec.rb
+++ b/modules/representation_management/spec/models/representation_management/form_2122_digital_submission_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe RepresentationManagement::Form2122DigitalSubmission, type: :model
         end
       end
 
-      context 'when the user has a participant id' do
+      context 'when the user has an ICN' do
         it 'does not add the blank ICN error to the form' do
           subject.valid?
 

--- a/modules/representation_management/spec/services/representation_management/gclaws/client_spec.rb
+++ b/modules/representation_management/spec/services/representation_management/gclaws/client_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'faraday'
+require 'json'
+
+RSpec.describe RepresentationManagement::GCLAWS::Client do
+  subject { described_class }
+
+  describe '.get_accredited_entities' do
+    context 'when the type is invalid' do
+      let(:type) { 'invalid' }
+
+      it 'returns an empty hash' do
+        response = subject.get_accredited_entities(type:)
+        expect(response).to eq({})
+      end
+    end
+
+    context 'when the type is valid' do
+      let(:type) { 'agents' }
+      let(:parsed_body) { { field: 'value' } }
+
+      context 'when the request is successful' do
+        it 'returns a successful response' do
+          stub_request(:get, Settings.gclaws.accreditation.agents.url)
+            .with(query: { 'page' => 1, 'pageSize' => 100, 'sortColumn' => 'LastName', 'sortOrder' => 'ASC' })
+            .to_return(status: 200, body: parsed_body.to_json, headers: { 'Content-Type' => 'application/json' })
+
+          response = subject.get_accredited_entities(type:)
+
+          expect(response.status).to eq(200)
+          expect(response.body).to eq(parsed_body.stringify_keys)
+        end
+      end
+
+      context 'when the connection fails' do
+        it 'logs the error and returns a service unavailable status' do
+          stub_request(:get, Settings.gclaws.accreditation.agents.url)
+            .with(query: { 'page' => 1, 'pageSize' => 100, 'sortColumn' => 'LastName', 'sortOrder' => 'ASC' })
+            .to_raise(Faraday::ConnectionFailed.new('GCLAWS Accreditation unavailable'))
+
+          expect(Rails.logger).to receive(:error).with("GCLAWS Accreditation connection failed for #{type}")
+
+          response = subject.get_accredited_entities(type:)
+
+          expect(response.status).to eq(:service_unavailable)
+          expect(JSON.parse(response.body)['errors']).to eq('GCLAWS Accreditation unavailable')
+        end
+      end
+
+      context 'when the request times out' do
+        it 'logs the error and returns a request timeout status' do
+          stub_request(:get, Settings.gclaws.accreditation.agents.url)
+            .with(query: { 'page' => 1, 'pageSize' => 100, 'sortColumn' => 'LastName', 'sortOrder' => 'ASC' })
+            .to_raise(Faraday::TimeoutError.new('GCLAWS Accreditation request timed out'))
+
+          expect(Rails.logger).to receive(:error).with(
+            "GCLAWS Accreditation request timed out for #{type}"
+          )
+
+          response = subject.get_accredited_entities(type:)
+
+          expect(response.status).to eq(:request_timeout)
+          expect(JSON.parse(response.body)['errors']).to eq('GCLAWS Accreditation request timed out')
+        end
+      end
+    end
+  end
+end

--- a/modules/representation_management/spec/services/representation_management/gclaws/configuration_spec.rb
+++ b/modules/representation_management/spec/services/representation_management/gclaws/configuration_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RepresentationManagement::GCLAWS::Configuration do
+  subject { described_class.new(type:, page:, page_size:) }
+
+  let(:type) { 'agents' }
+  let(:page) { 1 }
+  let(:page_size) { 10 }
+
+  describe '#connection' do
+    it 'creates a Faraday connection' do
+      expect(subject.connection).to be_a(Faraday::Connection)
+    end
+
+    it 'sets the search params' do
+      expect(subject.connection.params).to eq({ 'sortColumn' => 'LastName', 'sortOrder' => 'ASC', 'page' => 1,
+                                                'pageSize' => 10 })
+    end
+
+    it 'sets the url' do
+      expect(subject.connection.url_prefix.to_s).to eq(Settings.gclaws.accreditation.agents.url)
+    end
+
+    it 'sets the api_key' do
+      expect(subject.connection.headers['x-api-key']).to eq(Settings.gclaws.accreditation.api_key)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- This pr adds a client and configuration for a GCLAWS integration
  - the integration will be used in daily sidekiq jobs to fetch data on accredited entities and update records in the `accredited_individuals` and `accredited_organizations` tables
    - This will allow us to start moving away from the daily and supplemental weekly excel file processing jobs
    - This will allow the accredited representation teams to move away from the legacy `veteran_representatives` and `veteran_organizations` tables which are owned by LH and could block future LHDI migration
- This pr fixes some typos in the accredited rep space

## Related issue(s)

- [105455](https://github.com/department-of-veterans-affairs/va.gov-team/issues/105455)

## Testing done

- [x] *New code is covered by unit tests*
- A local connection to GCLAWS is not supported
- I used the ArgoCD staging rails console to make an instance of the Faraday connection and execute a test request
  - I am able to hit the GCLAWS lower environment. However, we get authentication errors for our api key because of some recent changes to GCLAWS' authentication. That team is working on fixing our access. There shouldn't be any impact to how the client and configuration are built.

## What areas of the site does it impact?
None yet, the client is not used. Will impact FAR, AAR, and ARP once data is saved in the new tables

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature