### PR TITLE
API-46261 Add one-off job to report bugged POA records

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/one_off/poa_v1_bad_box20_render_report_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/one_off/poa_v1_bad_box20_render_report_job.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module ClaimsApi
+  module OneOff
+    class PoaV1BadBox20RenderReportJob < ClaimsApi::ServiceBase
+      sidekiq_options expires_in: 1.hour, retry: true, unique_until: :success
+      LOG_TAG = 'claims_api_poa_box20_report_job'
+
+      # rubocop:disable Metrics/MethodLength
+      def perform(consumer_id, emails = [])
+        if consumer_id.blank?
+          ClaimsApi::Logger.log LOG_TAG, level: :warn, detail: 'Invlaid CID.'
+          slack_alert_on_failure LOG_TAG, 'Invalid CID'
+          return
+        end
+        if emails.blank? || !emails.all? { |e| e.downcase =~ /@va\.gov$/ }
+          ClaimsApi::Logger.log LOG_TAG, level: :warn, detail: 'Invalid email address list. All emails must be @va.gov'
+          slack_alert_on_failure LOG_TAG, 'Invalid email address list.'
+          return
+        end
+        ClaimsApi::Logger.log(LOG_TAG, detail: 'Started processing')
+        date_range = Date.parse('2025-01-07').beginning_of_day...Date.parse('2025-04-03').end_of_day
+        poas = ClaimsApi::PowerOfAttorney.where cid: consumer_id, created_at: date_range
+
+        memo = +'poa_id,eauth_pnid,created_date'
+        num_records = 0
+
+        poas.find_each(batch_size: 75) do |poa|
+          next unless poa.form_data['recordConsent'] && poa.form_data['consentLimits'].blank?
+
+          memo << "\n<br>"
+          memo << [poa.id, poa.auth_headers['va_eauth_pnid'], poa.created_at.iso8601].join(',')
+          num_records += 1
+        end
+
+        if num_records.zero?
+          ClaimsApi::Logger.log LOG_TAG, level: :warn, detail: 'No records found.'
+          slack_alert_on_failure LOG_TAG, 'No records found.'
+          return
+        end
+
+        ClaimsApi::Logger.log LOG_TAG, detail: "Found #{num_records} record(s)"
+        ClaimsApi::Logger.log LOG_TAG, detail: 'Sending email'
+        # rubocop:disable Rails/I18nLocaleTexts
+        ApplicationMailer.new.mail(to: emails, subject: 'POA v1 Bad Box20 PDF Render Report', content_type: 'text/html',
+                                   body: memo).deliver_now!
+        # rubocop:enable Rails/I18nLocaleTexts
+        ClaimsApi::Logger.log LOG_TAG, detail: 'Email sent. Job complete.'
+      rescue => e
+        # Only alert on the class name since an email exception may output the body, which would have PII
+        ClaimsApi::Logger.log LOG_TAG, detail: 'Exception thrown.', level: :error, error: e.class.name
+        slack_alert_on_failure LOG_TAG, "Exception thrown: #{e.class}"
+        raise e
+      end
+      # rubocop:enable Metrics/MethodLength
+    end
+  end
+end

--- a/modules/claims_api/spec/factories/claims_api_base_factory.rb
+++ b/modules/claims_api/spec/factories/claims_api_base_factory.rb
@@ -40,6 +40,19 @@ FactoryBot.define do
     }
   end
 
+  trait :with_fuzzed_headers do
+    auth_headers do
+      # NOTE: Some attributes have been removed since they are redundant or never proved useful enough to generate
+      ssn = Faker::IdNumber.ssn_valid.tr('-', '')
+      { va_eauth_firstName: Faker::Name.first_name,
+        va_eauth_lastName: Faker::Name.last_name,
+        va_eauth_birthdate: Faker::Date.birthday(min_age: 18).iso8601,
+        va_eauth_birlsfilenumber: Faker::Number.number(digits: 10).to_s,
+        va_eauth_pid: ssn,
+        va_eauth_pnid: ssn }
+    end
+  end
+
   trait :errored do
     status { 'errored' }
   end

--- a/modules/claims_api/spec/factories/power_of_attorney.rb
+++ b/modules/claims_api/spec/factories/power_of_attorney.rb
@@ -18,6 +18,42 @@ FactoryBot.define do
     vbms_error_message { 'A VBMS error has occurred' }
   end
 
