### PR TITLE
Fix parsing body by not parsing body

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/documents_service.rb
+++ b/modules/travel_pay/app/services/travel_pay/documents_service.rb
@@ -23,11 +23,8 @@ module TravelPay
 
       response = client.get_document_binary(veis_token, btsss_token, params)
 
-      # The content type comes across as the type of the binary data,
-      # but the actual content type of the response is application/json
-      # so we need to parse the response body in order to access the data
       {
-        body: JSON.parse(response.body)['data'],
+        body: response.body,
         disposition: response.headers['Content-Disposition'],
         type: response.headers['Content-Type'],
         content_length: response.headers['Content-Length'],


### PR DESCRIPTION
## Summary
Due to a discrepancy in the swagger docs for the external API, I assumed the response from the API would be in json format. It's not. Only the binary data comes back as a string (with headers and response metadata of course). 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/104858

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
Travel Pay
