### PR TITLE
Replace Common::Base with Vets::Model - EVSS::Response

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1488,6 +1488,7 @@ spec/lib/evss/documents_service_spec.rb @department-of-veterans-affairs/va-api-e
 spec/lib/evss/error_middleware_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/evss/letters @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-admin
 spec/lib/evss/pciu/request_body_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+spec/lib/evss/pciu/service_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/evss/pciu_address/response_strategy_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/evss/ppiu @department-of-veterans-affairs/vfs-authenticated-experience-backend  @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 spec/lib/evss/service_exception_spec.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/app/serializers/rating_info_serializer.rb
+++ b/app/serializers/rating_info_serializer.rb
@@ -6,7 +6,7 @@ class RatingInfoSerializer
   set_id { '' }
 
   attribute :user_percent_of_disability do |object|
-    object[:user_percent_of_disability]
+    object.user_percent_of_disability
   end
 
   attribute :source_system do |_|

--- a/app/serializers/rating_info_serializer.rb
+++ b/app/serializers/rating_info_serializer.rb
@@ -5,9 +5,7 @@ class RatingInfoSerializer
 
   set_id { '' }
 
-  attribute :user_percent_of_disability do |object|
-    object.user_percent_of_disability
-  end
+  attribute :user_percent_of_disability
 
   attribute :source_system do |_|
     'EVSS'

--- a/lib/evss/dependents/retrieved_info.rb
+++ b/lib/evss/dependents/retrieved_info.rb
@@ -39,7 +39,7 @@ module EVSS
       def body
         do_cached_with(key: "evss_dependents_retrieve_#{@user.uuid}") do
           raw_response = EVSS::Dependents::Service.new(@user).retrieve
-          EVSS::Dependents::RetrieveInfoResponse.new(raw_response.status, {response_body: raw_response.body})
+          EVSS::Dependents::RetrieveInfoResponse.new(raw_response.status, { response_body: raw_response.body })
         end.response_body
       end
 

--- a/lib/evss/dependents/retrieved_info.rb
+++ b/lib/evss/dependents/retrieved_info.rb
@@ -39,7 +39,7 @@ module EVSS
       def body
         do_cached_with(key: "evss_dependents_retrieve_#{@user.uuid}") do
           raw_response = EVSS::Dependents::Service.new(@user).retrieve
-          EVSS::Dependents::RetrieveInfoResponse.new(raw_response.status, raw_response)
+          EVSS::Dependents::RetrieveInfoResponse.new(raw_response.status, {response_body: raw_response.body})
         end.response_body
       end
 

--- a/lib/evss/disability_compensation_form/rated_disabilities_response.rb
+++ b/lib/evss/disability_compensation_form/rated_disabilities_response.rb
@@ -11,7 +11,7 @@ module EVSS
     #   @return [Array<EVSS::DisabilityCompensationForm::RatedDisability>] The list of rated disabilities
     #
     class RatedDisabilitiesResponse < EVSS::Response
-      attribute :rated_disabilities, Array[EVSS::DisabilityCompensationForm::RatedDisability]
+      attribute :rated_disabilities, EVSS::DisabilityCompensationForm::RatedDisability, array: true, default: []
 
       def initialize(status, response = nil)
         super(status, response.body) if response

--- a/lib/evss/letters/beneficiary_response.rb
+++ b/lib/evss/letters/beneficiary_response.rb
@@ -22,7 +22,7 @@ module EVSS
     #
     class BeneficiaryResponse < EVSS::Response
       attribute :benefit_information, EVSS::Letters::BenefitInformation
-      attribute :military_service, Array[EVSS::Letters::MilitaryService]
+      attribute :military_service, EVSS::Letters::MilitaryService, array: true, default: []
 
       def initialize(status, response = nil)
         attributes = response.body if response
@@ -31,9 +31,9 @@ module EVSS
 
       def benefit_information=(attrs)
         if veteran_attributes?(attrs)
-          super EVSS::Letters::BenefitInformationVeteran.new(attrs)
+          @benefit_information = EVSS::Letters::BenefitInformationVeteran.new(attrs)
         else
-          super EVSS::Letters::BenefitInformationDependent.new(attrs)
+          @benefit_information = EVSS::Letters::BenefitInformationDependent.new(attrs)
         end
       end
 

