### PR TITLE
BE | Ask VA APi: add LOA3 validation for authenticated inquiry endpoints

### DIFF
--- a/modules/ask_va_api/app/controllers/ask_va_api/application_controller.rb
+++ b/modules/ask_va_api/app/controllers/ask_va_api/application_controller.rb
@@ -12,15 +12,13 @@ module AskVAApi
       yield
     rescue Common::Exceptions::Unauthorized => e
       log_and_render_error('unauthorized', e, :unauthorized)
-    
     rescue ErrorHandler::ServiceError,
            Crm::ErrorHandler::ServiceError,
            Common::Exceptions::ValidationErrors,
            Inquiries::InquiriesCreatorError => e
-    
+
       status = e.message.include?('No Inquiries found') ? :not_found : :unprocessable_entity
       log_and_render_error('service_error', e, status)
-    
     rescue => e
       log_and_render_error('unexpected_error', e, :internal_server_error)
     end

--- a/modules/ask_va_api/app/controllers/ask_va_api/application_controller.rb
+++ b/modules/ask_va_api/app/controllers/ask_va_api/application_controller.rb
@@ -10,13 +10,17 @@ module AskVAApi
 
     def handle_exceptions
       yield
-    rescue ErrorHandler::ServiceError, Crm::ErrorHandler::ServiceError,
-           Common::Exceptions::ValidationErrors, Inquiries::InquiriesCreatorError => e
-
-      status = :unprocessable_entity
-      status = :not_found if e.message.include?('No Inquiries found')
-
+    rescue Common::Exceptions::Unauthorized => e
+      log_and_render_error('unauthorized', e, :unauthorized)
+    
+    rescue ErrorHandler::ServiceError,
+           Crm::ErrorHandler::ServiceError,
+           Common::Exceptions::ValidationErrors,
+           Inquiries::InquiriesCreatorError => e
+    
+      status = e.message.include?('No Inquiries found') ? :not_found : :unprocessable_entity
       log_and_render_error('service_error', e, status)
+    
     rescue => e
       log_and_render_error('unexpected_error', e, :internal_server_error)
     end

--- a/modules/ask_va_api/app/controllers/ask_va_api/v0/inquiries_controller.rb
+++ b/modules/ask_va_api/app/controllers/ask_va_api/v0/inquiries_controller.rb
@@ -4,6 +4,7 @@ module AskVAApi
   module V0
     class InquiriesController < ApplicationController
       around_action :handle_exceptions
+      before_action :require_loa3!, except: %i[unauth_create status]
       skip_before_action :authenticate, only: %i[unauth_create status]
 
       def index
@@ -102,6 +103,12 @@ module AskVAApi
 
       def fetch_parameters(key)
         I18n.t("ask_va_api.parameters.inquiry.#{key}")
+      end
+
+      def require_loa3!
+        unless current_user&.loa&.fetch(:current, nil) == 3
+          raise Common::Exceptions::Unauthorized
+        end
       end
 
       class InvalidAttachmentError < StandardError; end

--- a/modules/ask_va_api/app/controllers/ask_va_api/v0/inquiries_controller.rb
+++ b/modules/ask_va_api/app/controllers/ask_va_api/v0/inquiries_controller.rb
@@ -106,9 +106,7 @@ module AskVAApi
       end
 
       def require_loa3!
-        unless current_user&.loa&.fetch(:current, nil) == 3
-          raise Common::Exceptions::Unauthorized
-        end
+        raise Common::Exceptions::Unauthorized unless current_user&.loa&.fetch(:current, nil) == 3
       end
 
       class InvalidAttachmentError < StandardError; end

--- a/modules/ask_va_api/spec/requests/ask_va_api/v0/inquiries_spec.rb
+++ b/modules/ask_va_api/spec/requests/ask_va_api/v0/inquiries_spec.rb
@@ -303,7 +303,8 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
       end
     end
 
-    it_behaves_like 'an endpoint requiring loa3', :get, "/ask_va_api/v0/inquiries/A-1", { params: { user_mock_data: true } }
+    it_behaves_like 'an endpoint requiring loa3', :get, '/ask_va_api/v0/inquiries/A-1',
+                    { params: { user_mock_data: true } }
   end
 
   describe 'GET #download_attachment' do
@@ -313,17 +314,17 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
       before do
         sign_in(authorized_user)
       end
-  
+
       context 'when successful' do
         before do
           get '/ask_va_api/v0/download_attachment', params: { id:, mock: true }
         end
-  
+
         it 'response with 200' do
           expect(response).to have_http_status(:ok)
         end
       end
