### PR TITLE
Vets::Collection Caching

### DIFF
--- a/lib/vets/collection.rb
+++ b/lib/vets/collection.rb
@@ -74,7 +74,7 @@ module Vets
     # previously find_by on Common::Collection
     def where(conditions = {})
       results = Vets::Collections::Finder.new(data: @records).all(conditions)
-      Vets::Collection.new(results, metadata: { filter: conditions })
+      Vets::Collection.new(results, metadata: { filter: conditions }, errors:)
     end
 
     # previously find_first_by on Common::Collection
@@ -89,7 +89,7 @@ module Vets
         total_entries: @records.size,
         data: @records
       )
-      Vets::Collection.new(pagination.data, metadata: pagination.metadata)
+      Vets::Collection.new(pagination.data, metadata: pagination.metadata, errors:)
     end
 
     def serialize

--- a/lib/vets/collection.rb
+++ b/lib/vets/collection.rb
@@ -19,13 +19,22 @@ module Vets
 
     include Vets::Collections::Cacheable
 
-    attr_accessor :records, :metadata
+    attr_accessor :records, :metadata, :errors
+    attr_reader :model_class
 
-    def initialize(records, metadata: {}, cache_key: nil)
+    alias members records
+    alias type model_class
+
+    def initialize(records, model_class = nil, metadata: {}, errors: {}, cache_key: nil)
       records = Array.wrap(records)
-      @model_class = records.empty? ? nil : records.first.class
+      @model_class = model_class || records.first&.class
       @metadata = metadata
+      @errors = errors
       @cache_key = cache_key
+
+      records = records.collect do |record|
+        record.is_a?(Hash) ? model_class.new(record) : record
+      end
 
       unless records.all? { |record| record.is_a?(@model_class) }
         raise ArgumentError, "All records must be instances of #{@model_class}"
@@ -43,13 +52,14 @@ module Vets
       new(records)
     end
 
-    def self.from_hashes(model_class, records)
+    def self.from_hashes(model_class, records, metadata: {})
       raise ArgumentError, 'Expected an array of hashes' unless records.all? { |r| r.is_a?(Hash) }
 
       records = records.map { |record| model_class.new(**record) }
       new(records)
     end
 
+    # reviously sort on Common::Collection
     def order(clauses = {})
       validate_sort_clauses(clauses)
 
@@ -61,11 +71,13 @@ module Vets
       end
     end
 
+    # previously find_by on Common::Collection
     def where(conditions = {})
       results = Vets::Collections::Finder.new(data: @records).all(conditions)
       Vets::Collection.new(results, metadata: { filter: conditions })
     end
 
+    # previously find_first_by on Common::Collection
     def find_by(conditions = {})
       Vets::Collections::Finder.new(data: @records).first(conditions)
     end
@@ -78,6 +90,10 @@ module Vets
         data: @records
       )
       Vets::Collection.new(pagination.data, metadata: pagination.metadata)
+    end
+
+    def serialize
+      { data: records, metadata:, errors: }.to_json
     end
 
     private

--- a/lib/vets/collection.rb
+++ b/lib/vets/collection.rb
@@ -52,13 +52,6 @@ module Vets
       new(records)
     end
 
-    def self.from_hashes(records, model_class, metadata: {}, error: {})
-      raise ArgumentError, 'Expected an array of hashes' unless records.all? { |r| r.is_a?(Hash) }
-
-      records = records.map { |record| model_class.new(**record) }
-      new(records, model_class, metadata:, error:)
-    end
-
     # reviously sort on Common::Collection
     def order(clauses = {})
       validate_sort_clauses(clauses)

--- a/lib/vets/collection.rb
+++ b/lib/vets/collection.rb
@@ -9,6 +9,7 @@ require 'common/models/comparable/ascending'
 require 'common/models/comparable/descending'
 require 'vets/collections/finder'
 require 'vets/collections/pagination'
+require 'vets/collections/cacheable'
 
 # This will be a replacement for Common::Collection
 module Vets
@@ -16,12 +17,15 @@ module Vets
     DEFAULT_PER_PAGE = 10
     DEFAULT_MAX_PER_PAGE = 100
 
+    include Vets::Collections::Cacheable
+
     attr_accessor :records, :metadata
 
-    def initialize(records, metadata: {})
+    def initialize(records, metadata: {}, cache_key: nil)
       records = Array.wrap(records)
       @model_class = records.empty? ? nil : records.first.class
       @metadata = metadata
+      @cache_key = cache_key
 
       unless records.all? { |record| record.is_a?(@model_class) }
         raise ArgumentError, "All records must be instances of #{@model_class}"

--- a/lib/vets/collection.rb
+++ b/lib/vets/collection.rb
@@ -52,11 +52,11 @@ module Vets
       new(records)
     end
 
-    def self.from_hashes(model_class, records, metadata: {})
+    def self.from_hashes(records, model_class, metadata: {}, error: {})
       raise ArgumentError, 'Expected an array of hashes' unless records.all? { |r| r.is_a?(Hash) }
 
       records = records.map { |record| model_class.new(**record) }
-      new(records)
+      new(records, model_class, metadata:, error:)
     end
 
     # reviously sort on Common::Collection

--- a/lib/vets/collections/cacheable.rb
+++ b/lib/vets/collections/cacheable.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'active_support/concern'
+
+module Vets
+  module Collections
+    module Cacheable
+      extend ActiveSupport::Concern
+
+      CACHE_NAMESPACE = 'common_collection'
+      CACHE_DEFAULT_TTL = 3600 # default to 1 hour
+
+      class_methods do
+
+        def redis_namespace
+          @redis_namespace ||= Redis::Namespace.new(CACHE_NAMESPACE, redis: $redis)
+        end
+
+        def fetch(klass, cache_key: nil, ttl: CACHE_DEFAULT_TTL, &block)
+          raise ArgumentError, 'No block given' unless block
+
+          return new(klass, **block.call) unless cache_key
+
+          json_string = redis_namespace.get(cache_key)
+          return build_and_cache(klass, cache_key, ttl, &block) if json_string.nil?
+
+          from_cache(klass, json_string, cache_key)
+        end
+
+        def cache(json_hash, cache_key, ttl)
+          redis_namespace.set(cache_key, json_hash)
+          redis_namespace.expire(cache_key, ttl)
+        end
+
+        def bust(cache_keys)
+          Array.wrap(cache_keys).map { |key| redis_namespace.del(key) }
+        end
+
+        private
+
+        def build_and_cache(klass, cache_key, ttl)
+          collection = new(klass, **yield.merge(cache_key:))
+          cache(collection.serialize, cache_key, ttl)
+          collection
+        end
+
+        def from_cache(klass, json_string, cache_key)
+          json_hash = Oj.load(json_string)
+          new(klass, **json_hash.merge('cache_key' => cache_key).symbolize_keys)
+        end
+      end
+
+      def redis_namespace
+        @redis_namespace ||= self.class.redis_namespace
+      end
+
+      def bust
+        self.class.bust(@cache_key) if cached?
+      end
+
+      def cached?
+        @cache_key.present?
+      end
+
+      def ttl
+        @cache_key.present? ? redis_namespace.ttl(@cache_key) : nil
+      end
+
+    end
+  end
+end

--- a/lib/vets/collections/cacheable.rb
+++ b/lib/vets/collections/cacheable.rb
@@ -45,7 +45,8 @@ module Vets
         private
 
         def build_and_cache(results, klass, metadata, errors, caching)
-          collection = new(results, klass, metadata:, errors:, cache_key: caching[:caching_key])
+          cache_key = caching[:caching_key]
+          collection = new(results, klass, metadata:, errors:, cache_key:)
           cache(collection.serialize, cache_key, caching[:ttl])
           collection
         end