--- a/lib/evss/letters/beneficiary_response.rb
+++ b/lib/evss/letters/beneficiary_response.rb
@@ -30,11 +30,11 @@ module EVSS
       end
 
       def benefit_information=(attrs)
-        if veteran_attributes?(attrs)
-          @benefit_information = EVSS::Letters::BenefitInformationVeteran.new(attrs)
-        else
-          @benefit_information = EVSS::Letters::BenefitInformationDependent.new(attrs)
-        end
+        @benefit_information = if veteran_attributes?(attrs)
+                                 EVSS::Letters::BenefitInformationVeteran.new(attrs)
+                               else
+                                 EVSS::Letters::BenefitInformationDependent.new(attrs)
+                               end
       end
 
       private

--- a/lib/evss/letters/letters_response.rb
+++ b/lib/evss/letters/letters_response.rb
@@ -19,7 +19,7 @@ module EVSS
     #   @return [String] The recipient's full name
     #
     class LettersResponse < EVSS::Response
-      attribute :letters, Array[EVSS::Letters::Letter]
+      attribute :letters, EVSS::Letters::Letter, array: true, default: []
       attribute :full_name, String
 
       def initialize(status, response = nil)

--- a/lib/evss/pciu_address/address_response.rb
+++ b/lib/evss/pciu_address/address_response.rb
@@ -31,7 +31,7 @@ module EVSS
       end
 
       def address=(attrs)
-        super EVSS::PCIUAddress.build_address(attrs)
+        @address = EVSS::PCIUAddress.build_address(attrs)
       end
     end
   end

--- a/lib/evss/pciu_address/countries_response.rb
+++ b/lib/evss/pciu_address/countries_response.rb
@@ -14,7 +14,7 @@ module EVSS
     #   @return [Array[String]] An array of country names
     #
     class CountriesResponse < EVSS::Response
-      attribute :countries, Array[String]
+      attribute :countries, String, array: true, default: []
 
       def initialize(status, response = nil)
         countries = response&.body&.dig('cnp_countries') || response&.body&.dig('countries')

--- a/lib/evss/pciu_address/states_response.rb
+++ b/lib/evss/pciu_address/states_response.rb
@@ -14,7 +14,7 @@ module EVSS
     #   @return [Array[String]] An array of state names
     #
     class StatesResponse < EVSS::Response
-      attribute :states, Array[String]
+      attribute :states, String, array: true, default: []
 
       def initialize(status, response = nil)
         states = response&.body&.dig('cnp_states') || response&.body&.dig('states')

--- a/lib/evss/ppiu/payment_information_response.rb
+++ b/lib/evss/ppiu/payment_information_response.rb
@@ -15,7 +15,7 @@ module EVSS
     #   @return [Array[EVSS::PPIU::PaymentInformation]] An array of payment information objects
     #
     class PaymentInformationResponse < EVSS::Response
-      attribute :responses, Array[EVSS::PPIU::PaymentInformation]
+      attribute :responses, EVSS::PPIU::PaymentInformation, array: true, default: []
 
       def initialize(status, response = nil)
         super(status, response.body) if response

--- a/lib/evss/response.rb
+++ b/lib/evss/response.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'common/client/concerns/service_status'
-require 'common/models/base'
+require 'vets/model'
 
 module EVSS
   ##
@@ -10,14 +10,15 @@ module EVSS
   # @param status [Integer] The HTTP status code from the service
   # @param attributes [Hash] Additional response attributes
   #
-  class Response < Common::Base
+  class Response
+    include Vets::Model
     include Common::Client::Concerns::ServiceStatus
 
     attribute :status, Integer
 
     def initialize(status, attributes = nil)
       super(attributes) if attributes
-      self.status = status
+      @status = status
     end
 
     def ok?

--- a/modules/mobile/app/models/mobile/v0/adapters/legacy_rating.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/legacy_rating.rb
@@ -10,7 +10,7 @@ module Mobile
         def disability_ratings(combine_response, individual_response)
           Mobile::V0::Rating.new(
             id: 0,
-            combined_disability_rating: parse_rating(combine_response[:user_percent_of_disability]),
+            combined_disability_rating: parse_rating(combine_response.user_percent_of_disability),
             individual_ratings: individual_ratings(individual_response)
           )
         end
@@ -18,12 +18,12 @@ module Mobile
         private
 
         def individual_ratings(response)
