### PR TITLE
Use VAOS SessionService instead of Token Authenticator for CCRA service

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1628,7 +1628,6 @@ vanotify:
     bearer_token: <%= ENV['vanotify__status_callback__bearer_token'] %>
 vaos:
   ccra:
-    access_token_url: https://test.example.com/token
     api_url: https://api.ccra.placeholder.va.local
     base_path: csp/healthshare/ccraint/rest
     mock: <%= ENV['vaos__ccra__mock'] %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1649,7 +1649,6 @@ vanotify:
     bearer_token: fake_bearer_token
 vaos:
   ccra:
-    access_token_url: https://test.example.com/token
     api_url: https://api.ccra.placeholder.va.local
     base_path: csp/healthshare/ccraint/rest
     mock: false

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1643,7 +1643,6 @@ vanotify:
     bearer_token: fake_bearer_token
 vaos:
   ccra:
-    access_token_url: https://test.example.com/token
     api_url: https://api.ccra.placeholder.va.local
     base_path: csp/healthshare/ccraint/rest
     mock: false

--- a/modules/vaos/app/services/ccra/base_service.rb
+++ b/modules/vaos/app/services/ccra/base_service.rb
@@ -5,11 +5,8 @@ module Ccra
   # to the CCRA service.
   class BaseService < VAOS::SessionService
     include Common::Client::Concerns::Monitoring
-    include TokenAuthentication
 
     STATSD_KEY_PREFIX = 'api.ccra'
-    REDIS_TOKEN_KEY = REDIS_CONFIG[:ccra_access_token][:namespace]
-    REDIS_TOKEN_TTL = REDIS_CONFIG[:ccra_access_token][:each_ttl]
 
     ##
     # Returns the configuration for the CCRA service.

--- a/modules/vaos/spec/requests/vaos/v2/eps_appointments_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/eps_appointments_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe 'VAOS::V2::EpsAppointments', :skip_mvi, type: :request do
 
     # Setup a memory store for caching instead of using Rails.cache
     allow(Rails).to receive(:cache).and_return(memory_store)
-    # Cache the token for CCRA service
-    Rails.cache.write(Ccra::BaseService::REDIS_TOKEN_KEY, access_token)
+    # Cache the token for EPS service
     Rails.cache.write(Eps::BaseService::REDIS_TOKEN_KEY, access_token)
 
     Settings.vaos ||= OpenStruct.new

--- a/modules/vaos/spec/services/ccra/base_service_spec.rb
+++ b/modules/vaos/spec/services/ccra/base_service_spec.rb
@@ -23,4 +23,27 @@ describe Ccra::BaseService do
       expect(subject.settings).to eq(Settings.vaos.ccra)
     end
   end
+  
+  describe 'headers' do
+    let(:request_id) { 'test-request-id' }
+    let(:session_token) { 'test-session-token' }
+    
+    before do
+      RequestStore.store['request_id'] = request_id
+      allow_any_instance_of(VAOS::UserService).to receive(:session).with(user).and_return(session_token)
+    end
+    
+    it 'includes session authentication headers' do
+      headers = subject.send(:headers)
+      
+      # Should include headers from SessionService
+      expect(headers).to include(
+        'X-VAMF-JWT' => session_token,
+        'X-Request-ID' => request_id
+      )
+      
+      # Should not include headers from token authentication
+      expect(headers).not_to include('Authorization')
+    end
+  end
 end

--- a/modules/vaos/spec/services/ccra/base_service_spec.rb
+++ b/modules/vaos/spec/services/ccra/base_service_spec.rb
@@ -23,25 +23,25 @@ describe Ccra::BaseService do
       expect(subject.settings).to eq(Settings.vaos.ccra)
     end
   end
-  
+
   describe 'headers' do
     let(:request_id) { 'test-request-id' }
     let(:session_token) { 'test-session-token' }
-    
+
     before do
       RequestStore.store['request_id'] = request_id
       allow_any_instance_of(VAOS::UserService).to receive(:session).with(user).and_return(session_token)
     end
-    
+
     it 'includes session authentication headers' do
       headers = subject.send(:headers)
-      
+
       # Should include headers from SessionService
       expect(headers).to include(
         'X-VAMF-JWT' => session_token,
         'X-Request-ID' => request_id
       )
-      
+
       # Should not include headers from token authentication
       expect(headers).not_to include('Authorization')
     end

