### PR TITLE
Change CCRA to not be mocked in development.yml

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1629,7 +1629,7 @@ vanotify:
     bearer_token: <%= ENV['vanotify__status_callback__bearer_token'] %>
 vaos:
   ccra:
-    api_url: https://api.ccra.placeholder.va.local
+    api_url: <%= ENV['va_mobile__url'] %>
     base_path: csp/healthshare/ccraint/rest
     mock: <%= ENV['vaos__ccra__mock'] %>
   eps:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1652,7 +1652,7 @@ vaos:
   ccra:
     api_url: https://api.ccra.placeholder.va.local
     base_path: csp/healthshare/ccraint/rest
-    mock: true
+    mock: false
   eps:
     access_token_url: https://login.wellhive.com/oauth2/default/v1/token
     api_url: https://api.wellhive.com

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1650,7 +1650,7 @@ vanotify:
     bearer_token: fake_bearer_token
 vaos:
   ccra:
-    api_url: https://api.ccra.placeholder.va.local
+    api_url: https://veteran.apps.va.gov
     base_path: csp/healthshare/ccraint/rest
     mock: false
   eps:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1661,7 +1661,7 @@ vaos:
     client_assertion_type: urn:ietf:params:oauth:client-assertion-type:jwt-bearer
     client_id: fake_client_id
     grant_type: client_credentials
-    key_path: modules/health_quest/config/rsa/sandbox_rsa
+    key_path: <%= ENV['vaos__eps__key_path'] %>
     kid: fake_kid
     mock: false
     redis_token_expiry: 3500


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Change CCRA to not be mocked in development.yml
- Team: UAE Check In

## Related issue(s)
N/A - this is to be able to run in review instances

## Testing done
N/A

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

