### PR TITLE
105866 debt request count only param

### DIFF
--- a/app/controllers/v0/debts_controller.rb
+++ b/app/controllers/v0/debts_controller.rb
@@ -11,7 +11,7 @@ module V0
 
     def index
       count_only = ActiveModel::Type::Boolean.new.cast(params[:count_only])
-      render json: service.get_debts(count_only: count_only)
+      render json: service.get_debts(count_only:)
     end
 
     def show

--- a/app/controllers/v0/debts_controller.rb
+++ b/app/controllers/v0/debts_controller.rb
@@ -10,7 +10,8 @@ module V0
     rescue_from ::DebtManagementCenter::DebtsService::DebtNotFound, with: :render_not_found
 
     def index
-      render json: service.get_debts
+      count_only = ActiveModel::Type::Boolean.new.cast(params[:count_only])
+      render json: service.get_debts(count_only: count_only)
     end
 
     def show

--- a/app/swagger/swagger/requests/debts.rb
+++ b/app/swagger/swagger/requests/debts.rb
@@ -22,7 +22,8 @@ module Swagger
           response 200 do
             key :description, 'Successful debts lookup'
             schema do
-              property :debtsCount, type: :integer, description: 'Total number of debts (only returned when count_only=true)'
+              property :debtsCount, type: :integer,
+                                    description: 'Total number of debts (only returned when count_only=true)'
               property :has_dependent_debts, type: :boolean
               property :debts, type: :array do
                 items do

--- a/app/swagger/swagger/requests/debts.rb
+++ b/app/swagger/swagger/requests/debts.rb
@@ -11,23 +11,35 @@ module Swagger
           key :operationId, 'getDebts'
           key :tags, %w[debts]
 
+          parameter do
+            key :name, :count_only
+            key :in, :query
+            key :description, 'When true, returns only the count of debts'
+            key :required, false
+            key :type, :boolean
+          end
+
           response 200 do
             key :description, 'Successful debts lookup'
             schema do
-              items do
-                property :file_number, type: :string
-                property :payee_number, type: :string
-                property :person_entitled, type: :string
-                property :deduction_code, type: :string
-                property :benefit_type, type: :string
-                property :amount_overpaid, type: :string
-                property :amount_withheld, type: :string
-                property :debt_history, type: :array do
-                  items do
-                    property :date, type: :string
-                    property :letter_code, type: :string
-                    property :status, type: :string
-                    property :description, type: :string
+              property :debtsCount, type: :integer, description: 'Total number of debts (only returned when count_only=true)'
+              property :has_dependent_debts, type: :boolean
+              property :debts, type: :array do
+                items do
+                  property :file_number, type: :string
+                  property :payee_number, type: :string
+                  property :person_entitled, type: :string
+                  property :deduction_code, type: :string
+                  property :benefit_type, type: :string
+                  property :amount_overpaid, type: :string
+                  property :amount_withheld, type: :string
+                  property :debt_history, type: :array do
+                    items do
+                      property :date, type: :string
+                      property :letter_code, type: :string
+                      property :status, type: :string
+                      property :description, type: :string
+                    end
                   end
                 end
               end

--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -89,6 +89,7 @@
     :cache_multiple_responses:
       :uid_location: body
       :uid_locator: 'fileNumber":"(\w+)"'
+      :optional_code_locator: '"countOnly":(true|false)'
   - :method: :post
     :path: "/api/v1/digital-services/financial-status-report/formtopdf"
     :file_path: "debt_management_center/financial_status_reports/create"

--- a/lib/debt_management_center/debts_service.rb
+++ b/lib/debt_management_center/debts_service.rb
@@ -33,6 +33,7 @@ module DebtManagementCenter
 
       has_dependent_debts = veteran_has_dependent_debts?
       debts = debts_with_sorted_histories
