### PR TITLE
Cleanup VAOS feature toggles

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1636,10 +1636,6 @@ features:
     actor_type: user
     enable_in_development: false
     description: Toggle for the vaos module to use an alternate vaos-service route
-  va_online_scheduling_clinic_filter:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle for VAOS direct scheduling & appointment request clinic filtering
   va_online_scheduling_breadcrumb_url_update:
     actor_type: user
     enable_in_development: true
@@ -1725,10 +1721,6 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle for displaying past cancelled appointments.
-  va_online_scheduling_patient_history_future_appts:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle for including future appointments in the patient history retrieval.
   vba_documents_virus_scan:
     actor_type: user
     description: ClamAV virus scanning for Benefits Intake API upload submissions


### PR DESCRIPTION
## Summary

- Remove two feature toggles:
  - `va_online_scheduling_clinic_filter `
  - `va_online_scheduling_patient_history_future_appts `
- Appointments Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/104918

## Testing done

- N/A

## Screenshots
N/A

## What areas of the site does it impact?
Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
