### PR TITLE
make facility import job logging more concise

### DIFF
--- a/app/sidekiq/hca/std_institution_import_job.rb
+++ b/app/sidekiq/hca/std_institution_import_job.rb
@@ -80,10 +80,11 @@ module HCA
     private
 
     def import_institutions_from_csv(data)
+      new_facilities = []
       CSV.parse(data, headers: true) do |row|
         id = row['ID'].to_i
         std_institution_facility = StdInstitutionFacility.find_or_initialize_by(id:)
-        Rails.logger.info("[HCA] - institution #{id} new? #{std_institution_facility.new_record?}")
+        new_facilities << id if std_institution_facility.new_record?
 
         created = DateTime.strptime(row['CREATED'], '%F %H:%M:%S %z').to_s
         updated = DateTime.strptime(row['UPDATED'], '%F %H:%M:%S %z').to_s if row['UPDATED']
@@ -95,6 +96,7 @@ module HCA
 
         std_institution_facility.save!
       end
+      Rails.logger.info("[HCA] - #{new_facilities.count} new institutions: #{new_facilities}") if new_facilities.any?
     end
   end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Reduce logging noise. Currently we log one line for every Institution as we process them, whether they're new or already exist. This was useful for initial debug and rollout, but now that it's confirmed stable it's ~4000 lines of unnecessary noise a day. This reduces that output to a single line.
- Health Enrollment 10-10EZ/CG

## Related issue(s)
- Cleanup / followup to https://github.com/department-of-veterans-affairs/va.gov-team/issues/87005

## Testing done

- [x] *New code is covered by unit tests*
- Functionality is unchanged, only logging is reduced.
- Run `HCA::StdInstitutionImportJob.new.perform` in a console, and see that it only outputs a few summary lines instead of thousands of individual facility lines.

## Screenshots
<img width="1091" alt="Screenshot 2025-05-19 at 5 01 36 PM" src="https://github.com/user-attachments/assets/ec6834c1-ac06-48d9-9648-b2b494934c2b" />


## What areas of the site does it impact?
Facility selectors used in Health Enrollment (10-10EZ) and Caregiver (10-10CG) forms.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
