### PR TITLE
[VI-1105] adds user_account_id to FormEmailMatchesProfileLog

### DIFF
--- a/app/models/in_progress_form.rb
+++ b/app/models/in_progress_form.rb
@@ -110,7 +110,7 @@ class InProgressForm < ApplicationRecord
   private
 
   def log_hca_email_diff
-    HCA::LogEmailDiffJob.perform_async(id, real_user_uuid) if form_id == '1010ez'
+    HCA::LogEmailDiffJob.perform_async(id, real_user_uuid, user_account_id) if form_id == '1010ez'
   end
 
   def serialize_form_data

--- a/app/sidekiq/hca/log_email_diff_job.rb
+++ b/app/sidekiq/hca/log_email_diff_job.rb
@@ -5,8 +5,9 @@ module HCA
     include Sidekiq::Job
     sidekiq_options retry: false
 
-    def perform(in_progress_form_id, user_uuid)
-      return if FormEmailMatchesProfileLog.exists?(user_uuid:, in_progress_form_id:)
+    def perform(in_progress_form_id, user_uuid, user_account_id)
+      return if FormEmailMatchesProfileLog.exists?(user_uuid:, in_progress_form_id:) ||
+                FormEmailMatchesProfileLog.exists?(user_account_id:, in_progress_form_id:)
 
       in_progress_form = InProgressForm.find_by(id: in_progress_form_id)
       return if in_progress_form.nil?
@@ -25,7 +26,7 @@ module HCA
         "api.1010ez.in_progress_form_email.#{tag_text}"
       )
 
-      FormEmailMatchesProfileLog.create(user_uuid:, in_progress_form_id:)
+      FormEmailMatchesProfileLog.create(user_uuid:, user_account_id:, in_progress_form_id:)
     end
   end
 end

--- a/spec/factories/in_progress_forms/in_progress_forms.rb
+++ b/spec/factories/in_progress_forms/in_progress_forms.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :in_progress_form do
     user_uuid { SecureRandom.uuid }
     form_id { 'edu_benefits' }
-    user_account { nil }
+    user_account { create(:user_account) }
     metadata do
       {
         version: 1,

--- a/spec/lib/lighthouse/benefits_claims/intent_to_file/monitor_spec.rb
+++ b/spec/lib/lighthouse/benefits_claims/intent_to_file/monitor_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
   let(:monitor) { described_class.new }
   let(:itf_stats_key) { described_class::STATSD_KEY_PREFIX }
   let(:claim) { create(:pensions_saved_claim) }
-  let(:ipf) { create(:in_progress_form) }
+  let(:ipf) { create(:in_progress_form, user_account: current_user.user_account) }
 
   context 'with all params supplied' do
-    let(:current_user) { create(:user) }
+    let(:current_user) { create(:user, :with_terms_of_use_agreement) }
     let(:monitor_error) { create(:monitor_error) }
 
     describe '#track_create_itf_initiated' do

--- a/spec/requests/v0/in_progress_forms_controller_spec.rb
+++ b/spec/requests/v0/in_progress_forms_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe V0::InProgressFormsController do
   it_behaves_like 'a controller that does not log 404 to Sentry'
 
   context 'with a user' do
-    let(:loa3_user) { build(:user, :loa3) }
+    let(:loa3_user) { build(:user, :loa3, :with_terms_of_use_agreement) }
     let(:loa1_user) { build(:user, :loa1) }
 
     before do
@@ -323,7 +323,7 @@ RSpec.describe V0::InProgressFormsController do
         it 'runs the LogEmailDiffJob job' do
           new_form.form_id = '1010ez'
           new_form.save!
-          expect(HCA::LogEmailDiffJob).to receive(:perform_async).with(new_form.id, user.uuid)
+          expect(HCA::LogEmailDiffJob).to receive(:perform_async).with(new_form.id, user.uuid, user.user_account_uuid)
 
           put v0_in_progress_form_url(new_form.form_id), params: {
             formData: new_form.form_data,

--- a/spec/sidekiq/hca/log_email_diff_job_spec.rb
+++ b/spec/sidekiq/hca/log_email_diff_job_spec.rb
@@ -3,12 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe HCA::LogEmailDiffJob, type: :job do
-  let!(:in_progress_form) { create(:in_progress_1010ez_form_with_email) }
-  let!(:user) { create(:user, :loa3) }
+  let!(:user) { create(:user, :loa3, :with_terms_of_use_agreement) }
+  let!(:in_progress_form) do
+    create(:in_progress_1010ez_form_with_email, user_uuid: user.uuid, user_account_id: user.user_account_uuid)
+  end
 
   before do
     allow(Flipper).to receive(:enabled?).with(:remove_pciu, instance_of(User)).and_return(false)
-    in_progress_form.update!(user_uuid: user.uuid)
     allow(User).to receive(:find).with(user.uuid).and_return(user)
   end
 
@@ -19,7 +20,7 @@ RSpec.describe HCA::LogEmailDiffJob, type: :job do
       subject
 
       expect(FormEmailMatchesProfileLog).not_to receive(:create).with(
-        user_uuid: user.uuid, in_progress_form_id: in_progress_form.id
+        user_uuid: user.uuid, in_progress_form_id: in_progress_form.id, user_account_id: user.user_account_uuid
       )
     end
   end
@@ -30,12 +31,13 @@ RSpec.describe HCA::LogEmailDiffJob, type: :job do
         subject
       end.to trigger_statsd_increment("api.1010ez.in_progress_form_email.#{tag}")
 
-      expect(InProgressForm.where(user_uuid: user.uuid, id: in_progress_form.id)).to exist
+      expect(InProgressForm.where(user_uuid: user.uuid, user_account_id: user.user_account_uuid,
+                                  id: in_progress_form.id)).to exist
     end
   end
 
   describe '#perform' do
-    subject { described_class.new.perform(in_progress_form.id, user.uuid) }
+    subject { described_class.new.perform(in_progress_form.id, user.uuid, user.user_account_uuid) }
 
     context 'when the form has been deleted' do
       before do
@@ -59,7 +61,8 @@ RSpec.describe HCA::LogEmailDiffJob, type: :job do
 
         context 'when FormEmailMatchesProfileLog already exists' do
           before do
-            FormEmailMatchesProfileLog.create(user_uuid: user.uuid, in_progress_form_id: in_progress_form.id)
+            FormEmailMatchesProfileLog.create(user_uuid: user.uuid, in_progress_form_id: in_progress_form.id,
+                                              user_account_id: user.user_account_uuid)
           end
 
           expect_does_nothing


### PR DESCRIPTION
## Summary

- updates `InProgressForm` `log_hca_email_diff` method to include the form's `user_account_id`, this is then passed to the saved `FormEmailMatchesProfileLog` record created as part of the `HCA::LogEmailDiffJob`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/58
-[ Backfill rake task](https://github.com/department-of-veterans-affairs/vets-api/pull/21875) for `FormEmailoMatchesProfileLog` records that don't have a `user_account_id`

## Testing done

- [x] *New code is covered by unit tests*
- Make an (authenticated) request to create/update a 1010ez `InProgressForm`
```curl
curl --location --request PUT 'http://localhost:3000/v0/in_progress_forms/1010ez' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer ....'
--data '{ "form_data": { "some-form-key": "some-form-data" } }'
```
- A `HCA::LogEmailDiffJob` should be enqueued to perform with the form's `user_account_id` included.