### PR TITLE
Fix audit_log_appender

### DIFF
--- a/app/services/user_audit/appenders/audit_log_appender.rb
+++ b/app/services/user_audit/appenders/audit_log_appender.rb
@@ -65,7 +65,7 @@ module UserAudit
 
         case user_verification.credential_type
         when SAML::User::IDME_CSID         then 'idme_uuid'
-        when SAML::User::LOGINGOV_CSID     then 'login_uuid'
+        when SAML::User::LOGINGOV_CSID     then 'logingov_uuid'
         when SAML::User::MHV_ORIGINAL_CSID then 'mhv_id'
         when SAML::User::DSLOGON_CSID      then 'dslogon_id'
         end

--- a/spec/services/user_audit/appenders/audit_log_appender_spec.rb
+++ b/spec/services/user_audit/appenders/audit_log_appender_spec.rb
@@ -75,14 +75,46 @@ RSpec.describe UserAudit::Appenders::AuditLogAppender do
         let(:subject_user_icn) { nil }
         let(:acting_user_icn)  { nil }
 
-        it 'uses the user_verification credential_identifier for the user identifier' do
-          appender.log(log)
+        shared_examples 'a csp identifier' do
+          it 'maps to the correct identifier and identifier_type' do
+            appender.log(log)
 
-          audit_log = Audit::Log.last
-          expect(audit_log.subject_user_identifier).to eq(subject_user_verification.credential_identifier)
-          expect(audit_log.subject_user_identifier_type).to eq('idme_uuid')
-          expect(audit_log.acting_user_identifier).to eq(acting_user_verification.credential_identifier)
-          expect(audit_log.acting_user_identifier_type).to eq('idme_uuid')
+            audit_log = Audit::Log.last
+            expect(audit_log.subject_user_identifier).to eq(subject_user_verification.credential_identifier)
+            expect(audit_log.subject_user_identifier_type).to eq(expected_identifier_type)
+            expect(audit_log.acting_user_identifier).to eq(acting_user_verification.credential_identifier)
+            expect(audit_log.acting_user_identifier_type).to eq(expected_identifier_type)
+          end
+        end
+
+        context 'when the user_verification is idme' do
+          let(:expected_identifier_type) { 'idme_uuid' }
+
+          it_behaves_like 'a csp identifier'
+        end
+
+        context 'when the user_verification logingov' do
+          let!(:subject_user_verification) { create(:logingov_user_verification, user_account: subject_user_account) }
+          let!(:acting_user_verification) { create(:logingov_user_verification, user_account: acting_user_account) }
+          let(:expected_identifier_type) { 'logingov_uuid' }
+
+          it_behaves_like 'a csp identifier'
+        end
+
+        context 'when the user_verification is dslogon' do
+          let!(:subject_user_verification) { create(:dslogon_user_verification, user_account: subject_user_account) }
+          let!(:acting_user_verification) { create(:dslogon_user_verification, user_account: acting_user_account) }
+          let(:expected_identifier_type) { 'dslogon_id' }
+
+          it_behaves_like 'a csp identifier'
+        end
+
+        context 'when the user_verification is mhv' do
+          let!(:subject_user_verification) { create(:mhv_user_verification, user_account: subject_user_account) }
+          let!(:acting_user_verification) { create(:mhv_user_verification, user_account: acting_user_account) }
+          let(:expected_identifier_type) { 'mhv_id' }
+
+          it_behaves_like 'a csp identifier'
         end
       end
     end


### PR DESCRIPTION
# Summary

- Fix typo in `AuditLogAppender`

## Testing
- login with login.gov user and check if `Audit::Log` was created
`- or -`
- call UserAudit logger with a login.gov user_verification and check if `Audit::Log` was created
  ```ruby
   user_verification = UserVerification.where.not(logingov_uuid: nil).last
   UserAudit.logger.success(event: :sign_in, user_verification:)
   ```

## What areas of the site does it impact?
UserAudit logger

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.