### PR TITLE
[VI-1105] forces user_account relation on appeal submission model

### DIFF
--- a/app/models/appeal_submission.rb
+++ b/app/models/appeal_submission.rb
@@ -7,7 +7,7 @@ class AppealSubmission < ApplicationRecord
 
   APPEAL_TYPES = %w[HLR NOD SC].freeze
   validates :user_uuid, :submitted_appeal_uuid, presence: true
-  belongs_to :user_account, dependent: nil, optional: true
+  belongs_to :user_account, dependent: nil, optional: false
   validates :type_of_appeal, inclusion: APPEAL_TYPES
 
   has_kms_key


### PR DESCRIPTION
## Summary

- Requires new `AppealSubmission` records to have an associated `UserAccount`
- Existing `AppealSubmission` records [have been updated](https://github.com/department-of-veterans-affairs/vets-api/pull/21578).

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/58

## Testing done
- update `spec/factories/appeal_submissions.rb` to add `stub_mpi:false`
```ruby
FactoryBot.define do
  factory :appeal_submission do
    user_uuid do
      user = create(:user, :loa3, stub_mpi: false, ssn: '212222112')
      user.uuid
    end
```
- In the Rails console
```ruby
include FactoryBot::Syntax::Methods

# validation failure
create(:appeal_submission, user_account: nil)
=> ActiveRecord::RecordInvalid

# validation success
user_account = create(:user_account)
create(:appeal_submission, user_account:)
=> #<AppealSubmission id: ...>
```
