### PR TITLE
106951 - Update date format for `date_of_marriage` field - form 10-10d

### DIFF
--- a/modules/ivc_champva/app/services/ivc_champva/ves_data_formatter.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/ves_data_formatter.rb
@@ -206,7 +206,10 @@ module IvcChampva
       end
       validate_address(sponsor[:address], 'sponsor')
       sponsor[:date_of_birth] = validate_date(sponsor[:date_of_birth], 'date of birth')
-      sponsor[:date_of_marriage] = validate_date(sponsor[:date_of_marriage], 'date of marriage')
+      if sponsor[:date_of_marriage].presence
+        sponsor[:date_of_marriage] =
+          validate_date(sponsor[:date_of_marriage], 'date of marriage')
+      end
       validate_uuid(sponsor[:person_uuid], 'person uuid')
       validate_ssn(sponsor[:ssn], 'ssn')
       validate_phone(sponsor, 'sponsor phone') if sponsor[:phone_number]

--- a/modules/ivc_champva/app/services/ivc_champva/ves_data_formatter.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/ves_data_formatter.rb
@@ -206,6 +206,7 @@ module IvcChampva
       end
       validate_address(sponsor[:address], 'sponsor')
       sponsor[:date_of_birth] = validate_date(sponsor[:date_of_birth], 'date of birth')
+      sponsor[:date_of_marriage] = validate_date(sponsor[:date_of_marriage], 'date of marriage')
       validate_uuid(sponsor[:person_uuid], 'person uuid')
       validate_ssn(sponsor[:ssn], 'ssn')
       validate_phone(sponsor, 'sponsor phone') if sponsor[:phone_number]

--- a/modules/ivc_champva/spec/services/ves_data_formatter_spec.rb
+++ b/modules/ivc_champva/spec/services/ves_data_formatter_spec.rb
@@ -272,6 +272,16 @@ describe IvcChampva::VesDataFormatter do
     end
   end
 
+  describe 'sponsor date of marriage' do
+    it 'when formatted as MM-DD-YYYY, it reformats to YYYY-MM-DD' do
+      @parsed_form_data_copy['veteran']['date_of_marriage'] = '01-01-2020'
+
+      res = IvcChampva::VesDataFormatter.format_for_request(@parsed_form_data_copy)
+
+      expect(res.sponsor.date_of_marriage).to eq('2020-01-01')
+    end
+  end
+
   describe 'social security number is malformed' do
     describe 'too long' do
       it 'raises an exception' do


### PR DESCRIPTION
## Summary

This PR updates the VES data formatter to ensure the sponsor `date_of_marriage` field is properly formatted for VES ingestion. Previously, this date field was in the format `MM-DD-YYYY`. After this change it will be in the form `YYYY-MM-DD`, as per VES requirements.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/106951

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots

|before|after
|-|-|
|![Screenshot 2025-04-07 at 15 55 27](https://github.com/user-attachments/assets/982a1c83-938c-40f5-a737-ecc4d6e24c77)|![Screenshot 2025-04-07 at 15 54 38](https://github.com/user-attachments/assets/5213efd8-8849-44c3-8ee3-2ccf9ce24005)|

## What areas of the site does it impact?

IVC CHAMPVA form 10-10d

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA
