### PR TITLE
Revert "Revert "added encrypted_kms_key to submission tables and added failure enum""

### DIFF
--- a/db/migrate/20250312085108_create_bpds_submissions.rb
+++ b/db/migrate/20250312085108_create_bpds_submissions.rb
@@ -1,4 +1,4 @@
-class CreateBpdsSubmissions < ActiveRecord::Migration[7.2]
+class CreateBPDSSubmissions < ActiveRecord::Migration[7.2]
   def change
     create_enum :bpds_submission_status, %w[pending submitted]
 

--- a/db/migrate/20250312085126_create_bpds_submission_attempts.rb
+++ b/db/migrate/20250312085126_create_bpds_submission_attempts.rb
@@ -1,4 +1,4 @@
-class CreateBpdsSubmissionAttempts < ActiveRecord::Migration[7.2]
+class CreateBPDSSubmissionAttempts < ActiveRecord::Migration[7.2]
   def change
     create_table :bpds_submission_attempts do |t|
       t.timestamps

--- a/db/migrate/20250409194833_add_kms_encryption_key_to_submission_tables.rb
+++ b/db/migrate/20250409194833_add_kms_encryption_key_to_submission_tables.rb
@@ -1,0 +1,8 @@
+class AddKmsEncryptionKeyToSubmissionTables < ActiveRecord::Migration[7.2]
+  def change
+    add_column :bpds_submissions, :encrypted_kms_key, :text, comment: 'KMS key used to encrypt the reference data'
+    add_column :bpds_submission_attempts, :encrypted_kms_key, :text, comment: 'KMS key used to encrypt sensitive data'
+    add_column :lighthouse_submissions, :encrypted_kms_key, :text, comment: 'KMS key used to encrypt the reference data'
+    add_column :lighthouse_submission_attempts, :encrypted_kms_key, :text, comment: 'KMS key used to encrypt sensitive data'
+  end
+end

--- a/db/migrate/20250409194908_add_failure_to_bpds_submission_status_enum.rb
+++ b/db/migrate/20250409194908_add_failure_to_bpds_submission_status_enum.rb
@@ -1,4 +1,4 @@
-class AddFailureToBpdsSubmissionStatusEnum < ActiveRecord::Migration[7.2]
+class AddFailureToBPDSSubmissionStatusEnum < ActiveRecord::Migration[7.2]
   def up
     add_enum_value :bpds_submission_status, 'failure'
   end

--- a/db/migrate/20250409194908_add_failure_to_bpds_submission_status_enum.rb
+++ b/db/migrate/20250409194908_add_failure_to_bpds_submission_status_enum.rb
@@ -1,0 +1,56 @@
+class AddFailureToBpdsSubmissionStatusEnum < ActiveRecord::Migration[7.2]
+  def up
+    add_enum_value :bpds_submission_status, 'failure'
+  end
+
+  def down
+    # Retrieve list of all successful and failed submissions and attempts
+    submissions = BPDS::Submission.pluck(:id, :latest_status)
+    attempts = BPDS::SubmissionAttempt.pluck(:id, :status)
+
+    # Drop the enum list and remove columns using the enum
+    safety_assured do
+      remove_column :bpds_submissions, :latest_status
+      remove_column :bpds_submission_attempts, :status
+      drop_enum :bpds_submission_status
+    end
+
+    # Recreate the enum list without the failure status and add the columns back
+    create_enum :bpds_submission_status, ["pending", "submitted"]
+    add_column :bpds_submissions, :latest_status, :bpds_submission_status, default: "pending"
+    add_column :bpds_submission_attempts, :status, :bpds_submission_status, default: "pending"
+
+    # Update the status of the submissions and attempts to nil if they were previously "failure"
+    submissions.each do |submission|
+      id = submission[0]
+      status = submission[1]
+
+      if status == 'failure'
+        set_submission_status(id, nil)
+      else
+        set_submission_status(id, status)
+      end
+    end
+    attempts.each do |attempt|
+      id = attempt[0]
+      status = attempt[1]
+
+      if status == 'failure'
+        set_attempt_status(id, nil)
+      else
+        set_attempt_status(id, status)
+      end
+    end
+  end
+
+  def set_submission_status(id, latest_status)
+    return if latest_status == 'pending'
+    BPDS::Submission.find_by(id:)&.update(latest_status:)
+  end
+
+  def set_attempt_status(id, status)
+    return if status == 'pending'
+
+    BPDS::SubmissionAttempt.find_by(id:)&.update(status:)
+  end
+end

--- a/db/migrate/20250410151321_make_saved_claim_id_nullable_on_submissions.rb
+++ b/db/migrate/20250410151321_make_saved_claim_id_nullable_on_submissions.rb
@@ -1,0 +1,17 @@
+class MakeSavedClaimIdNullableOnSubmissions < ActiveRecord::Migration[7.2]
+  def up
+    change_column_null :bpds_submissions, :saved_claim_id, true
+    BPDS::Submission.where(saved_claim_id: 0).update_all(saved_claim_id: nil)
+
+    change_column_null :lighthouse_submissions, :saved_claim_id, true
+    Lighthouse::Submission.where(saved_claim_id: 0).update_all(saved_claim_id: nil)
+  end
+
+  def down
+    BPDS::Submission.where(saved_claim_id: nil).update_all(saved_claim_id: 0)
+    change_column_null :bpds_submissions, :saved_claim_id, false
+    
+    Lighthouse::Submission.where(saved_claim_id: nil).update_all(saved_claim_id: 0)
+    change_column_null :lighthouse_submissions, :saved_claim_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema[7.2].define(version: 2025_04_22_190711) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -24,7 +23,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_22_190711) do
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
-  create_enum "bpds_submission_status", ["pending", "submitted"]
+  create_enum "bpds_submission_status", ["pending", "submitted", "failure"]
   create_enum "itf_remediation_status", ["unprocessed"]
   create_enum "lighthouse_submission_status", ["pending", "submitted"]
   create_enum "user_action_status", ["initial", "success", "error"]
@@ -455,23 +454,25 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_22_190711) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "bpds_submission_id", null: false
-    t.enum "status", default: "pending", enum_type: "bpds_submission_status"
     t.jsonb "metadata_ciphertext", comment: "encrypted metadata sent with the submission"
     t.jsonb "error_message_ciphertext", comment: "encrypted error message from the bpds submission"
     t.jsonb "response_ciphertext", comment: "encrypted response from the bpds submission"
     t.datetime "bpds_updated_at", comment: "timestamp of the last update from bpds"
     t.string "bpds_id", comment: "ID of the submission in BPDS"
+    t.enum "status", default: "pending", enum_type: "bpds_submission_status"
+    t.text "encrypted_kms_key", comment: "KMS key used to encrypt sensitive data"
     t.index ["bpds_submission_id"], name: "index_bpds_submission_attempts_on_bpds_submission_id"
   end
 
   create_table "bpds_submissions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "saved_claim_id", null: false, comment: "ID of the saved claim in vets-api"
+    t.integer "saved_claim_id", comment: "ID of the saved claim in vets-api"
     t.enum "latest_status", default: "pending", enum_type: "bpds_submission_status"
     t.string "form_id", null: false, comment: "form type of the submission"
     t.string "va_claim_id", comment: "claim ID in VA (non-vets-api) systems"
     t.jsonb "reference_data_ciphertext", comment: "encrypted data that can be used to identify the resource - ie, ICN, etc"
+    t.text "encrypted_kms_key", comment: "KMS key used to encrypt the reference data"
   end
 
   create_table "central_mail_submissions", id: :serial, force: :cascade do |t|
@@ -1163,16 +1164,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_22_190711) do
     t.jsonb "response_ciphertext", comment: "encrypted response from the lighthouse submission"
     t.datetime "lighthouse_updated_at", comment: "timestamp of the last update from lighthouse"
     t.string "benefits_intake_uuid"
+    t.text "encrypted_kms_key", comment: "KMS key used to encrypt sensitive data"
     t.index ["lighthouse_submission_id"], name: "idx_on_lighthouse_submission_id_e6e3dbad55"
   end
 
   create_table "lighthouse_submissions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "saved_claim_id", null: false, comment: "ID of the saved claim in vets-api"
+    t.integer "saved_claim_id", comment: "ID of the saved claim in vets-api"
     t.enum "latest_status", default: "pending", enum_type: "lighthouse_submission_status"
     t.string "form_id", null: false, comment: "form type of the submission"
     t.jsonb "reference_data_ciphertext", comment: "encrypted data that can be used to identify the resource - ie, ICN, etc"
+    t.text "encrypted_kms_key", comment: "KMS key used to encrypt the reference data"
   end
 
   create_table "maintenance_windows", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#21894

Eric and I figured out a fix, so we're applying it here.

error:
```
NameError: uninitialized constant AddFailureToBPDSSubmissionStatusEnum (NameError)
Object.const_get(camel_cased_word)
^^^^^^^^^^
Did you mean?  AddFailureToBpdsSubmissionStatusEnum
Caused by:
NameError: uninitialized constant AddFailureToBPDSSubmissionStatusEnum (NameError)
Object.const_get(camel_cased_word)
^^^^^^^^^^
Did you mean?  AddFailureToBpdsSubmissionStatusEnum
```