### PR TITLE
108930: Add validation, logging, and metrics to V0 ITF controller

### DIFF
--- a/app/controllers/v0/intent_to_files_controller.rb
+++ b/app/controllers/v0/intent_to_files_controller.rb
@@ -130,7 +130,7 @@ module V0
       end
 
       if user.participant_id.blank?
-        error_message =  'ITF request failed. No veteran participant ID provided'
+        error_message = 'ITF request failed. No veteran participant ID provided'
         monitor.track_missing_user_pid_itf_controller(method, form_id, itf_type, user_uuid, error_message)
 
         raise MissingParticipantIDError, error_message

--- a/app/controllers/v0/intent_to_files_controller.rb
+++ b/app/controllers/v0/intent_to_files_controller.rb
@@ -3,11 +3,16 @@
 require 'disability_compensation/factories/api_provider_factory'
 require 'logging/third_party_transaction'
 require 'lighthouse/benefits_claims/intent_to_file/api_response'
+require 'lighthouse/benefits_claims/intent_to_file/monitor'
 
 module V0
   class IntentToFilesController < ApplicationController
     extend Logging::ThirdPartyTransaction::MethodWrapper
     service_tag 'intent-to-file'
+
+    class MissingICNError < StandardError; end
+    class MissingParticipantIDError < StandardError; end
+    class InvalidITFTypeError < StandardError; end
 
     before_action :authorize_service
     before_action :validate_type_param, only: %i[submit]
@@ -25,19 +30,23 @@ module V0
 
     TYPES = %w[compensation pension survivor].freeze
 
+    ITF_FORM_IDS = {
+      'compensation' => '21-526EZ',
+      'pension' => '21P-527EZ',
+      'survivor' => '21P-530EZ'
+    }.freeze
+
     def index
-      intent_to_file_provider = ApiProviderFactory.call(
-        type: ApiProviderFactory::FACTORIES[:intent_to_file],
-        provider: ApiProviderFactory::API_PROVIDER[:lighthouse],
-        options: {},
-        current_user: @current_user,
-        feature_toggle: nil
-      )
       type = params['itf_type'] || 'compensation'
 
       if %w[pension survivor].include? type
+        form_id = ITF_FORM_IDS[type]
+        validate_data(@current_user, 'get', form_id, type)
+
+        monitor.track_show_itf(form_id, type, @current_user.uuid)
         itf = BenefitsClaims::Service.new(@current_user.icn).get_intent_to_file(type, nil, nil)
         response = BenefitsClaims::IntentToFile::ApiResponse::GET.new(itf['data'])
+
         return render json: IntentToFileSerializer.new(response)
       end
 
@@ -51,18 +60,16 @@ module V0
     end
 
     def submit
-      intent_to_file_provider = ApiProviderFactory.call(
-        type: ApiProviderFactory::FACTORIES[:intent_to_file],
-        provider: ApiProviderFactory::API_PROVIDER[:lighthouse],
-        options: {},
-        current_user: @current_user,
-        feature_toggle: nil
-      )
       type = params['itf_type'] || 'compensation'
 
       if %w[pension survivor].include? type
+        form_id = ITF_FORM_IDS[type]
+        validate_data(@current_user, 'post', type, form_id)
+
+        monitor.track_submit_itf(form_id, type, @current_user.uuid)
         itf = BenefitsClaims::Service.new(@current_user.icn).create_intent_to_file(type, @current_user.ssn, nil)
         response = BenefitsClaims::IntentToFile::ApiResponse::POST.new(itf['data'])
+
         return render json: IntentToFileSerializer.new(response)
       end
 
@@ -76,6 +83,16 @@ module V0
     end
 
     private
