### PR TITLE
add nil check to db query for failed ves records

### DIFF
--- a/modules/ivc_champva/spec/jobs/ves_retry_failures_job_spec.rb
+++ b/modules/ivc_champva/spec/jobs/ves_retry_failures_job_spec.rb
@@ -112,8 +112,6 @@ RSpec.describe IvcChampva::VesRetryFailuresJob, type: :job do
 
       it 'does not include records with nil ves_status' do
         query_relation = double('ActiveRecord::Relation')
-        nil_record = instance_double(IvcChampvaForm, form_uuid: 'form-nil', ves_status: nil)
-        all_records = [recent_record, old_record, nil_record]
         filtered_records = [recent_record, old_record]
 
         # Simulate the where.not filtering by returning only non-nil records

--- a/modules/ivc_champva/spec/jobs/ves_retry_failures_job_spec.rb
+++ b/modules/ivc_champva/spec/jobs/ves_retry_failures_job_spec.rb
@@ -69,10 +69,10 @@ RSpec.describe IvcChampva::VesRetryFailuresJob, type: :job do
       before do
         query_relation = double('ActiveRecord::Relation')
         allow(IvcChampvaForm).to receive(:where).with(no_args).and_return(query_relation)
-        allow(query_relation).to receive(:not).with(ves_status: 'ok').and_return([recent_record, old_record])
+        allow(query_relation).to receive(:not).with(ves_status: [nil, 'ok']).and_return([recent_record, old_record])
       end
 
-      it 'processes only records newer than 4 hours' do
+      it 'processes only records newer than 5 hours' do
         job.perform
 
         expect(ves_client).to have_received(:submit_1010d).once
@@ -101,13 +101,29 @@ RSpec.describe IvcChampva::VesRetryFailuresJob, type: :job do
         expect(StatsD).to have_received(:gauge).with('ivc_champva.ves_submission_failures.count', 2)
       end
 
-      it 'properly queries for non-ok records' do
+      it 'properly queries for non-ok records excluding nil status' do
         query_relation = double('ActiveRecord::Relation')
 
         expect(IvcChampvaForm).to receive(:where).with(no_args).and_return(query_relation)
-        expect(query_relation).to receive(:not).with(ves_status: 'ok').and_return([recent_record, old_record])
+        expect(query_relation).to receive(:not).with(ves_status: [nil, 'ok']).and_return([recent_record, old_record])
 
         job.perform
+      end
+
+      it 'does not include records with nil ves_status' do
+        query_relation = double('ActiveRecord::Relation')
+        nil_record = instance_double(IvcChampvaForm, form_uuid: 'form-nil', ves_status: nil)
+        all_records = [recent_record, old_record, nil_record]
+        filtered_records = [recent_record, old_record]
+
+        # Simulate the where.not filtering by returning only non-nil records
+        allow(IvcChampvaForm).to receive(:where).with(no_args).and_return(query_relation)
+        allow(query_relation).to receive(:not).with(ves_status: [nil, 'ok']).and_return(filtered_records)
+
+        job.perform
+
+        # Verify we processed only the non-nil records
+        expect(StatsD).to have_received(:gauge).with('ivc_champva.ves_submission_failures.count', 2)
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Add nil filtering on database query, and nil check on processing db records

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103461

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
  - new unreleased feature

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
- CHAMPVA VES submissions for 10-10D

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
