### PR TITLE
Replace Virtus with Vets::Model - FormProfile

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1679,7 +1679,7 @@ spec/models/form526_submission_remediation_spec.rb @department-of-veterans-affai
 spec/models/form_attachment_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/form_profile_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/form_profile_v2_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-spec/models/form_profile/mdot_spec.rb  @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/backend-review-group
+spec/models/form_profiles/mdot_spec.rb  @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/backend-review-group
 spec/models/form_submission_spec.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/form_submission_attempt_spec.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/Disability-Experience @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/gi_bill_feedback_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/govcio-vfep-codereviewers

--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -26,18 +26,18 @@ end
 class FormMilitaryInformation
   include Vets::Model
 
-  attribute :service_episodes_by_date, Hash, array: true
+  attribute :service_episodes_by_date, VAProfile::Models::ServiceHistory, array: true
   attribute :last_service_branch, String
   attribute :hca_last_service_branch, String
   attribute :last_entry_date, String
   attribute :last_discharge_date, String
   attribute :discharge_type, String
-  attribute :post_nov111998_combat, Bool
-  attribute :sw_asia_combat, Bool
+  attribute :post_nov111998_combat, Bool, default: false
+  attribute :sw_asia_combat, Bool, default: false
   attribute :tours_of_duty, Hash, array: true
-  attribute :currently_active_duty, Bool
+  attribute :currently_active_duty, Bool, default: false
   attribute :currently_active_duty_hash, Hash
-  attribute :vic_verified, Bool
+  attribute :vic_verified, Bool, default: false
   attribute :service_branches, String, array: true
   attribute :service_periods, Hash, array: true
   attribute :guard_reserve_service_history, FormDate, array: true

--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -4,10 +4,11 @@ require 'string_helpers'
 require 'sentry_logging'
 require 'va_profile/configuration'
 require 'va_profile/prefill/military_information'
+require 'vets/model'
 
 # TODO(AJD): Virtus POROs for now, will become ActiveRecord when the profile is persisted
 class FormFullName
-  include Virtus.model
+  include Vets::Model
 
   attribute :first, String
   attribute :middle, String
@@ -16,51 +17,51 @@ class FormFullName
 end
 
 class FormDate
-  include Virtus.model
+  include Vets::Model
 
   attribute :from, Date
   attribute :to, Date
 end
 
 class FormMilitaryInformation
-  include Virtus.model
+  include Vets::Model
 
-  attribute :service_episodes_by_date, Array
+  attribute :service_episodes_by_date, Hash, array: true
   attribute :last_service_branch, String
   attribute :hca_last_service_branch, String
   attribute :last_entry_date, String
   attribute :last_discharge_date, String
   attribute :discharge_type, String
-  attribute :post_nov111998_combat, Boolean
-  attribute :sw_asia_combat, Boolean
-  attribute :tours_of_duty, Array
-  attribute :currently_active_duty, Boolean
+  attribute :post_nov111998_combat, Bool
+  attribute :sw_asia_combat, Bool
+  attribute :tours_of_duty, Hash, array: true
+  attribute :currently_active_duty, Bool
   attribute :currently_active_duty_hash, Hash
-  attribute :vic_verified, Boolean
-  attribute :service_branches, Array[String]
-  attribute :service_periods, Array
-  attribute :guard_reserve_service_history, Array[FormDate]
+  attribute :vic_verified, Bool
+  attribute :service_branches, String, array: true
+  attribute :service_periods, Hash, array: true
+  attribute :guard_reserve_service_history, FormDate, array: true
   attribute :latest_guard_reserve_service_period, FormDate
 end
 
 class FormAddress
-  include Virtus.model
+  include Vets::Model
 
-  attribute :street
-  attribute :street2
-  attribute :city
-  attribute :state
-  attribute :country
-  attribute :postal_code
+  attribute :street, String
+  attribute :street2, String
+  attribute :city, String
+  attribute :state, String
+  attribute :country, String
+  attribute :postal_code, String
 end
 
 class FormIdentityInformation
-  include Virtus.model
+  include Vets::Model
 
   attribute :full_name, FormFullName
   attribute :date_of_birth, Date
   attribute :gender, String
-  attribute :ssn
+  attribute :ssn, String
 
   def hyphenated_ssn
     StringHelpers.hyphenated_ssn(ssn)
@@ -72,7 +73,7 @@ class FormIdentityInformation
 end
 
 class FormContactInformation
-  include Virtus.model
+  include Vets::Model
 
   attribute :address, FormAddress
   attribute :home_phone, String
@@ -82,7 +83,7 @@ class FormContactInformation
 end
 
 class FormProfile
