### PR TITLE
restructure mobile labs and tests response format to include data object wrapper

### DIFF
--- a/modules/mobile/app/controllers/mobile/v1/labs_and_tests_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v1/labs_and_tests_controller.rb
@@ -12,7 +12,8 @@ module Mobile
         start_date = params[:startDate]
         end_date = params[:endDate]
         labs = service.get_labs(start_date:, end_date:)
-        render json: labs.map { |record| LabOrTestSerializer.serialize(record) }
+        response = { data: labs.map { |record| LabOrTestSerializer.serialize(record) } }
+        render json: response
       end
 
       private

--- a/modules/mobile/spec/requests/mobile/v1/health/labs_and_tests_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v1/health/labs_and_tests_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Mobile::V1::LabsAndTestsController', :skip_json_api_validation, 
       end
 
       it 'returns the correct lab records' do
-        json_response = JSON.parse(response.body)
+        json_response = JSON.parse(response.body)['data']
         expect(json_response.count).to eq(3)
         expect(json_response[0]).to eq(ch_response)
         expect(json_response[2]).to eq(sp_response)
@@ -63,7 +63,7 @@ RSpec.describe 'Mobile::V1::LabsAndTestsController', :skip_json_api_validation, 
       end
 
       it 'returns the correct lab records' do
-        json_response = JSON.parse(response.body)
+        json_response = JSON.parse(response.body)['data']
         expect(json_response.count).to eq(1)
         expect(json_response[0]).to eq(sp_response)
       end
@@ -84,7 +84,7 @@ RSpec.describe 'Mobile::V1::LabsAndTestsController', :skip_json_api_validation, 
       end
 
       it 'returns the correct lab records' do
-        json_response = JSON.parse(response.body)
+        json_response = JSON.parse(response.body)['data']
         expect(json_response.count).to eq(2)
         expect(json_response[0]).to eq(ch_response)
       end


### PR DESCRIPTION

## Summary
Just a small update to wrap response with `data:` per JSON:API spec


## Testing done

- [x] *New code is covered by unit tests* 
  - existing tests were updated as needed 
- *Describe what the old behavior was prior to the change*
  - response from the `GET /mobile/v1/health/labs-and-tests` endpoint would be an array of data, now the response is like: `{data:[<data objects>]`
- *Describe the steps required to verify your changes are working as expected. 

## What areas of the site does it impact?
- Mobile API endpoint for labs and tests

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature


