### PR TITLE
[VI-1105] updates SchemaContract::Validation to use user_account_id

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1294,6 +1294,7 @@ spec/factories/rated_disabilities.rb @department-of-veterans-affairs/Disability-
 spec/factories/representatives.rb @department-of-veterans-affairs/accredited-representation-management @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/accredited-representatives-admin
 spec/factories/rubysaml_settings.rb @department-of-veterans-affairs/octo-identity
 spec/factories/saml_attributes.rb @department-of-veterans-affairs/octo-identity
+spec/factories/schema_contract @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/secondary_appeal_forms.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-admin
 spec/factories/sequences.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/factories/sessions.rb @department-of-veterans-affairs/octo-identity

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -319,7 +319,7 @@ app/models/saved_claim/education_career_counseling_claim.rb @department-of-veter
 app/models/saved_claim/higher_level_review.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-admin
 app/models/saved_claim/notice_of_disagreement.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-admin
 app/models/saved_claim/supplemental_claim.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-admin
-app/models/schema_contract/validation.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/models/schema_contract @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/secondary_appeal_form.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-admin
 app/models/sign_in @department-of-veterans-affairs/octo-identity
 app/models/single_logout_request.rb @department-of-veterans-affairs/octo-identity

--- a/app/models/schema_contract/validation.rb
+++ b/app/models/schema_contract/validation.rb
@@ -5,11 +5,13 @@ module SchemaContract
     self.table_name = 'schema_contract_validations'
 
     attribute :contract_name, :string
+    attribute :user_account_id, :string
     attribute :user_uuid, :string
     attribute :response, :jsonb
     attribute :error_details, :string
 
     validates :contract_name, presence: true
+    validates :user_account_id, presence: true
     validates :user_uuid, presence: true
     validates :response, presence: true
     validates :status, presence: true

--- a/app/models/schema_contract/validation_initiator.rb
+++ b/app/models/schema_contract/validation_initiator.rb
@@ -7,7 +7,8 @@ module SchemaContract
         return if SchemaContract::Validation.where(contract_name:, created_at: Time.zone.today.all_day).any?
 
         record = SchemaContract::Validation.create(
-          contract_name:, user_uuid: user.uuid, response: response.body, status: 'initialized'
+          contract_name:, user_account_id: user.user_account_uuid, user_uuid: user.uuid,
+          response: response.body, status: 'initialized'
         )
         Rails.logger.info('Initiating schema contract validation', { contract_name:, record_id: record.id })
         SchemaContract::ValidationJob.perform_async(record.id)

--- a/modules/vaos/spec/factories/vaos_users.rb
+++ b/modules/vaos/spec/factories/vaos_users.rb
@@ -5,6 +5,7 @@ FactoryBot.modify do
     trait :vaos do
       authn_context { 'http://idmanagement.gov/ns/assurance/loa/1/vets' }
       uuid { '3071ca1783954ec19170f3c4bdfd0c95' }
+      idme_uuid { SecureRandom.uuid }
       last_signed_in { Time.now.utc }
       mhv_last_signed_in { Time.now.utc }
       email { 'judy.morrison@id.me' }
@@ -53,12 +54,15 @@ FactoryBot.modify do
             ssn: '796061976'
           )
         )
+        # build UserVerification & UserAccount records
+        verification = create(:idme_user_verification, idme_uuid: _user.idme_uuid)
       end
     end
 
     trait :jac do
       authn_context { 'http://idmanagement.gov/ns/assurance/loa/1/vets' }
       uuid { '3071ca1783954ec19170f3c4bdfd0c95' }
+      idme_uuid { SecureRandom.uuid }
       last_signed_in { Time.now.utc }
       mhv_last_signed_in { Time.now.utc }
       email { 'jacqueline.morgan@id.me' }
@@ -107,6 +111,8 @@ FactoryBot.modify do
             ssn: '796061976'
           )
         )
+        # build UserVerification & UserAccount records
+        verification = create(:idme_user_verification, idme_uuid: _user.idme_uuid)
       end
     end
   end

--- a/modules/vaos/spec/factories/vaos_users.rb
+++ b/modules/vaos/spec/factories/vaos_users.rb
@@ -27,7 +27,7 @@ FactoryBot.modify do
       end
 
       # add an MHV correlation_id and vha_facility_ids corresponding to va_patient
-      after(:build) do |_user, _t|
+      after(:build) do |user, _t|
         stub_mpi(
           build(
             :mpi_profile,
@@ -55,7 +55,7 @@ FactoryBot.modify do
           )
         )
         # build UserVerification & UserAccount records
-        verification = create(:idme_user_verification, idme_uuid: _user.idme_uuid)
+        create(:idme_user_verification, idme_uuid: user.idme_uuid)
       end
     end
 
@@ -84,7 +84,7 @@ FactoryBot.modify do
       end
 
       # add an MHV correlation_id and vha_facility_ids corresponding to va_patient
-      after(:build) do |_user, _t|
+      after(:build) do |user, _t|
         stub_mpi(
           build(
             :mpi_profile,
@@ -112,7 +112,7 @@ FactoryBot.modify do
           )
         )
         # build UserVerification & UserAccount records
-        verification = create(:idme_user_verification, idme_uuid: _user.idme_uuid)
+        create(:idme_user_verification, idme_uuid: user.idme_uuid)
       end
     end
   end

--- a/spec/factories/schema_contract/validations.rb
+++ b/spec/factories/schema_contract/validations.rb
@@ -2,7 +2,11 @@
 
 FactoryBot.define do
   factory :schema_contract_validation, class: 'SchemaContract::Validation' do
+    transient do
+      user_account { create(:user_account) }
+    end
     contract_name { 'test_index' }
+    user_account_id { user_account.id }
     user_uuid { '1234' }
     response { { key: 'value' } }
     status { 'initialized' }

--- a/spec/models/schema_contract/validation_initiator_spec.rb
+++ b/spec/models/schema_contract/validation_initiator_spec.rb
@@ -5,7 +5,8 @@ require_relative Rails.root.join('app', 'models', 'schema_contract', 'validation
 
 describe SchemaContract::ValidationInitiator do
   describe '.call' do
-    let(:user) { create(:user) }
+    let(:user) { create(:user, :with_terms_of_use_agreement) }
+    let(:user_account_id) { user.user_account_uuid }
     let(:response) do
       OpenStruct.new({ success?: true, status: 200, body: { key: 'value' } })
     end
@@ -17,7 +18,7 @@ describe SchemaContract::ValidationInitiator do
 
     context 'response is successful, feature flag is on, and no record exists for the current day' do
       before do
-        create(:schema_contract_validation, contract_name: 'test_index', user_uuid: '1234', response:,
+        create(:schema_contract_validation, contract_name: 'test_index', user_account_id:, user_uuid: '1234', response:,
                                             status: 'initialized', created_at: Time.zone.yesterday.beginning_of_day)
       end
 
@@ -31,7 +32,7 @@ describe SchemaContract::ValidationInitiator do
 
     context 'when a validation record already exists for the current day' do
       before do
-        create(:schema_contract_validation, contract_name: 'test_index', user_uuid: '1234', response:,
+        create(:schema_contract_validation, contract_name: 'test_index', user_account_id:, user_uuid: '1234', response:,
                                             status: 'initialized')
       end
 


### PR DESCRIPTION
## Summary

- updates `SchemaContract::Validation` to include a `user_account_id`
- part of the [`user_uuid` refactor](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity/Products/user_uuid%20Refactor/user_uuid_refactor_faq.md)

## Related issue(s)

- followup PR to https://github.com/department-of-veterans-affairs/vets-api/pull/21936
- https://github.com/department-of-veterans-affairs/identity-documentation/issues/58

## Testing done

- [x] *New code is covered by unit tests*


