### PR TITLE
106517 - Update mapping to properly check payment box - form 10-7959f-2

### DIFF
--- a/modules/ivc_champva/app/form_mappings/vha_10_7959f_2.json.erb
+++ b/modules/ivc_champva/app/form_mappings/vha_10_7959f_2.json.erb
@@ -1,5 +1,5 @@
 {
-  "vha107959fform[0].#subform[0].RadioButtonList[0]":             "<%= ['true', true].include?(form.data['send_payment']) ? 0 : 1 %>",
+  "vha107959fform[0].#subform[0].RadioButtonList[0]":             "<%= form.data.dig('veteran', 'send_payment') == 'Provider' ? 1 : 0 %>",
   "vha107959fform[0].#subform[0].LastName-1[0]":                  "<%= form.data.dig('veteran', 'full_name', 'last') %>",
   "vha107959fform[0].#subform[0].FirstName-1[0]":                 "<%= form.data.dig('veteran', 'full_name', 'first') %>",
   "vha107959fform[0].#subform[0].MiddleInitial-1[0]":             "<%= form.data.dig('veteran', 'full_name', 'middle')&.first %>",


### PR DESCRIPTION
## Summary

This PR updates the JSON ERB mapping for form 10-7959f-2 so that it properly checks the payment selection box. Previously, the checkbox always defaulted to "provider" because the logic didn't actually compare the value properly.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/106517

## Testing done

- [ ] *New code is covered by unit tests*
- Old behavior: payment checkbox was always set to "provider" regardless of user input
- To verify locally, run vets-api/vets-website and submit a 10-7959f-2 form. Verify the resulting PDF has the proper payment checkbox selected.

## Screenshots

| |Form input| PDF output|
|-|-|-|
|Payment to veteran|![Screenshot 2025-04-01 at 11 50 36](https://github.com/user-attachments/assets/71d53302-0a5e-471a-b6b5-c40b8200be58)|![Screenshot 2025-04-01 at 11 51 01](https://github.com/user-attachments/assets/d55f8dbc-ac6b-4448-8334-52311365e6c4)|
|Payment to provider|![Screenshot 2025-04-01 at 11 51 17](https://github.com/user-attachments/assets/1771b3ff-f0be-468b-bb67-8d0baed10f00)|![Screenshot 2025-04-01 at 11 51 31](https://github.com/user-attachments/assets/1333883e-d1bc-462d-8aed-fdc2641af986)|

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
