### PR TITLE
Remove participant_id from auth policy

### DIFF
--- a/app/policies/lighthouse_policy.rb
+++ b/app/policies/lighthouse_policy.rb
@@ -24,13 +24,7 @@ LighthousePolicy = Struct.new(:user, :lighthouse) do
   end
 
   def access_vet_status?
-    access = user.icn.present? && user.participant_id.present?
-    unless access
-      Rails.logger.info('Vet Status Lighthouse access denied',
-                        icn_present: user.icn.present?,
-                        participant_id_present: user.participant_id.present?)
-    end
-    access
+    user.icn.present?
   end
 
   alias_method :mobile_access?, :access_update?

--- a/spec/policies/lighthouse_policy_spec.rb
+++ b/spec/policies/lighthouse_policy_spec.rb
@@ -36,7 +36,7 @@ describe LighthousePolicy do
   end
 
   permissions :access_vet_status? do
-    context 'user has ICN and Participant ID' do
+    context 'user has ICN' do
       let(:user) { build(:user, :loa3) }
 
       it 'grants access' do
@@ -51,34 +51,6 @@ describe LighthousePolicy do
 
       it 'denies access' do
         expect(subject).not_to permit(user, :lighthouse)
-      end
-
-      it 'logs access denied' do
-        expect(Rails.logger).to receive(:info).with(
-          'Vet Status Lighthouse access denied',
-          icn_present: false,
-          participant_id_present: true
-        )
-        subject.new(user, :lighthouse).access_vet_status?
-      end
-    end
-
-    context 'user without Participant ID' do
-      let(:user) { build(:user, :loa3) }
-
-      before { allow(user).to receive(:participant_id).and_return(nil) }
-
-      it 'denies access' do
-        expect(subject).not_to permit(user, :lighthouse)
-      end
-
-      it 'logs access denied' do
-        expect(Rails.logger).to receive(:info).with(
-          'Vet Status Lighthouse access denied',
-          icn_present: true,
-          participant_id_present: false
-        )
-        subject.new(user, :lighthouse).access_vet_status?
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This change removes the check for `participant_id` from the endpoint policy. This is being done after doing some research and logging for about 3 weeks any failure of the policy, which showed out of 4,250 failures, all of them were missing a participant_id. participant_id is not needed for the data retrieval and there does not seem to be any reason to keep the check.
- I work on the IIR Product team and we currently own Veteran Status Card.

## Related issue(s)

- [1655](https://github.com/department-of-veterans-affairs/va-iir/issues/1655)

## Testing done

- [x] *New code is covered by unit tests*
- Prior to the change, the policy checked for both ICN and participant_id. Now it just checks for ICN.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
This only impacts the auth policy for the Vet Verification Status endpoint which is only used by the Vet Status Card app.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