-  include Virtus.model
+  include Vets::Model
   include SentryLogging
 
   MAPPINGS = Rails.root.glob('config/form_profile_mappings/*.yml').map { |f| File.basename(f, '.*') }

--- a/app/models/form_profiles/va_686c674.rb
+++ b/app/models/form_profiles/va_686c674.rb
@@ -15,7 +15,7 @@ class FormProfiles::VA686c674 < FormProfile
     attribute :international_postal_code, String
   end
 
-  attribute :form_address
+  attribute :form_address, FormAddress
 
   def prefill
     prefill_form_address

--- a/app/models/form_profiles/va_686c674v2.rb
+++ b/app/models/form_profiles/va_686c674v2.rb
@@ -15,7 +15,7 @@ class FormProfiles::VA686c674v2 < FormProfile
     attribute :international_postal_code, String
   end
 
-  attribute :form_address
+  attribute :form_address, FormAddress
 
   def prefill
     prefill_form_address

--- a/lib/pension_21p527ez/pension_military_information.rb
+++ b/lib/pension_21p527ez/pension_military_information.rb
@@ -2,12 +2,13 @@
 
 require 'va_profile/prefill/military_information'
 require 'claims_api/service_branch_mapper'
+require 'form_profile'
 
 module Pension21p527ez
   ##
   # extends FormMilitaryInformation to add additional military information fields to Pension prefill.
-  # @see app/models/form_profile.rb FormProfile::FormMilitaryInformation
-  class PensionFormMilitaryInformation < FormProfile::FormMilitaryInformation
+  # @see app/models/form_profile.rb FormMilitaryInformation
+  class PensionFormMilitaryInformation < FormMilitaryInformation
     include Virtus.model
 
     attribute :first_uniformed_entry_date, String

--- a/modules/pensions/app/models/pensions/form_military_information.rb
+++ b/modules/pensions/app/models/pensions/form_military_information.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
+require 'form_profile'
+
 module Pensions
   ##
   # Extends FormMilitaryInformation to add additional military information fields to Pension prefill
-  # @see app/models/form_profile.rb FormProfile::FormMilitaryInformation
-  class FormMilitaryInformation < ::FormProfile::FormMilitaryInformation
+  # @see app/models/form_profile.rb FormMilitaryInformation
+  class FormMilitaryInformation < ::FormMilitaryInformation
     include Virtus.model
 
     attribute :first_uniformed_entry_date, String

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -1179,7 +1179,8 @@ RSpec.describe FormProfile, type: :model do
       it 'prefills military data from va profile' do
         VCR.use_cassette('va_profile/military_personnel/post_read_service_histories_200',
                          allow_playback_repeats: true, match_requests_on: %i[uri method body]) do
-          output = form_profile.send(:initialize_military_information).attributes.transform_keys(&:to_s)
+
+          output = form_profile.send(:initialize_military_information).attribute_values.transform_keys(&:to_s)
 
           expected_output = initialize_va_profile_prefill_military_information_expected
           expected_output['vic_verified'] = false
@@ -1198,8 +1199,8 @@ RSpec.describe FormProfile, type: :model do
           expect(actual_service_histories.map(&:attributes)).to eq(expected_service_histories)
 
           first_item = actual_guard_reserve_service_history.map(&:attributes).first
-          expect(first_item[:from].to_s).to eq(expected_guard_reserve_service_history.first[:from])
-          expect(first_item[:to].to_s).to eq(expected_guard_reserve_service_history.first[:to])
+          expect(first_item['from'].to_s).to eq(expected_guard_reserve_service_history.first[:from])
+          expect(first_item['to'].to_s).to eq(expected_guard_reserve_service_history.first[:to])
 
           guard_period = actual_latest_guard_reserve_service_period.attributes.transform_keys(&:to_s)
           expect(guard_period['from'].to_s).to eq(expected_latest_guard_reserve_service_period[:from])

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -1179,7 +1179,6 @@ RSpec.describe FormProfile, type: :model do
       it 'prefills military data from va profile' do
         VCR.use_cassette('va_profile/military_personnel/post_read_service_histories_200',
                          allow_playback_repeats: true, match_requests_on: %i[uri method body]) do
-
           output = form_profile.send(:initialize_military_information).attribute_values.transform_keys(&:to_s)
 
           expected_output = initialize_va_profile_prefill_military_information_expected

