### PR TITLE
Adding VBMS to 0781  log

### DIFF
--- a/app/sidekiq/evss/disability_compensation_form/submit_form0781.rb
+++ b/app/sidekiq/evss/disability_compensation_form/submit_form0781.rb
@@ -187,8 +187,9 @@ module EVSS
           }.each do |form_key, form_id|
             form_content = parsed_forms[form_key]
             if form_content.present?
-              ::Rails.logger.info('Performing SubmitForm0781', { submission_id:, form_id: })
-              process_0781(submission.submitted_claim_id, form_id, form_content)
+              submitted_claim_id = submission.submitted_claim_id
+              ::Rails.logger.info('Performing SubmitForm0781', { submission_id:, form_id:, submitted_claim_id: })
+              process_0781(submitted_claim_id, form_id, form_content)
             end
           end
         end


### PR DESCRIPTION
Small logging improvement adding the submitted claim id (VBMS ID) to the log messages for 0781 generated PDFs

Related ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/108837