### PR TITLE
API-46261 Send emails in batches too

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/one_off/poa_v1_bad_box20_render_report_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/one_off/poa_v1_bad_box20_render_report_job.rb
@@ -53,10 +53,10 @@ module ClaimsApi
       def process_date_range(date_range)
         poas = ClaimsApi::PowerOfAttorney.where cid: consumer_id, created_at: date_range
 
-        start_date = date_range.first.to_date.to_s
-        finish_date = date_range.last.to_date.to_s
+        sd = date_range.first.to_date.to_s
+        fd = date_range.last.to_date.to_s
 
-        memo = +"<h3>IDS from #{start_date} to #{finish_date}</h3>"
+        memo = +"<h3>IDS from #{sd} to #{fd}</h3>\n<br>"
         memo << 'poa_id,eauth_pnid,created_date'
         num_records = 0
 
@@ -69,12 +69,12 @@ module ClaimsApi
         end
 
         if num_records.zero?
-          ClaimsApi::Logger.log LOG_TAG, detail: "No records for week of #{start_date}"
+          ClaimsApi::Logger.log LOG_TAG, detail: "No records for week of #{sd}"
           return
         end
 
         ClaimsApi::Logger.log LOG_TAG, detail: "Found #{num_records} record(s)"
-        ClaimsApi::Logger.log LOG_TAG, detail: "Sending email for week of #{start_date}"
+        ClaimsApi::Logger.log LOG_TAG, detail: "Sending email for week of #{sd}"
         ClaimsApi::OneOff::PoaV1BadBox20RenderReportMailer.build(emails, memo).deliver_now
         ClaimsApi::Logger.log LOG_TAG, detail: 'Email sent'
       end

--- a/modules/claims_api/app/sidekiq/claims_api/one_off/poa_v1_bad_box20_render_report_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/one_off/poa_v1_bad_box20_render_report_job.rb
@@ -12,12 +12,20 @@ module ClaimsApi
 
     class PoaV1BadBox20RenderReportJob < ClaimsApi::ServiceBase
       sidekiq_options retry: 5 # Retry for ~10 mins
+
+      attr_accessor :consumer_id, :emails
+
       LOG_TAG = 'claims_api_poa_box20_report_job'
 
       # rubocop:disable Metrics/MethodLength
-      def perform(consumer_id, emails = [])
+      def perform(consumer_id, emails = [], start_date = nil, finish_date = nil)
+        @consumer_id = consumer_id
+        @emails = emails
+        start_date ||= '2025-01-07'
+        finish_date ||= '2025-04-03'
+
         if consumer_id.blank?
-          ClaimsApi::Logger.log LOG_TAG, level: :warn, detail: 'Invlaid CID.'
+          ClaimsApi::Logger.log LOG_TAG, level: :warn, detail: 'Invalid CID'
           slack_alert_on_failure LOG_TAG, 'Invalid CID'
           return
         end
@@ -26,14 +34,33 @@ module ClaimsApi
           slack_alert_on_failure LOG_TAG, 'Invalid email address list.'
           return
         end
+
         ClaimsApi::Logger.log(LOG_TAG, detail: 'Started processing')
-        date_range = Date.parse('2025-01-07').beginning_of_day...Date.parse('2025-04-03').end_of_day
+        (Date.parse(start_date)..Date.parse(finish_date)).group_by(&:cweek).each_value do |dates|
+          process_date_range dates.first.beginning_of_day..dates.last.end_of_day
+        end
+        ClaimsApi::Logger.log LOG_TAG, detail: 'Job complete'
+      rescue => e
+        # Only alert on the class name since an email exception may output the body, which would have PII
+        ClaimsApi::Logger.log LOG_TAG, detail: 'Exception thrown', level: :error, error: e.class.name
+        slack_alert_on_failure LOG_TAG, "Exception thrown: #{e.class}"
+        raise e
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      protected
+
+      def process_date_range(date_range)
         poas = ClaimsApi::PowerOfAttorney.where cid: consumer_id, created_at: date_range
 
-        memo = +'poa_id,eauth_pnid,created_date'
+        start_date = date_range.first.to_date.to_s
+        finish_date = date_range.last.to_date.to_s
+
+        memo = +"<h3>IDS from #{start_date} to #{finish_date}</h3>"
+        memo << 'poa_id,eauth_pnid,created_date'
         num_records = 0
 
-        poas.find_each(batch_size: 75) do |poa|
+        poas.find_each(batch_size: 100) do |poa|
           next if poa.form_data['consentLimits'].present?
 
           memo << "\n<br>"
@@ -42,22 +69,15 @@ module ClaimsApi
         end
 
         if num_records.zero?
-          ClaimsApi::Logger.log LOG_TAG, level: :warn, detail: 'No records found.'
-          slack_alert_on_failure LOG_TAG, 'No records found.'
+          ClaimsApi::Logger.log LOG_TAG, detail: "No records for week of #{start_date}"
           return
         end
 
         ClaimsApi::Logger.log LOG_TAG, detail: "Found #{num_records} record(s)"
-        ClaimsApi::Logger.log LOG_TAG, detail: 'Sending email'
+        ClaimsApi::Logger.log LOG_TAG, detail: "Sending email for week of #{start_date}"
         ClaimsApi::OneOff::PoaV1BadBox20RenderReportMailer.build(emails, memo).deliver_now
-        ClaimsApi::Logger.log LOG_TAG, detail: 'Email sent. Job complete.'
-      rescue => e
-        # Only alert on the class name since an email exception may output the body, which would have PII
-        ClaimsApi::Logger.log LOG_TAG, detail: 'Exception thrown.', level: :error, error: e.class.name
-        slack_alert_on_failure LOG_TAG, "Exception thrown: #{e.class}"
-        raise e
+        ClaimsApi::Logger.log LOG_TAG, detail: 'Email sent'
       end
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/modules/claims_api/spec/sidekiq/one_off/poa_v1_bad_box20_render_report_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/one_off/poa_v1_bad_box20_render_report_job_spec.rb
@@ -18,23 +18,33 @@ RSpec.describe ClaimsApi::OneOff::PoaV1BadBox20RenderReportJob, type: :job do
         # Reported by job - consentLimit field provided, but no chosen limitation(s)
         create_list(:power_of_attorney, 4, :with_fuzzed_headers, :with_blank_consent_limit, cid: consumer_id)
       end
+      # Jump by 2 weeks to ensure job can handle weeks w/ no applicable records
+      Timecop.freeze('Jan 24, 2025') do
+        # Reported by job - consentLimit field provided, but no chosen limitation(s)
+        create_list(:power_of_attorney, 5, :with_fuzzed_headers, :with_blank_consent_limit, cid: consumer_id)
+      end
       # Skipped by job - Would apply, but falls outside date range of bugged PDF generation
-      create_list(:power_of_attorney, 5, :with_fuzzed_headers, :with_blank_consent_limit, cid: consumer_id)
+      create_list(:power_of_attorney, 6, :with_fuzzed_headers, :with_blank_consent_limit, cid: consumer_id)
     end
 
-    it 'logs progress and sends email' do
+    it 'logs progress and sends emails' do
       expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Started processing')
-      expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Found 7 record(s)')
-      expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Sending email')
+      expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Found 7 record(s)') # 3 + 4 week 1
+      expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Sending email for week of 2025-01-07')
+      expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Email sent')
+      expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'No records for week of 2025-01-13')
+      expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Found 5 record(s)') # 5 week 3
+      expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Sending email for week of 2025-01-20')
+      expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Email sent')
 
-      expect(ClaimsApi::OneOff::PoaV1BadBox20RenderReportMailer).to receive(:build).and_return(
+      allow(ClaimsApi::OneOff::PoaV1BadBox20RenderReportMailer).to receive(:build).and_return(
         double.tap do |mailer|
-          expect(mailer).to receive(:deliver_now).once
+          expect(mailer).to receive(:deliver_now).twice
         end
       )
 
-      expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Email sent. Job complete.')
-      subject.perform(consumer_id, %w[example@va.gov])
+      expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Job complete')
+      subject.perform(consumer_id, %w[example@va.gov], '2025-01-07', '2025-01-26')
     end
 
     context 'Non-retrying failures' do
@@ -63,8 +73,8 @@ RSpec.describe ClaimsApi::OneOff::PoaV1BadBox20RenderReportJob, type: :job do
         allow_any_instance_of(ApplicationMailer).to receive(:mail).and_raise(error)
         expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Started processing')
         expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Found 7 record(s)')
-        expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Sending email')
-        expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Exception thrown.',
+        expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Sending email for week of 2025-01-07')
+        expect(ClaimsApi::Logger).to receive(:log).with(log_tag, detail: 'Exception thrown',
                                                                  level: :error,
                                                                  error: error.class.name)
         expect_any_instance_of(SlackNotify::Client).to receive(:notify).once


### PR DESCRIPTION
## Summary

It's suspected that the original email of all 2077 records was too large to send through the mail system. Manual testing showed that ~100 made it through fine, so this will send an email for each week of records in the date range.

## Related issue(s)

See #22044 

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
> Would try to send one big email at the end of filtering through the records
- How to test
> `ClaimsApi::OneOff::PoaV1BadBox20RenderReportJob.perform_async('<consumer_id>', %w[<va emails>], '<start date in YYYY-MM-DD format>', '<finish date in YYYY-MM-DD format>').`

## What areas of the site does it impact?

Reporting job. Nothing veteran facing or modifying of data.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature