### PR TITLE
110096 ensure that global state doesnt step on the toes of other specs when run in parallel

### DIFF
--- a/spec/lib/breakers/statsd_plugin_spec.rb
+++ b/spec/lib/breakers/statsd_plugin_spec.rb
@@ -17,6 +17,7 @@ describe Breakers::StatsdPlugin do
       it 'adds source tag when available' do
         RequestStore.store = { 'additional_request_attributes' => { 'source' => 'myapp' } }
         expect(subject.get_tags(request)).to include('source:myapp')
+        RequestStore.clear!
       end
 
       it 'returns endpoint tag' do


### PR DESCRIPTION
## Summary
This work is a direct result of [this conversation
](https://dsva.slack.com/archives/C0581MN69TJ/p1747662757480529)
spec/lib/mdot/client_spec specs are flaky because of global state set in an unrelated spec
## Related issue(s)
[110096](https://github.com/department-of-veterans-affairs/va.gov-team/issues/110096)

## Testing done
specs green

## What areas of the site does it impact?
specs

## Acceptance criteria

- [ ] spec/lib/mdot/client_spec is no longer flaky