### PR TITLE
Pre-initialize and memoize UUID for form 4142 PDF naming

### DIFF
--- a/lib/decision_review_v1/utilities/form_4142_processor.rb
+++ b/lib/decision_review_v1/utilities/form_4142_processor.rb
@@ -28,8 +28,8 @@ module DecisionReviewV1
         @submission = Form526Submission.find_by(id: submission_id)
         @form = set_signature_date(form_data)
         validate_form4142
+        @uuid = SecureRandom.uuid # this needs to be above generate_stamp_pdf and generate_metadata.
         @pdf_path = generate_stamp_pdf
-        @uuid = SecureRandom.uuid
         @request_body = {
           'document' => to_faraday_upload,
           'metadata' => generate_metadata


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper):* NO

This PR is an attempt to fix flakey pdf specs across vets-api. I saw in our [flakey specs doc](https://vfs.atlassian.net/wiki/spaces/BCP/pages/3797057551/Vets-API+Flakey+Specs) that some flakey tests were in the `modules/decision_reviews` directory, so I ran: `bin/test modules/decision_reviews  --parallel` and got a pdf error! When I took off the --parallel flag, all tests pass. This failed 4/9 times when I ran the test in parallel, but passed 10/10 times with this fix.

**Why?** 
In `lib/decision_review_v1/utilities/form_4142_processor.rb`, we had this code: 
```ruby
def initialize(form_data:, submission_id: nil)
...
    @pdf_path = generate_stamp_pdf  # this method was using uuid before it was instantiated.
    @uuid = SecureRandom.uuid
...
end
def generate_stamp_pdf
    pdf = PdfFill::Filler.fill_ancillary_form(
      @form, @uuid, FORM_ID
    )
```
So `file_name_extension` (from [pdf_fill/filler.rb](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/pdf_fill/filler.rb#L130-L148)) was coming in as as nil, so the file path was as awkward, `tmp/pdfs/21-4142_.pdf` (with that trailing underscore). **And because of that, the file name was not unique across tests and would get deleted.** This was the error:
```
  1) DecisionReviews::Form4142Submit perform when form4142 data exists generates a 4142 PDF and sends it to Lighthouse API
     Failure/Error: PDFUtilities::PDFTK.stamp(file_path, stamp_path, stamped_pdf)
     
     PdfForms::PdftkError:
       Failed to generate datestamp file: PDF stamping failed: pdftk failed with command
       /usr/local/bin/pdftk tmp/pdfs/21-4142_.pdf stamp tmp/017b73f7a9ad1186a02300f55673b186 output tmp/b2f47fccec74199c1b01a83234b1ecdd.pdf
       command output was:
       Error: Unable to find file.
       Error: Failed to open PDF file: 
          tmp/pdfs/21-4142_.pdf
       Errors encountered.  No output created.
       Done.  Input errors, so no output created.
```

I'm on the Platform team. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/102814

But more speficically, I think this will resolve all of these:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/104792
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/104790
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/104832

## Testing done

Before the fix: there was some pdf failure when running specs in this module in parallel about 50% of the time. 
After the fix: Tests passed (when run in parallel) 10/10 times.
```
for i in {1..10}; do bin/test modules/decision_reviews --parallel; done
```
I had some trouble coming up with a good spec for this. [form4142_processor_spec.rb](https://github.com/department-of-veterans-affairs/vets-api/blob/master/spec/lib/decision_review_v1/processor/form4142_processor_spec.rb) uses `anything`. The tests show the file path as `tmp/bb19ff88873a21acaf952e7cc97bb8e5.pdf`, which doesn't match file paths in other pdf tests 🤷 
- [ ] *New code is covered by unit tests*

- Code coverage didn't change
![image](https://github.com/user-attachments/assets/2c18e81f-868d-48e5-9efb-7272a816bbff)
- with the only line not getting hit:
![image](https://github.com/user-attachments/assets/9fef47f7-7b4c-420c-9150-bb33de7e32d8)


## What areas of the site does it impact?
CI tests in decision_reviews module

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
