### PR TITLE
Vets::Collection updates to match Common::Collection

### DIFF
--- a/lib/vets/attributes.rb
+++ b/lib/vets/attributes.rb
@@ -31,17 +31,20 @@ module Vets
 
       # Lists the attributes that are filterable
       def filterable_attributes
-        attributes.select { |_, options| options[:filterable] }.keys
+        ancestors.select { |klass| klass.respond_to?(:attributes) }.flat_map do |klass|
+          klass.attributes.select { |_, options| options[:filterable] }.keys
+        end
       end
 
       # Creates a param hash for filterable
       def filterable_params
-        attributes.each_with_object({}) do |attribute, hash|
-          name = attribute.first
-          options = attribute.second
-
-          hash[name.to_s] = options[:filterable] if options[:filterable]
-        end.with_indifferent_access
+        ancestors
+          .select { |klass| klass.respond_to?(:attributes) }
+          .each_with_object({}.with_indifferent_access) do |klass, result|
+            klass.attributes.each do |name, options|
+              result[name.to_s] = options[:filterable] if options[:filterable]
+            end
+          end
       end
 
       private

--- a/lib/vets/collection.rb
+++ b/lib/vets/collection.rb
@@ -61,13 +61,13 @@ module Vets
 
     # previously sort on Common::Collection
     def order(clauses = {})
-      clauses = model_class.default_sort_criteria if clauses.to_h.empty?
+      clauses = normalize_clauses(clauses)
       validate_sort_clauses(clauses)
 
       results = @records.sort_by do |record|
         clauses.map do |attribute, direction|
-          value = record.public_send(attribute)
-          direction == :asc ? Common::Ascending.new(value) : Common::Descending.new(value)
+          value = record.public_send(attribute.to_sym)
+          direction.to_sym == :asc ? Common::Ascending.new(value) : Common::Descending.new(value)
         end
       end
 
@@ -83,7 +83,9 @@ module Vets
 
     # previously find_first_by on Common::Collection
     def find_by(conditions = {})
-      Vets::Collections::Finder.new(data: @records).first(conditions)
+      result = Vets::Collections::Finder.new(data: @records).first(conditions)
+      result.metadata = metadata if result.respond_to?(:metadata)
+      result
     end
 
     def paginate(page: nil, per_page: nil)
@@ -103,16 +105,16 @@ module Vets
     private
 
     def validate_sort_clauses(clauses)
-      raise ArgumentError, 'Order must have at least one sort clause' if clauses.empty?
+      raise Common::Exceptions::InvalidSortCriteria.new(@model_class, clauses) if clauses.empty?
 
       clauses.each do |attribute, direction|
-        raise ArgumentError, "Attribute #{attribute} must be a symbol" unless attribute.is_a?(Symbol)
-
         unless @records.first.respond_to?(attribute)
-          raise ArgumentError, "Attribute #{attribute} does not exist on the model"
+          raise Common::Exceptions::InvalidSortCriteria.new(@model_class, attribute)
         end
 
-        raise ArgumentError, "Direction #{direction} must be :asc or :desc" unless %i[asc desc].include?(direction)
+        unless %i[asc desc].include?(direction)
+          raise Common::Exceptions::InvalidSortCriteria.new(@model_class, attribute)
+        end
       end
     end
 
@@ -128,6 +130,30 @@ module Vets
 
     def max_per_page
       @model_class.try(:max_per_page) || DEFAULT_MAX_PER_PAGE
+    end
+
+    def normalize_clauses(input)
+      input = @model_class.default_sort_criteria if input.blank?
+      case input
+      when String
+        input.split(',').map(&:strip).each_with_object({}) do |clause, hash|
+          normalize_clause_string(clause, hash)
+        end
+      when Array
+        input.each_with_object({}) do |clause, hash|
+          normalize_clause_string(clause, hash)
+        end
+      when Hash
+        input.transform_keys(&:to_sym).transform_values(&:to_sym)
+      end
+    end
+
+    def normalize_clause_string(clause, hash)
+      if clause.start_with?('-')
+        hash[clause[1..].to_sym] = :desc
+      else
+        hash[clause.to_sym] = :asc
+      end
     end
   end
 end

