### PR TITLE
PBP Remove Unused Flippers

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1896,12 +1896,6 @@ features:
   burial_form_enabled:
     actor_type: user
     description: Enable the burial form
-  burial_document_upload_update:
-    actor_type: user
-    description: Show updated document upload page
-  burial_location_of_death_update:
-    actor_type: user
-    description: Show updated location of death pattern
   burial_confirmation_page:
     actor_type: user
     description: Toggle showing the updated confirmation page
@@ -1928,9 +1922,6 @@ features:
     actor_type: user
     description: Implement multiple page response pattern
     enable_in_development: true
-  pension_confirmation_update:
-    actor_type: user
-    description: Show updated confirmation page
   pension_form_profile_module_enabled:
     actor_type: user
     description: Use the module version of the FormProfile


### PR DESCRIPTION
## Summary

remove unused flippers

## Related issue(s)

[PBP | Remove 'burialLocationOfDeath' feature toggle](https://github.com/department-of-veterans-affairs/va.gov-team/issues/104955)
[PBP | Remove 'pension_confirmation_update' feature toggle](https://github.com/department-of-veterans-affairs/va.gov-team/issues/105422)
[PBP | Remove 'burial_document_upload_update' feature toggle](https://github.com/department-of-veterans-affairs/va.gov-team/issues/105974)
https://github.com/department-of-veterans-affairs/vets-website/pull/35803

## Testing done

- [x] *New code is covered by unit tests*
NA

## What areas of the site does it impact?

pension and burial

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
