### PR TITLE
keep_routes_comment_and_routes_together

### DIFF
--- a/modules/accredited_representative_portal/config/routes.rb
+++ b/modules/accredited_representative_portal/config/routes.rb
@@ -14,7 +14,6 @@ AccreditedRepresentativePortal::Engine.routes.draw do
     # TODO: Carry out this per-environment guard of these endpoints by using
     # Flipper feature toggling and controller before actions instead.
     #
-
     if Rails.env.development? || Rails.env.test?
       post 'form21a', to: 'form21a#submit'
       resources :in_progress_forms, only: %i[update show destroy]


### PR DESCRIPTION
## Summary

We have a comment in the routes file. We want to keep the relevant routes closest to the comment instead of being split by new routes