### PR TITLE
108137 fix ccra config endpoints

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1630,7 +1630,7 @@ vanotify:
 vaos:
   ccra:
     api_url: <%= ENV['va_mobile__url'] %>
-    base_path: csp/healthshare/ccraint/rest
+    base_path: vaos/v1/patients
     mock: <%= ENV['vaos__ccra__mock'] %>
   eps:
     access_token_url: https://login.wellhive.com/oauth2/default/v1/token

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1651,7 +1651,7 @@ vanotify:
 vaos:
   ccra:
     api_url: https://veteran.apps.va.gov
-    base_path: csp/healthshare/ccraint/rest
+    base_path: vaos/v1/patients
     mock: false
   eps:
     access_token_url: https://login.wellhive.com/oauth2/default/v1/token

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1645,7 +1645,7 @@ vanotify:
 vaos:
   ccra:
     api_url: https://api.ccra.placeholder.va.local
-    base_path: csp/healthshare/ccraint/rest
+    base_path: vaos/v1/patients
     mock: false
   eps:
     access_token_url: https://login.wellhive.com/oauth2/default/v1/token

--- a/modules/vaos/app/controllers/vaos/v2/eps_appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/eps_appointments_controller.rb
@@ -45,7 +45,6 @@ module VAOS
 
         begin
           # TODO: Need correct mode parameter, this one is hard-coded based on examples
-          ccra_referral_service.get_referral(referral_number, '2')
           ccra_referral_service.get_referral(referral_number, '2', current_user.icn)
         rescue => e
           Rails.logger.error "Failed to retrieve referral details: #{e.message}"

--- a/modules/vaos/app/controllers/vaos/v2/eps_appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/eps_appointments_controller.rb
@@ -46,6 +46,7 @@ module VAOS
         begin
           # TODO: Need correct mode parameter, this one is hard-coded based on examples
           ccra_referral_service.get_referral(referral_number, '2')
+          ccra_referral_service.get_referral(referral_number, '2', current_user.icn)
         rescue => e
           Rails.logger.error "Failed to retrieve referral details: #{e.message}"
           nil

--- a/modules/vaos/app/controllers/vaos/v2/referrals_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/referrals_controller.rb
@@ -30,7 +30,8 @@ module VAOS
 
         response = referral_service.get_referral(
           decrypted_id,
-          referral_mode_param
+          referral_mode_param,
+          current_user.icn
         )
 
         # Add uuid to the detailed response

--- a/modules/vaos/app/services/ccra/referral_service.rb
+++ b/modules/vaos/app/services/ccra/referral_service.rb
@@ -17,7 +17,7 @@ module Ccra
         req_headers = config.mock_enabled? ? {} : headers
         response = perform(
           :post,
-          "/#{config.base_path}/VAOS/patients/ReferralList",
+          "/#{config.base_path}/#{icn}/referrals",
           data,
           req_headers
         )
@@ -31,14 +31,14 @@ module Ccra
     # @param mode [String] The mode of the referral.
     #
     # @return [ReferralDetail] A ReferralDetail object representing the detailed referral information.
-    def get_referral(id, mode)
+    def get_referral(id, mode, icn)
       data = { Id: id, Mode: mode }
       with_monitoring do
         # Skip token authentication for mock requests
         req_headers = config.mock_enabled? ? {} : headers
         response = perform(
           :post,
-          "/#{config.base_path}/ReferralUtil/GetReferral",
+          "/#{config.base_path}/#{icn}/referrals/#{id}",
           data,
           req_headers
         )

--- a/modules/vaos/spec/controllers/v2/referrals_controller_spec.rb
+++ b/modules/vaos/spec/controllers/v2/referrals_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe VAOS::V2::ReferralsController, type: :request do
   let(:inflection_header) { { 'X-Key-Inflection' => 'camel' } }
   let(:referral_statuses) { "'AP','AC','I'" }
   let(:referral_mode) { 'C' }
+  let(:icn) { '1012845331V153043' }
 
   before do
     allow(Rails).to receive(:cache).and_return(memory_store)
@@ -41,7 +42,6 @@ RSpec.describe VAOS::V2::ReferralsController, type: :request do
     end
 
     context 'when called with authorization' do
-      let(:icn) { '1012845331V153043' }
       let(:user) { build(:user, :vaos, :loa3, icn:) }
       let(:referral_list_entries) { build_list(:ccra_referral_list_entry, 3) }
 
@@ -181,13 +181,13 @@ RSpec.describe VAOS::V2::ReferralsController, type: :request do
     end
 
     context 'when called with authorization' do