-  
+
       context 'when Crm raise an error' do
         let(:body) do
           '{"Data":null,"Message":"Data Validation: Invalid GUID, Parsing Failed",' \
@@ -331,21 +332,22 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
             ' Parsing Failed","MessageId":"c14c61c4-a3a8-4200-8c86-bdc09c261308"}'
         end
         let(:failure) { Faraday::Response.new(response_body: body, status: 400) }
-  
+
         before do
           allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('token')
           allow_any_instance_of(Crm::Service).to receive(:call)
             .with(endpoint: 'attachment', payload: { id: '1' }).and_return(failure)
           get '/ask_va_api/v0/download_attachment', params: { id:, mock: nil }
         end
-  
+
         it 'raise the error' do
           expect(response).to have_http_status(:unprocessable_entity)
         end
-      end  
+      end
     end
 
-    it_behaves_like 'an endpoint requiring loa3', :get, '/ask_va_api/v0/download_attachment', { params: { id:, mock: true } }
+    it_behaves_like 'an endpoint requiring loa3', :get, '/ask_va_api/v0/download_attachment',
+                    { params: { id:, mock: true } }
   end
 
   describe 'GET #profile' do
@@ -503,10 +505,10 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
             # inquiry_params is in include_context 'shared data'
             post '/ask_va_api/v0/inquiries/auth', params: inquiry_params
           end
-  
+
           it { expect(response).to have_http_status(:created) }
         end
-  
+
         context 'when crm api fail' do
           context 'when the API call fails' do
             let(:body) do
@@ -515,14 +517,14 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
                 'InquiryCategory","MessageId":"cb0dd954-ef25-4e56-b0d9-41925e5a190c"}'
             end
             let(:failure) { Faraday::Response.new(response_body: body, status: 400) }
-  
+
             before do
               allow_any_instance_of(Crm::Service).to receive(:call)
                 .and_return(failure)
               sign_in(authorized_user)
               post '/ask_va_api/v0/inquiries/auth', params: inquiry_params
             end
-  
+
             it 'raise InquiriesCreatorError and set span safe_fields' do
               expect(response).to have_http_status(:unprocessable_entity)
               safe_fields.each do |field|
@@ -532,7 +534,7 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
                 )
               end
             end
-  
+
             it_behaves_like 'common error handling', :unprocessable_entity, 'service_error',
                             'InquiriesCreatorError: {"Data":null,"Message":' \
                             '"Data Validation: missing InquiryCategory"' \
@@ -646,6 +648,7 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
       end
     end
 
-    it_behaves_like 'an endpoint requiring loa3', :post, '/ask_va_api/v0/inquiries/123/reply/new', { params: { reply: 'reply'} }
+    it_behaves_like 'an endpoint requiring loa3', :post, '/ask_va_api/v0/inquiries/123/reply/new',
+                    { params: { reply: 'reply' } }
   end
 end

--- a/modules/ask_va_api/spec/requests/ask_va_api/v0/inquiries_spec.rb
+++ b/modules/ask_va_api/spec/requests/ask_va_api/v0/inquiries_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
     end
 
     it 'returns unauthorized for LOA1 users' do
-      binding.pry
       expect(response).to have_http_status(:unauthorized)
     end
   end

--- a/modules/ask_va_api/spec/requests/ask_va_api/v0/inquiries_spec.rb
+++ b/modules/ask_va_api/spec/requests/ask_va_api/v0/inquiries_spec.rb
@@ -44,6 +44,22 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
     end
   end
 
+  # spec/support/shared_examples/loa3_protected.rb
+
+  shared_examples_for 'an endpoint requiring loa3' do |http_method, endpoint, request_options = {}|
+    let(:loa1_user) { build(:user) }
+
+    before do
+      sign_in(loa1_user)
+      send(http_method, endpoint, **request_options)
+    end
+
+    it 'returns unauthorized for LOA1 users' do
+      binding.pry
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
   describe 'GET #index' do
     context 'when user is signed in' do
       before { sign_in(authorized_user) }
@@ -129,6 +145,8 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
 
       it { expect(response).to have_http_status(:unauthorized) }
     end
+
+    it_behaves_like 'an endpoint requiring loa3', :get, '/ask_va_api/v0/inquiries'
   end
 
   describe 'GET #show' do
@@ -285,44 +303,50 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
                         'ID A-20240423-30709","MessageId":"ca5b990a-63fe-407d-a364-46caffce12c1"}'
       end
     end
