### PR TITLE
Added metrics for uploaded doctypes to 526 gathered from IPF prior to submission

### DIFF
--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -93,6 +93,7 @@ class Form526Submission < ApplicationRecord
   # go here and call start_evss_submission_job when done.
   def start
     log_max_cfi_metrics_on_submit
+    log_document_type_metrics
     start_evss_submission_job
   end
 

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -1632,4 +1632,150 @@ RSpec.describe Form526Submission do
       end
     end
   end
+
+  context 'Upload document type metrics logging' do
+    let!(:in_progress_form) do
+      ipf = create(:in_progress_526_form, user_uuid: user.uuid)
+      fd = ipf.form_data
+      fd = JSON.parse(fd)
+      fd['privateMedicalRecordAttachments'] = private_medical_record_attachments
+      fd['additionalDocuments'] = additional_documents
+      ipf.update!(form_data: fd)
+      ipf
+    end
+    let(:private_medical_record_attachments) { [] }
+    let(:additional_documents) { [] }
+
+    before do
+      allow(StatsD).to receive(:increment)
+      allow(Rails.logger).to receive(:info)
+    end
+
+    def expect_log_statement(additional_docs_by_type, private_medical_docs_by_type)
+      return if additional_docs_by_type.blank? && private_medical_docs_by_type.blank?
+
+      expect(Rails.logger).to have_received(:info).with(
+        'Form526 evidence document type metrics',
+        {
+          id: subject.id,
+          additional_docs_by_type:,
+          private_medical_docs_by_type:
+        }
+      )
+    end
+
+    def expect_additional_documents_metrics(additional_docs_by_type)
+      return if additional_docs_by_type.blank?
+
+      additional_docs_by_type.each do |type, count|
+        expect(StatsD).to have_received(:increment).with(
+          'worker.document_type_metrics.additional_documents_document_type',
+          value: count,
+          tags: ["document_type:#{type}"]
+        )
+      end
+    end
+
+    def expect_private_medical_records_metrics(private_medical_docs_by_type)
+      return if private_medical_docs_by_type.blank?
+
+      private_medical_docs_by_type.each do |type, count|
+        expect(StatsD).to have_received(:increment).with(
+          'worker.document_type_metrics.private_medical_record_attachments_document_type',
+          value: count,
+          tags: ["document_type:#{type}"]
+        )
+      end
+    end
+
+    context 'when form data has no documents' do
+      it 'logs empty document type breakdowns' do
+        subject.start
+
+        expect(Rails.logger).not_to have_received(:info).with(
+          'Form526 evidence document type metrics',
+          anything
+        )
+      end
+    end
+
+    context 'when form data has additional documents' do
+      let(:additional_documents) do
+        [
+          { 'name' => 'doc1', 'attachmentId' => 'type1' },
+          { 'name' => 'doc2', 'attachmentId' => 'type2' },
+          { 'name' => 'doc3', 'attachmentId' => 'type2' }
+        ]
+      end
+
+      it 'logs document type metrics for additional documents' do
+        subject.start
+        expect_log_statement({ 'type1' => 1, 'type2' => 2 }, {})
+        expect_additional_documents_metrics({ 'type1' => 1, 'type2' => 2 })
+        expect_private_medical_records_metrics({})
+      end
+    end
+
+    context 'when form data has private medical records' do
+      let(:private_medical_record_attachments) do
+        [
+          { 'name' => 'doc1', 'attachmentId' => 'type3' },
+          { 'name' => 'doc2', 'attachmentId' => 'type3' },
+          { 'name' => 'doc3', 'attachmentId' => 'type4' }
+        ]
+      end
+
+      it 'logs document type metrics for private medical records' do
+        subject.start
+        expect_log_statement({}, { 'type3' => 2, 'type4' => 1 })
+        expect_additional_documents_metrics({})
+        expect_private_medical_records_metrics({ 'type3' => 2, 'type4' => 1 })
+      end
+    end
+
+    context 'when form data has both additional documents and private medical records' do
+      let(:additional_documents) do
+        [
+          { 'name' => 'doc1', 'attachmentId' => 'type1' },
+          { 'name' => 'doc2', 'attachmentId' => 'type2' },
+          { 'name' => 'doc3', 'attachmentId' => 'type2' }
+        ]
+      end
+      let(:private_medical_record_attachments) do
+        [
+          { 'name' => 'doc4', 'attachmentId' => 'type3' },
+          { 'name' => 'doc5', 'attachmentId' => 'type3' },
+          { 'name' => 'doc6', 'attachmentId' => 'type4' }
+        ]
+      end
+
+      it 'logs summary metrics with document type breakdowns' do
+        subject.start
+        expect_log_statement({ 'type1' => 1, 'type2' => 2 }, { 'type3' => 2, 'type4' => 1 })
+        expect_additional_documents_metrics({ 'type1' => 1, 'type2' => 2 })
+        expect_private_medical_records_metrics({ 'type3' => 2, 'type4' => 1 })
+      end
+    end
+
+    context 'when documents have no attachmentId' do
+      let(:additional_documents) do
+        [
+          { 'name' => 'doc1' },
+          { 'name' => 'doc2' }
+        ]
+      end
+      let(:private_medical_record_attachments) do
+        [
+          { 'name' => 'doc3' }
+        ]
+      end
+
+      it 'uses "unknown" as the attachment type' do
+        subject.start
+        expect_log_statement({ 'unknown' => 2 }, { 'unknown' => 1 })
+        expect_additional_documents_metrics({ 'unknown' => 2 })
+        expect_private_medical_records_metrics({ 'unknown' => 1 })
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- *This work is behind a feature toggle (flipper): NO*
- this PR introduces statsD metrics logged for the doctypes uploaded from the IPF prior to 526 submission

## Related issue(s)
- https://github.com/department-of-veterans-affairs/abd-vro/issues/4238

## Testing done
- [x] *New code is covered by unit tests*
- Old behavior: unable to tell what kinds of doctypes are uploaded prior to submission
- New behavior: metrics should be logged to datadog when there are `additionalDocuments` or `privateMedicalRecordAttachments`. This will allow the Employee Experience team to gather metrics on the types and frequencies of documents attached to the 526 on the `Support Evidence` pages of the 526.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Will not effect user experience or form submission

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
