### PR TITLE
[VI-1122] - Remove identity settings from Settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,8 +29,6 @@ ask_va_api:
     tenant_id: <%= ENV['ask_va_api__crm_api__tenant_id'] %>
     veis_api_path: eis/vagov.lob.ava/api
   prefill: true
-audit_db:
-  url: <%= ENV['audit_db__url'] %>
 authorization_server_scopes_api:
   auth_server:
     url: <%= ENV['authorization_server_scopes_api__auth_server__url'] %>
@@ -624,13 +622,6 @@ iam_ssoe:
   client_key_path: <%= ENV['iam_ssoe__client_key_path'] %>
   oauth_url: <%= ENV['iam_ssoe__oauth_url'] %>
   timeout: 20
-idme:
-  client_cert_path: <%= ENV['idme__client_cert_path'] %>
-  client_id: <%= ENV['idme__client_id'] %>
-  client_key_path: <%= ENV['idme__client_key_path'] %>
-  client_secret: <%= ENV['idme__client_secret'] %>
-  oauth_url: <%= ENV['idme__oauth_url'] %>
-  redirect_uri: <%= ENV['idme__redirect_uri'] %>
 ihub:
   appointments:
     mock: <%= ENV['ihub__appointments__mock'] %>
@@ -800,14 +791,6 @@ locators:
   vha_access_waittime: <%= ENV['locators__vha_access_waittime'] %>
 lockbox:
   master_key: <%= ENV['lockbox__master_key'] %>
-logingov:
-  client_cert_path: <%= ENV['logingov__client_cert_path'] %>
-  client_id: <%= ENV['logingov__client_id'] %>
-  client_key_path: <%= ENV['logingov__client_key_path'] %>
-  logout_redirect_uri: <%= ENV['logingov__logout_redirect_uri'] %>
-  oauth_public_key: <%= ENV['logingov__oauth_public_key'] %>
-  oauth_url: <%= ENV['logingov__oauth_url'] %>
-  redirect_uri: <%= ENV['logingov__redirect_uri'] %>
 mail_automation:
   client_id: <%= ENV['mail_automation__client_id'] %>
   client_secret: <%= ENV['mail_automation__client_secret'] %>
@@ -881,20 +864,6 @@ maintenance:
     vetext_vaccine: <%= ENV['maintenance__services__vetext_vaccine'] %>
     vic: <%= ENV['maintenance__services__vic'] %>
     vre: <%= ENV['maintenance__services__vre'] %>
-map_services:
-  appointments_client_id: <%= ENV['map_services__appointments_client_id'] %>
-  chatbot_client_id: 2bb9803acfc3
-  check_in_client_id: bc75b71c7e67
-  client_cert_path: <%= ENV['map_services__client_cert_path'] %>
-  client_key_path: <%= ENV['map_services__client_key_path'] %>
-  oauth_url: <%= ENV['map_services__oauth_url'] %>
-  secure_token_service:
-    mock: <%= ENV['map_services__secure_token_service__mock'] %>
-  sign_up_service:
-    mock: <%= ENV['map_services__sign_up_service__mock'] %>
-  sign_up_service_client_id: c7d6e0fc9a39
-  sign_up_service_provisioning_api_key: <%= ENV['map_services__sign_up_service_provisioning_api_key'] %>
-  sign_up_service_url: <%= ENV['map_services__sign_up_service_url'] %>
 mcp:
   notifications:
     batch_size: 10
@@ -925,14 +894,6 @@ mdot:
 mhv:
   account:
     mock: <%= ENV['mhv__account__mock'] %>
-  account_creation:
-    access_key: <%= ENV['mhv__account_creation__access_key'] %>
-    create_after_login: <%= ENV['mhv__account_creation__create_after_login'] %>
-    host: <%= ENV['mhv__account_creation__host'] %>
-    mock: <%= ENV['mhv__account_creation__mock'] %>
-    sts:
-      issuer: <%= ENV['mhv__account_creation__sts__issuer'] %>
-      service_account_id: <%= ENV['mhv__account_creation__sts__service_account_id'] %>
   api_gateway:
     hosts:
       bluebutton: <%= ENV['mhv__api_gateway__hosts__bluebutton'] %>
@@ -1038,15 +999,6 @@ modules_appeals_api:
       api_key: <%= ENV['modules_appeals_api__token_validation__notice_of_disagreements__api_key'] %>
     supplemental_claims:
       api_key: <%= ENV['modules_appeals_api__token_validation__supplemental_claims__api_key'] %>
-mvi:
-  client_cert_path: <%= ENV['mvi__client_cert_path'] %>
-  client_key_path: "/etc/pki/tls/private/vetsgov-mvi.key"
-  mock: <%= ENV['mvi__mock'] %>
-  open_timeout: 15
-  pii_logging: <%= ENV['mvi__pii_logging'] %>
-  processing_code: <%= ENV['mvi__processing_code'] %>
-  timeout: 30
-  url: <%= ENV['mvi__url'] %>
 mvi_hca:
   url: http://example.com
 nod_vanotify_status_callback:
@@ -1240,25 +1192,6 @@ salesforce-gibft:
 saml:
   cert_path: ~
   key_path: ~
-saml_ssoe:
-  callback_url: <%= ENV['saml_ssoe__callback_url'] %>
-  cert_new_path: <%= ENV['saml_ssoe__cert_new_path'] %>
-  cert_path: <%= ENV['saml_ssoe__cert_path'] %>
-  certificate: <%= ENV['saml_ssoe__certificate'] %>
-  certificate_new: <%= ENV['saml_ssoe__certificate_new'] %>
-  identity_slack_webhook: <%= ENV['saml_ssoe__identity_slack_webhook'] %>
-  idp_metadata_file: <%= ENV['saml_ssoe__idp_metadata_file'] %>
-  idp_sso_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
-  issuer: <%= ENV['saml_ssoe__issuer'] %>
-  key: <%= ENV['saml_ssoe__key'] %>
-  key_path: <%= ENV['saml_ssoe__key_path'] %>
-  logout_app_key: <%= ENV['saml_ssoe__logout_app_key'] %>
-  logout_url: <%= ENV['saml_ssoe__logout_url'] %>
-  relay: <%= ENV['saml_ssoe__relay'] %>
-  request_signing: <%= ENV['saml_ssoe__request_signing'] %>
-  response_encryption: <%= ENV['saml_ssoe__response_encryption'] %>
-  response_signing: <%= ENV['saml_ssoe__response_signing'] %>
-  tou_decline_logout_app_key: <%= ENV['saml_ssoe__tou_decline_logout_app_key'] %>
 schema_contract:
   appointments_index: modules/vaos/app/schemas/appointments_index.json
   test_index: spec/fixtures/schema_contract/test_schema.json
@@ -1285,8 +1218,6 @@ search_typeahead:
 secret_key_base: <%= ENV['secret_key_base'] %>
 sentry:
   dsn: <%= ENV['sentry__dsn'] %>
-session_cookie:
-  secure: true
 shrine:
   claims:
     access_key_id: <%= ENV['shrine__claims__access_key_id'] %>
@@ -1315,32 +1246,6 @@ sidekiq:
   github_organization: department-of-veterans-affairs
   github_team: <%= ENV['sidekiq__github_team'] %>
 sidekiq_admin_panel: <%= ENV['sidekiq_admin_panel'] %>
