### PR TITLE
109615: Append calim_id to callback_metadata

### DIFF
--- a/modules/burials/lib/burials/notification_email.rb
+++ b/modules/burials/lib/burials/notification_email.rb
@@ -47,5 +47,11 @@ module Burials
     def callback_klass
       Burials::NotificationCallback.to_s
     end
+
+    # Add 'claim_id' to the metadata for consistency in DataDog and Burials::Monitor
+    # @see VeteranFacingServices::NotificationEmail::SavedClaim#callback_metadata
+    def callback_metadata
+      super.merge(claim_id: claim.id)
+    end
   end
 end

--- a/modules/pensions/lib/pensions/notification_email.rb
+++ b/modules/pensions/lib/pensions/notification_email.rb
@@ -35,5 +35,11 @@ module Pensions
     def callback_klass
       Pensions::NotificationCallback.to_s
     end
+
+    # Add 'claim_id' to the metadata for consistency in DataDog and Pensions::Monitor
+    # @see VeteranFacingServices::NotificationEmail::SavedClaim#callback_metadata
+    def callback_metadata
+      super.merge(claim_id: claim.id)
+    end
   end
 end


### PR DESCRIPTION
Update callback_metadata to help look up issues in DataDog by not having to guess saved_claim_id or claim_id in log queries


## Summary

- Add `claim_id` to callback_metadata

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/109615

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
