### PR TITLE
chore(rubocop): migrate to plugin-based config and update deprecated cop names

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,16 +2,16 @@ inherit_from:
   - .rubocop_explicit_enables.yml
   - .rubocop_todo.yml
 
-# in rakelib/lint.rake we require rubocop-thread_safety for the CI env only,
-# because codeclimate does not support rubocop-thread_safety
 require:
+  - './lib/rubocop/cops/ams_serializer.rb'
+
+plugins:
   - rubocop-rails
   - rubocop-rspec
   - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-rspec_rails
   - rubocop-thread_safety
-  - './lib/rubocop/cops/ams_serializer.rb'
 
 
 AllCops:

--- a/modules/debts_api/lib/debts_api/v0/one_debt_letter_service.rb
+++ b/modules/debts_api/lib/debts_api/v0/one_debt_letter_service.rb
@@ -5,12 +5,12 @@ require 'debt_management_center/debts_service'
 module DebtsApi
   module V0
     class OneDebtLetterService
-      # rubocop:disable Metrics/LineLength
+      # rubocop:disable Layout/LineLength
       COPAY_TABLE_DESCRIPTION = '<i>– You are receiving this billing statement because you are currently enrolled in a priority group requiring copayments for treatment of nonservice-connected conditions.</i>'
       COPAY_PAYMENT_INSTRUCTIONS = 'To Pay Your Copay Bills:<br><b>In Person:</b>: At your local Veteran Affairs Medical Center Agent Cashier’s Office<br><b>By Phone</b>: Contact VA at 1-888-827-4817<br><b>Online</b>: Pay by ACH withdrawal from your bank account, or by debit or credit card at www.pay.gov'
       DEBT_PAYMENT_INSTRUCTIONS = "To Pay Your VA Benefit Debt:\n<b>By Phone</b>: Contact VA’s Debt Management Center at 1-800-827-0648\n<b>Online</b>: Pay by ACH withdrawal from your bank account, or by debit or credit card at www.pay.va.gov"
       BENEFITS_TABLE_DESCRIPTION = '<i>– Veterans Benefits Administration overpayments are due to changes in your entitlement which result in you being paid more than you were entitled to receive.</i>'
-      # rubocop:enable Metrics/LineLength
+      # rubocop:enable Layout/LineLength
       COPAY_TOTAL_TEXT = 'Total Copayment Due'
       COPAY_TABLE_TITLE = '<b><i>VA Medical Center Copay Charges</i></b>'
       DEBT_TOTAL_TEXT = 'Total VBA Overpayment Due'

--- a/modules/vye/.rubocop.yml
+++ b/modules/vye/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from:
   - ../../.rubocop.yml
 
-require:
+plugins:
   - rubocop-rspec_rails
 
 Metrics/ModuleLength:

--- a/spec/sidekiq/education_form/create_daily_spool_files_spec.rb
+++ b/spec/sidekiq/education_form/create_daily_spool_files_spec.rb
@@ -340,14 +340,14 @@ RSpec.describe EducationForm::CreateDailySpoolFiles, form: :education_benefits, 
         end
       end
 
-      # rubocop:disable Rspec/NoExpectationExample
+      # rubocop:disable RSpec/NoExpectationExample
       it 'notifies the slack channel with a warning if no files were written' do
         stub_env_and_writer(
           byte_count: 0,
           expected_message: 'Warning: Uploaded 0 bytes to region: eastern'
         )
       end
-      # rubocop:enable Rspec/NoExpectationExample
+      # rubocop:enable RSpec/NoExpectationExample
 
       def stub_env_and_writer(byte_count:, expected_message:)
         allow(Rails.env).to receive(:production?).and_return(true)


### PR DESCRIPTION
- Switched from `require:` to `plugins:` in `.rubocop.yml` as per the plugin migration guide
- Updated deprecated cop namespaces:
  - Metrics/LineLength → Layout/LineLength
  - Rspec/NoExpectationExample → RSpec/NoExpectationExample