+
+    def intent_to_file_provider
+      ApiProviderFactory.call(
+        type: ApiProviderFactory::FACTORIES[:intent_to_file],
+        provider: ApiProviderFactory::API_PROVIDER[:lighthouse],
+        options: {},
+        current_user: @current_user,
+        feature_toggle: nil
+      )
+    end
 
     def set_success_response
       DisabilityCompensation::ApiProvider::IntentToFilesResponse.new(
@@ -100,6 +117,35 @@ module V0
     def validate_type_param
       raise Common::Exceptions::InvalidFieldValue.new('itf_type', params[:itf_type]) unless
         TYPES.include?(params[:itf_type])
+    end
+
+    def validate_data(user, method, form_id, itf_type)
+      user_uuid = user.uuid
+
+      if user.icn.blank?
+        error_message = 'ITF request failed. No veteran ICN provided'
+        monitor.track_missing_user_icn_itf_controller(method, form_id, itf_type, user_uuid, error_message)
+
+        raise MissingICNError, error_message
+      end
+
+      if user.participant_id.blank?
+        error_message =  'ITF request failed. No veteran participant ID provided'
+        monitor.track_missing_user_pid_itf_controller(method, form_id, itf_type, user_uuid, error_message)
+
+        raise MissingParticipantIDError, error_message
+      end
+
+      if form_id.blank?
+        error_message = 'ITF request failed. ITF type not supported'
+        monitor.track_invalid_itf_type_itf_controller(method, form_id, itf_type, user_uuid, error_message)
+
+        raise InvalidITFTypeError, error_message
+      end
+    end
+
+    def monitor
+      @monitor ||= BenefitsClaims::IntentToFile::Monitor.new
     end
   end
 end

--- a/app/controllers/v0/intent_to_files_controller.rb
+++ b/app/controllers/v0/intent_to_files_controller.rb
@@ -33,7 +33,7 @@ module V0
     ITF_FORM_IDS = {
       'compensation' => '21-526EZ',
       'pension' => '21P-527EZ',
-      'survivor' => '21P-530EZ'
+      'survivor' => '21P-534EZ'
     }.freeze
 
     def index

--- a/lib/lighthouse/benefits_claims/intent_to_file/monitor.rb
+++ b/lib/lighthouse/benefits_claims/intent_to_file/monitor.rb
@@ -119,6 +119,43 @@ module BenefitsClaims
         }
         Rails.logger.info('V0 InProgressFormsController async ITF invalid ITF type', context)
       end
+
+      # ITF controller metrics and logging
+
+      def track_show_itf(form_id, itf_type, user_uuid)
+        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}"]
+        StatsD.increment("#{STATSD_KEY_PREFIX}.#{itf_type}.show", tags:)
+        context = { itf_type:, form_id:, user_uuid: }
+        Rails.logger.info('V0 IntentToFilesController ITF show', context)
+      end
+
+      def track_submit_itf(form_id, itf_type, user_uuid)
+        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}"]
+        StatsD.increment("#{STATSD_KEY_PREFIX}.#{itf_type}.submit", tags:)
+        context = { itf_type:, form_id:, user_uuid: }
+        Rails.logger.info('V0 IntentToFilesController ITF submit', context)
+      end
+
+      def track_missing_user_icn_itf_controller(method, form_id, itf_type, user_uuid, error)
+        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "method:#{method}"]
+        StatsD.increment('user.icn.blank', tags:)
+        context = { error:, method:, form_id:, itf_type:, user_uuid: }
+        Rails.logger.info('V0 IntentToFilesController ITF user.icn is blank', context)
+      end
+
+      def track_missing_user_pid_itf_controller(method, form_id, itf_type, user_uuid, error)
+        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "method:#{method}"]
+        StatsD.increment('user.participant_id.blank', tags:)
+        context = { error:, method:, form_id:, itf_type:, user_uuid: }
+        Rails.logger.info('V0 IntentToFilesController ITF user.participant_id is blank', context)
+      end
+
+      def track_invalid_itf_type_itf_controller(method, form_id, itf_type, user_uuid, error)
+        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "method:#{method}"]
+        StatsD.increment('itf.type.invalid', tags:)
+        context = { error:, method:, form_id:, itf_type:, user_uuid: }
+        Rails.logger.info('V0 IntentToFilesController ITF invalid ITF type', context)
+      end
     end
   end
 end

