### PR TITLE
Replace Virtus with Vets::Model - BGS Dependents

### DIFF
--- a/app/models/bgs_dependents/adult_child_attending_school.rb
+++ b/app/models/bgs_dependents/adult_child_attending_school.rb
@@ -41,7 +41,11 @@ module BGSDependents
       @birth_date = @source['birth_date']
       @was_married = @is_v2 ? @source['was_married'] : @dependents_application['student_address_marriage_tuition']['was_married'] # rubocop:disable Layout/LineLength
       @dependent_income = @is_v2 ? @source['student_income'] : @source['dependent_income']
-      self.attributes = described_class_attribute_hash
+      @ever_married_ind = formatted_boolean(@was_married)
+      @dependent_income = formatted_boolean(@dependent_income)
+      @first = @full_name['first']
+      @middle = @full_name['middle']
+      @last = @full_name['last']
     end
 
     # Sets a hash with AdultChildAttendingSchool attributes
@@ -58,19 +62,6 @@ module BGSDependents
     #
     def address
       @is_v2 ? @source['address'] : @dependents_application['student_address_marriage_tuition']['address']
-    end
-
-    private
-
-    def described_class_attribute_hash
-      # we will raise an error here if not #valid? when we merge in exception PR
-
-      {
-        ssn: @ssn,
-        birth_date: @birth_date,
-        ever_married_ind: formatted_boolean(@was_married),
-        dependent_income: formatted_boolean(@dependent_income)
-      }.merge(@full_name)
     end
   end
 end

--- a/app/models/bgs_dependents/adult_child_attending_school.rb
+++ b/app/models/bgs_dependents/adult_child_attending_school.rb
@@ -46,6 +46,7 @@ module BGSDependents
       @first = @full_name['first']
       @middle = @full_name['middle']
       @last = @full_name['last']
+      @suffix = @full_name['suffix']
     end
 
     # Sets a hash with AdultChildAttendingSchool attributes

--- a/app/models/bgs_dependents/base.rb
+++ b/app/models/bgs_dependents/base.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module BGSDependents
-  class Base < Common::Base
-    include ActiveModel::Validations
+  class Base
+    include Vets::Model
     MILITARY_POST_OFFICE_TYPE_CODES = %w[APO DPO FPO].freeze
 
     # Gets the person's address based on the lives with veteran flag

--- a/app/models/bgs_dependents/child.rb
+++ b/app/models/bgs_dependents/child.rb
@@ -92,7 +92,7 @@ module BGSDependents
       @place_of_birth_country = place_of_birth['country']
       @place_of_birth_state = place_of_birth['state']
       @place_of_birth_city = place_of_birth['city']
-      @reason_marriage_ended =  reason_marriage_ended
+      @reason_marriage_ended = reason_marriage_ended
       @ever_married_ind = marriage_indicator
       @child_income = formatted_boolean(@is_v2 ? @child_info['income_in_last_year'] : @child_info['child_income'])
       @not_self_sufficient = formatted_boolean(@child_info['not_self_sufficient'])

--- a/app/models/bgs_dependents/child.rb
+++ b/app/models/bgs_dependents/child.rb
@@ -58,7 +58,8 @@ module BGSDependents
     def initialize(child_info)
       @child_info = child_info
       @is_v2 = v2?
-      self.attributes = child_attributes
+
+      assign_attributes
     end
 
     # Sets a hash with child attributes
@@ -84,20 +85,25 @@ module BGSDependents
 
     private
 
-    def child_attributes
-      place_of_birth = @is_v2 ? @child_info['birth_location'] : @child_info['place_of_birth']
-      {
-        ssn: @child_info['ssn'],
-        birth_date: @child_info['birth_date'],
-        family_relationship_type: child_status,
-        place_of_birth_country: @is_v2 ? place_of_birth.dig('location', 'country') : place_of_birth['country'],
-        place_of_birth_state: @is_v2 ? place_of_birth.dig('location', 'state') : place_of_birth['state'],
-        place_of_birth_city: @is_v2 ? place_of_birth.dig('location', 'city') : place_of_birth['city'],
-        reason_marriage_ended: @is_v2 ? @child_info['marriage_end_reason'] : @child_info.dig('previous_marriage_details', 'reason_marriage_ended'), # rubocop:disable Layout/LineLength
-        ever_married_ind: marriage_indicator,
-        child_income: formatted_boolean(@is_v2 ? @child_info['income_in_last_year'] : @child_info['child_income']),
-        not_self_sufficient: formatted_boolean(@child_info['not_self_sufficient'])
-      }.merge(@child_info['full_name'])
+    def assign_attributes
+      @ssn = @child_info['ssn']
+      @birth_date = @child_info['birth_date']
+      @family_relationship_type = child_status
+      @place_of_birth_country = place_of_birth['country']
+      @place_of_birth_state = place_of_birth['state']
+      @place_of_birth_city = place_of_birth['city']
+      @reason_marriage_ended =  reason_marriage_ended
+      @ever_married_ind = marriage_indicator
+      @child_income = formatted_boolean(@is_v2 ? @child_info['income_in_last_year'] : @child_info['child_income'])
+      @not_self_sufficient = formatted_boolean(@child_info['not_self_sufficient'])
+      @first = @child_info['full_name']['first']
+      @middle = @child_info['full_name']['middle']
+      @last = @child_info['full_name']['last']
+      @suffix = @child_info['full_name']['suffix']
+    end
+
+    def place_of_birth
+      @is_v2 ? @child_info.dig('birth_location', 'location') : @child_info['place_of_birth']
     end
 
     def child_status
