### PR TITLE
Replace Virtus with Vets::Model - Model Docs

### DIFF
--- a/app/models/evss_claim_document.rb
+++ b/app/models/evss_claim_document.rb
@@ -76,7 +76,7 @@ class EVSSClaimDocument
 
   def to_serializable_hash
     # file_obj is not suitable for serialization
-    to_hash.tap { |h| h.delete :file_obj }
+    attributes.tap { |h| h.delete :file_obj }
   end
 
   # The front-end URL encodes a nil tracked_item_id as the string 'null'

--- a/app/models/evss_claim_document.rb
+++ b/app/models/evss_claim_document.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
 require 'pdf_info'
 
-class EVSSClaimDocument < Common::Base
-  include ActiveModel::Validations
+class EVSSClaimDocument
+  include Vets::Model
   include ActiveModel::Validations::Callbacks
   include SentryLogging
 
@@ -79,10 +79,9 @@ class EVSSClaimDocument < Common::Base
     to_hash.tap { |h| h.delete :file_obj }
   end
 
-  # The front-end URLencodes a nil tracked_item_id as the string 'null'
+  # The front-end URL encodes a nil tracked_item_id as the string 'null'
   def tracked_item_id=(num)
-    num = nil if num == 'null'
-    super num
+    @tracked_item_id = num == 'null' ? nil : num
   end
 
   private

--- a/app/models/lighthouse_document.rb
+++ b/app/models/lighthouse_document.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
 require 'pdf_info'
 
-class LighthouseDocument < Common::Base
-  include ActiveModel::Validations
+class LighthouseDocument
+  include Vets::Model
   include ActiveModel::Validations::Callbacks
   include SentryLogging
 
@@ -84,10 +84,9 @@ class LighthouseDocument < Common::Base
     to_hash.tap { |h| h.delete :file_obj }
   end
 
-  # The front-end URLencodes a nil tracked_item_id as the string 'null'
+  # The front-end URL encodes a nil tracked_item_id as the string 'null'
   def tracked_item_id=(num)
-    num = nil if num == 'null'
-    super num
+    @tracked_item_id = num == 'null' ? nil : num
   end
 
   private

--- a/app/models/lighthouse_document.rb
+++ b/app/models/lighthouse_document.rb
@@ -81,7 +81,7 @@ class LighthouseDocument
 
   def to_serializable_hash
     # file_obj is not suitable for serialization
-    to_hash.tap { |h| h.delete :file_obj }
+    attributes.tap { |h| h.delete :file_obj }
   end
 
   # The front-end URL encodes a nil tracked_item_id as the string 'null'

--- a/lib/lighthouse/benefits_documents/configuration.rb
+++ b/lib/lighthouse/benefits_documents/configuration.rb
@@ -74,13 +74,13 @@ module BenefitsDocuments
       data = {
         data: {
           systemName: SYSTEM_NAME,
-          docType: document_data[:document_type],
-          claimId: document_data[:claim_id],
-          participantId: document_data[:participant_id],
-          fileName: document_data[:file_name],
+          docType: document_data.document_type,
+          claimId: document_data.claim_id,
+          participantId: document_data.participant_id,
+          fileName: document_data.file_name,
           # In theory one document can correspond to multiple tracked items
           # To do that, add multiple query parameters
-          trackedItemIds: document_data[:tracked_item_id]
+          trackedItemIds: document_data.tracked_item_id
         }
       }
 
@@ -89,10 +89,10 @@ module BenefitsDocuments
         'application/json'
       )
 
-      file = Tempfile.new(document_data[:file_name])
+      file = Tempfile.new(document_data.file_name)
       File.write(file, file_body)
 
-      mime_type = MimeMagic.by_path(document_data[:file_name]).type
+      mime_type = MimeMagic.by_path(document_data.file_name).type
       payload[:file] = Faraday::UploadIO.new(file, mime_type)
 
       payload

--- a/lib/lighthouse/benefits_documents/configuration.rb
+++ b/lib/lighthouse/benefits_documents/configuration.rb
@@ -74,13 +74,13 @@ module BenefitsDocuments
       data = {
         data: {
           systemName: SYSTEM_NAME,
-          docType: document_data.document_type,
-          claimId: document_data.claim_id,
-          participantId: document_data.participant_id,
-          fileName: document_data.file_name,
+          docType: document_data[:document_type],
+          claimId: document_data[:claim_id],
+          participantId: document_data[:participant_id],
+          fileName: document_data[:file_name],
           # In theory one document can correspond to multiple tracked items
           # To do that, add multiple query parameters
-          trackedItemIds: document_data.tracked_item_id
+          trackedItemIds: document_data[:tracked_item_id]
         }
       }
 
@@ -89,10 +89,10 @@ module BenefitsDocuments
         'application/json'
       )
 
-      file = Tempfile.new(document_data.file_name)
+      file = Tempfile.new(document_data[:file_name])
       File.write(file, file_body)
 
-      mime_type = MimeMagic.by_path(document_data.file_name).type
+      mime_type = MimeMagic.by_path(document_data[:file_name]).type
       payload[:file] = Faraday::UploadIO.new(file, mime_type)
 
       payload

--- a/spec/lib/lighthouse/benefits_documents/configuration_spec.rb
+++ b/spec/lib/lighthouse/benefits_documents/configuration_spec.rb
@@ -15,11 +15,13 @@ RSpec.describe BenefitsDocuments::Configuration do
   describe 'BenefitsDocuments Configuration' do
     context 'when file is pdf' do
       let(:document_data) do
-        { file_number: '796378881',
+        OpenStruct.new(
+          file_number: '796378881',
           claim_id: '600423040',
           tracked_item_id: nil,
           document_type: 'L023',
-          file_name: 'doctors-note.pdf' }
+          file_name: 'doctors-note.jpg'
+        )
       end
       let(:file_body) { File.read(fixture_file_upload('doctors-note.pdf', 'application/pdf')) }
 
@@ -34,11 +36,13 @@ RSpec.describe BenefitsDocuments::Configuration do
 
     context 'when file is jpg' do
       let(:document_data) do
-        { file_number: '796378881',
+        OpenStruct.new(
+          file_number: '796378881',
           claim_id: '600423040',
           tracked_item_id: nil,
           document_type: 'L023',
-          file_name: 'doctors-note.jpg' }
+          file_name: 'doctors-note.jpg'
+        )
       end
       let(:file_body) { File.read(fixture_file_upload('doctors-note.jpg', 'image/jpeg')) }
 

--- a/spec/lib/lighthouse/benefits_documents/service_spec.rb
+++ b/spec/lib/lighthouse/benefits_documents/service_spec.rb
@@ -23,10 +23,16 @@ RSpec.describe BenefitsDocuments::Service do
 
     describe 'when uploading single file' do
       let(:upload_file) do
-        f = Tempfile.new(['file with spaces', '.jpg'])
+        f = Tempfile.new(['file with spaces', '.txt'])
         f.write('test')
         f.rewind
-        Rack::Test::UploadedFile.new(f.path, 'image/jpeg')
+        rack_file = Rack::Test::UploadedFile.new(f.path, 'image/jpeg')
+
+        ActionDispatch::Http::UploadedFile.new(
+          tempfile: rack_file.tempfile,
+          filename: rack_file.original_filename,
+          type: rack_file.content_type
+        )
       end
 
       let(:params) do

--- a/spec/services/evss_claim_service_spec.rb
+++ b/spec/services/evss_claim_service_spec.rb
@@ -80,7 +80,13 @@ RSpec.describe EVSSClaimService do
         f = Tempfile.new(['file with spaces', '.txt'])
         f.write('test')
         f.rewind
-        Rack::Test::UploadedFile.new(f.path, 'image/jpeg')
+        rack_file = Rack::Test::UploadedFile.new(f.path, 'image/jpeg')
+
+        ActionDispatch::Http::UploadedFile.new(
+          tempfile: rack_file.tempfile,
+          filename: rack_file.original_filename,
+          type: rack_file.content_type
+        )
       end
 
       let(:document) do
@@ -129,8 +135,15 @@ RSpec.describe EVSSClaimService do
       f = Tempfile.new(['file with spaces', '.txt'])
       f.write('test')
       f.rewind
-      Rack::Test::UploadedFile.new(f.path, 'image/jpeg')
+      rack_file = Rack::Test::UploadedFile.new(f.path, 'image/jpeg')
+
+      ActionDispatch::Http::UploadedFile.new(
+        tempfile: rack_file.tempfile,
+        filename: rack_file.original_filename,
+        type: rack_file.content_type
+      )
     end
+
     let(:document) do
       EVSSClaimDocument.new(
         tracked_item_id: 1,


### PR DESCRIPTION
## Summary

- The virtus gem ([source](https://github.com/solnic/virtus)) is discontinued and must be replaced
- The replacement is `Vets::Model` ([source](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/vets/model.rb))
- This PR replaces `Virtus.model` with `Vets::Model` and updates the attributes according 
    - The attribute updates are minor and mostly related to Booleans and Arrays
- This change should not affect any functionality. 
- Some changes from hash notation to dot notation were required

## Related Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92439

## Testing

- [x] Make sure the specs pass
- [x] Manually checking the serialized responses are the same

## Acceptance Criteria 

- [x] Serialized responses are identical
- [x] No functionality changes