### PR TITLE
Fix DevContainer Configuration for Apple Silicon Macs and Github Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,9 +29,6 @@
     "ghcr.io/robbert229/devcontainer-features/postgresql-client:1": {
       "version": "15"
     },
-    "ghcr.io/devcontainers-contrib/features/redis-homebrew:1": {
-      "version": "6.2"
-    },
     "ghcr.io/devcontainers/features/sshd:1": {
       "version": "latest"
     },

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -9,8 +9,8 @@ asdf global ruby $( cat .ruby-version )
 echo "Ensuring packages are up to date..."
 bundle install
 
-echo "Starting redis..."
-nohup /home/linuxbrew/.linuxbrew/opt/redis@6.2/bin/redis-server /home/linuxbrew/.linuxbrew/etc/redis.conf >> log/redis.log 2>&1 &
+echo "Starting Redis ..."
+sudo /etc/init.d/redis-server restart
 
 echo "Starting postgres..."
 sudo /etc/init.d/postgresql restart


### PR DESCRIPTION
## Problem Statement
----
There are 2 Problems in the current DevContainer Configurations that enable development on Github Codespaces and/or Local Macs (with Apple Silicon)

1. When creating a Codespace on Github, it doesn't clone the `vets-api-mockdata` repository due to permissions issue when the image is being built (bug)
2. The current way of installing Redis through linuxbrew doesn't work on Macs with ARM based CPUs. This fix will (hopefully) speed up the onboarding process for new developers.

## What is being done
---------
1. Remove Dependency on Homebrew which is not supported on ARM architectures. Instead install Redis via `apt` package manager.
2. Ensure that the `vets-api-mockdata` repository is properly cloned. 


## Summary

- *This work is behind a feature toggle (flipper): YES/NO* : *
--*NO**
- *(Summarize the changes that have been made to the platform)*: 
--See [Problem Statement](#problem-statement)
- *(If bug, how to reproduce)* : 
-- Launch a new Codespace on Github. `cd /workspaces`. Notice the directory doesn't exist. You can also verify this by checking the container image build log. It reports a Permission issue.
- *(What is the solution, why is this the solution?)*: 
--Please see the [What is being done section] (#what-is-being-done)
- *(Which team do you work for, does your team own the maintenance of this component?)*
-- Platform Watchtower
- *(If introducing a flipper, what is the success criteria being targeted?)*
-- N/A

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
-- N/A
- *Link to previous change of the code/bug (if applicable)*
-- N/A
- *Link to epic if not included in ticket*
-- N/A

## Testing done
- I have tested the creation of the Codespace on Github
- I have tested the creation of a local devcontainer on Apple Macs (with ARM)
- `cd /workspaces` then `ls` - Note that the `vets-api-mockdata` directory exists
- Once Devcontainer or Github Codespace is launched, open a Terminal and type `redis-server --version`. This should report 6.2 matching what was previously being installed.

## What areas of the site does it impact?
*None. It should just enable development on Github Codespaces and Apple Macs (locally). No Change in behavior or releases.*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
-- N/A
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
-- N/A
- [ ]  Documentation has been updated (link to documentation)
-- N/A
- [X ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
-- N/A
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
-- N/A
- [ ]  I added a screenshot of the developed feature
--

## Requested Feedback
This PR is designed to fix the 2 issues with minimal amount of changes. Only concern is I haven't tested this on a Windows Machine. Having said that, the fact that the `vets-api-mockdata` was not being cloned due to permission issues, either the developer would have to do that manually, or no-one really uses devcontainers or codespaces.