-          response[:rated_disabilities].map do |rating|
+          response.rated_disabilities.map do |rating|
             Mobile::V0::IndividualRating.new(
-              decision: rating[:decision_text],
-              effective_date: rating[:effective_date],
-              rating_percentage: parse_rating(rating[:rating_percentage]),
-              diagnostic_text: rating[:name]
+              decision: rating.decision_text,
+              effective_date: rating.effective_date,
+              rating_percentage: parse_rating(rating.rating_percentage),
+              diagnostic_text: rating.name
             )
           end
         end

--- a/spec/lib/evss/pciu/service_spec.rb
+++ b/spec/lib/evss/pciu/service_spec.rb
@@ -21,7 +21,7 @@ describe EVSS::PCIU::Service do
       it 'returns a users email address value and effective_date' do
         VCR.use_cassette('evss/pciu/email') do
           response = subject.get_email_address
-          expect(response.attributes.keys).to include :effective_at, :email
+          expect(response.attributes.deep_symbolize_keys).to include :effective_at, :email
         end
       end
     end
@@ -40,7 +40,7 @@ describe EVSS::PCIU::Service do
       it 'returns a users primary phone number, extension and country code' do
         VCR.use_cassette('evss/pciu/primary_phone') do
           response = subject.get_primary_phone
-          expect(response.attributes.keys).to include :country_code, :number, :extension
+          expect(response.attributes.deep_symbolize_keys).to include :country_code, :number, :extension
         end
       end
     end
@@ -60,7 +60,7 @@ describe EVSS::PCIU::Service do
         VCR.use_cassette('evss/pciu/alternate_phone') do
           response = subject.get_alternate_phone
 
-          expect(response.attributes.keys).to include :country_code, :number, :extension
+          expect(response.attributes.deep_symbolize_keys).to include :country_code, :number, :extension
         end
       end
     end
@@ -82,7 +82,7 @@ describe EVSS::PCIU::Service do
         VCR.use_cassette('evss/pciu/post_primary_phone') do
           response = subject.post_primary_phone(phone)
 
-          expect(response.attributes.keys).to include :country_code, :number, :extension
+          expect(response.attributes.deep_symbolize_keys).to include :country_code, :number, :extension
         end
       end
     end
@@ -134,7 +134,7 @@ describe EVSS::PCIU::Service do
         VCR.use_cassette('evss/pciu/post_alternate_phone') do
           response = subject.post_alternate_phone(phone)
 
-          expect(response.attributes.keys).to include :country_code, :number, :extension
+          expect(response.attributes.deep_symbolize_keys).to include :country_code, :number, :extension
         end
       end
     end
@@ -186,7 +186,7 @@ describe EVSS::PCIU::Service do
         VCR.use_cassette('evss/pciu/post_email_address') do
           response = subject.post_email_address(email_address)
 
-          expect(response.attributes.keys).to include :effective_at, :email
+          expect(response.attributes.deep_symbolize_keys).to include :effective_at, :email
         end
       end
     end

--- a/spec/serializers/rating_info_serializer_spec.rb
+++ b/spec/serializers/rating_info_serializer_spec.rb
@@ -18,7 +18,7 @@ describe RatingInfoSerializer, type: :serializer do
   end
 
   it 'includes :user_percent_of_disability' do
-    expect(attributes['user_percent_of_disability']).to eq rating_info_response[:user_percent_of_disability]
+    expect(attributes['user_percent_of_disability']).to eq rating_info_response.user_percent_of_disability
   end
 
   it 'includes :source_system' do


### PR DESCRIPTION
## Summary

- Virtus is being replace with `Vets::Model`. Differences include:
    - There's no hash access for attributes `form[:attribute]` only dot notation `form.attribute`
    - Syntax change for Array attributes
    - Sorting uses a class method: `default_sort_by`
    - booleans are temporarily `Bool`, until Virtus is completely gone
- This PR replaces `Virtus.model` with `Vets::Model` and updates the _attributes_ and _implementation_ accordingly. 
- This change should not affect any functionality.

Part 1: https://github.com/department-of-veterans-affairs/vets-api/pull/22239

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92441

## Testing done

- [x] Manual testing for similar output

## Acceptance criteria

- [x] Virtus models are now Vets::Model
- [x] No functional change