### PR TITLE
Remove parameter filtering in `development` and `test`

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -38,21 +38,23 @@ ALLOWLIST = %w[
   content_type
 ].freeze
 
-Rails.application.config.filter_parameters = [
-  lambda do |k, v|
-    case v
-    when Hash # Recursively iterate over each key value pair in hashes
-      v.transform_values { |nested_value| Rails.application.config.filter_parameters.first.call(k, nested_value) }
-    when Array # Recursively map all elements in arrays
-      v.map { |element| Rails.application.config.filter_parameters.first.call(k, element) }
-    when ActionDispatch::Http::UploadedFile # Base case
-      v.instance_variables.each do |var| # could put specific instance vars here, but made more generic
-        var_name = var.to_s.delete_prefix('@')
-        v.instance_variable_set(var, '[FILTERED!]') unless ALLOWLIST.include?(var_name)
+unless Rails.env.local? # rubocop:disable Rails/UnknownEnv
+  Rails.application.config.filter_parameters = [
+    lambda do |k, v|
+      case v
+      when Hash # Recursively iterate over each key value pair in hashes
+        v.transform_values { |nested_value| Rails.application.config.filter_parameters.first.call(k, nested_value) }
+      when Array # Recursively map all elements in arrays
+        v.map { |element| Rails.application.config.filter_parameters.first.call(k, element) }
+      when ActionDispatch::Http::UploadedFile # Base case
+        v.instance_variables.each do |var| # could put specific instance vars here, but made more generic
+          var_name = var.to_s.delete_prefix('@')
+          v.instance_variable_set(var, '[FILTERED!]') unless ALLOWLIST.include?(var_name)
+        end
+      when String # Base case
+        # Apply filtering only if the key is NOT in the ALLOWLIST
+        v.replace('[FILTERED]') unless ALLOWLIST.include?(k.to_s)
       end
-    when String # Base case
-      # Apply filtering only if the key is NOT in the ALLOWLIST
-      v.replace('[FILTERED]') unless ALLOWLIST.include?(k.to_s)
     end
-  end
-]
+  ]
+end


### PR DESCRIPTION
## Summary

- Remove parameter filtering in `development` and `test`
- There was a[ Rails patch](https://github.com/rails/rails/pull/33756) that made these filters apply to database columns
  <img width="309" alt="Screenshot 2025-04-17 at 2 24 11 PM" src="https://github.com/user-attachments/assets/4757662d-44c6-4ecf-b358-c1898ec679c0" />

- This is annoying when developing and testing
