### PR TITLE
API-45838 Fix consent exemptions to check nothing when grants are blank

### DIFF
--- a/modules/claims_api/lib/claims_api/v1/poa_pdf_constructor/base.rb
+++ b/modules/claims_api/lib/claims_api/v1/poa_pdf_constructor/base.rb
@@ -156,9 +156,10 @@ module ClaimsApi
           @page2_path = temp_path
         end
 
-        # With how the PDF reads, we leave blank if included in the form data, all other scenarios they are checked
+        # positive grants are provided in the form data, but the pdf form reverses this logic in box 20
+        # e.g. if form data includes ['ABC'], then ABC in box 20 will NOT be checked, but everything else will
         def set_limitation_of_consent_check_box(consent_limits, item)
-          return 1 if consent_limits.blank?
+          return 0 if consent_limits.blank?
 
           consent_limits.include?(item) ? 0 : 1
         end

--- a/modules/claims_api/lib/claims_api/v2/poa_pdf_constructor/base.rb
+++ b/modules/claims_api/lib/claims_api/v2/poa_pdf_constructor/base.rb
@@ -144,9 +144,10 @@ module ClaimsApi
           @page2_path = temp_path
         end
 
-        # With how the PDF reads, we leave blank if included in the form data, all other scenarios they are checked
+        # positive grants are provided in the form data, but the pdf form reverses this logic in box 20
+        # e.g. if form data includes ['ABC'], then ABC in box 20 will NOT be checked, but everything else will
         def set_limitation_of_consent_check_box(consent_limits, item)
-          return 1 if consent_limits.blank?
+          return 0 if consent_limits.blank?
 
           consent_limits.include?(item) ? 0 : 1
         end

--- a/modules/claims_api/spec/lib/claims_api/shared_pdf_constructor_base_examples_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/shared_pdf_constructor_base_examples_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'shared pdf constructor base behavior' do
-  it 'select all the boxes when nothing is added on the form' do
+  it 'select none of the boxes when nothing is added on the form' do
     result = pdf_constructor_instance.send(:set_limitation_of_consent_check_box, nil, 'DRUG_ABUSE')
-    expect(result).to eq(1)
+    expect(result).to eq(0)
   end
 
   it 'does not select the box for an added consent limit' do


### PR DESCRIPTION
## Summary

Fixes consent checkboxes so that when no grants are put into the form data, NONE of the checkboxes in box 20 are filled. This will allow the widest range of disclosures possible rather than the buggy behavior of allowing next to no disclosure.

Behavior when a subset of grants are provided remains unchanged.

## Related issue(s)

[API-45838](https://jira.devops.va.gov/browse/API-45838)

## Testing done

- [x] *New code is covered by unit tests*
- [x] Manually reviewed generated forms before & after, verifying the fix.

## What areas of the site does it impact?

Power of Attorney form 21-22 (not 21-22a) pdf generation

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
