### PR TITLE
Replace Virtus with Vets::Model - GIDS

### DIFF
--- a/lib/gi/gids_response.rb
+++ b/lib/gi/gids_response.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module GI
   class GIDSResponse
-    include Virtus.model(nullify_blank: true)
+    include Vets::Model
 
     # @return  [Integer] the response status
     attribute :status, Integer


### PR DESCRIPTION
## Summary

- Virtus is being replace with `Vets::Model`. Differences include:
    - There's no hash access for attributes `form[:attribute]` only dot notation `form.attribute`
    - Syntax change for Array attributes
    - Sorting uses a class method: `default_sort_by`
    - booleans are temporarily `Bool`, until Virtus is completely gone
- This PR replaces `Virtus.model` with `Vets::Model` and updates the _attributes_ and _implementation_ accordingly. 
- This change should not affect any functionality.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92441

## Testing done

- [ ] Manual testing for similar output

## Acceptance criteria

- [x] Virtus models are now Vets::Model
- [x] No functional change