### PR TITLE
fix(docker): Compose test had undefined developemnt stage

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -11,7 +11,6 @@ services:
   web:
     build:
       context: .
-      target: development
       args:
         sidekiq_license: "${BUNDLE_ENTERPRISE__CONTRIBSYS__COM}"
         userid: "${VETS_API_USER_ID}"


### PR DESCRIPTION
### 🛠️ Remove invalid Docker build target

This PR removes the `target: development` line from `docker-compose.test.yml`.

#### 📌 Why?

The `Dockerfile` does not define a build stage named `development`, which causes the following error when building locally:

```
failed to solve: target stage "development" could not be found
```

This issue only affects **local development**, where we rely on `docker compose`. Our GitHub Actions CI uses `docker/build-push-action` to build the image directly, without referencing the Compose file, so it doesn’t trigger this error.

Removing the target allows Docker to default to the final stage defined in the `Dockerfile`, which is sufficient for our test environment.

#### 💪 How to test

Run the following command:

```bash
docker compose -f docker-compose.test.yml build
```

The build should complete without errors where (a fresh build) would fail before.