--- a/spec/models/form_profile_v2_spec.rb
+++ b/spec/models/form_profile_v2_spec.rb
@@ -712,12 +712,12 @@ RSpec.describe FormProfile, type: :model do
   let(:vfeedback_tool_expected) do
     {
       'address' => {
-        'street' => va_profile_address[:street],
-        'street2' => va_profile_address[:street2],
-        'city' => va_profile_address[:city],
-        'state' => va_profile_address[:state],
+        'street' => va_profile_address.street,
+        'street2' => va_profile_address.street2,
+        'city' => va_profile_address.city,
+        'state' => va_profile_address.state,
         'country' => 'US',
-        'postal_code' => va_profile_address[:postal_code]
+        'postal_code' => va_profile_address.postal_code
       },
       'serviceBranch' => 'Army',
       'fullName' => {

--- a/spec/models/form_profile_v2_spec.rb
+++ b/spec/models/form_profile_v2_spec.rb
@@ -48,12 +48,12 @@ RSpec.describe FormProfile, type: :model do
   end
   let(:address) do
     {
-      'street' => va_profile_address[:street],
-      'street2' => va_profile_address[:street2],
-      'city' => va_profile_address[:city],
-      'state' => va_profile_address[:state],
-      'country' => va_profile_address[:country],
-      'postal_code' => va_profile_address[:postal_code]
+      'street' => va_profile_address.street,
+      'street2' => va_profile_address.street2,
+      'city' => va_profile_address.city,
+      'state' => va_profile_address.state,
+      'country' => va_profile_address.country,
+      'postal_code' => va_profile_address.postal_code
     }
   end
   let(:veteran_address) do
@@ -773,12 +773,12 @@ RSpec.describe FormProfile, type: :model do
             'ssn' => user.ssn.last(4),
             'gender' => user.gender,
             'address' => {
-              'addressLine1' => va_profile_address[:street],
-              'addressLine2' => va_profile_address[:street2],
-              'city' => va_profile_address[:city],
-              'stateCode' => va_profile_address[:state],
-              'countryName' => va_profile_address[:country],
-              'zipCode5' => va_profile_address[:postal_code]
+              'addressLine1' => va_profile_address.street,
+              'addressLine2' => va_profile_address.street2,
+              'city' => va_profile_address.city,
+              'stateCode' => va_profile_address.state,
+              'countryName' => va_profile_address.country,
+              'zipCode5' => va_profile_address.postal_code
             },
             'phone' => {
               'areaCode' => us_phone[0..2],
@@ -995,7 +995,7 @@ RSpec.describe FormProfile, type: :model do
       it 'prefills military data from va profile' do
         VCR.use_cassette('va_profile/military_personnel/post_read_service_histories_200',
                          allow_playback_repeats: true, match_requests_on: %i[uri method body]) do
-          output = form_profile.send(:initialize_military_information).attributes.transform_keys(&:to_s)
+          output = form_profile.send(:initialize_military_information).attribute_values.transform_keys(&:to_s)
 
           expected_output = initialize_va_profile_prefill_military_information_expected
           expected_output['vic_verified'] = false
@@ -1014,8 +1014,8 @@ RSpec.describe FormProfile, type: :model do
           expect(actual_service_histories.map(&:attributes)).to eq(expected_service_histories)
 
           first_item = actual_guard_reserve_service_history.map(&:attributes).first
-          expect(first_item[:from].to_s).to eq(expected_guard_reserve_service_history.first[:from])
-          expect(first_item[:to].to_s).to eq(expected_guard_reserve_service_history.first[:to])
+          expect(first_item['from'].to_s).to eq(expected_guard_reserve_service_history.first[:from])
+          expect(first_item['to'].to_s).to eq(expected_guard_reserve_service_history.first[:to])
 
           guard_period = actual_latest_guard_reserve_service_period.attributes.transform_keys(&:to_s)
           expect(guard_period['from'].to_s).to eq(expected_latest_guard_reserve_service_period[:from])

--- a/spec/models/form_profiles/mdot_spec.rb
+++ b/spec/models/form_profiles/mdot_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe FormProfile::MDOT, type: :model do
+RSpec.describe FormProfiles::MDOT, type: :model do
   let(:user_details) do
     {
       first_name: 'Greg',


### PR DESCRIPTION
## Summary

- The virtus gem ([source](https://github.com/solnic/virtus)) is discontinued and must be replaced
- The replacement is `Vets::Model` ([source](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/vets/model.rb))
- This PR replaces `Virtus.model` with `Vets::Model` and updates the attributes according 
    - The attribute updates are minor and mostly related to Booleans and Arrays
- Subsequent PR will update the other FormProfile related model
- This change should not affect any functionality. 

## Related Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92440

## Testing

- [x] Make sure the specs pass
- [x] Manually checking the serialized responses are the same

Note: Some test required updates because of difference in hash keys (strings & symbols)

## Acceptance Criteria 

- [x] Serialized responses are identitcal
- [x] No functionality changes to FormProfile or related subclasses
  