### PR TITLE
EZR: Prefill Veteran contacts

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -192,6 +192,9 @@ features:
   ezr_associations_api_enabled:
     actor_type: user
     description: Enables VES's Associations REST API
+  ezr_prefill_contacts:
+    actor_type: user
+    description: Adds Veteran contacts to ezr prefill data
     enable_in_development: true
   cerner_override_653:
     actor_type: user

--- a/config/form_profile_mappings/10-10EZR.yml
+++ b/config/form_profile_mappings/10-10EZR.yml
@@ -17,5 +17,6 @@ dateOfMarriage: [ezr_data, dateOfMarriage]
 cohabitedLastYear: [ezr_data, cohabitedLastYear]
 maritalStatus: [ezr_data, maritalStatus]
 dependents: [ezr_data, dependents]
+veteranContacts: [ezr_data, veteranContacts]
 nonPrefill:
   previousFinancialInfo: [ezr_data, previousFinancialInfo]

--- a/lib/hca/enrollment_eligibility/service.rb
+++ b/lib/hca/enrollment_eligibility/service.rb
@@ -63,18 +63,18 @@ module HCA
         providers = parse_insurance_providers(response)
         dependents = parse_dependents(response)
         spouse = parse_spouse(response)
-        contacts = parse_contacts(response)
 
         ezr_data = financial_info.merge(convert_insurance_hash(response, providers).except!(:providers)).merge(spouse)
 
         if Flipper.enabled?(:ezr_form_prefill_with_providers_and_dependents)
-          ezr_data = financial_info.merge(convert_insurance_hash(response, providers)).merge(
-            dependents.present? ? { dependents: } : {}
-          ).merge(spouse)
+          ezr_data = financial_info.merge(convert_insurance_hash(response, providers))
+          ezr_data[:dependents] = dependents if dependents.present?
+          ezr_data.merge!(spouse)
         end
 
         if Flipper.enabled?(:ezr_prefill_contacts)
-          ezr_data.merge!(contacts.present? ? { veteranContacts: contacts } : {})
+          contacts = parse_contacts(response)
+          ezr_data.merge!({ veteranContacts: contacts }) if contacts.present?
         end
 
         OpenStruct.new(ezr_data)

--- a/spec/fixtures/form1010_ezr/veteran_data.json
+++ b/spec/fixtures/form1010_ezr/veteran_data.json
@@ -52,6 +52,78 @@
   "cohabitedLastYear": true,
   "spouseDateOfBirth": "1970-04-21",
   "spouseSocialSecurityNumber": "666112121",
+  "veteranContacts": [
+    {
+      "fullName": {
+        "first": "MARY",
+        "middle": "JESSICA",
+        "last": "BISHOP"
+      },
+      "primaryPhone": "(274)294-3384",
+      "address": {
+        "street": "748 TEST ST",
+        "street2": "APT 394",
+        "street3": "UNIT 2",
+        "city": "ALBUQUERQUE",
+        "state": "NM",
+        "country": "USA",
+        "postalCode": "87109"
+      },
+      "relationship": "Daughter",
+      "contactType": "Other Next of Kin"
+    },
+    {
+      "fullName": {
+        "first": "DEBORAH",
+        "last": "WILLIAMS"
+      },
+      "primaryPhone": "(927)737-7486",
+      "address": {
+        "street": "2645 TEST WAY",
+        "street2": "UNIT 192",
+        "city": "CLEARWATER",
+        "country": "USA",
+        "state": "FL",
+        "postalCode": "33760"
+      },
+      "relationship": "Unrelated friend",
+      "contactType": "Other emergency contact"
+    },
+    {
+      "fullName": {
+        "first": "ETHAN",
+        "middle": "JEREMY",
+        "last": "BISHOP"
+      },
+      "primaryPhone": "(439)573-8274",
+      "address": {
+        "street": "9758 TEST AVE",
+        "city": "ALBUQUERQUE",
+        "country": "USA",
+        "state": "NM",
+        "postalCode": "87109"
+      },
+      "relationship": "Brother",
+      "contactType": "Emergency Contact"
+    },
+    {
+      "fullName": {
+        "first": "JANE",
+        "last": "BISHOP"
+      },
+      "primaryPhone": "(202)394-6688",
+      "address": {
+        "street": "823 SE 2ND ST",
+        "street2": "BLDG 2",
+        "street3": "UNIT 163",
+        "city": "GUADALAJARA",
+        "country": "MEX",
+        "postalCode": "44100"
+      },
+      "relationship": "Mother",
+      "contactType": "Primary Next of Kin"
+    }
+  ],
   "nonPrefill": {
     "previousFinancialInfo": {
       "veteranFinancialInfo": {

--- a/spec/fixtures/form1010_ezr/veteran_data.json
+++ b/spec/fixtures/form1010_ezr/veteran_data.json
@@ -59,7 +59,7 @@
         "middle": "JESSICA",
         "last": "BISHOP"
       },
-      "primaryPhone": "(274)294-3384",
+      "primaryPhone": "2742943384",
       "address": {
         "street": "748 TEST ST",
         "street2": "APT 394",
@@ -69,7 +69,7 @@
         "country": "USA",
         "postalCode": "87109"
       },
-      "relationship": "Daughter",
+      "relationship": "DAUGHTER",
       "contactType": "Other Next of Kin"
     },
     {
@@ -77,7 +77,7 @@
         "first": "DEBORAH",
         "last": "WILLIAMS"
       },
-      "primaryPhone": "(927)737-7486",
+      "primaryPhone": "9277377486",
       "address": {
         "street": "2645 TEST WAY",
         "street2": "UNIT 192",
@@ -86,7 +86,7 @@
         "state": "FL",
         "postalCode": "33760"
       },
-      "relationship": "Unrelated friend",
+      "relationship": "UNRELATED FRIEND",
       "contactType": "Other emergency contact"
     },
     {
@@ -95,7 +95,7 @@
         "middle": "JEREMY",
         "last": "BISHOP"
       },
