### PR TITLE
feat(AccreditedRepresentativePortal): Expose user LOA in API response

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_users_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_users_controller.rb
@@ -19,7 +19,8 @@ module AccreditedRepresentativePortal
             verified: @current_user.user_account.verified?,
             signIn: {
               serviceName: @current_user.sign_in[:service_name]
-            }
+            },
+            loa: @current_user.loa
           },
           prefillsAvailable: [],
           inProgressForms: in_progress_forms

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/user_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/user_spec.rb
@@ -16,66 +16,102 @@ RSpec.describe 'AccreditedRepresentativePortal::V0::User', type: :request do
       before { login_as(user) }
 
       context 'as a user with an in progress form' do
-        first_name = Faker::Name.first_name
-        last_name = Faker::Name.last_name
-        sign_in_service_name = Faker::Company.name
-        in_progress_form_id = Faker::Form.id
+        let(:first_name_value) { Faker::Name.first_name }
+        let(:last_name_value) { Faker::Name.last_name }
+        let(:sign_in_service_name_value) { Faker::Company.name }
+        let(:in_progress_form_id_value) { Faker::Form.id }
+        let!(:expected_created_at) { Time.current }
+        let!(:expected_expires_at) { 60.days.from_now }
+        let!(:expected_last_updated) { Time.current }
 
         let(:user) do
           create(
             :representative_user,
             :with_in_progress_form,
             {
-              first_name:, last_name:,
-              sign_in_service_name:,
-              in_progress_form_id:
+              first_name: first_name_value,
+              last_name: last_name_value,
+              sign_in_service_name: sign_in_service_name_value,
+              in_progress_form_id: in_progress_form_id_value
             }
+          )
+        end
+
+        let!(:in_progress_form_record) do
+          InProgressForm.find_by(
+            form_id: in_progress_form_id_value,
+            user_account_id: user.user_account.id
           )
         end
 
         around do |example|
-          travel_to '2024-09-06T16:19:34-04:00'
-          example.run
-          travel_back
+          travel_to Time.zone.parse('2024-09-06T16:19:34-04:00') do
+            example.run
+          end
         end
 
-        it 'responds with the user and their in progress form' do
+        it 'responds with the user and their in progress form with explicit keys' do
           get '/accredited_representative_portal/v0/user'
 
           expect(response).to have_http_status(:ok)
-          expect(parsed_response).to eq(
-            {
-              'account' => {
-                'accountUuid' => user.user_account.id
-              },
-              'profile' => {
-                'firstName' => first_name,
-                'lastName' => last_name,
-                'verified' => true,
-                'signIn' => {
-                  'serviceName' => sign_in_service_name
-                }
-              },
-              'prefillsAvailable' => [],
-              'inProgressForms' => [
-                {
-                  'form' => in_progress_form_id,
-                  'metadata' => {
-                    'version' => 1,
-                    'returnUrl' => 'foo.com',
-                    'createdAt' => Time.current.to_i,
-                    'expiresAt' => 60.days.from_now.to_i,
-                    'lastUpdated' => Time.current.to_i,
-                    'inProgressFormId' => InProgressForm.find_by(
-                      form_id: in_progress_form_id,
-                      user_account_id: user.user_account.id
-                    ).id
-                  },
-                  'lastUpdated' => Time.current.to_i
-                }
-              ]
-            }
-          )
+
+          expect(parsed_response.keys).to match_array(%w[account profile prefillsAvailable inProgressForms])
+
+          # Check 'account' block
+          expect(parsed_response['account']).to be_a(Hash)
+          expect(parsed_response['account'].keys).to match_array(%w[accountUuid])
+          expect(parsed_response['account']['accountUuid']).to eq(user.user_account.id)
+
+          # Check 'profile' block
+          expect(parsed_response['profile']).to be_a(Hash)
+          expect(parsed_response['profile'].keys).to match_array(%w[firstName lastName verified signIn loa])
+          expect(parsed_response['profile']['firstName']).to eq(first_name_value)
+          expect(parsed_response['profile']['lastName']).to eq(last_name_value)
+          expect(parsed_response['profile']['verified']).to be(true)
+
+          # Check 'profile.signIn' block
+          expect(parsed_response['profile']['signIn']).to be_a(Hash)
+          expect(parsed_response['profile']['signIn'].keys).to match_array(%w[serviceName])
+          expect(parsed_response['profile']['signIn']['serviceName']).to eq(sign_in_service_name_value)
+
+          expect(parsed_response['profile']['loa']).to be_a(Hash)
+          expect(parsed_response['profile']['loa']).to eq(user.loa.to_h.stringify_keys)
+          expect(parsed_response['profile']['loa'].keys).to include('current')
+          expect(parsed_response['profile']['loa'].keys).to include('highest')
+          expect(parsed_response['profile']['loa']['current']).to eq(user.loa[:current])
+          expect(parsed_response['profile']['loa']['highest']).to eq(user.loa[:highest])
+
+          # Check 'prefillsAvailable' block
+          expect(parsed_response['prefillsAvailable']).to be_an(Array)
+          expect(parsed_response['prefillsAvailable']).to eq([])
+
+          # Check 'inProgressForms' block
+          expect(parsed_response['inProgressForms']).to be_an(Array)
+          expect(parsed_response['inProgressForms'].size).to eq(1)
+
+          in_progress_form_response = parsed_response['inProgressForms'].first
+          expect(in_progress_form_response).to be_a(Hash)
+          expect(in_progress_form_response.keys).to match_array(%w[form metadata lastUpdated])
+          expect(in_progress_form_response['form']).to eq(in_progress_form_id_value)
+
+          # Check 'inProgressForms.metadata' block
+          metadata_response = in_progress_form_response['metadata']
+          expect(metadata_response).to be_a(Hash)
+          expect(metadata_response.keys).to match_array(%w[version returnUrl createdAt expiresAt lastUpdated
+                                                           inProgressFormId])
+          expect(metadata_response['version']).to eq(1)
+          expect(metadata_response['returnUrl']).to eq('foo.com')
+
+          expect(metadata_response['createdAt']).to eq(expected_created_at.to_i)
+          expect(metadata_response['expiresAt']).to eq(expected_expires_at.to_i)
+          expect(metadata_response['lastUpdated']).to eq(expected_last_updated.to_i)
+
+          expect(in_progress_form_record).not_to be_nil, 'InProgressForm record not found ' \
+                                                         "with form_id: #{in_progress_form_id_value} " \
+                                                         "and user_account_id: #{user.user_account.id}"
+          expect(metadata_response['inProgressFormId']).to eq(in_progress_form_record.id)
+
+          expect(in_progress_form_response['lastUpdated']).to eq(expected_last_updated.to_i)
         end
       end
     end


### PR DESCRIPTION
This commit updates the `RepresentativeUsersController` within the Accredited Representative Portal to include the current user's Level of Assurance (LOA) in the API response.

The `loa` attribute is now part of the user object returned by the `/accredited_representative_portal/v0/user` endpoint.

The corresponding request specs in `user_spec.rb` have been updated to reflect this change and ensure the `loa` attribute is correctly serialized.

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/107802

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
