### PR TITLE
fix(actions): Ensure build workflow checkouts correct commit SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_commit.id }}
 
       - name: Setup Environment
         run: echo "VETS_API_USER_ID=$(id -u)" >> $GITHUB_ENV


### PR DESCRIPTION
When triggered by a workflow_run event, the build workflow was using the default checkout behavior
which grabs `github.ref` (whatever is latest for the current workflow) rather than the commit that
triggered the original workflow. This fixes the issue by explicitly
checking out the commit ID from the original workflow run.

This ensures the code being built matches the exact commit that was tested in the previous workflow.