-      "primaryPhone": "(439)573-8274",
+      "primaryPhone": "4395738274",
       "address": {
         "street": "9758 TEST AVE",
         "city": "ALBUQUERQUE",
@@ -103,7 +103,7 @@
         "state": "NM",
         "postalCode": "87109"
       },
-      "relationship": "Brother",
+      "relationship": "BROTHER",
       "contactType": "Emergency Contact"
     },
     {
@@ -111,7 +111,7 @@
         "first": "JANE",
         "last": "BISHOP"
       },
-      "primaryPhone": "(202)394-6688",
+      "primaryPhone": "2023946688",
       "address": {
         "street": "823 SE 2ND ST",
         "street2": "BLDG 2",
@@ -120,7 +120,7 @@
         "country": "MEX",
         "postalCode": "44100"
       },
-      "relationship": "Mother",
+      "relationship": "MOTHER",
       "contactType": "Primary Next of Kin"
     }
   ],

--- a/spec/lib/hca/enrollment_eligibility/service_spec.rb
+++ b/spec/lib/hca/enrollment_eligibility/service_spec.rb
@@ -26,7 +26,7 @@ describe HCA::EnrollmentEligibility::Service do
       end
     end
 
-    context "when 'ezr_prefill_contacts' is disabled" do
+    context "when 'ezr_prefill_contacts' flipper is disabled" do
       before do
         allow(Flipper).to receive(:enabled?).with(:ezr_prefill_contacts).and_return(false)
       end
@@ -46,13 +46,13 @@ describe HCA::EnrollmentEligibility::Service do
           allow(Flipper).to receive(:enabled?).with(:ezr_form_prefill_with_providers_and_dependents).and_return(false)
         end
 
-        it 'gets Veteran data with without contacts, providers, or dependents' do
+        it 'gets Veteran data without contacts, providers, or dependents' do
           expect_veteran_data_to_match(veteran_data.except('providers', 'dependents', 'veteranContacts'))
         end
       end
     end
 
-    context "when 'ezr_prefill_contacts' is enabled" do
+    context "when 'ezr_prefill_contacts' flipper is enabled" do
       before do
         allow(Flipper).to receive(:enabled?).with(:ezr_prefill_contacts).and_return(true)
       end
@@ -62,7 +62,7 @@ describe HCA::EnrollmentEligibility::Service do
           allow(Flipper).to receive(:enabled?).with(:ezr_form_prefill_with_providers_and_dependents).and_return(true)
         end
 
-        it 'gets Veteran data with contacts and with providers and dependents' do
+        it 'gets Veteran data with contacts, providers and dependents' do
           expect_veteran_data_to_match(veteran_data)
         end
       end
@@ -72,7 +72,7 @@ describe HCA::EnrollmentEligibility::Service do
           allow(Flipper).to receive(:enabled?).with(:ezr_form_prefill_with_providers_and_dependents).and_return(false)
         end
 
-        it 'gets Veteran data with without contacts and with providers and dependents' do
+        it 'gets Veteran data without contacts and with providers and dependents' do
           expect_veteran_data_to_match(veteran_data.except('providers', 'dependents'))
         end
       end

--- a/spec/lib/hca/enrollment_eligibility/service_spec.rb
+++ b/spec/lib/hca/enrollment_eligibility/service_spec.rb
@@ -13,41 +13,67 @@ describe HCA::EnrollmentEligibility::Service do
       data.merge('previousFinancialInfo' => financial_info)
     end
 
