### PR TITLE
Skip tracking overflow for unregistered forms

### DIFF
--- a/app/models/saved_claim.rb
+++ b/app/models/saved_claim.rb
@@ -206,6 +206,9 @@ class SavedClaim < ApplicationRecord
   def pdf_overflow_tracking
     tags = ["form_id:#{form_id}"]
 
+    # TODO: 686C-674 will require special handling
+    return if form_id.start_with? '686C-674'
+
     form_class = PdfFill::Filler::FORM_CLASSES[form_id]
     unless form_class
       return Rails.logger.info("#{self.class} Skipping tracking PDF overflow", form_id:, saved_claim_id: id)

--- a/app/models/saved_claim.rb
+++ b/app/models/saved_claim.rb
@@ -205,13 +205,19 @@ class SavedClaim < ApplicationRecord
 
   def pdf_overflow_tracking
     tags = ["form_id:#{form_id}"]
+
+    form_class = PdfFill::Filler::FORM_CLASSES[form_id]
+    unless form_class
+      return Rails.logger.info("#{self.class} Skipping tracking PDF overflow", form_id:, saved_claim_id: id)
+    end
+
     filename = to_pdf
 
     # @see PdfFill::Filler
     # https://github.com/department-of-veterans-affairs/vets-api/blob/96510bd1d17b9e5c95fb6c09d74e53f66b0a25be/lib/pdf_fill/filler.rb#L88
     StatsD.increment('saved_claim.pdf.overflow', tags:) if filename.end_with?('_final.pdf')
   rescue => e
-    Rails.logger.error("#{self.class} Error tracking PDF overflow", form_id:, saved_claim_id: id, error: e)
+    Rails.logger.warn("#{self.class} Error tracking PDF overflow", form_id:, saved_claim_id: id, error: e)
   ensure
     Common::FileHelpers.delete_file_if_exists(filename)
   end

--- a/modules/burials/spec/models/burials/saved_claim_spec.rb
+++ b/modules/burials/spec/models/burials/saved_claim_spec.rb
@@ -134,4 +134,14 @@ RSpec.describe Burials::SavedClaim do
       expect(instance.claimaint_first_name).to be_nil
     end
   end
+
+  context 'after create' do
+    it 'tracks pdf overflow' do
+      allow(Flipper).to receive(:enabled?).with(:saved_claim_pdf_overflow_tracking).and_return(true)
+      allow(StatsD).to receive(:increment)
+      instance.save!
+
+      expect(StatsD).to have_received(:increment).with('saved_claim.pdf.overflow', tags: ['form_id:21P-530EZ'])
+    end
+  end
 end

--- a/spec/lib/lighthouse/benefits_documents/form526/upload_status_updater_spec.rb
+++ b/spec/lib/lighthouse/benefits_documents/form526/upload_status_updater_spec.rb
@@ -63,7 +63,9 @@ RSpec.describe BenefitsDocuments::Form526::UploadStatusUpdater do
       it 'logs the latest_status_response to the Rails logger' do
         Timecop.freeze(past_date_time) do
           expect(Rails.logger).to receive(:info) do |message, _details|
