### PR TITLE
Testing uploading new artifacts

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -181,7 +181,7 @@ jobs:
         if: always()
         with:
           name: Test Artifacts (system tmp directory)
-          path: tmp
+          path: /tmp
           if-no-files-found: ignore
           retention-days: 1
   

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -65,7 +65,6 @@ jobs:
       DOCKER_BUILDKIT: 1
       COMPOSE_DOCKER_CLI_BUILD: 1
       COMPOSE_BASH_CMD: docker compose -f docker-compose.test.yml run web bash -c
-      TMPDIR: tmp/systmp
     permissions: write-all
     runs-on: ubuntu-32-cores-latest
     outputs:
@@ -127,6 +126,7 @@ jobs:
 
       - name: Setup system tmp dir
         run: |
+          TMPDIR=tmp/systmp
           ${{ env.COMPOSE_BASH_CMD }}
           "mkdir -p tmp/systmp"
 

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -174,16 +174,18 @@ jobs:
       
       - name: Upload Test Artifacts (rails tmp)
         uses: actions/upload-artifact@v4
-        if: always()
+        if: failure()
         with:
           name: Test Artifacts (rails tmp directory)
-          path: tmp
+          path: |
+            tmp
+            !tmp/systmp
           if-no-files-found: ignore
           retention-days: 14
 
       - name: Upload Test Artifacts (system tmp)
         uses: actions/upload-artifact@v4
-        if: always()
+        if: failure()
         with:
           name: Test Artifacts (system tmp directory)
           path: tmp/systmp

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -170,7 +170,6 @@ jobs:
             log
             !log/*.xml
           if-no-files-found: ignore
-          retention-days: 1
       
       - name: Upload Test Artifacts (rails tmp)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -65,6 +65,7 @@ jobs:
       DOCKER_BUILDKIT: 1
       COMPOSE_DOCKER_CLI_BUILD: 1
       COMPOSE_BASH_CMD: docker compose -f docker-compose.test.yml run web bash -c
+      TMPDIR: tmp/systmp
     permissions: write-all
     runs-on: ubuntu-32-cores-latest
     outputs:
@@ -93,6 +94,11 @@ jobs:
       - name: Setup Environment
         run: |
           echo "VETS_API_USER_ID=$(id -u)" >> $GITHUB_ENV
+
+      - name: Setup system tmp dir
+        run: |
+          mkdir -p tmp/systmp
+          chmod 777 tmp/systmp
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -172,7 +178,9 @@ jobs:
         if: failure()
         with:
           name: Test Artifacts (rails tmp directory)
-          path: tmp
+          path: |
+            tmp
+            !tmp/systmp
           if-no-files-found: ignore
           retention-days: 14
 
@@ -181,7 +189,7 @@ jobs:
         if: always()
         with:
           name: Test Artifacts (system tmp directory)
-          path: /tmp
+          path: tmp/systmp
           if-no-files-found: ignore
           retention-days: 1
   

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -125,14 +125,14 @@ jobs:
              "bundle exec rake parallel:setup[24]"
 
       - name: Setup system tmp dir
-        run: |
-          TMPDIR=tmp/systmp
+        run: >
           ${{ env.COMPOSE_BASH_CMD }}
           "mkdir -p tmp/systmp"
 
       - name: Run Specs
         timeout-minutes: 15
         run: >
+          TMPDIR=tmp/systmp
           ${{ env.COMPOSE_BASH_CMD }}
           "bundle exec rake 'parallel:spec[24, , , modules\/]'"
 

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -171,7 +171,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: Test Artifacts (tmp directory)
+          name: Test Artifacts (rails tmp directory)
           path: tmp
           if-no-files-found: ignore
           retention-days: 14
@@ -180,7 +180,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: Test Artifacts (/tmp directory)
+          name: Test Artifacts (system tmp directory)
           path: tmp
           if-no-files-found: ignore
           retention-days: 1

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -132,9 +132,8 @@ jobs:
       - name: Run Specs
         timeout-minutes: 15
         run: >
-          TMPDIR=tmp/systmp
           ${{ env.COMPOSE_BASH_CMD }}
-          "bundle exec rake 'parallel:spec[24, , , modules\/]'"
+          "TMPDIR=tmp/systmp bundle exec rake 'parallel:spec[24, , , modules\/]'"
 
       - name: Set Test Status
         id: test-status

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -177,20 +177,9 @@ jobs:
         if: failure()
         with:
           name: Test Artifacts (rails tmp directory)
-          path: |
-            tmp
-            !tmp/systmp
+          path: tmp
           if-no-files-found: ignore
           retention-days: 14
-
-      - name: Upload Test Artifacts (system tmp)
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: Test Artifacts (system tmp directory)
-          path: tmp/systmp
-          if-no-files-found: ignore
-          retention-days: 1
   
 
 

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -162,12 +162,12 @@ jobs:
         with:
           name: Test Artifacts (log directory)
           path: |
-            tmp
-            !tmp/*.xml
+            log
+            !log/*.xml
           if-no-files-found: ignore
           retention-days: 1
       
-      - name: Upload Test Artifacts (tmp)
+      - name: Upload Test Artifacts (rails tmp)
         uses: actions/upload-artifact@v4
         if: failure()
         with:
@@ -176,7 +176,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
-      - name: Upload Test Artifacts (/tmp)
+      - name: Upload Test Artifacts (system tmp)
         uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -178,9 +178,7 @@ jobs:
         if: failure()
         with:
           name: Test Artifacts (rails tmp directory)
-          path: |
-            tmp
-            !tmp/systmp
+          path: tmp
           if-no-files-found: ignore
           retention-days: 14
 

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -156,6 +156,17 @@ jobs:
           path: log/*.xml
           if-no-files-found: ignore
       
+      - name: Upload Test Artifacts (log)
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: Test Artifacts (log directory)
+          path: |
+            tmp
+            !tmp/*.xml
+          if-no-files-found: ignore
+          retention-days: 1
+      
       - name: Upload Test Artifacts (tmp)
         uses: actions/upload-artifact@v4
         if: failure()
@@ -169,19 +180,8 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: Test Artifacts (tmp directory)
+          name: Test Artifacts (/tmp directory)
           path: tmp
-          if-no-files-found: ignore
-          retention-days: 1
-      
-      - name: Upload Test Artifacts (log)
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: Test Artifacts (tmp directory)
-          path: |
-            tmp
-            !tmp/*.xml
           if-no-files-found: ignore
           retention-days: 1
   

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -175,7 +175,7 @@ jobs:
       
       - name: Upload Test Artifacts (rails tmp)
         uses: actions/upload-artifact@v4
-        if: failure()
+        if: always()
         with:
           name: Test Artifacts (rails tmp directory)
           path: tmp

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -95,11 +95,6 @@ jobs:
         run: |
           echo "VETS_API_USER_ID=$(id -u)" >> $GITHUB_ENV
 
-      - name: Setup system tmp dir
-        run: |
-          mkdir -p tmp/systmp
-          chmod 777 tmp/systmp
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -129,6 +124,11 @@ jobs:
           command: >
              ${{ env.COMPOSE_BASH_CMD }}
              "bundle exec rake parallel:setup[24]"
+
+      - name: Setup system tmp dir
+        run: |
+          ${{ env.COMPOSE_BASH_CMD }}
+          "mkdir -p tmp/systmp"
 
       - name: Run Specs
         timeout-minutes: 15

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -156,7 +156,7 @@ jobs:
           path: log/*.xml
           if-no-files-found: ignore
       
-      - name: Upload Test Artifacts
+      - name: Upload Test Artifacts (tmp)
         uses: actions/upload-artifact@v4
         if: failure()
         with:
@@ -164,6 +164,27 @@ jobs:
           path: tmp
           if-no-files-found: ignore
           retention-days: 14
+
+      - name: Upload Test Artifacts (/tmp)
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: Test Artifacts (tmp directory)
+          path: tmp
+          if-no-files-found: ignore
+          retention-days: 1
+      
+      - name: Upload Test Artifacts (log)
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: Test Artifacts (tmp directory)
+          path: |
+            tmp
+            !tmp/*.xml
+          if-no-files-found: ignore
+          retention-days: 1
+  
 
 
   update_labels:


### PR DESCRIPTION
## Summary
When the `pdf-forms` gem encounters an error filling a form PDF via `pdftk`, it saves the failed form data in an FDF file in the system temp directory (OS/System dependent, but for the Github runners it defaults to `/tmp`). It's not currently possible to configure `pdf-forms` to tell it where to save the FDF files, so I am setting the `TMPDIR` environment variable to `tmp/systmp` so that I can save the files there (rubys Tempfile library uses `TMPDIR` to determine which directory to store files in). These files are then uploaded as artifacts when there is a spec failure

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
