### PR TITLE
BE | Ask VA Api: Restrict /inquiries/:id and download_attachment endpoints to lower env

### DIFF
--- a/modules/ask_va_api/app/controllers/ask_va_api/v0/inquiries_controller.rb
+++ b/modules/ask_va_api/app/controllers/ask_va_api/v0/inquiries_controller.rb
@@ -12,6 +12,10 @@ module AskVAApi
       end
 
       def show
+        if Settings.vsp_environment == 'production'
+          render json: { error: 'This endpoint is not available in production.' }, status: :forbidden and return
+        end
+
         inq = retriever.fetch_by_id(id: params[:id])
         render json: Inquiries::Serializer.new(inq).serializable_hash, status: :ok
       end
@@ -25,6 +29,10 @@ module AskVAApi
       end
 
       def download_attachment
+        if Settings.vsp_environment == 'production'
+          render json: { error: 'This endpoint is not available in production.' }, status: :forbidden and return
+        end
+
         entity_class = Attachments::Entity
         att = Attachments::Retriever.new(
           icn: current_user.icn,


### PR DESCRIPTION
## Summary

The following endpoints are temporarily shutdown for `production`:
- `GET /inquiries/:id` (`#show`)
- `GET /download_attachment` (`#download_attachment`)

To reduce exposure risk in production, especially related to potential IDOR and attachment handling vulnerabilities, access to these endpoints is now **restricted to lower environments only**.

### Changes

- Added environment guards (`Settings.vsp_environment`) to both the `#show` and `#download_attachment` actions in `InquiriesController`
- Both endpoints will return a `403 Forbidden` response in production
- Remain accessible in **non-production environments** (e.g., dev, staging, sandbox)

### Production Behavior

When accessed in production, the following response is returned:

```json
{
  "error": "This endpoint is not available in production."
}
```

### Risk Level

**Low** – These changes are isolated to environment-specific access logic and do not affect other endpoints or core functionality.

## Related issue(s)



## Testing done

- [ ] *New code is covered by unit tests*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
