### PR TITLE
[ID-221] Create logingov risc event object and handler

### DIFF
--- a/app/controllers/sign_in/webhooks/logingov_controller.rb
+++ b/app/controllers/sign_in/webhooks/logingov_controller.rb
@@ -1,23 +1,33 @@
 # frozen_string_literal: true
 
+require 'sign_in/logingov/service'
+
 module SignIn
   module Webhooks
     class LogingovController < SignIn::ServiceAccountApplicationController
+      Mime::Type.register 'application/secevent+jwt', :secevent_jwt
       service_tag 'identity'
       before_action :authenticate_service_account
 
       def risc
+        Logingov::RiscEventHandler.new(payload: @risc_jwt).perform
+
         head :accepted
+      rescue SignIn::Errors::LogingovRiscEventHandlerError => e
+        render_error(e.message, :unprocessable_entity)
       end
 
       private
 
       def authenticate_service_account
-        jwt = request.raw_post
-        @risc_jwt = SignIn::Logingov::Service.new.jwt_decode(jwt)
+        @risc_jwt = Logingov::Service.new.jwt_decode(request.raw_post)
       rescue => e
-        Rails.logger.error('[SignIn][Webhooks][LogingovController] error', e)
-        render json: { error: e.message }, status: :unauthorized
+        render_error(e.message, :unauthorized)
+      end
+
+      def render_error(error_message, status)
+        Rails.logger.error("[SignIn][Webhooks][LogingovController] #{action_name} error", error_message:)
+        render json: { error: 'Failed to process RISC event' }, status:
       end
     end
   end

--- a/app/services/sign_in/errors.rb
+++ b/app/services/sign_in/errors.rb
@@ -47,6 +47,7 @@ module SignIn
     class InvalidTokenError < StandardError; end
     class InvalidTokenTypeError < StandardError; end
     class InvalidTypeError < StandardError; end
+    class LogingovRiscEventHandlerError < StandardError; end
     class LogoutAuthorizationError < StandardError; end
     class MalformedParamsError < StandardError; end
     class MHVMissingMPIRecordError < StandardError; end

--- a/app/services/sign_in/logingov/risc_event_handler.rb
+++ b/app/services/sign_in/logingov/risc_event_handler.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'sign_in/logingov/risc_event'
+
+module SignIn
+  module Logingov
+    class RiscEventHandler
+      attr_reader :payload
+
+      def initialize(payload:)
+        @payload = payload.deep_symbolize_keys
+      end
+
+      def perform
+        risc_event = SignIn::Logingov::RiscEvent.new(event: payload[:events])
+        risc_event.validate!
+
+        handle_event(risc_event)
+      rescue ActiveModel::ValidationError => e
+        Rails.logger.error('[SignIn][Logingov][RiscEventHandler] validation error',
+                           error: e.message,
+                           risc_event: risc_event.to_h_masked)
+        raise SignIn::Errors::LogingovRiscEventHandlerError.new message: "Invalid RISC event: #{e.message}"
+      end
+
+      private
+
+      def handle_event(risc_event)
+        Rails.logger.info('[SignIn][Logingov][RiscEventHandler] risc_event received',
+                          risc_event: risc_event.to_h_masked)
+      end
+    end
+  end
+end

--- a/lib/sign_in/logingov/risc_event.rb
+++ b/lib/sign_in/logingov/risc_event.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module SignIn
+  module Logingov
+    class RiscEvent
+      include ActiveModel::Validations
+
+      EVENT_TYPES = %i[
+        account_disabled
+        account_enabled
+        mfa_limit_account_locked
+        account_purged
+        identifier_changed
+        identifier_recycled
+        password_reset
+        recovery_activated
+        recovery_information_changed
+        reproof_completed
+      ].freeze
+
+      attr_accessor :event_type, :email, :logingov_uuid, :reason, :event_occurred_at
+
+      validates :event_type, presence: true, inclusion: { in: EVENT_TYPES }
+      validate :email_or_uuid_present
+
+      def initialize(event:)
+        event_uri = event.keys.first
+        subject = event.dig(event_uri, :subject)
+
+        @event_type = normalize_event_type(event_uri)
+        @email = subject[:email]
+        @logingov_uuid = subject[:sub]
+        @reason = event.dig(event_uri, :reason)
+        @event_occurred_at = Time.zone.at(event.dig(event_uri, :event_occurred_at) || Time.current)
+      end
+
+      def to_h_masked
+        {
+          event_type:,
+          email: email.present? ? '[FILTERED]' : nil,
+          logingov_uuid:,
+          reason:,
+          event_occurred_at: event_occurred_at.iso8601
+        }
+      end
+
+      private
+
+      def normalize_event_type(event_uri)
+        event_uri.to_s.split('/').last&.tr('-', '_')&.to_sym
+      end
+
+      def email_or_uuid_present
+        errors.add(:base, 'email or logingov_uuid must be present') if email.blank? && logingov_uuid.blank?
+      end
+    end
+  end
+end

