### PR TITLE
Update recent facilities look back logic

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -213,10 +213,7 @@ module VAOS
       end
 
       def get_sorted_recent_appointments
-        appointments = get_appointments(1.year.ago, 1.year.from_now, 'booked,fulfilled,arrived,proposed')
-        if appointments[:data].length.zero?
-          appointments = get_appointments(3.years.ago, Date.current.end_of_day.yesterday, 'booked,fulfilled,arrived')
-        end
+        appointments = get_appointments(1.year.ago, Date.current.end_of_day.yesterday, 'booked,fulfilled,arrived')
         sort_recent_appointments(appointments[:data])
       end
 

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -865,22 +865,6 @@ describe VAOS::V2::AppointmentsService do
       end
     end
 
-    context 'when old appointments are available' do
-      before do
-        allow(instance_of_class)
-          .to receive(:get_appointments).with(anything, anything, 'booked,fulfilled,arrived,proposed')
-          .and_return({ data: [] })
-        allow(instance_of_class)
-          .to receive(:get_appointments).with(anything, anything, 'booked,fulfilled,arrived')
-          .and_return({ data: [mock_appointment_one, mock_appointment_two, mock_appointment_three] })
-      end
-
-      it 'returns the recent sorted clinic appointments' do
-        expect(subject).to eq([mock_appointment_three, mock_appointment_one, mock_appointment_two])
-        expect(instance_of_class).to have_received(:get_appointments).exactly(2).times
-      end
-    end
-
     context 'when no appointments are available' do
       before do
         allow(instance_of_class).to receive(:get_appointments).and_return({ data: [] })
@@ -888,7 +872,7 @@ describe VAOS::V2::AppointmentsService do
 
       it 'returns nil' do
         expect(subject.first).to be_nil
-        expect(instance_of_class).to have_received(:get_appointments).exactly(2).times
+        expect(instance_of_class).to have_received(:get_appointments).once
       end
     end
   end

--- a/spec/support/vcr_cassettes/vaos/v2/mobile_facility_service/get_facilities_200_sort_by_recent_locations.yml
+++ b/spec/support/vcr_cassettes/vaos/v2/mobile_facility_service/get_facilities_200_sort_by_recent_locations.yml
@@ -166,7 +166,7 @@ http_interactions:
   recorded_at: Thu, 22 Jun 2023 15:44:07 GMT
 - request:
     method: get
-    uri: https://veteran.apps.va.gov/vaos/v1/patients/1012845331V153043/appointments?end=2024-08-31T13:00:00Z&pageSize=0&start=2022-08-31T13:00:00Z&statuses=booked,fulfilled,arrived,proposed
+    uri: https://veteran.apps.va.gov/vaos/v1/patients/1012845331V153043/appointments?end=2023-08-30T23:59:59Z&pageSize=0&start=2022-08-31T13:00:00Z&statuses=booked,fulfilled,arrived
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES, controlled by requests from vets-website gated by va_online_scheduling_recent_locations_filter
- We met with stakeholders and decided that for performance reasons, we are going to limit the past history to only appointments within the past year.
- Appointments team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/106715

## Testing done

- [x] New code is covered by unit tests

## Screenshots
N/A

## What areas of the site does it impact?
Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
