### PR TITLE
1501: decrease frequency of 1095b form record deletion

### DIFF
--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -172,7 +172,7 @@ PERIODIC_JOBS = lambda { |mgr| # rubocop:disable Metrics/BlockLength
   mgr.register('0 2 * * *', 'InProgressFormCleaner')
   # mgr.register('0 */4 * * *', 'MHV::AccountStatisticsJob')
   mgr.register('0 3 * * *', 'Form1095::New1095BsJob')
-  mgr.register('*/10 0-5 * * *', 'Form1095::DeleteOld1095BsJob')
+  mgr.register('0 4 * * *', 'Form1095::DeleteOld1095BsJob')
   mgr.register('0 2 * * *', 'Veteran::VSOReloader')
   mgr.register('15 2 * * *', 'Preneeds::DeleteOldUploads')
   mgr.register('* * * * *', 'ExternalServicesStatusJob')


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- Changes the frequency of 1095b form deletion to only happen once per day. This is being done because the old records have already been deleted. We can increase the rate again later if needed. Leaving as once per day for now.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-iir/issues/1501

## Testing done

No testing needed for schedule frequency change.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
How frequently this cron job runs.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