--- a/lib/vets/collections/cacheable.rb
+++ b/lib/vets/collections/cacheable.rb
@@ -20,17 +20,25 @@ module Vets
         def fetch(klass, cache_key: nil, ttl: CACHE_DEFAULT_TTL, &block)
           raise ArgumentError, 'No block given' unless block
 
-          results = block.call
-          records = results[:data]
-          metadata = results[:metadata] || {}
-          errors = results[:errors] || {}
+          if cache_key
+            json_string = redis_namespace.get(cache_key)
+            if json_string.nil?
+              results = block.call
+              records = results[:data]
+              metadata = results[:metadata] || {}
+              errors = results[:errors] || {}
+              build_and_cache(records, klass, metadata, errors, { cache_key:, ttl: })
+            else
+              from_cache(klass, json_string, cache_key)
+            end
+          else
+            results = block.call
+            records = results[:data]
+            metadata = results[:metadata] || {}
+            errors = results[:errors] || {}
 
-          return new(records, klass, metadata:, errors:) unless cache_key
-
-          json_string = redis_namespace.get(cache_key)
-          return build_and_cache(records, klass, metadata, errors, { cache_key:, ttl: }) if json_string.nil?
-
-          from_cache(klass, json_string, cache_key)
+            new(records, klass, metadata:, errors:)
+          end
         end
 
         def cache(json_hash, cache_key, ttl)
@@ -52,8 +60,11 @@ module Vets
         end
 
         def from_cache(klass, json_string, cache_key)
-          json_hash = Oj.load(json_string)
-          new(klass, **json_hash.merge('cache_key' => cache_key).symbolize_keys)
+          json_hash = Oj.load(json_string).deep_symbolize_keys
+          data = json_hash[:data]
+          metadata = json_hash[:metadata]
+          errors = json_hash[:errors]
+          new(data, klass, metadata:, errors:, cache_key:)
         end
       end
 

--- a/lib/vets/collections/finder.rb
+++ b/lib/vets/collections/finder.rb
@@ -21,6 +21,7 @@ module Vets
         @data = data
         @model_class = data.first.class
         @filterable_attributes = @model_class.filterable_attributes
+        @filterable_params = @model_class.filterable_params
       end
 
       def all(conditions)
@@ -40,13 +41,13 @@ module Vets
         raise Common::Exceptions::InvalidFiltersSyntax, 'Filters must be present' if conditions.blank?
 
         # Validate attributes are filterable
-        failed_attributes = (conditions.keys.map(&:to_s) - @filterable_attributes.keys.map(&:to_s)).join(', ')
+        failed_attributes = (conditions.keys.map(&:to_s) - @filterable_attributes.map(&:to_s)).join(', ')
         raise Common::Exceptions::FilterNotAllowed, failed_attributes unless failed_attributes.empty?
 
         # Validate the operations are valid for each attribute
         conditions.each do |attribute, predicates|
           predicates.each_key do |operation|
-            valid_operation = @filterable_attributes[attribute].include?(operation.to_s)
+            valid_operation = @filterable_params[attribute].include?(operation.to_s)
             message = "#{operation} for #{attribute}"
             raise Common::Exceptions::FilterNotAllowed, message unless valid_operation
           end
@@ -66,7 +67,8 @@ module Vets
               if operator == 'match'
                 object_value.downcase.include?(value.downcase)
               else
-                object_value.public_send(operator, value)
+                coerced_value = coerce_type(value, object_value)
+                object_value.public_send(operator, coerced_value)
               end
             end
             results.any?
@@ -75,6 +77,21 @@ module Vets
       rescue => e
         message = "The syntax for your filters is invalid: #{e.message}"
         raise Common::Exceptions::InvalidFiltersSyntax, message
+      end
+
+      def coerce_type(value, reference)
+        return nil if value.nil?
+
+        case reference
+        when TrueClass, FalseClass
+          value.to_s == 'true'
+        when Integer
+          value.to_i
+        when Float
+          value.to_f
+        else
+          value
+        end
       end
     end
   end

--- a/lib/vets/collections/finder.rb
+++ b/lib/vets/collections/finder.rb
@@ -86,9 +86,9 @@ module Vets
         when TrueClass, FalseClass
           value.to_s == 'true'
         when Integer
-          value.to_i
+          Integer(value)
         when Float
-          value.to_f
+          Float(value)
         else
           value
         end