--- a/spec/controllers/sign_in/webhooks/logingov_controller_spec.rb
+++ b/spec/controllers/sign_in/webhooks/logingov_controller_spec.rb
@@ -3,62 +3,62 @@
 require 'rails_helper'
 require 'sign_in/logingov/service'
 
-RSpec.describe 'LoginGovController', type: :request do
+RSpec.describe SignIn::Webhooks::LogingovController, type: :controller do
+  subject(:risc_request) { post :risc, body: jwt }
+
+  let(:jwt) { create(:logingov_risc_event_payload, :encoded) }
+  let(:jwks) { create(:logingov_risc_event_jwks) }
+  let(:decoded_jwt) { JWT.decode(jwt, nil, true, { algorithm: 'RS256', jwks: }).first }
+
+  before do
+    request.headers['Content-Type'] = 'application/secevent+jwt'
+    request.headers['Accept'] = 'application/json'
+
+    allow_any_instance_of(SignIn::Logingov::Service).to receive(:public_jwks).and_return(jwks)
+    allow(Rails.logger).to receive(:info)
+    allow(Rails.logger).to receive(:error)
+  end
+
   describe 'POST /sign_in/webhooks/logingov/risc' do
     context 'when JWT is invalid' do
+      let(:expected_error_message) { 'Failed to process RISC event' }
+      let(:jwt) { 'some-invalid-jwt' }
+
       it 'returns 401 when jwt_decode raises JWTDecodeError' do
-        allow_any_instance_of(SignIn::Logingov::Service)
-          .to receive(:jwt_decode)
-          .and_raise(SignIn::Logingov::Errors::JWTDecodeError.new('Invalid token'))
-
-        post '/sign_in/webhooks/logingov/risc',
-             params: 'not.a.real.jwt',
-             headers: { 'CONTENT_TYPE' => 'application/jwt' }
-
+        risc_request
         expect(response).to have_http_status(:unauthorized)
-        expect(response.parsed_body['error']).to include('Invalid token')
+        expect(response.parsed_body['error']).to include(expected_error_message)
       end
     end
 
-    context 'when JWT decoding raises unexpected error' do
-      it 'returns 401 when an unexpected error occurs' do
-        allow_any_instance_of(SignIn::Logingov::Service)
-          .to receive(:jwt_decode)
-          .and_raise(StandardError.new('Something went wrong'))
-
-        post '/sign_in/webhooks/logingov/risc',
-             params: 'some.jwt.token',
-             headers: { 'CONTENT_TYPE' => 'application/jwt' }
-
-        expect(response).to have_http_status(:unauthorized)
-        expect(response.parsed_body['error']).to include('Something went wrong')
-      end
-    end
-
-    context 'when JWT is valid' do
-      let(:valid_jwt) { 'valid.jwt.token' }
-
-      it 'returns 202 Accepted for valid JWT' do
-        allow_any_instance_of(SignIn::Logingov::Service)
-          .to receive(:jwt_decode)
-          .and_return({ 'sub' => 'valid-user' })
-
-        post '/sign_in/webhooks/logingov/risc',
-             params: valid_jwt,
-             headers: { 'CONTENT_TYPE' => 'application/jwt' }
-
-        expect(response).to have_http_status(:accepted)
-        expect(response.body).to be_empty
+    context 'when the JWT is valid' do
+      before do
+        allow(SignIn::Logingov::RiscEventHandler).to receive(:new).and_call_original
       end
 
