### PR TITLE
105776: Add new platform monitoring logic

### DIFF
--- a/lib/logging/base_monitor.rb
+++ b/lib/logging/base_monitor.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'logging/controller/monitor'
+require 'logging/benefits_intake/monitor'
+
+module Logging
+  class BaseMonitor < ::ZeroSilentFailures::Monitor
+    include Logging::Controller::Monitor
+    include Logging::BenefitsIntake::Monitor
+
+    private
+
+    def message_prefix
+      "#{name} #{form_id}"
+    end
+
+    # Abstract methods
+    def service_name
+      raise NotImplementedError, 'Subclasses must implement service_name'
+    end
+
+    def claim_stats_key
+      raise NotImplementedError, 'Subclasses must implement claim_stats_key'
+    end
+
+    def submission_stats_key
+      raise NotImplementedError, 'Subclasses must implement submission_stats_key'
+    end
+
+    def name
+      raise NotImplementedError, 'Subclasses must implement name'
+    end
+
+    def form_id
+      raise NotImplementedError, 'Subclasses must implement form_id'
+    end
+
+    # Default implementation for sending emails
+    # Subclasses can override this method to provide custom email functionality
+    #
+    # @param claim_id [Integer] The ID of the claim
+    # @param level [Symbol] The severity level of the email (e.g., :error, :info)
+    def send_email(claim_id, level)
+      # Default implementation does nothing
+    end
+
+    ##
+    # Handles email notification for silent failures
+    #
+    # @param claim_id [Integer] The ID of the claim
+    def handle_silent_failure_email(claim_id)
+      send_email(claim_id, :error)
+    rescue NotImplementedError
+      Rails.logger.warn("Email notification not implemented for claim_id: #{claim_id}")
+    end
+
+    ##
+    # Submits an event for tracking with standardized payload structure
+    #
+    # @param level [String] The severity level of the event (e.g., 'error', 'info', 'warn')
+    # @param message [String] The message describing the event
+    # @param stats_key [String] The key used for stats tracking
+    # @param options [Hash] Additional options for the event
+    #   @option options [SavedClaim, Integer, nil] :claim The claim object or claim ID
+    #   @option options [String, nil] :user_account_uuid The UUID of the user account
+    #   @option options [Hash] :**additional_context Additional context for the event
+    #
+    def submit_event(level, message, stats_key, options = {})
+      claim = options[:claim]
+      user_account_uuid = options[:user_account_uuid]
+      additional_context = options.except(:claim, :user_account_uuid)
+
+      claim_id = claim.respond_to?(:id) ? claim.id : claim
+      confirmation_number = claim.respond_to?(:confirmation_number) ? claim.confirmation_number : nil
+      form_id = claim.respond_to?(:form_id) ? claim.form_id : nil
+      tags = @tags || options[:tags] || []
+
+      payload = {
+        confirmation_number:,
+        user_account_uuid:,
+        claim_id:,
+        form_id:,
+        tags:,
+        **additional_context
+      }
+
+      track_request(level, message, stats_key, call_location: caller_locations.first, **payload)
+    end
+  end
+end

--- a/lib/logging/base_monitor.rb
+++ b/lib/logging/base_monitor.rb
@@ -39,25 +39,15 @@ module Logging
     # Subclasses can override this method to provide custom email functionality
     #
     # @param claim_id [Integer] The ID of the claim
-    # @param level [Symbol] The severity level of the email (e.g., :error, :info)
-    def send_email(claim_id, level)
+    # @param email_type [symbol] The type of the email (e.g., :error, :submitted)
+    def send_email(claim_id, email_type)
       # Default implementation does nothing
-    end
-
-    ##
-    # Handles email notification for silent failures
-    #
-    # @param claim_id [Integer] The ID of the claim
-    def handle_silent_failure_email(claim_id)
-      send_email(claim_id, :error)
-    rescue NotImplementedError
-      Rails.logger.warn("Email notification not implemented for claim_id: #{claim_id}")
     end
 
     ##
     # Submits an event for tracking with standardized payload structure
     #
-    # @param level [String] The severity level of the event (e.g., 'error', 'info', 'warn')
+    # @param level [String] The severity level of the event (e.g., :error, :info, :warn)
     # @param message [String] The message describing the event
     # @param stats_key [String] The key used for stats tracking
     # @param options [Hash] Additional options for the event

--- a/lib/logging/benefits_intake/monitor.rb
+++ b/lib/logging/benefits_intake/monitor.rb
@@ -96,7 +96,7 @@ module Logging
         )
 
         if claim
-          handle_silent_failure_email(claim.id)
+          send_email(claim.id, :error)
         else
           log_silent_failure(
             { user_account_uuid:, claim_id: msg['args'].first, message: msg, tags: },

--- a/lib/logging/benefits_intake/monitor.rb
+++ b/lib/logging/benefits_intake/monitor.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'logging/controller/monitor'
+
+module Logging
+  module BenefitsIntake
+    # Monitor class for tracking claim submission events
+    module Monitor
+      # log Sidkiq job started
+      #
+      # @param claim [SavedClaim]
+      # @param lighthouse_service [BenefitsIntake::Service]
+      # @param user_account_uuid [UUID]
+      def track_submission_begun(claim, lighthouse_service, user_account_uuid)
+        submit_event(
+          :info,
+          "#{message_prefix} submission to LH begun",
+          "#{submission_stats_key}.begun",
+          claim:,
+          user_account_uuid:,
+          benefits_intake_uuid: lighthouse_service&.uuid
+        )
+      end
+
+      # log Sidkiq job Lighthouse submission attempted
+      #
+      # @param claim [SavedClaim]
+      # @param lighthouse_service [BenefitsIntake::Service]
+      # @param user_account_uuid [UUID]
+      # @param upload [Hash] lighthouse upload data
+      def track_submission_attempted(claim, lighthouse_service, user_account_uuid, upload)
+        submit_event(
+          :info,
+          "#{message_prefix} submission to LH attempted",
+          "#{submission_stats_key}.attempt",
+          claim:,
+          user_account_uuid:,
+          benefits_intake_uuid: lighthouse_service&.uuid,
+          file: upload[:file],
+          attachments: upload[:attachments]
+        )
+      end
+
+      # log Sidkiq job completed
+      #
+      # @param claim [SavedClaim]
+      # @param lighthouse_service [BenefitsIntake::Service]
+      # @param user_account_uuid [UUID]
+      #
+      def track_submission_success(claim, lighthouse_service, user_account_uuid)
+        submit_event(
+          :info,
+          "#{message_prefix} submission to LH succeeded",
+          "#{submission_stats_key}.success",
+          claim:,
+          user_account_uuid:,
+          benefits_intake_uuid: lighthouse_service&.uuid
+        )
+      end
+
+      # log Sidkiq job failed, automatic retry
+      #
+      # @param claim [SavedClaim]
+      # @param lighthouse_service [BenefitsIntake::Service]
+      # @param user_account_uuid [UUID]
+      # @param e [Error]
+      #
+      def track_submission_retry(claim, lighthouse_service, user_account_uuid, e)
+        submit_event(
+          :warn,
+          "#{message_prefix} submission to LH failed, retrying",
+          "#{submission_stats_key}.failure",
+          claim:,
+          user_account_uuid:,
+          benefits_intake_uuid: lighthouse_service&.uuid,
+          message: e&.message
+        )
+      end
+
+      ##
+      # log Sidkiq job exhaustion, complete failure after all retries
+      #
+      # @param msg [Hash] sidekiq exhaustion response
+      # @param claim [SavedClaim]
+      #
+      def track_submission_exhaustion(msg, claim = nil)
+        user_account_uuid = msg['args'].length <= 1 ? nil : msg['args'][1]
+
+        submit_event(
+          :error,
+          "#{message_prefix} submission to LH exhausted!",
+          "#{submission_stats_key}.exhausted",
+          claim: claim || msg['args'].first,
+          user_account_uuid:,
+          message: msg
+        )
+
+        if claim
+          handle_silent_failure_email(claim.id)
+        else
+          log_silent_failure(
+            { user_account_uuid:, claim_id: msg['args'].first, message: msg, tags: },
+            user_account_uuid,
+            call_location: caller_locations.second
+          )
+        end
+      end
+
+      ##
+      # Tracks the failure to send a Submission in Progress email for a claim.
+      #
+      # @param claim [SavedClaim]
+      # @param lighthouse_service [LighthouseService]
+      # @param user_account_uuid [UUID]
+      # @param email_type [String] 'submitted' or 'confirmation'
+      # @param e [Exception]
+      #
+      def track_send_email_failure(claim, lighthouse_service, user_account_uuid, email_type, e)
+        submit_event(
+          :warn,
+          "#{message_prefix} send_#{email_type}_email failed",
+          "#{submission_stats_key}.send_#{email_type}_failed",
+          claim:,
+          user_account_uuid:,
+          benefits_intake_uuid: lighthouse_service&.uuid,
+          message: e&.message
+        )
+      end
+
+      # log Sidkiq job cleanup error occurred, this can occur post success or failure
+      #
+      # @param claim [SavedClaim]
+      # @param lighthouse_service [BenefitsIntake::Service]
+      # @param user_account_uuid [UUID]
+      # @param e [Error]
+      #
+      def track_file_cleanup_error(claim, lighthouse_service, user_account_uuid, e)
+        submit_event(
+          :error,
+          "#{message_prefix} cleanup failed",
+          "#{submission_stats_key}.cleanup_failed",
+          claim:,
+          user_account_uuid:,
+          benefits_intake_uuid: lighthouse_service&.uuid,
+          error: e&.message
+        )
+      end
+    end
+  end
+end

--- a/lib/logging/controller/monitor.rb
+++ b/lib/logging/controller/monitor.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+module Logging
+  module Controller
+    # Monitor class for tracking claim controller events
+    module Monitor
+      ##
+      # log GET 404 from controller
+      # @see ClaimsController
+      #
+      # @param confirmation_number [UUID] saved_claim guid
+      # @param current_user [User]
+      # @param e [ActiveRecord::RecordNotFound]
+      #
+      def track_show404(confirmation_number, current_user, e)
+        submit_event(
+          :error,
+          "#{message_prefix} submission not found",
+          claim_stats_key,
+          user_account_uuid: current_user&.user_account_uuid,
+          confirmation_number:,
+          message: e&.message
+        )
+      end
+
+      ##
+      # log GET 500 from controller
+      # @see ClaimsController
+      #
+      # @param confirmation_number [UUID] saved_claim guid
+      # @param current_user [User]
+      # @param e [Error]
+      #
+      def track_show_error(confirmation_number, current_user, e)
+        submit_event(
+          :error,
+          "#{message_prefix} fetching submission failed",
+          claim_stats_key,
+          claim: nil,
+          user_account_uuid: current_user&.user_account_uuid,
+          confirmation_number:,
+          message: e&.message
+        )
+      end
+
+      ##
+      # log POST processing started
+      # @see ClaimsController
+      #
+      # @param claim [SavedClaim]
+      # @param current_user [User]
+      #
+      def track_create_attempt(claim, current_user)
+        submit_event(
+          :info,
+          "#{message_prefix} submission to Sidekiq begun",
+          "#{claim_stats_key}.attempt",
+          claim:,
+          user_account_uuid: current_user&.user_account_uuid
+        )
+      end
+
+      ##
+      # log POST claim save validation error
+      # @see ClaimsController
+      #
+      # @param in_progress_form [InProgressForm]
+      # @param claim [SavedClaim]
+      # @param current_user [User]
+      def track_create_validation_error(in_progress_form, claim, current_user)
+        submit_event(
+          :error,
+          "#{message_prefix} submission validation error",
+          "#{claim_stats_key}.validation_error",
+          claim:,
+          user_account_uuid: current_user&.user_account_uuid,
+          in_progress_form_id: in_progress_form&.id,
+          errors: claim&.errors&.errors
+        )
+      end
+
+      ##
+      # log POST processing failure
+      # @see ClaimsController
+      #
+      # @param in_progress_form [InProgressForm]
+      # @param claim [SavedClaim]
+      # @param current_user [User]
+      # @param e [Error]
+      #
+      def track_create_error(in_progress_form, claim, current_user, e = nil)
+        submit_event(
+          :error,
+          "#{message_prefix} submission to Sidekiq failed",
+          "#{claim_stats_key}.failure",
+          claim:,
+          user_account_uuid: current_user&.user_account_uuid,
+          in_progress_form_id: in_progress_form&.id,
+          errors: claim&.errors&.errors,
+          message: e&.message
+        )
+      end
+
+      ##
+      # log POST processing success
+      # @see ClaimsController
+      #
+      # @param in_progress_form [InProgressForm]
+      # @param claim [SavedClaim]
+      # @param current_user [User]
+      #
+      def track_create_success(in_progress_form, claim, current_user)
+        submit_event(
+          :info,
+          "#{message_prefix} submission to Sidekiq success",
+          "#{claim_stats_key}.success",
+          claim:,
+          user_account_uuid: current_user&.user_account_uuid,
+          in_progress_form_id: in_progress_form&.id
+        )
+      end
+
+      ##
+      # log process_attachments! error
+      # @see ClaimsController
+      #
+      # @param in_progress_form [InProgressForm]
+      # @param claim [SavedClaim]
+      # @param current_user [User]
+      #
+      def track_process_attachment_error(in_progress_form, claim, current_user)
+        submit_event(
+          :error,
+          "#{message_prefix} process attachment error",
+          "#{claim_stats_key}.process_attachment_error",
+          claim:,
+          user_account_uuid: current_user&.user_account_uuid,
+          in_progress_form_id: in_progress_form&.id,
+          errors: claim&.errors&.errors
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/logging/base_monitor_spec.rb
+++ b/spec/lib/logging/base_monitor_spec.rb
@@ -50,13 +50,6 @@ RSpec.describe Logging::BaseMonitor do
     end
   end
 
-  describe '#handle_silent_failure_email' do
-    it 'calls send_email with the correct arguments' do
-      expect(base_monitor).to receive(:send_email).with(123, :error)
-      base_monitor.send(:handle_silent_failure_email, 123)
-    end
-  end
-
   describe '#submit_event' do
     it 'calls track_request with the correct arguments' do
       allow(base_monitor).to receive(:track_request)

--- a/spec/lib/logging/base_monitor_spec.rb
+++ b/spec/lib/logging/base_monitor_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'logging/base_monitor'
+
+class TestMonitor < Logging::BaseMonitor
+  def service_name
+    'TestService'
+  end
+
+  def claim_stats_key
+    'test.claim.stats'
+  end
+
+  def submission_stats_key
+    'test.submission.stats'
+  end
+
+  def name
+    'TestName'
+  end
+
+  def form_id
+    '12345'
+  end
+end
+
+RSpec.describe Logging::BaseMonitor do
+  let(:base_monitor) { TestMonitor.new('test-application') }
+
+  describe 'included modules' do
+    it 'includes Logging::Controller::Monitor' do
+      expect(described_class.included_modules).to include(Logging::Controller::Monitor)
+    end
+
+    it 'includes Logging::BenefitsIntake::Monitor' do
+      expect(described_class.included_modules).to include(Logging::BenefitsIntake::Monitor)
+    end
+  end
+
+  describe '#message_prefix' do
+    it 'returns the correct message prefix' do
+      expect(base_monitor.send(:message_prefix)).to eq('TestName 12345')
+    end
+  end
+
+  describe '#send_email' do
+    it 'does not raise an error when called' do
+      expect { base_monitor.send(:send_email, 123, :error) }.not_to raise_error
+    end
+  end
+
+  describe '#handle_silent_failure_email' do
+    it 'calls send_email with the correct arguments' do
+      expect(base_monitor).to receive(:send_email).with(123, :error)
+      base_monitor.send(:handle_silent_failure_email, 123)
+    end
+  end
+
+  describe '#submit_event' do
+    it 'calls track_request with the correct arguments' do
+      allow(base_monitor).to receive(:track_request)
+      base_monitor.send(:submit_event, 'info', 'Test message', 'test.stats.key',
+                        claim: double(id: 1, confirmation_number: 'ABC123', form_id: '12345'),
+                        user_account_uuid: 'uuid-123')
+
+      expect(base_monitor).to have_received(:track_request).with(
+        'info',
+        'Test message',
+        'test.stats.key',
+        call_location: anything,
+        confirmation_number: 'ABC123',
+        user_account_uuid: 'uuid-123',
+        claim_id: 1,
+        form_id: '12345',
+        tags: anything
+      )
+    end
+  end
+end


### PR DESCRIPTION
Add monitoring modules that make it easier for form modules to set up monitoring for claims and LightHouse sidekiq jobs


## Summary

- Add controller monitor 
- Add benefits intake monitor
- Add base_monitor to include the other two and can be inherited in form modules
- Add spec

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/105776

## Testing done

- [ ] *New code is covered by unit tests*

## What areas of the site does it impact?
Not used by anything yet
- https://github.com/department-of-veterans-affairs/vets-api/pull/21848 will be the first for module to use it
