### PR TITLE
fix: enable STDOUT logging for development environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,9 +82,9 @@ Rails.application.configure do
   config.rails_semantic_logger.started    = true
   config.rails_semantic_logger.processing = true
   config.rails_semantic_logger.rendered   = true
-  # Prepend all log lines with the following tags.
-  config.log_tags = {
-    request_id: :request_id,
-    correlation_id: ->(request) { request.headers['Correlation-ID'] }
-  }
+  config.semantic_logger.add_appender(
+    io: $stdout,
+    level: config.log_level,
+    formatter: config.rails_semantic_logger.format
+  )
 end


### PR DESCRIPTION
Redirects logs to STDOUT to prevent Foreman from eating request logs.

I also removed tagging (just in dev) which wasn't useful as it would display 'request_id' instead of the actual request ID value (same issue with correlation_id).