+      StatsD.increment("#{STATSD_KEY_PREFIX}.get_debts.success")
       {
         has_dependent_debts:,
         debts:

--- a/lib/debt_management_center/debts_service.rb
+++ b/lib/debt_management_center/debts_service.rb
@@ -145,13 +145,6 @@ module DebtManagementCenter
       response
     end
 
-    def add_debts_to_redis
-      debts = @debts.map { |d| d['id'] = SecureRandom.uuid }
-      debt_params = { REDIS_CONFIG[:debt][:namespace] => user.uuid }
-      debt_store = DebtManagementCenter::DebtStore.new(debt_params)
-      debt_store.update(uuid: user.uuid, debts:)
-    end
-
     def sort_by_date(debt_history)
       debt_history.sort_by { |d| Date.strptime(d['date'], '%m/%d/%Y') }.reverse
     end

--- a/lib/debt_management_center/debts_service.rb
+++ b/lib/debt_management_center/debts_service.rb
@@ -20,8 +20,10 @@ module DebtManagementCenter
     end
 
     def get_debts(count_only: false)
+      # @param count_only [Boolean] 
+      # When true, returns only { "debtsCount" => Integer }
+      # When false, returns full debt details with histories
       if count_only
-        # Get only the count directly from the API
         with_monitoring_and_error_handling do
           response = fetch_debts_from_dmc(count_only: true)
           StatsD.increment("#{STATSD_KEY_PREFIX}.get_debts_count.success")

--- a/lib/debt_management_center/debts_service.rb
+++ b/lib/debt_management_center/debts_service.rb
@@ -80,7 +80,7 @@ module DebtManagementCenter
     end
 
     def load_debts
-      @debts = init_cached_debts
+      @debts ||= init_cached_debts || []
     end
 
     def init_cached_debts

--- a/lib/debt_management_center/debts_service.rb
+++ b/lib/debt_management_center/debts_service.rb
@@ -106,10 +106,10 @@ module DebtManagementCenter
       with_monitoring_and_error_handling do
         options = { timeout: 30 }
         payload = { fileNumber: @file_number }
-        payload[:countOnly] = true if count_only
+        payload[:countOnly] = count_only ? true : false
 
         response = perform(:post, Settings.dmc.debts_endpoint, payload, nil, options).body
-        
+
         return response if count_only
         
         DebtManagementCenter::DebtsResponse.new(response).debts

--- a/spec/lib/debt_management_center/debts_service_spec.rb
+++ b/spec/lib/debt_management_center/debts_service_spec.rb
@@ -9,19 +9,9 @@ RSpec.describe DebtManagementCenter::DebtsService do
   let(:file_number) { '796043735' }
   let(:user) { build(:user, :loa3, ssn: file_number) }
   let(:user_no_ssn) { build(:user, :loa3, ssn: '') }
-  let(:cached_error_metric) { 'api.dmc.init_cached_debts.fail' }
-  let(:non_cached_error_metric) { 'api.dmc.init_debts.fail' }
-  let(:cached_total_metric) { 'api.dmc.init_cached_debts.total' }
-  let(:non_cached_total_metric) { 'api.dmc.init_debts.total' }
 
   describe '#get_debts' do
-    context 'with Flipper debts_cache_dmc_empty_response disabled' do
-      it_behaves_like 'Flipper debts_cache_dmc_empty_response behavior', false
-    end
-
-    context 'with Flipper debts_cache_dmc_empty_response enabled' do
-      it_behaves_like 'Flipper debts_cache_dmc_empty_response behavior', true
-    end
+    it_behaves_like 'debt service behavior'
   end
 
   describe '#get_debt_by_id' do

--- a/spec/lib/debt_management_center/shared_examples/debt_service_examples.rb
+++ b/spec/lib/debt_management_center/shared_examples/debt_service_examples.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples 'debt service behavior' do
   before do
     allow(StatsD).to receive(:increment)
   end
-  
+
   describe '#get_debts' do
     context 'with a valid file number' do
       it 'fetches the veterans debt data' do
@@ -73,32 +73,27 @@ RSpec.shared_examples 'debt service behavior' do
           VCR.use_cassette('debts/get_letters_count_only', VCR::MATCH_EVERYTHING) do
             # When requesting just the count
             response = described_class.new(user).get_debts(count_only: true)
-            
-            # Response should be a hash with debtsCount
+
             expect(response).to be_a(Hash)
             expect(response).to have_key('debtsCount')
-            expect(response['debtsCount']).to be > 0  # We know this test has debts
-            
-            # Verify metrics
+            expect(response['debtsCount']).to be > 0
+
             expect(StatsD).to have_received(:increment).with('api.dmc.fetch_debts_from_dmc.total')
             expect(StatsD).to have_received(:increment).with('api.dmc.get_debts_count.success')
           end
         end
       end
-    
+
       it 'returns full debt data when count_only is false' do
         VCR.use_cassette('bgs/people_service/person_data') do
           VCR.use_cassette('debts/get_letters', VCR::MATCH_EVERYTHING) do
-            # When requesting full debt data
             response = described_class.new(user).get_debts(count_only: false)
-            
-            # 1. Response should include both has_dependent_debts and debts array
+
             expect(response).to have_key(:has_dependent_debts)
             expect(response).to have_key(:debts)
             expect(response[:debts]).to be_an(Array)
             expect(response[:debts]).not_to be_empty
-            
-            # 2. Verify metrics
+
             expect(StatsD).to have_received(:increment).with('api.dmc.fetch_debts_from_dmc.total')
             expect(StatsD).to have_received(:increment).with('api.dmc.get_debts.success')
           end

--- a/spec/lib/debt_management_center/shared_examples/debt_service_examples.rb
+++ b/spec/lib/debt_management_center/shared_examples/debt_service_examples.rb
@@ -66,5 +66,44 @@ RSpec.shared_examples 'debt service behavior' do
         end
       end
     end
+
+    context 'with count_only parameter' do
+      it 'returns only count when count_only is true' do
+        VCR.use_cassette('bgs/people_service/person_data') do
+          VCR.use_cassette('debts/get_letters_count_only', VCR::MATCH_EVERYTHING) do
+            # When requesting just the count
+            response = described_class.new(user).get_debts(count_only: true)
+            
+            # Response should be a hash with debtsCount
+            expect(response).to be_a(Hash)
+            expect(response).to have_key('debtsCount')
+            expect(response['debtsCount']).to be > 0  # We know this test has debts
+            
+            # Verify metrics
+            expect(StatsD).to have_received(:increment).with('api.dmc.fetch_debts_from_dmc.total')
+            expect(StatsD).to have_received(:increment).with('api.dmc.get_debts_count.success')
+          end
+        end
+      end
+    
+      it 'returns full debt data when count_only is false' do
+        VCR.use_cassette('bgs/people_service/person_data') do
+          VCR.use_cassette('debts/get_letters', VCR::MATCH_EVERYTHING) do
+            # When requesting full debt data
+            response = described_class.new(user).get_debts(count_only: false)
+            
+            # 1. Response should include both has_dependent_debts and debts array
+            expect(response).to have_key(:has_dependent_debts)
+            expect(response).to have_key(:debts)
+            expect(response[:debts]).to be_an(Array)
+            expect(response[:debts]).not_to be_empty
+            
+            # 2. Verify metrics
+            expect(StatsD).to have_received(:increment).with('api.dmc.fetch_debts_from_dmc.total')
+            expect(StatsD).to have_received(:increment).with('api.dmc.get_debts.success')
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/lib/debt_management_center/shared_examples/debt_service_examples.rb
+++ b/spec/lib/debt_management_center/shared_examples/debt_service_examples.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'Flipper debts_cache_dmc_empty_response behavior' do |flipper_enabled|
+RSpec.shared_examples 'debt service behavior' do
   before do
-    allow(Flipper).to receive(:enabled?).with(:debts_cache_dmc_empty_response).and_return(flipper_enabled)
+    allow(StatsD).to receive(:increment)
   end
-
+  
   describe '#get_debts' do
     context 'with a valid file number' do
       it 'fetches the veterans debt data' do
@@ -23,16 +23,6 @@ RSpec.shared_examples 'Flipper debts_cache_dmc_empty_response behavior' do |flip
       it 'returns a bad request error' do
         VCR.use_cassette('bgs/people_service/no_person_data') do
           VCR.use_cassette('debts/get_letters_empty_ssn', VCR::MATCH_EVERYTHING) do
-            expect(StatsD).to receive(:increment).once.with('api.dmc.init_cached_debts.fired') if flipper_enabled
-
-            expect(StatsD).to receive(:increment).once.with(
-              flipper_enabled ? cached_error_metric : non_cached_error_metric, tags: [
-                'error:CommonClientErrorsClientError', 'status:400'
-              ]
-            )
-            expect(StatsD).to receive(:increment).once.with(
-              flipper_enabled ? cached_total_metric : non_cached_total_metric
-            )
             expect(Sentry).to receive(:set_tags).once.with(external_service: described_class.to_s.underscore)
             expect(Sentry).to receive(:set_extras).once.with(
               url: Settings.dmc.url,
@@ -45,6 +35,14 @@ RSpec.shared_examples 'Flipper debts_cache_dmc_empty_response behavior' do |flip
             ) do |e|
               expect(e.message).to match(/DMC400/)
             end
+
+            # Verify metrics were recorded
+            expect(StatsD).to have_received(:increment).with('api.dmc.init_cached_debts.fired')
+            expect(StatsD).to have_received(:increment).with(
+              'api.dmc.fetch_debts_from_dmc.fail',
+              tags: ['error:CommonClientErrorsClientError', 'status:400']
+            )
+            expect(StatsD).to have_received(:increment).with('api.dmc.fetch_debts_from_dmc.total')
           end
         end
       end
@@ -55,15 +53,11 @@ RSpec.shared_examples 'Flipper debts_cache_dmc_empty_response behavior' do |flip
         VCR.use_cassette('bgs/people_service/person_data') do
           VCR.use_cassette('debts/get_letters_empty_response', VCR::MATCH_EVERYTHING) do
             Timecop.freeze(Time.utc(2024, 8, 4, 3, 0, 0)) do
-              expected_expires_in = 2.hours
-
-              if flipper_enabled
-                expect(Rails.cache).to receive(:write).once.with(
-                  "debts_data_#{user.uuid}",
-                  [],
-                  hash_including(expires_in: be_within(1.second).of(expected_expires_in))
-                )
-              end
+              expect(Rails.cache).to receive(:write).once.with(
+                "debts_data_#{user.uuid}",
+                [],
+                hash_including(expires_in: be_within(1.second).of(2.hours))
+              )
 
               res = described_class.new(user).get_debts
               expect(JSON.parse(res.to_json)['debts']).to eq([])

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -9,6 +9,7 @@ VCR.configure do |c|
   c.filter_sensitive_data('<APP_TOKEN>') { Settings.mhv.rx.app_token }
   c.filter_sensitive_data('<AV_KEY>') { VAProfile::Configuration::SETTINGS.address_validation.api_key }
   c.filter_sensitive_data('<DMC_TOKEN>') { Settings.dmc.client_secret }
+  c.filter_sensitive_data('<DMC_BASE_URL>') { Settings.dmc.url }
   c.filter_sensitive_data('<BGS_BASE_URL>') { Settings.bgs.url }
   c.filter_sensitive_data('<EE_PASS>') { Settings.hca.ee.pass }
   c.filter_sensitive_data('<EVSS_AWS_BASE_URL>') { Settings.evss.aws.url }

--- a/spec/support/vcr_cassettes/debts/get_letters_count_only.yml
+++ b/spec/support/vcr_cassettes/debts/get_letters_count_only.yml
@@ -1,8 +1,9 @@
 ---
+
 http_interactions:
 - request:
     method: post
-    uri: https://fwdproxy-dev.vfs.va.gov:4465/api/v1/digital-services/debt-letter/get
+    uri: <DMC_BASE_URL>debt-letter/get
     body:
       encoding: UTF-8
       string: '{"fileNumber":"796043735","countOnly":true}'

--- a/spec/support/vcr_cassettes/debts/get_letters_count_only.yml
+++ b/spec/support/vcr_cassettes/debts/get_letters_count_only.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://fwdproxy-dev.vfs.va.gov:4465/api/v1/digital-services/debt-letter/get
+    body:
+      encoding: UTF-8
+      string: '{"fileNumber":"796043735","countOnly":true}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Client-Id:
+      - 0be3d60e3983438199f192b6e723a6f0
+      Client-Secret:
+      - "<DMC_TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 13 Nov 2020 17:14:44 GMT
+    body:
+      encoding: UTF-8
+      string: '{"debtsCount": 5}'
+  recorded_at: Fri, 13 Nov 2020 17:14:45 GMT
+recorded_with: VCR 6.0.0 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- *(Summarize the changes that have been made to the platform)*: Added an optional locator to the betamocks config for mocking responses for the new DMC count only query response
- *(If bug, how to reproduce)* N/A
- *(What is the solution, why is this the solution?)* This allows for count_only in a way that doesn't call debt fetching functions on initialization.  Lazy loading debts when needed will decrease load on DMC servers.  Additionally we removed unused flipper logic,  and unused code.  This change is backwards compatible, so any functions referencing get_debts should not require updating.
- *(Which team do you work for, does your team own the maintenance of this component?)* Financial Management, we own this component
- *(If introducing a flipper, what is the success criteria being targeted?)* N/A

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*: https://github.com/department-of-veterans-affairs/va.gov-team/issues/105866#issue-2941599782
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change* The old behavior was that debts were fetched on initialization, and without the option for including a count_only param.  the DMC has changed their endpoint, so that in situations like the my-va page, we are able to request only a count of debts, instead of requiring the entire users debt profile.  This will decrease load on the DMC servers.
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
  - Log into ruby console, 
  - define a user and debt service.
  - run get_debts() and get_debts(count_only: false)
  - Verify you get the complete debt profile
  - run get_debts(count_only: true)
  - Verify you get a hash with debtCounts
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)* betamocks config, debts service, debts test

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated: /v0/apidocs
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
