### PR TITLE
[VI-1104] udpates AppealSubmission user_account backfill raketask

### DIFF
--- a/rakelib/prod/backfill_user_account_for_appeal_submissions.rake
+++ b/rakelib/prod/backfill_user_account_for_appeal_submissions.rake
@@ -24,7 +24,7 @@ task backfill_user_account_for_appeal_submissions: :environment do
         icn = Account.find_by(idme_uuid: user_uuid)&.icn ||
               Account.find_by(logingov_uuid: user_uuid)&.icn ||
               mpi_service.find_profile_by_identifier(identifier: user_uuid, identifier_type: 'idme')&.profile&.icn
-        user_account = UserAccount.find_by(icn:) || UserAccount.new(icn:).save! if icn
+        user_account = UserAccount.find_or_create_by(icn:) if icn
       end
       sub.user_account = user_account
       sub.save!


### PR DESCRIPTION
## Summary

Fixes  a bug in the `UserAccount` creation process for `AppealSubmission` backfill raketask

## Related issue(s)

- Original PR: https://github.com/department-of-veterans-affairs/vets-api/pull/21578
- https://jira.devops.va.gov/browse/VI-1104

## Testing done

- Testing can be performed in a Rails console. To begin, monkey-patch the `spec/factories/appeal_submissions.rb` factory to disable the `stub_mpi` functionality:
```ruby
# monkey-patch spec/factories/appeal_submissions
FactoryBot.define do
  factory :appeal_submission do
    user_uuid do
      # user = create(:user, :loa3, ssn: '212222112')
      user = create(:user, :loa3, ssn: '212222112', stub_mpi: false)
      user.uuid
    end
```
### Fixed Behavior -  `UserAccount` does not exist

- Open a Rails console & create an appeal submission with a `user_uuid` that won't connect  to a `UserVerification`
```ruby
include FactoryBot::Syntax::Methods
appeal_submission = create(:appeal_submission)
user_uuid = appeal_submission.user_uuid
# confirm that no UserVerification exists with 'user_uuid' that could lead to a UserAccount
account = create(:account, idme_uuid: user_uuid)
...
appeal_submission.user_account
  => nil
UserAccount.all
  => [ ]
```
- In a separate terminal run the backfill raketask
  - `bundle exec rake backfill_user_account_for_appeal_submissions`
  - The raketask runs with batches of 1000
  - You should not see output in your terminal; check `log/development.log` for Rails logger messages.
- In your Rails console the submission should have its `user_account` updated with a newly created UserAccount:
```ruby
appeal_submission.reload
appeal_submission.user_account
	=> #<UserAccount:0x000...>
UserAccount.first.icn == appeal_submission.user_account.icn
=> true
```
