### PR TITLE
[SIMPLE-FORMS] fix: add name and email accessors for 4138

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4138.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4138.rb
@@ -31,7 +31,7 @@ module SimpleFormsApi
 
     def metadata
       {
-        'veteranFirstName' => data.dig('full_name', 'first'),
+        'veteranFirstName' => notification_first_name,
         'veteranLastName' => data.dig('full_name', 'last'),
         'fileNumber' => data.dig('id_number', 'va_file_number').presence || data.dig('id_number', 'ssn'),
         'zipCode' => data.dig('mailing_address', 'postal_code'),

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4138.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4138.rb
@@ -31,18 +31,26 @@ module SimpleFormsApi
 
     def metadata
       {
-        'veteranFirstName' => @data.dig('full_name', 'first'),
-        'veteranLastName' => @data.dig('full_name', 'last'),
-        'fileNumber' => @data.dig('id_number', 'va_file_number').presence || @data.dig('id_number', 'ssn'),
-        'zipCode' => @data.dig('mailing_address', 'postal_code'),
+        'veteranFirstName' => data.dig('full_name', 'first'),
+        'veteranLastName' => data.dig('full_name', 'last'),
+        'fileNumber' => data.dig('id_number', 'va_file_number').presence || data.dig('id_number', 'ssn'),
+        'zipCode' => data.dig('mailing_address', 'postal_code'),
         'source' => 'VA Platform Digital Forms',
-        'docType' => @data['form_number'],
+        'docType' => data['form_number'],
         'businessLine' => 'CMP'
       }
     end
 
+    def notification_first_name
+      data.dig('full_name', 'first')
+    end
+
+    def notification_email_address
+      data['email_address']
+    end
+
     def zip_code_is_us_based
-      @data.dig('mailing_address', 'country') == 'USA'
+      data.dig('mailing_address', 'country') == 'USA'
     end
 
     def track_user_identity(confirmation_number); end


### PR DESCRIPTION
## Summary

- This work adds a name and email accessor for form 21-4138. This enables email delivery to the expected recipient email, specified by the user during the form submission process.
- To reproduce the bug, complete form 21-4138 and submit normally. The notification emails will always be delivered to the user's account email, regardless of what's specified in the form itself.
- I work for the Veteran Facing Forms team who owns this form

## Related issue(s)

- [[Bug] 21-4138 emails are reverting to email address in Profile](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/2104)

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?

- This work only affects form 21-4138 email deliveries

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

## Requested Feedback

Any
