### PR TITLE
MHV-69244 Switch Notes FHIR call to 'category' from 'type'

### DIFF
--- a/lib/medical_records/client.rb
+++ b/lib/medical_records/client.rb
@@ -146,7 +146,7 @@ module MedicalRecords
     def list_clinical_notes
       loinc_codes = "#{PHYSICIAN_PROCEDURE_NOTE},#{DISCHARGE_SUMMARY},#{CONSULT_RESULT}"
       bundle = fhir_search(FHIR::DocumentReference,
-                           search: { parameters: { patient: patient_fhir_id, type: loinc_codes,
+                           search: { parameters: { patient: patient_fhir_id,
                                                    'status:not': 'entered-in-error' } })
 
       # Sort the bundle of notes based on the date field appropriate to each note type.

--- a/lib/medical_records/client.rb
+++ b/lib/medical_records/client.rb
@@ -145,8 +145,11 @@ module MedicalRecords
 
     def list_clinical_notes
       bundle = fhir_search(FHIR::DocumentReference,
-                           search: { parameters: { patient: patient_fhir_id,
-                                                   'status:not': 'entered-in-error' } })
+                           search: { parameters: {
+                             patient: patient_fhir_id,
+                             category: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category|clinical-note',
+                             'status:not': 'entered-in-error'
+                           } })
 
       # Sort the bundle of notes based on the date field appropriate to each note type.
       sort_bundle_with_criteria(bundle, :desc) do |resource|

--- a/lib/medical_records/client.rb
+++ b/lib/medical_records/client.rb
@@ -144,7 +144,6 @@ module MedicalRecords
     end
 
     def list_clinical_notes
-      loinc_codes = "#{PHYSICIAN_PROCEDURE_NOTE},#{DISCHARGE_SUMMARY},#{CONSULT_RESULT}"
       bundle = fhir_search(FHIR::DocumentReference,
                            search: { parameters: { patient: patient_fhir_id,
                                                    'status:not': 'entered-in-error' } })

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_clinical_notes.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_clinical_notes.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=2952&status:not=entered-in-error&type=11506-3,18842-5,11488-4"
+      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=2952&status:not=entered-in-error"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/mr_client/get_a_list_of_clinical_notes.yml
+++ b/spec/support/vcr_cassettes/mr_client/get_a_list_of_clinical_notes.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&patient=2952&status:not=entered-in-error"
+      uri: "<MHV_MR_HOST>/fhir/DocumentReference?_count=9999&category=http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category%7Cclinical-note&patient=2952&status:not=entered-in-error"
       body:
         encoding: US-ASCII
         string: ""


### PR DESCRIPTION
## Summary

- The `type` param will no longer be supported for FHIR DocumentReference in MHV. Instead, we should be using the `category` param to get Notes.

## Related issue(s)


### [MHV-69244](https://jira.devops.va.gov/browse/MHV-69244) - Care Summaries & Notes passing unsupported parameter ###

> The CS&N endpoint has been modified to no longer accept the "type" parameter. Pass the "category" parameter instead.
> 
> Slack thread: https://dsva.slack.com/archives/C03Q2UQL1AS/p1743776062702289
> 


## Testing done

- Updated spec tests to account for the modified parameter list.
- Local testing to verify that Notes didn't work before the change, and did work after the change. This was verified at the level of the backend endpoint and at the application level

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
MHV Medical Records

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
