### PR TITLE
[VI-1105] FormEmailMatchesProfileLog user_account_id backfill PR

### DIFF
--- a/rakelib/prod/backfill_user_account_for_form_email_matches_profile_logs.rake
+++ b/rakelib/prod/backfill_user_account_for_form_email_matches_profile_logs.rake
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+desc 'Backill user account id records for FormEmailMatchesProfileLog'
+task backfill_user_account_for_form_email_matches_profile_logs: :environment do
+  def null_user_account_id_count_message
+    '[BackfillUserAccountForFormEmailMatchesProfileLog] FormEmailMatchesProfileLog with user_account_id: nil, ' \
+      "count: #{user_account_nil.count}"
+  end
+
+  def user_account_nil
+    FormEmailMatchesProfileLog.where(user_account_id: nil)
+  end
+
+  Rails.logger.info('[BackfillUserAccountForFormEmailMatchesProfileLog] Starting rake task')
+  Rails.logger.info(null_user_account_id_count_message)
+  mpi_service = MPI::Service.new
+  user_account_nil.find_in_batches(batch_size: 1000) do |batch|
+    batch.each do |sub|
+      user_uuid = sub.user_uuid
+      user_account = UserVerification.find_by(idme_uuid: user_uuid)&.user_account ||
+                     UserVerification.find_by(backing_idme_uuid: user_uuid)&.user_account ||
+                     UserVerification.find_by(logingov_uuid: user_uuid)&.user_account
+      unless user_account
+        icn = Account.find_by(idme_uuid: user_uuid)&.icn ||
+              Account.find_by(logingov_uuid: user_uuid)&.icn ||
+              mpi_service.find_profile_by_identifier(identifier: user_uuid, identifier_type: 'idme')&.profile&.icn
+        user_account = UserAccount.find_or_create_by(icn:) if icn
+      end
+      sub.user_account_id = user_account.uuid
+      sub.save!
+    end
+  end
+  Rails.logger.info('[BackfillUserAccountForFormEmailMatchesProfileLog] Finished rake task')
+  Rails.logger.info(null_user_account_id_count_message)
+end

--- a/rakelib/prod/backfill_user_account_for_form_email_matches_profile_logs.rake
+++ b/rakelib/prod/backfill_user_account_for_form_email_matches_profile_logs.rake
@@ -1,20 +1,21 @@
 # frozen_string_literal: true
 
-desc 'Backill user account id records for FormEmailMatchesProfileLog'
+desc 'Backfill user account id records for FormEmailMatchesProfileLog'
 task backfill_user_account_for_form_email_matches_profile_logs: :environment do
-  def null_user_account_id_count_message
-    '[BackfillUserAccountForFormEmailMatchesProfileLog] FormEmailMatchesProfileLog with user_account_id: nil, ' \
-      "count: #{user_account_nil.count}"
-  end
-
-  def user_account_nil
+  def get_nil_user_account_ids
     FormEmailMatchesProfileLog.where(user_account_id: nil)
   end
 
+  def nil_user_account_ids_count_message(nil_user_account_id_count)
+    Rails.logger.info('[BackfillUserAccountForFormEmailMatchesProfileLog] FormEmailMatchesProfileLog ' \
+                      "with user_account_id: nil, count: #{nil_user_account_id_count}")
+  end
+
   Rails.logger.info('[BackfillUserAccountForFormEmailMatchesProfileLog] Starting rake task')
-  Rails.logger.info(null_user_account_id_count_message)
   mpi_service = MPI::Service.new
-  user_account_nil.find_in_batches(batch_size: 1000) do |batch|
+  starting_nil_user_account_ids = get_nil_user_account_ids
+  nil_user_account_ids_count_message(starting_nil_user_account_ids.count)
+  starting_nil_user_account_ids.find_in_batches(batch_size: 1000) do |batch|
     batch.each do |sub|
       user_uuid = sub.user_uuid
       user_account = UserVerification.find_by(idme_uuid: user_uuid)&.user_account ||
@@ -26,10 +27,10 @@ task backfill_user_account_for_form_email_matches_profile_logs: :environment do
               mpi_service.find_profile_by_identifier(identifier: user_uuid, identifier_type: 'idme')&.profile&.icn
         user_account = UserAccount.find_or_create_by(icn:) if icn
       end
-      sub.user_account_id = user_account.id
+      sub.user_account_id = user_account&.id
       sub.save!
     end
   end
   Rails.logger.info('[BackfillUserAccountForFormEmailMatchesProfileLog] Finished rake task')
-  Rails.logger.info(null_user_account_id_count_message)
+  nil_user_account_ids_count_message(get_nil_user_account_ids.count)
 end

--- a/rakelib/prod/backfill_user_account_for_form_email_matches_profile_logs.rake
+++ b/rakelib/prod/backfill_user_account_for_form_email_matches_profile_logs.rake
@@ -26,7 +26,7 @@ task backfill_user_account_for_form_email_matches_profile_logs: :environment do
               mpi_service.find_profile_by_identifier(identifier: user_uuid, identifier_type: 'idme')&.profile&.icn
         user_account = UserAccount.find_or_create_by(icn:) if icn
       end
-      sub.user_account_id = user_account.uuid
+      sub.user_account_id = user_account.id
       sub.save!
     end
   end


### PR DESCRIPTION
## Summary

- Backfill PR to enable [`user_uuid` refactor](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity/Products/user_uuid%20Refactor/user_uuid_refactor_faq.md).
- similar to earlier [`user_account` backfill PRs](https://github.com/department-of-veterans-affairs/vets-api/pull/21756)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/58

## Testing

- Testing can be performed in a Rails console
```ruby
include FactoryBot::Syntax::Methods
user_uuid = UserVerification.last.idme_uuid || UserVerification.last.logingov_uuid
in_progress_form = create(:in_progress_form, user_uuid:)
form_email_log = FormEmailMatchesProfileLog.new(user_uuid:, in_progress_form_id: in_progress_form.id)
form_email_log.save!
FormEmailMatchesProfileLog.where(user_account_id: nil).first == form_email_log
=> true
```
- In a separate terminal run the backfill raketask
  - `bundle exec rake backfill_user_account_for_form_email_matches_profile_logs`
  - The raketask runs with batches of 1000
  - You should see Rails logger messages for job start, initial `user_account:nil` count, job finish, and final `user_account:nil` count.
- In your Rails console the submission should have its `user_account` updated:
```ruby
form_email_log.reload
form_email_log.user_account_id
	=> '1abdb3ae-38...'
FormEmailMatchesProfileLog.where(user_account_id: nil).count
  => 0
```