### PR TITLE
MHV-71298 Added models for vaccine and health condition

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -273,6 +273,7 @@ app/models/messaging_preference.rb @department-of-veterans-affairs/vfs-mhv-secur
 app/models/messaging_signature.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/mhv_opt_in_flag.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/octo-identity
 app/models/mhv_user_account.rb @department-of-veterans-affairs/octo-identity
+app/models/mhv/mr @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/mpi_data.rb @department-of-veterans-affairs/octo-identity
 app/models/old_email.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/onsite_notification.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
@@ -1673,6 +1674,7 @@ spec/models/lighthouse526_document_upload_spec.rb @department-of-veterans-affair
 spec/models/message_spec.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/mhv_opt_in_flag_spec.rb @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/mhv_user_account_spec.rb @department-of-veterans-affairs/octo-identity
+spec/models/mhv/mr @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/mpi_data_spec.rb @department-of-veterans-affairs/octo-identity
 spec/models/onsite_notification_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/models/persistent_attachments @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/pension-and-burials @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/models/mhv/mr/fhir_record.rb
+++ b/app/models/mhv/mr/fhir_record.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'common/models/base'
+
+module MHV
+  module MR
+    # Abstract superclass for models built from FHIR resources
+    # template class that handles common lookup and construction logic
+    class FHIRRecord < Common::Base
+      # Build a new instance from a FHIR resource, or return nil if none
+      def self.from_fhir(fhir)
+        return nil if fhir.nil?
+
+        new(map_fhir(fhir))
+      end
+
+      # Subclasses must implement this to return a hash of attributes
+      def self.map_fhir(fhir)
+        raise NotImplementedError, "#{name}.map_fhir must be implemented by subclass"
+      end
+
+      # Locate a contained resource by its reference string ("#id"), optionally filtering by type
+      def self.find_contained(fhir, reference, type: nil)
+        return nil unless reference && fhir.contained
+
+        target_id = reference.delete_prefix('#')
+        resource = fhir.contained.detect { |res| res.id == target_id }
+        return nil unless resource
+        return resource if type.nil? || resource.resourceType == type
+
+        nil
+      end
+    end
+  end
+end

--- a/app/models/mhv/mr/health_condition.rb
+++ b/app/models/mhv/mr/health_condition.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'common/models/base'
+
+module MHV
+  module MR
+    class HealthCondition < MHV::MR::FHIRRecord
+      attribute :id,        String
+      attribute :name,      String
+      attribute :date,      String # Pass on as-is to the frontend
+      attribute :provider,  String
+      attribute :facility,  String
+      attribute :comments,  Array
+
+      def self.map_fhir(fhir)
+        facility_ref  = fhir.recorder&.extension&.first&.valueReference&.reference
+        provider_ref  = fhir.recorder&.reference
+        {
+          id: fhir.id,
+          name: fhir.code&.text,
+          date: fhir.recordedDate,
+          facility: find_contained(fhir, facility_ref, type: 'Location')&.name,
+          provider: find_contained(fhir, provider_ref, type: 'Practitioner')&.name&.first&.text,
+          comments: (fhir.note || []).map(&:text)
+        }
+      end
+    end
+  end
+end

--- a/app/models/mhv/mr/vaccine.rb
+++ b/app/models/mhv/mr/vaccine.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module MHV
+  module MR
+    class Vaccine < MHV::MR::FHIRRecord
+      attribute :id,            String
+      attribute :name,          String
+      attribute :date_received, String # Pass on as-is to the frontend
+      attribute :location,      String
+      attribute :manufacturer,  String
+      attribute :reactions,     String
+      attribute :notes,         Array
+
+      ##
+      # Map from a FHIR::Immunization resource
+      #
+      def self.map_fhir(fhir)
+        # extract location.name
+        loc_res = find_contained(fhir, fhir.location&.reference, type: 'Location')
+        # extract reaction Observation.code.text
+        obs_res = find_contained(fhir, fhir.reaction&.first&.detail&.reference, type: 'Observation')
+
+        {
+          id: fhir.id,
+          name: fhir.vaccineCode&.text,
+          date_received: fhir.occurrenceDateTime,
+          location: loc_res&.name,
+          manufacturer: fhir.manufacturer&.display,
+          reactions: obs_res&.code&.text,
+          notes: (fhir.note || []).map(&:text)
+        }
+      end
+    end
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -24,6 +24,7 @@ ActiveSupport::Inflector.inflections do |inflect|
   inflect.acronym 'MDOT'
   inflect.acronym 'MHV' # My HealtheVet
   inflect.acronym 'MPI' # Master Persons Index (formerly MVI for Veteran instead of Persons)
