### PR TITLE
move debug statement later

### DIFF
--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -122,4 +122,12 @@ Rails.application.reloader.to_prepare do
   Breakers.redis_prefix = ''
   Breakers.client = client
   Breakers.disabled = true if Settings.breakers_disabled
+
+  if Settings.vsp_environment == 'staging'
+    services.each do |service|
+      Rails.logger.info(
+        "#{service&.name} outage_ended?=#{service&.latest_outage&.ended?}"
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Summary

There was an error in db-migrate in staging because `client` hadn't been created yet by the time we were calling it in https://github.com/department-of-veterans-affairs/vets-api/pull/22250. This should fix the error. 
```
NoMethodError: undefined method `redis_connection' for nil (NoMethodError)
      data = Breakers.client.redis_connection.zrange(outages_key(service: service), -1, -1)[0]
                            ^^^^^^^^^^^^^^^^^
/app/config/initializers/breakers.rb:116:in `block (2 levels) in <top (required)>'
/app/config/initializers/breakers.rb:114:in `each'
/app/config/initializers/breakers.rb:114:in `block in <top (required)>'
/app/config/environment.rb:7:in `<top (required)>'
```

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-api/pull/22250

## Testing done
Will watch staging deploy post-merge. 


## What areas of the site does it impact?
this is only for debugging. 
