### PR TITLE
[105455] Add gclaws origin secret

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -516,6 +516,7 @@ gclaws:
     api_key: <%= ENV['gclaws__accreditation__api_key'] %>
     attorneys:
       url: <%= ENV['gclaws__accreditation__attorneys__url'] %>
+    origin: <%= ENV['gclaws__accreditation__origin'] %>
     representatives:
       url: <%= ENV['gclaws__accreditation__representatives__url'] %>
     veteran_service_organizations:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -515,6 +515,7 @@ gclaws:
     api_key: fake_key
     attorneys:
       url: http://localhost:5000/api/v2/accreditations/attorneys
+    origin: fake_origin
     representatives:
       url: http://localhost:5000/api/v2/accreditations/representatives
     veteran_service_organizations:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -514,6 +514,7 @@ gclaws:
     api_key: fake_key
     attorneys:
       url: http://localhost:5000/api/v2/accreditations/attorneys
+    origin: fake_origin
     representatives:
       url: http://localhost:5000/api/v2/accreditations/representatives
     veteran_service_organizations:


### PR DESCRIPTION
## Summary

- The GCLAWS team added a `Origin` header requirement to their api key provisioning. We need to add that to the client class Faraday request headers to get working api calls. This pr adds the expected origin as a secret.

## Related issue(s)
- [105455](https://github.com/department-of-veterans-affairs/va.gov-team/issues/105455)

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature