### PR TITLE
Downcase file extensions for validation

### DIFF
--- a/app/models/lighthouse_document.rb
+++ b/app/models/lighthouse_document.rb
@@ -138,7 +138,7 @@ class LighthouseDocument < Common::Base
   end
 
   def set_file_extension
-    self.file_extension = file_name.split('.').last
+    self.file_extension = file_name.downcase.split('.').last
   end
 
   def normalize_text

--- a/lib/lighthouse/benefits_documents/service.rb
+++ b/lib/lighthouse/benefits_documents/service.rb
@@ -60,8 +60,6 @@ module BenefitsDocuments
               ArgumentError.new('Claim id is required')
       end
 
-      Rails.logger.info('claim_id', claim_id:)
-      Rails.logger.info('document_type', document_type: document_data.document_type)
       Rails.logger.info('file_name present?', file&.original_filename.present?)
       Rails.logger.info('file extension', file&.original_filename&.split('.')&.last)
       Rails.logger.info('file content type', file&.content_type)


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

- While investigating validation errors, I found that some of the uploads were failing because the filenames were uppercase, and our validation method was only looking for lowercase characters ([here](https://vagov.ddog-gov.com/apm/traces?query=env%3Aeks-prod%20operation_name%3Arack.request%20resource_name%3A%22Mobile%3A%3AV0%3A%3AClaimsAndAppealsController%23upload_document%22%20service%3Amobile-app&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=flamegraph&historicalData=true&messageDisplay=inline&refresh_mode=sliding&shouldShowLegend=true&sort=time&spanID=1175672596999245749&spanType=all&spanViewType=logs&storage=hot&timeHint=1746213367477&trace=AwAAAZaSbW61-uM4RQAAABhBWmFTYlhlMEFBQlJLX0lEQWFZTGl6UTgAAAAkMDE5NjkyNzctNTQ1NC00YjAzLWExMzktMDRjM2RhMTZjNzA5AABNeQ&traceID=4338273179963598293&view=spans&start=1746209169690&end=1746223569690&paused=false) is an example)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-mobile-app/issues/10773
