### PR TITLE
106833 detect dead MDOT token and pull a new one

### DIFF
--- a/lib/mdot/client.rb
+++ b/lib/mdot/client.rb
@@ -135,9 +135,7 @@ module MDOT
 
     def handle_token
       existing_token = MDOT::Token.find(@user.uuid)
-      if !existing_token || existing_token.ttl < 5
-        get_supplies
-      end
+      get_supplies if !existing_token || existing_token.ttl < 5
       MDOT::Token.find(@user.uuid).try(:token)
     end
   end

--- a/lib/mdot/client.rb
+++ b/lib/mdot/client.rb
@@ -75,7 +75,7 @@ module MDOT
 
     def submission_headers
       {
-        VAAPIKEY: MDOT::Token.find(@user.uuid).token
+        VAAPIKEY: handle_token
       }
     end
 
@@ -131,6 +131,14 @@ module MDOT
       else
         raise error
       end
+    end
+
+    def handle_token
+      existing_token = MDOT::Token.find(@user.uuid)
+      if !existing_token || existing_token.ttl < 5
+        get_supplies
+      end
+      MDOT::Token.find(@user.uuid).try(:token)
     end
   end
 end

--- a/spec/lib/mdot/client_spec.rb
+++ b/spec/lib/mdot/client_spec.rb
@@ -376,5 +376,37 @@ describe MDOT::Client, type: :mdot_helpers do
         end
       end
     end
+
+    context 'with a nil token' do
+      it 'generates a new token' do
+        VCR.use_cassette(
+          'mdot/get_supplies_200',
+          match_requests_on: %i[method uri]
+        ) do
+          VCR.use_cassette('mdot/submit_order', match_requests_on: %i[method uri]) do
+            # set_mdot_token_for(user)
+            res = subject.submit_order(valid_order)
+            expect(res[0]['status']).to eq('Order Processed')
+            expect(res[0]['order_id']).to be_an(Integer)
+          end
+        end
+      end
+    end
+
+    context 'with an expired token' do
+      it 'generates a new token' do
+        VCR.use_cassette(
+          'mdot/get_supplies_200',
+          match_requests_on: %i[method uri]
+        ) do
+          VCR.use_cassette('mdot/submit_order', match_requests_on: %i[method uri]) do
+            set_expired_mdot_token_for(user)
+            res = subject.submit_order(valid_order)
+            expect(res[0]['status']).to eq('Order Processed')
+            expect(res[0]['order_id']).to be_an(Integer)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/support/mdot_helpers.rb
+++ b/spec/support/mdot_helpers.rb
@@ -7,4 +7,10 @@ module MDOTHelpers
     jwt = ::MDOT::Token.find_or_build(user.uuid)
     jwt.update(token:, uuid: user.uuid)
   end
+
+  def set_expired_mdot_token_for(user, token = 'abcd1234abcd1234abcd1234')
+    jwt = ::MDOT::Token.find_or_build(user.uuid)
+    jwt.update(token:, uuid: user.uuid)
+    jwt.expire(5)
+  end
 end


### PR DESCRIPTION
## Summary
We want to generate a new MDOT token if the current token expires instead of erroring out.

## Related issue(s)
[106833](https://github.com/department-of-veterans-affairs/va.gov-team/issues/106833)

## Testing done
specs added

## What areas of the site does it impact?
Supply Reorder Application, MDOT

## Acceptance criteria
When trying to submit a supply reorder with a dead token, attempt to generate a new token by getting supplies before throwing error.
