### PR TITLE
Bump statsd-instrument to 3.9.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1085,7 +1085,7 @@ GEM
       ffi
     ssrf_filter (1.2.0)
     staccato (0.5.3)
-    statsd-instrument (3.9.8)
+    statsd-instrument (3.9.9)
     stringio (3.1.2)
     strong_migrations (2.2.1)
       activerecord (>= 7)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1338,9 +1338,6 @@ ssoe_eauth_cookie:
   domain: <%= ENV['ssoe_eauth_cookie__domain'] %>
   name: <%= ENV['ssoe_eauth_cookie__name'] %>
   secure: <%= ENV['ssoe_eauth_cookie__secure'] %>
-statsd:
-  host: <%= ENV['statsd__host'] %>
-  port: 8125
 terms_of_use:
   current_version: v1
   enabled_clients: <%= ENV['terms_of_use__enabled_clients'] %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1359,9 +1359,6 @@ ssoe_eauth_cookie:
   domain: localhost
   name: vagov_saml_request_localhost
   secure: false
-statsd:
-  host: ~
-  port: ~
 terms_of_use:
   current_version: v1
   enabled_clients: vaweb, mhv, myvahealth

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1353,9 +1353,6 @@ ssoe_eauth_cookie:
   domain: localhost
   name: vagov_saml_request_localhost
   secure: false
-statsd:
-  host: ~
-  port: ~
 terms_of_use:
   current_version: v1
   enabled_clients: vaweb, mhv, myvahealth

--- a/rakelib/connectivity.rake
+++ b/rakelib/connectivity.rake
@@ -127,8 +127,8 @@ namespace :connectivity do
 
   desc 'Check StatsD'
   task statsd: :environment do
-    if Settings.statsd.host.present?
-      puts "StatsD configured for #{Settings.statsd.host}."
+    if ENV['STATSD_ADDR'].present?
+      puts "StatsD configured for #{ENV['STATSD_ADDR']}."
     else
       puts 'StatsD not configured!'
     end


### PR DESCRIPTION
DO NOT MERGE UNTIL PARAMETERS ARE ADDED:
`/dsva-vagov/vets-api/<env>/env_vars/STATSD_ADDR`

## Summary

- bump statsd-instrument to 3.9.9
- Remove Settings.statsd (using `ENV['STATSD_ADDR']` instead)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101229

## Testing done

- [ ] Testing on dev & staging

## Acceptance criteria

- [ ] Upon updating the statsd-instrument gem, metrics still flow into Datadog successfully