### PR TITLE
dbex/106340: [Toxic Exposure] Users are failing SavedClaim creation when exposure dates are incomplete, i.e. "XXXX-01-XX"

### DIFF
--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -58,6 +58,11 @@ module V0
       temp_separation_location_fix if Flipper.enabled?(:disability_compensation_temp_separation_location_code_string,
                                                        @current_user)
 
+      temp_toxic_exposure_optional_dates_fix if Flipper.enabled?(
+        :disability_compensation_temp_toxic_exposure_optional_dates_fix,
+        @current_user
+      )
+
       saved_claim = SavedClaim::DisabilityCompensation::Form526AllClaim.from_hash(form_content)
       saved_claim.save ? log_success(saved_claim) : log_failure(saved_claim)
       submission = create_submission(saved_claim)
@@ -187,6 +192,55 @@ module V0
             separation_location_code.to_s
         end
       end
+    end
+
+    # [Toxic Exposure] Users are failing SavedClaim creation when exposure dates are incomplete, i.e. "XXXX-01-XX"
+    # #106340 - https://github.com/department-of-veterans-affairs/va.gov-team/issues/106340
+    # malformed dates are coming through because the forms date component does not validate data if the user
+    # backs out of any Toxic Exposure section
+    # This temporary fix:
+    # 1. removes the malformed dates from the Toxic Exposure section
+    # 2. logs which section had the bad date to track which sections users are backing out of
+    def temp_toxic_exposure_optional_dates_fix
+      return unless form_content.is_a?(Hash) && form_content['form526'].is_a?(Hash)
+
+      toxic_exposure = form_content.dig('form526', 'toxicExposure')
+      return unless toxic_exposure
+
+      transformer = EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform.new
+      prefix = 'V0::DisabilityCompensationFormsController#submit_all_claim temp_toxic_exposure_optional_dates_fix:'
+
+      Form526Submission::TOXIC_EXPOSURE_DETAILS_MAPPING.each_key do |key|
+        next unless toxic_exposure[key].is_a?(Hash)
+
+        # Fix malformed dates for each sub-location
+        toxic_exposure[key].each do |location, values|
+          next unless values.is_a?(Hash)
+
+          fix_date_error(values, 'startDate', { prefix:, section: key, location: }, transformer)
+          fix_date_error(values, 'endDate',   { prefix:, section: key, location: }, transformer)
+        end
+
+        # Also fix malformed top-level dates if needed
+        next unless %w[otherHerbicideLocations specifyOtherExposures].include?(key)
+
+        fix_date_error(toxic_exposure[key], 'startDate', { prefix:, section: key }, transformer)
+        fix_date_error(toxic_exposure[key], 'endDate',   { prefix:, section: key }, transformer)
+      end
+    end
+
+    def fix_date_error(hash, date_key, context, transformer)
+      return if hash[date_key].blank?
+
+      date = transformer.send(:convert_date_no_day, hash[date_key])
+      return if date.present?
+
+      hash.delete(date_key)
+      # If `context[:location]` is nil, this squeezes out the extra space
+      Rails.logger.info(
+        "#{context[:prefix]} #{context[:section]} #{context[:location]} #{date_key} was malformed"
+          .squeeze(' ')
+      )
     end
     # END TEMPORARY
   end

--- a/app/models/form526_submission.rb
+++ b/app/models/form526_submission.rb
@@ -79,6 +79,17 @@ class Form526Submission < ApplicationRecord
   MAX_PENDING_TIME = 3.weeks
   ZSF_DD_TAG_SERVICE = 'disability-application'
 
+  # the keys of the Toxic Exposure details for each section
+  TOXIC_EXPOSURE_DETAILS_MAPPING = {
+    'gulfWar1990Details' => %w[afghanistan bahrain egypt iraq israel jordan kuwait neutralzone oman qatar saudiarabia
+                               somalia syria uae turkey waters airspace],
+    'gulfWar2001Details' => %w[djibouti lebanon uzbekistan yemen airspace],
+    'herbicideDetails' => %w[cambodia guam koreandemilitarizedzone johnston laos c123 thailand vietnam],
+    'otherExposuresDetails' => %w[asbestos chemical mos mustardgas radiation water],
+    'otherHerbicideLocations' => [],
+    'specifyOtherExposures' => []
+  }.freeze
+
   # used to track in APMs between systems such as Lighthouse
   # example: can be used as a search parameter in Datadog
   # TODO: follow-up in ticket #93563 to make this more robust, i.e. attempts of jobs, etc.

