### PR TITLE
Add encryption rotation fields and indices to submission and attempt tables

### DIFF
--- a/db/migrate/20250506172106_add_needs_kms_rotation_fields_to_submissions_tables.rb
+++ b/db/migrate/20250506172106_add_needs_kms_rotation_fields_to_submissions_tables.rb
@@ -1,0 +1,15 @@
+class AddNeedsKmsRotationFieldsToSubmissionsTables < ActiveRecord::Migration[7.2]
+  def change
+    tables = ApplicationRecord.descendants_using_encryption.select do |t|
+      !t.column_names.include?('needs_kms_rotation')
+    end.map(&:table_name).uniq
+
+    tables.each do |table|
+      add_column table, :needs_kms_rotation, :boolean, default: false, null: false
+      add_index table,
+                :needs_kms_rotation,
+                algorithm: :concurrently,
+                if_not_exists: true
+    end
+  end
+end

--- a/db/migrate/20250506172106_add_needs_kms_rotation_fields_to_submissions_tables.rb
+++ b/db/migrate/20250506172106_add_needs_kms_rotation_fields_to_submissions_tables.rb
@@ -6,10 +6,6 @@ class AddNeedsKmsRotationFieldsToSubmissionsTables < ActiveRecord::Migration[7.2
 
     tables.each do |table|
       add_column table, :needs_kms_rotation, :boolean, default: false, null: false
-      add_index table,
-                :needs_kms_rotation,
-                algorithm: :concurrently,
-                if_not_exists: true
     end
   end
 end

--- a/db/migrate/20250507151848_add_needs_kms_rotation_indices_to_submission_tables.rb
+++ b/db/migrate/20250507151848_add_needs_kms_rotation_indices_to_submission_tables.rb
@@ -1,4 +1,6 @@
 class AddNeedsKmsRotationIndicesToSubmissionTables < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+  
   def change
     tables = ApplicationRecord.descendants_using_encryption.select do |t|
       !t.column_names.include?('needs_kms_rotation')

--- a/db/migrate/20250507151848_add_needs_kms_rotation_indices_to_submission_tables.rb
+++ b/db/migrate/20250507151848_add_needs_kms_rotation_indices_to_submission_tables.rb
@@ -1,0 +1,14 @@
+class AddNeedsKmsRotationIndicesToSubmissionTables < ActiveRecord::Migration[7.2]
+  def change
+    tables = ApplicationRecord.descendants_using_encryption.select do |t|
+      !t.column_names.include?('needs_kms_rotation')
+    end.map(&:table_name).uniq
+
+    tables.each do |table|
+      add_index table,
+                :needs_kms_rotation,
+                algorithm: :concurrently,
+                if_not_exists: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_06_172106) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_07_151848) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_30_165555) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_06_172106) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -461,7 +461,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_30_165555) do
     t.datetime "bpds_updated_at", comment: "timestamp of the last update from bpds"
     t.string "bpds_id", comment: "ID of the submission in BPDS"
     t.text "encrypted_kms_key", comment: "KMS key used to encrypt sensitive data"
+    t.boolean "needs_kms_rotation", default: false, null: false
     t.index ["bpds_submission_id"], name: "index_bpds_submission_attempts_on_bpds_submission_id"
+    t.index ["needs_kms_rotation"], name: "index_bpds_submission_attempts_on_needs_kms_rotation"
   end
 
   create_table "bpds_submissions", force: :cascade do |t|
@@ -473,6 +475,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_30_165555) do
     t.string "va_claim_id", comment: "claim ID in VA (non-vets-api) systems"
     t.jsonb "reference_data_ciphertext", comment: "encrypted data that can be used to identify the resource - ie, ICN, etc"
     t.text "encrypted_kms_key", comment: "KMS key used to encrypt the reference data"
+    t.boolean "needs_kms_rotation", default: false, null: false
+    t.index ["needs_kms_rotation"], name: "index_bpds_submissions_on_needs_kms_rotation"
   end
 
   create_table "central_mail_submissions", id: :serial, force: :cascade do |t|
@@ -1165,7 +1169,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_30_165555) do
     t.datetime "lighthouse_updated_at", comment: "timestamp of the last update from lighthouse"
     t.string "benefits_intake_uuid"
     t.text "encrypted_kms_key", comment: "KMS key used to encrypt sensitive data"
+    t.boolean "needs_kms_rotation", default: false, null: false
     t.index ["lighthouse_submission_id"], name: "idx_on_lighthouse_submission_id_e6e3dbad55"
+    t.index ["needs_kms_rotation"], name: "index_lighthouse_submission_attempts_on_needs_kms_rotation"
   end
 
   create_table "lighthouse_submissions", force: :cascade do |t|
@@ -1176,6 +1182,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_30_165555) do
     t.string "form_id", null: false, comment: "form type of the submission"
     t.jsonb "reference_data_ciphertext", comment: "encrypted data that can be used to identify the resource - ie, ICN, etc"
     t.text "encrypted_kms_key", comment: "KMS key used to encrypt the reference data"
+    t.boolean "needs_kms_rotation", default: false, null: false
+    t.index ["needs_kms_rotation"], name: "index_lighthouse_submissions_on_needs_kms_rotation"
   end
 
   create_table "maintenance_windows", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This schema change is a follow up PR that re-adds the encryption rotation fields back to the new submissions and attempts tables. The migrations for this schema change already exist here: `20250421190417_add_needs_kms_rotation_to_encrypted_models.rb` and `20250422190711_add_index_on_needs_kms_rotation_to_encrypted_models.rb`.
- Pension and Burial program team to own this change.

## Related issue(s)

- [*Link to ticket created in va.gov-team repo*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/105115)
- *Link to previous change of the code/bug (if applicable)*: https://github.com/department-of-veterans-affairs/vets-api/pull/21655

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
