### PR TITLE
BE | Ask VA Api: Remove `skip_before_action :verify_authenticity_token` from high-risk…

### DIFF
--- a/modules/ask_va_api/app/controllers/ask_va_api/v0/address_validation_controller.rb
+++ b/modules/ask_va_api/app/controllers/ask_va_api/v0/address_validation_controller.rb
@@ -9,7 +9,6 @@ module AskVAApi
   module V0
     class AddressValidationController < ::ApplicationController
       skip_before_action :authenticate
-      skip_before_action :verify_authenticity_token
       service_tag 'profile'
 
       def create

--- a/modules/ask_va_api/app/controllers/ask_va_api/v0/health_facilities_controller.rb
+++ b/modules/ask_va_api/app/controllers/ask_va_api/v0/health_facilities_controller.rb
@@ -6,7 +6,6 @@ module AskVAApi
   module V0
     class HealthFacilitiesController < FacilitiesApi::ApplicationController
       around_action :handle_exceptions
-      skip_before_action :verify_authenticity_token
 
       def search
         params[:facilityIds] = params[:ids] if params[:ids].present?

--- a/modules/ask_va_api/app/controllers/ask_va_api/v0/inquiries_controller.rb
+++ b/modules/ask_va_api/app/controllers/ask_va_api/v0/inquiries_controller.rb
@@ -5,7 +5,6 @@ module AskVAApi
     class InquiriesController < ApplicationController
       around_action :handle_exceptions
       skip_before_action :authenticate, only: %i[unauth_create status]
-      skip_before_action :verify_authenticity_token, only: %i[unauth_create]
 
       def index
         inquiries = retriever.call


### PR DESCRIPTION
## Summary

This PR removes `skip_before_action :verify_authenticity_token` from the following controllers:

- `AddressValidationController`
- `HealthFacilitiesController`
- `InquiriesController`

These controllers previously bypassed Rails’ CSRF protection, exposing the application to potential **Cross-Site Request Forgery (CSRF)** vulnerabilities. This is especially risky given that these endpoints process or reference:

- Personally Identifiable Information (PII)
- Inquiry messages and metadata
- Potential health-related or location-specific data

### Why This Matters

Removing this skip ensures that all state-changing requests to these controllers must include a valid CSRF token, aligning with Rails' default security posture and **VA 6500/NIST 800-53** compliance expectations.

### Compliance Reference

- **NIST 800-53**: AC-3 (Access Enforcement), SC-23 (Session Integrity)
- **VA 6500 Handbook**: Application Security Requirements
- **OWASP Top 10**: A01 - Broken Access Control, A05 - Security Misconfiguration

### Risk Level: HIGH

Failure to validate authenticity tokens on these routes could allow malicious sites to trick authenticated users into unintentionally performing actions — potentially leaking or altering sensitive information.

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)