+
+    it_behaves_like 'an endpoint requiring loa3', :get, "/ask_va_api/v0/inquiries/A-1", { params: { user_mock_data: true } }
   end
 
   describe 'GET #download_attachment' do
     let(:id) { '1' }
 
-    before do
-      sign_in(authorized_user)
-    end
-
-    context 'when successful' do
+    context 'when a user is loa3' do
       before do
-        get '/ask_va_api/v0/download_attachment', params: { id:, mock: true }
+        sign_in(authorized_user)
       end
-
-      it 'response with 200' do
-        expect(response).to have_http_status(:ok)
+  
+      context 'when successful' do
+        before do
+          get '/ask_va_api/v0/download_attachment', params: { id:, mock: true }
+        end
+  
+        it 'response with 200' do
+          expect(response).to have_http_status(:ok)
+        end
       end
+  
+      context 'when Crm raise an error' do
+        let(:body) do
+          '{"Data":null,"Message":"Data Validation: Invalid GUID, Parsing Failed",' \
+            '"ExceptionOccurred":true,"ExceptionMessage":"Data Validation: Invalid GUID,' \
+            ' Parsing Failed","MessageId":"c14c61c4-a3a8-4200-8c86-bdc09c261308"}'
+        end
+        let(:failure) { Faraday::Response.new(response_body: body, status: 400) }
+  
+        before do
+          allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('token')
+          allow_any_instance_of(Crm::Service).to receive(:call)
+            .with(endpoint: 'attachment', payload: { id: '1' }).and_return(failure)
+          get '/ask_va_api/v0/download_attachment', params: { id:, mock: nil }
+        end
+  
+        it 'raise the error' do
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end  
     end
 
-    context 'when Crm raise an error' do
-      let(:body) do
-        '{"Data":null,"Message":"Data Validation: Invalid GUID, Parsing Failed",' \
-          '"ExceptionOccurred":true,"ExceptionMessage":"Data Validation: Invalid GUID,' \
-          ' Parsing Failed","MessageId":"c14c61c4-a3a8-4200-8c86-bdc09c261308"}'
-      end
-      let(:failure) { Faraday::Response.new(response_body: body, status: 400) }
-
-      before do
-        allow_any_instance_of(Crm::CrmToken).to receive(:call).and_return('token')
-        allow_any_instance_of(Crm::Service).to receive(:call)
-          .with(endpoint: 'attachment', payload: { id: '1' }).and_return(failure)
-        get '/ask_va_api/v0/download_attachment', params: { id:, mock: nil }
-      end
-
-      it 'raise the error' do
-        expect(response).to have_http_status(:unprocessable_entity)
-      end
-    end
+    it_behaves_like 'an endpoint requiring loa3', :get, '/ask_va_api/v0/download_attachment', { params: { id:, mock: true } }
   end
 
   describe 'GET #profile' do
@@ -367,6 +391,8 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
                       ',"ExceptionOccurred":true,"ExceptionMessage":"Data Validation: No Contact found ' \
                       '","MessageId":"ca5b990a-63fe-407d-a364-46caffce12c1"}'
     end
+
+    it_behaves_like 'an endpoint requiring loa3', :get, '/ask_va_api/v0/profile', { params: { user_mock_data: true } }
   end
 
   describe 'GET #status' do
@@ -461,59 +487,63 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
     end
 
     context 'POST #create' do
-      context 'when successful' do
-        before do
-          allow_any_instance_of(Crm::Service).to receive(:call)
-            .and_return({
-                          Data: {
-                            Id: '530d56a8-affd-ee11-a1fe-001dd8094ff1'
-                          },
-                          Message: '',
-                          ExceptionOccurred: false,
-                          ExceptionMessage: '',
-                          MessageId: 'b8ebd8e7-3bbf-49c5-aff0-99503e50ee27'
-                        })
-          sign_in(authorized_user)
-          # inquiry_params is in include_context 'shared data'
-          post '/ask_va_api/v0/inquiries/auth', params: inquiry_params
-        end
-
-        it { expect(response).to have_http_status(:created) }
-      end
-
-      context 'when crm api fail' do
-        context 'when the API call fails' do
-          let(:body) do
-            '{"Data":null,"Message":"Data Validation: missing InquiryCategory"' \
-              ',"ExceptionOccurred":true,"ExceptionMessage":"Data Validation: missing' \
-              'InquiryCategory","MessageId":"cb0dd954-ef25-4e56-b0d9-41925e5a190c"}'
-          end
-          let(:failure) { Faraday::Response.new(response_body: body, status: 400) }
-
+      context 'when user is loa3' do
+        context 'when successful' do
           before do
             allow_any_instance_of(Crm::Service).to receive(:call)
-              .and_return(failure)
+              .and_return({
+                            Data: {
+                              Id: '530d56a8-affd-ee11-a1fe-001dd8094ff1'
+                            },
+                            Message: '',
+                            ExceptionOccurred: false,
+                            ExceptionMessage: '',
+                            MessageId: 'b8ebd8e7-3bbf-49c5-aff0-99503e50ee27'
+                          })
             sign_in(authorized_user)
+            # inquiry_params is in include_context 'shared data'
             post '/ask_va_api/v0/inquiries/auth', params: inquiry_params
           end
-
-          it 'raise InquiriesCreatorError and set span safe_fields' do
-            expect(response).to have_http_status(:unprocessable_entity)
-            safe_fields.each do |field|
-              expect(span).to have_received(:set_tag).with(
-                "safe_field.#{field}",
-                inquiry_params[:inquiry][field]
-              )
+  
+          it { expect(response).to have_http_status(:created) }
+        end
+  
+        context 'when crm api fail' do
+          context 'when the API call fails' do
+            let(:body) do
+              '{"Data":null,"Message":"Data Validation: missing InquiryCategory"' \
+                ',"ExceptionOccurred":true,"ExceptionMessage":"Data Validation: missing' \
+                'InquiryCategory","MessageId":"cb0dd954-ef25-4e56-b0d9-41925e5a190c"}'
             end
+            let(:failure) { Faraday::Response.new(response_body: body, status: 400) }
+  
+            before do
+              allow_any_instance_of(Crm::Service).to receive(:call)
+                .and_return(failure)
+              sign_in(authorized_user)
+              post '/ask_va_api/v0/inquiries/auth', params: inquiry_params
+            end
+  
+            it 'raise InquiriesCreatorError and set span safe_fields' do
+              expect(response).to have_http_status(:unprocessable_entity)
+              safe_fields.each do |field|
+                expect(span).to have_received(:set_tag).with(
+                  "safe_field.#{field}",
+                  inquiry_params[:inquiry][field]
+                )
+              end
+            end
+  
+            it_behaves_like 'common error handling', :unprocessable_entity, 'service_error',
+                            'InquiriesCreatorError: {"Data":null,"Message":' \
+                            '"Data Validation: missing InquiryCategory"' \
+                            ',"ExceptionOccurred":true,"ExceptionMessage":"Data Validation: missing' \
+                            'InquiryCategory","MessageId":"cb0dd954-ef25-4e56-b0d9-41925e5a190c"}'
           end
-
-          it_behaves_like 'common error handling', :unprocessable_entity, 'service_error',
-                          'InquiriesCreatorError: {"Data":null,"Message":' \
-                          '"Data Validation: missing InquiryCategory"' \
-                          ',"ExceptionOccurred":true,"ExceptionMessage":"Data Validation: missing' \
-                          'InquiryCategory","MessageId":"cb0dd954-ef25-4e56-b0d9-41925e5a190c"}'
         end
       end
+
+      it_behaves_like 'an endpoint requiring loa3', :post, '/ask_va_api/v0/inquiries/auth', { params: { inquiry: {} } }
     end
 
     context 'POST #unauth_create' do
@@ -616,5 +646,7 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
                         'Missing Reply","MessageId":"e2cbe041-df91-41f4-8bd2-8b6d9dbb2e38"}'
       end
     end
+
+    it_behaves_like 'an endpoint requiring loa3', :post, '/ask_va_api/v0/inquiries/123/reply/new', { params: { reply: 'reply'} }
   end
 end


### PR DESCRIPTION
## Summary

### 🛡️ Enforce LOA3 for Authenticated Inquiry Endpoints

This PR adds a `require_loa3!` before_action to ensure that only users with Level of Assurance 3 (LOA3) can access endpoints that rely on `current_user.icn`. This helps maintain strict access control and prevents LOA1 users from interacting with inquiries tied to sensitive identity data.

#### ✅ Changes
- Added `require_loa3!` to `InquiriesController`, excluding `unauth_create` and `status`
- Returns `401 Unauthorized` for users who are not LOA3
- Introduced `loa3_valid?` helper method for readability and reuse
- Created shared example to validate LOA3 protection across applicable endpoints

## Related issue(s)

- [Validate that current_user is LOA3 before processing inquiries](https://github.com/department-of-veterans-affairs/ask-va/issues/1757)

## Testing done

- [x] *New code is covered by unit tests*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)