-    context "when the 'ezr_form_prefill_with_providers_and_dependents' flipper is enabled" do
+    def expect_veteran_data_to_match(veteran_data)
+      VCR.use_cassette(
+        'form1010_ezr/lookup_user_with_ezr_prefill_data',
+        match_requests_on: %i[method uri body], erb: true
+      ) do
+        expect(
+          described_class.new.get_ezr_data(
+            '1012829228V424035'
+          ).to_h.deep_stringify_keys
+        ).to eq(veteran_data)
+      end
+    end
+
+    context "when 'ezr_prefill_contacts' is disabled" do
       before do
-        allow(Flipper).to receive(:enabled?).with(:ezr_form_prefill_with_providers_and_dependents).and_return(true)
+        allow(Flipper).to receive(:enabled?).with(:ezr_prefill_contacts).and_return(false)
       end
 
-      it 'gets Veteran data relevant to the 1010ezr', run_at: 'Thu, 27 Feb 2025 01:10:06 GMT' do
-        VCR.use_cassette(
-          'form1010_ezr/lookup_user_with_ezr_prefill_data',
-          match_requests_on: %i[method uri body], erb: true
-        ) do
-          expect(
-            described_class.new.get_ezr_data(
-              '1012829228V424035'
-            ).to_h.deep_stringify_keys
-          ).to eq(veteran_data)
+      context "and 'ezr_form_prefill_with_providers_and_dependents' flipper is enabled" do
+        before do
+          allow(Flipper).to receive(:enabled?).with(:ezr_form_prefill_with_providers_and_dependents).and_return(true)
+        end
+
+        it 'gets Veteran data without contacts and with providers and dependents' do
+          expect_veteran_data_to_match(veteran_data.except('veteranContacts'))
+        end
+      end
+
+      context "and 'ezr_form_prefill_with_providers_and_dependents' flipper is disabled" do
+        before do
+          allow(Flipper).to receive(:enabled?).with(:ezr_form_prefill_with_providers_and_dependents).and_return(false)
+        end
+
+        it 'gets Veteran data with without contacts, providers, or dependents' do
+          expect_veteran_data_to_match(veteran_data.except('providers', 'dependents', 'veteranContacts'))
         end
       end
     end
 
-    context "when the 'ezr_form_prefill_with_providers_and_dependents' flipper is disabled" do
+    context "when 'ezr_prefill_contacts' is enabled" do
       before do
-        allow(Flipper).to receive(:enabled?).with(:ezr_form_prefill_with_providers_and_dependents).and_return(false)
+        allow(Flipper).to receive(:enabled?).with(:ezr_prefill_contacts).and_return(true)
       end
 
-      it 'gets Veteran data relevant to the 1010ezr, except for insurance providers and dependents',
-         run_at: 'Thu, 27 Feb 2025 01:10:06 GMT' do
-        VCR.use_cassette(
-          'form1010_ezr/lookup_user_with_ezr_prefill_data',
-          match_requests_on: %i[method uri body], erb: true
-        ) do
-          expect(
-            described_class.new.get_ezr_data(
-              '1012829228V424035'
-            ).to_h.deep_stringify_keys
-          ).to eq(veteran_data.except!('providers', 'dependents'))
+      context "and 'ezr_form_prefill_with_providers_and_dependents' flipper is enabled" do
+        before do
+          allow(Flipper).to receive(:enabled?).with(:ezr_form_prefill_with_providers_and_dependents).and_return(true)
+        end
+
+        it 'gets Veteran data with contacts and with providers and dependents' do
+          expect_veteran_data_to_match(veteran_data)
+        end
+      end
+
+      context "and 'ezr_form_prefill_with_providers_and_dependents' flipper is disabled" do
+        before do
+          allow(Flipper).to receive(:enabled?).with(:ezr_form_prefill_with_providers_and_dependents).and_return(false)
+        end
+
+        it 'gets Veteran data with without contacts and with providers and dependents' do
+          expect_veteran_data_to_match(veteran_data.except('providers', 'dependents'))
         end
       end
     end


### PR DESCRIPTION
## Summary

Form 10-10EZR
Adds prefill data for a Veteran's contacts: Emergency Contact(s) and Next Of Kin(s)

- *This work is behind a feature toggle (flipper): YES* `ezr_prefill_contacts`
- *(Summarize the changes that have been made to the platform)*
   1. Adds Veteran contacts to `get_ezr_data` method
   2. Adds `veteranContacts` to the 10-10EZR `FormProfile`:
       

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/104969

## Testing done

- [X] *New code is covered by unit tests*
- Tests are written for when the flag is enabled and disabled
- QA will be performed in the staging environment

## What areas of the site does it impact?
10-10EZR form

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
