### PR TITLE
[ID-16] - Create cerner provisioner job and call during authentication

### DIFF
--- a/app/controllers/v0/terms_of_use_agreements_controller.rb
+++ b/app/controllers/v0/terms_of_use_agreements_controller.rb
@@ -75,7 +75,7 @@ module V0
     end
 
     def provisioner
-      Identity::CernerProvisioner.new(icn: @user_account.icn)
+      Identity::CernerProvisioner.new(icn: @user_account.icn, source: :tou)
     end
 
     def recache_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -481,6 +481,12 @@ class User < Common::RedisStore
     MHV::AccountCreatorJob.perform_async(user_verification_id)
   end
 
+  def provision_cerner_async(source: nil)
+    return unless loa3? && cerner_id.present?
+
+    Identity::CernerProvisionerJob.perform_async(icn, source)
+  end
+
   def can_create_mhv_account?
     loa3? && !needs_accepted_terms_of_use
   end

--- a/app/services/identity/cerner_provisioner.rb
+++ b/app/services/identity/cerner_provisioner.rb
@@ -11,13 +11,16 @@ module Identity
     COOKIE_PATH = '/'
     COOKIE_EXPIRATION = 2.minutes
     COOKIE_DOMAIN = '.va.gov'
+    VALID_SOURCES = %i[ssoe sis tou].freeze
 
-    attr_reader :icn
+    attr_reader :icn, :source
 
     validates :icn, presence: true
+    validates :source, inclusion: { in: VALID_SOURCES }, allow_blank: true
 
-    def initialize(icn:)
+    def initialize(icn:, source: nil)
       @icn = icn
+      @source = source
 
       validate!
     rescue ActiveModel::ValidationError => e
@@ -29,13 +32,15 @@ module Identity
       response = update_provisioning
 
       if response[:agreement_signed].blank?
-        Rails.logger.error('[Identity] [CernerProvisioner] update_provisioning error', { icn:, response: })
+        Rails.logger.error('[Identity] [CernerProvisioner] update_provisioning error', { icn:, response:, source: })
         raise(Errors::CernerProvisionerError, 'Agreement not accepted')
       end
       if response[:cerner_provisioned].blank?
-        Rails.logger.error('[Identity] [CernerProvisioner] update_provisioning error', { icn:, response: })
+        Rails.logger.error('[Identity] [CernerProvisioner] update_provisioning error', { icn:, response:, source: })
         raise(Errors::CernerProvisionerError, 'Account not Provisioned')
       end
+
+      Rails.logger.info('[Identity] [CernerProvisioner] update_provisioning success', { icn:, source: })
     rescue Common::Client::Errors::ClientError => e
       log_provisioner_error(e)
       raise Errors::CernerProvisionerError, e.message
@@ -48,7 +53,7 @@ module Identity
     end
 
     def log_provisioner_error(error)
-      Rails.logger.error("[Identity] [CernerProvisioner] Error: #{error.message}", { icn: })
+      Rails.logger.error("[Identity] [CernerProvisioner] Error: #{error.message}", { icn:, source: })
     end
 
     def mpi_profile

--- a/app/services/login/after_login_actions.rb
+++ b/app/services/login/after_login_actions.rb
@@ -22,6 +22,7 @@ module Login
       update_account_login_stats(login_type)
       id_mismatch_validations
       create_mhv_account
+      current_user.provision_cerner_async(source: :ssoe)
 
       if Settings.test_user_dashboard.env == 'staging'
         TestUserDashboard::UpdateUser.new(current_user).call(Time.current)

--- a/app/services/sign_in/user_loader.rb
+++ b/app/services/sign_in/user_loader.rb
@@ -34,6 +34,7 @@ module SignIn
       current_user.invalidate_mpi_cache
       current_user.validate_mpi_profile
       current_user.create_mhv_account_async
+      current_user.provision_cerner_async(source: :sis)
 
       current_user
     end

--- a/app/sidekiq/identity/cerner_provisioner_job.rb
+++ b/app/sidekiq/identity/cerner_provisioner_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Identity
+  class CernerProvisionerJob
+    include Sidekiq::Job
+
+    sidekiq_options retry: false, unique_for: 5.minutes
+
+    def perform(icn, source = nil)
+      CernerProvisioner.new(icn:, source:).perform
+    rescue Errors::CernerProvisionerError => e
+      Rails.logger.error('[Identity] [CernerProvisionerJob] error', { icn:, error_message: e.message, source: })
+    end
+  end
+end

--- a/spec/controllers/v0/terms_of_use_agreements_controller_spec.rb
+++ b/spec/controllers/v0/terms_of_use_agreements_controller_spec.rb
@@ -394,6 +394,11 @@ RSpec.describe V0::TermsOfUseAgreementsController, type: :controller do
 
       after { Timecop.return }
 
