### PR TITLE
Update statsd-instrument pinned version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -157,7 +157,7 @@ gem 'sign_in_service'
 gem 'slack-notify'
 gem 'socksify'
 gem 'staccato'
-gem 'statsd-instrument', '3.9.8' # 3.9.9 breaking change - Address Family IPv6
+gem 'statsd-instrument'
 gem 'strong_migrations'
 gem 'swagger-blocks'
 # Include the IANA Time Zone Database on Windows, where Windows doesn't ship with a timezone database.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1365,7 +1365,7 @@ DEPENDENCIES
   slack-notify
   socksify
   staccato
-  statsd-instrument (= 3.9.8)
+  statsd-instrument
   strong_migrations
   super_diff
   swagger-blocks


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary
This PR removes the pinned `statsd-instrument (= 3.9.8)` version from the Gemfile. Although the Gemfile was still pinned to 3.9.8, the lockfile had already been updated to 3.9.9 [from this manual change](https://github.com/department-of-veterans-affairs/vets-api/pull/21568). Removing the outdated pin ensures consistency between the Gemfile and lockfile going forward.

All Dependabot PRs were attempting to downgrade statsd-instrument back to 3.9.8 due to the pinned version in the Gemfile, despite the lockfile being on 3.9.9. This change resolves that conflict.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/101229

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
