### PR TITLE
MFS: VetVerification Logging Differientiation 

### DIFF
--- a/modules/mobile/app/controllers/mobile/v0/vet_verification_statuses_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/vet_verification_statuses_controller.rb
@@ -13,7 +13,7 @@ module Mobile
       private
 
       def service
-        @service ||= VeteranVerification::Service.new
+        @service ||= Mobile::V0::VeteranVerification::Service.new
       end
     end
   end

--- a/modules/mobile/app/services/mobile/v0/veteran_verification/service.rb
+++ b/modules/mobile/app/services/mobile/v0/veteran_verification/service.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'lighthouse/veteran_verification/service'
+require 'lighthouse/veteran_verification/configuration'
+
+module Mobile
+  module V0
+    module VeteranVerification
+      class Service < ::VeteranVerification::Service
+        configuration ::VeteranVerification::Configuration
+        STATSD_KEY_PREFIX = 'api.lighthouse.veteran_verification_status.mobile'
+
+        def get_vet_verification_status(icn, lighthouse_client_id = nil, lighthouse_rsa_key_path = nil, options = {})
+          endpoint = 'status'
+          response = config.get(
+            "#{endpoint}/#{icn}",
+            lighthouse_client_id,
+            lighthouse_rsa_key_path,
+            options
+          ).body
+
+          transform_response(response)
+        rescue => e
+          StatsD.increment("#{STATSD_KEY_PREFIX}.fail")
+          handle_error(e, lighthouse_client_id, endpoint)
+        ensure
+          StatsD.increment("#{STATSD_KEY_PREFIX}.total")
+        end
+
+        private
+
+        def log_not_confirmed(reason)
+          ::Rails.logger.info('Mobile Vet Verification Status Success: not confirmed',
+                            { not_confirmed: true, not_confirmed_reason: reason })
+        end
+
+        def log_confirmed
+          ::Rails.logger.info('Mobile Vet Verification Status Success: confirmed', { confirmed: true })
+        end
+      end
+    end
+  end
+end 

--- a/modules/mobile/app/services/mobile/v0/veteran_verification/service.rb
+++ b/modules/mobile/app/services/mobile/v0/veteran_verification/service.rb
@@ -31,7 +31,7 @@ module Mobile
 
         def log_not_confirmed(reason)
           ::Rails.logger.info('Mobile Vet Verification Status Success: not confirmed',
-                            { not_confirmed: true, not_confirmed_reason: reason })
+                              { not_confirmed: true, not_confirmed_reason: reason })
         end
 
         def log_confirmed
@@ -40,4 +40,4 @@ module Mobile
       end
     end
   end
-end 
+end


### PR DESCRIPTION

## Summary

Add mobile VetVerification Service:
 - differentiates statsd + logging for tracking purposes
 - load the new service in the mobile controller

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-mobile-feature-support/issues/343
- https://github.com/department-of-veterans-affairs/va-mobile-feature-support/issues/344


## Testing done

- [x] *New code is covered by unit tests*
- Prior to this change all logging was shared amongst the mobile + web apis
- Logs should now properly separate themselves to be more granular in datadog tracking
- Once deployed to staging we'll validate in the datadog logs there

## What areas of the site does it impact?
None. This feature is still in the development stage for mobile and is completely quarantined off.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
  - DD Dashboards are WIP for this mobile feature
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

I originally posted about this differentiation issue in the platform CoP channel and the one response I got suggested I take a look at user agents. While there is a `VAMobile` user agent that is being logged, I felt that it was relatively unclear on how it was being set and wanted a more definitive and controllable way rather than relying on it. No other potential options were discussed. 