--- a/lib/vets/collections/cacheable.rb
+++ b/lib/vets/collections/cacheable.rb
@@ -45,7 +45,7 @@ module Vets
         private
 
         def build_and_cache(results, klass, metadata, errors, caching)
-          cache_key = caching[:caching_key]
+          cache_key = caching[:cache_key]
           collection = new(results, klass, metadata:, errors:, cache_key:)
           cache(collection.serialize, cache_key, caching[:ttl])
           collection

--- a/spec/lib/vets/collection_spec.rb
+++ b/spec/lib/vets/collection_spec.rb
@@ -54,21 +54,6 @@ RSpec.describe Vets::Collection do
     end
   end
 
-  describe '.from_hashes' do
-    it 'creates a collection from an WillPaginate::Collection' do
-      hashes = [{ name: 'Alice', age: 30 }, { name: 'Bob', age: 25 }]
-      collection = described_class.from_hashes(dummy_class, hashes)
-      expect(collection.records.map(&:name)).to eq(%w[Alice Bob])
-    end
-
-    it 'raises an error if not a WillPaginate::Collection' do
-      hashes = [{ name: 'Alice', age: 30 }, 'invalid']
-
-      expect { described_class.from_hashes(dummy_class, hashes) }
-        .to raise_error(ArgumentError, 'Expected an array of hashes')
-    end
-  end
-
   describe '.will_paginate' do
     it 'creates a collection from an array of hashes' do
       record1 = dummy_class.new(name: 'Bob', age: 25)

--- a/spec/lib/vets/collection_spec.rb
+++ b/spec/lib/vets/collection_spec.rb
@@ -19,10 +19,7 @@ RSpec.describe Vets::Collection do
       end
 
       def self.filterable_attributes
-        {
-          'name' => %w[match eq],
-          'age' => %w[eq gteq lteq]
-        }.with_indifferent_access
+        { name: %w[match eq], age: %w[eq lteq gteq] }.with_indifferent_access
       end
     end
   end

--- a/spec/lib/vets/collections/cacheable_spec.rb
+++ b/spec/lib/vets/collections/cacheable_spec.rb
@@ -42,17 +42,13 @@ RSpec.describe Vets::Collections::Cacheable do
   let(:record) { dummy_model.new(id: 1) }
   let(:cache_key) { 'test_key' }
   let(:redis_namespace) do
-    Redis::Namespace.new("common_collection_#{SecureRandom.hex(4)}", redis: Redis.new)
+    Redis::Namespace.new("common_collection_#{SecureRandom.hex(4)}", redis: $redis)
   end
   let(:instance_with_cache) { dummy_collection_class.new([record], dummy_model, cache_key: cache_key) }
   let(:instance_without_cache) { dummy_collection_class.new([record], dummy_model) }
 
   before do
     allow(Redis::Namespace).to receive(:new).and_return(redis_namespace)
-  end
-
-  after do
-    redis_namespace.redis.flushdb
   end
 
   describe '.redis_namespace' do

