### PR TITLE
MHV-69292 SM: check for treatment facilities before invoking session request

### DIFF
--- a/app/policies/mhv_messaging_policy.rb
+++ b/app/policies/mhv_messaging_policy.rb
@@ -4,14 +4,14 @@ require 'sm/client'
 
 MHVMessagingPolicy = Struct.new(:user, :mhv_messaging) do
   def access?
-    return false unless user.mhv_correlation_id
+    return false unless user.mhv_correlation_id && user.va_patient?
 
     client = SM::Client.new(session: { user_id: user.mhv_correlation_id, user_uuid: user.uuid })
     validate_client(client)
   end
 
   def mobile_access?
-    return false unless user.mhv_correlation_id
+    return false unless user.mhv_correlation_id && user.va_patient?
 
     client = Mobile::V0::Messaging::Client.new(session: { user_id: user.mhv_correlation_id })
     validate_client(client)


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- `mhv_messaging_policy.rb` was not checking for associations to VA treatment facilities before invoking SM Patient API `session` request. This resulted in mhv-sm-patient-api returning an error `code:105 - User was not found`
- adding a check for `user.va_patient?` before invoking a session since we know it will result in an error


## Related issue(s)

- [MHV-69292](https://jira.devops.va.gov/browse/MHV-69292)
- https://dsva.slack.com/archives/C044WNQT4P9/p1743103113313749

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