-      it 'calls jwt_decode in the before_action with the correct JWT' do
-        expect_any_instance_of(SignIn::Logingov::Service)
-          .to receive(:jwt_decode)
-          .with(valid_jwt)
+      context 'when the RISC event is valid' do
+        it 'processes the RISC event successfully' do
+          risc_request
+          expect(SignIn::Logingov::RiscEventHandler).to have_received(:new).with(payload: decoded_jwt)
+          expect(Rails.logger).to have_received(:info).with('[SignIn][Logingov][RiscEventHandler] risc_event received',
+                                                            anything)
+        end
+      end
 
-        post '/sign_in/webhooks/logingov/risc',
-             params: valid_jwt,
-             headers: { 'CONTENT_TYPE' => 'application/jwt' }
+      context 'when the RISC event is invalid' do
+        before do
+          allow_any_instance_of(SignIn::Logingov::RiscEventHandler).to receive(:perform).and_raise(
+            SignIn::Errors::LogingovRiscEventHandlerError.new(message: 'Invalid RISC event')
+          )
+        end
+
+        it 'returns 422 when the RISC event handler raises an error' do
+          risc_request
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body['error']).to include('Failed to process RISC event')
+          expect(Rails.logger).to have_received(:error).with('[SignIn][Webhooks][LogingovController] risc error',
+                                                             error_message: 'Invalid RISC event')
+        end
       end
     end
   end

--- a/spec/factories/sign_in/logingov_risc_event_payloads.rb
+++ b/spec/factories/sign_in/logingov_risc_event_payloads.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+DEFAULT_ISSUER = 'https://idp.int.identitysandbox.gov'
+IDENTIFIER_TYPES = %w[iss-sub email].freeze
+EVENT_TYPE_URIS     = {
+  account_disabled: :'https://schemas.openid.net/secevent/risc/event-type/account-disabled',
+  account_enabled: :'https://schemas.openid.net/secevent/risc/event-type/account-enabled',
+  mfa_limit_account_locked: :'https://schemas.login.gov/secevent/risc/event-type/mfa-limit-account-locked',
+  account_purged: :'https://schemas.openid.net/secevent/risc/event-type/account-purged',
+  identifier_changed: :'https://schemas.openid.net/secevent/risc/event-type/identifier-changed',
+  identifier_recycled: :'https://schemas.openid.net/secevent/risc/event-type/identifier-recycled',
+  password_reset: :'https://schemas.login.gov/secevent/risc/event-type/password-reset',
+  recovery_activated: :'https://schemas.openid.net/secevent/risc/event-type/recovery-activated',
+  recovery_information_changed: :'https://schemas.openid.net/secevent/risc/event-type/recovery-information-changed',
+  reproof_completed: :'https://schemas.login.gov/secevent/risc/event-type/reproof-completed'
+}.freeze
+
+FactoryBot.define do
+  sequence(:risc_uuid)  { Faker::Internet.uuid }
+  sequence(:risc_email) { Faker::Internet.email }
+
+  factory :logingov_risc_event_payload, class: Hash do
+    skip_create
+
+    transient do
+      event_name        { EVENT_TYPE_URIS.keys.first }
+      event_type        { EVENT_TYPE_URIS.fetch(event_name) }
+      subject_type      { IDENTIFIER_TYPES.sample }
+      email             { generate(:risc_email) }
+      logingov_uuid { generate(:risc_uuid) }
+      event_occurred_at { nil }
+      reason            { nil }
+    end
+
+    initialize_with do
+      {
+        iss: DEFAULT_ISSUER,
+        jti: generate(:risc_uuid),
+        iat: Time.current.to_i,
+        aud: 'https://va.gov',
+        events: {
+          event_type => {
+            subject: {
+              subject_type:,
+              iss: DEFAULT_ISSUER,
+              email:,
+              sub: logingov_uuid
+            },
+            reason:,
+            event_occurred_at:
+          }
+        }
+      }
+    end
+
+    EVENT_TYPE_URIS.each_key do |ename|
+      trait ename do
+        transient { event_name { ename } }
+      end
+    end
+
+    trait :encoded do
+      transient do
+        private_key_path { Rails.root.join('spec', 'fixtures', 'sign_in', 'oauth_test.key') }
+        private_key      { OpenSSL::PKey::RSA.new(File.read(private_key_path)) }
+        algorithm        { 'RS256' }
+        kid              { 'some-kid' }
+        header           { { typ: 'secevent+jwt', alg: algorithm, kid: } }
+      end
+
+      initialize_with do
+        payload = FactoryBot.build(
+          :logingov_risc_event_payload,
+          event_name:,
+          subject_type:,
+          email:,
+          logingov_uuid:,
+          event_occurred_at:,
+          reason:
+        )
+
+        JWT.encode(payload, private_key, algorithm, header)
+      end
+    end
+  end
+end
+
+FactoryBot.define do
+  factory :logingov_risc_event_jwks, class: Hash do
+    skip_create
+
+    transient do
+      private_key_path { Rails.root.join('spec', 'fixtures', 'sign_in', 'oauth_test.key') }
+      private_key      { OpenSSL::PKey::RSA.new(File.read(private_key_path)) }
+      algorithm        { 'RS256' }
+      kid              { 'some-kid' }
+    end
+
+    initialize_with do
+      {
+        keys: [
+          JWT::JWK.new(private_key, { alg: algorithm, use: 'sig', kid: }).export
+        ]
+      }
+    end
+  end
+end

