### PR TITLE
Schedule Form0781StateSnapshotJob to run every hour [#104645]

### DIFF
--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -84,6 +84,9 @@ PERIODIC_JOBS = lambda { |mgr| # rubocop:disable Metrics/BlockLength
   # Log a snapshot of everything in a full failure type state
   mgr.register('5 * * * *', 'Form526FailureStateSnapshotJob')
 
+  # Log a snapshot of Form 0781 submission metrics
+  mgr.register('5 * * * *', 'Form0781StateSnapshotJob')
+
   # Clear out processed 22-1990 applications that are older than 1 month
   mgr.register('0 0 * * *', 'EducationForm::DeleteOldApplications')
 


### PR DESCRIPTION
## Description
This PR adds the Form0781StateSnapshotJob to the periodic jobs scheduler, setting it to run at 5 minutes past every hour - the same schedule as the Form526FailureStateSnapshotJob.

## Motivation and Context
The Form0781StateSnapshotJob was previously created to collect metrics about Form 0781 submissions, but it wasn't scheduled to run automatically. This PR fixes that by adding it to the periodic jobs list.

After this change is deployed, metrics will be available in DataDog with names like:
- vets_api.statsd.form0781_state_snapshot_new_0781_in_progress_forms_count
- vets_api.statsd.form0781_state_snapshot_new_0781_submissions_count

## How Has This Been Tested?
The job itself has proper test coverage in Form0781StateSnapshotJob spec.

## Acceptance Criteria
- [ ] Form0781StateSnapshotJob runs every hour at 5 minutes past the hour
- [ ] Metrics appear in DataDog after deployment

## Related Issues
Resolves #104645 (Add Form0781StateSnapshotJob to scheduled jobs)