### PR TITLE
BMT1/102839: [CST] Migrate from connect_VBMS to LH document service for claim letters

### DIFF
--- a/lib/lighthouse/benefits_documents/configuration.rb
+++ b/lib/lighthouse/benefits_documents/configuration.rb
@@ -132,8 +132,7 @@ module BenefitsDocuments
             nil,
             {}
           )
-        }"
-      }
+        }" }
 
       body = {
         'data' => {
@@ -167,8 +166,7 @@ module BenefitsDocuments
             nil,
             {}
           )
-        }", 'Accept' => 'application/octet-stream, application/json'
-      }
+        }", 'Accept' => 'application/octet-stream, application/json' }
 
       body = {
         'data' => {

--- a/lib/lighthouse/benefits_documents/configuration.rb
+++ b/lib/lighthouse/benefits_documents/configuration.rb
@@ -18,6 +18,8 @@ module BenefitsDocuments
     BASE_PATH = 'services/benefits-documents/v1'
     DOCUMENTS_PATH = "#{BASE_PATH}/documents".freeze
     DOCUMENTS_STATUS_PATH = "#{BASE_PATH}/uploads/status".freeze
+    CLAIMS_LETTERS_SEARCH_PATH = "#{BASE_PATH}/claim-letters/search".freeze
+    CLAIMS_LETTER_DOWNLOAD_PATH = "#{BASE_PATH}/claim-letters/download".freeze
     TOKEN_PATH = 'oauth2/benefits-documents/system/v1/token'
     QA_TESTING_DOMAIN = Settings.lighthouse.benefits_documents.host
 
@@ -111,6 +113,71 @@ module BenefitsDocuments
       }.to_json
 
       documents_status_api_connection.post(DOCUMENTS_STATUS_PATH, body, headers)
+    end
+
+    # Returns the identifying information for all Claims Evidence claim letter documents
+    # that are eligible to be downloaded via the Documents Service,
+    # identified the fileNumber or participantId.
+    # @param doc_type_ids: string The numeric code of the types of documents to search for.
+    # If not provided, then all downloadable claim letter documents matching the other request criteria will be returned.
+    # @param participant_id: string A unique identifier assigned to each patient entry in the
+    # Master Patient Index linking patients to their records across VA systems.
+    # Example: 999012105
+    # @param file_number: string The Veteran's VBMS fileNumber used when uploading the document
+    # to VBMS. It indicates the eFolder in which the document resides. Example: 999012105
+    def claim_letters_search(doc_type_ids: nil, participant_id: nil, file_number: nil)
+      headers = { 'Authorization' => "Bearer #{
+          access_token(
+            nil,
+            nil,
+            {}
+          )
+        }"
+      }
+
+      body = {
+        'data' => {
+          'docTypeIds' => doc_type_ids,
+          'fileNumber' => file_number,
+          'participantId' => participant_id
+        }
+      }
+      connection.post(CLAIMS_LETTERS_SEARCH_PATH, body, headers)
+    end
+
+    # Downloads the binary content for the Claims Evidence claim letter document that is
+    # identified by the given documentId and associated with the given
+    # participantId or fileNumber.
+    # Note that downloading file content is only supported for certain document types.
+    # @param document_uuid: string The document's unique identifier in VBMS,
+    # obtained by making a Document Service API request to search for documents
+    # that are available to download for the Veteran.
+    # Note that this differs from the document's current version UUID.
+    # Example: "12345678-ABCD-0123-cdef-124345679ABC"
+    # @param participant_id: string A unique identifier assigned to each patient entry
+    # in the Master Patient Index linking patients to their records across VA systems.
+    # Example: 999012105
+    # @param file_number: The Veteran's VBMS fileNumber used when uploading the document to VBMS.
+    # It indicates the eFolder in which the document resides.
+    # Example: 999012105
+    def claim_letter_download(document_uuid: nil, participant_id: nil, file_number: nil)
+      headers = { 'Authorization' => "Bearer #{
+          access_token(
+            nil,
+            nil,
+            {}
+          )
+        }", 'Accept' => 'application/octet-stream, application/json'
+      }
+
+      body = {
+        'data' => {
+          'fileNumber' => file_number,
+          'participantId' => participant_id,
+          'documentUuid' => document_uuid
+        }
+      }
+      connection.post(CLAIMS_LETTER_DOWNLOAD_PATH, body, headers)
     end
 
     ##

--- a/lib/lighthouse/benefits_documents/configuration.rb
+++ b/lib/lighthouse/benefits_documents/configuration.rb
@@ -119,7 +119,8 @@ module BenefitsDocuments
     # that are eligible to be downloaded via the Documents Service,
     # identified the fileNumber or participantId.
     # @param doc_type_ids: string The numeric code of the types of documents to search for.
-    # If not provided, then all downloadable claim letter documents matching the other request criteria will be returned.
+    # If not provided, then all downloadable claim letter documents matching the other
+    # request criteria will be returned.
     # @param participant_id: string A unique identifier assigned to each patient entry in the
     # Master Patient Index linking patients to their records across VA systems.
     # Example: 999012105

--- a/lib/lighthouse/benefits_documents/service.rb
+++ b/lib/lighthouse/benefits_documents/service.rb
@@ -48,6 +48,18 @@ module BenefitsDocuments
       FileUtils.rm_rf(@base_path) if @base_path
     end
 