+  trait :fuzzed_consent_data do
+    form_data do
+      path = '/modules/claims_api/spec/fixtures/form_2122_json_api.json'.split('/')
+      json = JSON.parse(File.read(Rails.root.join(*path).to_s))
+      attrs = json.dig(*%w[data attributes])
+      attrs['recordConsent'] = [true, false].sample
+      attrs['consentLimits'] = [[
+        'DRUG ABUSE',
+        'ALCOHOLISM',
+        'HIV',
+        'SICKLE CELL',
+        nil
+      ].sample]
+      attrs.delete(%w[recordConsent consentLimits].sample) if [false, false, false, true].sample
+      attrs
+    end
+  end
+
+  trait :with_consent_limit do
+    after(:build) do |poa|
+      poa.form_data.deep_merge!(
+        'recordConsent' => true,
+        'consentLimits' => ['SICKLE CELL']
+      )
+    end
+  end
+
+  trait :with_blank_consent_limit do
+    after(:build) do |poa|
+      poa.form_data.deep_merge!(
+        'recordConsent' => true,
+        'consentLimits' => []
+      )
+    end
+  end
+
   factory :power_of_attorney_with_doc, class: 'ClaimsApi::PowerOfAttorney',
                                        parent: :power_of_attorney do
     after(:build) do |power_of_attorney|

--- a/modules/claims_api/spec/sidekiq/one_off/poa_v1_bad_box20_render_report_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/one_off/poa_v1_bad_box20_render_report_job_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClaimsApi::OneOff::PoaV1BadBox20RenderReportJob, type: :job do
+  subject { described_class.new }
+
+  let(:log_tag) { described_class::LOG_TAG }
+  let(:consumer_id) { Faker::Alphanumeric.alphanumeric(number: 10) }
+
+  describe '#perform' do
+    before do
+      Timecop.freeze('Jan 10, 2025') do
+        # Skipped by job - Has no consent limit fields in form_data
+        create_list(:power_of_attorney, 2, cid: consumer_id)
+        # Skipped by job - Consent limit true & a limitation is chosen
+        create_list(:power_of_attorney, 3, :with_fuzzed_headers, :with_consent_limit, cid: consumer_id)
+        # Reported by job - consent limit true but no chosen limitations
+        create_list(:power_of_attorney, 4, :with_fuzzed_headers, :with_blank_consent_limit, cid: consumer_id)
+      end
+      # Skipped by job - Would apply, but falls outside date range of bugged PDF generation
+      create_list(:power_of_attorney, 5, :with_fuzzed_headers, :with_blank_consent_limit, cid: consumer_id)
+    end
+
+    it 'logs progress' do
+      allow_any_instance_of(ApplicationMailer).to receive(:mail).and_return(
+        double.tap do |mailer|
+          allow(mailer).to receive(:deliver_now!).once
+        end
+      )
+      expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Started processing')
+      expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Found 4 record(s)')
+      expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Sending email')
+      expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Email sent. Job complete.')
+      subject.perform(consumer_id, %w[example@va.gov])
+    end
+
+    context 'Non-retrying failures' do
+      it 'Alerts when Consumer ID is blank' do
+        expect(ClaimsApi::Logger).to receive(:log).once
+        expect_any_instance_of(SlackNotify::Client).to receive(:notify)
+        subject.perform('', %w[example@va.gov])
+      end
+
+      it 'Alerts when no emails are provided' do
+        expect(ClaimsApi::Logger).to receive(:log).once
+        expect_any_instance_of(SlackNotify::Client).to receive(:notify).once
+        subject.perform(consumer_id, %w[])
+      end
+
+      it 'Alerts when non-VA email is provided' do
+        expect(ClaimsApi::Logger).to receive(:log).once
+        expect_any_instance_of(SlackNotify::Client).to receive(:notify).once
+        subject.perform(consumer_id, %w[valid@va.gov invalid@example.com])
+      end
+    end
+
+    context 'Exception thrown' do
+      it 'Alerts & re-raises the exception class' do
+        error = StandardError.new('Some error')
+        allow_any_instance_of(ApplicationMailer).to receive(:mail).and_raise(error)
+        expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Started processing')
+        expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Found 4 record(s)')
+        expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Sending email')
+        expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Exception thrown.',
+                                                                 level: :error,
+                                                                 error: error.class.name)
+        expect_any_instance_of(SlackNotify::Client).to receive(:notify).once
+        expect do
+          subject.perform consumer_id, %w[example@va.gov]
+        end.to raise_error(error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Will be manually run as a one-off job to report on the records that were generated incorrectly thanks to a 21-22 rendering bug that existed at the time.

## Related issue(s)

- [API-46261](https://jira.devops.va.gov/browse/API-46261)
- [Discussion w/ Platform](https://dsva.slack.com/archives/CBU0KDSB1/p1746123587754949) on best approach to run this report

## Testing done

- [x] *New code is covered by unit tests*
- Will roll out onto staging to run there as a test, then when confirmed will run on production.

## What areas of the site does it impact?
* None - this is a backround job that builds an email report

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
