### PR TITLE
[Payments] Payment data may not be an array, so wrap before iterating

### DIFF
--- a/app/services/bgs/payment_service.rb
+++ b/app/services/bgs/payment_service.rb
@@ -22,13 +22,15 @@ module BGS
       return empty_response if response[:payments].nil?
 
       if Flipper.enabled?(:payment_history_exclude_third_party_disbursements)
-        payments = response[:payments][:payment]
+        payments = Array.wrap(response[:payments][:payment])
         payments.select! do |pay|
           pay[:payee_type] != 'Third Party/Vendor' && pay[:beneficiary_participant_id] == pay[:recipient_participant_id]
         end
       end
 
-      recategorize_hardship(response[:payments][:payment]) if Flipper.enabled?(:payment_history_recategorize_hardship)
+      if Flipper.enabled?(:payment_history_recategorize_hardship)
+        recategorize_hardship(Array.wrap(response[:payments][:payment]))
+      end
 
       response
     rescue => e


### PR DESCRIPTION
Iteration on this previous PR: https://github.com/department-of-veterans-affairs/vets-api/pull/21906
This fixes an issue caught in Sentry.

Slack discussion here: https://dsva.slack.com/archives/CBU0KDSB1/p1746810044798179
Sentry here: https://sentry.vfs.va.gov/organizations/vsp/issues/334865/?environment=production&project=3&query=is%3Aunresolved&statsPeriod=14d

I have since disabled the two feature flippers, so the error is no longer happening. I will re-enable them when this PR goes out.

The actual fix is simple, `Array.wrap` the provided response before performing `.select` and `.each` on it in a manner that assumes it is an array. [The payment history adapter](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/models/adapters/payment_history_adapter.rb#L14) does this with `[payments].flatten`, but that's further down the chain than my changes in the service.