### PR TITLE
Fix: Vets::Attribute Bool bug

### DIFF
--- a/lib/vets/attributes.rb
+++ b/lib/vets/attributes.rb
@@ -48,14 +48,20 @@ module Vets
 
       def define_getter(name, default)
         define_method(name) do
-          instance_variable_get("@#{name}") || begin
-            return nil unless defined?(default)
+          # check if the attribute is assigned and not nil
+          if instance_variable_defined?("@#{name}")
+            value = instance_variable_get("@#{name}")
+            return value unless value.nil?
+          end
 
-            if default.is_a?(Symbol) && respond_to?(default)
-              send(default)
-            else
-              default
-            end
+          # if value is nil check for a default
+          return nil unless defined?(default)
+
+          # if there's a default, assign the default value
+          if default.is_a?(Symbol) && respond_to?(default)
+            send(default)
+          else
+            default
           end
         end
       end

--- a/spec/lib/vets/attributes_spec.rb
+++ b/spec/lib/vets/attributes_spec.rb
@@ -43,10 +43,11 @@ RSpec.describe Vets::Attributes do
       model.age = 30
       model.tags = %w[ruby rails]
       model.name = 'Steven'
+      model.active = false
       expect(model.age).to eq(30)
       expect(model.tags).to eq(%w[ruby rails])
       expect(model.name).to eq('Steven')
-      expect(model.active).to be_nil
+      expect(model.active).to be_falsey
     end
 
     it 'defines the defaults' do

--- a/spec/lib/vets/attributes_spec.rb
+++ b/spec/lib/vets/attributes_spec.rb
@@ -28,6 +28,7 @@ class DummyModel < DummyParentModel
   attribute :tags, String, array: true
   attribute :categories, FakeCategory, array: true
   attribute :created_at, DateTime, default: :current_time, filterable: %w[eq not_eq]
+  attribute :active, Bool
 
   def current_time
     DateTime.new(2024, 9, 25, 10, 30, 0)
@@ -45,6 +46,7 @@ RSpec.describe Vets::Attributes do
       expect(model.age).to eq(30)
       expect(model.tags).to eq(%w[ruby rails])
       expect(model.name).to eq('Steven')
+      expect(model.active).to be_nil
     end
 
     it 'defines the defaults' do
@@ -66,7 +68,8 @@ RSpec.describe Vets::Attributes do
         age: { type: Integer, default: nil, array: false, filterable: %w[eq lteq gteq] },
         tags: { type: String, default: nil, array: true, filterable: false },
         categories: { type: FakeCategory, default: nil, array: true, filterable: false },
-        created_at: { type: DateTime, default: :current_time, array: false, filterable: %w[eq not_eq] }
+        created_at: { type: DateTime, default: :current_time, array: false, filterable: %w[eq not_eq] },
+        active: { type: Bool, default: nil, array: false, filterable: false }
       }
       expect(DummyModel.attributes).to eq(expected_attributes)
     end


### PR DESCRIPTION
## Summary

- When an attribute is a Bool without a default, a false value will failed to be assigned and uses the default of nil
- This bug doesn't affect any existing attribute because all existing Bool attributes have a default value. 

## Related issue(s)

- n/a

## Testing done

- [x] new test added
- [x] manual testing
- [x] confirmed existing Bool attributes already have default values

## Acceptance criteria

- [x]  Bool attributes without defaults can be false 

## Requested Feedback

I don't love the way I fixed it, might refactor later