### PR TITLE
BE | Ask VA Api: link auth_url to parameter store

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,7 +17,7 @@ argocd:
     api_key: <%= ENV['argocd__slack__api_key'] %>
 ask_va_api:
   crm_api:
-    auth_url: https://login.microsoftonline.us
+    auth_url: <%= ENV['ask_va_api__crm_api__auth_url'] %>
     base_url: <%= ENV['ask_va_api__crm_api__base_url'] %>
     client_id: <%= ENV['ask_va_api__crm_api__client_id'] %>
     client_secret: <%= ENV['ask_va_api__crm_api__client_secret'] %>


### PR DESCRIPTION
## Summary

This PR updates the CRM API `auth_url` configuration for Ask VA to pull from an environment variable (`ask_va_api_crm_api_auth_url`) instead of hardcoding `https://login.microsoftonline.us`. 

By doing this, the `auth_url` is now managed via Parameter Store, allowing environment-specific configuration (e.g., staging/prod can each use the correct fwdproxy port). This improves flexibility and aligns with platform best practices for external service integrations.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/ask-va/issues/1809
## Testing done

- just update settings

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected