### PR TITLE
fix(actions): Deployment condition triggering on all branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
           cache-to: type=inline
   deploy:
     needs: build_and_push
-    if: github.ref == 'refs/heads/master' && ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: github.event.workflow_run.head_branch == 'master' && ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: department-of-veterans-affairs/vets-api/.github/workflows/deploy-template.yml@master
     with:
       ecr_repository: "vets-api"


### PR DESCRIPTION
The deployment job was incorrectly using `github.ref` to determine if the workflow should deploy to environments. When using workflow_run triggers, `github.ref` always refers to the branch where the current workflow file is located (master), not the branch that triggered the original workflow.

This led to erroneous deployments of feature branch code (like commit 8451484251689a95942ec3c6a8ee82a883b98655) to all environments, as the condition was always evaluating to true regardless of source branch.

Changed to use `github.event.workflow_run.head_branch` instead, which correctly identifies the source branch that triggered the original workflow, ensuring deployments only happen for commits that were actually made to master.
