### PR TITLE
MHV-69698 Decouple SelfEnteredController from MrController

### DIFF
--- a/modules/my_health/app/controllers/my_health/v1/medical_records/self_entered_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/medical_records/self_entered_controller.rb
@@ -3,65 +3,83 @@
 module MyHealth
   module V1
     module MedicalRecords
-      class SelfEnteredController < MrController
+      class SelfEnteredController < ApplicationController
+        include MyHealth::MHVControllerConcerns
+        service_tag 'mhv-medical-records'
+
         def index
-          render json: bb_client.get_all_sei_data.to_json
+          render json: client.get_all_sei_data.to_json
         end
 
         def vitals
-          render json: bb_client.get_sei_vital_signs_summary.to_json
+          render json: client.get_sei_vital_signs_summary.to_json
         end
 
         def allergies
-          render json: bb_client.get_sei_allergies.to_json
+          render json: client.get_sei_allergies.to_json
         end
 
         def family_history
-          render json: bb_client.get_sei_family_health_history.to_json
+          render json: client.get_sei_family_health_history.to_json
         end
 
         def vaccines
-          render json: bb_client.get_sei_immunizations.to_json
+          render json: client.get_sei_immunizations.to_json
         end
 
         def test_entries
-          render json: bb_client.get_sei_test_entries.to_json
+          render json: client.get_sei_test_entries.to_json
         end
 
         def medical_events
-          render json: bb_client.get_sei_medical_events.to_json
+          render json: client.get_sei_medical_events.to_json
         end
 
         def military_history
-          render json: bb_client.get_sei_military_history.to_json
+          render json: client.get_sei_military_history.to_json
         end
 
         def providers
-          render json: bb_client.get_sei_healthcare_providers.to_json
+          render json: client.get_sei_healthcare_providers.to_json
         end
 
         def health_insurance
-          render json: bb_client.get_sei_health_insurance.to_json
+          render json: client.get_sei_health_insurance.to_json
         end
 
         def treatment_facilities
-          render json: bb_client.get_sei_treatment_facilities.to_json
+          render json: client.get_sei_treatment_facilities.to_json
         end
 
         def food_journal
-          render json: bb_client.get_sei_food_journal.to_json
+          render json: client.get_sei_food_journal.to_json
         end
 
         def activity_journal
-          render json: bb_client.get_sei_activity_journal.to_json
+          render json: client.get_sei_activity_journal.to_json
         end
 
         def medications
-          render json: bb_client.get_sei_medications.to_json
+          render json: client.get_sei_medications.to_json
         end
 
         def emergency_contacts
-          render json: bb_client.get_sei_emergency_contacts.to_json
+          render json: client.get_sei_emergency_contacts.to_json
+        end
+
+        protected
+
+        def client
+          @client ||= BBInternal::Client.new(session: { user_id: current_user.mhv_correlation_id,
+                                                        icn: current_user.icn })
+        end
+
+        def authorize
+          raise_access_denied if current_user.mhv_correlation_id.is_blank? || current_user.icn.is_blank?
+        end
+
+        def raise_access_denied
+          raise Common::Exceptions::Forbidden, detail: 'You do not have access to self-entered information'
         end
       end
     end

--- a/modules/my_health/app/controllers/my_health/v1/medical_records/self_entered_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/medical_records/self_entered_controller.rb
@@ -75,7 +75,7 @@ module MyHealth
         end
 
         def authorize
-          raise_access_denied if current_user.mhv_correlation_id.is_blank? || current_user.icn.is_blank?
+          raise_access_denied if current_user.mhv_correlation_id.blank? || current_user.icn.blank?
         end
 
         def raise_access_denied


### PR DESCRIPTION
## Summary

- Made `SelfEnteredController` a direct child of `ApplicationController`, skipping `MrController` in the middle.
- A full policy for this behavior is not necessary; we instead just check for the necessary parameters and return `403` if they are not present.
- Users can have self-entered information _without_ an MHV Premium account, so we don't check for that.

## Related issue(s)

### [MHV-69698](https://jira.devops.va.gov/browse/MHV-69698) - Allow SEI API calls with reduced privileges on the backend ###

> Acceptance criteria:
> 
> - AC1: A new policy is created for users who have a premium MHV account (double-check this) but do NOT have a VA treatment facility
> - AC2: SEI actions are moved to a controller that uses the new policy
> - AC3: If necessary, move SEI functions to a new client. Determine if the intended user will ALSO have an ICN. If so, no new client is necessary.

## Testing done

- [x] *New code is covered by unit tests*
- The only functional change here is that the self entered endpoint no longer requires the user to have a VA Treatment Facility or be an MHV Premium user.


## What areas of the site does it impact?
MHV Medical Records

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
