### PR TITLE
add statsd logging for CG query durations

### DIFF
--- a/app/services/form1010cg/auditor.rb
+++ b/app/services/form1010cg/auditor.rb
@@ -11,7 +11,7 @@ module Form1010cg
     METRICS = lambda do
       submission_prefix = "#{STATSD_KEY_PREFIX}.submission"
       process_prefix = "#{STATSD_KEY_PREFIX}.process"
-      process_async_prefix = "#{STATSD_KEY_PREFIX}.process_async"
+      process_job_prefix = "#{STATSD_KEY_PREFIX}.process_job"
 
       OpenStruct.new(
         submission: OpenStruct.new(
@@ -36,9 +36,9 @@ module Form1010cg
           success: "#{process_prefix}.success",
           failure: "#{process_prefix}.failure"
         ),
-        process_async: OpenStruct.new(
-          success: "#{process_async_prefix}.success",
-          failure: "#{process_async_prefix}.failure"
+        process_job: OpenStruct.new(
+          success: "#{process_job_prefix}.success",
+          failure: "#{process_job_prefix}.failure"
         )
       )
     end.call

--- a/app/sidekiq/form1010cg/submission_job.rb
+++ b/app/sidekiq/form1010cg/submission_job.rb
@@ -62,15 +62,15 @@ module Form1010cg
       rescue => e
         log_exception_to_sentry(e, { claim_id: })
       end
-      Form1010cg::Auditor.new.log_caregiver_request_duration(context: :process_async, event: :success, start_time:)
+      Form1010cg::Auditor.new.log_caregiver_request_duration(context: :process_job, event: :success, start_time:)
     rescue CARMA::Client::MuleSoftClient::RecordParseError
       StatsD.increment("#{STATSD_KEY_PREFIX}record_parse_error", tags: ["claim_id:#{claim_id}"])
-      Form1010cg::Auditor.new.log_caregiver_request_duration(context: :process_async, event: :failure, start_time:)
+      Form1010cg::Auditor.new.log_caregiver_request_duration(context: :process_job, event: :failure, start_time:)
       self.class.send_failure_email(claim)
     rescue => e
       log_exception_to_sentry(e, { claim_id: })
       StatsD.increment("#{STATSD_KEY_PREFIX}retries")
-      Form1010cg::Auditor.new.log_caregiver_request_duration(context: :process_async, event: :failure, start_time:)
+      Form1010cg::Auditor.new.log_caregiver_request_duration(context: :process_job, event: :failure, start_time:)
 
       raise
     end

--- a/app/sidekiq/form1010cg/submission_job.rb
+++ b/app/sidekiq/form1010cg/submission_job.rb
@@ -52,6 +52,7 @@ module Form1010cg
     end
 
     def perform(claim_id)
+      start_time = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
       claim = SavedClaim::CaregiversAssistanceClaim.find(claim_id)
 
       Form1010cg::Service.new(claim).process_claim_v2!
@@ -61,12 +62,15 @@ module Form1010cg
       rescue => e
         log_exception_to_sentry(e, { claim_id: })
       end
+      Form1010cg::Auditor.new.log_caregiver_request_duration(context: :process_async, event: :success, start_time:)
     rescue CARMA::Client::MuleSoftClient::RecordParseError
       StatsD.increment("#{STATSD_KEY_PREFIX}record_parse_error", tags: ["claim_id:#{claim_id}"])
+      Form1010cg::Auditor.new.log_caregiver_request_duration(context: :process_async, event: :failure, start_time:)
       self.class.send_failure_email(claim)
     rescue => e
       log_exception_to_sentry(e, { claim_id: })
       StatsD.increment("#{STATSD_KEY_PREFIX}retries")
+      Form1010cg::Auditor.new.log_caregiver_request_duration(context: :process_async, event: :failure, start_time:)
 
       raise
     end

--- a/config/features.yml
+++ b/config/features.yml
@@ -113,6 +113,9 @@ features:
   caregiver_retry_form_validation:
     actor_type: user
     description: Enables 1010CG to retry schema validation
+  caregiver_request_duration_monitoring:
+    actor_type: user
+    description: Enables logging of 10-10CG request durations to StatsD
   document_upload_validation_enabled:
     actor_type: user
     description: Enables stamped PDF validation on document upload

--- a/spec/services/form1010cg/service_spec.rb
+++ b/spec/services/form1010cg/service_spec.rb
@@ -529,6 +529,15 @@ RSpec.describe Form1010cg::Service do
       end
 
       it 'submits to mulesoft' do
+        start_time = Time.current
+        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start_time }
+        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond)
+        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_THREAD_CPUTIME_ID, :float_millisecond)
+        expected_arguments = { context: :process, event: :success, start_time: }
+        expect(described_class::AUDITOR).to receive(:log_caregiver_request_duration).with(
+          **expected_arguments
+        )
+
         subject
         expect(mule_soft_client).to have_received(:create_submission_v2).with(mule_soft_payload)
       end
@@ -565,6 +574,15 @@ RSpec.describe Form1010cg::Service do
                   form: '10-10CG',
                   claim_guid: claim_with_mpi_veteran.guid
                 })
+
+        start_time = Time.current
+        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start_time }
+        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond)
+        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_THREAD_CPUTIME_ID, :float_millisecond)
+        expected_arguments = { context: :process, event: :failure, start_time: }
+        expect(described_class::AUDITOR).to receive(:log_caregiver_request_duration).with(
+          **expected_arguments
+        )
 
         expect { subject }.to raise_error(exception)
       end

--- a/spec/sidekiq/form1010cg/submission_job_spec.rb
+++ b/spec/sidekiq/form1010cg/submission_job_spec.rb
@@ -145,6 +145,15 @@ RSpec.describe Form1010cg::SubmissionJob do
 
     context 'when there is a standarderror' do
       it 'increments statsd except applications_retried' do
+        start_time = Time.current
+        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start_time }
+        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond)
+        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_THREAD_CPUTIME_ID, :float_millisecond)
+        expected_arguments = { context: :process_async, event: :failure, start_time: }
+        auditor_double = instance_double(Form1010cg::Auditor)
+        allow(Form1010cg::Auditor).to receive(:new) { auditor_double }
+        expect(auditor_double).to receive(:log_caregiver_request_duration).with(**expected_arguments).twice
+
         allow_any_instance_of(Form1010cg::Service).to receive(
           :process_claim_v2!
         ).and_raise(StandardError)
@@ -165,10 +174,21 @@ RSpec.describe Form1010cg::SubmissionJob do
     end
 
     context 'when the service throws a record parse error' do
+      before do
+        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond)
+        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_THREAD_CPUTIME_ID, :float_millisecond)
+      end
+
       context 'form has email' do
         let(:form) { form_with_email }
 
         it 'rescues the error, increments statsd, and attempts to send failure email' do
+          start_time = Time.current
+          expected_arguments = { context: :process_async, event: :failure, start_time: }
+          expect_any_instance_of(Form1010cg::Auditor).to receive(:log_caregiver_request_duration)
+            .with(**expected_arguments)
+          allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start_time }
+
           expect_any_instance_of(Form1010cg::Service).to receive(
             :process_claim_v2!
           ).and_raise(CARMA::Client::MuleSoftClient::RecordParseError.new)
@@ -190,6 +210,12 @@ RSpec.describe Form1010cg::SubmissionJob do
 
       context 'form does not have email' do
         it 'rescues the error, increments statsd, and attempts to send failure email' do
+          start_time = Time.current
+          expected_arguments = { context: :process_async, event: :failure, start_time: }
+          expect_any_instance_of(Form1010cg::Auditor).to receive(:log_caregiver_request_duration)
+            .with(**expected_arguments)
+          allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start_time }
+
           expect_any_instance_of(Form1010cg::Service).to receive(
             :process_claim_v2!
           ).and_raise(CARMA::Client::MuleSoftClient::RecordParseError.new)
@@ -217,6 +243,14 @@ RSpec.describe Form1010cg::SubmissionJob do
     end
 
     it 'calls process_claim_v2!' do
+      start_time = Time.current
+      expected_arguments = { context: :process_async, event: :success, start_time: }
+      expect_any_instance_of(Form1010cg::Auditor).to receive(:log_caregiver_request_duration).with(**expected_arguments)
+
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start_time }
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond)
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_THREAD_CPUTIME_ID, :float_millisecond)
+
       expect_any_instance_of(Form1010cg::Service).to receive(:process_claim_v2!)
 
       job.perform(claim.id)

--- a/spec/sidekiq/form1010cg/submission_job_spec.rb
+++ b/spec/sidekiq/form1010cg/submission_job_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Form1010cg::SubmissionJob do
         allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start_time }
         allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond)
         allow(Process).to receive(:clock_gettime).with(Process::CLOCK_THREAD_CPUTIME_ID, :float_millisecond)
-        expected_arguments = { context: :process_async, event: :failure, start_time: }
+        expected_arguments = { context: :process_job, event: :failure, start_time: }
         auditor_double = instance_double(Form1010cg::Auditor)
         allow(Form1010cg::Auditor).to receive(:new) { auditor_double }
         expect(auditor_double).to receive(:log_caregiver_request_duration).with(**expected_arguments).twice
@@ -184,7 +184,7 @@ RSpec.describe Form1010cg::SubmissionJob do
 
         it 'rescues the error, increments statsd, and attempts to send failure email' do
           start_time = Time.current
-          expected_arguments = { context: :process_async, event: :failure, start_time: }
+          expected_arguments = { context: :process_job, event: :failure, start_time: }
           expect_any_instance_of(Form1010cg::Auditor).to receive(:log_caregiver_request_duration)
             .with(**expected_arguments)
           allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start_time }
@@ -211,7 +211,7 @@ RSpec.describe Form1010cg::SubmissionJob do
       context 'form does not have email' do
         it 'rescues the error, increments statsd, and attempts to send failure email' do
           start_time = Time.current
-          expected_arguments = { context: :process_async, event: :failure, start_time: }
+          expected_arguments = { context: :process_job, event: :failure, start_time: }
           expect_any_instance_of(Form1010cg::Auditor).to receive(:log_caregiver_request_duration)
             .with(**expected_arguments)
           allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start_time }
@@ -244,7 +244,7 @@ RSpec.describe Form1010cg::SubmissionJob do
 
     it 'calls process_claim_v2!' do
       start_time = Time.current
-      expected_arguments = { context: :process_async, event: :success, start_time: }
+      expected_arguments = { context: :process_job, event: :success, start_time: }
       expect_any_instance_of(Form1010cg::Auditor).to receive(:log_caregiver_request_duration).with(**expected_arguments)
 
       allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start_time }


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*: `hca_cg_request_duration_monitoring`
- Add StatsD duration measure metrics to 10-10CG calls from the frontend, and between the backend and CARMA/Mulesoft
- Health Enrollment 10-10EZ/CG
- criteria: no performance degradation or errors

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101080

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
