### PR TITLE
[ID-103] - Add migration for creating sign_in_certificates table

### DIFF
--- a/db/migrate/20250428154055_create_sign_in_certificates.rb
+++ b/db/migrate/20250428154055_create_sign_in_certificates.rb
@@ -1,0 +1,8 @@
+class CreateSignInCertificates < ActiveRecord::Migration[7.2]
+  def change
+    create_table :sign_in_certificates, id: :uuid do |t|
+      t.text :pem, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250429014133_create_sign_in_config_certificates.rb
+++ b/db/migrate/20250429014133_create_sign_in_config_certificates.rb
@@ -1,0 +1,9 @@
+class CreateSignInConfigCertificates < ActiveRecord::Migration[7.2]
+  def change
+    create_table :sign_in_config_certificates do |t|
+      t.belongs_to :config, polymorphic: true, null: false, type: :integer, index: true
+      t.belongs_to :certificate, null: false, type: :uuid, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_22_190711) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_29_014133) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -1375,6 +1375,22 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_22_190711) do
     t.datetime "updated_at", null: false
     t.string "access_token_user_attributes", default: [], array: true
     t.index ["service_account_id"], name: "index_service_account_configs_on_service_account_id", unique: true
+  end
+
+  create_table "sign_in_certificates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "pem", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "sign_in_config_certificates", force: :cascade do |t|
+    t.string "config_type", null: false
+    t.integer "config_id", null: false
+    t.uuid "certificate_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["certificate_id"], name: "index_sign_in_config_certificates_on_certificate_id"
+    t.index ["config_type", "config_id"], name: "index_sign_in_config_certificates_on_config"
   end
 
   create_table "spool_file_events", force: :cascade do |t|


### PR DESCRIPTION
## Summary

- Create table for `SignIn::Certificate`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/103

## Testing 

- run migrations - `rails db:migrate`

## What areas of the site does it impact?

Database 

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
