### PR TITLE
Cfelix/106407 ccra session

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1644,6 +1644,10 @@ vaos:
     mock: <%= ENV['vaos__eps__mock'] %>
     redis_token_expiry: 3500
     scopes: care-nav
+  referral:
+    encryption:
+      hex_secret: <%= ENV['vaos__referral__encryption__hex_secret'] %>
+      hex_iv: <%= ENV['vaos__referral__encryption__hex_iv'] %>
 vba_documents:
   custom_metadata_allow_list: <%= ENV['vba_documents__custom_metadata_allow_list'] %>
   documentation:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1628,7 +1628,6 @@ vanotify:
     bearer_token: <%= ENV['vanotify__status_callback__bearer_token'] %>
 vaos:
   ccra:
-    access_token_url: https://test.example.com/token
     api_url: https://api.ccra.placeholder.va.local
     base_path: csp/healthshare/ccraint/rest
     mock: <%= ENV['vaos__ccra__mock'] %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1649,7 +1649,6 @@ vanotify:
     bearer_token: fake_bearer_token
 vaos:
   ccra:
-    access_token_url: https://test.example.com/token
     api_url: https://api.ccra.placeholder.va.local
     base_path: csp/healthshare/ccraint/rest
     mock: false

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1643,7 +1643,6 @@ vanotify:
     bearer_token: fake_bearer_token
 vaos:
   ccra:
-    access_token_url: https://test.example.com/token
     api_url: https://api.ccra.placeholder.va.local
     base_path: csp/healthshare/ccraint/rest
     mock: false

--- a/modules/vaos/app/models/ccra/referral_detail.rb
+++ b/modules/vaos/app/models/ccra/referral_detail.rb
@@ -5,6 +5,7 @@ module Ccra
   class ReferralDetail
     attr_reader :expiration_date, :type_of_care, :provider_name, :location,
                 :referral_number, :phone_number
+    attr_accessor :uuid
 
     ##
     # Initializes a new instance of ReferralDetail.
@@ -21,6 +22,7 @@ module Ccra
       @location = referral['TreatingFacility']
       @referral_number = referral['ReferralNumber']
       @phone_number = referral['ProviderPhone'] || referral['FacilityPhone']
+      @uuid = nil # Will be set by controller
     end
   end
 end

--- a/modules/vaos/app/models/ccra/referral_list_entry.rb
+++ b/modules/vaos/app/models/ccra/referral_list_entry.rb
@@ -3,7 +3,8 @@
 module Ccra
   # ReferralListEntry represents the essential referral data from the CCRA ReferralList endpoint.
   class ReferralListEntry
-    attr_reader :type_of_care, :referral_id, :expiration_date
+    attr_reader :type_of_care, :expiration_date
+    attr_accessor :referral_id, :uuid
 
     ##
     # Initializes a new instance of ReferralListEntry.
@@ -16,6 +17,7 @@ module Ccra
     def initialize(attributes)
       @type_of_care = attributes['CategoryOfCare']
       @referral_id = attributes['ID']
+      @uuid = nil # Will be set by controller
 
       start_date = parse_date(attributes['StartDate'])
       days = attributes['SEOCNumberOfDays'].to_i if attributes['SEOCNumberOfDays'].present?

--- a/modules/vaos/app/serializers/ccra/referral_detail_serializer.rb
+++ b/modules/vaos/app/serializers/ccra/referral_detail_serializer.rb
@@ -7,11 +7,14 @@ module Ccra
     include JSONAPI::Serializer
 
     set_id :referral_number
-    set_type :referral
+    set_type :referrals
 
     attribute :type_of_care
     attribute :provider_name
     attribute :location
     attribute :expiration_date
+
+    # Include the encrypted referral ID for use in URLs
+    attribute :uuid
   end
 end

--- a/modules/vaos/app/serializers/ccra/referral_list_serializer.rb
+++ b/modules/vaos/app/serializers/ccra/referral_list_serializer.rb
@@ -11,6 +11,9 @@ module Ccra
 
     attribute :type_of_care
 
