### PR TITLE
Updated swagger docs to match the pega status endpoint implementation

### DIFF
--- a/app/swagger/swagger/v1/requests/ivc_champva_forms.rb
+++ b/app/swagger/swagger/v1/requests/ivc_champva_forms.rb
@@ -10,39 +10,66 @@ class Swagger::V1::Requests::IvcChampvaForms
       key :description, 'Updates an existing form'
       key :operationId, 'Endpoint for updating an existing form'
       key :tags, %w[ivc_champva_forms]
+
       parameter :authorization
+
+      parameter do
+        key :name, :form_uuid
+        key :description, 'UUID of the form'
+        key :in, :body
+        key :required, true
+
+        schema do
+          key :type, :string
+          key :format, :uuid
+          key :example, '12345678-1234-5678-1234-567812345678'
+        end
+      end
+
+      parameter do
+        key :name, :file_names
+        key :description, 'List of file names associated with the form'
+        key :in, :body
+        key :required, true
+
+        schema do
+          key :type, :array
+          items do
+            key :type, :string
+          end
+          key :example,
+              ['12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
+               '12345678-1234-5678-1234-567812345678_vha_10_10d2.pdf']
+        end
+      end
+
+      parameter do
+        key :name, :status
+        key :description, 'Status of the form processing'
+        key :in, :body
+        key :required, true
+
+        schema do
+          key :type, :string
+          key :enum, ['Processed', 'Not Processed']
+          key :example, 'Processed'
+        end
+      end
+
+      parameter do
+        key :name, :case_id
+        key :description, 'PEGA System UUID'
+        key :in, :body
+        key :required, true
+
+        schema do
+          key :type, :string
+          key :example, 'D-40350'
+        end
+      end
 
       response 200 do
         key :description, 'Response is OK'
-        schema do
-          key :type, :object
-          property :form_uuid do
-            key :type, :string
-            key :format, :uuid
-            key :example, '12345678-1234-5678-1234-567812345678'
-            key :description, 'UUID of the form'
-          end
-          property :file_names do
-            key :type, :array
-            items do
-              key :type, :string
-              key :description, 'List of file names associated with the form'
-            end
-            key :example,
-                ['12345678-1234-5678-1234-567812345678_vha_10_10d.pdf',
-                 '12345678-1234-5678-1234-567812345678_vha_10_10d2.pdf']
-          end
-          property :status do
-            key :type, :string
-            key :example, 'Processed'
-            key :description, 'Status of the form processing'
-          end
-          property :case_id do
-            key :type, :string
-            key :example, 'D-40350'
-            key :description, 'PEGA System UUID'
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- This work is behind a feature toggle (flipper): No
- Updated swagger docs to match the pega status endpoint implementation
- I work for the IVC Forms team and we own the module that this documentation refers to

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/106090

## Testing done

- [ ] New code is covered by unit tests
- Prior to this change the documentation did not match the implementation of the `status_updates` endpoint
- To verify, manually compare the Swagger docs to the endpoint's code and unit tests

## Screenshots
None

## What areas of the site does it impact?
This impacts the Swagger docs

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
  - Go to [this page](https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/)
  - Change the explore bar to `https://dev-api.va.gov/v1/apidocs`
  - Expand the first section for `/ivc_champva/v1/forms/status_updates`
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
None
