### PR TITLE
[ID-103] - Create and update models for sign-in certificates

### DIFF
--- a/app/models/sign_in/certificate.rb
+++ b/app/models/sign_in/certificate.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module SignIn
+  class Certificate < ApplicationRecord
+    self.table_name = 'sign_in_certificates'
+
+    has_many :config_certificates, dependent: :destroy
+    has_many :client_configs, through: :config_certificates, source: :config, source_type: 'ClientConfig'
+    has_many :service_account_configs, through: :config_certificates, source: :config,
+                                       source_type: 'ServiceAccountConfig'
+
+    delegate :not_before, :not_after, :subject, :issuer, :serial, to: :certificate
+
+    validates :pem, presence: true
+    validate :validate_certificate!
+
+    def certificate
+      @certificate ||= OpenSSL::X509::Certificate.new(pem.to_s)
+    rescue OpenSSL::X509::CertificateError
+      nil
+    end
+
+    def expired?
+      return if certificate.blank?
+
+      not_after < Time.current
+    end
+
+    private
+
+    def validate_certificate!
+      unless certificate
+        errors.add(:pem, 'not a valid X.509 certificate')
+        return
+      end
+
+      errors.add(:pem, 'certificate is expired') if expired?
+      errors.add(:pem, 'certificate is not yet valid') if not_before > Time.current
+      errors.add(:pem, 'certificate is self-signed') if issuer == subject
+    end
+  end
+end

--- a/app/models/sign_in/client_config.rb
+++ b/app/models/sign_in/client_config.rb
@@ -7,6 +7,9 @@ module SignIn
     attribute :access_token_duration, :interval
     attribute :refresh_token_duration, :interval
 
+    has_many :config_certificates, as: :config, dependent: :destroy
+    has_many :certs, through: :config_certificates, class_name: 'SignIn::Certificate'
+
     validates :anti_csrf, inclusion: [true, false]
     validates :redirect_uri, presence: true
     validates :access_token_duration,

--- a/app/models/sign_in/config_certificate.rb
+++ b/app/models/sign_in/config_certificate.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module SignIn
+  class ConfigCertificate < ApplicationRecord
+    self.table_name = 'sign_in_config_certificates'
+
+    belongs_to :config, polymorphic: true
+    belongs_to :cert, class_name: 'SignIn::Certificate', foreign_key: :certificate_id, inverse_of: :config_certificates
+  end
+end

--- a/app/models/sign_in/service_account_config.rb
+++ b/app/models/sign_in/service_account_config.rb
@@ -6,6 +6,9 @@ module SignIn
 
     attribute :access_token_duration, :interval
 
+    has_many :config_certificates, as: :config, dependent: :destroy
+    has_many :certs, through: :config_certificates, class_name: 'SignIn::Certificate'
+
     validates :service_account_id, presence: true, uniqueness: true
     validates :description, presence: true
     validates :access_token_audience, presence: true

--- a/spec/factories/sign_in/certificates.rb
+++ b/spec/factories/sign_in/certificates.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  build_ca = lambda do |not_before, not_after|
+    key  = OpenSSL::PKey::RSA.new(2048)
+    name = OpenSSL::X509::Name.parse('/CN=Test CA')
+    cert = OpenSSL::X509::Certificate.new.tap do |c|
+      c.version    = 2
+      c.serial     = rand(1_000_000)
+      c.subject    = name
+      c.issuer     = name
+      c.public_key = key.public_key
+      c.not_before = not_before
+      c.not_after  = not_after
+      c.sign(key, OpenSSL::Digest.new('SHA256'))
+    end
+    [cert, key]
+  end
+
+  build_leaf = lambda do |ca_cert, ca_key, not_before, not_after, self_signed|
+    key = OpenSSL::PKey::RSA.new(2048)
+    subject_cn = 'Leaf Cert'
+    issuer_name = if self_signed
+                    OpenSSL::X509::Name.parse("/CN=#{subject_cn}")
+                  else
+                    ca_cert.subject
+                  end
+    signer_key = self_signed ? key : ca_key
+
+    OpenSSL::X509::Certificate.new.tap do |c|
+      c.version    = 2
+      c.serial     = rand(1_000_000)
+      c.subject    = OpenSSL::X509::Name.parse("/CN=#{subject_cn}")
+      c.issuer     = issuer_name
+      c.public_key = key.public_key
+      c.not_before = not_before
+      c.not_after  = not_after
+      c.sign(signer_key, OpenSSL::Digest.new('SHA256'))
+    end
+  end
+
+  factory :sign_in_certificate, class: 'SignIn::Certificate' do
+    transient do
+      not_before  { 1.hour.ago }
+      not_after   { 100.years.from_now }
+      self_signed { false }
+    end
+
+    pem do
+      if self_signed
+        build_leaf.call(nil, nil, not_before, not_after, true).to_pem
+      else
+        ca_cert, ca_key = build_ca.call(not_before - 1.day, not_after + 1.day)
+        build_leaf.call(ca_cert, ca_key, not_before, not_after, false).to_pem
+      end
+    end
+
+    trait :self_signed do
+      transient { self_signed { true } }
+    end
+
+    trait :expired do
+      transient do
+        not_before { 2.years.ago }
+        not_after  { 1.year.ago }
+      end
+    end
+
+    trait :not_yet_valid do
+      transient do
+        not_before { 1.day.from_now }
+        not_after  { 2.days.from_now }
+      end
+    end
+
+    trait :with_config_certificates do
+      transient do
+        config_certificates_count { 3 }
+      end
+
+      after(:build) do |certificate, evaluator|
+        create_list(:sign_in_config_certificate, evaluator.config_certificates_count, cert: certificate)
+      end
+    end
+  end
+end

