### PR TITLE
Remove silent_failure_avoided_no_confirmation for failed CST uploads

### DIFF
--- a/app/sidekiq/lighthouse/evidence_submissions/document_upload.rb
+++ b/app/sidekiq/lighthouse/evidence_submissions/document_upload.rb
@@ -72,9 +72,6 @@ module Lighthouse
           }.to_json
         )
         add_log('FAILED', evidence_submission.claim_id, evidence_submission.id, msg['jid'])
-        message = "#{name} EvidenceSubmission updated"
-        StatsD.increment('silent_failure_avoided_no_confirmation',
-                         tags: ['service:claim-status', "function: #{message}"])
       rescue => e
         error_message = "#{name} failed to update EvidenceSubmission"
         ::Rails.logger.error(error_message, { message: e.message })

--- a/app/sidekiq/lighthouse/evidence_submissions/failure_notification_email_job.rb
+++ b/app/sidekiq/lighthouse/evidence_submissions/failure_notification_email_job.rb
@@ -58,8 +58,6 @@ module Lighthouse
         upload.update(va_notify_id: response.id, va_notify_date: DateTime.current)
         message = "#{upload.job_class} va notify failure email queued"
         ::Rails.logger.info(message)
-        StatsD.increment('silent_failure_avoided_no_confirmation',
-                         tags: ['service:claim-status', "function: #{message}"])
       end
 
       def record_email_send_failure(upload, error)

--- a/spec/sidekiq/lighthouse/evidence_submissions/document_upload_spec.rb
+++ b/spec/sidekiq/lighthouse/evidence_submissions/document_upload_spec.rb
@@ -153,7 +153,6 @@ RSpec.describe Lighthouse::EvidenceSubmissions::DocumentUpload, type: :job do
             'error_class' => 'Faraday::BadRequestError'
           }
         end
-        let(:message) { "#{described_class} EvidenceSubmission updated" }
 
         it 'updates an evidence submission record to FAILED' do
           described_class.within_sidekiq_retries_exhausted_block(msg_with_errors) do
@@ -164,8 +163,6 @@ RSpec.describe Lighthouse::EvidenceSubmissions::DocumentUpload, type: :job do
             expect(Rails.logger)
               .to receive(:info)
               .with('LH - Updated Evidence Submission Record to FAILED', any_args)
-            expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation',
-                                                       tags: ['service:claim-status', "function: #{message}"])
           end
 
           failed_evidence_submission = EvidenceSubmission.find_by(id: evidence_submission_created.id)

--- a/spec/sidekiq/lighthouse/evidence_submissions/failure_notification_email_job_spec.rb
+++ b/spec/sidekiq/lighthouse/evidence_submissions/failure_notification_email_job_spec.rb
@@ -98,7 +98,6 @@ RSpec.describe Lighthouse::EvidenceSubmissions::FailureNotificationEmailJob, typ
         expect(vanotify_service).to receive(:send_email).with(send_email_params)
         expect(evidence_submission_failed).to receive(:update).and_call_original
         expect(Rails.logger).to receive(:info).with(message)
-        expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation', tags:)
         subject.new.perform
         expect(EvidenceSubmission.va_notify_email_queued.length).to eq(1)
       end
@@ -162,7 +161,6 @@ RSpec.describe Lighthouse::EvidenceSubmissions::FailureNotificationEmailJob, typ
         expect(vanotify_service).to receive(:send_email).with(send_email_params)
         expect(evidence_submission_failed).to receive(:update).and_call_original
         expect(Rails.logger).to receive(:info).with(message)
-        expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation', tags:)
         subject.new.perform
         expect(EvidenceSubmission.va_notify_email_queued.length).to eq(1)
         evidence_submission = EvidenceSubmission.find_by(id: evidence_submission_failed.id)
@@ -228,7 +226,6 @@ RSpec.describe Lighthouse::EvidenceSubmissions::FailureNotificationEmailJob, typ
         expect(vanotify_service).to receive(:send_email).with(send_email_params)
         expect(evidence_submission_failed).to receive(:update).and_call_original
         expect(Rails.logger).to receive(:info).with(message)
-        expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation', tags:)
         subject.new.perform
         expect(EvidenceSubmission.va_notify_email_queued.length).to eq(1)
         evidence_submission = EvidenceSubmission.find_by(id: evidence_submission_failed.id)
@@ -241,10 +238,6 @@ RSpec.describe Lighthouse::EvidenceSubmissions::FailureNotificationEmailJob, typ
     let(:message1) { "#{evidence_submission_failed1.job_class} va notify failure email queued" }
     let(:message2) { "#{evidence_submission_failed2.job_class} va notify failure email queued" }
     let(:message3) { "#{evidence_submission_failed3.job_class} va notify failure email queued" }
-
-    let(:tags1) { ['service:claim-status', "function: #{message1}"] }
-    let(:tags2) { ['service:claim-status', "function: #{message2}"] }
-    let(:tags3) { ['service:claim-status', "function: #{message3}"] }
 
     let!(:evidence_submission_failed1) { create(:bd_lh_evidence_submission_failed_type1_error) }
     let!(:evidence_submission_failed2) { create(:bd_lh_evidence_submission_failed_type2_error) }
@@ -271,10 +264,6 @@ RSpec.describe Lighthouse::EvidenceSubmissions::FailureNotificationEmailJob, typ
       expect(Rails.logger).to receive(:info).with(message1)
       expect(Rails.logger).to receive(:info).with(message2)
       expect(Rails.logger).to receive(:info).with(message3)
-
-      expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation', tags: tags1)
-      expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation', tags: tags2)
-      expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation', tags: tags3)
 
       subject.new.perform
       expect(EvidenceSubmission.va_notify_email_queued.length).to eq(3)


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): **NO**
- The metric `silent_failure_avoided_no_confirmation` is no longer necessary since CST now uses a VA Notify callback for confirmation of failure notification email delivery. [This callback](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/sidekiq/lighthouse/evidence_submissions/va_notify_email_status_callback.rb#L40) increments `silent_failure_avoided` / `silent_failure` according to the email delivery status. 
- Team: Benefits Management Tools

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *Code is covered by unit tests.* No new code.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

This removes a superfluous Datadog metric from the Lighthouse Document Upload and Failure Notification Email jobs, which are part of the Claim Status Tool.

## Acceptance criteria

- [x]  I updated unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature