### PR TITLE
[10-10CG] Remove clear_cache flag since new gem does not use it

### DIFF
--- a/app/models/saved_claim.rb
+++ b/app/models/saved_claim.rb
@@ -86,16 +86,14 @@ class SavedClaim < ApplicationRecord
     return unless form_is_string
 
     schema = VetsJsonSchema::SCHEMAS[self.class::FORM]
-    clear_cache = false
 
     schema_errors = validate_schema(schema)
     unless schema_errors.empty?
-      Rails.logger.error('SavedClaim schema failed validation! Attempting to clear cache.',
+      Rails.logger.error('SavedClaim schema failed validation.',
                          { form_id:, errors: schema_errors })
-      clear_cache = true
     end
 
-    validation_errors = validate_form(schema, clear_cache)
+    validation_errors = validate_form(schema)
     validation_errors.each do |e|
       errors.add(e[:fragment], e[:message])
       e[:errors]&.flatten(2)&.each { |nested| errors.add(nested[:fragment], nested[:message]) if nested.is_a? Hash }
@@ -165,7 +163,7 @@ class SavedClaim < ApplicationRecord
     reformatted_schemer_errors(errors)
   end
 
-  def validate_form(schema, _clear_cache)
+  def validate_form(schema)
     errors = JSONSchemer.schema(schema).validate(parsed_form).to_a
     return [] if errors.empty?
 

--- a/spec/models/saved_claim_spec.rb
+++ b/spec/models/saved_claim_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe TestSavedClaim, type: :model do # rubocop:disable RSpec/SpecFileP
 
         it 'logs schema failed error' do
           expect(Rails.logger).to receive(:error)
-            .with('SavedClaim schema failed validation! Attempting to clear cache.', { errors: schema_errors,
-                                                                                       form_id: saved_claim.form_id })
+            .with('SavedClaim schema failed validation.', { errors: schema_errors,
+                                                            form_id: saved_claim.form_id })
 
           expect(saved_claim.validate).to be(true)
         end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Cleanup from previous PRs to add new gem for validating json schemas for `SavedClaim`. We previously were passing a `clear_cache` flag to validate method for the old gem, and we no longer need to set it since we are not doing anything with the value in the new gem.
- 1010 Health Apps

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/109094

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
