### PR TITLE
Fix Vets::Collection Empty Records Ordering Bug

### DIFF
--- a/lib/vets/collection.rb
+++ b/lib/vets/collection.rb
@@ -42,7 +42,7 @@ module Vets
       end
 
       @size = records.size
-      @records = records
+      @records = order(records)
     end
 
     def self.from_will_paginate(records)

--- a/lib/vets/collection.rb
+++ b/lib/vets/collection.rb
@@ -105,15 +105,17 @@ module Vets
     private
 
     def validate_sort_clauses(clauses)
-      raise Common::Exceptions::InvalidSortCriteria.new(@model_class, clauses) if clauses.empty?
+      return if @records.empty?
+
+      raise Common::Exceptions::InvalidSortCriteria.new(@model_class.to_s, clauses) if clauses.empty?
 
       clauses.each do |attribute, direction|
-        unless @records.first.respond_to?(attribute)
-          raise Common::Exceptions::InvalidSortCriteria.new(@model_class, attribute)
+        unless @model_class.attribute_set.include?(attribute.to_sym)
+          raise Common::Exceptions::InvalidSortCriteria.new(@model_class.to_s, attribute)
         end
 
         unless %i[asc desc].include?(direction)
-          raise Common::Exceptions::InvalidSortCriteria.new(@model_class, attribute)
+          raise Common::Exceptions::InvalidSortCriteria.new(@model_class.to_s, attribute)
         end
       end
     end

--- a/lib/vets/collection.rb
+++ b/lib/vets/collection.rb
@@ -42,7 +42,7 @@ module Vets
       end
 
       @size = records.size
-      @records = order(records)
+      @records = records
     end
 
     def self.from_will_paginate(records)

--- a/spec/lib/vets/collection_spec.rb
+++ b/spec/lib/vets/collection_spec.rb
@@ -167,6 +167,12 @@ RSpec.describe Vets::Collection do
       sorted_collection = collection.order(age: :asc)
       expect(sorted_collection.records.last).to eq(record5)
     end
+
+    it 'returns an empty collection if no records exist' do
+      collection = described_class.new([])
+      sorted_collection = collection.order(age: :asc)
+      expect(sorted_collection.records).to eq([])
+    end
   end
 
   describe '#paginate' do

--- a/spec/lib/vets/collection_spec.rb
+++ b/spec/lib/vets/collection_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Vets::Collection do
   end
 
   describe '#initialize' do
-    it 'initializes with sorted records' do
+    it 'initializes with unsorted records' do
       record1 = dummy_class.new(name: 'Bob', age: 25)
       record2 = dummy_class.new(name: 'Alice', age: 30)
 


### PR DESCRIPTION
## Summary

- 2 PRs needed to be reverted to fix a live issue in production
    - https://github.com/department-of-veterans-affairs/vets-api/pull/22274
    - https://github.com/department-of-veterans-affairs/vets-api/pull/22265
- This PR fixes the bug that was caused when records are empty.
- Instead of validating the attribute to be ordered by the record, this uses the class method `attribute_set`
   - Since it's a class method, it avoids the empty record bug
   - Also added a guard statement to ensure that the bug is avoided even when the model_class is not set

## Related issue(s)

- n/a

## Testing done

- [x] Added new test for empty record when ordering (sorting)
- [x] Manual testing to confirm

without guard statement:

```ruby
{"errors"=>[{"title"=>"Invalid sort criteria", "detail"=>"\"prescription_name\" is not a valid sort criteria for \"PrescriptionDetails\"", "code"=>"106", "status"=>"400"}]}
```

with guard statement:
```ruby
{"data"=>[], "meta"=>{"pagination"=>{"currentPage"=>1, "perPage"=>10, "totalPages"=>0, "totalEntries"=>0}, "prescriptionStatusCount"=>{}}}
```

## Acceptance criteria

- [x] Vets::Collection orders with an empty records
- [x] No errors are produced when ordering empty records
- [x] Vets::Collection is returned with empty records and order clauses with metadata