-      let(:user) { build(:user, :vaos, :loa3) }
+      let(:user) { build(:user, :vaos, :loa3, icn:) }
       let(:referral_detail) { build(:ccra_referral_detail, referral_number:) }
 
       before do
         sign_in_as(user)
         allow_any_instance_of(Ccra::ReferralService).to receive(:get_referral)
-          .with(referral_number, referral_mode)
+          .with(referral_number, referral_mode, icn)
           .and_return(referral_detail)
       end
 
@@ -212,7 +212,7 @@ RSpec.describe VAOS::V2::ReferralsController, type: :request do
 
         before do
           allow_any_instance_of(Ccra::ReferralService).to receive(:get_referral)
-            .with(referral_number, custom_mode)
+            .with(referral_number, custom_mode, icn)
             .and_return(referral_detail)
         end
 

--- a/modules/vaos/spec/requests/v2/referrals_spec.rb
+++ b/modules/vaos/spec/requests/v2/referrals_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'VAOS V2 Referrals', type: :request do
       Rails.cache.clear
 
       allow(Ccra::ReferralService).to receive(:new).and_return(service_double)
-      allow(service_double).to receive(:get_referral).and_return(referral)
+      allow(service_double).to receive(:get_referral).with(referral_number, anything, icn).and_return(referral)
       allow(VAOS::ReferralEncryptionService).to receive(:encrypt).with(referral_number).and_return(encrypted_uuid)
       allow(VAOS::ReferralEncryptionService).to receive(:decrypt).with(encrypted_uuid).and_return(referral_number)
       allow(VAOS::ReferralEncryptionService)

--- a/modules/vaos/spec/requests/vaos/v2/eps_appointments_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/eps_appointments_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'VAOS::V2::EpsAppointments', :skip_mvi, type: :request do
     Settings.vaos.ccra ||= OpenStruct.new
     Settings.vaos.ccra.tap do |ccra|
       ccra.api_url = 'http://ccra.api.example.com'
-      ccra.base_path = 'csp/healthshare/ccraint/rest'
+      ccra.base_path = 'vaos/v1/patients'
     end
     Settings.vaos.eps ||= OpenStruct.new
     Settings.vaos.eps.tap do |eps|

--- a/modules/vaos/spec/services/ccra/referral_service_spec.rb
+++ b/modules/vaos/spec/services/ccra/referral_service_spec.rb
@@ -19,7 +19,7 @@ describe Ccra::ReferralService do
     Settings.vaos.ccra ||= OpenStruct.new
     Settings.vaos.ccra.tap do |ccra|
       ccra.api_url = 'http://ccra.api.example.com'
-      ccra.base_path = 'csp/healthshare/ccraint/rest'
+      ccra.base_path = 'vaos/v1/patients'
     end
   end
 
@@ -67,11 +67,12 @@ describe Ccra::ReferralService do
   describe '#get_referral' do
     let(:id) { '984_646372' }
     let(:mode) { '2' }
+    let(:icn) { '1012845331V153043' }
 
     context 'with successful response', :vcr do
       it 'returns a ReferralDetail object' do
         VCR.use_cassette('vaos/ccra/post_get_referral_success') do
-          result = subject.get_referral(id, mode)
+          result = subject.get_referral(id, mode, icn)
           expect(result).to be_a(Ccra::ReferralDetail)
           expect(result.category_of_care).to eq('CARDIOLOGY')
           expect(result.referral_number).to eq('VA0000005681')
@@ -84,7 +85,7 @@ describe Ccra::ReferralService do
 
       it 'raises not found error' do
         VCR.use_cassette('vaos/ccra/post_get_referral_not_found') do
-          expect { subject.get_referral(id, mode) }
+          expect { subject.get_referral(id, mode, icn) }
             .to raise_error(Common::Exceptions::BackendServiceException)
         end
       end
@@ -95,7 +96,7 @@ describe Ccra::ReferralService do
 
       it 'raises a BackendServiceException' do
         VCR.use_cassette('vaos/ccra/post_get_referral_error') do
-          expect { subject.get_referral(id, mode) }
+          expect { subject.get_referral(id, mode, icn) }
             .to raise_error(Common::Exceptions::BackendServiceException)
         end
       end

--- a/spec/support/vcr_cassettes/vaos/ccra/post_get_referral_error.yml
+++ b/spec/support/vcr_cassettes/vaos/ccra/post_get_referral_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<VAOS_CCRA_API_URL>/csp/healthshare/ccraint/rest/ReferralUtil/GetReferral"
+    uri: "<VAOS_CCRA_API_URL>/vaos/v1/patients/care-nav-patient-casey/referrals/error_id"
     body:
       encoding: UTF-8
       string: '{"Id":"984_646372","Mode":"invalid"}'

