### PR TITLE
Replace Virtus with Vets::Model - Disability Compensation

### DIFF
--- a/app/models/concerns/form526_claim_fast_tracking_concern.rb
+++ b/app/models/concerns/form526_claim_fast_tracking_concern.rb
@@ -67,7 +67,7 @@ module Form526ClaimFastTrackingConcern
   # @return [Boolean] whether there are any open EP 020's
   def pending_eps?
     pending = open_claims.any? do |claim|
-      claim['base_end_product_code'] == '020' && claim['status'].upcase != 'COMPLETE'
+      claim.base_end_product_code == '020' && claim.status.upcase != 'COMPLETE'
     end
     save_metadata(offramp_reason: 'pending_ep') if pending
     pending
@@ -271,7 +271,7 @@ module Form526ClaimFastTrackingConcern
         feature_toggle: nil
       )
       all_claims = api_provider.all_claims
-      all_claims['open_claims']
+      all_claims.open_claims
     end
   end
 

--- a/app/models/form_profiles/va_526ez.rb
+++ b/app/models/form_profiles/va_526ez.rb
@@ -140,7 +140,7 @@ class FormProfiles::VA526ez < FormProfile
 
     # Remap response object to schema fields
     VA526ez::FormRatedDisabilities.new(
-      rated_disabilities: response.rated_disabilities.map(&:to_h)
+      rated_disabilities: response.rated_disabilities.map(&:attribute_values)
     )
   end
 

--- a/lib/disability_compensation/requests/form526_request_body.rb
+++ b/lib/disability_compensation/requests/form526_request_body.rb
@@ -1,36 +1,31 @@
 # frozen_string_literal: true
 
-require 'active_model'
-require 'virtus'
+require 'vets/model'
 
 module Requests
   class Dates
-    include ActiveModel::Serialization
-    include Virtus.model
+    include Vets::Model
 
     attribute :begin_date, String
     attribute :end_date, String
   end
 
   class ContactNumber
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :telephone, String
     attribute :international_telephone, String
   end
 
   class UnitPhone
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :area_code, String
     attribute :phone_number, String
   end
 
   class MailingAddress
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     # rubocop:disable Naming/VariableNumber
     attribute :address_line_1, String
@@ -46,32 +41,28 @@ module Requests
   end
 
   class EmailAddress
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :email, String
-    attribute :agree_to_email_related_to_claim, Boolean
+    attribute :agree_to_email_related_to_claim, Bool
   end
 
   class VeteranNumber
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :telephone, String
     attribute :international_telephone, String
   end
 
   class GulfWarHazardService
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :served_in_gulf_war_hazard_locations, String
     attribute :service_dates, Dates
   end
 
   class HerbicideHazardService
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :served_in_herbicide_hazard_locations, String
     attribute :other_locations_served, String
@@ -79,17 +70,15 @@ module Requests
   end
 
   class AdditionalHazardExposures
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
-    attribute :additional_exposures, Array[String]
+    attribute :additional_exposures, String, array: true
     attribute :specify_other_exposures, String
     attribute :exposure_dates, Dates
   end
 
   class MultipleExposures
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :exposure_dates, Dates
     attribute :exposure_location, String
@@ -97,8 +86,7 @@ module Requests
   end
 
   class SecondaryDisability
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :name, String
     attribute :disability_action_type, String
@@ -107,23 +95,21 @@ module Requests
   end
 
   class Disability
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :disability_action_type, String
     attribute :name, String
     attribute :classification_code, String
     attribute :service_relevance, String
-    attribute :is_related_to_toxic_exposure, Boolean
+    attribute :is_related_to_toxic_exposure, Bool
     attribute :exposure_or_event_or_injury, String
     attribute :rated_disability_id, String
     attribute :diagnostic_code, Integer
-    attribute :secondary_disabilities, Array[SecondaryDisability]
+    attribute :secondary_disabilities, SecondaryDisability, array: true
   end
 
   class Center
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :name, String
     attribute :state, String
