### PR TITLE
Capitalize marriage type code Death

### DIFF
--- a/app/models/bgs_dependents/death.rb
+++ b/app/models/bgs_dependents/death.rb
@@ -16,7 +16,7 @@ module BGSDependents
         vet_ind: 'N',
         dependent_income: formatted_boolean(@is_v2 ? @death_info['deceased_dependent_income'] : @death_info['dependent_income']) # rubocop:disable Layout/LineLength
       }
-      info['marriage_termination_type_code'] = 'death' if dependent_type[:family] == 'Spouse'
+      info['marriage_termination_type_code'] = 'Death' if dependent_type[:family] == 'Spouse'
       info.merge(@death_info['full_name']).with_indifferent_access
     end
   end


### PR DESCRIPTION
## Summary

- The marriage type code should be capitalized. Corrects 'death' to 'Death'.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92031

## Testing done

- [ ] *New code is covered by unit tests*

## What areas of the site does it impact?
Dependents

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

