### PR TITLE
[CST] Friendly language consolidation & iteration

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -383,11 +383,7 @@ features:
     actor_type: user
     description: When enabled, CST overrides RV1 - Reserve Records Request tracked items to be NEEDED_FROM_OTHERS on mobile app
     enable_in_development: true
-  cst_friendly_evidence_requests_first_party:
-    actor_type: user
-    description: When enabled, CST overrides tracked items' display names and descriptions to be more human-readable
-    enable_in_development: true
-  cst_friendly_evidence_requests_third_party:
+  cst_friendly_evidence_requests:
     actor_type: user
     description: When enabled, CST overrides tracked items' display names and descriptions to be more human-readable
     enable_in_development: true

--- a/lib/lighthouse/benefits_claims/constants.rb
+++ b/lib/lighthouse/benefits_claims/constants.rb
@@ -6,16 +6,12 @@ module BenefitsClaims
       'Death' => 'expenses related to death or burial'
     }.freeze
 
-    FRIENDLY_DISPLAY_MAPPING_FIRST_PARTY = {
+    FRIENDLY_DISPLAY_MAPPING = {
       '21-4142/21-4142a' => 'Authorization to Disclose Information',
-      'Proof of Service (DD214, etc.)' => 'Proof of Service',
       'Employment info needed' => 'Employment information',
       'EFT - Treasury Mandate Notification' => 'Direct deposit information',
       'PTSD - Need stressor details/med evid of stressful incdnt' => 'Details about cause of PTSD',
-      'RV1 - Reserve Records Request' => 'Reserve records'
-    }.freeze
-
-    FRIENDLY_DISPLAY_MAPPING_THIRD_PARTY = {
+      'RV1 - Reserve Records Request' => 'Reserve records',
       'Proof of Service (DD214, etc.)' => 'Proof of Service',
       'PMR Request' => 'Non-VA medical records',
       'General Records Request (Medical)' => 'Non-VA medical records',
@@ -23,19 +19,15 @@ module BenefitsClaims
       'DBQ PSYCH Mental Disorders' => 'Mental health exam'
     }.freeze
 
-    FRIENDLY_DESCRIPTION_MAPPING_FIRST_PARTY = {
+    ACTIVITY_DESCRIPTION_MAPPING = {
       '21-4142/21-4142a' => 'We need your permission to request your personal information from a non-VA source,' \
                             ' like a private doctor or hospital.',
-      'Proof of Service (DD214, etc.)' => 'We need copies of your separation papers for all periods of service.',
       'Employment info needed' => 'We need employment information from your most recent employer.',
       'EFT - Treasury Mandate Notification' => 'We need your direct deposit information in order to pay benefits,' \
                                                ' if awarded.',
       'PTSD - Need stressor details/med evid of stressful incdnt' => 'We need information about the cause of' \
                                                                      ' your posttraumatic stress disorder (PTSD).',
-      'RV1 - Reserve Records Request' => 'We\'ve requested your reserve records on your behalf. No action is needed.'
-    }.freeze
-
-    FRIENDLY_DESCRIPTION_MAPPING_THIRD_PARTY = {
+      'RV1 - Reserve Records Request' => 'We\'ve requested your reserve records on your behalf. No action is needed.',
       'Proof of Service (DD214, etc.)' => 'We\'ve requested your Proof of Service on your behalf. No action is needed.',
       'PMR Request' => 'We\'ve requested your non-VA medical records on your behalf. No action is needed.',
       'General Records Request (Medical)' => 'We\'ve requested your non-VA medical records on your behalf.' \
@@ -46,17 +38,20 @@ module BenefitsClaims
                                       ' will contact you to schedule this appointment.'
     }.freeze
 
-    SUPPORT_ALIASES_MAPPING_FIRST_PARTY = {
+    SHORT_DESCRIPTION_MAPPING = {
+      'RV1 - Reserve Records Request' => 'For your benefits claim, we\'ve requested your service records' \
+                                         ' or treatment records from your reserve unit.',
+      'Proof of Service (DD214, etc.)' => 'For your benefits claim, we\'ve requested all your DD Form 214\'s' \
+                                          ' or other separation papers for all your periods of military service.'
+    }.freeze
+
+    SUPPORT_ALIASES_MAPPING = {
       '21-4142/21-4142a' => ['VA Form 21-4142'],
-      'Proof of Service (DD214, etc.)' => ['Form DD214'],
       'Employment info needed' => ['VA Form 21-4192'],
       'EFT - Treasury Mandate Notification' => ['EFT - Treasure Mandate Notification'],
       'PTSD - Need stressor details/med evid of stressful incdnt' => ['VA Form 21-0781',
                                                                       'PTSD - Need stressor details'],
-      'RV1 - Reserve Records Request' => ['RV1 - Reserve Records Request']
-    }.freeze
-
-    SUPPORT_ALIASES_MAPPING_THIRD_PARTY = {
+      'RV1 - Reserve Records Request' => ['RV1 - Reserve Records Request'],
       'Proof of Service (DD214, etc.)' => ['Proof of Service (DD214, etc.)'],
       'PMR Request' => ['PMR Request', 'General Records Request (Medical)'],
       'General Records Request (Medical)' => ['General Records Request (Medical)', 'PMR Request'],
@@ -64,16 +59,12 @@ module BenefitsClaims
       'DBQ PSYCH Mental Disorders' => ['DBQ PSYCH Mental Disorders']
     }.freeze
 
-    UPLOADER_MAPPING_FIRST_PARTY = {
+    UPLOADER_MAPPING = {
       '21-4142/21-4142a' => true,
-      'Proof of Service (DD214, etc.)' => true,
       'Employment info needed' => true,
       'EFT - Treasury Mandate Notification' => false,
       'PTSD - Need stressor details/med evid of stressful incdnt' => true,
-      'RV1 - Reserve Records Request' => true
-    }.freeze
-
-    UPLOADER_MAPPING_THIRD_PARTY = {
+      'RV1 - Reserve Records Request' => true,
       'Proof of Service (DD214, etc.)' => true,
       'PMR Request' => true,
       'General Records Request (Medical)' => true,

--- a/lib/lighthouse/benefits_claims/constants.rb
+++ b/lib/lighthouse/benefits_claims/constants.rb
@@ -12,7 +12,7 @@ module BenefitsClaims
       'EFT - Treasury Mandate Notification' => 'Direct deposit information',
       'PTSD - Need stressor details/med evid of stressful incdnt' => 'Details about cause of PTSD',
       'RV1 - Reserve Records Request' => 'Reserve records',
-      'Proof of Service (DD214, etc.)' => 'Proof of Service',
+      'Proof of service (DD214, etc.)' => 'Proof of Service',
       'PMR Request' => 'Non-VA medical records',
       'General Records Request (Medical)' => 'Non-VA medical records',
       'DBQ AUDIO Hearing Loss and Tinnitus' => 'Disability exam for hearing',
@@ -28,7 +28,7 @@ module BenefitsClaims
       'PTSD - Need stressor details/med evid of stressful incdnt' => 'We need information about the cause of' \
                                                                      ' your posttraumatic stress disorder (PTSD).',
       'RV1 - Reserve Records Request' => 'We\'ve requested your reserve records on your behalf. No action is needed.',
-      'Proof of Service (DD214, etc.)' => 'We\'ve requested your Proof of Service on your behalf. No action is needed.',
+      'Proof of service (DD214, etc.)' => 'We\'ve requested your Proof of Service on your behalf. No action is needed.',
       'PMR Request' => 'We\'ve requested your non-VA medical records on your behalf. No action is needed.',
       'General Records Request (Medical)' => 'We\'ve requested your non-VA medical records on your behalf.' \
                                              ' No action is needed.',
@@ -41,7 +41,7 @@ module BenefitsClaims
     SHORT_DESCRIPTION_MAPPING = {
       'RV1 - Reserve Records Request' => 'For your benefits claim, we\'ve requested your service records' \
                                          ' or treatment records from your reserve unit.',
-      'Proof of Service (DD214, etc.)' => 'For your benefits claim, we\'ve requested all your DD Form 214\'s' \
+      'Proof of service (DD214, etc.)' => 'For your benefits claim, we\'ve requested all your DD Form 214\'s' \
                                           ' or other separation papers for all your periods of military service.'
     }.freeze
 
@@ -52,7 +52,7 @@ module BenefitsClaims
       'PTSD - Need stressor details/med evid of stressful incdnt' => ['VA Form 21-0781',
                                                                       'PTSD - Need stressor details'],
       'RV1 - Reserve Records Request' => ['RV1 - Reserve Records Request'],
-      'Proof of Service (DD214, etc.)' => ['Proof of Service (DD214, etc.)'],
+      'Proof of service (DD214, etc.)' => ['Proof of Service (DD214, etc.)'],
       'PMR Request' => ['PMR Request', 'General Records Request (Medical)'],
       'General Records Request (Medical)' => ['General Records Request (Medical)', 'PMR Request'],
       'DBQ AUDIO Hearing Loss and Tinnitus' => ['DBQ AUDIO Hearing Loss and Tinnitus'],
@@ -65,7 +65,7 @@ module BenefitsClaims
       'EFT - Treasury Mandate Notification' => false,
       'PTSD - Need stressor details/med evid of stressful incdnt' => true,
       'RV1 - Reserve Records Request' => true,
-      'Proof of Service (DD214, etc.)' => true,
+      'Proof of service (DD214, etc.)' => true,
       'PMR Request' => true,
       'General Records Request (Medical)' => true,
       'DBQ AUDIO Hearing Loss and Tinnitus' => true,

--- a/lib/lighthouse/benefits_claims/service.rb
+++ b/lib/lighthouse/benefits_claims/service.rb
@@ -40,12 +40,7 @@ module BenefitsClaims
       # See https://github.com/department-of-veterans-affairs/va-mobile-app/issues/9671
       # This should be removed when the items are re-categorized by BGS
       override_tracked_items(claim['data']) if Flipper.enabled?(:cst_override_pmr_pending_tracked_items)
-      if Flipper.enabled?(:cst_friendly_evidence_requests_first_party)
-        apply_friendlier_language_first_party(claim['data'])
-      end
-      if Flipper.enabled?(:cst_friendly_evidence_requests_third_party)
-        apply_friendlier_language_third_party(claim['data'])
-      end
+      apply_friendlier_language(claim['data']) if Flipper.enabled?(:cst_friendly_evidence_requests)
       claim
     rescue Faraday::TimeoutError
       raise BenefitsClaims::ServiceException.new({ status: 504 }), 'Lighthouse Error'
@@ -296,37 +291,26 @@ module BenefitsClaims
         i['status'] = 'NEEDED_FROM_OTHERS'
         i['displayName'] = 'Private Medical Record'
       end
-      tracked_items
-    end
 
-    def apply_friendlier_language_first_party(claim)
-      tracked_items = claim['attributes']['trackedItems']
-      return unless tracked_items
-
-      tracked_items.select { |i| i['status'] == 'NEEDED_FROM_YOU' }.each do |i|
-        display_name = i['displayName']
-        i['canUploadFile'] =
-          BenefitsClaims::Constants::UPLOADER_MAPPING_FIRST_PARTY[display_name].nil? ||
-          BenefitsClaims::Constants::UPLOADER_MAPPING_FIRST_PARTY[display_name]
-        i['friendlyName'] = BenefitsClaims::Constants::FRIENDLY_DISPLAY_MAPPING_FIRST_PARTY[display_name]
-        i['friendlyDescription'] = BenefitsClaims::Constants::FRIENDLY_DESCRIPTION_MAPPING_FIRST_PARTY[display_name]
-        i['supportAliases'] = BenefitsClaims::Constants::SUPPORT_ALIASES_MAPPING_FIRST_PARTY[display_name] || []
+      tracked_items.select { |i| i['displayName'] == 'Proof of Service (DD214, etc.)' }.each do |i|
+        i['status'] = 'NEEDED_FROM_OTHERS'
       end
       tracked_items
     end
 
-    def apply_friendlier_language_third_party(claim)
+    def apply_friendlier_language(claim)
       tracked_items = claim['attributes']['trackedItems']
       return unless tracked_items
 
-      tracked_items.select { |i| i['status'] == 'NEEDED_FROM_OTHERS' }.each do |i|
+      tracked_items.each do |i|
         display_name = i['displayName']
         i['canUploadFile'] =
-          BenefitsClaims::Constants::UPLOADER_MAPPING_THIRD_PARTY[display_name].nil? ||
-          BenefitsClaims::Constants::UPLOADER_MAPPING_THIRD_PARTY[display_name]
-        i['friendlyName'] = BenefitsClaims::Constants::FRIENDLY_DISPLAY_MAPPING_THIRD_PARTY[display_name]
-        i['friendlyDescription'] = BenefitsClaims::Constants::FRIENDLY_DESCRIPTION_MAPPING_THIRD_PARTY[display_name]
-        i['supportAliases'] = BenefitsClaims::Constants::SUPPORT_ALIASES_MAPPING_THIRD_PARTY[display_name] || []
+          BenefitsClaims::Constants::UPLOADER_MAPPING[display_name].nil? ||
+          BenefitsClaims::Constants::UPLOADER_MAPPING[display_name]
+        i['friendlyName'] = BenefitsClaims::Constants::FRIENDLY_DISPLAY_MAPPING[display_name]
+        i['activityDescription'] = BenefitsClaims::Constants::ACTIVITY_DESCRIPTION_MAPPING[display_name]
+        i['shortDescription'] = BenefitsClaims::Constants::SHORT_DESCRIPTION_MAPPING[display_name]
+        i['supportAliases'] = BenefitsClaims::Constants::SUPPORT_ALIASES_MAPPING[display_name] || []
       end
       tracked_items
     end

--- a/lib/lighthouse/benefits_claims/service.rb
+++ b/lib/lighthouse/benefits_claims/service.rb
@@ -292,7 +292,7 @@ module BenefitsClaims
         i['displayName'] = 'Private Medical Record'
       end
 
-      tracked_items.select { |i| i['displayName'] == 'Proof of Service (DD214, etc.)' }.each do |i|
+      tracked_items.select { |i| i['displayName'] == 'Proof of service (DD214, etc.)' }.each do |i|
         i['status'] = 'NEEDED_FROM_OTHERS'
       end
       tracked_items

--- a/spec/controllers/v0/benefits_claims_controller_spec.rb
+++ b/spec/controllers/v0/benefits_claims_controller_spec.rb
@@ -249,11 +249,10 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
         end
       end
 
-      context 'when both friendly-language flippers are disabled' do
+      context 'when :cst_friendly_evidence_requests is disabled' do
         before do
           allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:cst_friendly_evidence_requests_third_party).and_return(false)
-          allow(Flipper).to receive(:enabled?).with(:cst_friendly_evidence_requests_first_party).and_return(false)
+          allow(Flipper).to receive(:enabled?).with(:cst_friendly_evidence_requests).and_return(false)
         end
 
         it 'does not modify the claim data and leaves the less-readable data as-is' do
@@ -265,18 +264,19 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
           expect(can_upload_values).to eq([nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
           friendly_name_values = tracked_items.map { |i| i['friendlyName'] }
           expect(friendly_name_values).to eq([nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
-          friendly_description_values = tracked_items.map { |i| i['friendlyDescription'] }
-          expect(friendly_description_values).to eq([nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+          activity_description_values = tracked_items.map { |i| i['activityDescription'] }
+          expect(activity_description_values).to eq([nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+          short_description_values = tracked_items.map { |i| i['shortDescription'] }
+          expect(short_description_values).to eq([nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
           support_alias_values = tracked_items.map { |i| i['supportAliases'] }
           expect(support_alias_values).to eq([nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
         end
       end
 
-      context 'when both friendly-language flippers are enabled' do
+      context 'when :cst_friendly_evidence_requests is enabled' do
         before do
           allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:cst_friendly_evidence_requests_third_party).and_return(true)
-          allow(Flipper).to receive(:enabled?).with(:cst_friendly_evidence_requests_first_party).and_return(true)
+          allow(Flipper).to receive(:enabled?).with(:cst_friendly_evidence_requests).and_return(true)
         end
 
         it 'modifies the claim data to include additional, human-readable fields' do
@@ -298,123 +298,42 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
           expect(friendly_name_values).to include('Non-VA medical records')
           expect(friendly_name_values).to include('Disability exam for hearing')
           expect(friendly_name_values).to include('Mental health exam')
-          friendly_description_values = tracked_items.map { |i| i['friendlyDescription'] }
-          expect(friendly_description_values).to include('We need your permission to request your personal' \
+          activity_description_values = tracked_items.map { |i| i['activityDescription'] }
+          expect(activity_description_values).to include('We need your permission to request your personal' \
                                                          ' information from a non-VA source, like a private' \
                                                          ' doctor or hospital.')
-          expect(friendly_description_values).to include('We need copies of your separation papers for all' \
-                                                         ' periods of service.')
-          expect(friendly_description_values).to include('We need employment information from your most' \
+          expect(activity_description_values).to include('We\'ve requested your Proof of Service on your behalf.' \
+                                                         ' No action is needed.')
+          expect(activity_description_values).to include('We need employment information from your most' \
                                                          ' recent employer.')
-          expect(friendly_description_values).to include('We need your direct deposit information in' \
+          expect(activity_description_values).to include('We need your direct deposit information in' \
                                                          ' order to pay benefits, if awarded.')
-          expect(friendly_description_values).to include('We need information about the cause of' \
+          expect(activity_description_values).to include('We need information about the cause of' \
                                                          ' your posttraumatic stress disorder (PTSD).')
-          expect(friendly_description_values).to include('We\'ve requested your reserve records on' \
+          expect(activity_description_values).to include('We\'ve requested your reserve records on' \
                                                          ' your behalf. No action is needed.')
-          expect(friendly_description_values).to include('We\'ve requested your Proof of Service on' \
+          expect(activity_description_values).to include('We\'ve requested your Proof of Service on' \
                                                          ' your behalf. No action is needed.')
-          expect(friendly_description_values).to include('We\'ve requested your non-VA medical records on' \
+          expect(activity_description_values).to include('We\'ve requested your non-VA medical records on' \
                                                          ' your behalf. No action is needed.')
-          expect(friendly_description_values).to include('We\'ve requested a disability exam for your hearing.' \
+          expect(activity_description_values).to include('We\'ve requested a disability exam for your hearing.' \
                                                          ' The examiner\'s office will contact you to schedule' \
                                                          ' this appointment.')
-          expect(friendly_description_values).to include('We\'ve requested a mental health exam for you.' \
+          expect(activity_description_values).to include('We\'ve requested a mental health exam for you.' \
                                                          ' The examiner\'s office will contact you to schedule' \
                                                          ' this appointment.')
+          short_description_values = tracked_items.map { |i| i['shortDescription'] }
+          expect(short_description_values).to include('For your benefits claim, we\'ve requested your service' \
+                                                      ' records or treatment records from your reserve unit.')
+          expect(short_description_values).to include('For your benefits claim, we\'ve requested all your' \
+                                                      ' DD Form 214\'s or other separation papers for all' \
+                                                      ' your periods of military service.')
           support_alias_values = tracked_items.map { |i| i['supportAliases'] }
           expect(support_alias_values).to include(['VA Form 21-4142'])
-          expect(support_alias_values).to include(['Form DD214'])
           expect(support_alias_values).to include(['VA Form 21-4192'])
           expect(support_alias_values).to include(['EFT - Treasure Mandate Notification'])
           expect(support_alias_values).to include(['VA Form 21-0781', 'PTSD - Need stressor details'])
           expect(support_alias_values).to include(['RV1 - Reserve Records Request'])
-          expect(support_alias_values).to include(['Proof of Service (DD214, etc.)'])
-          expect(support_alias_values).to include(['PMR Request', 'General Records Request (Medical)'])
-          expect(support_alias_values).to include(['General Records Request (Medical)', 'PMR Request'])
-          expect(support_alias_values).to include(['DBQ AUDIO Hearing Loss and Tinnitus'])
-          expect(support_alias_values).to include(['DBQ PSYCH Mental Disorders'])
-        end
-      end
-
-      context 'when only :cst_friendly_evidence_requests_first_party is enabled' do
-        before do
-          allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:cst_friendly_evidence_requests_third_party).and_return(false)
-          allow(Flipper).to receive(:enabled?).with(:cst_friendly_evidence_requests_first_party).and_return(true)
-        end
-
-        it 'modifies the claim data to include additional, human-readable fields' do
-          VCR.use_cassette('lighthouse/benefits_claims/show/200_response') do
-            get(:show, params: { id: '600383363' })
-          end
-          tracked_items = JSON.parse(response.body)['data']['attributes']['trackedItems']
-          can_upload_values = tracked_items.map { |i| i['canUploadFile'] }
-          expect(can_upload_values).to eq([nil, true, true, true, true, true, false, true, nil, nil, nil, nil, nil])
-          friendly_name_values = tracked_items.map { |i| i['friendlyName'] }
-          expect(friendly_name_values).to include('Authorization to Disclose Information')
-          expect(friendly_name_values).to include('Proof of Service')
-          expect(friendly_name_values).to include('Employment information')
-          expect(friendly_name_values).to include('Direct deposit information')
-          expect(friendly_name_values).to include('Details about cause of PTSD')
-          expect(friendly_name_values).to include('Reserve records')
-          friendly_description_values = tracked_items.map { |i| i['friendlyDescription'] }
-          expect(friendly_description_values).to include('We need your permission to request your personal' \
-                                                         ' information from a non-VA source, like a private' \
-                                                         ' doctor or hospital.')
-          expect(friendly_description_values).to include('We need copies of your separation papers for all' \
-                                                         ' periods of service.')
-          expect(friendly_description_values).to include('We need employment information from your most' \
-                                                         ' recent employer.')
-          expect(friendly_description_values).to include('We need your direct deposit information in' \
-                                                         ' order to pay benefits, if awarded.')
-          expect(friendly_description_values).to include('We need information about the cause of' \
-                                                         ' your posttraumatic stress disorder (PTSD).')
-          expect(friendly_description_values).to include('We\'ve requested your reserve records on' \
-                                                         ' your behalf. No action is needed.')
-          support_alias_values = tracked_items.map { |i| i['supportAliases'] }
-          expect(support_alias_values).to include(['VA Form 21-4142'])
-          expect(support_alias_values).to include(['Form DD214'])
-          expect(support_alias_values).to include(['VA Form 21-4192'])
-          expect(support_alias_values).to include(['EFT - Treasure Mandate Notification'])
-          expect(support_alias_values).to include(['VA Form 21-0781', 'PTSD - Need stressor details'])
-          expect(support_alias_values).to include(['RV1 - Reserve Records Request'])
-        end
-      end
-
-      context 'when only :cst_friendly_evidence_requests_third_party is enabled' do
-        before do
-          allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:cst_friendly_evidence_requests_third_party).and_return(true)
-          allow(Flipper).to receive(:enabled?).with(:cst_friendly_evidence_requests_first_party).and_return(false)
-        end
-
-        it 'modifies the claim data to include additional, human-readable fields' do
-          VCR.use_cassette('lighthouse/benefits_claims/show/200_response') do
-            get(:show, params: { id: '600383363' })
-          end
-          tracked_items = JSON.parse(response.body)['data']['attributes']['trackedItems']
-          can_upload_values = tracked_items.map { |i| i['canUploadFile'] }
-          expect(can_upload_values).to eq([true, nil, nil, nil, nil, nil, nil, nil, true, true, true, true,
-                                           true])
-          friendly_name_values = tracked_items.map { |i| i['friendlyName'] }
-          expect(friendly_name_values).to include('Proof of Service')
-          expect(friendly_name_values).to include('Non-VA medical records')
-          expect(friendly_name_values).to include('Non-VA medical records')
-          expect(friendly_name_values).to include('Disability exam for hearing')
-          expect(friendly_name_values).to include('Mental health exam')
-          friendly_description_values = tracked_items.map { |i| i['friendlyDescription'] }
-          expect(friendly_description_values).to include('We\'ve requested your Proof of Service on' \
-                                                         ' your behalf. No action is needed.')
-          expect(friendly_description_values).to include('We\'ve requested your non-VA medical records on' \
-                                                         ' your behalf. No action is needed.')
-          expect(friendly_description_values).to include('We\'ve requested a disability exam for your hearing.' \
-                                                         ' The examiner\'s office will contact you to schedule' \
-                                                         ' this appointment.')
-          expect(friendly_description_values).to include('We\'ve requested a mental health exam for you.' \
-                                                         ' The examiner\'s office will contact you to schedule' \
-                                                         ' this appointment.')
-          support_alias_values = tracked_items.map { |i| i['supportAliases'] }
           expect(support_alias_values).to include(['Proof of Service (DD214, etc.)'])
           expect(support_alias_values).to include(['PMR Request', 'General Records Request (Medical)'])
           expect(support_alias_values).to include(['General Records Request (Medical)', 'PMR Request'])

--- a/spec/support/vcr_cassettes/lighthouse/benefits_claims/show/200_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/benefits_claims/show/200_response.yml
@@ -281,7 +281,7 @@ http_interactions:
           {
           "closedDate": null,
           "description": "VA DD214",
-          "displayName": "Proof of Service (DD214, etc.)",
+          "displayName": "Proof of service (DD214, etc.)",
           "overdue": false,
           "receivedDate": "2023-03-15",
           "requestedDate": "2023-04-14",
@@ -385,7 +385,7 @@ http_interactions:
           {
           "closedDate": null,
           "description": "VA DD214",
-          "displayName": "Proof of Service (DD214, etc.)",
+          "displayName": "Proof of service (DD214, etc.)",
           "overdue": false,
           "receivedDate": "2023-03-15",
           "requestedDate": "2023-04-14",


### PR DESCRIPTION
Iterating on this one: https://github.com/department-of-veterans-affairs/vets-api/pull/21665

Changes include:
* One feature flipper, not two
* `friendlyDescription` is now `activityDescription`
* adds `shortDescription`
* override Proof Of Service to be 3rd party

### Summary
- This work is behind a feature toggle (flipper): **YES**
- I am on **Benefits Management 2**
- The `: cst_friendly_evidence_requests ` flipper is back, consolidating the old `first-` and `third-` party flippers.

## Related issue(s)

- [va.gov-team ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/106930)

## Testing done

- [X] New code is covered by unit tests