+      it 'calls provisioner with the correct params' do
+        subject
+        expect(Identity::CernerProvisioner).to have_received(:new).with(icn: user.icn, source: :tou)
+      end
+
       context 'when the acceptance and provisioning is successful' do
         it_behaves_like 'successful acceptance and provisioning'
       end
@@ -429,6 +434,7 @@ RSpec.describe V0::TermsOfUseAgreementsController, type: :controller do
       let(:expected_cookie_path) { '/' }
       let(:expected_cookie_expiration) { 2.minutes.from_now }
       let(:expected_log) { '[TermsOfUseAgreementsController] update_provisioning success' }
+      let(:expected_source) { 'tou' }
 
       before do
         allow(Rails.logger).to receive(:info)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1528,4 +1528,43 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#provision_cerner_async' do
+    let(:user) { build(:user, :loa3, cerner_id:) }
+    let(:cerner_id) { 'some-cerner-id' }
+
+    before do
+      allow(Identity::CernerProvisionerJob).to receive(:perform_async)
+    end
+
+    context 'when the user is loa3' do
+      context 'when the user has a cerner_id' do
+        it 'enqueues a job to provision the Cerner account' do
+          user.provision_cerner_async
+
+          expect(Identity::CernerProvisionerJob).to have_received(:perform_async).with(user.icn, nil)
+        end
+      end
+
+      context 'when the user does not have a cerner_id' do
+        let(:cerner_id) { nil }
+
+        it 'does not enqueue a job to provision the Cerner account' do
+          user.provision_cerner_async
+
+          expect(Identity::CernerProvisionerJob).not_to have_received(:perform_async)
+        end
+      end
+    end
+
+    context 'when the user is not loa3' do
+      let(:user) { build(:user, cerner_id:) }
+
+      it 'does not enqueue a job to provision the Cerner account' do
+        user.provision_cerner_async
+
+        expect(Identity::CernerProvisionerJob).not_to have_received(:perform_async)
+      end
+    end
+  end
 end

--- a/spec/services/sign_in/user_loader_spec.rb
+++ b/spec/services/sign_in/user_loader_spec.rb
@@ -158,6 +158,17 @@ RSpec.describe SignIn::UserLoader do
             expect(MHV::AccountCreatorJob).to have_received(:perform_async).with(user_verification.id)
           end
         end
+
+        context 'when the user can provision cerner' do
+          before do
+            allow(Identity::CernerProvisionerJob).to receive(:perform_async)
+          end
+
+          it 'enqueues a Cerner::ProvisionerJob' do
+            subject
+            expect(Identity::CernerProvisionerJob).to have_received(:perform_async).with(user_icn, :sis)
+          end
+        end
       end
     end
 

--- a/spec/sidekiq/identity/cerner_provisioner_job_spec.rb
+++ b/spec/sidekiq/identity/cerner_provisioner_job_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Identity::CernerProvisionerJob, type: :job do
+  subject(:job) { described_class.new }
+
+  let(:icn) { '123456789' }
+  let(:source) { :some_source }
+  let(:cerner_provisioner) { instance_double(Identity::CernerProvisioner) }
+
+  before do
+    allow(Identity::CernerProvisioner).to receive(:new).and_return(cerner_provisioner)
+    allow(cerner_provisioner).to receive(:perform)
+  end
+
+  it 'is unique for 5 minutes' do
+    expect(described_class.sidekiq_options['unique_for']).to eq(5.minutes)
+  end
+
+  it 'does not retry' do
+    expect(described_class.sidekiq_options['retry']).to be(false)
+  end
+
+  describe '#perform' do
+    it 'calls the CernerProvisioner service class' do
+      expect(cerner_provisioner).to receive(:perform)
+      job.perform(icn, source)
+    end
+
+    context 'when an error occurs' do
+      let(:error_message) { 'Some error occurred' }
+
+      before do
+        allow(cerner_provisioner).to receive(:perform).and_raise(Identity::Errors::CernerProvisionerError,
+                                                                 error_message)
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it 'logs the error message' do
+        expect(Rails.logger).to receive(:error).with('[Identity] [CernerProvisionerJob] error',
+                                                     { icn:, error_message:, source: })
+        job.perform(icn, source)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Create `Identity::CernerProvisionerJob` that is called during authentication

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/16
- https://github.com/department-of-veterans-affairs/identity-documentation/issues/14
- https://github.com/department-of-veterans-affairs/vets-api/pull/21943 <- ⚠️ MERGE FIRST

## Testing done

- Login with SiS and SSOe and make sure a `Identity::CernerProvisionerJob` job is enqueued - http://localhost:3000/sidekiq/queues/default

## What areas of the site does it impact?
Authentication, Cerner provisioning

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

