### PR TITLE
[ID-118] - Create and check cerner eligibility cookie

### DIFF
--- a/app/controllers/concerns/authentication_and_sso_concerns.rb
+++ b/app/controllers/concerns/authentication_and_sso_concerns.rb
@@ -98,11 +98,20 @@ module AuthenticationAndSSOConcerns # rubocop:disable Metrics/ModuleLength
   end
 
   # Sets a cookie "api_session" with all of the key/value pairs from session object.
-  def set_api_cookie!
+  def set_api_cookie
     return unless @session_object
 
     session.delete :value
     @session_object.to_hash.each { |k, v| session[k] = v }
+  end
+
+  def set_cerner_eligibility_cookie
+    cookie_name = V1::SessionsController::CERNER_ELIGIBLE_COOKIE_NAME
+    return if cookies.signed[cookie_name].present?
+
+    cookies.signed.permanent[cookie_name] = eligible = @current_user.cerner_eligible?
+
+    Rails.logger.info('[SessionsController] Cerner Eligibility', eligible:, cookie_action: :set, icn: @current_user.icn)
   end
 
   def set_session_expiration_header

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -33,6 +33,7 @@ module V1
                        INTERSTITIAL_SIGNUP = 'interstitial_signup',
                        MHV_EXCEPTION = 'mhv_exception',
                        MYHEALTHEVET_TEST_ACCOUNT = 'myhealthevet_test_account'].freeze
+    CERNER_ELIGIBLE_COOKIE_NAME = 'CERNER_ELIGIBLE'
 
     # Collection Action: auth is required for certain types of requests
     # @type is set automatically by the routes in config/routes.rb
@@ -190,12 +191,14 @@ module V1
     end
 
     def render_login(type)
+      check_cerner_eligibility
       login_url, post_params = login_params(type)
       renderer = ActionController::Base.renderer
       renderer.controller.prepend_view_path(Rails.root.join('lib', 'saml', 'templates'))
       result = renderer.render template: 'sso_post_form',
                                locals: { url: login_url, params: post_params },
                                format: :html
+
       render body: result, content_type: 'text/html'
       set_sso_saml_cookie!
       saml_request_stats
@@ -301,6 +304,14 @@ module V1
                               "client_id:#{tracker&.payload_attr(:application)}",
                               "context:#{saml_response.authn_context}",
                               VERSION_TAG])
+    end
+
+    def check_cerner_eligibility
+      value = ActiveModel::Type::Boolean.new.cast(cookies.signed[CERNER_ELIGIBLE_COOKIE_NAME])
+
+      Rails.logger.info('[SessionsController] Cerner Eligibility',
+                        eligible: value.nil? ? :unknown : value,
+                        cookie_action: value.nil? ? :not_found : :found)
     end
 
     def user_logout(saml_response)
@@ -411,7 +422,8 @@ module V1
 
     def set_cookies
       Rails.logger.info('SSO: LOGIN', sso_logging_info)
-      set_api_cookie!
+      set_api_cookie
+      set_cerner_eligibility_cookie
     end
 
     def after_login_actions

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -482,9 +482,13 @@ class User < Common::RedisStore
   end
 
   def provision_cerner_async(source: nil)
-    return unless loa3? && cerner_id.present?
+    return unless cerner_eligible?
 
     Identity::CernerProvisionerJob.perform_async(icn, source)
+  end
+
+  def cerner_eligible?
+    loa3? && cerner_id.present?
   end
 
   def can_create_mhv_account?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1567,4 +1567,33 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#cerner_eligible?' do
+    let(:user) { build(:user, :loa3, cerner_id:) }
+    let(:cerner_id) { 'some-cerner-id' }
+
+    context 'when the user is loa3' do
+      context 'when the user has a cerner_id' do
+        it 'returns true' do
+          expect(user.cerner_eligible?).to be true
+        end
+      end
+
+      context 'when the user does not have a cerner_id' do
+        let(:cerner_id) { nil }
+
+        it 'returns false' do
+          expect(user.cerner_eligible?).to be false
+        end
+      end
+    end
+
+    context 'when the user is not loa3' do
+      let(:user) { build(:user) }
+
+      it 'returns false' do
+        expect(user.cerner_eligible?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- After a user logs in with ssoe check if they are cerner eligible and set `true` or `false`
- When a user starts the ssoe login flow it will check if that cookie exists:
  - doesn't exist - log `unknown`
  - exists - log cookie value (`true` or `false`)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/118

## Testing 
- Log in with ssoe with a `loa3` user that has a `cerner_id` (`user+81`)
  - initially you should see a log like:
    ```ruby
    [SessionsController] Cerner Eligibility -- { :eligible => :unknown, :cookie_action => :not_found }
    ```
  - after you login you should see a log like:
    ```ruby
     [SessionsController] Cerner Eligibility -- { :eligible => true, :cookie_action => :set, icn: <icn> }
    ```
    - You should also have a `CERNER_ELIGIBILTY` cookie set.
  - Log out
  - Start ssoe login flow again, you should see a log like:
    ```ruby
    [SessionsController] Cerner Eligibility -- { :eligible => true, :cookie_action => :found }
    ```
- clear cookies, login with user that does not have a `cerner_id` (`user+0`)
  - initially you should see a log like:
    ```ruby
    [SessionsController] Cerner Eligibility -- { :eligible => :unknown, :cookie_action => :not_found }
    ```
  - after you login you should see a log like:
    ```ruby
     [SessionsController] Cerner Eligibility -- { :eligible => false, :cookie_action => :set, icn: <icn> }
    ```
    - You should also have a `CERNER_ELIGIBILTY` cookie set.
  - Log out
  - Start ssoe login flow again, you should see a log like:
    ```ruby
    [SessionsController] Cerner Eligibility -- { :eligible => false, :cookie_action => :found }
    ```

## What areas of the site does it impact?
ssoe authentication 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

