### PR TITLE
1588: remove show_digital_form_1095b feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1801,10 +1801,6 @@ features:
     actor_type: user
     description: Enables showing the overpayment and summary pages for the CDP Payment History
     enable_in_development: true
-  show_digital_form_1095b:
-    actor_type: user
-    description: Enables access to digital 1095-B form download
-    enable_in_development: true
   show_meb_dgi40_features:
     actor_type: user
     description: Enables the UI integration with the meb dgi


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- Removes a feature flag that is no longer needed. References to it have already been removed from the front end. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va-iir/issues/1588

## Testing done

Specs still pass.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Removes a feature flag that is no longer in use on the front end. It's also not used on the back end.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