+  inflect.acronym 'MR' # MHV Medical Records
   inflect.acronym 'NCA' # National Cemetery Administration
   inflect.acronym 'OAuth'
   inflect.acronym 'PagerDuty'

--- a/modules/my_health/app/controllers/my_health/mr_controller.rb
+++ b/modules/my_health/app/controllers/my_health/mr_controller.rb
@@ -6,7 +6,7 @@ require 'medical_records/phr_mgr/client'
 require 'medical_records/lighthouse_client'
 
 module MyHealth
-  class MrController < ApplicationController
+  class MRController < ApplicationController
     include MyHealth::MHVControllerConcerns
     service_tag 'mhv-medical-records'
 

--- a/modules/my_health/app/controllers/my_health/v1/allergies_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/allergies_controller.rb
@@ -2,7 +2,7 @@
 
 module MyHealth
   module V1
-    class AllergiesController < MrController
+    class AllergiesController < MRController
       def index
         render_resource client.list_allergies
       end

--- a/modules/my_health/app/controllers/my_health/v1/clinical_notes_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/clinical_notes_controller.rb
@@ -2,7 +2,7 @@
 
 module MyHealth
   module V1
-    class ClinicalNotesController < MrController
+    class ClinicalNotesController < MRController
       def index
         render_resource client.list_clinical_notes
       end

--- a/modules/my_health/app/controllers/my_health/v1/conditions_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/conditions_controller.rb
@@ -2,7 +2,7 @@
 
 module MyHealth
   module V1
-    class ConditionsController < MrController
+    class ConditionsController < MRController
       def index
         render_resource client.list_conditions
       end

--- a/modules/my_health/app/controllers/my_health/v1/labs_and_tests_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/labs_and_tests_controller.rb
@@ -2,7 +2,7 @@
 
 module MyHealth
   module V1
-    class LabsAndTestsController < MrController
+    class LabsAndTestsController < MRController
       def index
         render_resource client.list_labs_and_tests
       end

--- a/modules/my_health/app/controllers/my_health/v1/medical_records/bbmi_notification_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/medical_records/bbmi_notification_controller.rb
@@ -3,7 +3,7 @@
 module MyHealth
   module V1
     module MedicalRecords
-      class BbmiNotificationController < MrController
+      class BbmiNotificationController < MRController
         # Retrieves the BBMI notification setting
         # @return [JSON] BBMI notification setting
         def status

--- a/modules/my_health/app/controllers/my_health/v1/medical_records/ccd_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/medical_records/ccd_controller.rb
@@ -3,7 +3,7 @@
 module MyHealth
   module V1
     module MedicalRecords
-      class CcdController < MrController
+      class CcdController < MRController
         include MyHealth::AALClientConcerns
 
         # Generates a CCD

--- a/modules/my_health/app/controllers/my_health/v1/medical_records/imaging_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/medical_records/imaging_controller.rb
@@ -3,7 +3,7 @@
 module MyHealth
   module V1
     module MedicalRecords
-      class ImagingController < MrController
+      class ImagingController < MRController
         include ActionController::Live
 
         before_action :set_study_id, only: %i[request_download images image dicom]

--- a/modules/my_health/app/controllers/my_health/v1/medical_records/mr_session_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/medical_records/mr_session_controller.rb
@@ -3,7 +3,7 @@
 module MyHealth
   module V1
     module MedicalRecords
-      class MrSessionController < MRController
+      class MRSessionController < MRController
         def create
           client
           head :no_content

--- a/modules/my_health/app/controllers/my_health/v1/medical_records/mr_session_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/medical_records/mr_session_controller.rb
@@ -3,7 +3,7 @@
 module MyHealth
   module V1
     module MedicalRecords
-      class MrSessionController < MrController
+      class MrSessionController < MRController
         def create
           client
           head :no_content

