### PR TITLE
Add feature flag mobile_veteran_status_stage_1

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1823,6 +1823,9 @@ features:
   mobile_push_register_logging:
     actor_type: user
     description: For mobile app, logs push register errors for debugging
+  mobile_veteran_status_stage_1:
+    actor_type: user
+    description: For mobile app, enables the stage 1 features of the veteran status card
   form526_backup_submission_temp_killswitch:
     actor_type: user
     description: Provide a temporary killswitch to disable form526 backup submission if something were to go awry


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
  - YES
- This change adds a feature flag called `mobile_veteran_status_stage_1`; this feature flag has no features behind it yet.
- *(Which team do you work for, does your team own the maintenance of this component?)*
  - Mobile Feature Support
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-iir/issues/1569

## Testing done

- This flipper was added with no code behind it - there is no work to test yet.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
