### PR TITLE
Ignore whitespace in line count

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -166,7 +166,7 @@ module VSPDanger
     end
 
     def file_git_diff(file_name)
-      `git diff #{BASE_SHA}...#{HEAD_SHA} -- #{file_name}`
+      `git diff #{BASE_SHA}...#{HEAD_SHA} -w --ignore-blank-lines -- #{file_name}`
     end
   end
 


### PR DESCRIPTION
## Summary

Although the Dangerfile line length warning says that it ignores whitespace, it currently includes lines with whitespace-only changes in the count if the file has any non-whitespace line changes. That's because the filter to ignore whitespace changes is only applied to the `git diff` for the list of files, and not to the one for the file contents. This PR removes whitespace-only lines from the count.

## Testing done

- Manual runs of lines from the Dangerfile and the changed lines to confirm only desired lines are included in count

## Screenshots

Example of issue from current PR https://github.com/department-of-veterans-affairs/vets-api/pull/21586
<img width="822" alt="Screenshot 2025-04-09 at 3 11 55 PM" src="https://github.com/user-attachments/assets/c0255a47-0528-4a11-96bb-6bf4c4fdd324" />

Actual non-whitespace diff of modules/income_and_assets/lib/income_and_assets/pdf_fill/forms/va21p0969.rb
<img width="1041" alt="Screenshot 2025-04-09 at 3 11 09 PM" src="https://github.com/user-attachments/assets/4a7636ad-8da6-4eef-8c1f-89e237e55fe2" />

## What areas of the site does it impact?
CI

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
