### PR TITLE
[257] Adding participant_id to allowed user_attribute types for Sign in STS

### DIFF
--- a/app/services/sign_in/constants/service_account_access_token.rb
+++ b/app/services/sign_in/constants/service_account_access_token.rb
@@ -5,7 +5,7 @@ module SignIn
     module ServiceAccountAccessToken
       ISSUER = 'va.gov sign in'
       JWT_ENCODE_ALGORITHM = 'RS256'
-      USER_ATTRIBUTES = %w[icn type credential_id].freeze
+      USER_ATTRIBUTES = %w[icn type credential_id participant_id].freeze
       VALIDITY_LENGTHS = [VALIDITY_LENGTH_SHORT_MINUTES = 5.minutes, VALIDITY_LENGTH_LONG_MINUTES = 30.minutes].freeze
       VERSION_LIST = [
         CURRENT_VERSION = 'V0'


### PR DESCRIPTION
## Summary

- This PR adds the `participant_id` constant to the allowed list of user attributes when authenticating with a Sign in Service STS token

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/257
