### PR TITLE
[Dependents] Populate the form_start_date

### DIFF
--- a/app/controllers/v0/dependents_applications_controller.rb
+++ b/app/controllers/v0/dependents_applications_controller.rb
@@ -22,6 +22,10 @@ module V0
         claim = SavedClaim::DependencyClaim.new(form: dependent_params.to_json)
       end
 
+      # Populate the form_start_date from the IPF if available
+      in_progress_form = current_user ? InProgressForm.form_for_user(claim.form_id, current_user) : nil
+      claim.form_start_date = in_progress_form.created_at if in_progress_form
+
       unless claim.save
         StatsD.increment("#{stats_key}.failure")
         Sentry.set_tags(team: 'vfs-ebenefits') # tag sentry logs with team name


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Track the InProgressForm.created_at as form_start_date in order to track total time to submission for forms. 
- See [Burials](https://github.com/department-of-veterans-affairs/vets-api/blob/a530cc2b0a55e696a8be3ea4deb6a26f6bd1fce7/modules/burials/app/controllers/burials/v0/claims_controller.rb#L47) for an existing implementation of this pattern.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/107046

## Testing done

- [ ] *New code is covered by unit tests*

## What areas of the site does it impact?
Dependents

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