-sign_in:
-  arp_client_id: <%= ENV['sign_in__arp_client_id'] %>
-  auto_uplevel: true
-  client_redirect_uris:
-    mobile_test: <%= ENV['sign_in__client_redirect_uris__mobile_test'] %>
-  cookies_secure: <%= ENV['sign_in__cookies_secure'] %>
-  info_cookie_domain: <%= ENV['sign_in__info_cookie_domain'] %>
-  jwt_encode_key: <%= ENV['sign_in__jwt_encode_key'] %>
-  jwt_old_encode_key: <%= ENV['sign_in__jwt_old_encode_key'] %>
-  mock_auth_url: <%= ENV['sign_in__mock_auth_url'] %>
-  mock_redirect_uri: <%= ENV['sign_in__mock_redirect_uri'] %>
-  mockdata_sync_api_key: <%= ENV['sign_in__mockdata_sync_api_key'] %>
-  sts_client:
-    base_url: <%= ENV['sign_in__sts_client__base_url'] %>
-    key_path: <%= ENV['sign_in__sts_client__key_path'] %>
-  user_info_clients: <%= ENV['sign_in__user_info_clients'] %>
-  vamobile_client_id: <%= ENV['sign_in__vamobile_client_id'] %>
-  vaweb_client_id: vaweb
-  web_origins: <%= ENV['sign_in__web_origins'] %>
-ssoe_eauth_cookie:
-  domain: <%= ENV['ssoe_eauth_cookie__domain'] %>
-  name: <%= ENV['ssoe_eauth_cookie__name'] %>
-  secure: <%= ENV['ssoe_eauth_cookie__secure'] %>
-terms_of_use:
-  current_version: v1
-  enabled_clients: <%= ENV['terms_of_use__enabled_clients'] %>
 test_database_url: <%= ENV['test_database_url'] %>
 test_user_dashboard:
   env: <%= ENV['test_user_dashboard__env'] %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -29,8 +29,6 @@ ask_va_api:
     tenant_id: abcdefgh-1234-5678-12345-11e8b8ce491e
     veis_api_path: eis/vagov.lob.ava/api
   prefill: true
-audit_db:
-  url: ~
 authorization_server_scopes_api:
   auth_server:
     url: https://sandbox-api.va.gov/internal/auth/v2/server
@@ -623,13 +621,6 @@ iam_ssoe:
   client_key_path: spec/fixtures/iam_ssoe/oauth.key
   oauth_url: https://int.fed.eauth.va.gov:444
   timeout: 20
-idme:
-  client_cert_path: spec/fixtures/sign_in/oauth.crt
-  client_id: ef7f1237ed3c396e4b4a2b04b608a7b1
-  client_key_path: spec/fixtures/sign_in/oauth.key
-  client_secret: ae657fd2b253d17be7b48ecdb39d7b34
-  oauth_url: https://api.idmelabs.com
-  redirect_uri: http://localhost:3000/v0/sign_in/callback
 ihub:
   appointments:
     mock: true
@@ -808,14 +799,6 @@ locators:
   vha_access_waittime: ~
 lockbox:
   master_key: 0d78eaf0e90d4e7b8910c9112e16e66d8b00ec4054a89aa426e32712a13371e9
-logingov:
-  client_cert_path: spec/fixtures/sign_in/oauth.crt
-  client_id: https://sqa.eauth.va.gov/isam/sps/saml20sp/saml20
-  client_key_path: spec/fixtures/sign_in/oauth.key
-  logout_redirect_uri: http://localhost:3000/v0/sign_in/logingov_logout_proxy
-  oauth_public_key: spec/fixtures/logingov/logingov_oauth_pub.pem
-  oauth_url: https://idp.int.identitysandbox.gov
-  redirect_uri: http://localhost:3000/v0/sign_in/callback
 mail_automation:
   client_id: va_gov_test
   client_secret: fake_key
@@ -889,20 +872,6 @@ maintenance:
     vetext_vaccine: P9PG8HG
     vic: P7LW3MS
     vre: ~
