### PR TITLE
Adds logs to breakers initializer

### DIFF
--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -110,6 +110,13 @@ Rails.application.reloader.to_prepare do
     logger: Rails.logger,
     plugins: [plugin]
   )
+  if Settings.vsp_environment == 'staging'
+    services.each do |service|
+      Rails.logger.info(
+        "#{service&.name} outage_ended?=#{service&.latest_outage&.ended?}"
+      )
+    end
+  end
 
   # No need to prefix it when using the namespace
   Breakers.redis_prefix = ''


### PR DESCRIPTION
## Summary

- Adds logs to breakers initializer 
- temporary in order to debug an issue - this will be REMOVED next week

## Related issue(s)

- [issues/108975](https://github.com/department-of-veterans-affairs/va.gov-team/issues/108975)


## What areas of the site does it impact?
breakers init in vets-api

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