-            expect(message).to equal?('SavedClaim::DisabilityCompensation::Form526AllClaim Skipping tracking PDF overflow')
+            expect(message).to equal?(
+              'SavedClaim::DisabilityCompensation::Form526AllClaim Skipping tracking PDF overflow'
+            )
           end
 
           expect(Rails.logger).to receive(:info).with(
@@ -148,7 +150,9 @@ RSpec.describe BenefitsDocuments::Form526::UploadStatusUpdater do
       it 'logs the latest_status_response to the Rails logger' do
         Timecop.freeze(past_date_time) do
           expect(Rails.logger).to receive(:info) do |message, _details|
-            expect(message).to equal?('SavedClaim::DisabilityCompensation::Form526AllClaim Skipping tracking PDF overflow')
+            expect(message).to equal?(
+              'SavedClaim::DisabilityCompensation::Form526AllClaim Skipping tracking PDF overflow'
+            )
           end
 
           expect(Rails.logger).to receive(:info).with(

--- a/spec/lib/lighthouse/benefits_documents/form526/upload_status_updater_spec.rb
+++ b/spec/lib/lighthouse/benefits_documents/form526/upload_status_updater_spec.rb
@@ -62,6 +62,10 @@ RSpec.describe BenefitsDocuments::Form526::UploadStatusUpdater do
 
       it 'logs the latest_status_response to the Rails logger' do
         Timecop.freeze(past_date_time) do
+          expect(Rails.logger).to receive(:info) do |message, _details|
+            expect(message).to equal?('SavedClaim::DisabilityCompensation::Form526AllClaim Skipping tracking PDF overflow')
+          end
+
           expect(Rails.logger).to receive(:info).with(
             'BenefitsDocuments::Form526::UploadStatusUpdater',
             status:,
@@ -143,6 +147,10 @@ RSpec.describe BenefitsDocuments::Form526::UploadStatusUpdater do
 
       it 'logs the latest_status_response to the Rails logger' do
         Timecop.freeze(past_date_time) do
+          expect(Rails.logger).to receive(:info) do |message, _details|
+            expect(message).to equal?('SavedClaim::DisabilityCompensation::Form526AllClaim Skipping tracking PDF overflow')
+          end
+
           expect(Rails.logger).to receive(:info).with(
             'BenefitsDocuments::Form526::UploadStatusUpdater',
             status: 'IN_PROGRESS',

--- a/spec/models/saved_claim_spec.rb
+++ b/spec/models/saved_claim_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe TestSavedClaim, type: :model do # rubocop:disable RSpec/SpecFileP
 
   before do
     allow(Flipper).to receive(:enabled?).with(:validate_saved_claims_with_json_schemer).and_return(false)
+    allow(Flipper).to receive(:enabled?).with(:saved_claim_pdf_overflow_tracking).and_return(true)
     allow(VetsJsonSchema::SCHEMAS).to receive(:[]).and_return(schema)
     allow(JSON::Validator).to receive_messages(fully_validate_schema: [], fully_validate: [])
   end
@@ -100,6 +101,15 @@ RSpec.describe TestSavedClaim, type: :model do # rubocop:disable RSpec/SpecFileP
             be_within(1.second).of(claim_duration),
             tags: ["form_id:#{saved_claim.form_id}"]
           )
+        end
+      end
+
+      context 'if form_id is not registered with PdfFill::Filler' do
+        it 'skips tracking pdf overflow' do
+          allow(StatsD).to receive(:increment)
+          saved_claim.save!
+
+          expect(StatsD).not_to have_received(:increment)
         end
       end
     end

--- a/spec/models/saved_claim_spec.rb
+++ b/spec/models/saved_claim_spec.rb
@@ -109,7 +109,9 @@ RSpec.describe TestSavedClaim, type: :model do # rubocop:disable RSpec/SpecFileP
           allow(StatsD).to receive(:increment)
           saved_claim.save!
 
-          expect(StatsD).not_to have_received(:increment)
+          expect(StatsD).to have_received(:increment).with('saved_claim.create', { tags: ['form_id:SOME_FORM_ID'] })
+          expect(StatsD).not_to have_received(:increment).with('saved_claim.pdf.overflow',
+                                                               { tags: ['form_id:SOME_FORM_ID'] })
         end
       end
     end


### PR DESCRIPTION
## Summary

- The overflow tracking method is producing errors for a large number of forms. Instead, we want to skip tracking when the form filler isn't implemented for a form. Since failures in tracking aren't significant errors, we also want to downgrade the logging to a warning. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108401

## Testing done

- [ ] *New code is covered by unit tests*
- [ ] Submitted Burials and Dependents forms and confirmed tracker didn't error

## What areas of the site does it impact?
Saved Claims

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

