### PR TITLE
Replace Virtus with Vets::Model - Form Profile 2

### DIFF
--- a/app/models/form_profiles/va_0873.rb
+++ b/app/models/form_profiles/va_0873.rb
@@ -6,7 +6,7 @@ module VA0873
   FORM_ID = '0873'
 
   class FormPersonalInformation
-    include Virtus.model
+    include Vets::Model
 
     attribute :first, String
     attribute :middle, String
@@ -18,7 +18,7 @@ module VA0873
   end
 
   class FormAvaProfile
-    include Virtus.model
+    include Vets::Model
 
     attribute :school_facility_code, String
     attribute :school_name, String

--- a/app/models/form_profiles/va_0873.rb
+++ b/app/models/form_profiles/va_0873.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'va_profile/demographics/service'
+require 'vets/model'
 
 module VA0873
   FORM_ID = '0873'

--- a/app/models/form_profiles/va_0994.rb
+++ b/app/models/form_profiles/va_0994.rb
@@ -6,7 +6,7 @@ module VA0994
   FORM_ID = '22-0994'
 
   class FormPaymentAccountInformation
-    include Virtus.model
+    include Vets::Model
 
     attribute :account_type, String
     attribute :account_number, String

--- a/app/models/form_profiles/va_0994.rb
+++ b/app/models/form_profiles/va_0994.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'evss/ppiu/service'
+require 'vets/model'
 
 module VA0994
   FORM_ID = '22-0994'

--- a/app/models/form_profiles/va_10203.rb
+++ b/app/models/form_profiles/va_10203.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'lighthouse/benefits_education/service'
+require 'vets/model'
 
 module VA10203
   FORM_ID = '22-10203'

--- a/app/models/form_profiles/va_10203.rb
+++ b/app/models/form_profiles/va_10203.rb
@@ -6,7 +6,7 @@ module VA10203
   FORM_ID = '22-10203'
 
   class FormInstitutionInfo
-    include Virtus.model
+    include Vets::Model
 
     attribute :name, String
     attribute :city, String
@@ -15,7 +15,7 @@ module VA10203
   end
 
   class FormEntitlementInformation
-    include Virtus.model
+    include Vets::Model
 
     attribute :months, Integer
     attribute :days, Integer

--- a/app/models/form_profiles/va_1990s.rb
+++ b/app/models/form_profiles/va_1990s.rb
@@ -4,7 +4,7 @@ module VA1990s
   FORM_ID = '22-1990s'
 
   class FormPaymentAccountInformation
-    include Virtus.model
+    include Vets::Model
 
     attribute :account_type, String
     attribute :account_number, String

--- a/app/models/form_profiles/va_1990s.rb
+++ b/app/models/form_profiles/va_1990s.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module VA1990s
   FORM_ID = '22-1990s'
 

--- a/app/models/form_profiles/va_686c674.rb
+++ b/app/models/form_profiles/va_686c674.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 class FormProfiles::VA686c674 < FormProfile
   class FormAddress
     include Vets::Model

--- a/app/models/form_profiles/va_686c674.rb
+++ b/app/models/form_profiles/va_686c674.rb
@@ -2,7 +2,7 @@
 
 class FormProfiles::VA686c674 < FormProfile
   class FormAddress
-    include Virtus.model
+    include Vets::Model
 
     attribute :country_name, String
     attribute :address_line1, String

--- a/app/models/form_profiles/va_686c674v2.rb
+++ b/app/models/form_profiles/va_686c674v2.rb
@@ -2,7 +2,7 @@
 
 class FormProfiles::VA686c674v2 < FormProfile
   class FormAddress
-    include Virtus.model
+    include Vets::Model
 
     attribute :country_name, String
     attribute :address_line1, String

--- a/app/models/form_profiles/va_686c674v2.rb
+++ b/app/models/form_profiles/va_686c674v2.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 class FormProfiles::VA686c674v2 < FormProfile
   class FormAddress
     include Vets::Model


### PR DESCRIPTION
## Summary

- The virtus gem ([source](https://github.com/solnic/virtus)) is discontinued and must be replaced
- The replacement is `Vets::Model` ([source](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/vets/model.rb))
- This PR replaces `Virtus.model` with `Vets::Model` and updates the attributes according 
    - The attribute updates are minor and mostly related to Booleans and Arrays
- This change should not affect any functionality. 

## Related Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92440

## Testing

- [x] Make sure the specs pass
- [x] Manually checking the serialized responses are the same

Note: Some test required updates because of difference in hash keys (strings & symbols)

## Acceptance Criteria 

- [x] Serialized responses are identical
- [x] No functionality changes to FormProfile or related subclasses
 