-map_services:
-  appointments_client_id: 74b3145e1354555e
-  chatbot_client_id: 2bb9803acfc3
-  check_in_client_id: bc75b71c7e67
-  client_cert_path: spec/fixtures/map/oauth.crt
-  client_key_path: spec/fixtures/map/oauth.key
-  oauth_url: https://veteran.apps-staging.va.gov
-  secure_token_service:
-    mock: true
-  sign_up_service:
-    mock: true
-  sign_up_service_client_id: c7d6e0fc9a39
-  sign_up_service_provisioning_api_key: abcd1234
-  sign_up_service_url: https://cerner.apps-staging.va.gov
 mcp:
   notifications:
     batch_size: 10
@@ -933,14 +902,6 @@ mdot:
 mhv:
   account:
     mock: false
-  account_creation:
-    access_key: some-access-key
-    create_after_login: ~
-    host: https://apigw-intb.aws.myhealth.va.gov
-    mock: true
-    sts:
-      issuer: http://localhost:3000
-      service_account_id: c34b86f2130ff3cd4b1d309bc09d8740
   api_gateway:
     hosts:
       bluebutton: fake-host
@@ -1052,15 +1013,6 @@ modules_appeals_api:
       api_key: ''
     supplemental_claims:
       api_key: ''
-mvi:
-  client_cert_path: config/certs/vetsgov-localhost.crt
-  client_key_path: config/certs/vetsgov-localhost.key
-  mock: true
-  open_timeout: 15
-  pii_logging: false
-  processing_code: T
-  timeout: 30
-  url: http://ps-dev.commserv.healthevet.va.gov:8110/psim_webservice/IdMWebService
 mvi_hca:
   url: http://example.com
 nod_vanotify_status_callback:
@@ -1259,25 +1211,6 @@ salesforce-gibft:
 saml:
   cert_path: ~
   key_path: ~
-saml_ssoe:
-  callback_url: http://localhost:3000/v1/sessions/callback
-  cert_new_path: ~
-  cert_path: ~
-  certificate: ~
-  certificate_new: ~
-  identity_slack_webhook: ~
-  idp_metadata_file: config/ssoe_idp_int_metadata_isam.xml
-  idp_sso_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
-  issuer: https://ssoe-sp-localhost.va.gov
-  key: ~
-  key_path: ~
-  logout_app_key: https://ssoe-sp-dev.va.gov
-  logout_url: https://int.eauth.va.gov/slo/globallogout
-  relay: ~
-  request_signing: false
-  response_encryption: false
-  response_signing: false
-  tou_decline_logout_app_key: https://dev-api.va.gov/agreements_declined
 schema_contract:
   appointments_index: modules/vaos/app/schemas/appointments_index.json
   test_index: spec/fixtures/schema_contract/test_schema.json
@@ -1304,8 +1237,6 @@ search_typeahead:
 secret_key_base: c1a13acb916e6ebf1d2a93a3924586520508b609e80e048364902cd36ab602c9ec6ddcb47ac66e7903dbc77ae876df5564658a4f786b50497440b0c7dc029361
 sentry:
   dsn: ~
-session_cookie:
-  secure: false
 shrine:
   claims:
     access_key_id: ~
@@ -1334,34 +1265,6 @@ sidekiq:
   github_organization: ~
   github_team: ~
 sidekiq_admin_panel: false
-sign_in:
-  arp_client_id: arp
-  auto_uplevel: true
-  client_redirect_uris:
-    mobile_test: ~
-  cookies_secure: false
-  info_cookie_domain: localhost
-  jwt_encode_key: spec/fixtures/sign_in/privatekey.pem
-  jwt_old_encode_key: spec/fixtures/sign_in/privatekey_old.pem
-  mock_auth_url: http://localhost:3000/mocked_authentication/profiles
-  mock_redirect_uri: http://localhost:3000/v0/sign_in/callback
-  mockdata_sync_api_key: ~
-  sts_client:
-    base_url: http://localhost:3000
-    key_path: spec/fixtures/sign_in/sts_client.pem
-  user_info_clients:
-    - okta_test
-  vamobile_client_id: vamobile
-  vaweb_client_id: vaweb
-  web_origins:
-    - http://localhost:4000
-ssoe_eauth_cookie:
-  domain: localhost
-  name: vagov_saml_request_localhost
-  secure: false
-terms_of_use:
-  current_version: v1
-  enabled_clients: vaweb, mhv, myvahealth
 test_database_url: postgis:///vets-api-test
 test_user_dashboard:
   env: dev

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -28,8 +28,6 @@ ask_va_api:
     tenant_id: abcdefgh-1234-5678-12345-11e8b8ce491e
     veis_api_path: eis/vagov.lob.ava/api
   prefill: true
