### PR TITLE
Redis POAM Updates

### DIFF
--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -51,9 +51,9 @@ redis:
   host: localhost
   port: 6379
   app_data:
-    url: redis://localhost:6379
+    url: rediss://localhost:6379
   sidekiq:
-    url: redis://localhost:6379
+    url: rediss://localhost:6379
 
 betamocks:
   cache_dir: ../vets-api-mockdata

--- a/bin/lib/vets-api/setups/hybrid.rb
+++ b/bin/lib/vets-api/setups/hybrid.rb
@@ -31,10 +31,10 @@ module VetsApi
             'host' => 'localhost',
             'port' => '63790',
             'app_data' => {
-              'url' => 'redis://localhost:63790'
+              'url' => 'rediss://localhost:63790'
             },
             'sidekiq' => {
-              'url' => 'redis://localhost:63790'
+              'url' => 'rediss://localhost:63790'
             }
           }
         }

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: redis://localhost:6379/1
+  url: rediss://localhost:6379/1
   channel_prefix: vets_api_production

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1106,13 +1106,13 @@ rack_timeout:
   wait_timeout: ~
 redis:
   app_data:
-    url: redis://localhost:6379
+    url: rediss://localhost:6379
   host: localhost
   port: 6379
   rails_cache:
-    url: redis://localhost:6379
+    url: rediss://localhost:6379
   sidekiq:
-    url: redis://localhost:6379
+    url: rediss://localhost:6379
 relative_url_root: "/"
 reports:
   aws:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1100,13 +1100,13 @@ rack_timeout:
   wait_timeout: ~
 redis:
   app_data:
-    url: redis://localhost:6379
+    url: rediss://localhost:6379
   host: localhost
   port: 6379
   rails_cache:
-    url: redis://localhost:6379
+    url: rediss://localhost:6379
   sidekiq:
-    url: redis://localhost:6379
+    url: rediss://localhost:6379
 relative_url_root: "/"
 reports:
   aws:

--- a/docker-compose.review.yml
+++ b/docker-compose.review.yml
@@ -11,9 +11,9 @@ x-app: &common
     BUNDLE_ENTERPRISE__CONTRIBSYS__COM: "${BUNDLE_ENTERPRISE__CONTRIBSYS__COM}"
     SETTINGS__DATABASE_URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_development}?pool=4"
     SETTINGS__TEST_DATABASE_URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_test}"
-    SETTINGS__REDIS__APP_DATA__URL: "redis://redis:6379"
-    SETTINGS__REDIS__SIDEKIQ__URL: "redis://redis:6379"
-    SETTINGS__REDIS__RAILS_CACHE__URL: "redis://redis:6379"
+    SETTINGS__REDIS__APP_DATA__URL: "rediss://redis:6379"
+    SETTINGS__REDIS__SIDEKIQ__URL: "rediss://redis:6379"
+    SETTINGS__REDIS__RAILS_CACHE__URL: "rediss://redis:6379"
     SETTINGS__SAML_SSOE__IDP_METADATA_FILE: "config/ssoe_idp_sqa_metadata_isam.xml"
     SETTINGS__BETAMOCKS__CACHE_DIR: "config/vets-api-mockdata"
   image: vets-api:${DOCKER_IMAGE:-latest}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -22,8 +22,8 @@ services:
     environment:
       SETTINGS__DATABASE_URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_development}?pool=4"
       SETTINGS__TEST_DATABASE_URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_test}"
-      SETTINGS__REDIS__APP_DATA__URL: "redis://redis:6379"
-      SETTINGS__REDIS__SIDEKIQ__URL: "redis://redis:6379"
+      SETTINGS__REDIS__APP_DATA__URL: "rediss://redis:6379"
+      SETTINGS__REDIS__SIDEKIQ__URL: "rediss://redis:6379"
       POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       POSTGRES_USER: "${POSTGRES_USER:-postgres}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,9 @@ x-app: &common
     BUNDLE_ENTERPRISE__CONTRIBSYS__COM: "${BUNDLE_ENTERPRISE__CONTRIBSYS__COM}"
     SETTINGS__DATABASE_URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_development}?pool=4"
     SETTINGS__TEST_DATABASE_URL: "postgis://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DATABASE:-vets_api_test}"
