### PR TITLE
Updating yardoc GHA to use a fetch-depth of 1

### DIFF
--- a/.github/workflows/yardoc.yml
+++ b/.github/workflows/yardoc.yml
@@ -1,4 +1,5 @@
 name: Yardoc
+
 # check documentation in specified paths
 on: # `on` parses to `true` in ruby
   pull_request:
@@ -7,10 +8,12 @@ on: # `on` parses to `true` in ruby
       - modules/burials/**/*.rb
       - modules/pensions/**/*.rb
       - modules/income_and_assets/**/*.rb
+      
 permissions:
   contents: read
   pull-requests: write
   statuses: write
+
 jobs:
   yardoc:
     name: Yardoc
@@ -23,8 +26,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/yardoc.yml
+++ b/.github/workflows/yardoc.yml
@@ -19,8 +19,7 @@ jobs:
     name: Yardoc
 
     env:
-      COVERBAND_DISABLE: true
-      BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.BUNDLE_ENTERPRISE__CONTRIBSYS__COM }}
+      COVERBAND_DISABLE_AUTO_START: true
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
Removing the `fetch-depth` option (default is 1) to avoid pulling all tags and branches every time the action runs. This should improve the speed of the `checkout` action and lead to a smaller system resource footprint for the runners

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/108424

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