--- a/lib/vets/collections/pagination.rb
+++ b/lib/vets/collections/pagination.rb
@@ -17,6 +17,7 @@ module Vets
                 elsif use_will_paginate && defined?(::WillPaginate::Collection)
                   will_paginate_collection(data)
                 else
+                  validate_out_of_bounds
                   data[((page - 1) * per_page)...(page * per_page)]
                 end
       end
@@ -49,6 +50,11 @@ module Vets
 
           pager.replace records[pager.offset, pager.per_page]
         end
+      end
+
+      def validate_out_of_bounds
+        error_params = { page: @page, per_page: @per_page }
+        raise Common::Exceptions::InvalidPaginationParams, error_params if @page > total_pages
       end
     end
   end

--- a/lib/vets/type/utc_time.rb
+++ b/lib/vets/type/utc_time.rb
@@ -10,7 +10,7 @@ module Vets
       end
 
       def cast(value)
-        return nil if value.nil?
+        return nil if value.to_s.empty?
 
         Time.parse(value.to_s).utc
       rescue ArgumentError

--- a/spec/lib/vets/collection_spec.rb
+++ b/spec/lib/vets/collection_spec.rb
@@ -152,19 +152,14 @@ RSpec.describe Vets::Collection do
       expect(sorted_collection.records).to eq([record1, record2, record3, record4])
     end
 
-    it 'raises an error if an attribute is not a symbol' do
-      expect { collection.order('name' => :asc) }
-        .to raise_error(ArgumentError, 'Attribute name must be a symbol')
-    end
-
     it 'raises an error if an attribute does not exist' do
       expect { collection.order(nonexistent: :asc) }
-        .to raise_error(ArgumentError, 'Attribute nonexistent does not exist on the model')
+        .to raise_error(Common::Exceptions::InvalidSortCriteria, "Invalid sort criteria")
     end
 
     it 'raises an error if the direction is invalid' do
       expect { collection.order(name: :invalid) }
-        .to raise_error(ArgumentError, 'Direction invalid must be :asc or :desc')
+        .to raise_error(Common::Exceptions::InvalidSortCriteria, "Invalid sort criteria")
     end
 
     it 'forces null values to end of the array' do

--- a/spec/lib/vets/collection_spec.rb
+++ b/spec/lib/vets/collection_spec.rb
@@ -14,9 +14,7 @@ RSpec.describe Vets::Collection do
 
       set_pagination per_page: 21, max_per_page: 41
 
-      def <=>(other)
-        name <=> other.name
-      end
+      default_sort_by name: :asc
 
       def self.filterable_attributes
         { name: %w[match eq], age: %w[eq lteq gteq] }.with_indifferent_access
@@ -30,7 +28,7 @@ RSpec.describe Vets::Collection do
       record2 = dummy_class.new(name: 'Alice', age: 30)
 
       collection = described_class.new([record1, record2])
-      expect(collection.records).to eq([record2, record1])
+      expect(collection.records).to eq([record1, record2])
     end
 
     it 'raises an error if records are not all the same class' do
@@ -64,7 +62,7 @@ RSpec.describe Vets::Collection do
         pager.replace(records[0, 2])
       end
       collection = described_class.from_will_paginate(will_collection)
-      expect(collection.records.map(&:name)).to eq(%w[Alice Bob])
+      expect(collection.records.map(&:name)).to eq(%w[Bob Alice])
     end
 
     it 'raises an error if any element is not a hash' do
@@ -131,18 +129,23 @@ RSpec.describe Vets::Collection do
     let(:collection) { described_class.new([record4, record1, record2, record3]) }
 
     it 'returns records sorted by the specified attribute in ascending order' do
-      sorted = collection.order(name: :asc)
-      expect(sorted).to eq([record1, record2, record3, record4])
+      sorted_collection = collection.order(name: :asc)
+      expect(sorted_collection.records).to eq([record1, record2, record3, record4])
     end
 
     it 'returns records sorted by the specified attribute in descending order' do
-      sorted = collection.order(name: :desc)
-      expect(sorted).to eq([record4, record3, record2, record1])
+      sorted_collection = collection.order(name: :desc)
+      expect(sorted_collection.records).to eq([record4, record3, record2, record1])
     end
 
     it 'handles sorting by multiple attributes' do
