### PR TITLE
Pension 105759 create itf synchronous flipper

### DIFF
--- a/app/controllers/v0/in_progress_forms_controller.rb
+++ b/app/controllers/v0/in_progress_forms_controller.rb
@@ -26,8 +26,8 @@ module V0
 
       form.update!(form_data: params[:form_data] || params[:formData], metadata: params[:metadata])
 
-      if Flipper.enabled?(:intent_to_file_lighthouse_enabled, @current_user) && form.id_previously_changed? &&
-         Lighthouse::CreateIntentToFileJob::ITF_FORMS.include?(form.form_id)
+      itf_enabled = Flipper.enabled?(:intent_to_file_lighthouse_enabled, @current_user) && !Flipper.enabled?(:intent_to_file_synchronous_enabled, @current_user)
+      if itf_enabled && form.id_previously_changed? && Lighthouse::CreateIntentToFileJob::ITF_FORMS.include?(form.form_id)
         BenefitsClaims::IntentToFile::Monitor.new.track_create_itf_initiated(form.form_id, form.created_at,
                                                                              @current_user.uuid, form.id)
         Lighthouse::CreateIntentToFileJob.perform_async(form.id, @current_user.icn,

--- a/app/controllers/v0/in_progress_forms_controller.rb
+++ b/app/controllers/v0/in_progress_forms_controller.rb
@@ -26,8 +26,11 @@ module V0
 
       form.update!(form_data: params[:form_data] || params[:formData], metadata: params[:metadata])
 
-      itf_enabled = Flipper.enabled?(:intent_to_file_lighthouse_enabled, @current_user) && !Flipper.enabled?(:intent_to_file_synchronous_enabled, @current_user)
-      if itf_enabled && form.id_previously_changed? && Lighthouse::CreateIntentToFileJob::ITF_FORMS.include?(form.form_id)
+      itf_enabled = Flipper.enabled?(:intent_to_file_lighthouse_enabled,
+                                     @current_user) && !Flipper.enabled?(:intent_to_file_synchronous_enabled,
+                                                                         @current_user)
+      itf_valid_form = Lighthouse::CreateIntentToFileJob::ITF_FORMS.include?(form.form_id)
+      if itf_enabled && form.id_previously_changed? && itf_valid_form
         BenefitsClaims::IntentToFile::Monitor.new.track_create_itf_initiated(form.form_id, form.created_at,
                                                                              @current_user.uuid, form.id)
         Lighthouse::CreateIntentToFileJob.perform_async(form.id, @current_user.icn,

--- a/config/features.yml
+++ b/config/features.yml
@@ -1925,6 +1925,10 @@ features:
     actor_type: user
     description: Enable new Lighthouse ITF logic
     enable_in_development: true
+  intent_to_file_synchronous_enabled:
+    actor_type: user
+    description: Enable ITF synchronous call logic
+    enable_in_development: true
   central_mail_benefits_intake_submission:
     actor_type: user
     description: Enable central mail claims submission uses Benefits Intake API

--- a/spec/requests/v0/in_progress_forms_controller_spec.rb
+++ b/spec/requests/v0/in_progress_forms_controller_spec.rb
@@ -393,7 +393,8 @@ RSpec.describe V0::InProgressFormsController do
           before { allow(Lighthouse::CreateIntentToFileJob).to receive(:perform_async) }
 
           it 'calls aync CreateIntentToFileJob for newly created forms' do
-            expect(Flipper).to receive(:enabled?).with(:intent_to_file_synchronous_enabled, instance_of(User)).and_return(false)
+            expect(Flipper).to receive(:enabled?).with(:intent_to_file_synchronous_enabled,
+                                                       instance_of(User)).and_return(false)
 
             put v0_in_progress_form_url('21P-527EZ'),
                 params: {
@@ -408,7 +409,8 @@ RSpec.describe V0::InProgressFormsController do
           end
 
           it 'does not call aync CreateIntentToFileJob for newly created forms' do
-            expect(Flipper).to receive(:enabled?).with(:intent_to_file_synchronous_enabled, instance_of(User)).and_return(true)
+            expect(Flipper).to receive(:enabled?).with(:intent_to_file_synchronous_enabled,
+                                                       instance_of(User)).and_return(true)
 
             put v0_in_progress_form_url('21P-527EZ'),
                 params: {
@@ -417,7 +419,7 @@ RSpec.describe V0::InProgressFormsController do
                 }.to_json,
                 headers: { 'CONTENT_TYPE' => 'application/json' }
 
-            latest_form = InProgressForm.last
+            InProgressForm.last
             expect(Lighthouse::CreateIntentToFileJob).not_to have_received(:perform_async)
           end
         end

--- a/spec/requests/v0/in_progress_forms_controller_spec.rb
+++ b/spec/requests/v0/in_progress_forms_controller_spec.rb
@@ -392,7 +392,9 @@ RSpec.describe V0::InProgressFormsController do
         context 'when form type is pension' do
           before { allow(Lighthouse::CreateIntentToFileJob).to receive(:perform_async) }
 
-          it 'calls the CreateIntentToFileJob for newly created forms' do
+          it 'calls aync CreateIntentToFileJob for newly created forms' do
+            expect(Flipper).to receive(:enabled?).with(:intent_to_file_synchronous_enabled, instance_of(User)).and_return(false)
+
             put v0_in_progress_form_url('21P-527EZ'),
                 params: {
                   formData: new_form.form_data,
@@ -403,6 +405,20 @@ RSpec.describe V0::InProgressFormsController do
             latest_form = InProgressForm.last
             expect(Lighthouse::CreateIntentToFileJob).to have_received(:perform_async).with(latest_form.id, user.icn,
                                                                                             user.participant_id)
+          end
+
+          it 'does not call aync CreateIntentToFileJob for newly created forms' do
+            expect(Flipper).to receive(:enabled?).with(:intent_to_file_synchronous_enabled, instance_of(User)).and_return(true)
+
+            put v0_in_progress_form_url('21P-527EZ'),
+                params: {
+                  formData: new_form.form_data,
+                  metadata: new_form.metadata
+                }.to_json,
+                headers: { 'CONTENT_TYPE' => 'application/json' }
+
+            latest_form = InProgressForm.last
+            expect(Lighthouse::CreateIntentToFileJob).not_to have_received(:perform_async)
           end
         end
       end


### PR DESCRIPTION
## Summary

add flipper for synchronous ITF creation

## Related issue(s)

[Pension | Create flipper for ITF Synchronous call](https://github.com/department-of-veterans-affairs/va.gov-team/issues/105759)

## Testing done

- [x] *New code is covered by unit tests*
- in progress form will not trigger async job if synchronous flipper is enabled

## What areas of the site does it impact?

pension

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
