### PR TITLE
Adding grant_type to parameter allowlist

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -29,6 +29,7 @@ ALLOWLIST = %w[
   reply_id
   ids
   code
+  grant_type
   endpoint_sid
   message_id
   os_name


### PR DESCRIPTION
## Summary

- This PR adds `grant_type` to parameter allowlist, allowing us to group logs by this non-sensitive parameter value