+    # Include the encrypted referral number for use in URLs to prevent PII in logs
+    attribute :uuid
+
     attribute :expiration_date do |referral|
       referral.expiration_date&.strftime('%Y-%m-%d')
     end

--- a/modules/vaos/app/services/ccra/base_service.rb
+++ b/modules/vaos/app/services/ccra/base_service.rb
@@ -5,11 +5,8 @@ module Ccra
   # to the CCRA service.
   class BaseService < VAOS::SessionService
     include Common::Client::Concerns::Monitoring
-    include TokenAuthentication
 
     STATSD_KEY_PREFIX = 'api.ccra'
-    REDIS_TOKEN_KEY = REDIS_CONFIG[:ccra_access_token][:namespace]
-    REDIS_TOKEN_TTL = REDIS_CONFIG[:ccra_access_token][:each_ttl]
 
     ##
     # Returns the configuration for the CCRA service.

--- a/modules/vaos/app/services/vaos/referral_encryption_service.rb
+++ b/modules/vaos/app/services/vaos/referral_encryption_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'aes_256_cbc_encryptor'
+
+module VAOS
+  # ReferralEncryptionService handles the encryption and decryption of referral IDs
+  # to prevent PII from appearing in URLs that are logged
+  #
+  # This service uses AES-256-CBC encryption with a URL-safe Base64 encoding
+  # to ensure encrypted IDs can be used safely in URLs
+  class ReferralEncryptionService
+    # Encrypts a referral ID
+    #
+    # @param referral_id [String] The plain referral ID to encrypt
+    # @return [String] URL-safe encrypted referral ID
+    def self.encrypt(referral_id)
+      return nil if referral_id.blank?
+
+      encryptor.encrypt(referral_id.to_s)
+    end
+
+    # Decrypts an encrypted referral ID
+    #
+    # @param encrypted_id [String] The encrypted referral ID
+    # @return [String] The original plain referral ID
+    def self.decrypt(encrypted_id)
+      return nil if encrypted_id.blank?
+
+      encryptor.decrypt(encrypted_id)
+    end
+
+    # Creates and returns a configured instance of Aes256CbcEncryptor
+    #
+    # @return [Aes256CbcEncryptor] The configured encryptor
+    def self.encryptor
+      settings = Settings.vaos.referral.encryption
+      Thread.current[:vaos_referral_encryptor] ||= ::Aes256CbcEncryptor.new(settings.hex_secret, settings.hex_iv)
+    end
+  end
+end

--- a/modules/vaos/spec/models/ccra/referral_list_entry_spec.rb
+++ b/modules/vaos/spec/models/ccra/referral_list_entry_spec.rb
@@ -23,6 +23,10 @@ describe Ccra::ReferralListEntry do
       expect(subject.referral_id).to eq('5682')
     end
 
+    it 'initially sets uuid to nil' do
+      expect(subject.uuid).to be_nil
+    end
+
     it 'calculates expiration_date from StartDate and SEOCNumberOfDays' do
       expected_date = Date.parse('2024-03-28') + 60.days
       expect(subject.expiration_date).to eq(expected_date)
@@ -105,7 +109,11 @@ describe Ccra::ReferralListEntry do
     it 'sets correct attributes for each entry' do
       result = described_class.build_collection(referral_data)
       expect(result[0].type_of_care).to eq('CARDIOLOGY')
+      expect(result[0].referral_id).to eq('5682')
+      expect(result[0].uuid).to be_nil
       expect(result[1].type_of_care).to eq('PODIATRY')
+      expect(result[1].referral_id).to eq('5683')
+      expect(result[1].uuid).to be_nil
     end
 
     context 'with nil input' do

--- a/modules/vaos/spec/requests/v2/referrals_spec.rb
+++ b/modules/vaos/spec/requests/v2/referrals_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe 'VAOS V2 Referrals', type: :request do
 
       allow(Ccra::ReferralService).to receive(:new).and_return(service_double)
       allow(service_double).to receive(:get_vaos_referral_list).and_return(referrals)
