### PR TITLE
Remove static landing toggle flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1660,10 +1660,6 @@ features:
     actor_type: user
     description: Allows veterans to submit requests for VA appointments
     enable_in_development: true
-  va_online_scheduling_static_landing_page:
-    actor_type: user
-    description: Allows updates to the static landing widget on the Public Websites page
-    enable_in_development: true
   va_online_scheduling_vaos_alternate_route:
     actor_type: user
     enable_in_development: false


### PR DESCRIPTION


## Summary

This PR removes the feature toggle flag,  `va_online_scheduling_static_landing_page`

## Related issue(s)

- Link to ticket created in va.gov-team repo [#103686](https://github.com/department-of-veterans-affairs/va.gov-team/issues/103686) 

## Testing done

n/a

## Screenshots
n/a

## What areas of the site does it impact?
feature.yml

## Acceptance criteria

- [ ]  Remove the feature toggle flag,  `va_online_scheduling_static_landing_page`

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