-      sorted = collection.order(age: :asc, name: :desc)
-      expect(sorted).to eq([record4, record2, record1, record3])
+      sorted_collection = collection.order(age: :asc, name: :desc)
+      expect(sorted_collection.records).to eq([record4, record2, record1, record3])
+    end
+
+    it 'sort by default order if no clauses are provided' do
+      sorted_collection = collection.order
+      expect(sorted_collection.records).to eq([record1, record2, record3, record4])
     end
 
     it 'raises an error if an attribute is not a symbol' do
@@ -160,15 +163,10 @@ RSpec.describe Vets::Collection do
         .to raise_error(ArgumentError, 'Direction invalid must be :asc or :desc')
     end
 
-    it 'raises an error if no clauses are provided' do
-      expect { collection.order }
-        .to raise_error(ArgumentError, 'Order must have at least one sort clause')
-    end
-
     it 'forces null values to end of the array' do
       collection = described_class.new([record4, record1, record5, record2, record3])
-      sorted = collection.order(age: :asc)
-      expect(sorted.last).to eq(record5)
+      sorted_collection = collection.order(age: :asc)
+      expect(sorted_collection.records.last).to eq(record5)
     end
   end
 

--- a/spec/lib/vets/collection_spec.rb
+++ b/spec/lib/vets/collection_spec.rb
@@ -16,8 +16,12 @@ RSpec.describe Vets::Collection do
 
       default_sort_by name: :asc
 
-      def self.filterable_attributes
+      def self.filterable_params
         { name: %w[match eq], age: %w[eq lteq gteq] }.with_indifferent_access
+      end
+
+      def self.filterable_attributes
+        filterable_params.keys
       end
     end
   end

--- a/spec/lib/vets/collection_spec.rb
+++ b/spec/lib/vets/collection_spec.rb
@@ -154,12 +154,12 @@ RSpec.describe Vets::Collection do
 
     it 'raises an error if an attribute does not exist' do
       expect { collection.order(nonexistent: :asc) }
-        .to raise_error(Common::Exceptions::InvalidSortCriteria, "Invalid sort criteria")
+        .to raise_error(Common::Exceptions::InvalidSortCriteria, 'Invalid sort criteria')
     end
 
     it 'raises an error if the direction is invalid' do
       expect { collection.order(name: :invalid) }
-        .to raise_error(Common::Exceptions::InvalidSortCriteria, "Invalid sort criteria")
+        .to raise_error(Common::Exceptions::InvalidSortCriteria, 'Invalid sort criteria')
     end
 
     it 'forces null values to end of the array' do

--- a/spec/lib/vets/collections/finder_spec.rb
+++ b/spec/lib/vets/collections/finder_spec.rb
@@ -14,8 +14,12 @@ RSpec.describe Vets::Collections::Finder do
 
       set_pagination per_page: 21, max_per_page: 41
 
-      def self.filterable_attributes
+      def self.filterable_params
         { name: %w[match eq], age: %w[eq lteq gteq] }.with_indifferent_access
+      end
+
+      def self.filterable_attributes
+        filterable_params.keys
       end
     end
   end

--- a/spec/lib/vets/collections/pagination_spec.rb
+++ b/spec/lib/vets/collections/pagination_spec.rb
@@ -14,9 +14,10 @@ RSpec.describe Vets::Collections::Pagination do
         expect(pagination.data).to eq((11..20).to_a)
       end
 
-      it 'returns an empty array for out-of-bounds page' do
-        pagination = described_class.new(page: 6, per_page: 10, total_entries: data.size, data:)
-        expect(pagination.data).to eq([])
+      it 'raises an error for out-of-bounds page' do
+        expect do
+          described_class.new(page: 6, per_page: 10, total_entries: data.size, data:)
+        end.to raise_error(Common::Exceptions::InvalidPaginationParams)
       end
 
       context 'when data is nil' do


### PR DESCRIPTION
## Summary

- This PR allows Common::Collection and Vets::Collection to be used more interchangeable 
- This PR also helps reduce the size of https://github.com/department-of-veterans-affairs/vets-api/pull/21991
- Updates include:
    - Aliasing methods
    - Matching sorting metadata output
    - Pagination errors
    - Edge case String coercion 

## Related issue(s)

- n/a

## Testing done

- [ ] Testing via https://github.com/department-of-veterans-affairs/vets-api/pull/21991

## Acceptance criteria

- [ ] Allow Common::Collection and Vets::Collection to be used more interchangeable 