### PR TITLE
SRE-101229-update-statsD

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -156,7 +156,7 @@ gem 'sign_in_service'
 gem 'slack-notify'
 gem 'socksify'
 gem 'staccato'
-gem 'statsd-instrument', '3.9.8' # 3.9.9 breaking change - Address Family IPv6
+gem 'statsd-instrument'
 gem 'strong_migrations'
 gem 'swagger-blocks'
 # Include the IANA Time Zone Database on Windows, where Windows doesn't ship with a timezone database.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1363,7 +1363,7 @@ DEPENDENCIES
   slack-notify
   socksify
   staccato
-  statsd-instrument (= 3.9.8)
+  statsd-instrument
   strong_migrations
   super_diff
   swagger-blocks

--- a/rakelib/connectivity.rake
+++ b/rakelib/connectivity.rake
@@ -127,8 +127,8 @@ namespace :connectivity do
 
   desc 'Check StatsD'
   task statsd: :environment do
-    if Settings.statsd.host.present? && Settings.statsd.port.present?
-      puts "StatsD configured for #{Settings.statsd.host}:#{Settings.statsd.port}."
+    if Settings.statsd.host.present?
+      puts "StatsD configured for #{Settings.statsd.host}."
     else
       puts 'StatsD not configured!'
     end


### PR DESCRIPTION
## Summary

- Removes version on StatsD gem. 
- [PRs from vsp-infra-application-manifests](https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pulls/stiehlrod)
- [Updates AWS param store](https://console.amazonaws-us-gov.com/systems-manager/parameters/%252Fdsva-vagov%252Fvets-api%252Fprod%252Fstatsd%252Fhost/description?region=us-gov-west-1&tab=Table#list_parameter_filters=Name:Contains:statsd)
- Alerted in #sign-in-experience channel: https://dsva.slack.com/archives/C078GBPDMGB/p1743616088961279

## Related issue(s)

- [issue: 101229](https://github.com/department-of-veterans-affairs/va.gov-team/issues/101229)

## What areas of the site does it impact?
	modified:   Gemfile
	modified:   Gemfile.lock
	modified:   rakelib/connectivity.rake

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
