### PR TITLE
Adding protection for nil vals

### DIFF
--- a/lib/evss/disability_compensation_form/form0781.rb
+++ b/lib/evss/disability_compensation_form/form0781.rb
@@ -53,7 +53,6 @@ module EVSS
       end
 
       def create_form_v2
-        Rails.logger.info("Form0781v2: Form content: #{@form_content}")
         events = @form_content['events'].nil? ? nil : sanitize_details(@form_content['events'])
         behavior_details = @form_content['behaviorsDetails'].nil? ? nil : sanitize_hash_values(@form_content['behaviorsDetails'])
         additional_info = @form_content['additionalInformation'].nil? ? nil : sanitize_text(@form_content['additionalInformation'])

--- a/lib/evss/disability_compensation_form/form0781.rb
+++ b/lib/evss/disability_compensation_form/form0781.rb
@@ -54,19 +54,20 @@ module EVSS
 
       def create_form_v2
         events = @form_content['events'].nil? ? nil : sanitize_details(@form_content['events'])
-        behavior_details = @form_content['behaviorsDetails'].nil? ? nil : sanitize_hash_values(@form_content['behaviorsDetails'])
-        additional_info = @form_content['additionalInformation'].nil? ? nil : sanitize_text(@form_content['additionalInformation'])
+        bd = @form_content['behaviorsDetails'].nil? ? nil : sanitize_hash_values(@form_content['behaviorsDetails'])
+        ai = @form_content['additionalInformation'].nil? ? nil : sanitize_text(@form_content['additionalInformation'])
+
         prepare_veteran_info.merge({
                                      'eventTypes' => @form_content['eventTypes'],
                                      'events' => events,
                                      'behaviors' => aggregate_behaviors,
-                                     'behaviorsDetails' => behavior_details,
+                                     'behaviorsDetails' => bd,
                                      'evidence' => aggregate_supporting_evidence,
                                      'treatmentNoneCheckbox' => @form_content['treatmentNoneCheckbox'],
                                      'treatmentProviders' => aggregate_treatment_providers,
                                      'treatmentProvidersDetails' => @form_content['treatmentProvidersDetails'],
                                      'optionIndicator' => @form_content['optionIndicator'],
-                                     'additionalInformation' => additional_info
+                                     'additionalInformation' => ai
                                    })
       end
 

--- a/lib/evss/disability_compensation_form/form0781.rb
+++ b/lib/evss/disability_compensation_form/form0781.rb
@@ -53,17 +53,21 @@ module EVSS
       end
 
       def create_form_v2
+        Rails.logger.info("Form0781v2: Form content: #{@form_content}")
+        events = @form_content['events'].nil? ? nil : sanitize_details(@form_content['events'])
+        behavior_details = @form_content['behaviorsDetails'].nil? ? nil : sanitize_hash_values(@form_content['behaviorsDetails'])
+        additional_info = @form_content['additionalInformation'].nil? ? nil : sanitize_text(@form_content['additionalInformation'])
         prepare_veteran_info.merge({
                                      'eventTypes' => @form_content['eventTypes'],
-                                     'events' => sanitize_details(@form_content['events']),
+                                     'events' => events,
                                      'behaviors' => aggregate_behaviors,
-                                     'behaviorsDetails' => sanitize_hash_values(@form_content['behaviorsDetails']),
+                                     'behaviorsDetails' => behavior_details,
                                      'evidence' => aggregate_supporting_evidence,
                                      'treatmentNoneCheckbox' => @form_content['treatmentNoneCheckbox'],
                                      'treatmentProviders' => aggregate_treatment_providers,
                                      'treatmentProvidersDetails' => @form_content['treatmentProvidersDetails'],
                                      'optionIndicator' => @form_content['optionIndicator'],
-                                     'additionalInformation' => sanitize_text(@form_content['additionalInformation'])
+                                     'additionalInformation' => additional_info
                                    })
       end
 


### PR DESCRIPTION
This change fixes a bug where the submission will error if data is not present, which happens in certain states of submission. 