### PR TITLE
[10-10CG] Update caregiver facilities endpoint to use v2 module

### DIFF
--- a/app/controllers/v0/caregivers_assistance_claims_controller.rb
+++ b/app/controllers/v0/caregivers_assistance_claims_controller.rb
@@ -70,7 +70,12 @@ module V0
     private
 
     def lighthouse_facilities_service
-      @lighthouse_facilities_service ||= Lighthouse::Facilities::V1::Client.new
+      @lighthouse_facilities_service ||=
+        if Flipper.enabled?(:caregiver_use_facilities_API_V2)
+          FacilitiesApi::V2::Lighthouse::Client.new
+        else
+          Lighthouse::Facilities::V1::Client.new
+        end
     end
 
     def lighthouse_facilities_params

--- a/config/features.yml
+++ b/config/features.yml
@@ -92,6 +92,9 @@ features:
   caregiver_use_facilities_API:
     actor_type: cookie_id
     description: Allow list of caregiver facilites to be fetched by way of the Facilities API.
+  caregiver_use_facilities_API_V2:
+    actor_type: cookie_id
+    description: Allow list of caregiver facilites to be fetched with the V2 facilities client.
   caregiver_browser_monitoring_enabled:
     actor_type: user
     description: Enables Datadog Real Time User Monitoring

--- a/modules/facilities_api/app/services/facilities_api/v2/lighthouse/client.rb
+++ b/modules/facilities_api/app/services/facilities_api/v2/lighthouse/client.rb
@@ -55,6 +55,20 @@ module FacilitiesApi
           response = perform(:get, '/services/va_facilities/v1/facilities', filtered_params)
           V2::Lighthouse::Response.new(response.body, response.status).facilities
         end
+
+        ##
+        # Request a list of all facilities or only facilities matching the params provided
+        # @param params [Hash] a hash of parameter objects
+        #   see https://developer.va.gov/explore/api/va-facilities/docs for more options
+        # @example  client.get_paginated_facilities(bbox: [60.99, 10.54, 180.00, 20.55])
+        # @example  client.get_paginated_facilities(facilityIds: 'vha_358,vba_358')
+        # @example  client.get_paginated_facilities(lat: 10.54, long: 180.00, per_page: 50, page: 2)
+        # @return [V2::Lighthouse::Response]
+        #
+        def get_paginated_facilities(params)
+          response = perform(:get, '/services/va_facilities/v1/facilities', params)
+          V2::Lighthouse::Response.new(response.body, response.status)
+        end
       end
     end
   end

--- a/modules/facilities_api/spec/services/facilities_api/v2/lighthouse/client_spec.rb
+++ b/modules/facilities_api/spec/services/facilities_api/v2/lighthouse/client_spec.rb
@@ -224,4 +224,22 @@ RSpec.describe FacilitiesApi::V2::Lighthouse::Client, team: :facilities, vcr: vc
       expect(r[0]).to be_a(FacilitiesApi::V2::Lighthouse::Facility)
     end
   end
+
+  describe '#get_paginated_facilities' do
+    it 'returns full facilities response object for request' do
+      meta = {
+        'pagination' => {
+          'currentPage' => 1,
+          'perPage' => 10,
+          'totalPages' => 1,
+          'totalEntries' => 9
+        }
+      }
+
+      r = facilities_client.get_paginated_facilities(params)
+      expect(r).to be_a(FacilitiesApi::V2::Lighthouse::Response)
+      expect(r.facilities).to be_an(Array)
+      expect(r.meta).to eq meta
+    end
+  end
 end

--- a/spec/requests/swagger_spec.rb
+++ b/spec/requests/swagger_spec.rb
@@ -407,17 +407,39 @@ RSpec.describe 'the v0 API documentation', order: :defined, type: %i[apivore req
             ]
           }
         end
-        let(:lighthouse_service) { double('Lighthouse::Facilities::V1::Client') }
 
-        it 'successfully returns list of facilities' do
-          expect(Lighthouse::Facilities::V1::Client).to receive(:new).and_return(lighthouse_service)
-          expect(lighthouse_service).to receive(:get_paginated_facilities).and_return(mock_facility_response)
+        context ':caregiver_use_facilities_API_V2 disabled' do
+          before { allow(Flipper).to receive(:enabled?).with(:caregiver_use_facilities_API_V2).and_return(false) }
 
