### PR TITLE
remove file_obj from doc hash in doc upload job

### DIFF
--- a/app/sidekiq/lighthouse/evidence_submissions/document_upload.rb
+++ b/app/sidekiq/lighthouse/evidence_submissions/document_upload.rb
@@ -33,6 +33,8 @@ module Lighthouse
 
       def perform(user_icn, document_hash, evidence_submission_id = nil)
         @user_icn = user_icn
+        document_hash.delete('file_obj')
+        document_hash.delete(:file_obj)
         @document_hash = document_hash
 
         initialize_upload_document


### PR DESCRIPTION
## Summary

- Lighthouse::EvidenceSubmissions::DocumentUpload retry job still have bad arguments from a previous PR
- file_obj needs to be deleted for the job to run correctly because file_obj doesn't work with serialization

## Related issue(s)

[Slack thread](https://dsva.slack.com/archives/C04KHCT3ZMY/p1746713446248649?thread_ts=1746552735.655099&cid=C04KHCT3ZMY)

## Testing done

- [ ] manual testing

## Acceptance criteria

- [ ]  Job will run correctly 
