### PR TITLE
Add 10-7959a to source_app_middleware

### DIFF
--- a/lib/source_app_middleware.rb
+++ b/lib/source_app_middleware.rb
@@ -33,6 +33,7 @@ class SourceAppMiddleware
     10206-pa
     10207-pp
     10210-lay-witness-statement
+    10-7959a
     10-7959C
     10-7959f-1-FMP
     1330m2-medallions


### PR DESCRIPTION
## Summary
This will fix the alerting monitor: [vets-api source app monitor - un-mapped source app detected](https://vagov.ddog-gov.com/monitors/200229?event_id=8073461996306547886&link_source=monitor_notif&live=1w)

Error:
```
Unrecognized value for HTTP_SOURCE_APP_NAME request header... [10-7959a]
```

## Related issue(s)

Message in [#oncall](https://dsva.slack.com/archives/C30LCU8S3/p1745478700909819)