--- a/spec/support/vcr_cassettes/vaos/ccra/post_get_referral_error.yml
+++ b/spec/support/vcr_cassettes/vaos/ccra/post_get_referral_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<VAOS_CCRA_API_URL>/vaos/v1/patients/care-nav-patient-casey/referrals/error_id"
+    uri: "<VAOS_CCRA_API_URL>/vaos/v1/patients/1012845331V153043/referrals/error_id"
     body:
       encoding: UTF-8
       string: '{"Id":"984_646372","Mode":"invalid"}'

--- a/spec/support/vcr_cassettes/vaos/ccra/post_get_referral_not_found.yml
+++ b/spec/support/vcr_cassettes/vaos/ccra/post_get_referral_not_found.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<VAOS_CCRA_API_URL>/csp/healthshare/ccraint/rest/patients/1012845331V153043/referrals/invalid_id"
+    uri: "<VAOS_CCRA_API_URL>/vaos/v1/patients/1012845331V153043/referrals/invalid_id"
     body:
       encoding: UTF-8
       string: '{"Id":"invalid_id","Mode":"2"}'

--- a/spec/support/vcr_cassettes/vaos/ccra/post_get_referral_not_found.yml
+++ b/spec/support/vcr_cassettes/vaos/ccra/post_get_referral_not_found.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<VAOS_CCRA_API_URL>/csp/healthshare/ccraint/rest/ReferralUtil/GetReferral"
+    uri: "<VAOS_CCRA_API_URL>/csp/healthshare/ccraint/rest/patients/1012845331V153043/referrals/invalid_id"
     body:
       encoding: UTF-8
       string: '{"Id":"invalid_id","Mode":"2"}'

--- a/spec/support/vcr_cassettes/vaos/ccra/post_get_referral_success.yml
+++ b/spec/support/vcr_cassettes/vaos/ccra/post_get_referral_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<VAOS_CCRA_API_URL>/csp/healthshare/ccraint/rest/patients/1012845331V153043/referrals/984_646372"
+    uri: "<VAOS_CCRA_API_URL>/vaos/v1/patients/1012845331V153043/referrals/984_646372"
     body:
       encoding: UTF-8
       string: '{"Id":"984_646372","Mode":"2"}'

--- a/spec/support/vcr_cassettes/vaos/ccra/post_get_referral_success.yml
+++ b/spec/support/vcr_cassettes/vaos/ccra/post_get_referral_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<VAOS_CCRA_API_URL>/csp/healthshare/ccraint/rest/ReferralUtil/GetReferral"
+    uri: "<VAOS_CCRA_API_URL>/csp/healthshare/ccraint/rest/patients/1012845331V153043/referrals/984_646372"
     body:
       encoding: UTF-8
       string: '{"Id":"984_646372","Mode":"2"}'

--- a/spec/support/vcr_cassettes/vaos/ccra/post_get_referral_with_phone.yml
+++ b/spec/support/vcr_cassettes/vaos/ccra/post_get_referral_with_phone.yml
@@ -1,7 +1,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<VAOS_CCRA_API_URL>/csp/healthshare/ccraint/rest/ReferralUtil/GetReferral"
+    uri: "<VAOS_CCRA_API_URL>/vaos/v1/patients/care-nav-patient-casey/referrals/12345"
     body:
       encoding: UTF-8
       string: '{"Id":"12345","Mode":"2"}'

--- a/spec/support/vcr_cassettes/vaos/ccra/post_referral_list_empty.yml
+++ b/spec/support/vcr_cassettes/vaos/ccra/post_referral_list_empty.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<VAOS_CCRA_API_URL>/csp/healthshare/ccraint/rest/VAOS/patients/ReferralList"
+    uri: "<VAOS_CCRA_API_URL>/csp/healthshare/ccraint/rest/patients/1012845331V153043/referrals"
     body:
       encoding: UTF-8
       string: '{"ICN":"1012845331V153043","ReferralStatus":"''S'',''BP'',''AP'',''AC'',''A'',''I''"}'

--- a/spec/support/vcr_cassettes/vaos/ccra/post_referral_list_empty.yml
+++ b/spec/support/vcr_cassettes/vaos/ccra/post_referral_list_empty.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<VAOS_CCRA_API_URL>/csp/healthshare/ccraint/rest/patients/1012845331V153043/referrals"
+    uri: "<VAOS_CCRA_API_URL>/vaos/v1/patients/1012845331V153043/referrals"
     body:
       encoding: UTF-8
       string: '{"ICN":"1012845331V153043","ReferralStatus":"''S'',''BP'',''AP'',''AC'',''A'',''I''"}'

