### PR TITLE
Remove two feature flags to make tests less flakey

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -826,10 +826,6 @@ features:
     actor_type: user
     description: Enables form 5495 email submission confirmation (VaNotify)
     enable_in_development: true
-  simple_forms_email_confirmations:
-    actor_type: user
-    description: Enables form email submission confirmations (for allowed email types via VaNotify)
-    enable_in_development: true
   simple_forms_email_notifications:
     actor_type: user
     description: Enables form email notifications upon certain state changes (error and received)
@@ -1431,10 +1427,6 @@ features:
     actor_type: user
     description: Enables the VHA Payment history (including copay resolution) feature for combined debt portal
     enable_in_development: true
-  submission_pdf_s3_upload:
-    actor_type: user
-    description: Used to toggle use of uploading a submission pdf to S3 and returning a pre-signed url.
-    enable_in_development: false
   meb_1606_30_automation:
     actor_type: user
     description: Enables MEB form to handle Chapter 1606/30 forms as well as Chapter 33.

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -103,9 +103,7 @@ module SimpleFormsApi
         confirmation_number, expiration_date = intent_service.submit
         form.track_user_identity(confirmation_number)
 
-        if confirmation_number && Flipper.enabled?(:simple_forms_email_confirmations)
-          send_intent_received_email(parsed_form_data, confirmation_number, expiration_date)
-        end
+        send_intent_received_email(parsed_form_data, confirmation_number, expiration_date) if confirmation_number
 
         json_for210966(confirmation_number, expiration_date, existing_intents)
       rescue Common::Exceptions::UnprocessableEntity, Exceptions::BenefitsClaimsApiDownError => e
@@ -127,15 +125,13 @@ module SimpleFormsApi
           { form_number: params[:form_number], status:, reference_number: }
         )
 
-        if Flipper.enabled?(:simple_forms_email_confirmations)
-          case status
-          when 'VALIDATED', 'ACCEPTED'
-            send_sahsha_email(parsed_form_data, :confirmation, reference_number)
-          when 'REJECTED'
-            send_sahsha_email(parsed_form_data, :rejected, reference_number)
-          when 'DUPLICATE'
-            send_sahsha_email(parsed_form_data, :duplicate)
-          end
+        case status
+        when 'VALIDATED', 'ACCEPTED'
+          send_sahsha_email(parsed_form_data, :confirmation, reference_number)
+        when 'REJECTED'
+          send_sahsha_email(parsed_form_data, :rejected, reference_number)
+        when 'DUPLICATE'
+          send_sahsha_email(parsed_form_data, :duplicate)
         end
 
         { json: { reference_number:, status:, submission_api: 'sahsha' }, status: lgy_response.status }
@@ -251,7 +247,7 @@ module SimpleFormsApi
       end
 
       def upload_pdf_to_s3(id, file_path, metadata, submission, form)
-        return unless Flipper.enabled?(:submission_pdf_s3_upload)
+        return unless Rails.env.production? || Rails.env.test?
 
         config = SimpleFormsApi::FormRemediation::Configuration::VffConfig.new
         attachments = form_id == 'vba_20_10207' ? form.get_attachments : []
@@ -313,8 +309,6 @@ module SimpleFormsApi
       end
 
       def send_confirmation_email(parsed_form_data, confirmation_number)
-        return unless Flipper.enabled?(:simple_forms_email_confirmations)
-
         config = {
           form_data: parsed_form_data,
           form_number: form_id,

--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -247,7 +247,7 @@ module SimpleFormsApi
       end
 
       def upload_pdf_to_s3(id, file_path, metadata, submission, form)
-        return unless Rails.env.production? || Rails.env.test?
+        return unless %w[production staging test].include?(Settings.vsp_environment)
 
         config = SimpleFormsApi::FormRemediation::Configuration::VffConfig.new
         attachments = form_id == 'vba_20_10207' ? form.get_attachments : []

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/simple_forms_spec.rb
@@ -55,16 +55,12 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
         allow(Common::FileHelpers).to receive(:generate_clamav_temp_file).and_wrap_original do |original_method, *args|
           original_method.call(args[0], random_string)
         end
-        Flipper.disable(:simple_forms_email_confirmations)
-        Flipper.enable(:submission_pdf_s3_upload)
       end
 
       after do
         VCR.eject_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location')
         VCR.eject_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload')
         Common::FileHelpers.delete_file_if_exists(metadata_file)
-        Flipper.enable(:simple_forms_email_confirmations)
-        Flipper.disable(:submission_pdf_s3_upload)
       end
 
       shared_examples 'form submission' do |form, is_authenticated|
@@ -286,8 +282,6 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
 
         context 'transliteration succeeds' do
           it 'responds with ok' do
-            Flipper.disable(:form21_0966_confirmation_email)
-
             fixture_path = Rails.root.join('modules', 'simple_forms_api', 'spec', 'fixtures', 'form_json',
                                            'form_with_accented_chars_21_0966.json')
             data = JSON.parse(fixture_path.read)
@@ -295,8 +289,6 @@ RSpec.describe 'SimpleFormsApi::V1::SimpleForms', type: :request do
             post '/simple_forms_api/v1/simple_forms', params: data
 
             expect(response).to have_http_status(:ok)
-
-            Flipper.enable(:form21_0966_confirmation_email)
           end
         end
 


### PR DESCRIPTION
## Summary
This PR removes two feature flags `simple_forms_email_confirmations` and `submission_pdf_s3_upload`, both of which are ENABLED in prod and staging. I believe we have no plans to disable to tweak them at all, at this point. One of them (probably the S3 one) was causing some test flakiness. I think just removing them outright is the cleanest solution.

## Related issue(s)
https://dsva.slack.com/archives/C044AGZFG2W/p1743454383697389
