### PR TITLE
Arp/form upload/1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -284,6 +284,7 @@ app/models/persistent_attachments/dependency_claim.rb @department-of-veterans-af
 app/models/persistent_attachments/lgy_claim.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/persistent_attachments/pension_burial.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/pension-and-burials @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/persistent_attachments/va_form.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/models/persistent_attachments/va_form_attachment.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/personal_information_log.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/power_of_attorney.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/preneeds @department-of-veterans-affairs/mbs-core-team @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/models/persistent_attachments/va_form_attachment.rb
+++ b/app/models/persistent_attachments/va_form_attachment.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class PersistentAttachments::VAFormAttachment < PersistentAttachment
+  include ::FormUpload::Uploader::Attachment.new(:file)
+
+  before_destroy(:delete_file)
+
+  private
+
+  def delete_file
+    file.delete
+  end
+end

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/saved_claim/benefits_intake.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/saved_claim/benefits_intake.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  module SavedClaim
+    class BenefitsIntake < ::SavedClaim
+      class << self
+        def define_claim(form_id:, business_line:)
+          const_set :FORM_ID, form_id
+          const_set :BUSINESS_LINE, business_line
+
+          validates! :form_id, inclusion: [form_id]
+          after_initialize { self.form_id = self.class::FORM_ID }
+        end
+      end
+
+      FORM = 'BENEFITS-INTAKE'
+
+      module BusinessLines
+        COMPENSATION = 'COMPENSATION'
+      end
+
+      with_options inverse_of: :saved_claim, dependent: :destroy do
+        ##
+        # TODO: Add some application-level validation that this claim has _only
+        # one_ `form_attachment`?
+        #
+        has_one(
+          :form_attachment,
+          -> { where(type: PersistentAttachments::VAForm) },
+          class_name: 'PersistentAttachment',
+          required: true
+        )
+
+        has_many(
+          :persistent_attachments,
+          -> { where(type: PersistentAttachments::VAFormAttachment) }
+        )
+      end
+
+      delegate :to_pdf, to: :form_attachment
+
+      def business_line
+        self.class::BUSINESS_LINE
+      end
+
+      class DependencyClaim < self
+        define_claim(
+          form_id: '21-686C_BENEFITS-INTAKE',
+          business_line: BusinessLines::COMPENSATION
+        )
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/docs/BENEFITS_INTAKE_CLAIMS.md
+++ b/modules/accredited_representative_portal/docs/BENEFITS_INTAKE_CLAIMS.md
@@ -1,0 +1,1 @@
+# Benefits Intake Claims

--- a/modules/accredited_representative_portal/spec/models/accredited_representative_portal/saved_claim/benefits_intake_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representative_portal/saved_claim/benefits_intake_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccreditedRepresentativePortal::SavedClaim::BenefitsIntake, type: :model do
+  subject(:claim) do
+    form = {}.to_json
+    described_class::DependencyClaim.new(form:)
+  end
+
+  before do
+    allow(VetsJsonSchema::SCHEMAS).to(
+      receive(:[]).and_return({})
+    )
+  end
+
+  describe 'form_id' do
+    context 'when set automatically' do
+      it 'is set validly' do
+        expect(claim.form_id).to eq(
+          '21-686C_BENEFITS-INTAKE'
+        )
+
+        claim.valid?
+        errors = claim.errors.details[:form_id]
+        expect(errors).to eq([])
+      end
+    end
+
+    context 'when reset invalidly' do
+      before do
+        claim.form_id = 'INVALID'
+      end
+
+      it 'raises `ActiveModel::StrictValidationFailed` when validated' do
+        expect { claim.valid? }.to raise_error(
+          ActiveModel::StrictValidationFailed
+        )
+      end
+    end
+  end
+
+  describe 'form_attachment' do
+    context 'without setting a `form_attachment`' do
+      it 'is invalid when validating' do
+        claim.valid?
+        errors = claim.errors.details[:form_attachment]
+        expect(errors).to eq([{ error: :blank }])
+      end
+    end
+
+    context 'with setting a `form_attachment`' do
+      before do
+        claim.form_attachment = PersistentAttachments::VAForm.new
+      end
+
+      it 'is invalid when validating' do
+        claim.valid?
+        errors = claim.errors.details[:form_attachment]
+        expect(errors).to eq([])
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/models/accredited_representative_portal/saved_claim/benefits_intake_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representative_portal/saved_claim/benefits_intake_spec.rb
@@ -54,11 +54,19 @@ RSpec.describe AccreditedRepresentativePortal::SavedClaim::BenefitsIntake, type:
         claim.form_attachment = PersistentAttachments::VAForm.new
       end
 
-      it 'is invalid when validating' do
+      it 'is valid when validating' do
         claim.valid?
         errors = claim.errors.details[:form_attachment]
         expect(errors).to eq([])
       end
+    end
+  end
+
+  describe 'business_line' do
+    it 'is is defined correctly' do
+      expect(claim.business_line).to eq(
+        'COMPENSATION'
+      )
     end
   end
 end


### PR DESCRIPTION
Here is a PR (first in a stack) that introduces the core of the data model that would give us a generic benefits intake claim submission that interoperates w/ platform's code for doing this generically too.

Goal is being small, nonintrusive, and leading the way towards any areas where platform code gets inappropriately specific. If/when we reach any instances of that, we'd be bold about putting workarounds in platform code rather than duplicate the entire system (which has happened multiple times already in vets-api) .

Service classes that wrap interactions w/ this data model forthcoming now that the hard part is "figured out".

The key features of our solution include:
- Interoperating w/ existing `SubmitBenefitsIntakeClaim` asynchronous BI API integration
  - Form data will map to BI API metadata
- Use `SavedClaim` as a container for attachments
  - Distinguish between one main form attachment vs non-main-form attachments, matching BI API
- We'll associate representative data to this container as well
