### PR TITLE
MHV-69302 Added AAL to SEI action; refactored AAL code

### DIFF
--- a/modules/my_health/app/controllers/concerns/my_health/aal_client_concerns.rb
+++ b/modules/my_health/app/controllers/concerns/my_health/aal_client_concerns.rb
@@ -47,6 +47,24 @@ module MyHealth
       aal_client.authenticate
     end
 
+    ##
+    # This method yields a block and automatically logs an AAL, capturing whether it succeeded
+    # (status = 1) or failed (status = 0). It re-raises any errors after logging so downstream error
+    # handling remains unaffected.
+    #
+    # @yield The block of code to execute and log.
+    # @return [Object] The result of the yielded block.
+    # @raise [Exception] Re-raises any exception raised within the block after logging the failure.
+    #
+    def handle_aal(activity_type, action, detail_value = nil, performer_type = 'Self')
+      response = yield
+      create_aal({ activity_type:, action:, performer_type:, detail_value:, status: 1 })
+      response
+    rescue => e
+      create_aal({ activity_type:, action:, performer_type:, detail_value:, status: 0 })
+      raise e
+    end
+
     private
 
     def aal_client

--- a/modules/my_health/app/controllers/concerns/my_health/aal_client_concerns.rb
+++ b/modules/my_health/app/controllers/concerns/my_health/aal_client_concerns.rb
@@ -56,12 +56,12 @@ module MyHealth
     # @return [Object] The result of the yielded block.
     # @raise [Exception] Re-raises any exception raised within the block after logging the failure.
     #
-    def handle_aal(activity_type, action, detail_value = nil, performer_type = 'Self')
+    def handle_aal(activity_type, action, detail_value = nil, performer_type = 'Self', once_per_session: false)
       response = yield
-      create_aal({ activity_type:, action:, performer_type:, detail_value:, status: 1 })
+      create_aal({ activity_type:, action:, performer_type:, detail_value:, status: 1 }, once_per_session:)
       response
     rescue => e
-      create_aal({ activity_type:, action:, performer_type:, detail_value:, status: 0 })
+      create_aal({ activity_type:, action:, performer_type:, detail_value:, status: 0 }, once_per_session:)
       raise e
     end
 

--- a/modules/my_health/app/controllers/my_health/v1/health_records_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/health_records_controller.rb
@@ -24,13 +24,13 @@ module MyHealth
       end
 
       def optin
-        handle_aal_action('Opt back into electronic sharing with community providers') do
+        handle_aal('VA Health Record', 'Opt back into electronic sharing with community providers') do
           client.post_opt_in
         end
       end
 
       def optout
-        handle_aal_action('Opt out of electronic sharing with community providers') do
+        handle_aal('VA Health Record', 'Opt out of electronic sharing with community providers') do
           client.post_opt_out
         end
       end
@@ -42,26 +42,6 @@ module MyHealth
 
       def product
         :mr
-      end
-
-      private
-
-      def handle_aal_action(action_description)
-        response = yield
-        log_aal_action(action_description, 1)
-        response
-      rescue => e
-        log_aal_action(action_description, 0)
-        raise e
-      end
-
-      def log_aal_action(action, status)
-        create_aal({
-                     activity_type: 'VA Health Record',
-                     action:,
-                     performer_type: 'Self',
-                     status:
-                   })
       end
     end
   end

--- a/modules/my_health/app/controllers/my_health/v1/medical_records/self_entered_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/medical_records/self_entered_controller.rb
@@ -8,7 +8,10 @@ module MyHealth
         service_tag 'mhv-medical-records'
 
         def index
-          render json: client.get_all_sei_data.to_json
+          resource = handle_aal('Self entered health information', 'Download') do
+            client.get_all_sei_data.to_json
+          end
+          render json: resource
         end
 
         def vitals

--- a/modules/my_health/app/controllers/my_health/v1/medical_records/self_entered_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/medical_records/self_entered_controller.rb
@@ -5,10 +5,11 @@ module MyHealth
     module MedicalRecords
       class SelfEnteredController < ApplicationController
         include MyHealth::MHVControllerConcerns
+        include MyHealth::AALClientConcerns
         service_tag 'mhv-medical-records'
 
         def index
-          resource = handle_aal('Self entered health information', 'Download') do
+          resource = handle_aal('Self entered health information', 'Download', once_per_session: true) do
             client.get_all_sei_data.to_json
           end
           render json: resource
@@ -83,6 +84,10 @@ module MyHealth
 
         def raise_access_denied
           raise Common::Exceptions::Forbidden, detail: 'You do not have access to self-entered information'
+        end
+
+        def product
+          :mr
         end
       end
     end


### PR DESCRIPTION
## Summary

- Added AAL logging to Self-Entered (only to the unified call)
- Refactored some common code into `AALClientConcerns`

## Related issue(s)

### [MHV-69302](https://jira.devops.va.gov/browse/MHV-69302) - Implement required AAL entry for Self-entered download ###

> Implement required AAL entry for Self-entered download
> 
> 
> 
> 
> AAL work to be done spreadsheet link below (See Medical Records tab-line 43- dark tan highlight)
> 
> https://dvagov.sharepoint.com/:x:/r/sites/HealthApartment/_layouts/15/Doc.aspx?sourcedoc=%7B80534FA8-97C2-4726-9E08-20166C9609DF%7D&file=AAL%20work%20to%20be%20done-VHA%20Privacy%20Office%20additions.xlsx&action=default&mobileredirect=true 
> 
> Approved content for all MR domains on va.gov is as follows:
> 
> Date/Time = Completion_Time
> 
> Activity Details = Detail_Value
> 
> Activity = Activity_Type
> 
> Action = Action
> 
> Performer Type = Performer_Type
> 
> Results = Status
> 
> Figma Link: N/A
> 
> 
> 
> 
> DEV:
> 
> Feature Flag Y/N ? N
> 
> Collab Cycle Y/N ? N
> 
> Platform Approval T/N ? N
> 
> 
> 
> 
> UCD:
> 
> DataDog Analytics Y/N ? n
> 
> Analytics Tagging Changes needed (Datadog or other)?  Y/N ? N
> 
> 
> 
> 
> Testing:
> 
> Manual Testing Y/N ? Y-Maruf
> 
> Automated Testing Y/N ? N
> 
> Accessibility Testing Y/N ? N
> 
> UCD Validation Y/N ? N
> 
> 
> 
> 
> Acceptance Criteria:
> 
> AC1 Self-entered download reports on VA.gov generate the AAL entry as described in linked spreadsheet (See Medical Records tab-line 43- dark tan highlight)
> 
> AC2  
> 
> AC3

## Testing done

- [x] *New code is covered by unit tests*
- To test, generate an SEI report and verify in MHV Classic NP that an AAL log was created
- Not behind a Flipper

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
MHV Medical Records

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
