### PR TITLE
BE | Ask VA Api: CRM Integration Enhancement: ICN Header Support + Retriever Improvements

### DIFF
--- a/modules/ask_va_api/app/controllers/ask_va_api/v0/inquiries_controller.rb
+++ b/modules/ask_va_api/app/controllers/ask_va_api/v0/inquiries_controller.rb
@@ -13,7 +13,7 @@ module AskVAApi
       end
 
       def show
-        inq = retriever(icn: nil).fetch_by_id(id: params[:id])
+        inq = retriever.fetch_by_id(id: params[:id])
         render json: Inquiries::Serializer.new(inq).serializable_hash, status: :ok
       end
 
@@ -28,6 +28,7 @@ module AskVAApi
       def download_attachment
         entity_class = Attachments::Entity
         att = Attachments::Retriever.new(
+          icn: current_user.icn,
           id: params[:id],
           service: mock_service,
           user_mock_data: nil,

--- a/modules/ask_va_api/app/lib/ask_va_api/attachments/retriever.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/attachments/retriever.rb
@@ -6,10 +6,11 @@ module AskVAApi
     class AttachmentsRetrieverError < StandardError; end
 
     class Retriever < BaseRetriever
-      attr_reader :id, :service
+      attr_reader :icn, :id, :service
 
-      def initialize(id:, service: nil, **args)
+      def initialize(icn:, id:, service: nil, **args)
         super(**args)
+        @icn = icn
         @id = id
         @service = service || default_service
       end
@@ -17,7 +18,7 @@ module AskVAApi
       private
 
       def default_service
-        Crm::Service.new(icn: nil)
+        Crm::Service.new(icn:)
       end
 
       def fetch_data

--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/retriever.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/retriever.rb
@@ -64,16 +64,9 @@ module AskVAApi
       # Fetch inquiry data from CRM
       def fetch_crm_data(id)
         endpoint = 'inquiries'
-        payload = build_payload(id)
+        payload = id ? { inquiryNumber: id } : {}
         response = Crm::Service.new(icn:).call(endpoint:, payload:)
         handle_response_data(response:, error_class: InquiriesRetrieverError)
-      end
-
-      # Build API payload for CRM call
-      def build_payload(id)
-        raise ArgumentError, 'Either ID or ICN must be provided' if id.nil? && icn.nil?
-
-        id ? { inquiryNumber: id } : { ICN: icn }
       end
 
       # Add category name to each inquiry based on category ID

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/attachments/retriever_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/attachments/retriever_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe AskVAApi::Attachments::Retriever do
-  subject(:retriever) { described_class.new(id: '1', entity_class: entity, user_mock_data: false) }
+  subject(:retriever) { described_class.new(icn: '123', id: '1', entity_class: entity, user_mock_data: false) }
 
   describe '#call' do
     let(:entity) { AskVAApi::Attachments::Entity }
@@ -11,7 +11,7 @@ RSpec.describe AskVAApi::Attachments::Retriever do
 
     context 'when successful' do
       before do
-        allow(Crm::Service).to receive(:new).and_return(service)
+        allow(Crm::Service).to receive(:new).with(icn: '123').and_return(service)
         allow(service).to receive(:call)
           .with(endpoint: 'attachment', payload: { id: '1' })
           .and_return({ Data: {
@@ -34,9 +34,8 @@ RSpec.describe AskVAApi::Attachments::Retriever do
       let(:failure) { Faraday::Response.new(response_body: body, status: 400) }
 
       before do
-        allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('token')
-        allow_any_instance_of(Crm::Service).to receive(:call)
-          .with(endpoint: 'attachment', payload: { id: '1' }).and_return(failure)
+        allow(Crm::Service).to receive(:new).with(icn: '123').and_return(service)
+        allow(service).to receive(:call).with(endpoint: 'attachment', payload: { id: '1' }).and_return(failure)
       end
 
       it 'raise the error' do

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/retriever_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/retriever_spec.rb
@@ -7,264 +7,144 @@ RSpec.describe AskVAApi::Inquiries::Retriever do
     described_class.new(user_mock_data:, entity_class: AskVAApi::Inquiries::Entity, icn:)
   end
 
-  def mock_response(status:, body:)
-    instance_double(Faraday::Response, status:, body: body.to_json)
+  let(:icn) { '1013694290V263188' }
+  let(:user_mock_data) { false }
+  let(:token) { 'Token' }
+  let(:redis_client) { instance_double(AskVAApi::RedisClient) }
+  let(:correspondence_retriever) { instance_double(AskVAApi::Correspondences::Retriever) }
+
+  def response_body(data)
+    {
+      Data: data,
+      Message: nil,
+      ExceptionOccurred: false,
+      ExceptionMessage: nil,
+      MessageId: SecureRandom.uuid
+    }
   end
 
-  let(:service) { instance_double(Crm::Service) }
-  let(:icn) { nil }
-  let(:user_mock_data) { false }
+  def inquiry_data
+    {
+      InquiryHasBeenSplit: true,
+      CategoryId: '5c524deb-d864-eb11-bb24-000d3a579c45',
+      CreatedOn: '8/5/2024 4:51:52 PM',
+      Id: 'a6c3af1b-ec8c-ee11-8178-001dd804e106',
+      InquiryLevelOfAuthentication: 'Personal',
+      InquiryNumber: 'A-123456',
+      InquiryStatus: 'In Progress',
+      InquiryTopic: 'Cemetery Debt',
+      LastUpdate: '1/1/1900',
+      QueueId: '9876t54',
+      QueueName: 'Debt Management Center',
+      SchoolFacilityCode: '0123',
+      SubmitterQuestion: 'My question is... ',
+      VeteranRelationship: 'self',
+      AttachmentNames: [{ Id: '012345', Name: 'File A.pdf' }]
+    }
+  end
 
   before do
-    allow(Crm::Service).to receive(:new).and_return(service)
-    allow(service).to receive(:call)
+    crm_config = Config::Options.new.merge!(
+      base_url: 'https://fake.crm.url',
+      veis_api_path: 'eis/vagov.lob.ava/api',
+      ocp_apim_subscription_key: 'fake-key',
+      service_name: 'crm'
+    )
+
+    allow(Settings).to receive_messages(
+      ask_va_api: double(crm_api: crm_config),
+      vsp_environment: 'development'
+    )
+
+    allow(Crm::CrmToken).to receive(:new).and_return(double(call: token))
+
+    allow(AskVAApi::RedisClient).to receive(:new).and_return(redis_client)
+    allow(redis_client).to receive(:fetch).with('categories_topics_subtopics')
+                                          .and_return({ Topics: [{ Name: 'Veteran Affairs  - Debt',
+                                                                   Id: '5c524deb-d864-eb11-bb24-000d3a579c45' }] })
+
+    allow(AskVAApi::Correspondences::Retriever).to receive(:new).and_return(correspondence_retriever)
+    allow(correspondence_retriever).to receive(:call).and_return([])
+  end
+
+  def stub_faraday(endpoint:, payload:, response:)
+    allow_any_instance_of(Faraday::Connection).to receive(:public_send)
+      .with(:get, endpoint, payload)
+      .and_wrap_original do |_method, *_args, &block|
+        request = double('request')
+        allow(request).to receive(:headers=).with(hash_including('X-VA-ICN' => icn))
+        block.call(request)
+        instance_double(Faraday::Response, body: response)
+      end
   end
 
   describe '#call' do
-    context 'when Crm raise an error' do
-      let(:icn) { '123' }
-      let(:body) do
-        '{"Data":null,"Message":"Data Validation: No Inquiries found by ID A-20240423-30709"' \
-          ',"ExceptionOccurred":true,"ExceptionMessage":"Data Validation: No Inquiries found by ' \
-          'ID A-20240423-30709","MessageId":"ca5b990a-63fe-407d-a364-46caffce12c1"}'
-      end
-      let(:failure) { Faraday::Response.new(response_body: body, status: 400) }
-
+    context 'when ICN is given and CRM returns valid inquiries' do
       before do
-        allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('Token')
-        allow(service).to receive(:call).and_return(failure)
+        stub_faraday(
+          endpoint: 'eis/vagov.lob.ava/api/inquiries',
+          payload: { organizationName: 'iris-dev' },
+          response: response_body([inquiry_data]).to_json
+        )
       end
 
-      it 'raise InquiriesRetrieverrError' do
-        expect { retriever.call }.to raise_error(ErrorHandler::ServiceError)
+      it 'returns an array of inquiry entities with expected attributes' do
+        result = retriever.call
+
+        expect(result).to all(be_a(AskVAApi::Inquiries::Entity))
+        expect(result.size).to eq(1)
+        expect(result.first.inquiry_number).to eq('A-123456')
+        expect(result.first.queue_name).to eq('Debt Management Center')
       end
     end
 
-    context 'when successful' do
-      let(:cache_data) do
+    context 'when ID is given and CRM returns a single inquiry' do
+      let(:id) { 'A-123456' }
+
+      before do
+        stub_faraday(
+          endpoint: 'eis/vagov.lob.ava/api/inquiries',
+          payload: { inquiryNumber: id, organizationName: 'iris-dev' },
+          response: response_body([inquiry_data]).to_json
+        )
+      end
+
+      it 'returns a single inquiry entity' do
+        result = retriever.fetch_by_id(id:)
+
+        expect(result).to be_a(AskVAApi::Inquiries::Entity)
+        expect(result.inquiry_number).to eq('A-123456')
+        expect(result.queue_name).to eq('Debt Management Center')
+      end
+    end
+
+    context 'when CRM returns error' do
+      let(:error_body) do
         {
-          Topics: [
-            {
-              Name: 'Veteran Affairs  - Debt',
-              Id: '5c524deb-d864-eb11-bb24-000d3a579c45',
-              ParentId: nil,
-              Description: nil,
-              RequiresAuthentication: true,
-              AllowAttachments: true,
-              RankOrder: 4,
-              DisplayName: 'Veteran Affairs  - Debt',
-              TopicType: 'Category',
-              ContactPreferences: []
-            }
-          ]
-        }
+          Data: nil,
+          Message: 'Data Validation: No Inquiries found',
+          ExceptionOccurred: true,
+          ExceptionMessage: 'Some exception',
+          MessageId: SecureRandom.uuid
+        }.to_json
       end
 
       before do
-        allow_any_instance_of(AskVAApi::RedisClient).to receive(:fetch)
-          .with('categories_topics_subtopics')
-          .and_return(cache_data)
+        stub_faraday(
+          endpoint: 'eis/vagov.lob.ava/api/Topics',
+          payload: anything,
+          response: { Data: [] }.to_json
+        )
+
+        stub_faraday(
+          endpoint: 'eis/vagov.lob.ava/api/inquiries',
+          payload: anything,
+          response: error_body
+        )
       end
 
-      context 'with user_mock_data' do
-        context 'when an ID is given' do
-          let(:user_mock_data) { true }
-          let(:id) { 'A-1' }
-
-          it 'returns an array object with correct data' do
-            expect(retriever.fetch_by_id(id:)).to be_a(AskVAApi::Inquiries::Entity)
-          end
-        end
-
-        context 'when an ICN is given' do
-          let(:user_mock_data) { true }
-          let(:icn) { '1008709396V637156' }
-
-          it 'returns an array object with correct data' do
-            expect(retriever.call.first).to be_a(AskVAApi::Inquiries::Entity)
-          end
-        end
-      end
-
-      context 'with Crm::Service' do
-        context 'when an ID is given' do
-          let(:id) { '123' }
-          let(:inquiry_data) do
-            {
-              InquiryHasBeenSplit: true,
-              CategoryId: '5c524deb-d864-eb11-bb24-000d3a579c45',
-              CreatedOn: '8/5/2024 4:51:52 PM',
-              Id: 'a6c3af1b-ec8c-ee11-8178-001dd804e106',
-              InquiryLevelOfAuthentication: 'Personal',
-              InquiryNumber: 'A-123456',
-              InquiryStatus: 'In Progress',
-              InquiryTopic: 'Cemetery Debt',
-              LastUpdate: '1/1/1900',
-              QueueId: '9876t54',
-              QueueName: 'Debt Management Center',
-              SchoolFacilityCode: '0123',
-              SubmitterQuestion: 'My question is... ',
-              VeteranRelationship: 'self',
-              AttachmentNames: [{ Id: '012345', Name: 'File A.pdf' }]
-            }
-          end
-          let(:response) { { Data: [inquiry_data] } }
-          let(:correspondence_data) do
-            {
-              Id: 'f4b12ee3-93bb-ed11-9886-001dd806a6a7',
-              ModifiedOn: '3/5/2023 8:25:49 PM',
-              StatusReason: 'Sent',
-              Description: 'Dear aminul, Thank you for submitting your ' \
-                           'Inquiry with the U.S. Department of Veteran Affairs.',
-              MessageType: 'Notification',
-              EnableReply: true,
-              AttachmentNames: nil
-            }
-          end
-          let(:correspondence) { AskVAApi::Correspondences::Entity.new(correspondence_data) }
-
-          before do
-            allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('Token')
-            allow(service).to receive(:call).and_return(response)
-            allow_any_instance_of(AskVAApi::Correspondences::Retriever).to receive(:call)
-              .and_return([correspondence])
-          end
-
-          it 'returns an inquiry entity with expected attributes' do
-            result = retriever.fetch_by_id(id:)
-
-            # Inquiry-level expectations
-            expect(result).to be_a(AskVAApi::Inquiries::Entity)
-            expect(result.id).to eq(inquiry_data[:Id])
-            expect(result.inquiry_number).to eq(inquiry_data[:InquiryNumber])
-            expect(result.status).to eq(inquiry_data[:InquiryStatus])
-            expect(result.category_name).to eq('Veteran Affairs  - Debt')
-            expect(result.inquiry_topic).to eq(inquiry_data[:InquiryTopic])
-            expect(result.created_on).to eq(inquiry_data[:CreatedOn])
-            expect(result.last_update).to eq(inquiry_data[:LastUpdate])
-            expect(result.submitter_question).to eq(inquiry_data[:SubmitterQuestion])
-            expect(result.attachments).to eq(inquiry_data[:AttachmentNames])
-
-            # Correspondence-level expectations using correspondence_data
-            correspondence_result = result.correspondences.first
-            expect(correspondence_result).to be_a(AskVAApi::Correspondences::Entity)
-            expect(correspondence_result.id).to eq(correspondence_data[:Id])
-            expect(correspondence_result.description).to eq(correspondence_data[:Description])
-            expect(correspondence_result.status_reason).to eq(correspondence_data[:StatusReason])
-            expect(correspondence_result.enable_reply).to eq(correspondence_data[:EnableReply])
-            expect(correspondence_result.message_type).to eq(correspondence_data[:MessageType])
-            expect(correspondence_result.modified_on).to eq(correspondence_data[:ModifiedOn])
-
-            # Queue expectations
-            expect(result.queue_id).to eq(inquiry_data[:QueueId])
-            expect(result.queue_name).to eq(inquiry_data[:QueueName])
-            expect(result.veteran_relationship).to eq(inquiry_data[:VeteranRelationship])
-          end
-
-          context 'when Correspondence::Retriever returns an error' do
-            before do
-              allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('Token')
-              allow(service).to receive(:call).and_return(response)
-              allow_any_instance_of(AskVAApi::Correspondences::Retriever).to receive(:call)
-                .and_return('Data Validation: No Inquiry Found')
-            end
-
-            it 'returns correspondences as an empty array' do
-              inquiry = retriever.fetch_by_id(id:)
-
-              expect(inquiry.correspondences).to eq([])
-            end
-          end
-        end
-
-        context 'when an ICN is given' do
-          let(:icn) { '1013694290V263188' }
-          let(:response) do
-            {
-              Data: [
-                {
-                  InquiryHasBeenSplit: true,
-                  CategoryId: '5c524deb-d864-eb11-bb24-000d3a579c45',
-                  CreatedOn: '8/5/2024 4:51:52 PM',
-                  Id: 'a6c3af1b-ec8c-ee11-8178-001dd804e106',
-                  InquiryLevelOfAuthentication: 'Personal',
-                  InquiryNumber: 'A-123456',
-                  InquiryStatus: 'In Progress',
-                  InquiryTopic: 'Cemetery Debt',
-                  LastUpdate: '1/1/1900',
-                  QueueId: '9876t54',
-                  QueueName: 'Debt Management Center',
-                  SchoolFacilityCode: '0123',
-                  SubmitterQuestion: 'My question is... ',
-                  VeteranRelationship: 'self',
-                  AttachmentNames: [
-                    {
-                      Id: '012345',
-                      Name: 'File A.pdf'
-                    }
-                  ]
-                },
-                {
-                  InquiryHasBeenSplit: true,
-                  CategoryId: '5c524deb-d864-eb11-bb24-000d3a579c45',
-                  CreatedOn: '8/5/2024 4:51:52 PM',
-                  Id: 'a6c3af1b-ec8c-ee11-8178-001dd804e106',
-                  InquiryLevelOfAuthentication: 'Personal',
-                  InquiryNumber: 'A-123456',
-                  InquiryStatus: 'In Progress',
-                  InquiryTopic: 'Cemetery Debt',
-                  LastUpdate: '1/1/1900',
-                  QueueId: '9876t54',
-                  QueueName: 'Debt Management Center',
-                  SchoolFacilityCode: '0123',
-                  SubmitterQuestion: 'My question is... ',
-                  VeteranRelationship: 'self',
-                  AttachmentNames: [
-                    {
-                      Id: '012345',
-                      Name: 'File A.pdf'
-                    }
-                  ]
-                },
-                {
-                  InquiryHasBeenSplit: true,
-                  CategoryId: '5c524deb-d864-eb11-bb24-000d3a579c45',
-                  CreatedOn: '8/5/2024 4:51:52 PM',
-                  Id: 'a6c3af1b-ec8c-ee11-8178-001dd804e106',
-                  InquiryLevelOfAuthentication: 'Personal',
-                  InquiryNumber: 'A-123456',
-                  InquiryStatus: 'In Progress',
-                  InquiryTopic: 'Cemetery Debt',
-                  LastUpdate: '1/1/1900',
-                  QueueId: '9876t54',
-                  QueueName: 'Debt Management Center',
-                  SchoolFacilityCode: '0123',
-                  SubmitterQuestion: 'My question is... ',
-                  VeteranRelationship: 'self',
-                  AttachmentNames: [
-                    {
-                      Id: '012345',
-                      Name: 'File A.pdf'
-                    }
-                  ]
-                }
-              ],
-              Message: nil,
-              ExceptionOccurred: false,
-              ExceptionMessage: nil,
-              MessageId: '3779a3c5-15a5-4846-8198-d499a0bbfe1f'
-            }
-          end
-
-          before do
-            allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('Token')
-            allow(service).to receive(:call).and_return(response)
-          end
-
-          it 'returns an array object with correct data' do
-            expect(retriever.call.first).to be_a(AskVAApi::Inquiries::Entity)
-          end
-        end
+      it 'raises a ServiceError when response indicates failure' do
+        expect { retriever.call }.to raise_error(ErrorHandler::ServiceError)
       end
     end
   end

--- a/modules/ask_va_api/spec/services/crm/service_spec.rb
+++ b/modules/ask_va_api/spec/services/crm/service_spec.rb
@@ -3,69 +3,59 @@
 require 'rails_helper'
 
 RSpec.describe Crm::Service do
-  let(:service) { described_class.new(icn: '123') }
+  let(:icn) { '123' }
+  let(:mock_data) do
+    {
+      data: [
+        {
+          respond_reply_id: 'Original Question',
+          inquiryNumber: 'A-1',
+          inquiryTopic: 'Topic',
+          inquiryProcessingStatus: 'Close',
+          lastUpdate: '08/07/23',
+          submitterQuestions: 'When is Sergeant Joe Smith birthday?',
+          attachments: [{ activity: 'activity_1', date_sent: '08/7/23' }],
+          icn: '0001740097'
+        }
+      ]
+    }
+  end
+  let(:service) { described_class.new(icn:) }
+  let(:endpoint) { 'inquiries' }
 
   def mock_response(status:, body:)
     instance_double(Faraday::Response, status:, body: body.to_json)
   end
 
-  describe '#call' do
-    let(:endpoint) { 'inquiries' }
+  shared_examples 'crm request with header' do |env, expected_org|
+    let(:response) { mock_response(status: 200, body: mock_data) }
 
-    context 'when server response successful' do
-      context 'with valid JSON' do
-        let(:response) do
-          mock_response(
-            status: 200,
-            body: {
-              data: [
-                {
-                  respond_reply_id: 'Original Question',
-                  inquiryNumber: 'A-1',
-                  inquiryTopic: 'Topic',
-                  inquiryProcessingStatus: 'Close',
-                  lastUpdate: '08/07/23',
-                  submitterQuestions: 'When is Sergeant Joe Smith birthday?',
-                  attachments: [{ activity: 'activity_1', date_sent: '08/7/23' }],
-                  icn: '0001740097'
-                }
-              ]
-            }
-          )
-        end
+    before do
+      allow(Settings).to receive(:vsp_environment).and_return(env)
+      allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('token')
 
-        context 'when on local/dev env' do
-          before do
-            allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('token')
-            allow_any_instance_of(Faraday::Connection).to receive(:get).with('eis/vagov.lob.ava/api/inquiries',
-                                                                             icn: '123',
-                                                                             organizationName: 'iris-dev')
-                                                                       .and_return(response)
-          end
-
-          it 'returns a parsed response' do
-            res = JSON.parse(response.body, symbolize_names: true)
-            expect(service.call(endpoint:)[:data].first).to eq(res[:data].first)
-          end
-        end
-
-        context 'when on staging env' do
-          before do
-            allow(Settings).to receive(:vsp_environment).and_return('staging')
-            allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('token')
-            allow_any_instance_of(Faraday::Connection).to receive(:get).with('eis/vagov.lob.ava/api/inquiries',
-                                                                             icn: '123',
-                                                                             organizationName: 'veft-preprod')
-                                                                       .and_return(response)
-          end
-
-          it 'returns a parsed response' do
-            res = JSON.parse(response.body, symbolize_names: true)
-            expect(service.call(endpoint:)[:data].first).to eq(res[:data].first)
-          end
-        end
+      allow_any_instance_of(Faraday::Connection).to receive(:get).with(
+        'eis/vagov.lob.ava/api/inquiries',
+        organizationName: expected_org
+      ) do |_, _, &block|
+        request = double('request')
+        expect(request).to receive(:headers=).with(hash_including('X-VA-ICN' => icn))
+        block.call(request)
+        response
       end
     end
+
+    it "sends ICN header and returns parsed response in #{env} env" do
+      res = JSON.parse(response.body, symbolize_names: true)
+      expect(service.call(endpoint:)[:data].first).to eq(res[:data].first)
+    end
+  end
+
+  describe '#call' do
+    include_examples 'crm request with header', 'development', 'iris-dev'
+    include_examples 'crm request with header', 'test', 'iris-dev'
+    include_examples 'crm request with header', 'staging', 'veft-preprod'
+    include_examples 'crm request with header', 'production', 'veft'
 
     context 'when the server returns an error' do
       let(:resp) { mock_response(body: { error: 'server error' }, status: 500) }
@@ -74,15 +64,83 @@ RSpec.describe Crm::Service do
       before do
         allow(Settings).to receive(:vsp_environment).and_return('development')
         allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('token')
-        allow_any_instance_of(Faraday::Connection).to receive(:get).with('eis/vagov.lob.ava/api/inquiries',
-                                                                         { icn: '123',
-                                                                           organizationName: 'iris-dev' })
-                                                                   .and_raise(exception)
+
+        allow_any_instance_of(Faraday::Connection).to receive(:get).with(
+          'eis/vagov.lob.ava/api/inquiries',
+          { organizationName: 'iris-dev' }
+        ).and_raise(exception)
       end
 
-      it 'raises a service error' do
+      it 'returns an error response with matching status' do
         response = service.call(endpoint:)
         expect(response.status).to eq(resp.status)
+      end
+    end
+
+    context 'when X-VA-ICN header is missing' do
+      let(:error_body) { { Message: 'Missing required header: X-VA-ICN' } }
+      let(:resp) { mock_response(status: 400, body: error_body) }
+      let(:exception) { Common::Exceptions::BackendServiceException.new(nil, {}, resp.status, resp.body) }
+
+      before do
+        allow(Settings).to receive(:vsp_environment).and_return('development')
+        allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('token')
+
+        allow_any_instance_of(Faraday::Connection).to receive(:get).and_raise(exception)
+      end
+
+      it 'raises an error when ICN header is missing' do
+        response = service.call(endpoint:)
+        expect(response.status).to eq(400)
+        expect(response.body).to include('Missing required header')
+      end
+    end
+
+    context 'when ICN is empty while retrieving by Inquiry Number' do
+      let(:service) { described_class.new(icn: '') }
+      let(:error_body) do
+        { Message: 'Submitter ICN header value cannot be empty if retrieving by Inquiry Number' }
+      end
+      let(:resp) { mock_response(status: 400, body: error_body) }
+      let(:exception) { Common::Exceptions::BackendServiceException.new(nil, {}, resp.status, resp.body) }
+
+      before do
+        allow(Settings).to receive(:vsp_environment).and_return('production')
+        allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('token')
+
+        allow_any_instance_of(Faraday::Connection).to receive(:get).and_raise(exception)
+      end
+
+      it 'raises an error for empty ICN with inquiry number search' do
+        response = service.call(endpoint:, payload: { inquiryNumber: 'A-20250221-05679' })
+        expect(response.status).to eq(400)
+        expect(response.body).to include('ICN header value cannot be empty')
+      end
+    end
+
+    context 'when inquiry does not belong to the user' do
+      let(:mock_success_body) do
+        {
+          Data: [],
+          Message: nil,
+          ExceptionOccurred: false,
+          ExceptionMessage: nil,
+          MessageId: 'e6e69752-6a20-4ba3-a437-90eb67e8b127'
+        }
+      end
+      let(:response) { mock_response(status: 200, body: mock_success_body) }
+
+      before do
+        allow(Settings).to receive(:vsp_environment).and_return('production')
+        allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('token')
+
+        allow_any_instance_of(Faraday::Connection).to receive(:get).and_return(response)
+      end
+
+      it 'returns an empty data array if inquiry does not belong to the user' do
+        res = service.call(endpoint:, payload: { inquiryNumber: 'A-20250221-05679' })
+        expect(res[:Data]).to eq([])
+        expect(res[:MessageId]).to eq('e6e69752-6a20-4ba3-a437-90eb67e8b127')
       end
     end
   end


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

CRM Integration Enhancement: ICN Header Support + Retriever Improvements

This PR enhances how ICN (Integration Control Number) is handled across AskVA API requests to CRM. It ensures that all service calls include the `X-VA-ICN` header and improves the consistency and reliability of inquiry-related data retrieval.

- **CRM Service**: Adds `X-VA-ICN` to all outgoing headers for user identification in CRM logs and filtering.
- **InquiriesController**: Updated to pass ICN from the authenticated user into the retriever logic.
- **Inquiries::Retriever**: Refactored to support ICN-aware lookups and improved error propagation.
- **Attachments::Retriever**: Aligned with the new CRM service structure and header inclusion.

### ✅ Why It Matters
- Provides a more traceable link between the front-end user and CRM entries.
- Enables CRM-side debugging and filtering by ICN.
- Supports future-proofing for potential access control or audit mechanisms.
- Lays groundwork for improving user-specific caching.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/ask-va/issues/1743

## Testing done

- [x] *New code is covered by unit tests*
- [x] Verified CRM service includes `X-VA-ICN` in headers using Faraday mocks.
- [x] Added unit and integration tests for both success and failure flows in retrievers and controller.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected