### PR TITLE
[Pensions] Moving constants into a separate file

### DIFF
--- a/modules/pensions/lib/pensions/pdf_fill/constants.rb
+++ b/modules/pensions/lib/pensions/pdf_fill/constants.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module Pensions
-  ##
-  # Constants used for PDF mapping
-  #
   module PdfFill
+    ##
+    # Constants used for PDF mapping
+    #
     module Constants
       # The Recipients Type
       RECIPIENTS = {

--- a/modules/pensions/lib/pensions/pdf_fill/constants.rb
+++ b/modules/pensions/lib/pensions/pdf_fill/constants.rb
@@ -4,41 +4,43 @@ module Pensions
   ##
   # Constants used for PDF mapping
   #
-  module Constants
-    # The Recipients Type
-    RECIPIENTS = {
-      'VETERAN' => 0,
-      'SPOUSE' => 1,
-      'DEPENDENT' => 2
-    }.freeze
+  module PdfFill
+    module Constants
+      # The Recipients Type
+      RECIPIENTS = {
+        'VETERAN' => 0,
+        'SPOUSE' => 1,
+        'DEPENDENT' => 2
+      }.freeze
 
-    # The Income Types
-    INCOME_TYPES = {
-      'SOCIAL_SECURITY' => 0,
-      'INTEREST_DIVIDEND' => 1,
-      'CIVIL_SERVICE' => 2,
-      'PENSION_RETIREMENT' => 3,
-      'OTHER' => 4
-    }.freeze
+      # The Income Types
+      INCOME_TYPES = {
+        'SOCIAL_SECURITY' => 0,
+        'INTEREST_DIVIDEND' => 1,
+        'CIVIL_SERVICE' => 2,
+        'PENSION_RETIREMENT' => 3,
+        'OTHER' => 4
+      }.freeze
 
-    # Medical Care Types
-    CARE_TYPES = {
-      'CARE_FACILITY' => 0,
-      'IN_HOME_CARE_PROVIDER' => 1
-    }.freeze
+      # Medical Care Types
+      CARE_TYPES = {
+        'CARE_FACILITY' => 0,
+        'IN_HOME_CARE_PROVIDER' => 1
+      }.freeze
 
-    # The Payment Frequency
-    PAYMENT_FREQUENCY = {
-      'ONCE_MONTH' => 0,
-      'ONCE_YEAR' => 1,
-      'ONE_TIME' => 2
-    }.freeze
+      # The Payment Frequency
+      PAYMENT_FREQUENCY = {
+        'ONCE_MONTH' => 0,
+        'ONCE_YEAR' => 1,
+        'ONE_TIME' => 2
+      }.freeze
 
-    # The reason for marital separation
-    REASONS_FOR_SEPARATION = {
-      'DEATH' => 0,
-      'DIVORCE' => 1,
-      'OTHER' => 2
-    }.freeze
+      # The reason for marital separation
+      REASONS_FOR_SEPARATION = {
+        'DEATH' => 0,
+        'DIVORCE' => 1,
+        'OTHER' => 2
+      }.freeze
+    end
   end
 end

--- a/modules/pensions/lib/pensions/pdf_fill/constants.rb
+++ b/modules/pensions/lib/pensions/pdf_fill/constants.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Pensions
+  ##
+  # Constants used for PDF mapping
+  #
+  module Constants
+    # The Recipients Type
+    RECIPIENTS = {
+      'VETERAN' => 0,
+      'SPOUSE' => 1,
+      'DEPENDENT' => 2
+    }.freeze
+
+    # The Income Types
+    INCOME_TYPES = {
+      'SOCIAL_SECURITY' => 0,
+      'INTEREST_DIVIDEND' => 1,
+      'CIVIL_SERVICE' => 2,
+      'PENSION_RETIREMENT' => 3,
+      'OTHER' => 4
+    }.freeze
+
+    # Medical Care Types
+    CARE_TYPES = {
+      'CARE_FACILITY' => 0,
+      'IN_HOME_CARE_PROVIDER' => 1
+    }.freeze
+
+    # The Payment Frequency
+    PAYMENT_FREQUENCY = {
+      'ONCE_MONTH' => 0,
+      'ONCE_YEAR' => 1,
+      'ONE_TIME' => 2
+    }.freeze
+
+    # The reason for marital separation
+    REASONS_FOR_SEPARATION = {
+      'DEATH' => 0,
+      'DIVORCE' => 1,
+      'OTHER' => 2
+    }.freeze
+  end
+end

--- a/modules/pensions/lib/pensions/pdf_fill/va21p527ez.rb
+++ b/modules/pensions/lib/pensions/pdf_fill/va21p527ez.rb
@@ -5,6 +5,8 @@ require 'pdf_fill/forms/form_base'
 require 'pdf_fill/forms/form_helper'
 require 'string_helpers'
 
+require_relative 'constants'
+
 # rubocop:disable Metrics/ClassLength
 module Pensions
   module PdfFill
@@ -22,42 +24,6 @@ module Pensions
 
       # The Index Iterator Key
       ITERATOR = ::PdfFill::HashConverter::ITERATOR
-
-      # The Recipients Type
-      RECIPIENTS = {
-        'VETERAN' => 0,
-        'SPOUSE' => 1,
-        'DEPENDENT' => 2
-      }.freeze
-
-      # The Income Types
-      INCOME_TYPES = {
-        'SOCIAL_SECURITY' => 0,
-        'INTEREST_DIVIDEND' => 1,
-        'CIVIL_SERVICE' => 2,
-        'PENSION_RETIREMENT' => 3,
-        'OTHER' => 4
-      }.freeze
-
-      # Medical Care Types
-      CARE_TYPES = {
-        'CARE_FACILITY' => 0,
-        'IN_HOME_CARE_PROVIDER' => 1
-      }.freeze
-
-      # The Payment Frequency
-      PAYMENT_FREQUENCY = {
-        'ONCE_MONTH' => 0,
-        'ONCE_YEAR' => 1,
-        'ONE_TIME' => 2
-      }.freeze
-
-      # The reason for marital separation
-      REASONS_FOR_SEPARATION = {
-        'DEATH' => 0,
-        'DIVORCE' => 1,
-        'OTHER' => 2
-      }.freeze
 
       # The PDF Keys
       KEY = {
@@ -1495,7 +1461,7 @@ module Pensions
                            'dateOfMarriage' => split_date(marriage['dateOfMarriage']),
                            'dateOfSeparation' => split_date(marriage['dateOfSeparation']),
                            'dateRangeOfMarriageOverflow' => build_date_range_string(marriage_date_range),
-                           'reasonForSeparation' => REASONS_FOR_SEPARATION[reason_for_separation],
+                           'reasonForSeparation' => Constants::REASONS_FOR_SEPARATION[reason_for_separation],
                            'reasonForSeparationOverflow' => reason_for_separation.humanize })
         end
       end
