### PR TITLE
Fix failing Yardoc Github Action

### DIFF
--- a/.github/workflows/yardoc.yml
+++ b/.github/workflows/yardoc.yml
@@ -27,7 +27,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2 # Using HEAD~ in the yardoc rake task, need at least a depth of 2
+          fetch-depth: 2
+
+      - name: Fetch target branch
+        run: git fetch origin "${GITHUB_BASE_REF}" --depth=1
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/yardoc.yml
+++ b/.github/workflows/yardoc.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 2 # Using HEAD~ in the yardoc rake task, need at least a depth of 2
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/rakelib/yardoc.rake
+++ b/rakelib/yardoc.rake
@@ -5,9 +5,12 @@ task yardoc: :environment do
   require 'rainbow'
   require 'yaml'
 
+<<<<<<< Updated upstream
   head_sha = `git rev-parse --abbrev-ref HEAD`.chomp.freeze
   base_sha = 'origin/master'
 
+=======
+>>>>>>> Stashed changes
   # git diff the glob list - only want to check the changed files
   globs = ['*.rb']
   globs = globs.map { |g| "'#{g}'" }.join(' ')

--- a/rakelib/yardoc.rake
+++ b/rakelib/yardoc.rake
@@ -5,12 +5,10 @@ task yardoc: :environment do
   require 'rainbow'
   require 'yaml'
 
-<<<<<<< Updated upstream
   head_sha = `git rev-parse --abbrev-ref HEAD`.chomp.freeze
-  base_sha = 'origin/master'
+  # GITHUB_BASE_REF points to the target branch for the pull request
+  base_sha = "origin/#{ENV.fetch('GITHUB_BASE_REF', 'master')}"
 
-=======
->>>>>>> Stashed changes
   # git diff the glob list - only want to check the changed files
   globs = ['*.rb']
   globs = globs.map { |g| "'#{g}'" }.join(' ')


### PR DESCRIPTION
## Summary
Need to fetch the target branch in the GH action if the `fetch-depth` is not 0. Updating the yardoc rake task to work when the base branch is not `master`

- *This work is behind a feature toggle (flipper): NO*

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/108424

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
