### PR TITLE
MHV-71086 Added AAL logging for military service

### DIFF
--- a/modules/my_health/spec/requests/my_health/v1/medical_records/military_service_spec.rb
+++ b/modules/my_health/spec/requests/my_health/v1/medical_records/military_service_spec.rb
@@ -1,14 +1,36 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'support/mr_client_helpers'
 require 'medical_records/client'
 require 'medical_records/phr_mgr/client'
+require 'mhv/aal/client'
+require 'support/mr_client_helpers'
 require 'support/shared_examples_for_mhv'
 
 RSpec.describe 'MyHealth::V1::MedicalRecords::MilitaryServiceController', type: :request do
   include MedicalRecords::ClientHelpers
   include SchemaMatchers
+
+  let(:aal_client) { instance_spy(AAL::MRClient) }
+
+  before do
+    allow(Flipper).to receive(:enabled?).with(:mhv_medical_records_migrate_to_api_gateway).and_return(false)
+
+    allow(AAL::MRClient).to receive(:new).and_return(aal_client)
+
+    phr_mgr_client = PHRMgr::Client.new(
+      session: {
+        user_id: 11_375_034,
+        icn: '1000000000V000000',
+        patient_id: '11382904',
+        expires_at: 1.hour.from_now,
+        token: '<SESSION_TOKEN>'
+      }
+    )
+
+    allow(PHRMgr::Client).to receive(:new).and_return(phr_mgr_client)
+    sign_in_as(current_user)
+  end
 
   context 'Unauthorized User' do
     context 'with no EDIPI' do
@@ -61,30 +83,52 @@ RSpec.describe 'MyHealth::V1::MedicalRecords::MilitaryServiceController', type: 
     let(:current_user) { build(:user, :mhv, mhv_account_type:, edipi: '1234567890') }
     let(:mhv_account_type) { 'Premium' }
 
-    before do
-      allow(Flipper).to receive(:enabled?).with(:mhv_medical_records_migrate_to_api_gateway).and_return(false)
+    context 'retrieving a standalone report' do
+      it 'responds to GET #index and logs an AAL' do
+        VCR.use_cassette('phr_mgr_client/get_military_service') do
+          get '/my_health/v1/medical_records/military_service'
+        end
 
-      phr_mgr_client = PHRMgr::Client.new(
-        session: {
-          user_id: 11_375_034,
-          icn: '1000000000V000000',
-          patient_id: '11382904',
-          expires_at: 1.hour.from_now,
-          token: '<SESSION_TOKEN>'
-        }
-      )
-
-      allow(PHRMgr::Client).to receive(:new).and_return(phr_mgr_client)
-      sign_in_as(current_user)
-    end
-
-    it 'responds to GET #index' do
-      VCR.use_cassette('phr_mgr_client/get_military_service') do
-        get '/my_health/v1/medical_records/military_service'
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to be_a(String)
+        expect_aal_logged(1)
       end
 
-      expect(response).to be_successful
-      expect(response.body).to be_a(String)
+      it 'responds to GET #index with a failure and logs an AAL' do
+        allow_any_instance_of(PHRMgr::Client)
+          .to receive(:get_military_service)
+          .and_raise(StandardError.new('Military service error'))
+
+        get '/my_health/v1/medical_records/military_service'
+
+        expect(response).to have_http_status(:internal_server_error)
+        expect_aal_logged(0)
+      end
     end
+
+    context 'retrieving a Blue Button report' do
+      it 'responds to GET #index and does not log an AAL' do
+        VCR.use_cassette('phr_mgr_client/get_military_service') do
+          get '/my_health/v1/medical_records/military_service?bb=true'
+        end
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to be_a(String)
+        expect(aal_client).not_to have_received(:create_aal)
+      end
+    end
+  end
+
+  def expect_aal_logged(status)
+    expect(aal_client).to have_received(:create_aal).with(
+      hash_including(
+        activity_type: 'DOD military service information records',
+        action: 'Download',
+        performer_type: 'Self',
+        status:
+      ),
+      true,
+      anything # unique session ID could be different things depending on how it's implemented
+    )
   end
 end


### PR DESCRIPTION
## Summary

- Added an AAL entry for accessing military service
- Added a `bb` param to indicate that this is being pulled as part of a Blue Button report, in which case we do NOT create an AAL entry
- Corresponding FE PR: https://github.com/department-of-veterans-affairs/vets-website/pull/36494

## Related issue(s)

### [MHV-71086](https://jira.devops.va.gov/browse/MHV-71086) - Implement DOD report AAL entry ###

> Implement DOD report AAL entry-pass a parameter to the BackEnd that indicates AAL needed 
> 
> This is a new report being implemented.  Once the report functionality is complete, this AAL will need to be added.
> 
> AAL work to be done spreadsheet link below (See Medical Records tab-line 42, red highlighted line item)
> 
> https://dvagov.sharepoint.com/:x:/r/sites/HealthApartment/_layouts/15/Doc.aspx?sourcedoc=%7B80534FA8-97C2-4726-9E08-20166C9609DF%7D&file=AAL%20work%20to%20be%20done-VHA%20Privacy%20Office%20additions.xlsx&action=default&mobileredirect=true 
> 
> Approved content for all MR domains on va.gov is as follows:
> 
> Date/Time = Completion_Time
> 
> Activity Details = Detail_Value
> 
> Activity = Activity_Type
> 
> Action = Action
> 
> Performer Type = Performer_Type
> 
> Results = Status
> 
> 
> 
> 
> User Story: As a Medical Records User, I want to see my MR usage by looking at my AAL entries, so that I can have a list of my MR usage.
> 
> GIVEN:
> WHEN:
> THEN:
> 
> Feature Flag Y/N ? N
> Manual Testing Y/N ? Y-Maruf
> Automated Testing Y/N ? N
> Accessibility Testing Y/N ? N
> 
> Acceptance Criteria:
> AC1 DoD AAL has been added (See Medical Records tab-line 42, red highlighted line items)
> AC2 Content will follow the approved content outlined above
> AC3 
> AC4
> AC5
> 
>  ** 

## Testing done

- [x] *New code is covered by unit tests*
- To validate:
  - Access the `military_service` API without a `bb` flag and see that an AAL was created in MHV NP
  - Access the `military_service` API with a `bb` flag and see that an AAL was NOT created in MHV NP
- NOT behind a Flipper

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
