### PR TITLE
Bug: Remove master branch from Settings Check runs

### DIFF
--- a/.github/workflows/settings_checks.yml
+++ b/.github/workflows/settings_checks.yml
@@ -1,8 +1,6 @@
 name: Settings Checks
 
 on:
-  push:
-    branches: [master]
   pull_request:
     types: [opened, reopened, synchronize]
     paths:


### PR DESCRIPTION
## Summary

- Settings Check runs on master, but only work when there's a code difference between master
- It would be inefficient to re-check all parameters on all PRs so instead we're option to not run on master
- The bug is not blocking merging or deploying

## Related issue(s)

- n/a

## Testing done

- [ ] n/a

## Acceptance criteria

- [ ] Settings Checks won't run on master branch