--- a/spec/lib/vets/collections/cacheable_spec.rb
+++ b/spec/lib/vets/collections/cacheable_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'vets/model'
+require 'vets/collections/cacheable'
+
+RSpec.describe Vets::Collections::Cacheable do
+  let(:dummy_model) do
+    Class.new do
+      include Comparable
+
+      attr_reader :id
+
+      def initialize(id:)
+        @id = id
+      end
+
+      def <=>(other)
+        id <=> other.id
+      end
+    end
+  end
+
+  let(:dummy_collection_class) do
+    Class.new do
+      include Vets::Collections::Cacheable
+
+      attr_reader :records, :metadata, :cache_key
+
+      def initialize(_klass, records:, metadata: {}, cache_key: nil)
+        @records = records
+        @metadata = metadata
+        @cache_key = cache_key
+      end
+
+      def serialize
+        Oj.dump({ records: @records.map { |r| { id: r.id } }, metadata: @metadata })
+      end
+    end
+  end
+
+  let(:record) { dummy_model.new(id: 1) }
+  let(:cache_key) { 'test_key' }
+  let(:redis_namespace) do
+    Redis::Namespace.new("common_collection_#{SecureRandom.hex(4)}", redis: Redis.new)
+  end
+  let(:instance_with_cache) { dummy_collection_class.new(dummy_model, records: [record], cache_key: cache_key) }
+  let(:instance_without_cache) { dummy_collection_class.new(dummy_model, records: [record]) }
+
+  before do
+    allow(Redis::Namespace).to receive(:new).and_return(redis_namespace)
+  end
+
+  after do
+    redis_namespace.redis.flushdb
+  end
+
+  describe '.redis_namespace' do
+    it 'has the correct namespace' do
+      expect(dummy_collection_class.redis_namespace.namespace).to include("common_collection_")
+    end
+  end
+
+  describe '.fetch' do
+    it 'builds and caches when key is missing' do
+      result = dummy_collection_class.fetch(dummy_model, cache_key: cache_key) do
+        { records: [record], metadata: {} }
+      end
+
+      expect(result.records.first.id).to eq(1)
+      expect(result.metadata).to eq({})
+    end
+
+    it 'raises ArgumentError without a block' do
+      expect {
+        dummy_collection_class.fetch(dummy_model, cache_key: cache_key)
+      }.to raise_error(ArgumentError, 'No block given')
+    end
+  end
+
+  describe '.cache' do
+    it 'writes data to redis and sets TTL' do
+      dummy_collection_class.cache('{"foo":"bar"}', cache_key, 60)
+      expect(redis_namespace.get(cache_key)).to eq('{"foo":"bar"}')
+      expect(redis_namespace.ttl(cache_key)).to be <= 60
+    end
+  end
+
+  describe '.bust' do
+    it 'deletes the key from redis' do
+      redis_namespace.set(cache_key, '{"foo":"bar"}')
+      expect(redis_namespace.get(cache_key)).to eq('{"foo":"bar"}')
+
+      dummy_collection_class.bust(cache_key)
+      expect(redis_namespace.get(cache_key)).to be_nil
+    end
+
+    it 'handles array of keys' do
+      keys = [cache_key, "#{cache_key}_2"]
+      keys.each { |k| redis_namespace.set(k, '{"foo":"bar"}') }
+
+      dummy_collection_class.bust(keys)
+      keys.each { |k| expect(redis_namespace.get(k)).to be_nil }
+    end
+  end
+
+  describe '#redis_namespace' do
+    it 'returns the same Redis::Namespace as the class method' do
+      expect(instance_with_cache.redis_namespace).to eq(dummy_collection_class.redis_namespace)
+    end
+  end
+
+  describe '#ttl' do
+    it 'returns ttl if cached' do
+      json_data = '{"foo":"bar"}'
+      dummy_collection_class.cache(json_data, cache_key, 1234)
+
+      expect(instance_with_cache.ttl).to eq(1234)
+    end
+
+    it 'returns nil if not cached' do
+      expect(instance_without_cache.ttl).to be_nil
+    end
+  end
+
+  describe '#bust' do
+    context 'when cached' do
+      before do
+        dummy_collection_class.cache('{"foo":"bar"}', cache_key, 60)
+      end
+
+      it 'removes the cache' do
+        expect(redis_namespace.get(cache_key)).to eq('{"foo":"bar"}')
+        instance_with_cache.bust
+        expect(redis_namespace.get(cache_key)).to be_nil
+      end
+    end
+
+    context 'when not cached' do
+      it 'does not call the Redis cache' do
+        expect(redis_namespace).not_to receive(:get)
+        instance_without_cache.bust
+      end
+    end
+  end
+
+  describe '#cached?' do
+    it 'returns true when cache_key is present' do
+      expect(instance_with_cache.cached?).to eq(true)
+    end
+
+    it 'returns false when cache_key is nil' do
+      expect(instance_without_cache.cached?).to eq(false)
+    end
+  end
+end

