### PR TITLE
Dependents Notification Emails

### DIFF
--- a/app/controllers/v0/dependents_applications_controller.rb
+++ b/app/controllers/v0/dependents_applications_controller.rb
@@ -36,6 +36,8 @@ module V0
       dependent_service.submit_686c_form(claim)
 
       Rails.logger.info "ClaimID=#{claim.confirmation_number} Form=#{claim.class::FORM}"
+      claim.send_submitted_email(current_user) if Flipper.enabled?(:dependents_submitted_email)
+
       # clear_saved_form(claim.form_id) # We do not want to destroy the InProgressForm for this submission
 
       render json: SavedClaimSerializer.new(claim)

--- a/app/sidekiq/bgs/submit_form674_job.rb
+++ b/app/sidekiq/bgs/submit_form674_job.rb
@@ -117,16 +117,11 @@ module BGS
     end
 
     def send_confirmation_email
-      return if user.va_profile_email.blank?
+      return claim.send_received_email(user) if Flipper.enabled?(:dependents_separate_confirmation_email)
 
       template_id = Settings.vanotify.services.va_gov.template_id.form686c_confirmation_email
 
-      if Flipper.enabled?(:dependents_separate_confirmation_email)
-        template_id = Settings.vanotify.services.va_gov.template_id.form674_only_confirmation_email
-        if @claim.submittable_686?
-          template_id = Settings.vanotify.services.va_gov.template_id.form686c_674_confirmation_email
-        end
-      end
+      return if user.va_profile_email.blank?
 
       VANotify::ConfirmationEmail.send(
         email_address: user.va_profile_email,

--- a/app/sidekiq/bgs/submit_form686c_job.rb
+++ b/app/sidekiq/bgs/submit_form686c_job.rb
@@ -139,14 +139,7 @@ module BGS
     end
 
     def send_686c_confirmation_email
-      return if user&.va_profile_email.blank?
-
-      VANotify::ConfirmationEmail.send(
-        email_address: user.va_profile_email,
-        template_id: Settings.vanotify.services.va_gov.template_id.form686c_only_confirmation_email,
-        first_name: user&.first_name&.upcase,
-        user_uuid_and_form_id: "#{user.uuid}_#{FORM_ID}"
-      )
+      claim.send_received_email(user)
     end
 
     def send_confirmation_email

--- a/app/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job.rb
+++ b/app/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job.rb
@@ -253,6 +253,8 @@ module Lighthouse
       end
 
       def send_confirmation_email(user)
+        return claim.send_received_email(user) if Flipper.enabled?(:dependents_separate_confirmation_email)
+
         return if user.va_profile_email.blank?
 
         form_id = Flipper.enabled?(:va_dependents_v2) ? FORM_ID_V2 : FORM_ID

--- a/spec/controllers/v0/dependents_applications_controller_spec.rb
+++ b/spec/controllers/v0/dependents_applications_controller_spec.rb
@@ -42,15 +42,24 @@ RSpec.describe V0::DependentsApplicationsController do
   describe 'POST create' do
     context 'with valid params v1' do
       before do
+        allow(Flipper).to receive(:enabled?).with(:dependents_separate_confirmation_email).and_return(true)
+        allow(Flipper).to receive(:enabled?).with(:dependents_submitted_email).and_return(true)
         allow(Flipper).to receive(:enabled?).with(:va_dependents_v2).and_return(false)
         allow(Flipper).to receive(:enabled?).with(:remove_pciu, instance_of(User)).and_return(false)
         allow(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync)
         allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_686?).and_return(true)
         allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(true)
+        allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:confirmation_number).and_return('')
         allow_any_instance_of(BGS::PersonWebService).to receive(:find_by_ssn).and_return({ file_nbr: '796043735' })
       end
 
       it 'validates successfully' do
+        expect(VANotify::EmailJob).to receive(:perform_async) do |email, template_id, personalization, secret|
+          expect(email).to_be(user.va_profile_email)
+          expect(template_id).to_be('fake_submitted686c674')
+          expect(personalization).to_have.keys(%w[date_submitted first_name confirmation_number])
+          expect(secret).to_be('fake_secret')
+        end
         VCR.use_cassette('bgs/dependent_service/submit_686c_form') do
           post(:create, params: test_form)
         end

