### PR TITLE
MHV-69701 Decouple MilitaryServiceController from MrController

### DIFF
--- a/modules/my_health/spec/requests/my_health/v1/medical_records/military_service_spec.rb
+++ b/modules/my_health/spec/requests/my_health/v1/medical_records/military_service_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/mr_client_helpers'
+require 'medical_records/client'
+require 'medical_records/phr_mgr/client'
+require 'support/shared_examples_for_mhv'
+
+RSpec.describe 'MyHealth::V1::MedicalRecords::MilitaryServiceController', type: :request do
+  include MedicalRecords::ClientHelpers
+  include SchemaMatchers
+
+  context 'Unuthorized User' do
+    context 'with no EDIPI' do
+      let(:user_id) { '21207668' }
+      let(:current_user) { build(:user) }
+
+      before do
+        sign_in_as(current_user)
+      end
+
+      it 'returns 400 Bad Request when EDIPI is missing' do
+        sign_in_as(current_user)
+
+        get '/my_health/v1/medical_records/military_service'
+
+        expect(current_user.icn).not_to be_nil
+        expect(current_user.edipi).to be_nil
+        expect(response).to have_http_status(:bad_request)
+        json = JSON.parse(response.body)
+        puts "json: #{json}"
+        expect(json['error']).to eq('No EDIPI found for the current user')
+      end
+    end
+
+    context 'with no ICN' do
+      let(:user_id) { '21207668' }
+      let(:current_user) { build(:user, :mhv, mhv_account_type:, edipi: '1234567890', icn: nil) }
+      let(:mhv_account_type) { 'Premium' }
+
+      before do
+        sign_in_as(current_user)
+      end
+
+      it 'returns 403 Forbidden when ICN is missing' do
+        sign_in_as(current_user)
+
+        get '/my_health/v1/medical_records/military_service'
+
+        expect(current_user.icn).to be_nil
+        expect(current_user.edipi).not_to be_nil
+        expect(response).to have_http_status(:forbidden)
+        json = JSON.parse(response.body)
+        expect(json['errors'].first['detail']).to eq('You do not have access to military service information')
+      end
+    end
+  end
+
+  context 'Authorized User' do
+    let(:user_id) { '21207668' }
+    let(:current_user) { build(:user, :mhv, mhv_account_type:, edipi: '1234567890') }
+    let(:mhv_account_type) { 'Premium' }
+
+    before do
+      allow(Flipper).to receive(:enabled?).with(:mhv_medical_records_migrate_to_api_gateway).and_return(false)
+
+      phr_mgr_client = PHRMgr::Client.new(
+        session: {
+          user_id: 11_375_034,
+          icn: '1000000000V000000',
+          patient_id: '11382904',
+          expires_at: 1.hour.from_now,
+          token: '<SESSION_TOKEN>'
+        }
+      )
+
+      allow(PHRMgr::Client).to receive(:new).and_return(phr_mgr_client)
+      sign_in_as(current_user)
+    end
+
+    it 'responds to GET #index' do
+      VCR.use_cassette('phr_mgr_client/get_military_service') do
+        get '/my_health/v1/medical_records/military_service'
+      end
+
+      expect(response).to be_successful
+      expect(response.body).to be_a(String)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Made `MilitaryServiceController` a direct child of `ApplicationController` bypassing `MrController` in the middle. Done to support work for the cartography team.
- A full policy is not needed here. Just return errors if the required parameters are not present.

## Related issue(s)

### [MHV-69701](https://jira.devops.va.gov/browse/MHV-69701) - Allow DoD history API calls with reduced privileges on the backend ###

> Acceptance criteria:
> 
> AC1: A new policy is created for users who have a premium MHV account (double-check this) but do NOT have a VA treatment facility – Work shared with [MHV-69698](https://jira.devops.va.gov/browse/MHV-69698)
> AC2: DoD history action is moved to a controller that uses the new policy
> AC3: Confirm that the intended users will have an EDIPI, as that's what we use to get DoD history

## Testing done

- [x] *New code is covered by unit tests*
- The only functional change here is that the military service endpoint no longer requires the user to have a VA Treatment Facility.

## What areas of the site does it impact?
MHV Medical Records

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
