### PR TITLE
Kafka - don't redact icn on staging and rescue all icn lookup errors

### DIFF
--- a/app/models/health_care_application.rb
+++ b/app/models/health_care_application.rb
@@ -227,7 +227,7 @@ class HealthCareApplication < ApplicationRecord
 
     begin
       user_icn = user&.icn || self.class.user_icn(self.class.user_attributes(parsed_form))
-    rescue Common::Exceptions::ValidationErrors
+    rescue
       # if certain user attributes are missing, we can't get an ICN
       user_icn = nil
     end

--- a/lib/kafka/concerns/kafka.rb
+++ b/lib/kafka/concerns/kafka.rb
@@ -36,7 +36,7 @@ module Kafka
   # @param hash [Hash] Hash to be searched
   # @return [Hash] Redacted Hash
   def self.redact_icn(hash)
-    return hash unless hash.is_a?(Hash)
+    return hash unless Rails.env.production? || hash.is_a?(Hash)
 
     stack = [hash]
 

--- a/lib/kafka/concerns/kafka.rb
+++ b/lib/kafka/concerns/kafka.rb
@@ -36,7 +36,7 @@ module Kafka
   # @param hash [Hash] Hash to be searched
   # @return [Hash] Redacted Hash
   def self.redact_icn(hash)
-    return hash unless Rails.env.production? || hash.is_a?(Hash)
+    return hash unless Settings.vsp_environment == 'production' && hash.is_a?(Hash)
 
     stack = [hash]
 

--- a/spec/lib/kafka/concerns/kafka_spec.rb
+++ b/spec/lib/kafka/concerns/kafka_spec.rb
@@ -24,7 +24,9 @@ RSpec.describe Kafka do
       let(:expected) { { 'icn' => '[REDACTED]', 'name' => 'test' } }
 
       it 'redacts the ICN value' do
-        expect(Kafka.redact_icn(input)).to eq(expected)
+        with_settings(Settings, vsp_environment: 'production') do
+          expect(Kafka.redact_icn(input)).to eq(expected)
+        end
       end
     end
 
@@ -51,7 +53,9 @@ RSpec.describe Kafka do
       end
 
       it 'redacts the nested ICN value' do
-        expect(Kafka.redact_icn(input)).to eq(expected)
+        with_settings(Settings, vsp_environment: 'production') do
+          expect(Kafka.redact_icn(input)).to eq(expected)
+        end
       end
     end
 
@@ -74,7 +78,9 @@ RSpec.describe Kafka do
       end
 
       it 'redacts ICN values in the array' do
-        expect(Kafka.redact_icn(input)).to eq(expected)
+        with_settings(Settings, vsp_environment: 'production') do
+          expect(Kafka.redact_icn(input)).to eq(expected)
+        end
       end
     end
 
@@ -82,7 +88,9 @@ RSpec.describe Kafka do
       let(:input) { { 'name' => 'test', 'data' => { 'value' => 123 } } }
 
       it 'returns the hash unchanged' do
-        expect(Kafka.redact_icn(input)).to eq(input)
+        with_settings(Settings, vsp_environment: 'production') do
+          expect(Kafka.redact_icn(input)).to eq(input)
+        end
       end
     end
 
@@ -90,7 +98,19 @@ RSpec.describe Kafka do
       let(:input) { 'not a hash' }
 
       it 'returns the input unchanged' do
-        expect(Kafka.redact_icn(input)).to eq(input)
+        with_settings(Settings, vsp_environment: 'production') do
+          expect(Kafka.redact_icn(input)).to eq(input)
+        end
+      end
+    end
+
+    context 'in a non-production vsp environment' do
+      let(:input) { { 'icn' => '12345', 'name' => 'test' } }
+
+      it 'returns the input unchanged' do
+        with_settings(Settings, vsp_environment: 'staging') do
+          expect(Kafka.redact_icn(input)).to eq(input)
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
Some clean up of the kafka code. Removes redaction of icn on non prod env and rescue all icn lookup errors not just validation errors

https://github.com/orgs/department-of-veterans-affairs/projects/1509/views/1?pane=issue&itemId=108934925&issue=department-of-veterans-affairs%7CVES%7C4827

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