--- a/spec/factories/sign_in/client_configs.rb
+++ b/spec/factories/sign_in/client_configs.rb
@@ -18,5 +18,15 @@ FactoryBot.define do
     enforced_terms { SignIn::Constants::Auth::VA_TERMS }
     terms_of_use_url { Faker::Internet.url }
     shared_sessions { false }
+
+    trait :with_certificates do
+      ignore do
+        certs_count { 1 }
+      end
+
+      after(:create) do |client_config, evaluator|
+        create_list(:sign_in_config_certificate, evaluator.certs_count, config: client_config)
+      end
+    end
   end
 end

--- a/spec/factories/sign_in/config_certificates.rb
+++ b/spec/factories/sign_in/config_certificates.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :sign_in_config_certificate, class: 'SignIn::ConfigCertificate' do
+    for_client_config
+    association :cert, factory: :sign_in_certificate
+
+    trait :for_client_config do
+      association :config, factory: :client_config
+    end
+
+    trait :for_service_account_config do
+      association :config, factory: :service_account_config
+    end
+  end
+end

--- a/spec/factories/sign_in/service_account_configs.rb
+++ b/spec/factories/sign_in/service_account_configs.rb
@@ -9,5 +9,15 @@ FactoryBot.define do
     access_token_duration { SignIn::Constants::ServiceAccountAccessToken::VALIDITY_LENGTH_SHORT_MINUTES }
     access_token_user_attributes { [] }
     certificates { [] }
+
+    trait :with_certificates do
+      ignore do
+        certs_count { 1 }
+      end
+
+      after(:create) do |service_account_config, evaluator|
+        create_list(:sign_in_config_certificate, evaluator.certs_count, config: service_account_config)
+      end
+    end
   end
 end

