### PR TITLE
Add claim_id to form submission attempt logs

### DIFF
--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -33,7 +33,9 @@ class FormSubmissionAttempt < ApplicationRecord
     event :fail do
       after do
         form_type = form_submission.form_type
+        claim_id = form_submission&.saved_claim_id
         log_info = { form_submission_id:,
+                     claim_id:,
                      benefits_intake_uuid:,
                      form_type:,
                      user_account_uuid: form_submission.user_account_id }
@@ -97,6 +99,7 @@ class FormSubmissionAttempt < ApplicationRecord
       form_submission_id:,
       benefits_intake_uuid:,
       form_type: form_submission&.form_type,
+      claim_id: form_submission&.saved_claim_id,
       from_state: aasm.from_state,
       to_state: aasm.to_state,
       event: aasm.current_event


### PR DESCRIPTION
We notice in the logs as seen in the screenshot below that we are missing claim_id from this payload. It is difficult to locate when this occurs.


## Summary

- Add `claim_id` to the log hash

## Screenshots
<img width="545" alt="Screenshot 2025-05-16 at 11 53 25 AM" src="https://github.com/user-attachments/assets/d59c503c-339d-4335-b286-73385d64e6a8" />


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