--- a/spec/lib/sign_in/logingov/risc_event_spec.rb
+++ b/spec/lib/sign_in/logingov/risc_event_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sign_in/logingov/risc_event'
+
+Rspec.describe SignIn::Logingov::RiscEvent do
+  subject(:risc_event) { described_class.new(event:) }
+  let(:event) { risc_event_payload[:events] }
+  let(:risc_event_payload) { {} }
+
+  describe 'validations' do
+    shared_examples 'an invalid risc_event' do
+      it 'is invalid' do
+        expect(risc_event).not_to be_valid
+        expect(risc_event.errors[error_attribute].first).to include(expected_error)
+      end
+    end
+
+    context 'when risc_event is valid' do
+      context 'when risc event is account-disabled' do
+        let(:risc_event_payload) { build(:logingov_risc_event_payload, :account_disabled) }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when risc event is account-enabled' do
+        let(:risc_event_payload) { build(:logingov_risc_event_payload, :account_enabled) }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when risc event is mfa-limit-account-locked' do
+        let(:risc_event_payload) { build(:logingov_risc_event_payload, :mfa_limit_account_locked) }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when risc event is account-purged' do
+        let(:risc_event_payload) { build(:logingov_risc_event_payload, :account_purged) }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when risc event is identifier-changed' do
+        let(:risc_event_payload) { build(:logingov_risc_event_payload, :identifier_changed) }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when risc event is identifier-recycled' do
+        let(:risc_event_payload) { build(:logingov_risc_event_payload, :identifier_recycled) }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when risc event is password-reset' do
+        let(:risc_event_payload) { build(:logingov_risc_event_payload, :password_reset) }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when risc event is recovery-activated' do
+        let(:risc_event_payload) { build(:logingov_risc_event_payload, :recovery_activated) }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when risc event is recovery-information-changed' do
+        let(:risc_event_payload) { build(:logingov_risc_event_payload, :recovery_information_changed) }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when risc event is reproof-completed' do
+        let(:risc_event_payload) { build(:logingov_risc_event_payload, :reproof_completed) }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when event_occurred_at is missing' do
+        let(:risc_event_payload) { build(:logingov_risc_event_payload, :account_disabled, event_occurred_at: nil) }
+
+        before do
+          Timecop.freeze(Time.current)
+        end
+
+        after do
+          Timecop.return
+        end
+
+        it 'sets event_occurred_at to current time' do
+          expect(risc_event.event_occurred_at).to eq(Time.current)
+        end
+      end
+
+      context 'when reason is present' do
+        let(:risc_event_payload) { build(:logingov_risc_event_payload, :account_disabled, reason: 'some reason') }
+
+        it 'sets reason' do
+          expect(risc_event.reason).to eq('some reason')
+        end
+      end
+    end
+
+    context 'when risc_event is invalid' do
+      context 'when event_type is missing' do
+        let(:risc_event_payload) { build(:logingov_risc_event_payload, :account_disabled, event_type: nil) }
+        let(:error_attribute) { :event_type }
+        let(:expected_error) { "can't be blank" }
+        let(:event_type) { nil }
+
+        it_behaves_like 'an invalid risc_event'
+      end
+
+      context 'when event_type is unsupported' do
+        let(:risc_event_payload) do
+          build(:logingov_risc_event_payload, :account_disabled, event_type: 'unsupported_event')
+        end
+        let(:error_attribute) { :event_type }
+        let(:event_type) { 'unsupported_event' }
+        let(:expected_error) { 'is not included in the list' }
+      end
+
+      context 'when both email and logingov_uuid are missing' do
+        let(:risc_event_payload) do
+          build(:logingov_risc_event_payload, :account_disabled, email: nil, logingov_uuid: nil)
+        end
+        let(:error_attribute) { :base }
+        let(:expected_error) { 'email or logingov_uuid must be present' }
+
+        it_behaves_like 'an invalid risc_event'
+      end
+    end
+  end
+
+  describe 'to_h_masked' do
+    let(:risc_event_payload) { build(:logingov_risc_event_payload, :account_disabled, :identifier_changed) }
+
+    it 'masks the email address' do
+      expect(risc_event.to_h_masked).to include(email: '[FILTERED]')
+    end
+  end
+end

