### PR TITLE
Replace Virtus with Vets::Model - Veteran Module

### DIFF
--- a/modules/veteran/app/models/veteran/base.rb
+++ b/modules/veteran/app/models/veteran/base.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
 require 'evss/auth_headers'
 
 # Veteran model
 module Veteran
-  class Base < Common::Base
+  class Base
+    include Vets::Model
   end
 end


### PR DESCRIPTION
## Summary

- The virtus gem ([source](https://github.com/solnic/virtus)) is discontinued and must be replaced
- The replacement is `Vets::Model` ([source](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/vets/model.rb))
- This PR replaces `Virtus.model` with `Vets::Model` and updates the attributes according 
    - The attribute updates are minor and mostly related to Booleans and Arrays
- This change should not affect any functionality. 
- Some changes from hash notation to dot notation were required

## Related Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92450

## Testing

- [x] Make sure the specs pass
- [x] Manually checking the serialized responses are the same

## Acceptance Criteria 

- [x] Serialized responses are identical
- [x] No functionality changes