@@ -113,6 +119,14 @@ module BGSDependents
         @child_info['has_child_ever_been_married'] ? 'Y' : 'N'
       else
         @child_info['previously_married'] == 'Yes' ? 'Y' : 'N'
+      end
+    end
+
+    def reason_marriage_ended
+      if @is_v2
+        @child_info['marriage_end_reason']
+      else
+        @child_info.dig('previous_marriage_details', 'reason_marriage_ended')
       end
     end
   end

--- a/app/models/bgs_dependents/child_school.rb
+++ b/app/models/bgs_dependents/child_school.rb
@@ -12,7 +12,8 @@ module BGSDependents
       @vnp_participant_id = vnp_participant_id
       @student = student
       @is_v2 = v2?
-      self.attributes = @is_v2 ? student : dependents_application
+
+      assign_attributes(@is_v2 ? student : dependents_application)
     end
 
     # rubocop:disable Metrics/MethodLength
@@ -90,5 +91,14 @@ module BGSDependents
       }
     end
     # rubocop:enable Metrics/MethodLength
+
+    private
+
+    def assign_attributes(data)
+      @last_term_school_information = data.dig('last_term_school_information')
+      @school_information = data.dig('school_information')
+      @program_information = data.dig('program_information')
+      @current_term_dates = data.dig('current_term_dates')
+    end
   end
 end

--- a/app/models/bgs_dependents/child_school.rb
+++ b/app/models/bgs_dependents/child_school.rb
@@ -95,10 +95,10 @@ module BGSDependents
     private
 
     def assign_attributes(data)
-      @last_term_school_information = data.dig('last_term_school_information')
-      @school_information = data.dig('school_information')
-      @program_information = data.dig('program_information')
-      @current_term_dates = data.dig('current_term_dates')
+      @last_term_school_information = data['last_term_school_information']
+      @school_information = data['school_information']
+      @program_information = data['program_information']
+      @current_term_dates = data['current_term_dates']
     end
   end
 end

--- a/app/models/bgs_dependents/child_student.rb
+++ b/app/models/bgs_dependents/child_student.rb
@@ -14,7 +14,8 @@ module BGSDependents
       @dependents_application = dependents_application
       @is_v2 = v2?
       @student = student
-      self.attributes = @is_v2 ? student : dependents_application
+
+      assign_attributes(@is_v2 ? student : dependents_application)
     end
 
     # rubocop:disable Metrics/MethodLength
@@ -79,6 +80,14 @@ module BGSDependents
 
     def convert_boolean(bool)
       bool == true ? 'Y' : 'N'
+    end
+
+    def assign_attributes(data)
+      @student_address_marriage_tuition = data.dig('student_address_marriage_tuition')
+      @student_earnings_from_school_year = data.dig('student_earnings_from_school_year')
+      @student_networth_information = data.dig('student_networth_information')
+      @student_expected_earnings_next_year = data.dig('student_expected_earnings_next_year')
+      @student_information = data.dig('student_information')
     end
   end
 end

--- a/app/models/bgs_dependents/child_student.rb
+++ b/app/models/bgs_dependents/child_student.rb
@@ -83,11 +83,11 @@ module BGSDependents
     end
 
     def assign_attributes(data)
-      @student_address_marriage_tuition = data.dig('student_address_marriage_tuition')
-      @student_earnings_from_school_year = data.dig('student_earnings_from_school_year')
-      @student_networth_information = data.dig('student_networth_information')
-      @student_expected_earnings_next_year = data.dig('student_expected_earnings_next_year')
-      @student_information = data.dig('student_information')
+      @student_address_marriage_tuition = data['student_address_marriage_tuition']
+      @student_earnings_from_school_year = data['student_earnings_from_school_year']
+      @student_networth_information = data['student_networth_information']
+      @student_expected_earnings_next_year = data['student_expected_earnings_next_year']
+      @student_information = data['student_information']
     end
   end
 end

--- a/app/models/bgs_dependents/spouse.rb
+++ b/app/models/bgs_dependents/spouse.rb
@@ -71,6 +71,7 @@ module BGSDependents
       @first = @spouse_information['full_name']['first']
       @middle = @spouse_information['full_name']['middle']
       @last = @spouse_information['full_name']['last']
+      @suffix = @spouse_information['full_name']['suffix']
       @va_file_number = @spouse_information['va_file_number'] if spouse_is_veteran == 'Y'
     end
 

--- a/app/models/bgs_dependents/spouse.rb
+++ b/app/models/bgs_dependents/spouse.rb
@@ -47,7 +47,7 @@ module BGSDependents
       @spouse_information = @dependents_application['spouse_information']
       @is_v2 = v2?
 
-      self.attributes = spouse_attributes
+      assign_attributes
     end
 
     # Sets a hash with spouse attributes
@@ -60,23 +60,18 @@ module BGSDependents
 
     private
 
-    # Sets a hash with spouse attributes
-    #
-    # @return [Hash] spouse info including name and address info
-    #
-    def spouse_attributes
-      spouse_info = {
-        ssn: @spouse_information['ssn'],
-        birth_date: @spouse_information['birth_date'],
-        ever_married_ind: 'Y',
-        martl_status_type_cd: marital_status,
-        vet_ind: spouse_is_veteran,
-        address: spouse_address,
-        spouse_income: formatted_boolean(@dependents_application['does_live_with_spouse']['spouse_income'])
-      }.merge(@spouse_information['full_name'])
-      spouse_info.merge!({ va_file_number: @spouse_information['va_file_number'] }) if spouse_is_veteran == 'Y'
-
-      spouse_info
+    def assign_attributes
+      @ssn = @spouse_information['ssn']
+      @birth_date = @spouse_information['birth_date']
+      @ever_married_ind = 'Y'
+      @martl_status_type_cd = marital_status
+      @vet_ind = spouse_is_veteran
+      @address = spouse_address
+      @spouse_income = formatted_boolean(@dependents_application['does_live_with_spouse']['spouse_income'])
+      @first = @spouse_information['full_name']['first']
+      @middle = @spouse_information['full_name']['middle']
+      @last = @spouse_information['full_name']['last']
+      @va_file_number = @spouse_information['va_file_number'] if spouse_is_veteran == 'Y'
     end
 
     def lives_with_vet

--- a/app/models/bgs_dependents/veteran.rb
+++ b/app/models/bgs_dependents/veteran.rb
@@ -11,7 +11,7 @@ module BGSDependents
     def initialize(proc_id, user)
       @proc_id = proc_id
       @user = user
-      self.attributes = user_veteran_attributes
+      assign_attributes
     end
 
     def formatted_params(payload)
@@ -64,14 +64,12 @@ module BGSDependents
 
     private
 
-    def user_veteran_attributes
-      {
-        participant_id: @user.participant_id,
-        ssn: @user.ssn,
-        first_name: @user.first_name,
-        middle_name: @user.middle_name,
-        last_name: @user.last_name
-      }
+    def assign_attributes
+      @participant_id = @user.participant_id
+      @ssn = @user.ssn
+      @first_name = @user.first_name
+      @middle_name = @user.middle_name
+      @last_name = @user.last_name
     end
 
     def marital_status(dependents_application)

--- a/lib/bgs/children.rb
+++ b/lib/bgs/children.rb
@@ -38,7 +38,7 @@ module BGS
         bgs_service.create_person(person_params(child, participant, formatted_info))
         send_address(child, participant, child.address(@dependents_application))
 
-        step_child_parent(child_info) if child['family_relationship_type'] == 'Stepchild'
+        step_child_parent(child_info) if child.family_relationship_type == 'Stepchild'
 
         @children << child.serialize_dependent_result(
           participant,


### PR DESCRIPTION
## Summary

- The virtus gem ([source](https://github.com/solnic/virtus)) is discontinued and must be replaced
- The replacement is `Vets::Model` ([source](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/vets/model.rb))
- This PR replaces `Virtus.model` with `Vets::Model` and updates the attributes according 
    - The attribute updates are minor and mostly related to Booleans and Arrays
- This change should not affect any functionality. 
- Some changes from hash notation to dot notation were required

In this case, attributes where assigned via `self.attributes`, but that won't work correct with `Vets::Model` because it by-passes the code that deletes "Unknown Attributes" aka attributes not set up for the class.  

## Related Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92439

## Testing

- [x] Make sure the specs pass
- [x] Manually checking the serialized responses are the same

## Acceptance Criteria 

- [x] Serialized responses are identical
- [x] No functionality changes