### PR TITLE
ARM: Remove unused `record_consent` field from POA request handling

### DIFF
--- a/modules/representation_management/app/controllers/representation_management/v0/power_of_attorney_requests_controller.rb
+++ b/modules/representation_management/app/controllers/representation_management/v0/power_of_attorney_requests_controller.rb
@@ -32,7 +32,6 @@ module RepresentationManagement
           {
             representative_id: form_params[:representative][:id],
             organization_id: form_params[:representative][:organization_id],
-            record_consent: [true, 'true'].include?(form_params[:record_consent]),
             consent_limits:,
             consent_address_change: [true, 'true'].include?(form_params[:consent_address_change])
           }.merge(flatten_veteran_params(form_params))

--- a/modules/representation_management/spec/services/power_of_attorney_request_service/orchestrate_spec.rb
+++ b/modules/representation_management/spec/services/power_of_attorney_request_service/orchestrate_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe RepresentationManagement::PowerOfAttorneyRequestService::Orchestr
     let(:service_branch) { 'ARMY' }
     let(:data) do
       {
-        record_consent: true,
         consent_limits: ['HIV'],
         consent_address_change: true,
         veteran_first_name: 'John',
@@ -90,13 +89,16 @@ RSpec.describe RepresentationManagement::PowerOfAttorneyRequestService::Orchestr
 
     context 'when there is an error' do
       before do
-        data[:record_consent] = 'abc'
+        data[:consent_limits] = ['foobar']
       end
 
       it 'returns a meaningful error message' do
         result = subject.call
 
-        expect(result[:errors]).to eq(['value at `/authorizations/recordDisclosure` is not a boolean'])
+        expect(result[:errors]).to eq(
+          ['value at `/authorizations/recordDisclosureLimitations/0` is not one of: ["ALCOHOLISM", ' \
+           '"DRUG_ABUSE", "HIV", "SICKLE_CELL"]']
+        )
       end
 
       it 'does not create a new AccreditedRepresentativePortal::PowerOfAttorneyRequest' do


### PR DESCRIPTION
What Changed
	•	Removed the record_consent parameter from PowerOfAttorneyRequestsController.
	•	Removed associated record_consent test data from orchestrate_spec.rb.

Why
	•	record_consent is no longer used in the POA request flow and has been removed for clarity and maintainability.
	•	Updated tests to reflect the change and ensure accurate validation coverage for existing fields like consent_limits.

Impact
	•	No functional change in the current behavior.


## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/105522

https://github.com/department-of-veterans-affairs/vets-api/pull/21426

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
