### PR TITLE
Sjc virtus simple form mod

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/base_form.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/base_form.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module SimpleFormsApi
   class BaseForm
-    include Virtus.model(nullify_blank: true)
+    include Vets::Model
 
     attribute :data
 

--- a/modules/simple_forms_api/app/models/simple_forms_api/base_form.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/base_form.rb
@@ -6,12 +6,13 @@ module SimpleFormsApi
   class BaseForm
     include Vets::Model
 
-    attribute :data
+    attribute :data, Hash
 
     attr_accessor :signature_date
 
     def initialize(data)
-      @data = data
+      data = data&.to_unsafe_h unless data.is_a?(Hash)
+      super({data: data})
       @signature_date = Time.current.in_time_zone('America/Chicago')
     end
 


### PR DESCRIPTION
## Summary

- The virtus gem ([source](https://github.com/solnic/virtus)) is discontinued and must be replaced
- The replacement is `Vets::Model` ([source](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/vets/model.rb))
- This PR replaces `Virtus.model` with `Vets::Model` and updates the attributes according 
    - The attribute updates are minor and mostly related to Booleans and Arrays
- This change should not affect any functionality. 
- Some changes from hash notation to dot notation were required

## Related Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92449

## Testing

- [x] Make sure the specs pass
- [x] Manually checking the serialized responses are the same

## Acceptance Criteria 

- [x] Serialized responses are identical
- [x] No functionality changes