### PR TITLE
108753: Fix up saved_claim.rb; fix typo in Burial

### DIFF
--- a/modules/burials/app/models/burials/saved_claim.rb
+++ b/modules/burials/app/models/burials/saved_claim.rb
@@ -102,7 +102,7 @@ module Burials
     # Utility function to retrieve claimant first name from form
     #
     # @return [String]
-    def claimaint_first_name
+    def claimant_first_name
       parsed_form.dig('claimantFullName', 'first')
     end
 

--- a/modules/burials/lib/burials/notification_email.rb
+++ b/modules/burials/lib/burials/notification_email.rb
@@ -35,7 +35,7 @@ module Burials
         'street_address' => street_address,
         'city_state_zip' => city_state_zip,
         # confirmation, error
-        'first_name' => claim.claimaint_first_name&.upcase,
+        'first_name' => claim.claimant_first_name&.upcase,
         # received
         'date_received' => claim.form_submissions&.last&.form_submission_attempts&.last&.lighthouse_updated_at
       }

--- a/modules/burials/spec/models/burials/saved_claim_spec.rb
+++ b/modules/burials/spec/models/burials/saved_claim_spec.rb
@@ -123,15 +123,15 @@ RSpec.describe Burials::SavedClaim do
     end
   end
 
-  describe '#claimaint_first_name' do
+  describe '#claimant_first_name' do
     it 'returns the first name of the claimant from parsed_form' do
       allow(instance).to receive(:parsed_form).and_return({ 'claimantFullName' => { 'first' => 'Derrick' } })
-      expect(instance.claimaint_first_name).to eq('Derrick')
+      expect(instance.claimant_first_name).to eq('Derrick')
     end
 
     it 'returns nil if the key does not exist' do
       allow(instance).to receive(:parsed_form).and_return({})
-      expect(instance.claimaint_first_name).to be_nil
+      expect(instance.claimant_first_name).to be_nil
     end
   end
 

--- a/modules/income_and_assets/app/models/income_and_assets/saved_claim.rb
+++ b/modules/income_and_assets/app/models/income_and_assets/saved_claim.rb
@@ -3,8 +3,10 @@
 require 'income_and_assets/benefits_intake/benefit_intake_job'
 
 module IncomeAndAssets
+  ##
   # IncomeAndAssets 21P-0969 Active::Record
   # @see app/model/saved_claim
+  #
   class SavedClaim < ::SavedClaim
     # Income and Assets Form ID
     FORM = IncomeAndAssets::FORM_ID
@@ -19,12 +21,19 @@ module IncomeAndAssets
        'Janesville, Wisconsin 53547-5365']
     end
 
-    # utility function to retrieve claimant email from form
+    ##
+    # Returns the business line associated with this process
+    #
+    # @return [String]
+    def business_line
+      'NCA'
+    end
+
+    # Utility function to retrieve claimant email from form
     #
     # @return [String] the claimant email
     def email
-      # parsed_form['email'] # TODO add email field to the form
-      'test@example.com'
+      parsed_form['email'] || 'test@example.com' # TODO: update this when we have a real email field
     end
 
     # Utility function to retrieve veteran first name from form
@@ -46,6 +55,26 @@ module IncomeAndAssets
     # @return [String]
     def claimant_first_name
       parsed_form.dig('claimantFullName', 'first')
+    end
+
+    ##
+    # claim attachment list
+    #
+    # @see PersistentAttachment
+    #
+    # @return [Array<String>] list of attachments
+    #
+    def attachment_keys
+      [:files].freeze
+    end
+
+    # Run after a claim is saved, this processes any files and workflows that are present
+    # and sends them to our internal partners for processing.
+    # Only removed Sidekiq call from super
+    def process_attachments!
+      refs = attachment_keys.map { |key| Array(open_struct_form.send(key)) }.flatten
+      files = PersistentAttachment.where(guid: refs.map(&:confirmationCode))
+      files.find_each { |f| f.update(saved_claim_id: id) }
     end
   end
 end

--- a/modules/income_and_assets/spec/factories/income_and_assets/income_and_assets_claim.rb
+++ b/modules/income_and_assets/spec/factories/income_and_assets/income_and_assets_claim.rb
@@ -10,6 +10,11 @@ FactoryBot.define do
           middle: 'Edmund',
           last: 'Doe'
         },
+        claimantFullName: {
+          first: 'Derrick',
+          middle: 'A',
+          last: 'Stewart'
+        },
         veteranSocialSecurityNumber: '333224444',
         statementOfTruthCertified: true,
         statementOfTruthSignature: 'John Edmund Doe'

--- a/modules/income_and_assets/spec/models/income_and_assets/saved_claim_spec.rb
+++ b/modules/income_and_assets/spec/models/income_and_assets/saved_claim_spec.rb
@@ -1,12 +1,82 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'lib/saved_claims_spec_helper'
 
-RSpec.describe IncomeAndAssets::SavedClaim, :uploader_helpers do
+RSpec.describe IncomeAndAssets::SavedClaim do
   subject { described_class.new }
 
   let(:instance) { build(:income_and_assets_claim) }
 
-  it_behaves_like 'saved_claim_with_confirmation_number'
+  it 'responds to #confirmation_number' do
+    expect(subject.confirmation_number).to eq(subject.guid)
+  end
+
+  it 'has necessary constants' do
+    expect(described_class).to have_constant(:FORM)
+  end
+
+  it 'descends from saved_claim' do
+    expect(described_class.ancestors).to include(SavedClaim)
+  end
+
+  describe '#email' do
+    it 'returns the users email' do
+      expect(instance.email).to eq('test@example.com')
+    end
+  end
+
+  describe '#business_line' do
+    it 'returns the correct business line' do
+      expect(subject.business_line).to eq('NCA')
+    end
+  end
+
+  describe '#veteran_first_name' do
+    it 'returns the first name of the veteran from parsed_form' do
+      allow(instance).to receive(:parsed_form).and_return({ 'veteranFullName' => { 'first' => 'John' } })
+      expect(instance.veteran_first_name).to eq('John')
+    end
+
+    it 'returns nil if the key does not exist' do
+      allow(instance).to receive(:parsed_form).and_return({})
+      expect(instance.veteran_first_name).to be_nil
+    end
+  end
+
+  describe '#veteran_last_name' do
+    it 'returns the last name of the veteran from parsed_form' do
+      allow(instance).to receive(:parsed_form).and_return({ 'veteranFullName' => { 'last' => 'Doe' } })
+      expect(instance.veteran_last_name).to eq('Doe')
+    end
+
+    it 'returns nil if the key does not exist' do
+      allow(instance).to receive(:parsed_form).and_return({})
+      expect(instance.veteran_last_name).to be_nil
+    end
+  end
+
+  describe '#claimant_first_name' do
+    it 'returns the first name of the claimant from parsed_form' do
+      allow(instance).to receive(:parsed_form).and_return({ 'claimantFullName' => { 'first' => 'Derrick' } })
+      expect(instance.claimant_first_name).to eq('Derrick')
+    end
+
+    it 'returns nil if the key does not exist' do
+      allow(instance).to receive(:parsed_form).and_return({})
+      expect(instance.claimant_first_name).to be_nil
+    end
+  end
+
+  it 'inherits init callsbacks from saved_claim' do
+    expect(subject.form_id).to eq(IncomeAndAssets::FORM_ID)
+    expect(subject.guid).not_to be_nil
+    expect(subject.type).to eq(IncomeAndAssets::SavedClaim.to_s)
+  end
+
+  describe '#process_attachments!' do
+    it 'does NOT start a job to submit the saved claim via Benefits Intake' do
+      expect(Lighthouse::SubmitBenefitsIntakeClaim).not_to receive(:perform_async)
+      instance.process_attachments!
+    end
+  end
 end


### PR DESCRIPTION
0969 was missing some key methods when it came to saved claims


## Summary

- Update 0969 SavedClaim to add missing methods
- Update related spec file
- Found and fixed typo in `claimant` for Burial
- Updated tests as well

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108753

## Testing done

- [ ] *New code is covered by unit tests*
