### PR TITLE
Removed validation_key attribute from VAProfile::Models::V3::Address

### DIFF
--- a/app/controllers/concerns/vet360/writeable.rb
+++ b/app/controllers/concerns/vet360/writeable.rb
@@ -50,10 +50,7 @@ module Vet360
         model = 'VAProfile::Models::V3::Address'
 
         # Validation Key was deprecated with ContactInformationV2
-        Rails.logger.info("Params: #{params}") if Settings.vsp_environment == 'staging'
-
         params[:override_validation_key] ||= params[:validation_key]
-        params[:validation_key] ||= params[:override_validation_key]
 
         # Ensures the address_pou is valid
         params[:address_pou] = 'RESIDENCE' if params[:address_pou] == 'RESIDENCE/CHOICE'

--- a/lib/va_profile/models/v3/address.rb
+++ b/lib/va_profile/models/v3/address.rb
@@ -52,12 +52,7 @@ module VAProfile
             effectiveEndDate: @effective_end_date
           }
 
-          key = @override_validation_key.presence || @validation_key
-          if key
-            address_attributes[:overrideValidationKey] ||= key
-            address_attributes[:validationKey] ||= key
-          end
-
+          address_attributes[:overrideValidationKey] = @override_validation_key if @override_validation_key.present?
           address_attributes[:badAddress] = false if correspondence?
 
           {

--- a/lib/va_profile/models/v3/base_address.rb
+++ b/lib/va_profile/models/v3/base_address.rb
@@ -51,7 +51,6 @@ module VAProfile
         attribute :transaction_id, String
         attribute :updated_at, Common::ISO8601Time
         attribute :override_validation_key, Integer
-        attribute :validation_key, Integer
         attribute :vet360_id, String
         attribute :va_profile_id, String
         attribute :zip_code, String

--- a/spec/factories/va_profile/v3/addresses.rb
+++ b/spec/factories/va_profile/v3/addresses.rb
@@ -64,7 +64,6 @@ FactoryBot.define do
       state_code { 'MS' }
       zip_code { '38843' }
       override_validation_key { 713_117_306 }
-      validation_key { 713_117_306 }
       vet360_id { '1781151' }
       source_system_user { '123498767V234859' }
       source_date { '2024-09-16T16:09:37.000Z' }

--- a/spec/support/vcr_cassettes/va_profile/v2/contact_information/put_address_override.yml
+++ b/spec/support/vcr_cassettes/va_profile/v2/contact_information/put_address_override.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: <VETS360_URL>/contact-information-hub/contact-information/v2/2.16.840.1.113883.4.349/1%5EPI%5E200VETS%5EUSDVA/addresses
     body:
       encoding: UTF-8
-      string: '{"bio":{"addressId":577127,"addressLine1":"1494 Martin Luther King Rd","addressLine2":null,"addressLine3":null,"addressPOU":"RESIDENCE","addressType":"Domestic","cityName":"Fulton","country":{"countryName":null,"countryCodeFIPS":null,"countryCodeISO2":null,"countryCodeISO3":"USA"},"county":{"countyCode":null,"countyName":null},"province":{"provinceName":null,"provinceCode":null},"state":{"stateName":null,"stateCode":"MS"},"intPostalCode":null,"zipCode5":"38843","zipCode4":null,"originatingSourceSystem":"VETSGOV","sourceSystemUser":"123498767V234859","sourceDate":"2024-09-16T16:09:37.000Z","effectiveStartDate":"2024-09-16T16:09:37.000Z","effectiveEndDate":null,"overrideValidationKey":713117306,"validationKey":713117306}}'
+      string: '{"bio":{"addressId":577127,"addressLine1":"1494 Martin Luther King Rd","addressLine2":null,"addressLine3":null,"addressPOU":"RESIDENCE","addressType":"Domestic","cityName":"Fulton","country":{"countryName":null,"countryCodeFIPS":null,"countryCodeISO2":null,"countryCodeISO3":"USA"},"county":{"countyCode":null,"countyName":null},"province":{"provinceName":null,"provinceCode":null},"state":{"stateName":null,"stateCode":"MS"},"intPostalCode":null,"zipCode5":"38843","zipCode4":null,"originatingSourceSystem":"VETSGOV","sourceSystemUser":"123498767V234859","sourceDate":"2024-09-16T16:09:37.000Z","effectiveStartDate":"2024-09-16T16:09:37.000Z","effectiveEndDate":null,"overrideValidationKey":713117306}}'
     headers:
       User-Agent:
       - Vets.gov Agent

--- a/spec/support/vcr_cassettes/va_profile/v2/contact_information/put_address_success.yml
+++ b/spec/support/vcr_cassettes/va_profile/v2/contact_information/put_address_success.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: <VETS360_URL>/contact-information-hub/contact-information/v2/2.16.840.1.113883.4.349/1%5EPI%5E200VETS%5EUSDVA/addresses
     body:
       encoding: UTF-8
-      string: '{"bio":{"addressId":577127,"addressLine1":"1494 Martin Luther King Rd","addressLine2":null,"addressLine3":null,"addressPOU":"RESIDENCE","addressType":"Domestic","cityName":"Fulton","country":{"countryName":"USA","countryCodeFIPS":null,"countryCodeISO2":null,"countryCodeISO3":"USA"},"county":{"countyCode":null,"countyName":null},"province":{"provinceName":null,"provinceCode":null},"state":{"stateName":null,"stateCode":"MS"},"intPostalCode":null,"zipCode5":"38843","zipCode4":null,"originatingSourceSystem":"VETSGOV","sourceSystemUser":"123498767V234859","sourceDate":"2024-09-16T16:09:37.000Z","effectiveStartDate":"2024-09-16T16:09:37.000Z","effectiveEndDate":null,"overrideValidationKey":713117306,"validationKey":713117306}}'
+      string: '{"bio":{"addressId":577127,"addressLine1":"1494 Martin Luther King Rd","addressLine2":null,"addressLine3":null,"addressPOU":"RESIDENCE","addressType":"Domestic","cityName":"Fulton","country":{"countryName":"USA","countryCodeFIPS":null,"countryCodeISO2":null,"countryCodeISO3":"USA"},"county":{"countyCode":null,"countyName":null},"province":{"provinceName":null,"provinceCode":null},"state":{"stateName":null,"stateCode":"MS"},"intPostalCode":null,"zipCode5":"38843","zipCode4":null,"originatingSourceSystem":"VETSGOV","sourceSystemUser":"123498767V234859","sourceDate":"2024-09-16T16:09:37.000Z","effectiveStartDate":"2024-09-16T16:09:37.000Z","effectiveEndDate":null,"overrideValidationKey":713117306}}'
     headers:
       User-Agent:
       - Vets.gov Agent


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

Removed validation_key attribute from VAProfile::Models::V3::Address. The validation_key does not need to be saved to the address object, the validation_key only needs to be returned in the AddressResponse for UI purposes. This [ticket](department-of-veterans-affairs/va.gov-team/issues/109399) was created to fix this in the UI after ContactInformationV2.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team/issues/109399

- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change* Returning validation_key in the V3 AddressResponse
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing* Working in staging
- *If this work is behind a flipper:* Yes
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?* 05/13/2025

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
