### PR TITLE
Add feature toggle for logging Vet Status Card pdf download events

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1704,6 +1704,9 @@ features:
     actor_type: user
     description: Conditionally display the "Welcome to VA" message to new (LOA1 or LOA3) users
     enable_in_development: false
+  vet_status_pdf_logging:
+    actor_type: user
+    description: Enables the Veteran Status Card to log PDF download events/failures
   vre_trigger_action_needed_email:
     actor_type: user
     description: Set whether to enable VANotify email to Veteran for VRE failure exhaustion


### PR DESCRIPTION
## Summary

- This change introduces a feature toggle that will be used for testing out FE Datadog logging of PDF generation events for the Veteran Status Card app.
- I work on the IIR Product team and we currently own Veteran Status Card.

## Related issue(s)

- [1598](https://github.com/department-of-veterans-affairs/va-iir/issues/1598)

## Testing done

- This only introduces the feature toggle that will be used in future changes, so no tests at this time.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
This only impacts the list of feature toggles available.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