@@ -131,17 +117,15 @@ module Requests
   end
 
   class Treatment
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
-    attribute :treated_disability_names, Array[String]
+    attribute :treated_disability_names, String, array: true
     attribute :center, Center
     attribute :begin_date, String
   end
 
   class ServicePeriod
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :service_branch, String
     attribute :active_duty_begin_date, String
@@ -151,16 +135,14 @@ module Requests
   end
 
   class Confinement
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :approximate_begin_date, String
     attribute :approximate_end_date, String
   end
 
   class ObligationTermsOfService
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :begin_date, String
     attribute :end_date, String
@@ -168,16 +150,14 @@ module Requests
 
   # used to be "Title10Activation"
   class FederalActivation
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :anticipated_separation_date, String
     attribute :activation_date, String
   end
 
   class ReservesNationalGuardService
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :obligation_terms_of_service, ObligationTermsOfService
     attribute :unit_name, String
@@ -189,8 +169,7 @@ module Requests
   end
 
   class SeparationSeverancePay
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :date_payment_received, String
     attribute :branch_of_service, String
@@ -198,42 +177,38 @@ module Requests
   end
 
   class MilitaryRetiredPay
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :branch_of_service, String
     attribute :monthly_amount, Float
   end
 
   class DirectDeposit
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :account_type, String
     attribute :account_number, String
     attribute :routing_number, String
     attribute :financial_institution_name, String
-    attribute :no_account, Boolean
+    attribute :no_account, Bool
   end
 
   class ServiceInformation
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
-    attribute :service_periods, Array[ServicePeriod]
-    attribute :confinements, Array[Confinement]
+    attribute :service_periods, ServicePeriod, array: true
+    attribute :confinements, Confinement, array: true
     attribute :reserves_national_guard_service, ReservesNationalGuardService
-    attribute :alternate_names, Array[String]
-    attribute :served_in_active_combat_since911, Boolean
+    attribute :alternate_names, String, array: true
+    attribute :served_in_active_combat_since911, Bool
     # used to be "Title10Activation"
     attribute :federal_activation, FederalActivation
   end
 
   class VeteranIdentification
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
-    attribute :current_va_employee, Boolean
+    attribute :current_va_employee, Bool
     attribute :mailing_address, MailingAddress
     attribute :service_number, String
     attribute :email_address, EmailAddress
@@ -241,24 +216,21 @@ module Requests
   end
 
   class CurrentlyHomeless
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :homeless_situation_options, String
     attribute :other_description, String
   end
 
   class RiskOfBecomingHomeless
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :living_situation_options, String
     attribute :other_description, String
   end
 
   class Homeless
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :point_of_contact, String
     attribute :point_of_contact_number, ContactNumber
@@ -267,18 +239,16 @@ module Requests
   end
 
   class ToxicExposure
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :gulf_war_hazard_service, GulfWarHazardService
     attribute :herbicide_hazard_service, HerbicideHazardService
     attribute :additional_hazard_exposures, AdditionalHazardExposures
-    attribute :multiple_exposures, Array[MultipleExposures]
+    attribute :multiple_exposures, MultipleExposures, array: true
   end
 
   class ChangeOfAddress
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
     attribute :dates, Dates
     attribute :type_of_address_change, String
@@ -296,11 +266,10 @@ module Requests
   end
 
   class ServicePay
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
-    attribute :favor_training_pay, Boolean
-    attribute :favor_military_retired_pay, Boolean
+    attribute :favor_training_pay, Bool
+    attribute :favor_military_retired_pay, Bool
     # "YES", "NO", or nil
     attribute :receiving_military_retired_pay, String
     # "YES", "NO", or nil
@@ -313,17 +282,16 @@ module Requests
   end
 
   class Form526
-    include Virtus.model
-    include ActiveModel::Serialization
+    include Vets::Model
 
