### PR TITLE
Clean up failure metrics for Lighthouse::FailureNotification job

### DIFF
--- a/app/sidekiq/lighthouse/evidence_submissions/document_upload.rb
+++ b/app/sidekiq/lighthouse/evidence_submissions/document_upload.rb
@@ -86,8 +86,6 @@ module Lighthouse
         Lighthouse::FailureNotification.perform_async(icn, create_personalisation(msg))
 
         ::Rails.logger.info("#{name} exhaustion handler email queued")
-        StatsD.increment('silent_failure_avoided_no_confirmation',
-                         tags: ['service:claim-status', 'function: evidence upload to Lighthouse'])
       rescue => e
         ::Rails.logger.error("#{name} exhaustion handler email error",
                              { message: e.message })

--- a/app/sidekiq/lighthouse/failure_notification.rb
+++ b/app/sidekiq/lighthouse/failure_notification.rb
@@ -15,7 +15,9 @@ class Lighthouse::FailureNotification
   end
 
   sidekiq_retries_exhausted do
-    ::Rails.logger.info('Lighthouse::FailureNotification email could not be sent')
+    message = 'Lighthouse::FailureNotification email could not be sent'
+    ::Rails.logger.info(message)
+    StatsD.increment('silent_failure', tags: ['service:claim-status', "function: #{message}"])
   end
 
   def notify_client

--- a/spec/sidekiq/lighthouse/evidence_submissions/document_upload_spec.rb
+++ b/spec/sidekiq/lighthouse/evidence_submissions/document_upload_spec.rb
@@ -360,7 +360,6 @@ RSpec.describe Lighthouse::EvidenceSubmissions::DocumentUpload, type: :job do
           expect(Rails.logger)
             .to receive(:info)
             .with(log_message)
-          expect(StatsD).to receive(:increment).with('silent_failure_avoided_no_confirmation', tags: statsd_tags)
         end
       end
     end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): **NO**
- The `Lighthouse::FailureNotification` job now uses a [callback](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/sidekiq/lighthouse/evidence_submissions/va_notify_email_status_callback.rb#L40) from VA Notify to increment `silent_failure_avoided` / `silent_failure` according to the email delivery status, thus `silent_failure_avoided_no_confirmation` is removed. In addition, the `silent_failure` metric is now emitted when job retries are exhausted.
- Team: Benefits Management Tools

## Related issue(s)

- 

## Testing done

- [x] *Code is covered by unit tests.*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature