### PR TITLE
feat(console): add commands to reveal/conceal attribute filters in console

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -770,6 +770,7 @@ config/initializers/breakers.rb @department-of-veterans-affairs/va-api-engineers
 config/initializers/clamav.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/combine_pdf_log_patch.rb @department-of-veterans-affairs/backend-review-group
 config/initializers/config.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+config/initializers/console_filter_toggles.rb @department-of-veterans-affairs/backend-review-group
 config/initializers/cookie_rotation.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 config/initializers/core_extensions.rb @department-of-veterans-affairs/backend-review-group
 config/initializers/datadog.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/config/initializers/console_filter_toggles.rb
+++ b/config/initializers/console_filter_toggles.rb
@@ -1,3 +1,48 @@
+# frozen_string_literal: true
+
+module ConsoleFilterStorage
+  # We will assign constants here using const_set after initialization
+end
+
+module ConsoleFilterToggles
+  def reveal!
+    Rails.application.config.filter_parameters = []
+    ActiveRecord::Base.filter_attributes = []
+
+    ActiveRecord::Base.descendants.each do |model|
+      model.filter_attributes = [] if model.respond_to?(:filter_attributes)
+    end
+
+    $stdout.puts 'All filters removed: attributes will not be concealed.'
+  end
+
+  def conceal!
+    Rails.application.config.filter_parameters = ConsoleFilterStorage::ORIGINAL_FILTERS.dup
+    ActiveRecord::Base.filter_attributes = ConsoleFilterStorage::ORIGINAL_AR_FILTERS.dup
+
+    ActiveRecord::Base.descendants.each do |model|
+      if model.respond_to?(:filter_attributes)
+        original_filters = ConsoleFilterStorage::ORIGINAL_MODEL_FILTERS[model.name] || []
+        model.filter_attributes = []
+        model.filter_attributes.concat(original_filters)
+      end
+    end
+
+    $stdout.puts 'All filters re-applied: attributes are concealed.'
+  end
+end
+
 if defined?(Rails::Console)
-  ORIGINAL_FILTERS = Rails.application.config.filter_parameters.dup
+  Rails.application.config.after_initialize do
+    ConsoleFilterStorage.const_set('ORIGINAL_FILTERS', Rails.application.config.filter_parameters.dup.freeze)
+    ConsoleFilterStorage.const_set('ORIGINAL_AR_FILTERS', ActiveRecord::Base.filter_attributes.dup.freeze)
+
+    model_filters = {}
+    ActiveRecord::Base.descendants.each do |model|
+      model_filters[model.name] = model.filter_attributes.dup if model.respond_to?(:filter_attributes)
+    end
+    ConsoleFilterStorage.const_set('ORIGINAL_MODEL_FILTERS', model_filters.freeze)
+
+    TOPLEVEL_BINDING.eval('self').extend(ConsoleFilterToggles)
+  end
 end

--- a/config/initializers/console_filter_toggles.rb
+++ b/config/initializers/console_filter_toggles.rb
@@ -1,0 +1,3 @@
+if defined?(Rails::Console)
+  ORIGINAL_FILTERS = Rails.application.config.filter_parameters.dup
+end

--- a/config/initializers/console_filter_toggles.rb
+++ b/config/initializers/console_filter_toggles.rb
@@ -44,5 +44,8 @@ if defined?(Rails::Console)
     ConsoleFilterStorage.const_set('ORIGINAL_MODEL_FILTERS', model_filters.freeze)
 
     TOPLEVEL_BINDING.eval('self').extend(ConsoleFilterToggles)
+
+    # Automatically reveal! in console
+    TOPLEVEL_BINDING.eval('self').reveal!
   end
 end


### PR DESCRIPTION
This commit introduces a reveal! and conceal! mechanism within the Rails console.
It allows developers to temporarily remove and later restore filtered attributes
(e.g., passwords, tokens) for debugging purposes without permanently altering the
global configuration.

Related convo: https://dsva.slack.com/archives/CBU0KDSB1/p1734037958582009?thread_ts=1734029085.406129&cid=CBU0KDSB1
Old PR: https://github.com/department-of-veterans-affairs/vets-api/pull/19866