### PR TITLE
Updated return value for `submit_1010d` to return http response on success - IVC CHAMPVA

### DIFF
--- a/modules/ivc_champva/lib/ves_api/client.rb
+++ b/modules/ivc_champva/lib/ves_api/client.rb
@@ -35,6 +35,8 @@ module IvcChampva
         monitor.track_ves_response(transaction_uuid, resp.status, resp.body)
 
         raise "response code: #{resp.status}, response body: #{resp.body}" unless resp.status == 200
+
+        resp
       rescue => e
         raise VesApiError, e.message.to_s
       end

--- a/modules/ivc_champva/spec/lib/ves_api_client_spec.rb
+++ b/modules/ivc_champva/spec/lib/ves_api_client_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe IvcChampva::VesApi::Client do
 
         client.submit_1010d(transaction_uuid, acting_user, ves_request_data)
       end
+
+      it 'does not return nil on success' do
+        expect(client.submit_1010d(transaction_uuid, acting_user, ves_request_data).nil?).to be(false)
+      end
     end
 
     context '400 response from VES' do


### PR DESCRIPTION
## Summary

This PR updates the `submit_1010d` method of the `IvcChampva::VesApi::Client` class to return the http response from VES after submitting a successful request (previously just returned `nil` in the event of success)

- This work is behind a feature toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/107624

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA
