### PR TITLE
95922 - Removes featureBreadcrumbUrlUpdate from VAOS

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1641,10 +1641,6 @@ features:
     actor_type: user
     enable_in_development: false
     description: Toggle for the vaos module to use an alternate vaos-service route
-  va_online_scheduling_breadcrumb_url_update:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle for the breadcrumb and url changes for mhv
   va_dependents_v2:
     actor_type: user
     description: Allows us to toggle bewteen V1 and V2 of the 686c-674 forms.


### PR DESCRIPTION
> [!CAUTION]
> This should only be merged **after** the [frontend PR](https://github.com/department-of-veterans-affairs/vets-website/pull/36364) has been merged and deployed


## Summary

- *This work is behind a feature toggle (flipper): NO*
- This PR removes the `va_online_scheduling_breadcrumb_url_update` feature -- it is no longer used in VAOS.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/95922

## Testing done

- Local automated tests


## What areas of the site does it impact?
The VAOS application 

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
