### PR TITLE
API-45155 Retire SentryLogger

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/application_controller.rb
@@ -238,9 +238,9 @@ module ClaimsApi
         vet
       end
 
+      # This is still called by the ApplicationController even though sentry use has been deprecated
       def set_sentry_tags_and_extra_context
         RequestStore.store['additional_request_attributes'] = { 'source' => 'claims_api' }
-        Sentry.set_tags(source: 'claims_api')
       end
 
       def edipi_check

--- a/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/disability_compensation_controller.rb
@@ -277,7 +277,11 @@ module ClaimsApi
         end
 
         def unprocessable_response(e)
-          log_message_to_sentry('Upload error in 526', :warning, body: e.message)
+          ClaimsApi::Logger.log '526',
+                                detail: 'Upload error in 526',
+                                level: :warn,
+                                error_message: e&.message,
+                                error_source: e&.key
 
           {
             errors: [{ status: 422, detail: e&.message, source: e&.key }]

--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb
@@ -221,10 +221,10 @@ module ClaimsApi
         def nullable_icn
           current_user.icn
         rescue => e
-          log_message_to_sentry('Failed to retrieve icn for consumer',
-                                :warning,
-                                body: e.message)
-
+          ClaimsApi::Logger.log 'POABaseController',
+                                level: :warn,
+                                detail: 'Failed to retrieve icn for consumer',
+                                error_message: e.message
           nil
         end
 

--- a/modules/claims_api/app/services/claims_api/unsynchronized_evss_claim_service.rb
+++ b/modules/claims_api/app/services/claims_api/unsynchronized_evss_claim_service.rb
@@ -4,10 +4,11 @@ require 'evss/claims_service'
 require 'evss/documents_service'
 require 'evss/auth_headers'
 require 'evss/error_middleware'
+require 'vets/shared_logging'
 
 module ClaimsApi
   class UnsynchronizedEVSSClaimService
-    include SentryLogging
+    include Vets::SharedLogging
     EVSS_CLAIM_KEYS = %w[open_claims historical_claims].freeze
     delegate :power_of_attorney, to: :veteran
 

--- a/modules/claims_api/app/services/claims_api/unsynchronized_evss_claim_service.rb
+++ b/modules/claims_api/app/services/claims_api/unsynchronized_evss_claim_service.rb
@@ -4,11 +4,9 @@ require 'evss/claims_service'
 require 'evss/documents_service'
 require 'evss/auth_headers'
 require 'evss/error_middleware'
-require 'vets/shared_logging'
 
 module ClaimsApi
   class UnsynchronizedEVSSClaimService
-    include Vets::SharedLogging
     EVSS_CLAIM_KEYS = %w[open_claims historical_claims].freeze
     delegate :power_of_attorney, to: :veteran
 

--- a/modules/claims_api/app/sidekiq/claims_api/flash_updater.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/flash_updater.rb
@@ -34,7 +34,7 @@ module ClaimsApi
         auto_claim.bgs_flash_responses = auto_claim.bgs_flash_responses + [message]
         auto_claim.save
       end
-      log_exception_to_sentry(e)
+      log_exception_to_rails e
     end
 
     def add_flash(user, flash_name)

--- a/modules/claims_api/app/sidekiq/claims_api/flash_updater.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/flash_updater.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 require 'bgs_service/claimant_web_service'
+require 'vets/shared_logging'
+
 module ClaimsApi
   class FlashUpdater < UpdaterService
+    include Vets::SharedLogging
+
     def perform(flashes, auto_claim_id)
       user = bgs_headers(auto_claim_id)
 

--- a/modules/claims_api/app/sidekiq/claims_api/service_base.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/service_base.rb
@@ -3,13 +3,13 @@
 require 'sidekiq'
 require 'claims_api/claim_logger'
 require 'sidekiq/monitored_worker'
-require 'sentry_logging'
+require 'vets/shared_logging'
 
 module ClaimsApi
   class ServiceBase
     include Sidekiq::Job
     include Sidekiq::MonitoredWorker
-    include SentryLogging
+    include Vets::SharedLogging
 
     RETRY_STATUS_CODES = %w[500 502 503 504].freeze
     NO_RETRY_ERROR_CODES = ['form526.submit.noRetryError', 'form526.InProcess'].freeze

--- a/modules/claims_api/app/sidekiq/claims_api/special_issue_updater.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/special_issue_updater.rb
@@ -31,7 +31,7 @@ module ClaimsApi
       service.manage_contentions(options)
     rescue BGS::ShareError, BGS::PublicError => e
       log_exception_to_claim_record(auto_claim_id, { key: e.code, text: e.message })
-      log_exception_to_sentry(e)
+      log_exception_to_rails e
     end
 
     # Store off exception information on the claim record within the database
@@ -53,13 +53,6 @@ module ClaimsApi
     # @param message [any] Anything in any format that explains the error
     def self.log_exception_to_claim_record(auto_claim_id, message)
       ClaimsApi::SpecialIssueUpdater.new.log_exception_to_claim_record(auto_claim_id, message)
-    end
-
-    # Passthru to allow calling from sidekiq_retries_exhausted section above
-    #
-    # @param e [StandardError] Error to be logged
-    def self.log_exception_to_sentry(e)
-      ClaimsApi::SpecialIssueUpdater.new.log_exception_to_sentry(e)
     end
 
     # Service object to interface with BGS

--- a/modules/claims_api/app/sidekiq/claims_api/special_issue_updater.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/special_issue_updater.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 require 'bgs_service/contention_service'
+require 'vets/shared_logging'
 
 module ClaimsApi
   class SpecialIssueUpdater < UpdaterService
+    include Vets::SharedLogging
     # Update special issues for a single contention/disability
     #
     # @param user [OpenStruct] Veteran to attach special issues to

--- a/modules/claims_api/app/sidekiq/claims_api/updater_service.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/updater_service.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
 require 'sidekiq'
-require 'sentry_logging'
 require 'claims_api/claim_logger'
 
 module ClaimsApi
   class UpdaterService
     extend ActiveSupport::Concern
     include Sidekiq::Job
-    include SentryLogging
 
     sidekiq_retries_exhausted do |message|
       ClaimsApi::Logger.log(

--- a/modules/claims_api/app/sidekiq/claims_api/v2/disability_compensation_benefits_documents_uploader.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/v2/disability_compensation_benefits_documents_uploader.rb
@@ -33,8 +33,6 @@ module ClaimsApi
         error_message = get_error_message(e)
         log_job_progress(claim_id,
                          "BD failure #{e.class}: #{error_message}")
-        log_exception_to_sentry(e)
-
         raise e
       end
 

--- a/modules/claims_api/app/sidekiq/claims_api/v2/disability_compensation_docker_container_upload.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/v2/disability_compensation_docker_container_upload.rb
@@ -41,15 +41,12 @@ module ClaimsApi
         error_status = get_error_status_code(e)
         log_job_progress(claim_id,
                          "Docker container job errored #{e.class}: #{error_status} #{auto_claim&.evss_response}")
-        log_exception_to_sentry(e)
-
         raise e
       rescue ::Common::Exceptions::BackendServiceException => e
         set_errored_state_on_claim(auto_claim)
         set_evss_response(auto_claim, e)
         log_job_progress(claim_id,
                          "Docker container job errored #{e.class}: #{auto_claim&.evss_response}")
-        log_exception_to_sentry(e)
         if will_retry?(auto_claim, e)
           raise e
         else # form526.submit.noRetryError OR form526.InProcess error returned
@@ -60,7 +57,7 @@ module ClaimsApi
         set_evss_response(auto_claim, e) if auto_claim.evss_response.blank?
         log_job_progress(claim_id,
                          "Docker container job errored #{e.class}: #{e&.detailed_message}")
-        log_exception_to_sentry(e)
+        log_exception_to_rails e
 
         raise e
       end

--- a/modules/claims_api/app/sidekiq/claims_api/v2/disability_compensation_pdf_generator.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/v2/disability_compensation_pdf_generator.rb
@@ -65,7 +65,6 @@ module ClaimsApi
 
         log_job_progress(claim_id,
                          "526EZ PDF generator faraday error #{e.class}: #{error_status} #{auto_claim&.evss_response}")
-        log_exception_to_sentry(e)
 
         raise e
       rescue ::Common::Exceptions::BackendServiceException => e
@@ -75,8 +74,6 @@ module ClaimsApi
 
         log_job_progress(claim_id,
                          "526EZ PDF generator errored #{e.class}: #{error_status} #{auto_claim&.evss_response}")
-        log_exception_to_sentry(e)
-
         raise e
       rescue => e
         set_errored_state_on_claim(auto_claim)
@@ -84,8 +81,6 @@ module ClaimsApi
 
         log_job_progress(claim_id,
                          "526EZ PDF generator errored #{e.class}: #{e}")
-        log_exception_to_sentry(e)
-
         raise e
       end
 

--- a/modules/claims_api/lib/claims_api/poa_vbms_sidekiq.rb
+++ b/modules/claims_api/lib/claims_api/poa_vbms_sidekiq.rb
@@ -3,6 +3,7 @@
 require 'claims_api/vbms_uploader'
 require 'bgs_service/person_web_service'
 require 'vets/shared_logging'
+require 'claims_api/claim_logger'
 
 module ClaimsApi
   module PoaVbmsSidekiq

--- a/modules/claims_api/lib/claims_api/poa_vbms_sidekiq.rb
+++ b/modules/claims_api/lib/claims_api/poa_vbms_sidekiq.rb
@@ -2,10 +2,11 @@
 
 require 'claims_api/vbms_uploader'
 require 'bgs_service/person_web_service'
+require 'vets/shared_logging'
 
 module ClaimsApi
   module PoaVbmsSidekiq
-    include SentryLogging
+    include Vets::SharedLogging
 
     def upload_to_vbms(power_of_attorney, path)
       uploader = VBMSUploader.new(

--- a/modules/claims_api/lib/claims_api/poa_vbms_sidekiq.rb
+++ b/modules/claims_api/lib/claims_api/poa_vbms_sidekiq.rb
@@ -58,7 +58,7 @@ module ClaimsApi
         status: ClaimsApi::PowerOfAttorney::ERRORED,
         vbms_error_message: error_message
       )
-      log_message_to_sentry(self.class.name, :warning, body: error_message)
+      log_message_to_rails error_message, :warn, class: self.class.name
     end
 
     private
@@ -70,7 +70,7 @@ module ClaimsApi
         bgs_service(power_of_attorney:).find_by_ssn(ssn)&.[](:file_nbr) # rubocop:disable Rails/DynamicFindBy
       rescue BGS::ShareError => e
         error_message = "A BGS failure occurred while trying to retrieve Veteran 'FileNumber'"
-        log_exception_to_sentry(e, nil, { message: error_message }, 'warn')
+        ClaimsApi::Logger.log 'PoaVbmsSidekiq', detail: error_message, error_message: e.message
         raise ::Common::Exceptions::FailedDependency
       end
     end

--- a/modules/claims_api/lib/claims_api/vbms_uploader.rb
+++ b/modules/claims_api/lib/claims_api/vbms_uploader.rb
@@ -12,45 +12,22 @@ module ClaimsApi
       @doc_type = doc_type
     end
 
-    # rubocop:disable Metrics/MethodLength
     def upload!
       upload_token_response = fetch_upload_token(
         filepath: @filepath,
         file_number: @file_number
       )
 
-      # TODO: remove temp logging for troubleshooting related to VRE claim upload to VBMS
-      file_exists = File.exist?(@filepath)
-      if !file_exists && caller.first.match(/veteran_readiness_employment_claim.rb/)
-        log_message_to_sentry(
-          "VBMSUploader#upload! file exists?: #{file_exists}",
-          :warn,
-          {},
-          { team: 'vfs-ebenefits' }
-        )
-      end
-
       upload_response = upload_document(
         filepath: @filepath,
         upload_token: upload_token_response.upload_token
       )
 
-      # TODO: remove temp logging for troubleshooting related to VRE claim upload to VBMS
-      file_exists = File.exist?(@filepath)
-      if !file_exists && caller.first.match(/veteran_readiness_employment_claim.rb/)
-        log_message_to_sentry(
-          "VBMSUploader#upload! upload_response: #{upload_response}",
-          :warn,
-          {},
-          { team: 'vfs-ebenefits' }
-        )
-      end
       {
         vbms_new_document_version_ref_id: upload_response.upload_document_response[:@new_document_version_ref_id],
         vbms_document_series_ref_id: upload_response.upload_document_response[:@document_series_ref_id]
       }
     end
-    # rubocop:enable Metrics/MethodLength
 
     def fetch_upload_token(filepath:, file_number:)
       content_hash = Digest::SHA1.hexdigest(File.read(filepath))

--- a/modules/claims_api/lib/claims_api/vbms_uploader.rb
+++ b/modules/claims_api/lib/claims_api/vbms_uploader.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-require 'vets/shared_logging'
-
 module ClaimsApi
   class VBMSUploader
-    include Vets::SharedLogging
-
     def initialize(filepath:, file_number:, doc_type:)
       @filepath = filepath
       @file_number = file_number

--- a/modules/claims_api/lib/claims_api/vbms_uploader.rb
+++ b/modules/claims_api/lib/claims_api/vbms_uploader.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require 'vets/shared_logging'
+
 module ClaimsApi
   class VBMSUploader
-    include SentryLogging
+    include Vets::SharedLogging
 
     def initialize(filepath:, file_number:, doc_type:)
       @filepath = filepath

--- a/modules/claims_api/spec/sidekiq/poa_vbms_sidekiq_spec.rb
+++ b/modules/claims_api/spec/sidekiq/poa_vbms_sidekiq_spec.rb
@@ -36,11 +36,11 @@ RSpec.describe ClaimsApi::PoaVbmsSidekiq, vcr: 'bgs/person_web_service/find_by_s
     end
 
     context 'error occurs while retrieving Veteran file number from BGS' do
-      it "raises a 'FailedDependency' exception and logs to Sentry" do
+      it "raises a 'FailedDependency' exception and logs" do
         allow_any_instance_of(BGS::PersonWebService).to receive(:find_by_ssn).and_raise(
           BGS::ShareError.new('HelloWorld')
         )
-        expect(dummy_class).to receive(:log_exception_to_sentry)
+        expect(ClaimsApi::Logger).to receive(:log)
 
         expect { dummy_class.upload_to_vbms(power_of_attorney, '/some/random/path') }.to raise_error(
           Common::Exceptions::FailedDependency


### PR DESCRIPTION
## Summary

Retired the use of SentryLogging in the `claims_api` module. Removed where logging was already in place, replaced with Vets::SharedLogging's `log_exception_to_rails`, or replaced with `ClaimsApi::Logger` where appropriate.

Also a bit of logging cleanup for a "temporary" feature test that was introduced in 2021 and hasn't logged anything in production for the last 90 days.

## Related issue(s)

[API-45155](https://jira.devops.va.gov/browse/API-45155)

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?

Various logging items around Claims APIs. Should be transparent to end users.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
