### PR TITLE
API-45423: Fix Benefits Intake API Virus Scanning

### DIFF
--- a/modules/vba_documents/lib/vba_documents/multipart_parser.rb
+++ b/modules/vba_documents/lib/vba_documents/multipart_parser.rb
@@ -66,7 +66,7 @@ module VBADocuments
     end
 
     def self.validate_virus_free(file_path)
-      temp_path = Common::FileHelpers.generate_clamav_temp_file(file_path)
+      temp_path = Common::FileHelpers.generate_clamav_temp_file(File.read(file_path))
       file_safe = Common::VirusScan.scan(temp_path)
       Common::FileHelpers.delete_file_if_exists(temp_path)
 

--- a/modules/vba_documents/spec/lib/multipart_parser_spec.rb
+++ b/modules/vba_documents/spec/lib/multipart_parser_spec.rb
@@ -119,6 +119,16 @@ RSpec.describe VBADocuments::MultipartParser do
     context 'when vba_documents_virus_scan feature flag is enabled' do
       before { expect(Flipper).to receive(:enabled?).with(:vba_documents_virus_scan).and_return(true) }
 
+      it 'creates a clamav temp file with the same contents as the original file' do
+        allow(Common::FileHelpers).to receive(:generate_clamav_temp_file)
+        allow(Common::VirusScan).to receive(:scan).and_return(true)
+
+        valid_doc = get_fixture('valid_multipart_pdf.blob')
+        described_class.parse(valid_doc.path)
+
+        expect(Common::FileHelpers).to have_received(:generate_clamav_temp_file).with(valid_doc.read)
+      end
+
       it 'successfully parses the payload when no virus is found' do
         expect(Common::VirusScan).to receive(:scan).and_return(true)
 


### PR DESCRIPTION
## Summary
- This work is behind a feature toggle (flipper): *YES*, `vba_documents_virus_scan`

This PR is a follow-up to #21818 which added virus scanning to the Lighthouse Benefits Intake API. In that PR, there was a mistake in the implementation where I passed a file path to `Common::FileHelpers.generate_clamav_temp_file` rather than the file contents. Since that method expects the file contents, it was only scanning the string it received, which was the file path.

My team (Lighthouse Banana Peels) owns the `vba_documents` module.

## Related issue(s)
- See #21818 for original ticket screenshot.

## Testing done
- [x] *New code is covered by unit tests*
- Prior to the change in this PR, the upload submission's file path was being scanned by ClamAV rather than the file contents. Now, the file contents will be scanned, as was originally intended to catch submissions with viruses.
- To release this feature, I will disable the `vba_documents_virus_scan` feature flag, merge the PR, and once the deploy completes, enable the feature for 10% of actors, and if all goes well, then 25%, and finally 100%.

## Screenshots
N/A

## What areas of the site does it impact?
This PR impacts the `vba_documents` module only.

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable) – N/A
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested for this PR.
