### PR TITLE
 MHV-67096-add-x-api-key

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -987,6 +987,8 @@ mhv:
     subject: "Proxy Client"
     user_type: <%= ENV['mhv__uhd__user_type'] %>
 mhv_mobile:
+  rx:
+      x_api_key: <%= ENV['mhv_mobile__rx__x_api_key'] %>
   sm:
     app_token: <%= ENV['mhv_mobile__sm__app_token'] %>
   x_api_key: <%= ENV['mhv_mobile__x_api_key'] %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1001,6 +1001,8 @@ mhv:
     subject: "Proxy Client"
     user_type: usertype
 mhv_mobile:
+  rx:
+    x_api_key: fake-x-api-key
   sm:
     app_token: fake-app-token
   x_api_key: fake-x-api-key

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -995,6 +995,8 @@ mhv:
     subject: "Proxy Client"
     user_type: usertype
 mhv_mobile:
+  rx:
+    x_api_key: fake-x-api-key
   sm:
     app_token: fake-app-token
   x_api_key: fake-x-api-key

--- a/lib/rx/client.rb
+++ b/lib/rx/client.rb
@@ -226,7 +226,7 @@ module Rx
     def get_headers(headers)
       headers = headers.dup
       if Settings.mhv.rx.use_new_api.present? && Settings.mhv.rx.use_new_api
-        api_key = @app_token == config.app_token_va_gov ? Settings.mhv.rx.x_api_key : Settings.mhv_mobile.x_api_key
+        api_key = @app_token == config.app_token_va_gov ? Settings.mhv.rx.x_api_key : Settings.mhv_mobile.rx.x_api_key
         headers.merge('x-api-key' => api_key)
       else
         headers


### PR DESCRIPTION
## Summary

- Adds Rx/VAHB x-api-key for new API Gateway

## Related issue(s)

- MHV-67096
![Screenshot 2025-03-06 at 4 45 11 PM](https://github.com/user-attachments/assets/1d5e4f12-a9bf-4e28-a8a0-939a09c1439d)

## Testing done

- Updates tests
- Tested locally

## Screenshots
N/A

## What areas of the site does it impact?
MHV medications endpoints/VAHB endpoints

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
