### PR TITLE
[DBEX] Correct event types bug in 0781 pdf fill

### DIFF
--- a/lib/pdf_fill/forms/va210781v2.rb
+++ b/lib/pdf_fill/forms/va210781v2.rb
@@ -151,10 +151,10 @@ module PdfFill
           'combat' => {
             key: 'F[0].#subform[2].Combat_Traumatic_Events[0]'
           },
-          'mst' => {
+          'nonMst' => {
             key: 'F[0].#subform[2].Personal_Traumatic_Events_Not_Involving_Military_Sexual_Trauma[0]'
           },
-          'nonMst' => {
+          'mst' => {
             key: 'F[0].#subform[2].Personal_Traumatic_Events_Involving_Military_Sexual_Trauma[0]'
           },
           'other' => {

--- a/spec/fixtures/pdf_fill/21-0781V2/kitchen_sink.json
+++ b/spec/fixtures/pdf_fill/21-0781V2/kitchen_sink.json
@@ -14,8 +14,8 @@
   "additionalInformation": "Lorem ipsum dolor sit amet",
   "eventTypes": {
     "combat": true,
-    "mst": false,
-    "nonMst": true,
+    "mst": true,
+    "nonMst": false,
     "other": false
   },
   "events": [

--- a/spec/fixtures/pdf_fill/21-0781V2/merge_fields.json
+++ b/spec/fixtures/pdf_fill/21-0781V2/merge_fields.json
@@ -27,8 +27,8 @@
   "additionalInformation": "Lorem ipsum dolor sit amet",
   "eventTypes": {
     "combat": true,
-    "mst": false,
-    "nonMst": true,
+    "mst": true,
+    "nonMst": false,
     "other": false
   },
   "events": [

--- a/spec/fixtures/pdf_fill/21-0781V2/overflow.json
+++ b/spec/fixtures/pdf_fill/21-0781V2/overflow.json
@@ -13,8 +13,8 @@
   "veteranSecondaryPhone": "3133456789",
   "eventTypes": {
     "combat": true,
-    "mst": false,
-    "nonMst": true,
+    "mst": true,
+    "nonMst": false,
     "other": false
   },
   "events": [


### PR DESCRIPTION
 ## Summary

- *This work is behind a feature toggle (flipper): YES/~NO~*
  - [disability_compensation_sync_modern0781_flow_metadata](https://api.va.gov/flipper/features/disability_compensation_sync_modern0781_flow_metadata) (**enabled**)
- *(Summarize the changes that have been made to the platform)*
  - corrects a bug discovered in manual tracking
- *(If bug, how to reproduce)*
  - checkboxes on generated PDF did not match JSON data
- *(What is the solution, why is this the solution?)*
  - correct the miskeyed assignments and update associated fixture JSON files
- *(Which team do you work for, does your team own the maintenance of this component?)*
  - Disability Benefits Crew
- *(If introducing a flipper, what is the success criteria being targeted?)* 
  - n/a

## Related issue(s)

- https://dsva.slack.com/archives/C04KW0B46N5/p1746733887788209?thread_ts=1746660502.165749&cid=C04KW0B46N5

## Testing done

- *New code is covered by unit tests*
  - JSON fixtures updated to reflect the correction and expected PDF fixture files
- *Describe what the old behavior was prior to the change*
  - data did not map to expected checkbox
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
  - compare JSON data with generated PDF
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots

Example of previous result: `"eventTypes"=>{"nonMst"=>true, "other"=>true},`

![Screenshot 2025-05-08 at 2 55 51 PM](https://github.com/user-attachments/assets/f7b2c57d-7ade-46ed-974d-fb7cadffeb5b)

Should, instead, appear as:
<img width="970" alt="Screenshot 2025-05-09 at 9 14 22 AM" src="https://github.com/user-attachments/assets/de10d7bc-6615-4a04-b9fb-be186415471c" />

## What areas of the site does it impact?

Affects field inputs on generated form 0781 PDF from JSON data

## Acceptance criteria

- [x]  I fixed|~updated~|~added~ ~unit tests and integration tests~ JSON fixtures for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

Please expedite review and approval to limit production impact.
