### PR TITLE
Replace Common::Collection with Vets::Collection - Preneeds Service

### DIFF
--- a/app/controllers/v0/preneeds/cemeteries_controller.rb
+++ b/app/controllers/v0/preneeds/cemeteries_controller.rb
@@ -5,7 +5,7 @@ module V0
     class CemeteriesController < PreneedsController
       def index
         resource = client.get_cemeteries
-        render json: CemeterySerializer.new(resource.data)
+        render json: CemeterySerializer.new(resource.records)
       end
     end
   end

--- a/lib/preneeds/service.rb
+++ b/lib/preneeds/service.rb
@@ -29,7 +29,6 @@ module Preneeds
       soap = savon_client.build_request(:get_cemeteries, message: {})
       json = with_monitoring { perform(:post, '', soap.body).body }
 
-
       Vets::Collection.new(json[:data], Cemetery, metadata: json[:metadata], errors: json[:errors])
     end
 

--- a/lib/preneeds/service.rb
+++ b/lib/preneeds/service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'common/client/base'
+require 'vets/collection'
 
 module Preneeds
   # Proxy Service for the EOAS (Eligibility Office Automation System) Service's PreNeed Applications endpoints.
@@ -28,7 +29,8 @@ module Preneeds
       soap = savon_client.build_request(:get_cemeteries, message: {})
       json = with_monitoring { perform(:post, '', soap.body).body }
 
-      Common::Collection.new(Cemetery, **json)
+
+      Vets::Collection.new(json[:data], Cemetery, metadata: json[:metadata], errors: json[:errors])
     end
 
     # POST to submit a {Preneeds::BurialForm}

--- a/modules/mobile/app/controllers/mobile/v0/cemeteries_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/cemeteries_controller.rb
@@ -8,7 +8,7 @@ module Mobile
       def index
         resource = client.get_cemeteries
 
-        render json: Mobile::V0::CemeteriesSerializer.new(resource.attributes)
+        render json: Mobile::V0::CemeteriesSerializer.new(resource)
       end
 
       def client

--- a/modules/mobile/app/serializers/mobile/v0/cemeteries_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/cemeteries_serializer.rb
@@ -13,10 +13,10 @@ module Mobile
       attribute :type
 
       def initialize(cemeteries_info)
-        resource = cemeteries_info.collect do |cemetery_info|
-          CemeteriesStruct.new(id: cemetery_info['num'],
-                               name: cemetery_info['name'],
-                               type: cemetery_info['cemetery_type'])
+        resource = cemeteries_info.records.map do |cemetery_info|
+          CemeteriesStruct.new(id: cemetery_info.num,
+                               name: cemetery_info.name,
+                               type: cemetery_info.cemetery_type)
         end
 
         super(resource)

--- a/spec/lib/preneeds/service_spec.rb
+++ b/spec/lib/preneeds/service_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require 'preneeds/service'
+require 'vets/collection'
 
 describe Preneeds::Service do
   let(:subject) { described_class.new }
@@ -13,7 +14,7 @@ describe Preneeds::Service do
         subject.get_cemeteries
       end
 
-      expect(cemeteries).to be_a(Common::Collection)
+      expect(cemeteries).to be_a(Vets::Collection)
       expect(cemeteries.type).to eq(Preneeds::Cemetery)
     end
   end


### PR DESCRIPTION
## Summary

- The virtus gem ([source](https://github.com/solnic/virtus)) is discontinued and must be replaced
- This PR updates Common::Collection with Vets::Collection
   - Vets::Collection is a near match with Common::Collection 

## Related Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92439

## Testing

- [x] Make sure the specs pass
- [x] Manually checking the serialized responses are the same

## Acceptance Criteria 

- [x] Serialized responses are identical
- [x] No functionality changes