+
+      # Mock the encryption service for each referral in the list
+      referrals.each do |ref|
+        allow(VAOS::ReferralEncryptionService).to receive(:encrypt)
+          .with(ref.referral_id)
+          .and_return("encrypted-#{ref.referral_id}")
+      end
     end
 
     context 'when user is not authenticated' do
@@ -46,6 +53,7 @@ RSpec.describe 'VAOS V2 Referrals', type: :request do
         expect(first_referral).to have_key('type')
         expect(first_referral).to have_key('attributes')
         expect(first_referral['attributes']).to have_key('type_of_care')
+        expect(first_referral['attributes']).to have_key('uuid')
       end
     end
 
@@ -95,6 +103,7 @@ RSpec.describe 'VAOS V2 Referrals', type: :request do
     let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
     let(:icn) { '1012845331V153043' }
     let(:referral_id) { '5682' }
+    let(:encrypted_uuid) { 'encrypted-5682' }
     let(:user) { build(:user, :vaos, :loa3, icn:) }
     let(:referral) { build(:ccra_referral_detail, referral_number: referral_id) }
     let(:service_double) { instance_double(Ccra::ReferralService) }
@@ -105,11 +114,14 @@ RSpec.describe 'VAOS V2 Referrals', type: :request do
 
       allow(Ccra::ReferralService).to receive(:new).and_return(service_double)
       allow(service_double).to receive(:get_referral).and_return(referral)
+      allow(VAOS::ReferralEncryptionService).to receive(:encrypt).with(referral_id).and_return(encrypted_uuid)
+      allow(VAOS::ReferralEncryptionService).to receive(:decrypt).with(encrypted_uuid).and_return(referral_id)
+      allow(VAOS::ReferralEncryptionService).to receive(:decrypt).with('invalid').and_raise(Common::Exceptions::ParameterMissing.new('id'))
     end
 
     context 'when user is not authenticated' do
       it 'returns 401 unauthorized' do
-        get "/vaos/v2/referrals/#{referral_id}"
+        get "/vaos/v2/referrals/#{encrypted_uuid}"
 
         expect(response).to have_http_status(:unauthorized)
       end
@@ -121,7 +133,7 @@ RSpec.describe 'VAOS V2 Referrals', type: :request do
       end
 
       it 'returns referral detail in JSON:API format' do
-        get "/vaos/v2/referrals/#{referral_id}"
+        get "/vaos/v2/referrals/#{encrypted_uuid}"
 
         expect(response).to have_http_status(:ok)
         response_data = JSON.parse(response.body)
@@ -130,7 +142,7 @@ RSpec.describe 'VAOS V2 Referrals', type: :request do
         expect(response_data['data']).to have_key('id')
         expect(response_data['data']['id']).to eq(referral_id)
         expect(response_data['data']).to have_key('type')
-        expect(response_data['data']['type']).to eq('referral')
+        expect(response_data['data']['type']).to eq('referrals')
         expect(response_data['data']).to have_key('attributes')
         expect(response_data['data']['attributes']).to have_key('type_of_care')
         expect(response_data['data']['attributes']).to have_key('provider_name')
@@ -143,9 +155,6 @@ RSpec.describe 'VAOS V2 Referrals', type: :request do
 
       before do
         sign_in_as(user)
-        allow(service_double).to receive(:get_referral)
-          .with(invalid_id, anything)
-          .and_raise(Common::Exceptions::ParameterMissing.new('id'))
       end
 
       it 'returns appropriate error status' do

--- a/modules/vaos/spec/requests/vaos/v2/eps_appointments_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/eps_appointments_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe 'VAOS::V2::EpsAppointments', :skip_mvi, type: :request do
 
     # Setup a memory store for caching instead of using Rails.cache
     allow(Rails).to receive(:cache).and_return(memory_store)
-    # Cache the token for CCRA service
-    Rails.cache.write(Ccra::BaseService::REDIS_TOKEN_KEY, access_token)
+    # Cache the token for EPS service
     Rails.cache.write(Eps::BaseService::REDIS_TOKEN_KEY, access_token)
 
     Settings.vaos ||= OpenStruct.new

--- a/modules/vaos/spec/serializers/ccra/referral_detail_serializer_spec.rb
+++ b/modules/vaos/spec/serializers/ccra/referral_detail_serializer_spec.rb
@@ -6,13 +6,14 @@ RSpec.describe Ccra::ReferralDetailSerializer do
   describe 'serialization' do
     context 'with a valid referral detail' do
       let(:referral_number) { 'VA0000005681' }
+      let(:referral_uuid) { 'encrypted123456' }
       let(:type_of_care) { 'CARDIOLOGY' }
       let(:provider_name) { 'Dr. Smith' }
       let(:location) { 'VA Medical Center' }
       let(:expiration_date) { '2024-05-27' }
 
       let(:referral) do
-        build(
+        result = build(
           :ccra_referral_detail,
           referral_number:,
           type_of_care:,
@@ -20,6 +21,8 @@ RSpec.describe Ccra::ReferralDetailSerializer do
           location:,
           expiration_date:
         )
+        result.uuid = referral_uuid
+        result
       end
 
       let(:serializer) { described_class.new(referral) }
@@ -31,11 +34,12 @@ RSpec.describe Ccra::ReferralDetailSerializer do
 
       it 'serializes the referral detail correctly' do
         expect(serialized_data[:data][:id]).to eq(referral_number)
-        expect(serialized_data[:data][:type]).to eq(:referral)
+        expect(serialized_data[:data][:type]).to eq(:referrals)
         expect(serialized_data[:data][:attributes][:type_of_care]).to eq(type_of_care)
         expect(serialized_data[:data][:attributes][:provider_name]).to eq(provider_name)
         expect(serialized_data[:data][:attributes][:location]).to eq(location)
         expect(serialized_data[:data][:attributes][:expiration_date]).to eq(expiration_date)
+        expect(serialized_data[:data][:attributes][:uuid]).to eq(referral_uuid)
       end
     end
 
@@ -62,11 +66,12 @@ RSpec.describe Ccra::ReferralDetailSerializer do
 
       it 'includes nil attributes in JSON:API format' do
         expect(serialized_data[:data][:id]).to eq(referral_number)
-        expect(serialized_data[:data][:type]).to eq(:referral)
+        expect(serialized_data[:data][:type]).to eq(:referrals)
         expect(serialized_data[:data][:attributes][:type_of_care]).to eq(type_of_care)
         expect(serialized_data[:data][:attributes][:provider_name]).to be_nil
         expect(serialized_data[:data][:attributes][:location]).to be_nil
         expect(serialized_data[:data][:attributes][:expiration_date]).to be_nil
+        expect(serialized_data[:data][:attributes][:uuid]).to be_nil
       end
     end
 

--- a/modules/vaos/spec/serializers/ccra/referral_list_serializer_spec.rb
+++ b/modules/vaos/spec/serializers/ccra/referral_list_serializer_spec.rb
@@ -7,16 +7,22 @@ RSpec.describe Ccra::ReferralListSerializer do
     context 'with a list of referrals' do
       # These values should calculate to May 27, 2024
       let(:cardiology_referral) do
-        build(:ccra_referral_list_entry, referral_id: '5682', type_of_care: 'CARDIOLOGY', start_date: '2024-03-28',
-                                         seoc_days: '60')
+        ref = build(:ccra_referral_list_entry, referral_id: '5682', type_of_care: 'CARDIOLOGY', start_date: '2024-03-28',
+                                               seoc_days: '60')
+        ref.uuid = 'encrypted-5682'
+        ref
       end
       let(:podiatry_referral) do
-        build(:ccra_referral_list_entry, referral_id: '5683', type_of_care: 'PODIATRY', start_date: '2024-03-28',
-                                         seoc_days: '60')
+        ref = build(:ccra_referral_list_entry, referral_id: '5683', type_of_care: 'PODIATRY', start_date: '2024-03-28',
+                                               seoc_days: '60')
+        ref.uuid = 'encrypted-5683'
+        ref
       end
       let(:optometry_referral) do
-        build(:ccra_referral_list_entry, referral_id: '5684', type_of_care: 'OPTOMETRY', start_date: '2024-03-28',
-                                         seoc_days: '60')
+        ref = build(:ccra_referral_list_entry, referral_id: '5684', type_of_care: 'OPTOMETRY', start_date: '2024-03-28',
+                                               seoc_days: '60')
+        ref.uuid = 'encrypted-5684'
+        ref
       end
       let(:referrals) { [cardiology_referral, podiatry_referral, optometry_referral] }
       let(:serializer) { described_class.new(referrals) }
@@ -33,16 +39,19 @@ RSpec.describe Ccra::ReferralListSerializer do
         expect(serialized_data[:data][0][:type]).to eq(:referrals)
         expect(serialized_data[:data][0][:attributes][:type_of_care]).to eq('CARDIOLOGY')
         expect(serialized_data[:data][0][:attributes][:expiration_date]).to eq('2024-05-27')
+        expect(serialized_data[:data][0][:attributes][:uuid]).to eq('encrypted-5682')
 
         expect(serialized_data[:data][1][:id]).to eq('5683')
         expect(serialized_data[:data][1][:type]).to eq(:referrals)
         expect(serialized_data[:data][1][:attributes][:type_of_care]).to eq('PODIATRY')
         expect(serialized_data[:data][1][:attributes][:expiration_date]).to eq('2024-05-27')
+        expect(serialized_data[:data][1][:attributes][:uuid]).to eq('encrypted-5683')
 
         expect(serialized_data[:data][2][:id]).to eq('5684')
         expect(serialized_data[:data][2][:type]).to eq(:referrals)
         expect(serialized_data[:data][2][:attributes][:type_of_care]).to eq('OPTOMETRY')
         expect(serialized_data[:data][2][:attributes][:expiration_date]).to eq('2024-05-27')
+        expect(serialized_data[:data][2][:attributes][:uuid]).to eq('encrypted-5684')
       end
     end
 

--- a/modules/vaos/spec/services/ccra/base_service_spec.rb
+++ b/modules/vaos/spec/services/ccra/base_service_spec.rb
@@ -23,4 +23,27 @@ describe Ccra::BaseService do
       expect(subject.settings).to eq(Settings.vaos.ccra)
     end
   end
+  
+  describe 'headers' do
+    let(:request_id) { 'test-request-id' }
+    let(:session_token) { 'test-session-token' }
+    
+    before do
+      RequestStore.store['request_id'] = request_id
+      allow_any_instance_of(VAOS::UserService).to receive(:session).with(user).and_return(session_token)
+    end
+    
+    it 'includes session authentication headers' do
+      headers = subject.send(:headers)
+      
+      # Should include headers from SessionService
+      expect(headers).to include(
+        'X-VAMF-JWT' => session_token,
+        'X-Request-ID' => request_id
+      )
+      
+      # Should not include headers from token authentication
+      expect(headers).not_to include('Authorization')
+    end
+  end
 end

--- a/modules/vaos/spec/services/ccra/base_service_spec.rb
+++ b/modules/vaos/spec/services/ccra/base_service_spec.rb
@@ -23,25 +23,25 @@ describe Ccra::BaseService do
       expect(subject.settings).to eq(Settings.vaos.ccra)
     end
   end
-  
+
   describe 'headers' do
     let(:request_id) { 'test-request-id' }
     let(:session_token) { 'test-session-token' }
-    
+
     before do
       RequestStore.store['request_id'] = request_id
       allow_any_instance_of(VAOS::UserService).to receive(:session).with(user).and_return(session_token)
     end
-    
+
     it 'includes session authentication headers' do
       headers = subject.send(:headers)
-      
+
       # Should include headers from SessionService
       expect(headers).to include(
         'X-VAMF-JWT' => session_token,
         'X-Request-ID' => request_id
       )
-      
+
       # Should not include headers from token authentication
       expect(headers).not_to include('Authorization')
     end

--- a/modules/vaos/spec/services/ccra/base_service_spec.rb
+++ b/modules/vaos/spec/services/ccra/base_service_spec.rb
@@ -17,4 +17,10 @@ describe Ccra::BaseService do
       expect(subject.config).to equal(config)
     end
   end
+
+  describe '#settings' do
+    it 'returns the CCRA settings from VAOS configuration' do
+      expect(subject.settings).to eq(Settings.vaos.ccra)
+    end
+  end
 end

--- a/modules/vaos/spec/services/ccra/referral_service_spec.rb
+++ b/modules/vaos/spec/services/ccra/referral_service_spec.rb
@@ -5,17 +5,15 @@ require 'rails_helper'
 describe Ccra::ReferralService do
   subject { described_class.new(user) }
 
-  let(:user) { double('User', account_uuid: '1234', flipper_id: '1234') }
-  let(:access_token) { 'fake-access-token' }
+  let(:user) { double('User', account_uuid: '1234', flipper_id: '1234', icn: '1012845331V153043') }
+  let(:session_token) { 'fake-session-token' }
+  let(:request_id) { 'request-id' }
 
   before do
-    allow(RequestStore.store).to receive(:[]).with('request_id').and_return('request-id')
+    allow(RequestStore.store).to receive(:[]).with('request_id').and_return(request_id)
 
-    # Allow any cache fetch call to return the access token if it matches our key, otherwise nil
-    # This makes it so we don't need to make a real call to the token endpoint
-    allow(Rails.cache).to receive(:fetch) do |key|
-      access_token if key == Ccra::BaseService::REDIS_TOKEN_KEY
-    end
+    # Mock the session token from UserService
+    allow_any_instance_of(VAOS::UserService).to receive(:session).with(user).and_return(session_token)
 
     Settings.vaos ||= OpenStruct.new
     Settings.vaos.ccra ||= OpenStruct.new

--- a/modules/vaos/spec/services/concerns/token_authentication_spec.rb
+++ b/modules/vaos/spec/services/concerns/token_authentication_spec.rb
@@ -19,7 +19,7 @@ class TestTokenService < VAOS::SessionService
     super(user)
     @user = user
     @config = OpenStruct.new(
-      access_token_url: 'https://test.example.com/token',
+      access_token_url: 'https://login.wellhive.com/oauth2/default/v1/token',
       grant_type: 'client_credentials',
       scopes: 'test.scope',
       client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',

--- a/modules/vaos/spec/services/vaos/referral_encryption_service_spec.rb
+++ b/modules/vaos/spec/services/vaos/referral_encryption_service_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'aes_256_cbc_encryptor'
+
+describe VAOS::ReferralEncryptionService do
+  let(:referral_id) { '12345abc' }
+  let(:hex_secret) { 'EC121FF80513AE58ED478D5C5787075BF53C35733BFA55ABB18F323A3AD8EDE5' }
+  let(:hex_iv) { '00ABEB85AB5C293F15DDF1647449A00C' }
+  let(:encryption_stub) { OpenStruct.new(hex_secret:, hex_iv:) }
+  let(:referral_stub) { OpenStruct.new(encryption: encryption_stub) }
+  let(:vaos_stub) { OpenStruct.new(referral: referral_stub) }
+  let(:encrypted_id) { described_class.encrypt(referral_id) }
+
+  # Clear the thread-local encryptor between tests
+  before do
+    Thread.current[:vaos_referral_encryptor] = nil
+    allow(Settings).to receive(:vaos).and_return(vaos_stub)
+  end
+
+  after { Thread.current[:vaos_referral_encryptor] = nil }
+
+  describe '.encrypt' do
+    it 'returns a URL-safe string' do
+      expect(encrypted_id).to be_a(String)
+      expect(encrypted_id).not_to include('+')
+      expect(encrypted_id).not_to include('/')
+      expect(encrypted_id).not_to include(referral_id)
+    end
+
+    it 'returns nil for blank input' do
+      expect(described_class.encrypt(nil)).to be_nil
+      expect(described_class.encrypt('')).to be_nil
+    end
+  end
+
+  describe '.decrypt' do
+    it 'decrypts the encrypted id back to the original value' do
+      expect(described_class.decrypt(encrypted_id)).to eq(referral_id)
+    end
+
+    it 'returns nil for blank input' do
+      expect(described_class.decrypt(nil)).to be_nil
+      expect(described_class.decrypt('')).to be_nil
+    end
+  end
+
+  describe '.encryptor' do
+    it 'returns an instance of Aes256CbcEncryptor' do
+      expect(described_class.encryptor).to be_a(Aes256CbcEncryptor)
+    end
+
+    it 'caches the encryptor instance per thread' do
+      first_call = described_class.encryptor
+      second_call = described_class.encryptor
+      expect(first_call).to be(second_call)
+      expect(Thread.current[:vaos_referral_encryptor]).to be(first_call)
+    end
+  end
+end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -62,7 +62,7 @@ VCR.configure do |c|
   c.filter_sensitive_data('<ARP_ALLOW_LIST_REPO>') { Settings.accredited_representative_portal.allow_list.github.repo }
   c.filter_sensitive_data('<ARP_ALLOW_LIST_PATH>') { Settings.accredited_representative_portal.allow_list.github.path }
   c.filter_sensitive_data('<VAOS_CCRA_API_URL>') { Settings.vaos.ccra.api_url }
-  c.filter_sensitive_data('<VAOS_CCRA_TOKEN_URL>') { Settings.vaos.ccra.access_token_url }
+  c.filter_sensitive_data('<VAOS_EPS_TOKEN_URL>') { Settings.vaos.eps.access_token_url }
   c.filter_sensitive_data('<VAOS_EPS_API_URL>') { Settings.vaos.eps.api_url }
   c.before_record do |i|
     %i[response request].each do |env|

--- a/spec/support/vcr_cassettes/vaos/concerns/token/token_200.yml
+++ b/spec/support/vcr_cassettes/vaos/concerns/token/token_200.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<VAOS_CCRA_TOKEN_URL>"
+    uri: "<VAOS_EPS_TOKEN_URL>"
     body:
       encoding: US-ASCII
       string: grant_type=client_credentials&scope=test.scope&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&client_assertion=test-jwt-assertion

--- a/spec/support/vcr_cassettes/vaos/concerns/token/token_400.yml
+++ b/spec/support/vcr_cassettes/vaos/concerns/token/token_400.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<VAOS_CCRA_TOKEN_URL>"
+    uri: "<VAOS_EPS_TOKEN_URL>"
     body:
       encoding: US-ASCII
       string: grant_type=client_credentials&scope=test.scope&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&client_assertion=test-jwt-assertion


### PR DESCRIPTION
## Summary
- *This work is behind a feature toggle (flipper): NO*
- Adds a UUID to the referrals controller responses to be used by the frontend to request referral details without exposing PII due to logging URLs.
- The referral ID/number is considered PII. The frontend would need to provide the referral number as part of the request URL when requesting a referral's details. The URL would have been logged with the referral number and hence would have exposed PII. This change makes it so the referral number is encrypted and provided as a UUID for the referral, so when the URL is logged is does not expose PII.
- Team: UAE Check In

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/106674

## Testing done
- [ X ] *New code is covered by unit tests*
- Manual testing:
  - Run vets-api with CCRA mocks turned on.
  - Authenticate to vets-api using mock authentication
  - Request the referrals list and verify the UUIDs are present.

## Screenshots
N/A

## What areas of the site does it impact?
Unreleased Community of Care referrals feature

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
