### PR TITLE
Fix and expand sending Form 526 ancillary data to MAS API

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -637,6 +637,9 @@ features:
   disability_526_send_form526_submitted_email:
     actor_type: user
     description: enables sending submitted email in both primary and backup paths
+  disability_526_send_mas_all_ancillaries:
+    actor_type: user
+    description: enables sending all 526 uploads and ancillary forms to MAS's APCAS API
   disability_526_send_received_email_from_backup_path:
     actor_type: user
     description: enables received email in complete success state of backup path

--- a/lib/mail_automation/client.rb
+++ b/lib/mail_automation/client.rb
@@ -17,13 +17,11 @@ module MailAutomation
     #   claim_id: 1234
     #   file_number: 1234
     #   form526: {}
-    #   form526_uploads: []
     # })
     def initialize(params)
       @claim_id = params[:claim_id]
       @file_number = params[:file_number]
       @form526 = params[:form526]
-      @form526_uploads = params[:form526_uploads]
 
       raise ArgumentError, 'no file_number passed in for API request.' if @file_number.blank?
       raise ArgumentError, 'no claim_id passed in for API request.' if @claim_id.blank?
@@ -36,8 +34,7 @@ module MailAutomation
       params = {
         file_number: @file_number,
         claim_id: @claim_id,
-        form526: @form526['form526'],
-        form526_uploads: @form526_uploads
+        form526: @form526['form526']
       }
       if Flipper.enabled?(:disability_526_send_mas_all_ancillaries)
         params.merge!(@form526.slice(*%w[form526_uploads form4142 form0781]).symbolize_keys)

--- a/lib/mail_automation/client.rb
+++ b/lib/mail_automation/client.rb
@@ -39,6 +39,9 @@ module MailAutomation
         form526: @form526['form526'],
         form526_uploads: @form526_uploads
       }
+      if Flipper.enabled?(:disability_526_send_mas_all_ancillaries)
+        params.merge!(@form526.slice(*%w[form526_uploads form4142 form0781]).symbolize_keys)
+      end
 
       perform(:post, Settings.mail_automation.endpoint, params.to_json.to_s, headers_hash)
     end

--- a/spec/lib/mail_automation/client_spec.rb
+++ b/spec/lib/mail_automation/client_spec.rb
@@ -36,9 +36,11 @@ RSpec.describe MailAutomation::Client do
       let(:generic_response) do
         double('mail automation response', status: 200, body: { packetId: '12345' }.as_json)
       end
+      let(:flipper_enabled) { true }
 
       before do
         allow(client).to receive_messages(perform: generic_response, authenticate: bearer_token_object)
+        allow(Flipper).to receive(:enabled?).with(:disability_526_send_mas_all_ancillaries).and_return(flipper_enabled)
       end
 
       it 'sets the headers to include the bearer token' do
@@ -47,9 +49,7 @@ RSpec.describe MailAutomation::Client do
       end
 
       context 'when sending all ancillaries is turned on' do
-        before do
-          allow(Flipper).to receive(:enabled?).with(:disability_526_send_mas_all_ancillaries).and_return(true)
-        end
+        let(:flipper_enabled) { true }
 
         it 'includes forms 4142 and 0781' do
           client.initiate_apcas_processing
@@ -63,9 +63,7 @@ RSpec.describe MailAutomation::Client do
       end
 
       context 'when sending all ancillaries is turned off' do
-        before do
-          allow(Flipper).to receive(:enabled?).with(:disability_526_send_mas_all_ancillaries).and_return(false)
-        end
+        let(:flipper_enabled) { false }
 
         it 'excludes forms 4142 and 0781' do
           client.initiate_apcas_processing

--- a/spec/lib/mail_automation/client_spec.rb
+++ b/spec/lib/mail_automation/client_spec.rb
@@ -22,7 +22,15 @@ RSpec.describe MailAutomation::Client do
           email: 'test@example.com'
         },
         form0781: nil,
-        form526_uploads: []
+        form526_uploads: [
+          {
+            name: 'test_filename.pdf',
+            confirmationCode: '01234567-89ab-cdef-0123-456789abcdef',
+            attachmentId: 'L023',
+            size: 9876,
+            isEncrypted: false
+          }
+        ]
       }.as_json,
       file_number:,
       claim_id:
@@ -50,6 +58,16 @@ RSpec.describe MailAutomation::Client do
 
       context 'when sending all ancillaries is turned on' do
         let(:flipper_enabled) { true }
+
+        it 'includes form 526 uploads' do
+          client.initiate_apcas_processing
+          expect(client).to have_received(:perform) do |_method, _path, params, _headers, _options|
+            expect(JSON.parse(params)['form526_uploads'][0]).to include(
+              'name' => 'test_filename.pdf',
+              'size' => 9876
+            )
+          end
+        end
 
         it 'includes forms 4142 and 0781' do
           client.initiate_apcas_processing


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- This fixes a long-standing bug that omitted 526 uploads when notifying MAS of new 526 submissions. Motivated by this fix, we now also include 526 ancillary forms (4142 and 0781) in the MAS notification.
- I am part of the Employee Experience team working with DBEX team
- Success criteria for Flipper flag: confirmation from MAS team that they're receiving 526 uploads and ancillaries.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/abd-vro/issues/4285

## Testing done
- [x] *New code is covered by unit tests*
- Old behavior: only 526 form data was included in MAS call
- New behavior: 526 uploads, and ancillary 4142 and 0781 forms, are included in MAS call
- *If this work is behind a flipper:*
  - [x] Tests need to be written for both the flipper on and flipper off scenarios.
  - Testing plan for rolling out the feature: Work with MAS team to confirm that they're receiving all the expected data.

## What areas of the site does it impact?
* No user-facing impact

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
