### PR TITLE
Remove clinic friendlyName field

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -408,11 +408,10 @@ module VAOS
 
         clinic = mobile_facility_service.get_clinic(appt[:location_id], appt[:clinic])
         if clinic&.[](:service_name)
-          appt[:service_name] = clinic[:service_name]
           # In VAOS Service there is no dedicated clinic friendlyName field.
           # If the clinic is configured with a patient-friendly name then that will be the value
           # in the clinic service name; otherwise it will be the internal clinic name.
-          appt[:friendly_name] = clinic[:service_name]
+          appt[:service_name] = clinic[:service_name]
         end
 
         appt[:physical_location] = clinic[:physical_location] if clinic&.[](:physical_location)

--- a/modules/vaos/spec/requests/vaos/v2/appointments_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/appointments_spec.rb
@@ -428,7 +428,6 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
               expect(data.size).to eq(16)
               expect(data[0]['attributes']['serviceName']).to eq('service_name')
               expect(data[0]['attributes']['physicalLocation']).to eq('physical_location')
-              expect(data[0]['attributes']['friendlyName']).to eq('service_name')
               expect(data[0]['attributes']['location']).to eq(expected_facility)
               expect(response).to match_camelized_response_schema('vaos/v2/appointments', { strict: false })
             end
@@ -810,7 +809,7 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
           end
         end
 
-        it 'updates the service name, physical location, friendly name, and location' do
+        it 'updates the service name, physical location, and location' do
           stub_facilities
           allow_any_instance_of(VAOS::V2::MobileFacilityService).to receive(:get_clinic)
             .and_return(service_name: 'Service Name', physical_location: 'Physical Location')
@@ -823,7 +822,6 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
             data = json_body_for(response)['attributes']
             expect(data['serviceName']).to eq('Service Name')
             expect(data['physicalLocation']).to eq('Physical Location')
-            expect(data['friendlyName']).to eq('Service Name')
             expect(data['location']).to eq(expected_facility)
             expect(Rails.logger).to have_received(:info).with(
               'VAOS::V2::AppointmentsController appointment creation time: 2021-12-13T14:03:02Z',
@@ -987,7 +985,7 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
         end
 
         context 'when clinic and location_id are present' do
-          it 'updates the service name, physical location, friendly name, and location' do
+          it 'updates the service name, physical location, and location' do
             allow_any_instance_of(VAOS::V2::MobileFacilityService).to receive(:get_clinic)
               .and_return(service_name: 'Service Name', physical_location: 'Physical Location')
             stub_facilities
@@ -998,7 +996,6 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
               data = json_body_for(response)['attributes']
               expect(data['serviceName']).to eq('Service Name')
               expect(data['physicalLocation']).to eq('Physical Location')
-              expect(data['friendlyName']).to eq('Service Name')
               expect(data['location']).to eq(expected_facility)
             end
           end


### PR DESCRIPTION


**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- This work is behind a feature toggle (flipper): NO
- The VAOS service uses the required fallback logic for serviceName so friendly name is no longer required
- Appointments Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108275

## Testing done

- [x] New code is covered by unit tests

## Screenshots
N/A

## What areas of the site does it impact?
Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
