### PR TITLE
Fixed failing VAOS referrals test

### DIFF
--- a/modules/vaos/spec/controllers/v2/referrals_controller_spec.rb
+++ b/modules/vaos/spec/controllers/v2/referrals_controller_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe VAOS::V2::ReferralsController, type: :request do
         expect(first_referral['type']).to eq('referrals')
         expect(first_referral['attributes']['categoryOfCare']).to eq('CARDIOLOGY')
         expect(first_referral['attributes']['referralNumber']).to eq('5682')
-        expect(first_referral['attributes']['expirationDate']).to eq('2025-06-13')
+        expect(first_referral['attributes']['expirationDate']).to eq((Date.current + 60.days).strftime('%Y-%m-%d'))
       end
 
       context 'with a custom status parameter' do


### PR DESCRIPTION
## Summary
- *This work is behind a feature toggle (flipper): NO*
- Fixed failing VAOS referrals test
  - Unknown how this got passed the build
- UAE Check in

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/107260

## Testing done
- [x] *code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