--- a/spec/models/sign_in/certificate_spec.rb
+++ b/spec/models/sign_in/certificate_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SignIn::Certificate, type: :model do
+  subject(:certificate) { create(:sign_in_certificate) }
+
+  describe 'associations' do
+    it { is_expected.to have_many(:config_certificates).dependent(:destroy) }
+    it { is_expected.to have_many(:client_configs).through(:config_certificates) }
+    it { is_expected.to have_many(:service_account_configs).through(:config_certificates) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:pem) }
+
+    context 'when PEM is invalid' do
+      subject(:certificate) { build(:sign_in_certificate, pem: 'not a valid pem') }
+
+      it 'is not valid and adds X.509 error' do
+        expect(certificate).not_to be_valid
+        expect(certificate.errors[:pem]).to include('not a valid X.509 certificate')
+      end
+    end
+
+    context 'when certificate is valid' do
+      it { is_expected.to be_valid }
+    end
+
+    context 'when the certificate is expired' do
+      subject(:certificate) { build(:sign_in_certificate, :expired) }
+
+      it 'is not valid and adds expired error' do
+        expect(certificate).not_to be_valid
+        expect(certificate.errors[:pem]).to include('certificate is expired')
+      end
+
+      it '#expired? returns true' do
+        expect(certificate.expired?).to be true
+      end
+    end
+
+    context 'when the certificate is not yet valid' do
+      subject(:certificate) { build(:sign_in_certificate, :not_yet_valid) }
+
+      it 'is not valid and adds “not yet valid” error' do
+        expect(certificate).not_to be_valid
+        expect(certificate.errors[:pem]).to include('certificate is not yet valid')
+      end
+    end
+
+    context 'when the certificate is self-signed' do
+      subject(:certificate) { build(:sign_in_certificate, :self_signed) }
+
+      it 'is not valid and adds self‑signed error' do
+        expect(certificate).not_to be_valid
+        expect(certificate.errors[:pem]).to include('certificate is self-signed')
+      end
+    end
+  end
+
+  describe 'delegations' do
+    it { is_expected.to delegate_method(:not_before).to(:certificate) }
+    it { is_expected.to delegate_method(:not_after).to(:certificate) }
+    it { is_expected.to delegate_method(:subject).to(:certificate) }
+    it { is_expected.to delegate_method(:issuer).to(:certificate) }
+    it { is_expected.to delegate_method(:serial).to(:certificate) }
+  end
+
+  describe '#expired?' do
+    context 'when the certificate is expired' do
+      subject(:certificate) { build(:sign_in_certificate, :expired) }
+
+      it 'returns true' do
+        expect(certificate.expired?).to be true
+      end
+
+      context 'when the certificate is not expired' do
+        subject(:certificate) { build(:sign_in_certificate) }
+
+        it 'returns false' do
+          expect(certificate.expired?).to be false
+        end
+      end
+    end
+  end
+end

--- a/spec/models/sign_in/client_config_spec.rb
+++ b/spec/models/sign_in/client_config_spec.rb
@@ -45,6 +45,11 @@ RSpec.describe SignIn::ClientConfig, type: :model do
     it_behaves_like 'implements certifiable concern'
   end
 
+  describe 'associations' do
+    it { is_expected.to have_many(:config_certificates).dependent(:destroy) }
+    it { is_expected.to have_many(:certs).through(:config_certificates).class_name('SignIn::Certificate') }
+  end
+
   describe 'validations' do
     subject { client_config }
 

--- a/spec/models/sign_in/config_certificate_spec.rb
+++ b/spec/models/sign_in/config_certificate_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SignIn::ConfigCertificate, type: :model do
+  subject(:config_certificate) { create(:sign_in_config_certificate) }
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:cert) }
+    it { is_expected.to belong_to(:config) }
+  end
+end

--- a/spec/models/sign_in/service_account_config_spec.rb
+++ b/spec/models/sign_in/service_account_config_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe SignIn::ServiceAccountConfig, type: :model do
            certificates:)
   end
 
+  describe 'associations' do
+    it { is_expected.to have_many(:config_certificates).dependent(:destroy) }
+    it { is_expected.to have_many(:certs).through(:config_certificates).class_name('SignIn::Certificate') }
+  end
+
   describe 'concerns' do
     subject { service_account_config }
 


### PR DESCRIPTION
## Summary

- Create models for tables: `sign_in_certificates` and `sign_in_config_certificates` and add associations to `SignIn::ClientConfig` and `SignIn::ServiceAccountConfig`
- Delegate attributes from `OpenSSL::X509::Certificate`
- After this is merged:
  -  existing certificates will be backfilled
  - PR with migrations to remove `certificates` columns from `ClientConfig` and `ServiceAccountConfig`
  - PR to change `SignIn::Certificate#certs` association to `certificates`

## Related issue(s)

- department-of-veterans-affairs/identity-documentation#103

## Testing 

- in rails console
  ```ruby
  pem = File.read('spec/fixtures/sign_in/sample_client.crt')
  config = SignIn::ClientConfig.last

  certificate = config.certs.create(pem:)

  certificate.not_before # => 2024-05-14 17:25:14 UTC
  certificate.not_after  # => 2051-09-30 17:25:14 UTC
  certificate.subject    # => #<OpenSSL::X509::Name CN=va.gov,OU=vets-api ...>
  certificate.issuer     # => #<OpenSSL::X509::Name OU=OCTO...>
  certificate.serial     # => #<OpenSSL::BN 155899904190010676188270788522204217112053295553>
  ``` 

## What areas of the site does it impact?
`SignIn::ClientConfig`s, `SignIn::ServiceAccountConfig`s

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