--- a/config/features.yml
+++ b/config/features.yml
@@ -588,6 +588,9 @@ features:
   disability_compensation_temp_separation_location_code_string:
     actor_type: user
     description: enables forcing separation location code to be a string in submit_all_claim endpoint.
+  disability_compensation_temp_toxic_exposure_optional_dates_fix:
+    actor_type: user
+    description: enables removing malformed optional dates from the Toxic Exposure node of a Form526Submission at SavedClaim creation.
   disability_compensation_form4142_supplemental:
     actor_type: user
     description: Use Lighthouse API to submit supplemental Form 21-4142 from Form 526EZ submissions

--- a/spec/requests/v0/disability_compensation_form_spec.rb
+++ b/spec/requests/v0/disability_compensation_form_spec.rb
@@ -146,6 +146,112 @@ RSpec.describe 'V0::DisabilityCompensationForm', type: :request do
           expect(response).to match_response_schema('submit_disability_form')
         end
 
+        describe 'temp_toxic_exposure_optional_dates_fix' do
+          # Helper that handles POST + response check + returning the submission form
+          def post_and_get_submission(payload)
+            post('/v0/disability_compensation_form/submit_all_claim',
+                 params: JSON.generate(payload),
+                 headers:)
+            expect(response).to have_http_status(:ok)
+            Form526Submission.last.form
+          end
+
+          # Helper to build the "optional_xx_dates" mapping
+          def build_optional_xx_dates
+            Form526Submission::TOXIC_EXPOSURE_DETAILS_MAPPING.transform_values do |exposures|
+              if exposures.empty?
+                {
+                  'description' => 'some description or fallback field',
+                  'startDate' => 'XXXX-03-XX',
+                  'endDate' => 'XXXX-01-XX'
+                }
+              else
+                exposures.index_with do
+                  {
+                    'startDate' => 'XXXX-03-XX',
+                    'endDate' => 'XXXX-01-XX'
+                  }
+                end
+              end
+            end
+          end
+
+          context 'when flipper feature disability_compensation_temp_toxic_exposure_optional_dates_fix is enabled' do
+            before do
+              allow(Flipper).to receive(:enabled?)
+                .with(:disability_compensation_temp_toxic_exposure_optional_dates_fix, anything)
+                .and_return(true)
+              # make sure the submission job is triggered even if there are bad dates in the toxic exposure section
+              expect(EVSS::DisabilityCompensationForm::SubmitForm526AllClaim).to receive(:perform_async).once
+            end
+
+            it 'maximal' do
+              parsed_payload = JSON.parse(all_claims_form)
+              # Replace the toxicExposure section with all "XXXX-XX-XX" data
+              parsed_payload['form526']['toxicExposure'] = build_optional_xx_dates
+
+              submission = post_and_get_submission(parsed_payload)
+              toxic_exposure = submission.dig('form526', 'form526', 'toxicExposure')
+
+              toxic_exposure.each do |tek, tev|
+                tev.each_value do |value|
+                  # Expect all optional date attributes to be removed, leaving an empty hash
+                  # except for otherHerbicideLocations / specifyOtherExposures which keep description
+                  expect(value).to eq({}) unless %w[otherHerbicideLocations specifyOtherExposures].include?(tek)
+                end
+
+                if %w[otherHerbicideLocations specifyOtherExposures].include?(tek)
+                  expect(tev).to eq({ 'description' => 'some description or fallback field' })
+                end
+              end
+            end
+
+            it 'minimal' do
+              parsed_payload = JSON.parse(all_claims_form)
+
+              # Only one date is "XXXX-03-XX", the rest are valid
+              parsed_payload['form526']['toxicExposure']['gulfWar1990Details']['iraq'] = {
+                'startDate' => 'XXXX-03-XX',
+                'endDate' => '1991-01-01'
+              }
+
+              submission = post_and_get_submission(parsed_payload)
+              toxic_exposure = submission.dig('form526', 'form526', 'toxicExposure')
+              gulf_war_details_iraq = toxic_exposure['gulfWar1990Details']['iraq']
+
+              # It should have only removed the malformed startDate
+              expect(gulf_war_details_iraq).to eq({ 'endDate' => '1991-01-01' })
+
+              # The rest remain untouched
+              gulf_war_details_qatar = toxic_exposure['gulfWar1990Details']['qatar']
+              expect(gulf_war_details_qatar).to eq({
+                                                     'startDate' => '1991-02-12',
+                                                     'endDate' => '1991-06-01'
+                                                   })
+            end
+          end
+
+          context 'when flipper feature disability_compensation_temp_toxic_exposure_optional_dates_fix is disabled' do
+            before do
+              allow(Flipper).to receive(:enabled?)
+                                  .with(:disability_compensation_temp_toxic_exposure_optional_dates_fix, anything)
+                                  .and_return(false)
+            end
+
+            it 'fails validation' do
+              parsed_payload = JSON.parse(all_claims_form)
+              # Replace the toxicExposure section with all "XXXX-XX-XX" data
+              parsed_payload['form526']['toxicExposure'] = build_optional_xx_dates
+
+              post('/v0/disability_compensation_form/submit_all_claim',
+                   params: JSON.generate(parsed_payload),
+                   headers:)
+
+              expect(response).to have_http_status(:unprocessable_entity)
+            end
+          end
+        end
+
         context 'where the startedFormVersion indicator is true' do
           it 'creates a submission that includes a toxic exposure component' do
             post('/v0/disability_compensation_form/submit_all_claim', params: all_claims_form, headers:)

