### PR TITLE
replace Sentry logging with Rails in CG

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -124,6 +124,9 @@ features:
   caregiver_request_duration_monitoring:
     actor_type: user
     description: Enables logging of 10-10CG request durations to StatsD
+  caregiver_use_rails_logging_over_sentry:
+    actor_type: user
+    description: Use Rails for logging instead of Sentry
   document_upload_validation_enabled:
     actor_type: user
     description: Enables stamped PDF validation on document upload

--- a/spec/services/form1010cg/service_spec.rb
+++ b/spec/services/form1010cg/service_spec.rb
@@ -438,10 +438,28 @@ RSpec.describe Form1010cg::Service do
   end
 
   describe '#assert_veteran_status' do
-    it "raises error if veteran's icn can not be found" do
-      expect(subject).to receive(:icn_for).with('veteran').and_return('NOT_FOUND')
-      expect(subject).to receive(:log_exception_to_sentry).with(instance_of(described_class::InvalidVeteranStatus))
-      expect { subject.assert_veteran_status }.to raise_error(described_class::InvalidVeteranStatus)
+    context 'with :caregiver_use_rails_logging_over_sentry enabled' do
+      it "raises error if veteran's icn can not be found" do
+        allow(Flipper).to receive(:enabled?).with(:caregiver_use_rails_logging_over_sentry).and_return(true)
+        expect(subject).to receive(:icn_for).with('veteran').and_return('NOT_FOUND')
+        # expect(subject).to receive(:log_exception_to_sentry).with(instance_of(described_class::InvalidVeteranStatus))
+        expect(Rails.logger).to receive(:error).with(
+          '[10-10CG] - Error fetching Veteran ICN',
+          { error: instance_of(described_class::InvalidVeteranStatus) }
+        )
+
+        expect { subject.assert_veteran_status }.to raise_error(described_class::InvalidVeteranStatus)
+      end
+    end
+
+    context 'with :caregiver_use_rails_logging_over_sentry disabled' do
+      it "raises error if veteran's icn can not be found" do
+        allow(Flipper).to receive(:enabled?).with(:caregiver_use_rails_logging_over_sentry).and_return(false)
+        expect(subject).to receive(:icn_for).with('veteran').and_return('NOT_FOUND')
+        expect(subject).to receive(:log_exception_to_sentry).with(instance_of(described_class::InvalidVeteranStatus))
+
+        expect { subject.assert_veteran_status }.to raise_error(described_class::InvalidVeteranStatus)
+      end
     end
 
     it "does not raise error if veteran's icn is found" do
@@ -568,23 +586,47 @@ RSpec.describe Form1010cg::Service do
         allow(mule_soft_client).to receive(:create_submission_v2).and_raise(exception)
       end
 
-      it 'logs claim_guid for any exceptions and raises error' do
-        expect(service).to receive(:log_exception_to_sentry)
-          .with(exception, {
-                  form: '10-10CG',
-                  claim_guid: claim_with_mpi_veteran.guid
-                })
+      context 'with :caregiver_use_rails_logging_over_sentry enabled' do
+        it 'logs claim_guid for any exceptions and raises error' do
+          allow(Flipper).to receive(:enabled?).with(:caregiver_use_rails_logging_over_sentry).and_return(true)
+          expect(Rails.logger).to receive(:error).with(
+            '[10-10CG] - Error processing Caregiver submission',
+            { form: '10-10CG', exception:, claim_guid: claim_with_mpi_veteran.guid }
+          )
 
-        start_time = Time.current
-        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start_time }
-        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond)
-        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_THREAD_CPUTIME_ID, :float_millisecond)
-        expected_arguments = { context: :process, event: :failure, start_time: }
-        expect(described_class::AUDITOR).to receive(:log_caregiver_request_duration).with(
-          **expected_arguments
-        )
+          start_time = Time.current
+          allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start_time }
+          allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond)
+          allow(Process).to receive(:clock_gettime).with(Process::CLOCK_THREAD_CPUTIME_ID, :float_millisecond)
+          expected_arguments = { context: :process, event: :failure, start_time: }
+          expect(described_class::AUDITOR).to receive(:log_caregiver_request_duration).with(
+            **expected_arguments
+          )
 
-        expect { subject }.to raise_error(exception)
+          expect { subject }.to raise_error(exception)
+        end
+      end
+
+      context 'with :caregiver_use_rails_logging_over_sentry disabled' do
+        it 'logs claim_guid for any exceptions and raises error' do
+          allow(Flipper).to receive(:enabled?).with(:caregiver_use_rails_logging_over_sentry).and_return(false)
+          expect(service).to receive(:log_exception_to_sentry)
+            .with(exception, {
+                    form: '10-10CG',
+                    claim_guid: claim_with_mpi_veteran.guid
+                  })
+
+          start_time = Time.current
+          allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start_time }
+          allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond)
+          allow(Process).to receive(:clock_gettime).with(Process::CLOCK_THREAD_CPUTIME_ID, :float_millisecond)
+          expected_arguments = { context: :process, event: :failure, start_time: }
+          expect(described_class::AUDITOR).to receive(:log_caregiver_request_duration).with(
+            **expected_arguments
+          )
+
+          expect { subject }.to raise_error(exception)
+        end
       end
     end
   end

