### PR TITLE
Update hashing method for ves request class - IVC CHAMPVA forms

### DIFF
--- a/modules/ivc_champva/app/models/ivc_champva/ves_request.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/ves_request.rb
@@ -9,11 +9,17 @@ def instance_vars_to_hash(instance)
   # Create hash where keys are the instance variables with '@' removed and
   # converted from snake_case to camelCase
   # e.g.: '@phone_number' -> :phoneNumber
-  hash = instance.instance_variables.to_h do |name|
-    [name.to_s.tr('@', '').camelize(:lower).to_sym, instance.instance_variable_get(name)]
+  instance_vars_hash = instance.instance_variables.each_with_object({}) do |var, hash|
+    key = var.to_s.delete_prefix('@').camelize(:lower).to_sym
+    value = instance.instance_variable_get(var)
+    hash[key] = value
   end
-  hash[:address] = instance.address.to_hash if instance.address
-  hash.compact
+
+  if instance.respond_to?(:address) && instance.address.respond_to?(:to_hash)
+    instance_vars_hash[:address] = instance.address.to_hash
+  end
+
+  instance_vars_hash.compact
 end
 
 module IvcChampva

--- a/modules/ivc_champva/spec/services/ves_data_formatter_spec.rb
+++ b/modules/ivc_champva/spec/services/ves_data_formatter_spec.rb
@@ -136,7 +136,7 @@ describe IvcChampva::VesDataFormatter do
       validated_data = IvcChampva::VesDataFormatter.format_for_request(parsed_form_data)
 
       # Check that all the original keys/values present in @request_body
-      # are still present in the formatted object. 
+      # are still present in the formatted object.
       h1 = JSON.parse(@request_body.to_json).sort.to_h
       h2 = JSON.parse(validated_data.to_json).sort.to_h
       # Get the intersection and verify h2 contained all original keys

--- a/modules/ivc_champva/spec/services/ves_data_formatter_spec.rb
+++ b/modules/ivc_champva/spec/services/ves_data_formatter_spec.rb
@@ -132,10 +132,16 @@ describe IvcChampva::VesDataFormatter do
   end
 
   describe 'data is valid' do
-    it 'returns unmodified data' do
+    it 'maintains all the original keys/values after validating' do
       validated_data = IvcChampva::VesDataFormatter.format_for_request(parsed_form_data)
 
-      expect(validated_data.to_json).to eq(@request_body.to_json)
+      # Check that all the original keys/values present in @request_body
+      # are still present in the formatted object. 
+      h1 = JSON.parse(@request_body.to_json).sort.to_h
+      h2 = JSON.parse(validated_data.to_json).sort.to_h
+      # Get the intersection and verify h2 contained all original keys
+      h3 = h1.slice(*h2.keys)
+      expect(h3.to_json).to eq(h1.to_json)
     end
   end
 


### PR DESCRIPTION
## Summary

This PR changes the custom `to_hash` functions used inside the IVC CHAMPVA VES request class so that rather than requiring manual mapping of properties, we automatically create hashes that include all instance variables (which was the original intent).

- Adds new helper function to gather instance variables and convert to a hash (with keyname modifications)
- Sets all custom `to_hash` methods to use the new helper
- Updates relevant unit test

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103456

## Testing done

- [X] *New code is covered by unit tests*
- Prior to this change the hashes were created via a manual mapping, which was error prone. Now, we ensure that the hash accurately represents all instance variables in the sponsor, certifier, and beneficiary classes.

## Screenshots

NA

## What areas of the site does it impact?

The IVC CHAMPVA VES data formatter class

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA