### PR TITLE
Replace Virtus with Vets::Model - MDOT

### DIFF
--- a/lib/mdot/address.rb
+++ b/lib/mdot/address.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module MDOT
   class Address
-    include Virtus.model
+    include Vets::Model
 
     attribute :street, String
     attribute :street2, String
@@ -10,6 +12,6 @@ module MDOT
     attribute :state, String
     attribute :country, String
     attribute :postal_code, String
-    attribute :is_military_base, Boolean, default: false
+    attribute :is_military_base, Bool, default: false
   end
 end

--- a/lib/mdot/eligibility.rb
+++ b/lib/mdot/eligibility.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module MDOT
   class Eligibility
-    include Virtus.model
+    include Vets::Model
 
-    attribute :batteries, Boolean, default: false
-    attribute :accessories, Boolean, default: false
-    attribute :apneas, Boolean, default: false
-    attribute :assistive_devices, Boolean, default: false
+    attribute :batteries, Bool, default: false
+    attribute :accessories, Bool, default: false
+    attribute :apneas, Bool, default: false
+    attribute :assistive_devices, Bool, default: false
   end
 end

--- a/lib/mdot/response.rb
+++ b/lib/mdot/response.rb
@@ -1,18 +1,19 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
 require_relative 'eligibility'
 require_relative 'supply'
 require_relative 'token'
 require_relative 'address'
 
 module MDOT
-  class Response < Common::Base
+  class Response
+    include Vets::Model
     attr_reader :status
 
     attribute :permanent_address, MDOT::Address
     attribute :temporary_address, MDOT::Address
-    attribute :supplies, Array[MDOT::Supply]
+    attribute :supplies, MDOT::Supply, array: true, default: []
     attribute :eligibility, MDOT::Eligibility
     attribute :vet_email, String
 

--- a/lib/mdot/supply.rb
+++ b/lib/mdot/supply.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module MDOT
   class Supply
-    include Virtus.model
+    include Vets::Model
 
     attribute :device_name, String, default: ''
     attribute :product_name, String
     attribute :product_group, String
     attribute :product_id, Integer
-    attribute :available_for_reorder, Boolean, default: false
+    attribute :available_for_reorder, Bool, default: false
     attribute :last_order_date, Date
     attribute :next_availability_date, Date
     attribute :quantity, Integer


### PR DESCRIPTION
## Summary

- Virtus is being replace with `Vets::Model`. Differences include:
    - There's no hash access for attributes `form[:attribute]` only dot notation `form.attribute`
    - Syntax change for Array attributes
    - Sorting uses a class method: `default_sort_by`
    - booleans are temporarily `Bool`, until Virtus is completely gone
- This PR replaces `Virtus.model` with `Vets::Model` and updates the _attributes_ and _implementation_ accordingly. 
- This change should not affect any functionality.

**Note**: I deleted the ihub base model because it wasn't necessary 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92441

## Testing done

- [x] Manual testing for similar output

## Acceptance criteria

- [x] Virtus models are now Vets::Model
- [x] No functional change