### PR TITLE
BE | Ask VA API: Add ICN to Correspondences Creator and Retriever payloads; loosen pro…

### DIFF
--- a/modules/ask_va_api/app/controllers/ask_va_api/v0/inquiries_controller.rb
+++ b/modules/ask_va_api/app/controllers/ask_va_api/v0/inquiries_controller.rb
@@ -13,10 +13,6 @@ module AskVAApi
       end
 
       def show
-        if Settings.vsp_environment == 'production'
-          render json: { error: 'This endpoint is not available in production.' }, status: :forbidden and return
-        end
-
         inq = retriever.fetch_by_id(id: params[:id])
         render json: Inquiries::Serializer.new(inq).serializable_hash, status: :ok
       end
@@ -30,10 +26,6 @@ module AskVAApi
       end
 
       def download_attachment
-        if Settings.vsp_environment == 'production'
-          render json: { error: 'This endpoint is not available in production.' }, status: :forbidden and return
-        end
-
         entity_class = Attachments::Entity
         att = Attachments::Retriever.new(
           icn: current_user.icn,
@@ -61,7 +53,13 @@ module AskVAApi
       end
 
       def create_reply
-        response = Correspondences::Creator.new(params: reply_params, inquiry_id: params[:id], service: nil).call
+        response = Correspondences::Creator.new(
+          icn: current_user&.icn,
+          params: reply_params,
+          inquiry_id: params[:id],
+          service: nil
+        ).call
+
         render json: response.to_json, status: :ok
       end
 

--- a/modules/ask_va_api/app/lib/ask_va_api/correspondences/creator.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/correspondences/creator.rb
@@ -5,16 +5,18 @@ module AskVAApi
     class CorrespondencesCreatorError < StandardError; end
 
     class Creator
-      attr_reader :params, :inquiry_id, :service
+      attr_reader :params, :inquiry_id, :service, :icn
 
-      def initialize(params:, inquiry_id:, service:)
+      def initialize(icn:, params:, inquiry_id:, service:)
         @params = params
+        @icn = icn
         @inquiry_id = inquiry_id
         @service = service || default_service
       end
 
       def call
         payload = {
+          icn:,
           Reply: params[:reply],
           ListOfAttachments: list_of_attachments
         }

--- a/modules/ask_va_api/app/lib/ask_va_api/correspondences/retriever.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/correspondences/retriever.rb
@@ -3,12 +3,13 @@
 module AskVAApi
   module Correspondences
     class Retriever
-      attr_reader :inquiry_id, :entity_class, :user_mock_data
+      attr_reader :inquiry_id, :entity_class, :user_mock_data, :icn
 
-      def initialize(inquiry_id:, user_mock_data:, entity_class:)
+      def initialize(icn:, inquiry_id:, user_mock_data:, entity_class:)
         @user_mock_data = user_mock_data
         @entity_class = entity_class
         @inquiry_id = inquiry_id
+        @icn = icn
       end
 
       def call
@@ -32,7 +33,7 @@ module AskVAApi
         else
           endpoint = "inquiry/#{inquiry_id}/replies"
 
-          response = Crm::Service.new(icn: nil).call(endpoint:)
+          response = Crm::Service.new(icn:).call(endpoint:)
           handle_response_data(response)
         end
       end

--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/retriever.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/retriever.rb
@@ -7,7 +7,7 @@ module AskVAApi
     class Retriever < BaseRetriever
       attr_reader :icn
 
-      def initialize(icn: nil, **args)
+      def initialize(icn:, **args)
         super(**args)
         @icn = icn
       end
@@ -31,6 +31,7 @@ module AskVAApi
       # Fetch correspondences related to the inquiry
       def fetch_correspondences(inquiry_id:)
         correspondences = Correspondences::Retriever.new(
+          icn:,
           inquiry_id:,
           user_mock_data:,
           entity_class: AskVAApi::Correspondences::Entity

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/correspondences/creator_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/correspondences/creator_spec.rb
@@ -5,9 +5,10 @@ require 'rails_helper'
 module AskVAApi
   module Correspondences
     RSpec.describe Creator do
-      subject(:creator) { described_class.new(params:, inquiry_id: '123', service: nil) }
+      subject(:creator) { described_class.new(icn:, params:, inquiry_id: '123', service: nil) }
 
       let(:params) { { reply: 'this is a corespondence message', files: [{ file_name: nil, file_content: nil }] } }
+      let(:icn) { '123' }
 
       describe '#call' do
         context 'when successful' do

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/correspondences/retriever_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/correspondences/retriever_spec.rb
@@ -4,11 +4,12 @@ require 'rails_helper'
 
 RSpec.describe AskVAApi::Correspondences::Retriever do
   subject(:retriever) do
-    described_class.new(inquiry_id:, user_mock_data:, entity_class: AskVAApi::Correspondences::Entity)
+    described_class.new(icn:, inquiry_id:, user_mock_data:, entity_class: AskVAApi::Correspondences::Entity)
   end
 
   let(:service) { instance_double(Crm::Service) }
   let(:inquiry_id) { 'A-1' }
+  let(:icn) { '123' }
   let(:error_message) { 'Some error occurred' }
   let(:user_mock_data) { false }
 

--- a/modules/ask_va_api/spec/requests/ask_va_api/v0/inquiries_spec.rb
+++ b/modules/ask_va_api/spec/requests/ask_va_api/v0/inquiries_spec.rb
@@ -632,7 +632,11 @@ RSpec.describe 'AskVAApi::V0::Inquiries', type: :request do
           sign_in(authorized_user)
           allow_any_instance_of(Crm::Service).to receive(:call)
             .with(endpoint:, method: :put,
-                  payload: { Reply: 'this is my reply', ListOfAttachments: nil }).and_return(failure)
+                  payload: {
+                    icn: authorized_user.icn,
+                    Reply: 'this is my reply',
+                    ListOfAttachments: nil
+                  }).and_return(failure)
           post '/ask_va_api/v0/inquiries/123/reply/new', params: payload
         end
 


### PR DESCRIPTION
## Summary

This PR strengthens the security and integrity of correspondence operations by ensuring the authenticated user's ICN is included in both creation and retrieval requests to CRM. Specifically:

- **InquiriesController**:
  - Updated `create_reply` to include `current_user.icn` when creating correspondences.
  - Removed the production lock from the `show` and `download_attachment` actions to allow functionality across all environments.

- **Correspondences::Creator**:
  - Injected `icn` into the payload sent to CRM to ensure that correspondences are created for the correct user ICN and inquiry number.

- **Correspondences::Retriever**:
  - Added `icn` to CRM service calls so replies are validated against the signed-in user's ICN.

- **Inquiries::Retriever**:
  - Updated `fetch_correspondences` to include ICN, aligning with CRM requirements for secure retrieval.

This ensures CRM can cross-check ICNs for both creation and retrieval, improving security and preventing data leaks across users.

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
