### PR TITLE
Mock flippers in claims_api specs

### DIFF
--- a/modules/claims_api/spec/requests/v1/rswag_claims_spec.rb
+++ b/modules/claims_api/spec/requests/v1/rswag_claims_spec.rb
@@ -184,7 +184,7 @@ Rspec.describe 'EVSS Claims management', openapi_spec: 'modules/claims_api/app/s
       description claim_by_id_description
 
       before do
-        Flipper.disable :claims_load_testing
+        allow(Flipper).to receive(:enabled?).with(:claims_load_testing).and_return false
       end
 
       describe 'Getting a 200 response' do

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_526_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_526_spec.rb
@@ -367,7 +367,7 @@ describe 'DisabilityCompensation', openapi_spec: Rswag::TextHelpers.new.claims_a
           schema SwaggerSharedComponents::V2.schemas[:sync_disability_compensation]
 
           def make_request(example)
-            Flipper.disable :claims_load_testing
+            allow(Flipper).to receive(:enabled?).with(:claims_load_testing).and_return false
 
             with_settings(Settings.claims_api.benefits_documents, use_mocks: true) do
               VCR.use_cassette('claims_api/disability_comp') do

--- a/modules/claims_api/spec/sidekiq/evidence_waiver_builder_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/evidence_waiver_builder_job_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ClaimsApi::EvidenceWaiverBuilderJob, type: :job do
 
   context 'when the claims_api_ews_uploads_bd_refactor BD refactor feature flag is enabled' do
     before do
-      Flipper.enable(:claims_api_ews_uploads_bd_refactor)
+      allow(Flipper).to receive(:enabled?).with(:claims_api_ews_uploads_bd_refactor).and_return true
     end
 
     it 'calls the Benefits Documents upload_document instead of upload' do
@@ -59,7 +59,7 @@ RSpec.describe ClaimsApi::EvidenceWaiverBuilderJob, type: :job do
 
   context 'when the claims_api_ews_uploads_bd_refactor BD refactor feature flag is disabled' do
     before do
-      Flipper.disable(:claims_api_ews_uploads_bd_refactor)
+      allow(Flipper).to receive(:enabled?).with(:claims_api_ews_uploads_bd_refactor).and_return false
     end
 
     it 'calls the Benefits Documents upload_document instead of upload' do

--- a/modules/claims_api/spec/sidekiq/poa_form_builder_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/poa_form_builder_job_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe ClaimsApi::V1::PoaFormBuilderJob, type: :job, vcr: 'bgs/person_we
   let(:bad_b64_image) { File.read('modules/claims_api/spec/fixtures/signature_b64_prefix_bad.txt') }
 
   before do
-    Flipper.disable(:lighthouse_claims_api_poa_use_bd)
+    allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_poa_use_bd).and_return false
+
     Sidekiq::Job.clear_all
     allow_any_instance_of(ClaimsApi::V2::BenefitsDocuments::Service)
       .to receive(:get_auth_token).and_return('some-value-here')
@@ -180,8 +181,8 @@ RSpec.describe ClaimsApi::V1::PoaFormBuilderJob, type: :job, vcr: 'bgs/person_we
     let(:doc_type) { 'L075' }
 
     it 'calls the benefits document API upload instead of VBMS' do
-      Flipper.enable(:lighthouse_claims_api_poa_use_bd)
-      Flipper.disable(:claims_api_poa_uploads_bd_refactor)
+      allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_poa_use_bd).and_return true
+      allow(Flipper).to receive(:enabled?).with(:claims_api_poa_uploads_bd_refactor).and_return false
       expect_any_instance_of(ClaimsApi::VBMSUploader).not_to receive(:upload_document)
       expect_any_instance_of(ClaimsApi::BD).to receive(:upload)
 
@@ -189,8 +190,9 @@ RSpec.describe ClaimsApi::V1::PoaFormBuilderJob, type: :job, vcr: 'bgs/person_we
     end
 
     it 'calls the benefits document API upload_document instead of upload' do
-      Flipper.enable(:lighthouse_claims_api_poa_use_bd)
-      Flipper.enable(:claims_api_poa_uploads_bd_refactor)
+      allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_poa_use_bd).and_return true
+      allow(Flipper).to receive(:enabled?).with(:claims_api_poa_uploads_bd_refactor).and_return true
+
       expect_any_instance_of(ClaimsApi::VBMSUploader).not_to receive(:upload_document)
       expect_any_instance_of(ClaimsApi::BD).not_to receive(:upload)
       expect_any_instance_of(ClaimsApi::BD).to receive(:upload_document)
@@ -199,7 +201,7 @@ RSpec.describe ClaimsApi::V1::PoaFormBuilderJob, type: :job, vcr: 'bgs/person_we
     end
 
     it 'rescues errors from BD and sets the status to errored' do
-      Flipper.enable(:lighthouse_claims_api_poa_use_bd)
+      allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_poa_use_bd).and_return true
 
       VCR.use_cassette('claims_api/bd/upload_error') do
         allow(ClaimsApi::BD.new).to receive(:upload).with(claim: power_of_attorney, pdf_path:, doc_type:)

--- a/modules/claims_api/spec/sidekiq/poa_updater_spec.rb
+++ b/modules/claims_api/spec/sidekiq/poa_updater_spec.rb
@@ -128,7 +128,6 @@ RSpec.describe ClaimsApi::PoaUpdater, type: :job, vcr: 'bgs/person_web_service/f
     context 'when the flipper is off' do
       it 'does not send the vanotify job' do
         allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_v2_poa_va_notify).and_return false
-        Flipper.disable(:lighthouse_claims_api_v2_poa_va_notify)
 
         poa.auth_headers.merge!({
                                   header_key => 'this_value'


### PR DESCRIPTION
⚠️ I'll leave this as a draft until Lighthouse PRs can be merged again. ⚠️ 

## Summary

There have been some flakey specs in claims_api. This is an attempt to fix them... although I'm not convinced it's the cure to all of them. https://github.com/department-of-veterans-affairs/va.gov-team/issues/104789 can address the others. I'm updating the flipper calls based on the guidance [in this example](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#FeatureTogglesGuide-Backendexample).

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/102814

## Testing done
I ran this module ~10 times on this branch (`bin/test modules/claims_api --parallel`) and the error rate improved slightly compared to when I ran it on `master`.

## What areas of the site does it impact?
Tests in `modules/claims_api`

## Acceptance criteria

- [x]  No error nor warning in the console.
