### PR TITLE
Replace Virtus with Vets::Model - Form Profile 526ez

### DIFF
--- a/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_in_progress_forms_controller.rb
@@ -30,7 +30,7 @@ module V0
       # If EVSS's list of rated disabilities does not match our prefilled rated disabilities
       if rated_disabilities_evss.present? &&
          arr_to_compare(parsed_form_data['ratedDisabilities']) !=
-         arr_to_compare(rated_disabilities_evss.rated_disabilities)
+         arr_to_compare(rated_disabilities_evss.rated_disabilities.map(&:attributes))
 
         if parsed_form_data['ratedDisabilities'].present? &&
            parsed_form_data.dig('view:claimType', 'view:claimingIncrease')

--- a/app/models/form_profiles/va_526ez.rb
+++ b/app/models/form_profiles/va_526ez.rb
@@ -138,6 +138,8 @@ class FormProfiles::VA526ez < FormProfile
     response = api_provider.get_rated_disabilities(nil, nil, { invoker: })
     ClaimFastTracking::MaxRatingAnnotator.annotate_disabilities(response)
 
+    binding.pry
+
     # Remap response object to schema fields
     VA526ez::FormRatedDisabilities.new(
       rated_disabilities: response.rated_disabilities

--- a/app/models/form_profiles/va_526ez.rb
+++ b/app/models/form_profiles/va_526ez.rb
@@ -4,6 +4,7 @@ require 'evss/disability_compensation_form/service'
 require 'evss/pciu_address/service'
 require 'evss/ppiu/service'
 require 'disability_compensation/factories/api_provider_factory'
+require 'vets/model'
 
 module VA526ez
   class FormSpecialIssue

--- a/app/models/form_profiles/va_526ez.rb
+++ b/app/models/form_profiles/va_526ez.rb
@@ -138,11 +138,9 @@ class FormProfiles::VA526ez < FormProfile
     response = api_provider.get_rated_disabilities(nil, nil, { invoker: })
     ClaimFastTracking::MaxRatingAnnotator.annotate_disabilities(response)
 
-    binding.pry
-
     # Remap response object to schema fields
     VA526ez::FormRatedDisabilities.new(
-      rated_disabilities: response.rated_disabilities
+      rated_disabilities: response.rated_disabilities.map(&:to_h)
     )
   end
 

--- a/app/models/form_profiles/va_526ez.rb
+++ b/app/models/form_profiles/va_526ez.rb
@@ -7,14 +7,14 @@ require 'disability_compensation/factories/api_provider_factory'
 
 module VA526ez
   class FormSpecialIssue
-    include Virtus.model
+    include Vets::Model
 
     attribute :code, String
     attribute :name, String
   end
 
   class FormRatedDisability
-    include Virtus.model
+    include Vets::Model
 
     attribute :name, String
     attribute :rated_disability_id, String
@@ -27,13 +27,13 @@ module VA526ez
   end
 
   class FormRatedDisabilities
-    include Virtus.model
+    include Vets::Model
 
-    attribute :rated_disabilities, Array[FormRatedDisability]
+    attribute :rated_disabilities, FormRatedDisability, array: true
   end
 
   class FormPaymentAccountInformation
-    include Virtus.model
+    include Vets::Model
 
     attribute :account_type, String
     attribute :account_number, String
@@ -42,19 +42,19 @@ module VA526ez
   end
 
   class FormAddress
-    include Virtus.model
+    include Vets::Model
 
-    attribute :country
-    attribute :city
-    attribute :state
-    attribute :zip_code
-    attribute :address_line_1
-    attribute :address_line_2
-    attribute :address_line_3
+    attribute :country, String
+    attribute :city, String
+    attribute :state, String
+    attribute :zip_code, String
+    attribute :address_line_1, String
+    attribute :address_line_2, String
+    attribute :address_line_3, String
   end
 
   class FormContactInformation
-    include Virtus.model
+    include Vets::Model
 
     attribute :mailing_address, FormAddress
     attribute :primary_phone, String
@@ -62,7 +62,7 @@ module VA526ez
   end
 
   class FormVeteranContactInformation
-    include Virtus.model
+    include Vets::Model
 
     attribute :veteran, FormContactInformation
   end
@@ -70,10 +70,10 @@ module VA526ez
   # internal form prefill
   # does not reach out to external services
   class Form526Prefill
-    include Virtus.model
+    include Vets::Model
 
     attribute :started_form_version, String
-    attribute :sync_modern_0781_flow, Boolean
+    attribute :sync_modern_0781_flow, Bool, default: false
   end
 end
 

--- a/app/models/form_profiles/va_526ez.rb
+++ b/app/models/form_profiles/va_526ez.rb
@@ -74,7 +74,7 @@ module VA526ez
     include Vets::Model
 
     attribute :started_form_version, String
-    attribute :sync_modern_0781_flow, Bool, default: false
+    attribute :sync_modern_0781_flow, Bool
   end
 end
 


### PR DESCRIPTION
## Summary

- The virtus gem ([source](https://github.com/solnic/virtus)) is discontinued and must be replaced
- The replacement is `Vets::Model` ([source](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/vets/model.rb))
- This PR replaces `Virtus.model` with `Vets::Model` and updates the attributes according 
    - The attribute updates are minor and mostly related to Booleans and Arrays
- This change should not affect any functionality. 

## Related Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92440

## Testing

- [x] Make sure the specs pass
- [x] Manually checking the serialized responses are the same

Note: Some test required updates because of difference in hash keys (strings & symbols)

## Acceptance Criteria 

- [x] Serialized responses are identical
- [x] No functionality changes to FormProfile or related subclasses
  