-    attribute :claimant_certification, Boolean
+    attribute :claimant_certification, Bool
     attribute :claim_process_type, String
     attribute :veteran_identification, VeteranIdentification
     attribute :change_of_address, ChangeOfAddress
     attribute :homeless, Homeless
     attribute :toxic_exposure, ToxicExposure
-    attribute :disabilities, Array[Disability]
-    attribute :treatments, Array[Treatment]
+    attribute :disabilities, Disability, array: true
+    attribute :treatments, Treatment, array: true
     attribute :service_information, ServiceInformation
     attribute :service_pay, ServicePay
     attribute :direct_deposit, DirectDeposit

--- a/lib/disability_compensation/requests/form526_request_body.rb
+++ b/lib/disability_compensation/requests/form526_request_body.rb
@@ -72,7 +72,7 @@ module Requests
   class AdditionalHazardExposures
     include Vets::Model
 
-    attribute :additional_exposures, String, array: true
+    attribute :additional_exposures, String, array: true, default: []
     attribute :specify_other_exposures, String
     attribute :exposure_dates, Dates
   end
@@ -105,7 +105,7 @@ module Requests
     attribute :exposure_or_event_or_injury, String
     attribute :rated_disability_id, String
     attribute :diagnostic_code, Integer
-    attribute :secondary_disabilities, SecondaryDisability, array: true
+    attribute :secondary_disabilities, SecondaryDisability, array: true, default: []
   end
 
   class Center
@@ -119,7 +119,7 @@ module Requests
   class Treatment
     include Vets::Model
 
-    attribute :treated_disability_names, String, array: true
+    attribute :treated_disability_names, String, array: true, default: []
     attribute :center, Center
     attribute :begin_date, String
   end
@@ -196,10 +196,10 @@ module Requests
   class ServiceInformation
     include Vets::Model
 
-    attribute :service_periods, ServicePeriod, array: true
-    attribute :confinements, Confinement, array: true
+    attribute :service_periods, ServicePeriod, array: true, default: []
+    attribute :confinements, Confinement, array: true, default: []
     attribute :reserves_national_guard_service, ReservesNationalGuardService
-    attribute :alternate_names, String, array: true
+    attribute :alternate_names, String, array: true, default: []
     attribute :served_in_active_combat_since911, Bool
     # used to be "Title10Activation"
     attribute :federal_activation, FederalActivation
@@ -244,7 +244,7 @@ module Requests
     attribute :gulf_war_hazard_service, GulfWarHazardService
     attribute :herbicide_hazard_service, HerbicideHazardService
     attribute :additional_hazard_exposures, AdditionalHazardExposures
-    attribute :multiple_exposures, MultipleExposures, array: true
+    attribute :multiple_exposures, MultipleExposures, array: true, default: []
   end
 
   class ChangeOfAddress
@@ -290,8 +290,8 @@ module Requests
     attribute :change_of_address, ChangeOfAddress
     attribute :homeless, Homeless
     attribute :toxic_exposure, ToxicExposure
-    attribute :disabilities, Disability, array: true
-    attribute :treatments, Treatment, array: true
+    attribute :disabilities, Disability, array: true, default: []
+    attribute :treatments, Treatment, array: true, default: []
     attribute :service_information, ServiceInformation
     attribute :service_pay, ServicePay
     attribute :direct_deposit, DirectDeposit

--- a/lib/disability_compensation/responses/claims_service_response.rb
+++ b/lib/disability_compensation/responses/claims_service_response.rb
@@ -1,32 +1,31 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module DisabilityCompensation
   module ApiProvider
     # Used in conjunction with the PPIU/Direct Deposit Provider
     class ClaimPhaseDates
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
       attribute :phase_change_date, String
     end
 
     class Claim
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
       attribute :id, String
       attribute :base_end_product_code, String
-      attribute :development_letter_sent, Boolean
+      attribute :development_letter_sent, Bool
       attribute :status, String
       attribute :claim_date, String
       attribute :claim_phase_dates, ClaimPhaseDates
     end
 
     class ClaimsServiceResponse
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
-      attribute :open_claims, Array[DisabilityCompensation::ApiProvider::Claim]
+      attribute :open_claims, DisabilityCompensation::ApiProvider::Claim, array: true
     end
   end
 end

--- a/lib/disability_compensation/responses/intake_sites_response.rb
+++ b/lib/disability_compensation/responses/intake_sites_response.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module DisabilityCompensation
   module ApiProvider
     class SeparationLocation
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
       attribute :code, String
       attribute :description, String
     end
 
     class IntakeSitesResponse
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
-      attribute :separation_locations, Array[DisabilityCompensation::ApiProvider::SeparationLocation]
+      attribute :separation_locations, DisabilityCompensation::ApiProvider::SeparationLocation, array: true
       attribute :status, Integer
 
       def cache?

--- a/lib/disability_compensation/responses/intent_to_files_response.rb
+++ b/lib/disability_compensation/responses/intent_to_files_response.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module DisabilityCompensation
   module ApiProvider
     class IntentToFile
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
       # The spelling of these status types has been validated with the partner team
       STATUS_TYPES = %w[
@@ -27,16 +28,14 @@ module DisabilityCompensation
 
     # array of Intent to Files
     class IntentToFilesResponse
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
-      attribute :intent_to_file, Array[DisabilityCompensation::ApiProvider::IntentToFile]
+      attribute :intent_to_file, DisabilityCompensation::ApiProvider::IntentToFile, array: true
     end
 
     # a single Intent to File
     class IntentToFileResponse
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
       attribute :intent_to_file, DisabilityCompensation::ApiProvider::IntentToFile
     end

--- a/lib/disability_compensation/responses/payment_information_response.rb
+++ b/lib/disability_compensation/responses/payment_information_response.rb
@@ -1,25 +1,25 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module DisabilityCompensation
   module ApiProvider
     class ControlInformation
-      include Virtus.model
+      include Vets::Model
 
-      attribute :can_update_address, Boolean
-      attribute :corp_avail_indicator, Boolean
-      attribute :corp_rec_found_indicator, Boolean
-      attribute :has_no_bdn_payments_indicator, Boolean
-      attribute :identity_indicator, Boolean
-      attribute :is_competent_indicator, Boolean
-      attribute :index_indicator, Boolean
-      attribute :no_fiduciary_assigned_indicator, Boolean
-      attribute :not_deceased_indicator, Boolean
+      attribute :can_update_address, Bool
+      attribute :corp_avail_indicator, Bool
+      attribute :corp_rec_found_indicator, Bool
+      attribute :has_no_bdn_payments_indicator, Bool
+      attribute :identity_indicator, Bool
+      attribute :is_competent_indicator, Bool
+      attribute :index_indicator, Bool
+      attribute :no_fiduciary_assigned_indicator, Bool
+      attribute :not_deceased_indicator, Bool
     end
 
     class PaymentAccount
-      include Virtus.model
-      include ActiveModel::Validations
-      include ActiveModel::Serialization
+      include Vets::Model
 
       attribute :account_type, String
       attribute :financial_institution_name, String
@@ -28,7 +28,7 @@ module DisabilityCompensation
     end
 
     class PaymentAddress
-      include Virtus.model
+      include Vets::Model
 
       attribute :type, String
       attribute :address_effective_date, DateTime
@@ -46,8 +46,7 @@ module DisabilityCompensation
 
     # Used in conjunction with the PPIU/Direct Deposit Provider
     class PaymentInformation
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
       attribute :control_information, DisabilityCompensation::ApiProvider::ControlInformation
       attribute :payment_account, DisabilityCompensation::ApiProvider::PaymentAccount
@@ -56,10 +55,9 @@ module DisabilityCompensation
     end
 
     class PaymentInformationResponse
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
-      attribute :responses, Array[DisabilityCompensation::ApiProvider::PaymentInformation]
+      attribute :responses, DisabilityCompensation::ApiProvider::PaymentInformation, array: true
     end
   end
 end

--- a/lib/disability_compensation/responses/rated_disabilities_response.rb
+++ b/lib/disability_compensation/responses/rated_disabilities_response.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module DisabilityCompensation
   module ApiProvider
     class SpecialIssue
-      include Virtus.model
-
+      include Vets::Model
       attribute :code, String
       attribute :name, String
     end
 
     class RatedDisability
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
       attribute :decision_code, String
       attribute :decision_text, String
@@ -24,14 +24,13 @@ module DisabilityCompensation
       attribute :rating_percentage, Integer
       attribute :maximum_rating_percentage, Integer
       attribute :related_disability_date, DateTime
-      attribute :special_issues, Array[DisabilityCompensation::ApiProvider::SpecialIssue]
+      attribute :special_issues, DisabilityCompensation::ApiProvider::SpecialIssue, array: true
     end
 
     class RatedDisabilitiesResponse
-      include ActiveModel::Serialization
-      include Virtus.model
+      include Vets::Model
 
-      attribute :rated_disabilities, Array[DisabilityCompensation::ApiProvider::RatedDisability]
+      attribute :rated_disabilities, DisabilityCompensation::ApiProvider::RatedDisability, array: true
     end
   end
 end

--- a/lib/disability_compensation/responses/rated_disabilities_response.rb
+++ b/lib/disability_compensation/responses/rated_disabilities_response.rb
@@ -6,6 +6,7 @@ module DisabilityCompensation
   module ApiProvider
     class SpecialIssue
       include Vets::Model
+
       attribute :code, String
       attribute :name, String
     end
@@ -24,13 +25,13 @@ module DisabilityCompensation
       attribute :rating_percentage, Integer
       attribute :maximum_rating_percentage, Integer
       attribute :related_disability_date, DateTime
-      attribute :special_issues, DisabilityCompensation::ApiProvider::SpecialIssue, array: true
+      attribute :special_issues, DisabilityCompensation::ApiProvider::SpecialIssue, array: true, default: []
     end
 
     class RatedDisabilitiesResponse
       include Vets::Model
 
-      attribute :rated_disabilities, DisabilityCompensation::ApiProvider::RatedDisability, array: true
+      attribute :rated_disabilities, DisabilityCompensation::ApiProvider::RatedDisability, array: true, default: []
     end
   end
 end

--- a/lib/vets/attributes.rb
+++ b/lib/vets/attributes.rb
@@ -62,10 +62,10 @@ module Vets
 
           # if there's a default, assign the default value
           value = if default.is_a?(Symbol) && respond_to?(default)
-            send(default)
-          else
-            default.duplicable? ? default.dup : default
-          end
+                    send(default)
+                  else
+                    default.duplicable? ? default.dup : default
+                  end
 
           instance_variable_set("@#{name}", value)
           value

--- a/lib/vets/attributes.rb
+++ b/lib/vets/attributes.rb
@@ -64,7 +64,7 @@ module Vets
           value = if default.is_a?(Symbol) && respond_to?(default)
                     send(default)
                   else
-                    default.duplicable? ? default.dup : default
+                    default.dup
                   end
 
           instance_variable_set("@#{name}", value)

--- a/lib/vets/attributes.rb
+++ b/lib/vets/attributes.rb
@@ -10,7 +10,7 @@ module Vets
 
     module ClassMethods
       def attributes
-        @attributes ||= Concurrent::Hash.new
+        @attributes ||= {} # rubocop:disable ThreadSafety/ClassInstanceVariable
       end
 
       def attribute(name, klass, **options)

--- a/spec/lib/disability_compensation/providers/claims_service/lighthouse_claims_service_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/claims_service/lighthouse_claims_service_provider_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe LighthouseClaimsServiceProvider do
   it 'retrieves claim service from the Lighthouse API' do
     VCR.use_cassette('lighthouse/claims/200_response') do
       response = @provider.all_claims('', '')
-      expect(response['open_claims'].length).to eq(1)
+      expect(response.open_claims.length).to eq(1)
     end
   end
 

--- a/spec/lib/disability_compensation/providers/intent_to_file/lighthouse_intent_to_file_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/intent_to_file/lighthouse_intent_to_file_provider_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe LighthouseIntentToFileProvider do
     VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/200_response') do
       response = provider.get_intent_to_file('compensation', '', '')
       expect(response).to be_an_instance_of(DisabilityCompensation::ApiProvider::IntentToFilesResponse)
-      expect(response['intent_to_file'].length).to eq(1)
+      expect(response.intent_to_file.length).to eq(1)
     end
   end
 
@@ -28,8 +28,8 @@ RSpec.describe LighthouseIntentToFileProvider do
     VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/create_compensation_200_response') do
       response = provider.create_intent_to_file('compensation', '', '')
       expect(response).to be_an_instance_of(DisabilityCompensation::ApiProvider::IntentToFileResponse)
-      expect(response['intent_to_file']['type']).to eq('compensation')
-      expect(response['intent_to_file']['id']).to be_present
+      expect(response.intent_to_file.type).to eq('compensation')
+      expect(response.intent_to_file.id).to be_present
     end
   end
 
@@ -37,8 +37,8 @@ RSpec.describe LighthouseIntentToFileProvider do
     VCR.use_cassette('lighthouse/benefits_claims/intent_to_file/create_survivor_200_response') do
       response = provider.create_intent_to_file('survivor', '', '')
       expect(response).to be_an_instance_of(DisabilityCompensation::ApiProvider::IntentToFileResponse)
-      expect(response['intent_to_file']['type']).to eq('survivor')
-      expect(response['intent_to_file']['id']).to be_present
+      expect(response.intent_to_file.type).to eq('survivor')
+      expect(response.intent_to_file.id).to be_present
     end
   end
 

--- a/spec/lib/disability_compensation/providers/rated_disabilities/lighthouse_rated_disabilities_provider_spec.rb
+++ b/spec/lib/disability_compensation/providers/rated_disabilities/lighthouse_rated_disabilities_provider_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe LighthouseRatedDisabilitiesProvider do
   it 'retrieves rated disabilities from the Lighthouse API' do
     VCR.use_cassette('lighthouse/veteran_verification/disability_rating/200_response') do
       response = @provider.get_rated_disabilities('', '')
-      expect(response['rated_disabilities'].length).to eq(1)
+      expect(response.rated_disabilities.length).to eq(1)
     end
   end
 

--- a/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
@@ -742,6 +742,19 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
       expect(result.additional_exposures.length).to eq(1)
       expect(result.additional_exposures[0]).to eq('OTHER')
 
+      all_options_nil_and_other_partial = data.merge({
+                                                      'otherExposures' => nil,
+                                                      'specifyOtherExposures' => {
+                                                        'description' => 'Lead, burn pits',
+                                                        'startDate' => '',
+                                                        'endDate' => ''
+                                                      }
+                                                    })
+      result = transformer.send(:transform_other_exposures, all_options_nil_and_other_partial['otherExposures'],
+      all_options_nil_and_other_partial['specifyOtherExposures'])
+      expect(result.additional_exposures.length).to eq(1)
+      expect(result.additional_exposures[0]).to eq('OTHER')
+
       all_options_nil_and_other_blank = data.merge({
                                                      'otherExposures' => nil,
                                                      'specifyOtherExposures' => {

--- a/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
@@ -742,19 +742,6 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
       expect(result.additional_exposures.length).to eq(1)
       expect(result.additional_exposures[0]).to eq('OTHER')
 
-      all_options_nil_and_other_partial = data.merge({
-                                                       'otherExposures' => nil,
-                                                       'specifyOtherExposures' => {
-                                                         'description' => 'Lead, burn pits',
-                                                         'startDate' => '',
-                                                         'endDate' => ''
-                                                       }
-                                                     })
-      result = transformer.send(:transform_other_exposures, all_options_nil_and_other_partial['otherExposures'],
-                                all_options_nil_and_other_partial['specifyOtherExposures'])
-      expect(result.additional_exposures.length).to eq(1)
-      expect(result.additional_exposures[0]).to eq('OTHER')
-
       all_options_nil_and_other_blank = data.merge({
                                                      'otherExposures' => nil,
                                                      'specifyOtherExposures' => {
@@ -763,8 +750,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
                                                        'endDate' => ''
                                                      }
                                                    })
-      result = transformer.send(:transform_other_exposures, all_options_nil_and_other_blank['otherExposures'],
-                                all_options_nil_and_other_blank['specifyOtherExposures'])
+
+      result = transformer.send(:transform_other_exposures, all_options_nil_and_other_blank['otherExposures'], all_options_nil_and_other_blank['specifyOtherExposures'])
       expect(result).to be_nil
 
       all_nil = data.merge({
@@ -789,6 +776,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
                                           })
       result = transformer.send(:transform_other_exposures, none_option_with_other['otherExposures'],
                                 none_option_with_other['specifyOtherExposures'])
+
       expect(result.additional_exposures.length).to eq(1)
       expect(result.additional_exposures[0]).to eq('OTHER')
 

--- a/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
@@ -743,15 +743,15 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
       expect(result.additional_exposures[0]).to eq('OTHER')
 
       all_options_nil_and_other_partial = data.merge({
-                                                      'otherExposures' => nil,
-                                                      'specifyOtherExposures' => {
-                                                        'description' => 'Lead, burn pits',
-                                                        'startDate' => '',
-                                                        'endDate' => ''
-                                                      }
-                                                    })
+                                                       'otherExposures' => nil,
+                                                       'specifyOtherExposures' => {
+                                                         'description' => 'Lead, burn pits',
+                                                         'startDate' => '',
+                                                         'endDate' => ''
+                                                       }
+                                                     })
       result = transformer.send(:transform_other_exposures, all_options_nil_and_other_partial['otherExposures'],
-      all_options_nil_and_other_partial['specifyOtherExposures'])
+                                all_options_nil_and_other_partial['specifyOtherExposures'])
       expect(result.additional_exposures.length).to eq(1)
       expect(result.additional_exposures[0]).to eq('OTHER')
 

--- a/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
@@ -751,7 +751,8 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
                                                      }
                                                    })
 
-      result = transformer.send(:transform_other_exposures, all_options_nil_and_other_blank['otherExposures'], all_options_nil_and_other_blank['specifyOtherExposures'])
+      result = transformer.send(:transform_other_exposures, all_options_nil_and_other_blank['otherExposures'],
+                                all_options_nil_and_other_blank['specifyOtherExposures'])
       expect(result).to be_nil
 
       all_nil = data.merge({


### PR DESCRIPTION
## Summary

- Virtus is being replace with `Vets::Model`. Differences include:
    - There's no hash access for attributes `form[:attribute]` only dot notation `form.attribute`
    - Syntax change for Array attributes
    - Sorting uses a class method: `default_sort_by`
    - booleans are temporarily `Bool`, until Virtus is completely gone
- This PR replaces `Virtus.model` with `Vets::Model` and updates the _attributes_ and _implementation_ accordingly. 
- This change should not affect any functionality.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92441

## Testing done

- [ ] Manual testing for similar output

## Acceptance criteria

- [ ] Virtus models are now Vets::Model
- [ ] No functional change