-    SETTINGS__REDIS__APP_DATA__URL: "redis://redis:6379"
-    SETTINGS__REDIS__SIDEKIQ__URL: "redis://redis:6379"
-    SETTINGS__REDIS__RAILS_CACHE__URL: "redis://redis:6379"
+    SETTINGS__REDIS__APP_DATA__URL: "rediss://redis:6379"
+    SETTINGS__REDIS__SIDEKIQ__URL: "rediss://redis:6379"
+    SETTINGS__REDIS__RAILS_CACHE__URL: "rediss://redis:6379"
   image: vets-api:${DOCKER_IMAGE:-latest}
   volumes:
     - "../vets-api-mockdata:/cache"

--- a/docs/setup/hybrid.md
+++ b/docs/setup/hybrid.md
@@ -20,9 +20,9 @@ redis:
   host: localhost
   port: 63790
   app_data:
-    url: redis://localhost:63790
+    url: rediss://localhost:63790
   sidekiq:
-    url: redis://localhost:63790
+    url: rediss://localhost:63790
 ```
 
 *Note: If you have local instances of Postgres or Redis that were only for use by vets-api, you can stop them to save system resources.*


### PR DESCRIPTION
## Summary

**DO NOT DEPLOY UNTIL 4/9/2025**

Updates all instances of `redis://` to use the secure protocol `rediss://` 

The following ParameterStore references will be updated in coordination with the DevOps deploy 4/9 (dev)  as well:
For dev: [app_cache](https://console.amazonaws-us-gov.com/systems-manager/parameters/%252Fdsva-vagov%252Fvets-api%252Fdev%252Fredis%252Fapp_cache%252Fpassword/description?region=us-gov-west-1&tab=Table#list_parameter_filters=Name:Contains:%2Fdsva-vagov%2Fvets-api%2Fdev%2Fredis), [rails_cache](https://console.amazonaws-us-gov.com/systems-manager/parameters/%252Fdsva-vagov%252Fvets-api%252Fdev%252Fredis%252Frails_cache%252Fpassword/description?region=us-gov-west-1&tab=Table#list_parameter_filters=Name:Contains:%2Fdsva-vagov%2Fvets-api%2Fdev%2Fredis), and [sidekiq](https://console.amazonaws-us-gov.com/systems-manager/parameters/%252Fdsva-vagov%252Fvets-api%252Fdev%252Fredis%252Fsidekiq%252Fpassword/description?region=us-gov-west-1&tab=Table#list_parameter_filters=Name:Contains:%2Fdsva-vagov%2Fvets-api%2Fdev%2Fredis)
For staging: [app_cache](https://console.amazonaws-us-gov.com/systems-manager/parameters/%252Fdsva-vagov%252Fvets-api%252Fstaging%252Fredis%252Fapp_cache%252Fpassword/description?region=us-gov-west-1&tab=Table#list_parameter_filters=Name:Contains:%2Fdsva-vagov%2Fvets-api%2Fstaging%2Fredis), [rails_cache](https://console.amazonaws-us-gov.com/systems-manager/parameters/%252Fdsva-vagov%252Fvets-api%252Fstaging%252Fredis%252Frails_cache%252Fpassword/description?region=us-gov-west-1&tab=Table#list_parameter_filters=Name:Contains:%2Fdsva-vagov%2Fvets-api%2Fstaging%2Fredis), and [sidekiq](https://console.amazonaws-us-gov.com/systems-manager/parameters/%252Fdsva-vagov%252Fvets-api%252Fstaging%252Fredis%252Fsidekiq%252Fpassword/description?region=us-gov-west-1&tab=Table#list_parameter_filters=Name:Contains:%2Fdsva-vagov%2Fvets-api%2Fstaging%2Fredis)

Planning on deploying this along with the [following DevOps ticket](https://github.com/department-of-veterans-affairs/terraform-aws-vsp-vets-api/pull/42).

## Related issue(s)

- [Redis POAM Staging ticket](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/2259). 
- [Redis POAM Dev ticket](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/2258)