+    def claim_letters_search(doc_type_ids: nil, participant_id: nil, file_number: nil)
+      config.claim_letters_search(doc_type_ids:, participant_id:, file_number:)
+    rescue Faraday::ClientError, Faraday::ServerError => e
+      handle_error(e, nil, 'services/benefits-documents/v1/claim-letters/search')
+    end
+
+    def claim_letter_download(document_uuid:, participant_id: nil, file_number: nil)
+      config.claim_letter_download(document_uuid:, participant_id:, file_number:)
+    rescue Faraday::ClientError, Faraday::ServerError => e
+      handle_error(e, nil, 'services/benefits-documents/v1/claim-letters/download')
+    end
+
     private
 
     def submit_document(file, file_params, lighthouse_client_id = nil) # rubocop:disable Metrics/MethodLength

--- a/lib/lighthouse/benefits_documents/service.rb
+++ b/lib/lighthouse/benefits_documents/service.rb
@@ -48,12 +48,14 @@ module BenefitsDocuments
       FileUtils.rm_rf(@base_path) if @base_path
     end
 
+    # gets all claim letters from the lighthouse claims-letters/search endpoint
     def claim_letters_search(doc_type_ids: nil, participant_id: nil, file_number: nil)
       config.claim_letters_search(doc_type_ids:, participant_id:, file_number:)
     rescue Faraday::ClientError, Faraday::ServerError => e
       handle_error(e, nil, 'services/benefits-documents/v1/claim-letters/search')
     end
 
+    # retrieves the octet-stream of a single claim letter from the lighthouse claims-letters/download endpoint
     def claim_letter_download(document_uuid:, participant_id: nil, file_number: nil)
       config.claim_letter_download(document_uuid:, participant_id:, file_number:)
     rescue Faraday::ClientError, Faraday::ServerError => e

--- a/spec/lib/lighthouse/benefits_documents/service_spec.rb
+++ b/spec/lib/lighthouse/benefits_documents/service_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe BenefitsDocuments::Service do
   end
 
   describe '#queue_document_upload' do
-
     describe 'when uploading single file' do
       let(:upload_file) do
         f = Tempfile.new(['file with spaces', '.txt'])
@@ -117,7 +116,6 @@ RSpec.describe BenefitsDocuments::Service do
   end
 
   context 'claim letters' do
-
     describe '#claim_letters_search' do
       it 'receives a list of claim letters' do
         response_body = {

--- a/spec/lib/lighthouse/benefits_documents/service_spec.rb
+++ b/spec/lib/lighthouse/benefits_documents/service_spec.rb
@@ -12,14 +12,13 @@ RSpec.describe BenefitsDocuments::Service do
   let(:user_account) { create(:user_account) }
   let(:service) { BenefitsDocuments::Service.new(user) }
 
+  before do
+    allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_access_token')
+    user.user_account_uuid = user_account.id
+    user.save!
+  end
+
   describe '#queue_document_upload' do
-    before do
-      allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_access_token')
-      token = 'abcd1234'
-      allow_any_instance_of(BenefitsDocuments::Configuration).to receive(:access_token).and_return(token)
-      user.user_account_uuid = user_account.id
-      user.save!
-    end
 
     describe 'when uploading single file' do
       let(:upload_file) do
@@ -113,6 +112,57 @@ RSpec.describe BenefitsDocuments::Service do
             expect(EvidenceSubmission.count).to eq(0)
           end
         end
+      end
+    end
+  end
+
+  context 'claim letters' do
+
+    describe '#claim_letters_search' do
+      it 'receives a list of claim letters' do
+        response_body = {
+          data: {
+            documents: [
+              {
+                docTypeId: 184,
+                subject: 'string',
+                documentUuid: '12345678-ABCD-0123-cdef-124345679ABC',
+                originalFileName: 'SupportingDocument.pdf',
+                documentTypeLabel: 'VA 21-526 Veterans Application for Compensation or Pension',
+                trackedItemId: 600_000_001,
+                uploadedDateTime: '2016-02-04T17:51:56Z'
+              }
+            ]
+          }
+        }
+
+        allow_any_instance_of(Faraday::Connection).to receive(:post)
+          .and_return(Faraday::Response.new(
+                        status: 200, body: response_body
+                      ))
+        expect_any_instance_of(BenefitsDocuments::Configuration)
+          .to(receive(:claim_letters_search).once.and_call_original)
+
+        response = subject.claim_letters_search(file_number: user.ssn)
+
+        expect(response.body.as_json['data']['documents'][0]['docTypeId']).to eq(184)
+      end
+    end
+
+    describe '#claim_letter_download' do
+      it 'receives content of a claim letter pdf' do
+        response_body = 'claim letter pdf file content'
+
+        allow_any_instance_of(Faraday::Connection).to receive(:post)
+          .and_return(Faraday::Response.new(
+                        status: 200, body: response_body
+                      ))
+        expect_any_instance_of(BenefitsDocuments::Configuration)
+          .to(receive(:claim_letter_download).once.and_call_original)
+
+        response = subject.claim_letter_download(document_uuid: 'a-required-uuid', file_number: user.ssn)
+
+        expect(response.body).to eq(response_body)
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO* but it is not used anywhere. This simply adds the service for further use
- add lighthouse service and configuration to call:
  - claims-letters/search
  - claims-letters/download

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/102839

## Testing done

- [x] *New code is covered by unit tests* 
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
n/a

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