--- a/modules/my_health/app/controllers/my_health/v1/medical_records/patient_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/medical_records/patient_controller.rb
@@ -3,7 +3,7 @@
 module MyHealth
   module V1
     module MedicalRecords
-      class PatientController < MrController
+      class PatientController < MRController
         # Gets a user's treatment facilities
         # @return [Array] of treatment facilities and related user info
         def index

--- a/modules/my_health/app/controllers/my_health/v1/medical_records/radiology_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/medical_records/radiology_controller.rb
@@ -3,7 +3,7 @@
 module MyHealth
   module V1
     module MedicalRecords
-      class RadiologyController < MrController
+      class RadiologyController < MRController
         def index
           resource = bb_client.list_radiology
           render json: resource.to_json

--- a/modules/my_health/app/controllers/my_health/v1/vaccines_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/vaccines_controller.rb
@@ -2,7 +2,7 @@
 
 module MyHealth
   module V1
-    class VaccinesController < MrController
+    class VaccinesController < MRController
       def index
         render_resource client.list_vaccines
       end

--- a/modules/my_health/app/controllers/my_health/v1/vitals_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/vitals_controller.rb
@@ -2,7 +2,7 @@
 
 module MyHealth
   module V1
-    class VitalsController < MrController
+    class VitalsController < MRController
       def index
         render_resource client.list_vitals(params[:from], params[:to])
       end

--- a/spec/models/mhv/mr/health_condition_spec.rb
+++ b/spec/models/mhv/mr/health_condition_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MHV::MR::HealthCondition, type: :model do
+  describe '.from_fhir' do
+    context 'with a valid FHIR::Condition resource' do
+      subject(:health_condition) { described_class.from_fhir(fhir_condition) }
+
+      let(:location_resource) do
+        FHIR::Location.new(
+          id: 'loc-1',
+          name: 'Test Facility'
+        )
+      end
+
+      let(:practitioner_resource) do
+        FHIR::Practitioner.new(
+          id: 'prov-1',
+          name: [FHIR::HumanName.new(text: 'Dr. Test')]
+        )
+      end
+
+      let(:extension) do
+        FHIR::Extension.new(
+          url: 'http://hl7.org/fhir/StructureDefinition/alternate-reference',
+          valueReference: FHIR::Reference.new(reference: '#loc-1')
+        )
+      end
+
+      let(:recorder_reference) do
+        FHIR::Reference.new(
+          reference: '#prov-1',
+          extension: [extension]
+        )
+      end
+
+      let(:fhir_condition) do
+        FHIR::Condition.new(
+          id: '123',
+          code: FHIR::CodeableConcept.new(text: 'Test Condition'),
+          recordedDate: '2022-04-29',
+          recorder: recorder_reference,
+          contained: [location_resource, practitioner_resource],
+          note: [
+            FHIR::Annotation.new(text: 'Note one'),
+            FHIR::Annotation.new(text: 'Note two')
+          ]
+        )
+      end
+
+      it 'maps id correctly' do
+        expect(health_condition.id).to eq('123')
+      end
+
+      it 'maps name correctly' do
+        expect(health_condition.name).to eq('Test Condition')
+      end
+
+      it 'maps date correctly' do
+        expect(health_condition.date).to eq('2022-04-29')
+      end
+
+      it 'maps facility correctly' do
+        expect(health_condition.facility).to eq('Test Facility')
+      end
+
+      it 'maps provider correctly' do
+        expect(health_condition.provider).to eq('Dr. Test')
+      end
+
+      it 'maps comments correctly' do
+        expect(health_condition.comments).to eq(['Note one', 'Note two'])
+      end
+    end
+
+    context 'when given nil' do
+      it 'returns nil' do
+        expect(described_class.from_fhir(nil)).to be_nil
+      end
+    end
+
+    context 'with missing fields and contained resources' do
+      subject(:health_condition) { described_class.from_fhir(fhir_condition) }
+
+      let(:fhir_condition) { FHIR::Condition.new(id: '456') }
+
+      it 'sets id correctly' do
+        expect(health_condition.id).to eq('456')
+      end
+
+      it 'defaults name to nil' do
+        expect(health_condition.name).to be_nil
+      end
+
+      it 'defaults date to nil' do
+        expect(health_condition.date).to be_nil
+      end
+
+      it 'defaults facility to nil' do
+        expect(health_condition.facility).to be_nil
+      end
+
+      it 'defaults provider to nil' do
+        expect(health_condition.provider).to be_nil
+      end
+
+      it 'defaults comments to an empty array' do
+        expect(health_condition.comments).to eq([])
+      end
+    end
+  end
+end