--- a/spec/sidekiq/form1010cg/submission_job_spec.rb
+++ b/spec/sidekiq/form1010cg/submission_job_spec.rb
@@ -145,6 +145,7 @@ RSpec.describe Form1010cg::SubmissionJob do
 
     context 'when there is a standarderror' do
       it 'increments statsd except applications_retried' do
+        allow(Flipper).to receive(:enabled?).with(:caregiver_use_rails_logging_over_sentry).and_return(false)
         start_time = Time.current
         allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start_time }
         allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond)
@@ -169,6 +170,47 @@ RSpec.describe Form1010cg::SubmissionJob do
           expect do
             job.perform(claim.id)
           end.to raise_error(StandardError)
+        end
+      end
+
+      context 'with :caregiver_use_rails_logging_over_sentry enabled' do
+        it 'increments statsd except applications_retried' do
+          allow(Flipper).to receive(:enabled?).with(:caregiver_use_rails_logging_over_sentry).and_return(true)
+
+          allow_any_instance_of(Form1010cg::Service).to receive(
+            :process_claim_v2!
+          ).and_raise(StandardError)
+
+          expect(Rails.logger).to receive(:error).with(
+            '[10-10CG] - Error processing Caregiver claim submission in job',
+            { exception: StandardError, claim_id: claim.id }
+          ).twice
+          expect(job).not_to receive(:log_exception_to_sentry)
+
+          2.times do
+            expect do
+              job.perform(claim.id)
+            end.to raise_error(StandardError)
+          end
+        end
+      end
+
+      context 'with :caregiver_use_rails_logging_over_sentry disabled' do
+        it 'increments statsd except applications_retried' do
+          allow(Flipper).to receive(:enabled?).with(:caregiver_use_rails_logging_over_sentry).and_return(false)
+
+          allow_any_instance_of(Form1010cg::Service).to receive(
+            :process_claim_v2!
+          ).and_raise(StandardError)
+
+          expect(Rails.logger).not_to receive(:error)
+          expect_any_instance_of(SentryLogging).to receive(:log_exception_to_sentry).twice
+
+          2.times do
+            expect do
+              job.perform(claim.id)
+            end.to raise_error(StandardError)
+          end
         end
       end
     end
@@ -231,14 +273,35 @@ RSpec.describe Form1010cg::SubmissionJob do
       end
     end
 
-    context 'when claim cant be destroyed' do
-      it 'logs the exception to sentry' do
-        expect_any_instance_of(Form1010cg::Service).to receive(:process_claim_v2!)
-        error = StandardError.new
-        expect_any_instance_of(SavedClaim::CaregiversAssistanceClaim).to receive(:destroy!).and_raise(error)
+    context 'when claim can not be destroyed' do
+      context 'with :caregiver_use_rails_logging_over_sentry enabled' do
+        it 'logs the exception using the Rails logger' do
+          allow(Flipper).to receive(:enabled?).with(:caregiver_use_rails_logging_over_sentry).and_return(true)
+          expect_any_instance_of(Form1010cg::Service).to receive(:process_claim_v2!)
+          error = StandardError.new
+          expect_any_instance_of(SavedClaim::CaregiversAssistanceClaim).to receive(:destroy!).and_raise(error)
 
-        expect(job).to receive(:log_exception_to_sentry).with(error, { claim_id: claim.id })
-        job.perform(claim.id)
+          expect(Rails.logger).to receive(:error).with(
+            '[10-10CG] - Error destroying Caregiver claim after processing submission in job',
+            { exception: error, claim_id: claim.id }
+          )
+          expect(job).not_to receive(:log_exception_to_sentry)
+
+          job.perform(claim.id)
+        end
+      end
+
+      context 'with :caregiver_use_rails_logging_over_sentry disabled' do
+        it 'logs the exception to sentry' do
+          allow(Flipper).to receive(:enabled?).with(:caregiver_use_rails_logging_over_sentry).and_return(false)
+          expect_any_instance_of(Form1010cg::Service).to receive(:process_claim_v2!)
+          error = StandardError.new
+          expect_any_instance_of(SavedClaim::CaregiversAssistanceClaim).to receive(:destroy!).and_raise(error)
+
+          expect(Rails.logger).not_to receive(:error)
+          expect(job).to receive(:log_exception_to_sentry).with(error, { claim_id: claim.id })
+          job.perform(claim.id)
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES* `:caregiver_use_rails_logging_over_sentry`
- Use Rails logger instead of Sentry to handle errors in Caregiver backend
- In the interests of shifting away from using Sentry, this disentangles the CG backend from that logger in favor of the standard Rails logger
- Health Enrollment 10-10CG
- Feature flag can be removed if we see no performance degradation, or unexpectedly sensitive data in the logs

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108604

## Testing done

- [x] *New code is covered by unit tests*
- Before the change, the errors would be logged to Sentry. After, they go to the Rails logs
- Verify by submitting in a context where the request will fail:
- *If this work is behind a flipper:*
  - [x] Tests cover both sides of the flipper.
  - Testing plan: Enable in environment, confirm the errors we get in Datadog are as expected, covering what we had gotten in Sentry.

## What areas of the site does it impact?
10-10CG form submission backend processing

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