--- a/spec/sidekiq/bgs/submit_form674_job_spec.rb
+++ b/spec/sidekiq/bgs/submit_form674_job_spec.rb
@@ -77,11 +77,17 @@ RSpec.describe BGS::SubmitForm674Job, type: :job do
           .and_return(user_struct)
         expect(VANotify::EmailJob).to receive(:perform_async).with(
           user.va_profile_email,
-          '686c_674_confirmation_template_id',
-          {
-            'date' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
-            'first_name' => 'WESLEY'
-          }
+          'fake_received686c674',
+          { 'confirmation_number' => dependency_claim.confirmation_number,
+            'date_submitted' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
+            'first_name' => 'WESLEY' },
+          'fake_secret',
+          { callback_klass: 'VeteranFacingServices::NotificationCallback::SavedClaim',
+            callback_metadata: { email_template_id: 'fake_received686c674',
+                                 email_type: :received686c674,
+                                 form_id: '686C-674',
+                                 saved_claim_id: dependency_claim.id,
+                                 service_name: 'dependents' } }
         )
 
         subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
@@ -150,11 +156,17 @@ RSpec.describe BGS::SubmitForm674Job, type: :job do
           .and_return(user_struct)
         expect(VANotify::EmailJob).to receive(:perform_async).with(
           user.va_profile_email,
-          '674_confirmation_template_id',
-          {
-            'date' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
-            'first_name' => 'WESLEY'
-          }
+          'fake_received674',
+          { 'confirmation_number' => dependency_claim_674_only.confirmation_number,
+            'date_submitted' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
+            'first_name' => 'WESLEY' },
+          'fake_secret',
+          { callback_klass: 'VeteranFacingServices::NotificationCallback::SavedClaim',
+            callback_metadata: { email_template_id: 'fake_received674',
+                                 email_type: :received674,
+                                 form_id: '686C-674',
+                                 saved_claim_id: dependency_claim_674_only.id,
+                                 service_name: 'dependents' } }
         )
 
         subject.perform(user.uuid, user.icn, dependency_claim_674_only.id, encrypted_vet_info, encrypted_user_struct)

--- a/spec/sidekiq/bgs/submit_form686c_job_spec.rb
+++ b/spec/sidekiq/bgs/submit_form686c_job_spec.rb
@@ -68,11 +68,17 @@ RSpec.describe BGS::SubmitForm686cJob, type: :job do
 
         expect(VANotify::EmailJob).to receive(:perform_async).with(
           user.va_profile_email,
-          '686c_confirmation_template_id',
-          {
-            'date' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
-            'first_name' => 'WESLEY'
-          }
+          'fake_received686',
+          { 'confirmation_number' => dependency_claim.confirmation_number,
+            'date_submitted' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
+            'first_name' => 'WESLEY' },
+          'fake_secret',
+          { callback_klass: 'VeteranFacingServices::NotificationCallback::SavedClaim',
+            callback_metadata: { email_template_id: 'fake_received686',
+                                 email_type: :received686,
+                                 form_id: '686C-674',
+                                 saved_claim_id: dependency_claim.id,
+                                 service_name: 'dependents' } }
         )
 
         expect { job }.not_to raise_error

--- a/spec/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job_spec.rb
+++ b/spec/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Lighthouse::BenefitsIntake::SubmitCentralForm686cJob, :uploader_h
         datestamp_double3 = double
         timestamp = claim.created_at
 
-        expect(SavedClaim::DependencyClaim).to receive(:find).with(claim.id).and_return(claim)
+        expect(SavedClaim::DependencyClaim).to receive(:find).with(claim.id).and_return(claim).at_least(:once)
         expect(claim).to receive(:to_pdf).and_return('path1')
         expect(PDFUtilities::DatestampPdf).to receive(:new).with('path1').and_return(datestamp_double1)
         expect(datestamp_double1).to receive(:run).with(text: 'VA.GOV', x: 5, y: 5, timestamp:).and_return('path2')
@@ -139,14 +139,20 @@ RSpec.describe Lighthouse::BenefitsIntake::SubmitCentralForm686cJob, :uploader_h
       it 'submits the saved claim and updates submission to success' do
         expect(VANotify::EmailJob).to receive(:perform_async).with(
           user_struct.va_profile_email,
-          'fake_template_id',
-          {
-            'date' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
-            'first_name' => 'MARK'
-          }
+          'fake_received686',
+          { 'confirmation_number' => claim.confirmation_number,
+            'date_submitted' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
+            'first_name' => 'MARK' },
+          'fake_secret',
+          { callback_klass: 'VeteranFacingServices::NotificationCallback::SavedClaim',
+            callback_metadata: { email_template_id: 'fake_received686',
+                                 email_type: :received686,
+                                 form_id: '686C-674',
+                                 saved_claim_id: claim.id,
+                                 service_name: 'dependents' } }
         )
-        expect(claim).to receive(:submittable_686?).and_return(true).exactly(:twice)
-        expect(claim).to receive(:submittable_674?).and_return(false)
+        expect(claim).to receive(:submittable_686?).and_return(true).exactly(4).times
+        expect(claim).to receive(:submittable_674?).and_return(false).at_least(:once)
         subject.perform(claim.id, encrypted_vet_info, encrypted_user_struct)
         expect(central_mail_submission.reload.state).to eq('success')
       end
@@ -281,7 +287,7 @@ RSpec.describe Lighthouse::BenefitsIntake::SubmitCentralForm686cJob, :uploader_h
         datestamp_double3 = double
         timestamp = claim_v2.created_at
 
-        expect(SavedClaim::DependencyClaim).to receive(:find).with(claim_v2.id).and_return(claim_v2)
+        expect(SavedClaim::DependencyClaim).to receive(:find).with(claim_v2.id).and_return(claim_v2).at_least(:once)
         expect(claim_v2).to receive(:to_pdf).and_return('path1')
         expect(PDFUtilities::DatestampPdf).to receive(:new).with('path1').and_return(datestamp_double1)
         expect(datestamp_double1).to receive(:run).with(text: 'VA.GOV', x: 5, y: 5, timestamp:).and_return('path2')
@@ -339,14 +345,20 @@ RSpec.describe Lighthouse::BenefitsIntake::SubmitCentralForm686cJob, :uploader_h
       it 'submits the saved claim and updates submission to success' do
         expect(VANotify::EmailJob).to receive(:perform_async).with(
           user_struct.va_profile_email,
-          'fake_template_id',
-          {
-            'date' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
-            'first_name' => 'MARK'
-          }
+          'fake_received686',
+          { 'confirmation_number' => claim_v2.confirmation_number,
+            'date_submitted' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
+            'first_name' => 'MARK' },
+          'fake_secret',
+          { callback_klass: 'VeteranFacingServices::NotificationCallback::SavedClaim',
+            callback_metadata: { email_template_id: 'fake_received686',
+                                 email_type: :received686,
+                                 form_id: '686C-674-V2',
+                                 saved_claim_id: claim_v2.id,
+                                 service_name: 'dependents' } }
         )
-        expect(claim_v2).to receive(:submittable_686?).and_return(true).exactly(:twice)
-        expect(claim_v2).to receive(:submittable_674?).and_return(false)
+        expect(claim_v2).to receive(:submittable_686?).and_return(true).exactly(4).times
+        expect(claim_v2).to receive(:submittable_674?).and_return(false).at_least(:once)
         subject.perform(claim_v2.id, encrypted_vet_info, encrypted_user_struct)
         expect(central_mail_submission_v2.reload.state).to eq('success')
       end


### PR DESCRIPTION
## Summary

- This work sets up the code needed to implement submitted emails for Dependents and update received emails for Dependents. It's not yet called in the code - see https://github.com/department-of-veterans-affairs/vets-api/pull/22005 for full implementation. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/97892
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86710

## Testing done

- [ ] *New code is covered by unit tests*

For manual testing, turn on `dependents_separate_confirmation_email` and `dependents_submitted_email` flippers
- [ ] Create a claim, then in the rails console: `claim.send_submitted_email` and `claim.send_received_email`. Optionally send a user as a param. Email success will be logged. 
- [ ] Submit a claim via the UI and note email success logs

## What areas of the site does it impact?
Dependents

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