--- a/spec/services/sign_in/logingov/risc_event_handler_spec.rb
+++ b/spec/services/sign_in/logingov/risc_event_handler_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SignIn::Logingov::RiscEventHandler, type: :service do
+  subject(:handler) { described_class.new(payload:) }
+
+  let(:payload) do
+    build(
+      :logingov_risc_event_payload,
+      :identifier_changed,
+      email:,
+      logingov_uuid: nil,
+      reason:,
+      event_occurred_at:
+    )
+  end
+
+  let(:event_type) { :identifier_changed }
+  let(:email) { 'some-email@example.com' }
+  let(:logingov_uuid) { nil }
+  let(:reason) { 'User changed email' }
+  let(:event_occurred_at) { Time.current }
+
+  before do
+    Timecop.freeze(event_occurred_at)
+    allow(Rails.logger).to receive(:info)
+    allow(Rails.logger).to receive(:error)
+  end
+
+  after do
+    Timecop.return
+  end
+
+  describe '#perform' do
+    context 'when the event is valid' do
+      let(:expected_log_message) { '[SignIn][Logingov][RiscEventHandler] risc_event received' }
+      let(:expected_log_payload) do
+        {
+          risc_event: {
+            event_type: :identifier_changed,
+            email: '[FILTERED]',
+            logingov_uuid:,
+            reason:,
+            event_occurred_at: event_occurred_at.iso8601
+          }
+        }
+      end
+
+      it 'logs the masked risc event receipt' do
+        handler.perform
+
+        expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
+      end
+    end
+
+    context 'when validation fails' do
+      let(:email) { nil }
+      let(:logingov_uuid) { nil }
+      let(:expected_log_payload) do
+        {
+          risc_event: {
+            event_type: :identifier_changed,
+            email:,
+            logingov_uuid:,
+            reason:,
+            event_occurred_at: event_occurred_at.iso8601
+          }
+        }
+      end
+      let(:expected_log_message) { '[SignIn][Logingov][RiscEventHandler] validation error' }
+      let(:error_message) do
+        'Validation failed: email or logingov_uuid must be present'
+      end
+
+      it 'rescues and logs the validation error' do
+        expect do
+          handler.perform
+        end.to raise_error(SignIn::Errors::LogingovRiscEventHandlerError, "Invalid RISC event: #{error_message}")
+
+        expect(Rails.logger).to have_received(:error).with(expected_log_message,
+                                                           { error: error_message }.merge(expected_log_payload))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Create logingov risc event handler and class.
- The class will parse the event
- The handler receives a decoded jwt, creates a risc event, and currently logs the event. (other functionality such as flagging an account could be added to the handler in the future)
- Create a factory for example RISC payloads. These can also be encoded witht the oauth_test private key
- [Login.gov Docs](https://developers.login.gov/security-events/#receiving-a-security-event-token-set)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/221

## Testing 
- Create some test payloads and call the handler and create RiscEvents in rails console'
### `RiscEventHandler`
```ruby
include FactoryBot::Syntax::Methods

payload = build(:logingov_risc_event_payload)

# call handler
SignIn::Logingov::RiscEventHandler.new(payload:).perform
```
you should see a log like:
```ruby
Rails -- [SignIn][Logingov][RiscEventHandler] risc_event received -- { :risc_event => { :event_type => :account_disabled, :email => "[FILTERED]", :logingov_uuid => "0180dfb1-c4f1-482a-b3f3-9e528f51b82d", :reason => nil, :event_occurred_at => "2025-05-16T14:12:48Z" } }
```
### `RiscEvent`
```ruby
include FactoryBot::Syntax::Methods

payload = build(:logingov_risc_event_payload)

event = payload[:events]

risc_event = SignIn::Logingov::RiscEvent.new(event:)

# mask the email for logging
risc_event.to_h_masked
```

### Test Risc event webhook call
- change [lib/sign_in/logingov/service.rb#98](https://github.com/department-of-veterans-affairs/vets-api/blob/db39231d4c34167e279b71e8d45023c9c9c541c1/lib/sign_in/logingov/service.rb#L98) to:
  ```ruby
   { verify_expiration:, algorithm: config.jwt_decode_algorithm, jwks: FactoryBot.create(:logingov_risc_event_jwks) }
  ```
- Generate a JWT in the rails console -
   ```ruby
   FactoryBot.create(:logingov_risc_event_payload, :encoded)
   ```
- start rails server and make request with the JWT in the body
   ```bash
   curl --request POST \
  --url http://localhost:3000/sign_in/webhooks/logingov/risc \
  --header 'accept: application/json' \
  --header 'content-type: application/secevent+jwt' \
  --data eyJ0eXAiOiJzZWNldmVudCtqd3QiLCJhbGciOiJSUzI1NiIsImtpZCI6InNvbWUta2lkIn0.eyJpc3MiOiJodHRwczovL2lkcC5pbnQuaWRlbnRpdHlzYW5kYm94LmdvdiIsImp0aSI6ImU0NjAwNjYxLWRkZDUtNDdkZS1hNGVjLTNmZWMwMjMxNTVmYyIsImlhdCI6MTc0ODYzOTY5MSwiYXVkIjoiaHR0cHM6Ly92YS5nb3YiLCJldmVudHMiOnsiaHR0cHM6Ly9zY2hlbWFzLm9wZW5pZC5uZXQvc2VjZXZlbnQvcmlzYy9ldmVudC10eXBlL2FjY291bnQtZGlzYWJsZWQiOnsic3ViamVjdCI6eyJzdWJqZWN0X3R5cGUiOiJpc3Mtc3ViIiwiaXNzIjoiaHR0cHM6Ly9pZHAuaW50LmlkZW50aXR5c2FuZGJveC5nb3YiLCJlbWFpbCI6ImNoZXJ5X2hvd2VAb2tlZWZlLnRlc3QiLCJzdWIiOiI0OWFhZTEzMy1lMjkxLTQwZWUtYjczOC0wMTY1MTg4YWZhYmIifSwicmVhc29uIjpudWxsLCJldmVudF9vY2N1cnJlZF9hdCI6bnVsbH19fQ.l1ySreGmF4XJISKCf9h7hLk3KDDkJF_53E0C98c5kmfoy1TAxEvrzZTHV36bnuR3iYOoWR_gw4zlsLW1WDYJraf3bYIEuVZ2ZZKNE49Mgr5NSDDsDqDJkGZfWqz96s8VSfMhvy8oAKmcpiaAJQhuGjaHEGPaDB_5_srbgAoLLNrlDfUrsraPPhs75LTc5lQdCkKgGJ-m-cT0598QFI90cB_46LVk2sq_iHgzRS_3D8v-or24oDIOx6NMoYI5X6EXhzdDCdg2IYzrUBZgEee9lYqFC_GDohR2FN_MrzMCppUqyiUg7Ky95LGYtrnWblFbu3VUauuaYOQKDqynaMkkBw
   ```
  - You should get a `202 Accepted` with no body
  - In your logs you should see the event logged
    ```ruby
    Rails -- [SignIn][Logingov][RiscEventHandler] risc_event received -- 
    { :risc_event => { :event_type => :account_disabled, :email => "[FILTERED]", :logingov_uuid => "49aae133-e291-40ee-b738-0165188afabb", :reason => nil, :event_occurred_at => "2025-05-30T21:15:40Z" } }
    ```

## What areas of the site does it impact?
logingov risc events

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