--- a/modules/vaos/spec/services/ccra/base_service_spec.rb
+++ b/modules/vaos/spec/services/ccra/base_service_spec.rb
@@ -17,4 +17,10 @@ describe Ccra::BaseService do
       expect(subject.config).to equal(config)
     end
   end
+
+  describe '#settings' do
+    it 'returns the CCRA settings from VAOS configuration' do
+      expect(subject.settings).to eq(Settings.vaos.ccra)
+    end
+  end
 end

--- a/modules/vaos/spec/services/ccra/referral_service_spec.rb
+++ b/modules/vaos/spec/services/ccra/referral_service_spec.rb
@@ -5,17 +5,15 @@ require 'rails_helper'
 describe Ccra::ReferralService do
   subject { described_class.new(user) }
 
-  let(:user) { double('User', account_uuid: '1234', flipper_id: '1234') }
-  let(:access_token) { 'fake-access-token' }
+  let(:user) { double('User', account_uuid: '1234', flipper_id: '1234', icn: '1012845331V153043') }
+  let(:session_token) { 'fake-session-token' }
+  let(:request_id) { 'request-id' }
 
   before do
-    allow(RequestStore.store).to receive(:[]).with('request_id').and_return('request-id')
+    allow(RequestStore.store).to receive(:[]).with('request_id').and_return(request_id)
 
-    # Allow any cache fetch call to return the access token if it matches our key, otherwise nil
-    # This makes it so we don't need to make a real call to the token endpoint
-    allow(Rails.cache).to receive(:fetch) do |key|
-      access_token if key == Ccra::BaseService::REDIS_TOKEN_KEY
-    end
+    # Mock the session token from UserService
+    allow_any_instance_of(VAOS::UserService).to receive(:session).with(user).and_return(session_token)
 
     Settings.vaos ||= OpenStruct.new
     Settings.vaos.ccra ||= OpenStruct.new

--- a/modules/vaos/spec/services/concerns/token_authentication_spec.rb
+++ b/modules/vaos/spec/services/concerns/token_authentication_spec.rb
@@ -19,7 +19,7 @@ class TestTokenService < VAOS::SessionService
     super(user)
     @user = user
     @config = OpenStruct.new(
-      access_token_url: 'https://test.example.com/token',
+      access_token_url: 'https://login.wellhive.com/oauth2/default/v1/token',
       grant_type: 'client_credentials',
       scopes: 'test.scope',
       client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -62,7 +62,7 @@ VCR.configure do |c|
   c.filter_sensitive_data('<ARP_ALLOW_LIST_REPO>') { Settings.accredited_representative_portal.allow_list.github.repo }
   c.filter_sensitive_data('<ARP_ALLOW_LIST_PATH>') { Settings.accredited_representative_portal.allow_list.github.path }
   c.filter_sensitive_data('<VAOS_CCRA_API_URL>') { Settings.vaos.ccra.api_url }
-  c.filter_sensitive_data('<VAOS_CCRA_TOKEN_URL>') { Settings.vaos.ccra.access_token_url }
+  c.filter_sensitive_data('<VAOS_EPS_TOKEN_URL>') { Settings.vaos.eps.access_token_url }
   c.filter_sensitive_data('<VAOS_EPS_API_URL>') { Settings.vaos.eps.api_url }
   c.before_record do |i|
     %i[response request].each do |env|

--- a/spec/support/vcr_cassettes/vaos/concerns/token/token_200.yml
+++ b/spec/support/vcr_cassettes/vaos/concerns/token/token_200.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<VAOS_CCRA_TOKEN_URL>"
+    uri: "<VAOS_EPS_TOKEN_URL>"
     body:
       encoding: US-ASCII
       string: grant_type=client_credentials&scope=test.scope&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&client_assertion=test-jwt-assertion

--- a/spec/support/vcr_cassettes/vaos/concerns/token/token_400.yml
+++ b/spec/support/vcr_cassettes/vaos/concerns/token/token_400.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<VAOS_CCRA_TOKEN_URL>"
+    uri: "<VAOS_EPS_TOKEN_URL>"
     body:
       encoding: US-ASCII
       string: grant_type=client_credentials&scope=test.scope&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&client_assertion=test-jwt-assertion


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Things have changes and the CCRA service needs to get a session token instead of the token authentication used by EPS.
- Refactored the code to use the SessionService for the CCRA session.
- Team: UAE Check In

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/106407

## Testing done
- [x] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
None. This service is still not being used.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

