### PR TITLE
106004 Add error logging for direct deposit

### DIFF
--- a/app/controllers/v0/profile/direct_deposits_controller.rb
+++ b/app/controllers/v0/profile/direct_deposits_controller.rb
@@ -17,6 +17,15 @@ module V0
         error = { status: exception.status_code, body: exception.errors.first }
         response = Lighthouse::DirectDeposit::ErrorParser.parse(error)
 
+        if response.status.between?(500, 599)
+          Rails.logger.error("Direct Deposit API error: #{exception.message}", {
+                               error_class: exception.class.to_s,
+                               error_message: exception.message,
+                               user_uuid: @current_user&.uuid,
+                               backtrace: exception.backtrace.first(3).join("\n")
+                             })
+        end
+
         render status: response.status, json: response.body
       end
 

--- a/spec/support/vcr_cassettes/lighthouse/direct_deposit/show/errors/502_update_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/direct_deposit/show/errors/502_update_response.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://sandbox-api.va.gov/services/direct-deposit-management/v1/direct-deposit?icn=1012666073V986297
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Authorization:
+      - Bearer blahblech
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 502
+      message: ''
+    headers:
+      Date:
+      - Thu, 29 Jun 2023 14:50:51 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Connection:
+      - keep-alive
+      Ratelimit-Limit:
+      - '120'
+      Ratelimit-Remaining:
+      - '119'
+      X-Ratelimit-Limit-Minute:
+      - '120'
+      Ratelimit-Reset:
+      - '9'
+      X-Ratelimit-Remaining-Minute:
+      - '119'
+      Www-Authenticate:
+      - Bearer
+      X-Kong-Response-Latency:
+      - '102'
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+      - max-age=31536000; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - ''
+      X-Frame-Options:
+      - SAMEORIGIN
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        <html>
+        <head><title>504 Gateway Time-out</title></head>
+        <body>
+        <center><h1>504 Gateway Time-out</h1></center>
+        </body>
+        </html>
+  recorded_at: Thu, 29 Jun 2023 14:50:51 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- We are adding explicit error logging in Direct Deposit for improved visibility and debugging in DataDog. These changes will allow DataDog to classify the log as an error instead of info - as it currently does
- MyVA & Profile Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/106004

## Testing done

- [ ] *New code is covered by unit tests* 
N/A
- Before this change, all errors from our Direct Deposit endpoints would be logged/classified as info by DataDog
- We will be able to confirm these changes work as expected when exploring DataDog logs for Direct Deposit and there is a count greater than 0 for Errors category. Additionally, we will not see any red/error status codes under the info category.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
None

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
