### PR TITLE
API-46261 Use more standard Mailer class for report

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/one_off/poa_v1_bad_box20_render_report_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/one_off/poa_v1_bad_box20_render_report_job.rb
@@ -2,6 +2,14 @@
 
 module ClaimsApi
   module OneOff
+    class PoaV1BadBox20RenderReportMailer < ApplicationMailer
+      def build(emails, csv_str)
+        # rubocop:disable Rails/I18nLocaleTexts
+        mail to: emails, subject: 'POA v1 Bad Box20 PDF Render Report', content_type: 'text/html', body: csv_str
+        # rubocop:enable Rails/I18nLocaleTexts
+      end
+    end
+
     class PoaV1BadBox20RenderReportJob < ClaimsApi::ServiceBase
       sidekiq_options retry: 5 # Retry for ~10 mins
       LOG_TAG = 'claims_api_poa_box20_report_job'
@@ -41,10 +49,7 @@ module ClaimsApi
 
         ClaimsApi::Logger.log LOG_TAG, detail: "Found #{num_records} record(s)"
         ClaimsApi::Logger.log LOG_TAG, detail: 'Sending email'
-        # rubocop:disable Rails/I18nLocaleTexts
-        ApplicationMailer.new.mail(to: emails, subject: 'POA v1 Bad Box20 PDF Render Report', content_type: 'text/html',
-                                   body: memo).deliver
-        # rubocop:enable Rails/I18nLocaleTexts
+        ClaimsApi::OneOff::PoaV1BadBox20RenderReportMailer.build(emails, memo).deliver_now
         ClaimsApi::Logger.log LOG_TAG, detail: 'Email sent. Job complete.'
       rescue => e
         # Only alert on the class name since an email exception may output the body, which would have PII

--- a/modules/claims_api/spec/sidekiq/one_off/poa_v1_bad_box20_render_report_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/one_off/poa_v1_bad_box20_render_report_job_spec.rb
@@ -22,15 +22,17 @@ RSpec.describe ClaimsApi::OneOff::PoaV1BadBox20RenderReportJob, type: :job do
       create_list(:power_of_attorney, 5, :with_fuzzed_headers, :with_blank_consent_limit, cid: consumer_id)
     end
 
-    it 'logs progress' do
-      allow_any_instance_of(ApplicationMailer).to receive(:mail).and_return(
-        double.tap do |mailer|
-          allow(mailer).to receive(:deliver).once
-        end
-      )
+    it 'logs progress and sends email' do
       expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Started processing')
       expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Found 7 record(s)')
       expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Sending email')
+
+      expect(ClaimsApi::OneOff::PoaV1BadBox20RenderReportMailer).to receive(:build).and_return(
+        double.tap do |mailer|
+          expect(mailer).to receive(:deliver_now).once
+        end
+      )
+
       expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Email sent. Job complete.')
       subject.perform(consumer_id, %w[example@va.gov])
     end


### PR DESCRIPTION
## Summary

Support suggested I try using the builder class to do the email delivery instead of invoking ApplicationMailer directly. With nothing else to go on for why this particular email isn't sending out, it can't hurt to try!

## Related issue(s)

- #22044
- [Support thread](https://dsva.slack.com/archives/CBU0KDSB1/p1746813703362399)

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
Async one-off job. Nothing veteran facing.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature