### PR TITLE
Update Cerner eligible cookie domain

### DIFF
--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -841,12 +841,17 @@ RSpec.describe V1::SessionsController, type: :controller do
         end
 
         context 'when the cerner eligible cookie is not present' do
+          before do
+            allow(IdentitySettings.sign_in).to receive(:info_cookie_domain).and_return('some-domain')
+          end
+
           context 'when the user is cerner eligible' do
             let(:eligible) { true }
 
             it 'sets the cookie and logs the cerner eligibility' do
               call_endpoint
 
+              expect(response.headers['set-cookie']).to include('domain=some-domain')
               expect(cookies.signed[cerner_eligible_cookie]).to eq(eligible)
               expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
             end
@@ -870,7 +875,7 @@ RSpec.describe V1::SessionsController, type: :controller do
             cookies.signed[cerner_eligible_cookie] = 'true'
           end
 
-          it 'does nothing' do
+          it 'does not log a message' do
             call_endpoint
 
             expect(Rails.logger).not_to have_received(:info).with(expected_log_message, anything)


### PR DESCRIPTION
## Summary

- Currently the cookie is being set with api.va.gov, change to .va.gov so frontend can read it

## Testing 
- login with ssoe and you should see the CERNER_ELIGIBLE cookie with `localhost` domain 

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

