### PR TITLE
chore(PE): Add semver tag to vets-api docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,22 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-gov-west-1
 
+      - name: Git Version
+        id: version
+        uses: codacy/git-version@2.8.0
+        with:
+          release-branch: master
+
+      - name: Echo the version
+        run: |
+          echo ${{ steps.version.outputs.version }}
+
+      - name: Create git tag if on master
+        if: github.ref == 'refs/heads/master'
+        run: |
+          git tag ${{ steps.version.outputs.version }}
+          git push origin ${{ steps.version.outputs.version }}
+
       - name: Login to ECR
         id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
@@ -65,6 +81,7 @@ jobs:
           push: true
           tags: |
             ${{ steps.ecr-login.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:${{ github.event.workflow_run.head_commit.id }}
+            ${{ steps.ecr-login.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:${{ steps.version.outputs.version }} # for semantic release
           cache-from: type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY
           cache-to: type=inline
   deploy:


### PR DESCRIPTION
## Summary

The current process for tagging the vets-api image uses the commit sha for docker image builds and tagging for deployments. To allow more robust versioning, better ECR repo purge policies, and better awareness of code versions, we need to add semvers to the versioning pattern.

This PR adds the semver tag on the vets-api docker image when created and pushed to AWS ECR. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/105668

## Testing done
> [!Note]
> Kickoff build.yaml workflow and ensure both tags are on the newly created image

## Screenshots
> [!Note]
> Add screenshot here

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

Vets-api image creation and deployment

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