@@ -1618,9 +1584,9 @@ module Pensions
       def merge_income_sources(income_sources)
         income_sources&.map do |income_source|
           income_source_hash = {
-            'receiver' => RECIPIENTS[income_source['receiver']],
+            'receiver' => Constants::RECIPIENTS[income_source['receiver']],
             'receiverOverflow' => income_source['receiver']&.humanize,
-            'typeOfIncome' => INCOME_TYPES[income_source['typeOfIncome']],
+            'typeOfIncome' => Constants::INCOME_TYPES[income_source['typeOfIncome']],
             'typeOfIncomeOverflow' => income_source['typeOfIncome']&.humanize,
             'amount' => split_currency_amount(income_source['amount']),
             'amountOverflow' => number_to_currency(income_source['amount'])
@@ -1651,9 +1617,9 @@ module Pensions
       # Expand a care expense data hash.
       def care_expense_to_hash(care_expense)
         {
-          'recipients' => RECIPIENTS[care_expense['recipients']],
+          'recipients' => Constants::RECIPIENTS[care_expense['recipients']],
           'recipientsOverflow' => care_expense['recipients']&.humanize,
-          'careType' => CARE_TYPES[care_expense['careType']],
+          'careType' => Constants::CARE_TYPES[care_expense['careType']],
           'careTypeOverflow' => care_expense['careType']&.humanize,
           'ratePerHour' => split_currency_amount(care_expense['ratePerHour']),
           'ratePerHourOverflow' => number_to_currency(care_expense['ratePerHour']),
@@ -1664,7 +1630,7 @@ module Pensions
           },
           'careDateRangeOverflow' => build_date_range_string(care_expense['careDateRange']),
           'noCareEndDate' => to_checkbox_on_off(care_expense['noCareEndDate']),
-          'paymentFrequency' => PAYMENT_FREQUENCY[care_expense['paymentFrequency']],
+          'paymentFrequency' => Constants::PAYMENT_FREQUENCY[care_expense['paymentFrequency']],
           'paymentFrequencyOverflow' => care_expense['paymentFrequency'],
           'paymentAmount' => split_currency_amount(care_expense['paymentAmount']),
           'paymentAmountOverflow' => number_to_currency(care_expense['paymentAmount'])
@@ -1675,11 +1641,11 @@ module Pensions
       def merge_medical_expenses(medical_expenses)
         medical_expenses&.map do |medical_expense|
           medical_expense.merge({
-                                  'recipients' => RECIPIENTS[medical_expense['recipients']],
+                                  'recipients' => Constants::RECIPIENTS[medical_expense['recipients']],
                                   'recipientsOverflow' => medical_expense['recipients']&.humanize,
                                   'paymentDate' => split_date(medical_expense['paymentDate']),
                                   'paymentDateOverflow' => to_date_string(medical_expense['paymentDate']),
-                                  'paymentFrequency' => PAYMENT_FREQUENCY[medical_expense['paymentFrequency']],
+                                  'paymentFrequency' => Constants::PAYMENT_FREQUENCY[medical_expense['paymentFrequency']],
                                   'paymentFrequencyOverflow' => medical_expense['paymentFrequency'],
                                   'paymentAmount' => split_currency_amount(medical_expense['paymentAmount']),
                                   'paymentAmountOverflow' => number_to_currency(

--- a/modules/pensions/lib/pensions/pdf_fill/va21p527ez.rb
+++ b/modules/pensions/lib/pensions/pdf_fill/va21p527ez.rb
@@ -1645,7 +1645,8 @@ module Pensions
                                   'recipientsOverflow' => medical_expense['recipients']&.humanize,
                                   'paymentDate' => split_date(medical_expense['paymentDate']),
                                   'paymentDateOverflow' => to_date_string(medical_expense['paymentDate']),
-                                  'paymentFrequency' => Constants::PAYMENT_FREQUENCY[medical_expense['paymentFrequency']],
+                                  'paymentFrequency' =>
+                                    Constants::PAYMENT_FREQUENCY[medical_expense['paymentFrequency']],
                                   'paymentFrequencyOverflow' => medical_expense['paymentFrequency'],
                                   'paymentAmount' => split_currency_amount(medical_expense['paymentAmount']),
                                   'paymentAmountOverflow' => number_to_currency(


### PR DESCRIPTION
## Summary
Moving constants defined in the `va21p527ez.rb` pdf mapping file into their own file to improve the organization of the module

- *This work is behind a feature toggle (flipper): NO*

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/109164

## Testing done
There aren't any functional changes, as long as tests continue to pass all is well

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
