### PR TITLE
Add exception logging to VRE send_vbms_confirmation_email failures

### DIFF
--- a/app/models/saved_claim/veteran_readiness_employment_claim.rb
+++ b/app/models/saved_claim/veteran_readiness_employment_claim.rb
@@ -165,8 +165,8 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
     end
 
     send_vbms_confirmation_email(user)
-  rescue
-    Rails.logger.error('Error uploading VRE claim to VBMS.', { user_uuid: user.uuid })
+  rescue => e
+    Rails.logger.error('Error uploading VRE claim to VBMS.', { user_uuid: user.uuid, e: })
     send_to_lighthouse!(user)
   end
 

--- a/app/models/saved_claim/veteran_readiness_employment_claim.rb
+++ b/app/models/saved_claim/veteran_readiness_employment_claim.rb
@@ -362,7 +362,7 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
 
   def log_error(user, e)
     if Flipper.enabled?(:vre_enable_vbms_exception_logging)
-      Rails.logger.error('Error uploading VRE claim to VBMS.', { user_uuid: user.uuid, e: })
+      Rails.logger.error('Error uploading VRE claim to VBMS.', { user_uuid: user.uuid, messsage: e.message })
     else
       Rails.logger.error('Error uploading VRE claim to VBMS.', { user_uuid: user.uuid })
     end

--- a/app/models/saved_claim/veteran_readiness_employment_claim.rb
+++ b/app/models/saved_claim/veteran_readiness_employment_claim.rb
@@ -166,7 +166,7 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
 
     send_vbms_confirmation_email(user)
   rescue => e
-    Rails.logger.error('Error uploading VRE claim to VBMS.', { user_uuid: user.uuid, e: })
+    log_error(user, e)
     send_to_lighthouse!(user)
   end
 
@@ -358,5 +358,13 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
     yield
     elapsed_time = Time.current - start_time
     StatsD.measure("api.1900.#{service}.response_time", elapsed_time, tags: {})
+  end
+
+  def log_error(user, e)
+    if Flipper.enabled?(:vre_enable_vbms_exception_logging)
+      Rails.logger.error('Error uploading VRE claim to VBMS.', { user_uuid: user.uuid, e: })
+    else
+      Rails.logger.error('Error uploading VRE claim to VBMS.', { user_uuid: user.uuid })
+    end
   end
 end

--- a/config/features.yml
+++ b/config/features.yml
@@ -1769,6 +1769,9 @@ features:
   vre_trigger_action_needed_email:
     actor_type: user
     description: Set whether to enable VANotify email to Veteran for VRE failure exhaustion
+  vre_enable_vbms_exception_logging:
+    actor_type: user
+    description: Enables exception logging for failures in upload_to_vbms method
   vre_modular_api:
     actor_type: user
     description: Enables calls to the modularized VRE API

--- a/modules/vre/app/models/vre/vre_veteran_readiness_employment_claim.rb
+++ b/modules/vre/app/models/vre/vre_veteran_readiness_employment_claim.rb
@@ -86,8 +86,12 @@ module VRE
 
       send_vbms_confirmation_email(user)
     rescue => e
-      Rails.logger.error('Error uploading VRE claim to VBMS.', { user_uuid: user.uuid, e: })
+      log_error(user, e)
       send_to_lighthouse!(user)
+    end
+
+    def to_pdf(file_name = nil)
+      PdfFill::Filler.fill_form(self, file_name, { created_at: })
     end
 
     # Submit claim into lighthouse service, adds veteran info to top level of form,
@@ -243,9 +247,13 @@ module VRE
       elapsed_time = Time.current - start_time
       StatsD.measure("api.1900.#{service}.response_time", elapsed_time, tags: {})
     end
-  end
 
-  def to_pdf(file_name = nil)
-    PdfFill::Filler.fill_form(self, file_name, { created_at: })
+    def log_error(user, e)
+      if Flipper.enabled?(:vre_enable_vbms_exception_logging)
+        Rails.logger.error('Error uploading VRE claim to VBMS.', { user_uuid: user.uuid, e: })
+      else
+        Rails.logger.error('Error uploading VRE claim to VBMS.', { user_uuid: user.uuid })
+      end
+    end
   end
 end

--- a/modules/vre/app/models/vre/vre_veteran_readiness_employment_claim.rb
+++ b/modules/vre/app/models/vre/vre_veteran_readiness_employment_claim.rb
@@ -85,8 +85,8 @@ module VRE
       end
 
       send_vbms_confirmation_email(user)
-    rescue
-      Rails.logger.error('Error uploading VRE claim to VBMS.', { user_uuid: user.uuid })
+    rescue => e
+      Rails.logger.error('Error uploading VRE claim to VBMS.', { user_uuid: user.uuid, e: })
       send_to_lighthouse!(user)
     end
 

--- a/modules/vre/app/models/vre/vre_veteran_readiness_employment_claim.rb
+++ b/modules/vre/app/models/vre/vre_veteran_readiness_employment_claim.rb
@@ -250,7 +250,7 @@ module VRE
 
     def log_error(user, e)
       if Flipper.enabled?(:vre_enable_vbms_exception_logging)
-        Rails.logger.error('Error uploading VRE claim to VBMS.', { user_uuid: user.uuid, e: })
+        Rails.logger.error('Error uploading VRE claim to VBMS.', { user_uuid: user.uuid, messsage: e.message })
       else
         Rails.logger.error('Error uploading VRE claim to VBMS.', { user_uuid: user.uuid })
       end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- This change adds exception logging to the existing `send_vbms_confirmation_email` failure logging, which currently only reports user uuid. This will assist us in investigating any issues that occur. It's being implemented behind a feature toggle to control usage.
- I work on the IIR Product team and we currently own VR&E (Ch 31).
- The success criteria targeted is ensuring that the exception logs contain appropriate information for the logging strategy. 

## Related issue(s)

- [1563](https://github.com/department-of-veterans-affairs/va-iir/issues/1563)

## Testing done

- [ ] *New code is covered by unit tests*
- Old behavior only logged user uuid. This adds the exception to that logging.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
This only impacts VR&E (Ch 31) app.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
