### PR TITLE
[VI-1136] fixes string to symbol typo

### DIFF
--- a/app/controllers/concerns/vet360/writeable.rb
+++ b/app/controllers/concerns/vet360/writeable.rb
@@ -10,7 +10,7 @@ module Vet360
 
     PROFILE_AUDIT_LOG_TYPES = { email: :update_email_address,
                                 address: :update_mailing_address,
-                                telephone: :update_phone_number }.freeze
+                                telephone: :update_phone_number }.with_indifferent_access.freeze
 
     # For the passed VAProfile model type and params, it:
     #   - builds and validates a VAProfile models

--- a/app/controllers/concerns/vet360/writeable.rb
+++ b/app/controllers/concerns/vet360/writeable.rb
@@ -27,7 +27,7 @@ module Vet360
       record = build_record(type, params)
       validate!(record)
       response = write_valid_record!(http_verb, type, record)
-      create_user_audit_log(type) if PROFILE_AUDIT_LOG_TYPES.keys.include?(type.to_sym)
+      create_user_audit_log(type) if PROFILE_AUDIT_LOG_TYPES[type].present?
       render_new_transaction!(type, response)
     end
 

--- a/app/controllers/concerns/vet360/writeable.rb
+++ b/app/controllers/concerns/vet360/writeable.rb
@@ -8,9 +8,9 @@ module Vet360
   module Writeable
     extend ActiveSupport::Concern
 
-    PROFILE_AUDIT_LOG_TYPES = { email: 'update_email_address',
-                                address: 'update_mailing_address',
-                                telephone: 'update_phone_number' }.freeze
+    PROFILE_AUDIT_LOG_TYPES = { email: :update_email_address,
+                                address: :update_mailing_address,
+                                telephone: :update_phone_number }.freeze
 
     # For the passed VAProfile model type and params, it:
     #   - builds and validates a VAProfile models
@@ -27,7 +27,7 @@ module Vet360
       record = build_record(type, params)
       validate!(record)
       response = write_valid_record!(http_verb, type, record)
-      create_user_audit_log(type) if PROFILE_AUDIT_LOG_TYPES.keys.include?(type)
+      create_user_audit_log(type) if PROFILE_AUDIT_LOG_TYPES.keys.include?(type.to_sym)
       render_new_transaction!(type, response)
     end
 
@@ -56,7 +56,7 @@ module Vet360
     end
 
     def create_user_audit_log(type)
-      UserAudit.logger.success(event: PROFILE_AUDIT_LOG_TYPES[type].to_sym,
+      UserAudit.logger.success(event: PROFILE_AUDIT_LOG_TYPES[type],
                                user_verification: @current_user.user_verification)
     end
 


### PR DESCRIPTION
## Summary

- Bugfix PR for #21613 , correcting mismatch between String `type` passed in as an argument and the Symbol keys of the `PROFILE_AUDIT_LOG_TYPES` constant.

## Related issue(s)

- https://jira.devops.va.gov/browse/VI-1136

## Testing done

- Testing of the `type` comparison can be done in a Rails console
```ruby
PROFILE_AUDIT_LOG_TYPES = { email: :update_email_address, address: :update_mailing_address, telephone: :update_phone_number }.with_indifferent_access.freeze
 => {"email"=>:update_email_address, "address"=>:update_mailing_address, "telephone"=>:update_phone_number}
type = 'email'
 => "email" 
PROFILE_AUDIT_LOG_TYPES[type].present?
 => true 
```