--- a/spec/support/vcr_cassettes/vaos/ccra/post_referral_list_error.yml
+++ b/spec/support/vcr_cassettes/vaos/ccra/post_referral_list_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<VAOS_CCRA_API_URL>/csp/healthshare/ccraint/rest/patients/invalid/referrals"
+    uri: "<VAOS_CCRA_API_URL>/vaos/v1/patients/invalid/referrals"
     body:
       encoding: UTF-8
       string: '{"ICN":"invalid","ReferralStatus":"''S'',''BP'',''AP'',''AC'',''A'',''I''"}'

--- a/spec/support/vcr_cassettes/vaos/ccra/post_referral_list_error.yml
+++ b/spec/support/vcr_cassettes/vaos/ccra/post_referral_list_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<VAOS_CCRA_API_URL>/csp/healthshare/ccraint/rest/VAOS/patients/ReferralList"
+    uri: "<VAOS_CCRA_API_URL>/csp/healthshare/ccraint/rest/patients/invalid/referrals"
     body:
       encoding: UTF-8
       string: '{"ICN":"invalid","ReferralStatus":"''S'',''BP'',''AP'',''AC'',''A'',''I''"}'

--- a/spec/support/vcr_cassettes/vaos/ccra/post_referral_list_success.yml
+++ b/spec/support/vcr_cassettes/vaos/ccra/post_referral_list_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<VAOS_CCRA_API_URL>/csp/healthshare/ccraint/rest/VAOS/patients/ReferralList"
+    uri: "<VAOS_CCRA_API_URL>/csp/healthshare/ccraint/rest/patients/1012845331V153043/referrals"
     body:
       encoding: UTF-8
       string: '{"ICN":"1012845331V153043","ReferralStatus":"''S'',''BP'',''AP'',''AC'',''A'',''I''"}'

--- a/spec/support/vcr_cassettes/vaos/ccra/post_referral_list_success.yml
+++ b/spec/support/vcr_cassettes/vaos/ccra/post_referral_list_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<VAOS_CCRA_API_URL>/csp/healthshare/ccraint/rest/patients/1012845331V153043/referrals"
+    uri: "<VAOS_CCRA_API_URL>/vaos/v1/patients/1012845331V153043/referrals"
     body:
       encoding: UTF-8
       string: '{"ICN":"1012845331V153043","ReferralStatus":"''S'',''BP'',''AP'',''AC'',''A'',''I''"}'


### PR DESCRIPTION
## Summary

- **This work is behind a feature toggle (flipper):** YES
- **Summary of changes:** 
  - Updated the `base_path` configuration for VAOS-related settings to use `/vaos/v1/patients` instead of `csp/healthshare/ccraint/rest`.
  - Modified methods in the `ReferralService` to include the user's ICN in API requests.
  - Updated controller actions to pass the `current_user.icn` when calling referral-related services.
  - Refactored request specs and VCR cassettes to align with the new `base_path` and ICN requirements.
- **If bug, how to reproduce:** Not a bug; this is a feature enhancement.
- **What is the solution, why is this the solution?**
  - This solution centralizes and simplifies the API paths while integrating user-specific data (ICN) into API calls for more personalized and accurate responses.
- **Which team owns this change:** VAOS team
- **If introducing a flipper, what is the success criteria being targeted?** Not applicable.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108137

## Testing done

- [x] New code is covered by unit tests.
- **Old behavior:** 
  - API paths used `csp/healthshare/ccraint/rest`.
  - ICN was not passed in referral-related service calls.
- **New behavior:** 
  - API paths now use `/vaos/v1/patients`.
  - ICN is included in referral-related service calls.
- **Steps to verify changes:**
  - Ensure referral data is correctly retrieved for the authenticated user.
  - Verify that VCR cassettes accurately reflect the new paths and ICN-based requests.
  - Run all existing and updated specs to ensure no regressions.
- **Testing for flipper scenarios:** Not applicable since no feature toggle is introduced.
- **Testing plan for rollout:**
  - Ensure all tests pass in staging.
  - Perform end-to-end testing of referral-related functionality.

## Screenshots
_Note: Not applicable._

## What areas of the site does it impact?

- Impacts VAOS referral-related functionality:
  - API calls for retrieving referral details.
  - Referral list retrieval and referral detail views.

## Acceptance criteria

- [x] Updated unit tests and integration tests for all affected methods.
- [x] No errors or warnings in the console during development or testing.
- [x] Events are being sent to the appropriate logging solution.
- [x] Documentation has been updated to reflect the new API paths.
- [x] No sensitive information (PII, credentials, internal URLs) is captured in logs, hardcoded, or in specs.
- [x] Verified functionality in a local build with authenticated routes.
- [ ] Monitor built into Datadog for affected areas (if applicable).
- [ ] Screenshot of the developed feature (not applicable).