--- a/spec/lib/vets/collections/cacheable_spec.rb
+++ b/spec/lib/vets/collections/cacheable_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Vets::Collections::Cacheable do
       def initialize(records, _klass, metadata: {}, errors: {}, cache_key: nil)
         @records = records
         @metadata = metadata
+        @errors = errors
         @cache_key = cache_key
       end
 
@@ -44,7 +45,7 @@ RSpec.describe Vets::Collections::Cacheable do
   let(:redis_namespace) do
     Redis::Namespace.new("common_collection_#{SecureRandom.hex(4)}", redis: $redis)
   end
-  let(:instance_with_cache) { dummy_collection_class.new([record], dummy_model, cache_key: cache_key) }
+  let(:instance_with_cache) { dummy_collection_class.new([record], dummy_model, cache_key:) }
   let(:instance_without_cache) { dummy_collection_class.new([record], dummy_model) }
 
   before do
@@ -53,13 +54,13 @@ RSpec.describe Vets::Collections::Cacheable do
 
   describe '.redis_namespace' do
     it 'has the correct namespace' do
-      expect(dummy_collection_class.redis_namespace.namespace).to include("common_collection_")
+      expect(dummy_collection_class.redis_namespace.namespace).to include('common_collection_')
     end
   end
 
   describe '.fetch' do
     it 'builds and caches when key is missing' do
-      result = dummy_collection_class.fetch(dummy_model, cache_key: cache_key) do
+      result = dummy_collection_class.fetch(dummy_model, cache_key:) do
         { data: [record], metadata: {} }
       end
 
@@ -68,9 +69,9 @@ RSpec.describe Vets::Collections::Cacheable do
     end
 
     it 'raises ArgumentError without a block' do
-      expect {
-        dummy_collection_class.fetch(dummy_model, cache_key: cache_key)
-      }.to raise_error(ArgumentError, 'No block given')
+      expect do
+        dummy_collection_class.fetch(dummy_model, cache_key:)
+      end.to raise_error(ArgumentError, 'No block given')
     end
   end
 
@@ -142,11 +143,11 @@ RSpec.describe Vets::Collections::Cacheable do
 
   describe '#cached?' do
     it 'returns true when cache_key is present' do
-      expect(instance_with_cache.cached?).to eq(true)
+      expect(instance_with_cache.cached?).to be(true)
     end
 
     it 'returns false when cache_key is nil' do
-      expect(instance_without_cache.cached?).to eq(false)
+      expect(instance_without_cache.cached?).to be(false)
     end
   end
 end

--- a/spec/lib/vets/collections/finder_spec.rb
+++ b/spec/lib/vets/collections/finder_spec.rb
@@ -14,9 +14,8 @@ RSpec.describe Vets::Collections::Finder do
 
       set_pagination per_page: 21, max_per_page: 41
 
-      # Simulating filterable attributes for this dummy model
       def self.filterable_attributes
-        { name: %w[match eq], age: %w[eq lteq gteq] }
+        { name: %w[match eq], age: %w[eq lteq gteq] }.with_indifferent_access
       end
     end
   end


### PR DESCRIPTION
## Summary

- Add Caching functionality to `Vets::Collection` via Cacheable concern
- Mimics `Common::Collection`
- There are differences between `Vets::Collection` and `Common::Collection`. Most are related to method naming. 
- Some alias are added to provided a better bridge between the two
- errors were added to `Vets::Collection`
- Vets::Collection _**does work**_ with Common::Models 
- removed .from_hashes because that's covered by the init method

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/102951

## Testing done

- [x] Manual Testing with module
- [x] Manual Testing with Common::Models
- [x] New spec added for cacheable concern

## Acceptance criteria

- [x]  Caching functional is identical to Common::Collection