-audit_db:
-  url: ~
 authorization_server_scopes_api:
   auth_server:
     url: https://sandbox-api.va.gov/internal/auth/v2/server
@@ -617,13 +615,6 @@ iam_ssoe:
   client_key_path: spec/fixtures/iam_ssoe/oauth.key
   oauth_url: https://int.fed.eauth.va.gov:444
   timeout: 20
-idme:
-  client_cert_path: spec/fixtures/sign_in/oauth.crt
-  client_id: ef7f1237ed3c396e4b4a2b04b608a7b1
-  client_key_path: spec/fixtures/sign_in/oauth.key
-  client_secret: ae657fd2b253d17be7b48ecdb39d7b34
-  oauth_url: https://api.idmelabs.com
-  redirect_uri: http://localhost:3000/v0/sign_in/callback
 ihub:
   appointments:
     mock: true
@@ -802,14 +793,6 @@ locators:
   vha_access_waittime: ~
 lockbox:
   master_key: 0d78eaf0e90d4e7b8910c9112e16e66d8b00ec4054a89aa426e32712a13371e9
-logingov:
-  client_cert_path: spec/fixtures/sign_in/oauth.crt
-  client_id: https://sqa.eauth.va.gov/isam/sps/saml20sp/saml20
-  client_key_path: spec/fixtures/sign_in/oauth.key
-  logout_redirect_uri: http://localhost:3000/v0/sign_in/logingov_logout_proxy
-  oauth_public_key: spec/fixtures/logingov/logingov_oauth_pub.pem
-  oauth_url: https://idp.int.identitysandbox.gov
-  redirect_uri: http://localhost:3000/v0/sign_in/callback
 mail_automation:
   client_id: va_gov_test
   client_secret: fake_key
@@ -883,20 +866,6 @@ maintenance:
     vetext_vaccine: P9PG8HG
     vic: P7LW3MS
     vre: ~
-map_services:
-  appointments_client_id: 74b3145e1354555e
-  chatbot_client_id: 2bb9803acfc3
-  check_in_client_id: bc75b71c7e67
-  client_cert_path: spec/fixtures/map/oauth.crt
-  client_key_path: spec/fixtures/map/oauth.key
-  oauth_url: https://veteran.apps-staging.va.gov
-  secure_token_service:
-    mock: true
-  sign_up_service:
-    mock: true
-  sign_up_service_client_id: c7d6e0fc9a39
-  sign_up_service_provisioning_api_key: abcd1234
-  sign_up_service_url: https://cerner.apps-staging.va.gov
 mcp:
   notifications:
     batch_size: 100
@@ -927,14 +896,6 @@ mdot:
 mhv:
   account:
     mock: false
-  account_creation:
-    access_key: some-access-key
-    create_after_login: ~
-    host: https://apigw-intb.aws.myhealth.va.gov
-    mock: true
-    sts:
-      issuer: http://localhost:3000
-      service_account_id: c34b86f2130ff3cd4b1d309bc09d8740
   api_gateway:
     hosts:
       bluebutton: http://example.org
@@ -1046,15 +1007,6 @@ modules_appeals_api:
       api_key: ''
     supplemental_claims:
       api_key: ''
