### PR TITLE
Extra tests for VAOS referral detail spec

### DIFF
--- a/modules/vaos/spec/models/ccra/referral_detail_spec.rb
+++ b/modules/vaos/spec/models/ccra/referral_detail_spec.rb
@@ -3,6 +3,18 @@
 require 'rails_helper'
 
 describe Ccra::ReferralDetail do
+  # Shared example for testing nil attributes
+  shared_examples 'has nil attributes' do
+    it 'sets all attributes to nil' do
+      # Use reflection to iterate through the object's instance variables
+      instance_variables = subject.instance_variables.reject { |v| v == :@uuid }
+      instance_variables.each do |var|
+        value = subject.instance_variable_get(var)
+        expect(value).to be_nil, "Expected #{var} to be nil, but got #{value.inspect}"
+      end
+    end
+  end
+
   describe '#initialize' do
     subject { described_class.new(valid_attributes) }
 
@@ -68,6 +80,18 @@ describe Ccra::ReferralDetail do
       expect(subject.referring_facility_address[:zip]).to eq('87106')
     end
 
+    context 'with missing Referral key' do
+      subject { described_class.new({}) }
+
+      include_examples 'has nil attributes'
+    end
+
+    context 'with nil Referral value' do
+      subject { described_class.new({ 'Referral' => nil }) }
+
+      include_examples 'has nil attributes'
+    end
+
     context 'when phone number comes from provider info' do
       subject { described_class.new(provider_phone_attributes) }
 
@@ -98,6 +122,24 @@ describe Ccra::ReferralDetail do
         attributes = { 'Referral' => { 'APPTYesNo1' => 'N' } }
         detail = described_class.new(attributes)
         expect(detail.has_appointments).to be(false)
+      end
+
+      it 'handles nil value' do
+        attributes = { 'Referral' => { 'APPTYesNo1' => nil } }
+        detail = described_class.new(attributes)
+        expect(detail.has_appointments).to be_nil
+      end
+
+      it 'handles blank value' do
+        attributes = { 'Referral' => { 'APPTYesNo1' => '' } }
+        detail = described_class.new(attributes)
+        expect(detail.has_appointments).to be_nil
+      end
+
+      it 'handles invalid value' do
+        attributes = { 'Referral' => { 'APPTYesNo1' => 'X' } }
+        detail = described_class.new(attributes)
+        expect(detail.has_appointments).to be_nil
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Adding extra tests to referral detail spec.
- Team: UAE Check In

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/107260

## Testing done
- [ ] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
