### PR TITLE
[CST]: Un-skip previously flaky test

### DIFF
--- a/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
+++ b/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
@@ -136,39 +136,41 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
           VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
             VCR.use_cassette('form526_backup/200_evss_get_pdf') do
               VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
-                jid = subject.perform_async(submission.id)
-                last = subject.jobs.last
-                jid_from_jobs = last['jid']
-                expect(jid).to eq(jid_from_jobs)
-                described_class.drain
-                expect(jid).not_to be_empty
-                # The Backup Submission process gathers form 526 and any ancillary forms
-                # to send to Central Mail at the same time
+                VCR.use_cassette('lighthouse/benefits_claims/submit526/200_response_generate_pdf') do
+                  jid = subject.perform_async(submission.id)
+                  last = subject.jobs.last
+                  jid_from_jobs = last['jid']
+                  expect(jid).to eq(jid_from_jobs)
+                  described_class.drain
+                  expect(jid).not_to be_empty
+                  # The Backup Submission process gathers form 526 and any ancillary forms
+                  # to send to Central Mail at the same time
 
-                # Form 4142 Backup Submission Process
-                expect(submission.form['form4142']).not_to be_nil
-                form4142_processor = DecisionReviewV1::Processor::Form4142Processor.new(
-                  form_data: submission.form['form4142'], submission_id: submission.id
-                )
-                request_body = form4142_processor.request_body
-                metadata_hash = JSON.parse(request_body['metadata'])
-                form4142_received_date = metadata_hash['receiveDt'].in_time_zone('Central Time (US & Canada)')
-                expect(
-                  submission.created_at.in_time_zone('Central Time (US & Canada)')
-                ).to be_within(1.second).of(form4142_received_date)
+                  # Form 4142 Backup Submission Process
+                  expect(submission.form['form4142']).not_to be_nil
+                  form4142_processor = DecisionReviewV1::Processor::Form4142Processor.new(
+                    form_data: submission.form['form4142'], submission_id: submission.id
+                  )
+                  request_body = form4142_processor.request_body
+                  metadata_hash = JSON.parse(request_body['metadata'])
+                  form4142_received_date = metadata_hash['receiveDt'].in_time_zone('Central Time (US & Canada)')
+                  expect(
+                    submission.created_at.in_time_zone('Central Time (US & Canada)')
+                  ).to be_within(1.second).of(form4142_received_date)
 
-                # Form 0781 Backup Submission Process
-                expect(submission.form['form0781']).not_to be_nil
-                # not really a way to test the dates here
+                  # Form 0781 Backup Submission Process
+                  expect(submission.form['form0781']).not_to be_nil
+                  # not really a way to test the dates here
 
-                job_status = Form526JobStatus.last
-                expect(job_status.form526_submission_id).to eq(submission.id)
-                expect(job_status.job_class).to eq('BackupSubmission')
-                expect(job_status.job_id).to eq(jid)
-                expect(job_status.status).to eq('success')
-                submission = Form526Submission.last
-                expect(submission.backup_submitted_claim_id).not_to be_nil
-                expect(submission.submit_endpoint).to eq('benefits_intake_api')
+                  job_status = Form526JobStatus.last
+                  expect(job_status.form526_submission_id).to eq(submission.id)
+                  expect(job_status.job_class).to eq('BackupSubmission')
+                  expect(job_status.job_id).to eq(jid)
+                  expect(job_status.status).to eq('success')
+                  submission = Form526Submission.last
+                  expect(submission.backup_submitted_claim_id).not_to be_nil
+                  expect(submission.submit_endpoint).to eq('benefits_intake_api')
+                end
               end
             end
           end

--- a/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
+++ b/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
   end
 
   %w[single multi].each do |payload_method|
-    describe ".perform_async, enabled, #{payload_method} payload", skip: 'Flaky test' do
+    describe ".perform_async, enabled, #{payload_method} payload" do
       before do
         allow(Settings.form526_backup).to receive_messages(submission_method: payload_method, enabled: true)
       end

--- a/spec/support/disability_compensation_form/submissions/with_everything.json
+++ b/spec/support/disability_compensation_form/submissions/with_everything.json
@@ -281,12 +281,12 @@
         "providerFacilityName": "provider 1",
         "treatmentDateRange": [
           {
-            "from": "1980-1-1",
-            "to": "1985-1-1"
+            "from": "1980-01-01",
+            "to": "1985-01-01"
           },
           {
-            "from": "1986-1-1",
-            "to": "1987-1-1"
+            "from": "1986-01-01",
+            "to": "1987-01-01"
           }
         ],
         "providerFacilityAddress": {
@@ -302,12 +302,12 @@
         "providerFacilityName": "provider 2",
         "treatmentDateRange": [
           {
-            "from": "1980-2-1",
-            "to": "1985-2-1"
+            "from": "1980-02-01",
+            "to": "1985-02-01"
           },
           {
-            "from": "1986-2-1",
-            "to": "1987-2-1"
+            "from": "1986-02-01",
+            "to": "1987-02-01"
           }
         ],
         "providerFacilityAddress": {
@@ -323,12 +323,12 @@
         "providerFacilityName": "provider 3",
         "treatmentDateRange": [
           {
-            "from": "1980-3-1",
-            "to": "1985-3-1"
+            "from": "1980-03-01",
+            "to": "1985-03-01"
           },
           {
-            "from": "1986-3-1",
-            "to": "1987-3-1"
+            "from": "1986-03-01",
+            "to": "1987-03-01"
           }
         ],
         "providerFacilityAddress": {
@@ -344,12 +344,12 @@
         "providerFacilityName": "provider 4",
         "treatmentDateRange": [
           {
-            "from": "1980-4-1",
-            "to": "1985-4-1"
+            "from": "1980-04-01",
+            "to": "1985-04-01"
           },
           {
-            "from": "1986-4-1",
-            "to": "1987-4-1"
+            "from": "1986-04-01",
+            "to": "1987-04-01"
           }
         ],
         "providerFacilityAddress": {
@@ -365,12 +365,12 @@
         "providerFacilityName": "provider 5",
         "treatmentDateRange": [
           {
-            "from": "1980-5-1",
-            "to": "1985-5-1"
+            "from": "1980-05-01",
+            "to": "1985-05-01"
           },
           {
-            "from": "1986-5-1",
-            "to": "1987-5-1"
+            "from": "1986-05-01",
+            "to": "1987-05-01"
           }
         ],
         "providerFacilityAddress": {

--- a/spec/support/disability_compensation_form/submissions/with_everything_toxic_exposure.json
+++ b/spec/support/disability_compensation_form/submissions/with_everything_toxic_exposure.json
@@ -320,12 +320,12 @@
         "providerFacilityName": "provider 1",
         "treatmentDateRange": [
           {
-            "from": "1980-1-1",
-            "to": "1985-1-1"
+            "from": "1980-01-01",
+            "to": "1985-01-01"
           },
           {
-            "from": "1986-1-1",
-            "to": "1987-1-1"
+            "from": "1986-01-01",
+            "to": "1987-01-01"
           }
         ],
         "providerFacilityAddress": {
@@ -341,12 +341,12 @@
         "providerFacilityName": "provider 2",
         "treatmentDateRange": [
           {
-            "from": "1980-2-1",
-            "to": "1985-2-1"
+            "from": "1980-02-01",
+            "to": "1985-02-01"
           },
           {
-            "from": "1986-2-1",
-            "to": "1987-2-1"
+            "from": "1986-02-01",
+            "to": "1987-02-01"
           }
         ],
         "providerFacilityAddress": {
@@ -362,12 +362,12 @@
         "providerFacilityName": "provider 3",
         "treatmentDateRange": [
           {
-            "from": "1980-3-1",
-            "to": "1985-3-1"
+            "from": "1980-03-01",
+            "to": "1985-03-01"
           },
           {
-            "from": "1986-3-1",
-            "to": "1987-3-1"
+            "from": "1986-03-01",
+            "to": "1987-03-01"
           }
         ],
         "providerFacilityAddress": {
@@ -383,12 +383,12 @@
         "providerFacilityName": "provider 4",
         "treatmentDateRange": [
           {
-            "from": "1980-4-1",
-            "to": "1985-4-1"
+            "from": "1980-04-01",
+            "to": "1985-04-01"
           },
           {
-            "from": "1986-4-1",
-            "to": "1987-4-1"
+            "from": "1986-04-01",
+            "to": "1987-04-01"
           }
         ],
         "providerFacilityAddress": {
@@ -404,12 +404,12 @@
         "providerFacilityName": "provider 5",
         "treatmentDateRange": [
           {
-            "from": "1980-5-1",
-            "to": "1985-5-1"
+            "from": "1980-05-01",
+            "to": "1985-05-01"
           },
           {
-            "from": "1986-5-1",
-            "to": "1987-5-1"
+            "from": "1986-05-01",
+            "to": "1987-05-01"
           }
         ],
         "providerFacilityAddress": {


### PR DESCRIPTION
va-gov-team issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/102017

Nests another cassette to handle the Form 526 generation.
Changes date formatting in the test data to comply with the schema validation.