### PR TITLE
Add feature flag to begin removal of EDU and C&P email templates #92636

### DIFF
--- a/app/mailers/direct_deposit_mailer.rb
+++ b/app/mailers/direct_deposit_mailer.rb
@@ -9,7 +9,6 @@ class DirectDepositMailer < TransactionalEmailMailer
   TEMPLATE = 'direct_deposit'
 
   DD_TYPES = {
-    ch33: 'education',
     comp_pen: 'disability compensation or pension'
   }.freeze
 

--- a/app/sidekiq/va_notify_dd_email_job.rb
+++ b/app/sidekiq/va_notify_dd_email_job.rb
@@ -42,8 +42,7 @@ class VANotifyDdEmailJob
   end
 
   def template_type(dd_type)
-    return 'direct_deposit_edu' if dd_type&.to_sym == :ch33
-    return 'direct_deposit_comp_pen' if %i[comp_pen comp_and_pen].include? dd_type&.to_sym
+    return 'direct_deposit_comp_pen' if use_comp_pen_email_template?(dd_type)
 
     'direct_deposit'
   end
@@ -53,5 +52,13 @@ class VANotifyDdEmailJob
     StatsD.increment(STATSD_ERROR_NAME)
 
     raise ex if ex.status_code.between?(500, 599)
+  end
+
+  def use_direct_deposit_email_template?
+    Flipper.enabled?(:only_use_direct_deposit_email_template)
+  end
+
+  def use_comp_pen_email_template?(dd_type)
+    %i[comp_pen comp_and_pen].include?(dd_type&.to_sym) && !use_direct_deposit_email_template?
   end
 end

--- a/config/features.yml
+++ b/config/features.yml
@@ -29,7 +29,7 @@ features:
     enable_in_development: true
   accredited_representative_portal_search:
     actor_type: user
-    description: Enables the people search of the accredited representative portal 
+    description: Enables the people search of the accredited representative portal
     enable_in_development: true
   aedp_vadx:
     actor_type: user
@@ -2109,3 +2109,6 @@ features:
   forms_10215_10216_release:
     actor_type: user
     description: If enabled, show links to new forms instead of download links on SCO page
+  only_use_direct_deposit_email_template:
+    description: If enabled, VANotifyDdEmailJob will not use the EDU and/or C&P email templates
+

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1556,7 +1556,6 @@ vanotify:
         covid_vaccine_registration: <%= ENV['vanotify__services__va_gov__template_id__covid_vaccine_registration'] %>
         direct_deposit: <%= ENV['vanotify__services__va_gov__template_id__direct_deposit'] %>
         direct_deposit_comp_pen: <%= ENV['vanotify__services__va_gov__template_id__direct_deposit_comp_pen'] %>
-        direct_deposit_edu: <%= ENV['vanotify__services__va_gov__template_id__direct_deposit_edu'] %>
         form0994_confirmation_email: <%= ENV['vanotify__services__va_gov__template_id__form0994_confirmation_email'] %>
         form0994_extra_action_confirmation_email: <%= ENV['vanotify__services__va_gov__template_id__form0994_extra_action_confirmation_email'] %>
         form1010ez_reminder_email: <%= ENV['vanotify__services__va_gov__template_id__form1010ez_reminder_email'] %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1577,7 +1577,6 @@ vanotify:
         covid_vaccine_registration: ~
         direct_deposit: direct_deposit_template_id
         direct_deposit_comp_pen: comp_pen_template_id
-        direct_deposit_edu: edu_template_id
         form0994_confirmation_email: form0994_confirmation_email_template_id
         form0994_extra_action_confirmation_email: form0994_extra_action_confirmation_email_template_id
         form1010ez_reminder_email: fake_template_id

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1571,7 +1571,6 @@ vanotify:
         covid_vaccine_registration: ~
         direct_deposit: direct_deposit_template_id
         direct_deposit_comp_pen: comp_pen_template_id
-        direct_deposit_edu: edu_template_id
         form0994_confirmation_email: form0994_confirmation_email_template_id
         form0994_extra_action_confirmation_email: form0994_extra_action_confirmation_email_template_id
         form1010ez_reminder_email: fake_template_id

--- a/spec/mailers/direct_deposit_mailer_spec.rb
+++ b/spec/mailers/direct_deposit_mailer_spec.rb
@@ -30,25 +30,5 @@ RSpec.describe DirectDepositMailer, feature: :direct_deposit,
         )
       end
     end
-
-    context 'ch33 email' do
-      let(:dd_type) { :ch33 }
-
-      it 'includes the right text' do
-        expect(subject.body.raw_source).to include(
-          "We'll use your updated information to deposit any education benefits you may receive"
-        )
-      end
-
-      context 'string dd_type' do
-        let(:dd_type) { 'ch33' }
-
-        it 'includes the right text' do
-          expect(subject.body.raw_source).to include(
-            "We'll use your updated information to deposit any education benefits you may receive"
-          )
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- This work is behind a feature toggle (flipper): `only_use_direct_deposit_email_template`

We want to remove the EDU and C&P email templates. EDU template has had no triggers in the last 30 days and is safe to remove alongside all remaining mentions of the template. 
However, the C&P template is _still_ being triggered in VA Notify Production. We have decided to take the feature flag approach to smoothly ensure complete removal of the template and remaining mentions.

Team: Authenticated Experience

**Success criteria being targeted:**
When the flag is on, the C&P template will be replaced by the Direct Deposit email template. That is the work that’s already been started and mostly completed so we will continue it in this cleanup effort.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92636

## Testing done

- [x] *New code is covered by unit tests*

- *Describe what the old behavior was prior to the change*
There was no feature flag that would allow us to switch any use of the C&P email template to the Direct Deposit email template.

- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
1. We toggle the `only_use_direct_deposit_email_template` flag on in staging
2. We monitor the C&P email template in staging to make sure that triggers steadily decrease
3. We monitor DataDog to ensure no errors occur due to the “missing” C&P template
4. We toggle the `only_use_direct_deposit_email_template` flag on in production
5. We repeat steps 2 and 3 for production

- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