-          expect(subject).to validate(
-            :post,
-            '/v0/caregivers_assistance_claims/facilities',
-            200
-          )
+          let(:lighthouse_service) { double('Lighthouse::Facilities::V1::Client') }
+
+          it 'successfully returns list of facilities' do
+            expect(Lighthouse::Facilities::V1::Client).to receive(:new).and_return(lighthouse_service)
+            expect(lighthouse_service).to receive(:get_paginated_facilities).and_return(mock_facility_response)
+
+            expect(subject).to validate(
+              :post,
+              '/v0/caregivers_assistance_claims/facilities',
+              200
+            )
+          end
+        end
+
+        context ':caregiver_use_facilities_API_V2 enabled' do
+          before { allow(Flipper).to receive(:enabled?).with(:caregiver_use_facilities_API_V2).and_return(true) }
+
+          let(:lighthouse_service) { double('FacilitiesApi::V2::Lighthouse::Client') }
+
+          it 'successfully returns list of facilities' do
+            expect(FacilitiesApi::V2::Lighthouse::Client).to receive(:new).and_return(lighthouse_service)
+            expect(lighthouse_service).to receive(:get_paginated_facilities).and_return(mock_facility_response)
+
+            expect(subject).to validate(
+              :post,
+              '/v0/caregivers_assistance_claims/facilities',
+              200
+            )
+          end
         end
       end
     end

--- a/spec/requests/v0/caregivers_assistance_claims_spec.rb
+++ b/spec/requests/v0/caregivers_assistance_claims_spec.rb
@@ -413,27 +413,57 @@ RSpec.describe 'V0::CaregiversAssistanceClaims', type: :request do
         ]
       }
     end
-    let(:lighthouse_service) { double('Lighthouse::Facilities::V1::Client') }
 
-    before do
-      allow(Lighthouse::Facilities::V1::Client).to receive(:new).and_return(lighthouse_service)
-      allow(lighthouse_service).to receive(:get_paginated_facilities).and_return(mock_facility_response)
+    context ':caregiver_use_facilities_API_V2 enabled' do
+      let(:lighthouse_service) { double('FacilitiesApi::V2::Lighthouse::Client') }
+
+      before do
+        allow(Flipper).to receive(:enabled?).with(:caregiver_use_facilities_API_V2).and_return(true)
+        allow(FacilitiesApi::V2::Lighthouse::Client).to receive(:new).and_return(lighthouse_service)
+        allow(lighthouse_service).to receive(:get_paginated_facilities).and_return(mock_facility_response)
+      end
+
+      it 'returns the response as JSON' do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq(mock_facility_response.to_json)
+      end
+
+      it 'calls the Lighthouse facilities service with the permitted params' do
+        subject
+
+        expected_params = unmodified_params.merge(facilityIds: 'vha_123,vha_456')
+
+        expect(lighthouse_service).to have_received(:get_paginated_facilities)
+          .with(expected_params)
+      end
     end
 
-    it 'returns the response as JSON' do
-      subject
+    context ':caregiver_use_facilities_API_V2 disabled' do
+      let(:lighthouse_service) { double('Lighthouse::Facilities::V1::Client') }
 
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to eq(mock_facility_response.to_json)
-    end
+      before do
+        allow(Flipper).to receive(:enabled?).with(:caregiver_use_facilities_API_V2).and_return(false)
+        allow(Lighthouse::Facilities::V1::Client).to receive(:new).and_return(lighthouse_service)
+        allow(lighthouse_service).to receive(:get_paginated_facilities).and_return(mock_facility_response)
+      end
 
-    it 'calls the Lighthouse facilities service with the permitted params' do
-      subject
+      it 'returns the response as JSON' do
+        subject
 
-      expected_params = unmodified_params.merge(facilityIds: 'vha_123,vha_456')
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq(mock_facility_response.to_json)
+      end
 
-      expect(lighthouse_service).to have_received(:get_paginated_facilities)
-        .with(expected_params)
+      it 'calls the Lighthouse facilities service with the permitted params' do
+        subject
+
+        expected_params = unmodified_params.merge(facilityIds: 'vha_123,vha_456')
+
+        expect(lighthouse_service).to have_received(:get_paginated_facilities)
+          .with(expected_params)
+      end
     end
   end
 end


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- This work is behind a feature toggle (flipper): YES
- When the facilities endpoint for the 10-10CG was added it used a V1 module to call the Lighthouse Facilities API, and since then we have learned a better one to use is the V2 module. They call the same Lighthouse Facilitiies API so the responses are pretty much the same.
- 1010 Health Apps
- Added behind `caregiver_use_facilities_API_V2` toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101118

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
