### PR TITLE
[VI-1104] adds AppealSubmission user_account_id backfill raketask

### DIFF
--- a/rakelib/prod/backfill_user_account_for_appeal_submissions.rake
+++ b/rakelib/prod/backfill_user_account_for_appeal_submissions.rake
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+desc 'Backill user account id records for AppealSubmission forms'
+task backfill_user_account_for_appeal_submissions: :environment do
+  def null_user_account_id_count_message
+    '[BackfillUserAccountForAppealSubmissions] AppealSubmission with user_account_id: nil, ' \
+      "count: #{user_account_nil.count}"
+  end
+
+  def user_account_nil
+    AppealSubmission.where(user_account: nil)
+  end
+
+  Rails.logger.info('[BackfillUserAccountForAppealSubmissions] Starting rake task')
+  Rails.logger.info(null_user_account_id_count_message)
+  mpi_service = MPI::Service.new
+  user_account_nil.find_in_batches(batch_size: 1000) do |batch|
+    batch.each do |sub|
+      user_uuid = sub.user_uuid
+      user_account = UserVerification.find_by(idme_uuid: user_uuid)&.user_account ||
+                     UserVerification.find_by(backing_idme_uuid: user_uuid)&.user_account ||
+                     UserVerification.find_by(logingov_uuid: user_uuid)&.user_account
+      unless user_account
+        icn = Account.find_by(idme_uuid: user_uuid)&.icn ||
+              Account.find_by(logingov_uuid: user_uuid)&.icn ||
+              mpi_service.find_profile_by_identifier(identifier: user_uuid, identifier_type: 'idme')&.profile&.icn
+        user_account = UserAccount.find_by(icn:) || UserAccount.new(icn:).save! if icn
+      end
+      sub.user_account = user_account
+      sub.save!
+    end
+  end
+  Rails.logger.info('[BackfillUserAccountForAppealSubmissions] Finished rake task')
+  Rails.logger.info(null_user_account_id_count_message)
+end


### PR DESCRIPTION
## Summary

- creates `rakelib/prod/backfill_user_account_for_appeal_submissions` Raketask; this task queries `AppealSubmission` records that do not have a `UserAccount` relation & uses their user_uuid to look up their ICN from `UserVerification` and `Account` records. Records that have ICNs that lead to a `UserAccount` have that account added to their submission record.

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-1104
- refactor PR https://github.com/department-of-veterans-affairs/vets-api/pull/21427

## Testing done

- Testing can be performed in a Rails console. To begin, monkey-patch the `spec/factories/appeal_submissions.rb` factory to disable the `stub_mpi` functionality:
```ruby
# monkey-patch spec/factories/appeal_submissions
FactoryBot.define do
  factory :appeal_submission do
    user_uuid do
      # user = create(:user, :loa3, ssn: '212222112')
      user = create(:user, :loa3, ssn: '212222112', stub_mpi: false)
      user.uuid
    end
```
- Open a Rails console
```ruby
include FactoryBot::Syntax::Methods
appeal_submission = create(:appeal_submission)
user_uuid = appeal_submission.user_uuid
user_verification = UserVerification.find_by(idme_uuid: user_uuid) || create(:user_verification, idme_uuid: user_uuid)
...
appeal_submission.user_account
  => nil
AppealSubmission.where(user_account_id: nil).first == appeal_submission
  => true
```
- In a separate terminal run the backfill raketask
  - `bundle exec rake backfill_user_account_for_appeal_submissions`
  - The raketask runs with batches of 1000
  - You should not see output in your terminal; check `log/development.log` for Rails logger messages.
- In your Rails console the submission should have its `user_account` updated:
```ruby
appeal_submission.reload
appeal_submission.user_account
	=> #<UserAccount:0x000...>
AppealSubmission.where(user_account_id: nil).count
  => 0
```

## What areas of the site does it impact?
- `AppealSubmission` records

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