--- a/spec/models/mhv/mr/vaccine_spec.rb
+++ b/spec/models/mhv/mr/vaccine_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MHV::MR::Vaccine do
+  describe '.from_fhir' do
+    context 'with a valid FHIR::Immunization resource' do
+      subject(:vaccine) { described_class.from_fhir(immunization) }
+
+      let(:location_resource) do
+        FHIR::Location.new(
+          id: 'in-location-2',
+          name: 'Test Location'
+        )
+      end
+
+      let(:observation_resource) do
+        FHIR::Observation.new(
+          id: 'in-reaction-2',
+          code: FHIR::CodeableConcept.new(text: 'FEVER')
+        )
+      end
+
+      let(:immunization) do
+        FHIR::Immunization.new(
+          id: '12345',
+          vaccineCode: FHIR::CodeableConcept.new(text: 'TEST VACCINE'),
+          occurrenceDateTime: '2023-10-27T10:00:00-04:00',
+          location: FHIR::Reference.new(reference: '#in-location-2'),
+          manufacturer: FHIR::Reference.new(display: 'Test Manufacturer'),
+          reaction: [
+            FHIR::Immunization::Reaction.new(
+              detail: FHIR::Reference.new(reference: '#in-reaction-2')
+            )
+          ],
+          note: [
+            FHIR::Annotation.new(text: 'Note 1'),
+            FHIR::Annotation.new(text: 'Note 2')
+          ],
+          contained: [location_resource, observation_resource]
+        )
+      end
+
+      it 'maps id correctly' do
+        expect(vaccine.id).to eq('12345')
+      end
+
+      it 'maps name correctly' do
+        expect(vaccine.name).to eq('TEST VACCINE')
+      end
+
+      it 'maps date_received correctly' do
+        expect(vaccine.date_received).to eq('2023-10-27T10:00:00-04:00')
+      end
+
+      it 'maps location correctly' do
+        expect(vaccine.location).to eq('Test Location')
+      end
+
+      it 'maps manufacturer correctly' do
+        expect(vaccine.manufacturer).to eq('Test Manufacturer')
+      end
+
+      it 'maps reactions correctly' do
+        expect(vaccine.reactions).to eq('FEVER')
+      end
+
+      it 'maps notes correctly' do
+        expect(vaccine.notes).to eq(['Note 1', 'Note 2'])
+      end
+    end
+
+    context 'when given nil' do
+      it 'returns nil' do
+        expect(described_class.from_fhir(nil)).to be_nil
+      end
+    end
+
+    context 'with missing contained resources and attributes' do
+      subject(:vaccine) { described_class.from_fhir(immunization) }
+
+      let(:immunization) { FHIR::Immunization.new(id: '1') }
+
+      it 'sets id correctly' do
+        expect(vaccine.id).to eq('1')
+      end
+
+      it 'defaults name to nil' do
+        expect(vaccine.name).to be_nil
+      end
+
+      it 'defaults date_received to nil' do
+        expect(vaccine.date_received).to be_nil
+      end
+
+      it 'defaults location to an empty string' do
+        expect(vaccine.location).to be_nil
+      end
+
+      it 'defaults manufacturer to an empty string' do
+        expect(vaccine.manufacturer).to be_nil
+      end
+
+      it 'defaults reactions to an empty string' do
+        expect(vaccine.reactions).to be_nil
+      end
+
+      it 'defaults notes to an empty array' do
+        expect(vaccine.notes).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Added models to convert backend FHIR results into simpler objects for eventual use in the frontend
- Renamed some controllers with capital "MR"

## Related issue(s)

### [MHV-71298](https://jira.devops.va.gov/browse/MHV-71298) - Create models in the backend for our FHIR objects ###

> Add backend models for all our FHIR objects. They should be able to build themselves from a returned FHIR resource.


## Testing done

- [x] *New code is covered by unit tests*
- This is prep-work for moving functionality to the backend in the future. Should have no impact on current functionality.
- Not behind a feature flag (yet)

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
MHV Medical Records

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
