### PR TITLE
Update telehealth modality for vvskind nil

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -921,8 +921,10 @@ module VAOS
           'vaVideoCareAtAnAtlasLocation'
         elsif %w[CLINIC_BASED STORE_FORWARD].include?(vvs_kind)
           'vaVideoCareAtAVaLocation'
-        elsif vvs_kind.nil? || vvs_kind == 'MOBILE_ANY' || vvs_kind == 'ADHOC'
+        elsif %w[MOBILE_ANY ADHOC].include?(vvs_kind)
           'vaVideoCareAtHome'
+        elsif vvs_kind.nil?
+          'vaInPerson'
         end
       end
 

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -2169,13 +2169,20 @@ describe VAOS::V2::AppointmentsService do
       expect(appt[:modality]).to eq('vaVideoCareAtAVaLocation')
     end
 
-    [nil, 'MOBILE_ANY', 'ADHOC'].each do |input|
+    %w[MOBILE_ANY ADHOC].each do |input|
       it "is vaVideoCareAtHome for #{input} vvsKind" do
         appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth).attributes
         appt[:telehealth][:vvs_kind] = input
         subject.send(:set_modality, appt)
         expect(appt[:modality]).to eq('vaVideoCareAtHome')
       end
+    end
+
+    it 'is vaInPerson for nil vvsKind' do
+      appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth).attributes
+      appt[:telehealth][:vvs_kind] = nil
+      subject.send(:set_modality, appt)
+      expect(appt[:modality]).to eq('vaInPerson')
     end
 
     it 'is nil for unrecognized vvsKind' do


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES, controlled by requests from vets-website gated by va_online_scheduling_fe_source_of_truth_modality
- Updating vets-api logic to match the logic in vets-website
- Appointments team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/107827

## Testing done

- [x] New code is covered by unit tests

## Screenshots
N/A

## What areas of the site does it impact?
Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