-mvi:
-  client_cert_path: "/fake/client/cert/path"
-  client_key_path: "/fake/client/key/path"
-  mock: false
-  open_timeout: 15
-  pii_logging: false
-  processing_code: T
-  timeout: 30
-  url: http://www.example.com/
 mvi_hca:
   url: http://example.com
 nod_vanotify_status_callback:
@@ -1253,25 +1205,6 @@ salesforce-gibft:
 saml:
   cert_path: spec/support/certificates/ruby-saml.crt
   key_path: spec/support/certificates/ruby-saml.key
-saml_ssoe:
-  callback_url: http://localhost:3000/v1/sessions/callback
-  cert_new_path: ~
-  cert_path: spec/support/certificates/ruby-saml.crt
-  certificate: ~
-  certificate_new: ~
-  identity_slack_webhook: ~
-  idp_metadata_file: config/ssoe_idp_int_metadata_isam.xml
-  idp_sso_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
-  issuer: https://ssoe-sp-localhost.va.gov
-  key: ~
-  key_path: spec/support/certificates/ruby-saml.key
-  logout_app_key: https://ssoe-sp-dev.va.gov
-  logout_url: https://int.eauth.va.gov/slo/globallogout
-  relay: ~
-  request_signing: false
-  response_encryption: false
-  response_signing: false
-  tou_decline_logout_app_key: https://dev-api.va.gov/agreements_declined
 schema_contract:
   appointments_index: modules/vaos/app/schemas/appointments_index.json
   test_index: spec/fixtures/schema_contract/test_schema.json
@@ -1298,8 +1231,6 @@ search_typeahead:
 secret_key_base: be8e6b6b16993e899c2c4fd08f7c6a6e5ad5f295b369d22f126d4569d2a0e44c4f04b13c02d65ab701452ef0a24ed2db7af441214ed5ae98c6113442f5846605
 sentry:
   dsn: ~
-session_cookie:
-  secure: false
 shrine:
   claims:
     access_key_id: ~
@@ -1328,34 +1259,6 @@ sidekiq:
   github_organization: organization
   github_team: 0
 sidekiq_admin_panel: false
-sign_in:
-  arp_client_id: arp
-  auto_uplevel: true
-  client_redirect_uris:
-    mobile_test: ~
-  cookies_secure: false
-  info_cookie_domain: localhost
-  jwt_encode_key: spec/fixtures/sign_in/privatekey.pem
-  jwt_old_encode_key: spec/fixtures/sign_in/privatekey_old.pem
-  mock_auth_url: http://localhost:3000/mocked_authentication/profiles
-  mock_redirect_uri: http://localhost:3000/v0/sign_in/callback
-  mockdata_sync_api_key: ~
-  sts_client:
-    base_url: http://localhost:3000
-    key_path: spec/fixtures/sign_in/sts_client.pem
-  user_info_clients:
-    - okta_test
-  vamobile_client_id: vamobile
-  vaweb_client_id: vaweb
-  web_origins:
-    - http://localhost:4000
-ssoe_eauth_cookie:
-  domain: localhost
-  name: vagov_saml_request_localhost
-  secure: false
-terms_of_use:
-  current_version: v1
-  enabled_clients: vaweb, mhv, myvahealth
 test_database_url: postgis:///vets-api-test
 test_user_dashboard:
   env: staging


### PR DESCRIPTION
## Summary

- Remove identity settings from settings
- These have all been removed from parameter store
- The following are removed from `config/settings.yml`, `config/settings/development.yml`, and `config/settings/test.yml`
  - [ ] `audit_db`
  - [ ] `idme`
  - [ ] `logingov`
  - [ ] `map_services`
  - [ ] `mhv.account_creation`
  - [ ] `mvi`
  - [ ] `saml_ssoe`
  - [ ] `session_cookie`
  - [ ] `sign_in`
  - [ ] `ssoe_eauth_cookie`
  - [ ] `terms_of_use`

## Related issue(s)
- https://jira.devops.va.gov/browse/VI-1122


## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Settings, IdentitySettings

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
