### PR TITLE
Add partialErrorMessage field to support unified error messaging

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -959,7 +959,21 @@ module VAOS
         log_partial_errors(response, method_name)
 
         {
-          failures: response.body[:failures]
+          failures: response.body[:failures],
+          partialErrorMessage: {
+            request: {
+              title: 'We can’t show some of your requests right now.',
+              body: 'We’re working to fix this problem. To reschedule a request that’s not in this list, ' \
+                    'contact the VA facility where it was requested.'
+            },
+            booked: {
+              title: 'We can’t show some of your appointments right now.',
+              body: 'We’re working to fix this problem. To manage an appointment that’s not in this list, ' \
+                    'contact the VA facility where it was scheduled.'
+            },
+            linkText: 'Find your VA health facility',
+            linkUrl: '/find-locations'
+          }
         }
       end
 

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -468,6 +468,20 @@ describe VAOS::V2::AppointmentsService do
           end
         end
 
+        it 'returns partial error message' do
+          VCR.use_cassette('vaos/v2/appointments/get_appointments_200_with_facilities_200_and_log_data',
+                           match_requests_on: %i[method path query]) do
+            response = subject.get_appointments(start_date3, end_date3)
+            partial_error_message = response[:meta][:partialErrorMessage]
+            expect(partial_error_message[:request][:title]).to eq('We can’t show some of your requests right now.')
+            expect(partial_error_message[:request][:body]).to eq('We’re working to fix this problem. To reschedule a request that’s not in this list, contact the VA facility where it was requested.')
+            expect(partial_error_message[:booked][:title]).to eq('We can’t show some of your appointments right now.')
+            expect(partial_error_message[:booked][:body]).to eq('We’re working to fix this problem. To manage an appointment that’s not in this list, contact the VA facility where it was scheduled.')
+            expect(partial_error_message[:linkText]).to eq('Find your VA health facility')
+            expect(partial_error_message[:linkUrl]).to eq('/find-locations')
+          end
+        end
+
         it 'logs the failures and anonymizes the ICNs sent to the log' do
           VCR.use_cassette('vaos/v2/appointments/get_appointments_200_with_facilities_200_and_log_data',
                            match_requests_on: %i[method path query]) do

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -474,9 +474,13 @@ describe VAOS::V2::AppointmentsService do
             response = subject.get_appointments(start_date3, end_date3)
             partial_error_message = response[:meta][:partialErrorMessage]
             expect(partial_error_message[:request][:title]).to eq('We can’t show some of your requests right now.')
-            expect(partial_error_message[:request][:body]).to eq('We’re working to fix this problem. To reschedule a request that’s not in this list, contact the VA facility where it was requested.')
+            expect(partial_error_message[:request][:body]).to eq('We’re working to fix this problem. To reschedule ' \
+                                                                 'a request that’s not in this list, contact the ' \
+                                                                 'VA facility where it was requested.')
             expect(partial_error_message[:booked][:title]).to eq('We can’t show some of your appointments right now.')
-            expect(partial_error_message[:booked][:body]).to eq('We’re working to fix this problem. To manage an appointment that’s not in this list, contact the VA facility where it was scheduled.')
+            expect(partial_error_message[:booked][:body]).to eq('We’re working to fix this problem. To manage an ' \
+                                                                'appointment that’s not in this list, contact the ' \
+                                                                'VA facility where it was scheduled.')
             expect(partial_error_message[:linkText]).to eq('Find your VA health facility')
             expect(partial_error_message[:linkUrl]).to eq('/find-locations')
           end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- We're adding `partialErrorMessage` to the API response to ensure messaging consistency across web and mobile FE
- Appointments Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/107947

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