--- a/spec/requests/v0/disability_compensation_form_spec.rb
+++ b/spec/requests/v0/disability_compensation_form_spec.rb
@@ -234,8 +234,8 @@ RSpec.describe 'V0::DisabilityCompensationForm', type: :request do
           context 'when flipper feature disability_compensation_temp_toxic_exposure_optional_dates_fix is disabled' do
             before do
               allow(Flipper).to receive(:enabled?)
-                                  .with(:disability_compensation_temp_toxic_exposure_optional_dates_fix, anything)
-                                  .and_return(false)
+                .with(:disability_compensation_temp_toxic_exposure_optional_dates_fix, anything)
+                .and_return(false)
             end
 
             it 'fails validation' do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- add flipper flag `disability_compensation_temp_toxic_exposure_optional_dates_fix`
- add functionality to remove botched dates from SavedClaim creation in optional Toxic Exposure section

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/106340

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*: users would back out of Toxic Exposure sections with bad dates, thus failing the final transmission submission on SavedClaim creation - not passing validation
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
0. don't turn on the flipper flag yet
1. start a new form 526 submission
2. have at least 1 new disability
3. reach the Toxic Exposure section
4. proceed to the section of filling out dates for a toxic exposure disability
5. choose a month and don't fill out a date or a year. this should populate "XXXX-01-XX" in the form data
6. hit "Back"
7. uncheck filling out a toxic exposure date for the disability, then move forward
8. reach the review and submit page
9. submit the form
10. at this point, the form should fail with a validation error
11. turn on the `disability_compensation_temp_toxic_exposure_optional_dates_fix` flipper flag at https://staging-api.va.gov/flipper/features/disability_compensation_temp_toxic_exposure_optional_dates_fix 
12. submit the form
13. this should come back "green" now!
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - tests are for both flipper enabled and disabled
  - *What is the testing plan for rolling out the feature?* Turn on flipper flag and complete the steps outlined above

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Form526Submission: at the end of the Form526 form flow, the user hits "Submit", and va.gov reaches out to the `submit_all_claim` endpoint.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