--- a/spec/lib/lighthouse/benefits_claims/intent_to_file/monitor_spec.rb
+++ b/spec/lib/lighthouse/benefits_claims/intent_to_file/monitor_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
           user_uuid: current_user.uuid
         }
 
-        expect(StatsD).to receive(:increment).with("user.icn.blank", tags:)
+        expect(StatsD).to receive(:increment).with('user.icn.blank', tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_missing_user_icn_itf_controller('post', '21P-527EZ', 'pension', current_user.uuid, 'error')
@@ -250,7 +250,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
           user_uuid: current_user.uuid
         }
 
-        expect(StatsD).to receive(:increment).with("user.participant_id.blank", tags:)
+        expect(StatsD).to receive(:increment).with('user.participant_id.blank', tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_missing_user_pid_itf_controller('post', '21P-527EZ', 'pension', current_user.uuid, 'error')
@@ -269,7 +269,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
           user_uuid: current_user.uuid
         }
 
-        expect(StatsD).to receive(:increment).with("itf.type.invalid", tags:)
+        expect(StatsD).to receive(:increment).with('itf.type.invalid', tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_invalid_itf_type_itf_controller('post', '21P-527EZ', 'pension', current_user.uuid, 'error')

--- a/spec/lib/lighthouse/benefits_claims/intent_to_file/monitor_spec.rb
+++ b/spec/lib/lighthouse/benefits_claims/intent_to_file/monitor_spec.rb
@@ -184,5 +184,96 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
         monitor.track_invalid_itf_type(ipf, monitor_error)
       end
     end
+
+    describe '#track_show_itf' do
+      it 'logs a show ITF' do
+        tags = ['form_id:21P-527EZ', 'itf_type:pension']
+        log = 'V0 IntentToFilesController ITF show'
+        payload = {
+          itf_type: 'pension',
+          form_id: '21P-527EZ',
+          user_uuid: current_user.uuid
+        }
+
+        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.pension.show", tags:)
+        expect(Rails.logger).to receive(:info).with(log, payload)
+
+        monitor.track_show_itf('21P-527EZ', 'pension', current_user.uuid)
+      end
+    end
+
+    describe '#track_submit_itf' do
+      it 'logs a submit ITF' do
+        tags = ['form_id:21P-527EZ', 'itf_type:pension']
+        log = 'V0 IntentToFilesController ITF submit'
+        payload = {
+          itf_type: 'pension',
+          form_id: '21P-527EZ',
+          user_uuid: current_user.uuid
+        }
+
+        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.pension.submit", tags:)
+        expect(Rails.logger).to receive(:info).with(log, payload)
+
+        monitor.track_submit_itf('21P-527EZ', 'pension', current_user.uuid)
+      end
+    end
+
+    describe '#track_missing_user_icn_itf_controller' do
+      it 'logs a missing user ICN' do
+        tags = ['form_id:21P-527EZ', 'itf_type:pension', 'method:post']
+        log = 'V0 IntentToFilesController ITF user.icn is blank'
+        payload = {
+          error: 'error',
+          method: 'post',
+          itf_type: 'pension',
+          form_id: '21P-527EZ',
+          user_uuid: current_user.uuid
+        }
+
+        expect(StatsD).to receive(:increment).with("user.icn.blank", tags:)
+        expect(Rails.logger).to receive(:info).with(log, payload)
+
+        monitor.track_missing_user_icn_itf_controller('post', '21P-527EZ', 'pension', current_user.uuid, 'error')
+      end
+    end
+
+    describe '#track_missing_user_pid_itf_controller' do
+      it 'logs a missing user PID' do
+        tags = ['form_id:21P-527EZ', 'itf_type:pension', 'method:post']
+        log = 'V0 IntentToFilesController ITF user.participant_id is blank'
+        payload = {
+          error: 'error',
+          method: 'post',
+          itf_type: 'pension',
+          form_id: '21P-527EZ',
+          user_uuid: current_user.uuid
+        }
+
+        expect(StatsD).to receive(:increment).with("user.participant_id.blank", tags:)
+        expect(Rails.logger).to receive(:info).with(log, payload)
+
+        monitor.track_missing_user_pid_itf_controller('post', '21P-527EZ', 'pension', current_user.uuid, 'error')
+      end
+    end
+
+    describe '#track_invalid_itf_type_itf_controller' do
+      it 'logs an invalid ITF type' do
+        tags = ['form_id:21P-527EZ', 'itf_type:pension', 'method:post']
+        log = 'V0 IntentToFilesController ITF invalid ITF type'
+        payload = {
+          error: 'error',
+          method: 'post',
+          itf_type: 'pension',
+          form_id: '21P-527EZ',
+          user_uuid: current_user.uuid
+        }
+
+        expect(StatsD).to receive(:increment).with("itf.type.invalid", tags:)
+        expect(Rails.logger).to receive(:info).with(log, payload)
+
+        monitor.track_invalid_itf_type_itf_controller('post', '21P-527EZ', 'pension', current_user.uuid, 'error')
+      end
+    end
   end
 end

--- a/spec/requests/v0/intent_to_file_spec.rb
+++ b/spec/requests/v0/intent_to_file_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require 'disability_compensation/factories/api_provider_factory'
+require 'lighthouse/benefits_claims/intent_to_file/monitor'
 
 RSpec.describe 'V0::IntentToFile', type: :request do
   include SchemaMatchers
@@ -10,10 +11,13 @@ RSpec.describe 'V0::IntentToFile', type: :request do
   let(:camel_inflection_header) { { 'X-Key-Inflection' => 'camel' } }
   let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
   let(:headers_with_camel) { headers.merge('X-Key-Inflection' => 'camel') }
+  let(:monitor) { double('monitor') }
 
   before do
     sign_in
     Flipper.disable(:disability_compensation_production_tester)
+
+    allow(BenefitsClaims::IntentToFile::Monitor).to receive(:new).and_return(monitor)
   end
 
   describe 'GET /v0/intent_to_file' do
@@ -76,11 +80,14 @@ RSpec.describe 'V0::IntentToFile', type: :request do
           let(:itf_type) { 'pension' }
 
           it 'matches the intent to files schema' do
+            expect(monitor).to receive(:track_show_itf)
+
             get '/v0/intent_to_file/pension'
 
             expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('intent_to_files')
             expect(JSON.parse(response.body)['data']['attributes']['intent_to_file'][0]['type']).to eq itf_type
+
           end
         end
 
@@ -88,6 +95,8 @@ RSpec.describe 'V0::IntentToFile', type: :request do
           let(:itf_type) { 'survivor' }
 
           it 'matches the intent to files schema' do
+            expect(monitor).to receive(:track_show_itf)
+
             get '/v0/intent_to_file/survivor'
 
             expect(response).to have_http_status(:ok)
@@ -126,6 +135,43 @@ RSpec.describe 'V0::IntentToFile', type: :request do
           end
         end
       end
+
+      context 'data validation and monitoring' do
+        before do
+          allow(monitor).to receive(:track_missing_user_icn_itf_controller)
+          allow(monitor).to receive(:track_missing_user_pid_itf_controller)
+          allow(monitor).to receive(:track_invalid_itf_type_itf_controller)
+        end
+
+        subject { V0::IntentToFilesController.new }
+
+        it 'raises MissingICNError' do
+          user_no_icn = build(:disabilities_compensation_user, icn: nil)
+
+          expect {
+            subject.send(:validate_data, user_no_icn, 'post', 'form_id', 'pension')
+          }.to raise_error V0::IntentToFilesController::MissingICNError
+          expect(monitor).to have_received(:track_missing_user_icn_itf_controller)
+        end
+
+        it 'raises MissingParticipantIDError' do
+          user_no_pid = build(:disabilities_compensation_user, participant_id: nil)
+
+          expect {
+            subject.send(:validate_data, user_no_pid, 'get', 'form_id', 'survivor')
+          }.to raise_error V0::IntentToFilesController::MissingParticipantIDError
+
+          expect(monitor).to have_received(:track_missing_user_pid_itf_controller)
+        end
+
+        it 'raises InvalidITFTypeError' do
+          expect {
+            subject.send(:validate_data, user, 'get', nil, 'survivor')
+          }.to raise_error V0::IntentToFilesController::InvalidITFTypeError
+
+          expect(monitor).to have_received(:track_invalid_itf_type_itf_controller)
+        end
+      end
     end
   end
 
@@ -153,6 +199,7 @@ RSpec.describe 'V0::IntentToFile', type: :request do
       it 'matches the respective intent to file schema' do
         expect_any_instance_of(BenefitsClaims::Service).to receive(:create_intent_to_file)
           .with(itf_type, user.ssn, nil).and_return(intent_to_file)
+        expect(monitor).to receive(:track_submit_itf)
 
         post "/v0/intent_to_file/#{itf_type}"
 

--- a/spec/requests/v0/intent_to_file_spec.rb
+++ b/spec/requests/v0/intent_to_file_spec.rb
@@ -87,7 +87,6 @@ RSpec.describe 'V0::IntentToFile', type: :request do
             expect(response).to have_http_status(:ok)
             expect(response).to match_response_schema('intent_to_files')
             expect(JSON.parse(response.body)['data']['attributes']['intent_to_file'][0]['type']).to eq itf_type
-
           end
         end
 
@@ -137,37 +136,34 @@ RSpec.describe 'V0::IntentToFile', type: :request do
       end
 
       context 'data validation and monitoring' do
+        subject { V0::IntentToFilesController.new }
+
         before do
           allow(monitor).to receive(:track_missing_user_icn_itf_controller)
           allow(monitor).to receive(:track_missing_user_pid_itf_controller)
           allow(monitor).to receive(:track_invalid_itf_type_itf_controller)
         end
 
-        subject { V0::IntentToFilesController.new }
-
         it 'raises MissingICNError' do
           user_no_icn = build(:disabilities_compensation_user, icn: nil)
 
-          expect {
-            subject.send(:validate_data, user_no_icn, 'post', 'form_id', 'pension')
-          }.to raise_error V0::IntentToFilesController::MissingICNError
+          expect { subject.send(:validate_data, user_no_icn, 'post', 'form_id', 'pension') }
+            .to raise_error V0::IntentToFilesController::MissingICNError
           expect(monitor).to have_received(:track_missing_user_icn_itf_controller)
         end
 
         it 'raises MissingParticipantIDError' do
           user_no_pid = build(:disabilities_compensation_user, participant_id: nil)
 
-          expect {
-            subject.send(:validate_data, user_no_pid, 'get', 'form_id', 'survivor')
-          }.to raise_error V0::IntentToFilesController::MissingParticipantIDError
+          expect { subject.send(:validate_data, user_no_pid, 'get', 'form_id', 'survivor') }
+            .to raise_error V0::IntentToFilesController::MissingParticipantIDError
 
           expect(monitor).to have_received(:track_missing_user_pid_itf_controller)
         end
 
         it 'raises InvalidITFTypeError' do
-          expect {
-            subject.send(:validate_data, user, 'get', nil, 'survivor')
-          }.to raise_error V0::IntentToFilesController::InvalidITFTypeError
+          expect { subject.send(:validate_data, user, 'get', nil, 'survivor') }
+            .to raise_error V0::IntentToFilesController::InvalidITFTypeError
 
           expect(monitor).to have_received(:track_invalid_itf_type_itf_controller)
         end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This adds validation, logging, and statsd metrics to the `V0::IntentToFilesController` similar to the checks and logging already in place for `InProgressController` and `CreateIntentToFileJob`
- To be owned by Pension Benefits team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108930

## Testing done

- [x] *New code is covered by unit tests*
- Tested locally and ran spec tests

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
