### PR TITLE
Replace Virtus with Vets::Model - DMC

### DIFF
--- a/lib/debt_management_center/models/payment.rb
+++ b/lib/debt_management_center/models/payment.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module DebtManagementCenter
   class Payment
-    include Virtus.model
+    include Vets::Model
+
     attribute :education_amount, String
     attribute :compensation_amount, String
     attribute :veteran_or_spouse, String


### PR DESCRIPTION
## Summary

- Virtus is being replace with Vets::Model. Differences include:
    - There's no hash access for attributes form[:attribute] only dot notation form.attribute
    - Syntax change for Array attributes
    - Sorting uses a class method: default_sort_by
    - booleans are temporarily Bool, until Virtus is completely gone
- This PR replaces Virtus.model with Vets::Model and updates the attributes and implementation accordingly. 
- This change should not affect any functionality.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92441

## Testing done

- [ ] Manual testing for similar output

## Acceptance criteria

- [ ] Virtus models are now Vets::Model
- [ ] No functional change