### PR TITLE
Updated VCR URLs for EPS and CCRA tests to use settings

### DIFF
--- a/spec/support/vcr_cassettes/vaos/eps/draft_appointment/200.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/draft_appointment/200.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.wellhive.com/care-navigation/v1/appointments
+    uri: <VAOS_EPS_API_URL>/care-navigation/v1/appointments
     body:
       encoding: UTF-8
       string: '{"patientId":"care-nav-patient-casey","referralId":"ref-123"}'

--- a/spec/support/vcr_cassettes/vaos/eps/draft_appointment/400_invalid_patientid.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/draft_appointment/400_invalid_patientid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.wellhive.com/care-navigation/v1/appointments
+    uri: <VAOS_EPS_API_URL>/care-navigation/v1/appointments
     body:
       encoding: UTF-8
       string: '{"patientId":"1012845331V153043","referralId":"ref-123"}'

--- a/spec/support/vcr_cassettes/vaos/eps/get_appointment/404.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/get_appointment/404.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.wellhive.com/care-navigation/v1/appointments/qdm61cJ5?retrieveLatestDetails=true
+    uri: <VAOS_EPS_API_URL>/care-navigation/v1/appointments/qdm61cJ5?retrieveLatestDetails=true
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/vaos/eps/get_appointment/500.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/get_appointment/500.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.wellhive.com/care-navigation/v1/appointments/qdm61cJ5?retrieveLatestDetails=true
+    uri: <VAOS_EPS_API_URL>/care-navigation/v1/appointments/qdm61cJ5?retrieveLatestDetails=true
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/vaos/eps/get_appointment/booked_200.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/get_appointment/booked_200.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://api.wellhive.com/care-navigation/v1/appointments/qdm61cJ5?retrieveLatestDetails=true
+      uri: <VAOS_EPS_API_URL>/care-navigation/v1/appointments/qdm61cJ5?retrieveLatestDetails=true
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/support/vcr_cassettes/vaos/eps/get_appointment/draft_200.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/get_appointment/draft_200.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://api.wellhive.com/care-navigation/v1/appointments/qdm61cJ5?retrieveLatestDetails=true
+      uri: <VAOS_EPS_API_URL>/care-navigation/v1/appointments/qdm61cJ5?retrieveLatestDetails=true
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/support/vcr_cassettes/vaos/eps/get_appointments/500_error.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/get_appointments/500_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "https://api.wellhive.com/care-navigation/v1/appointments?patientId=care-nav-patient-casey"
+    uri: "<VAOS_EPS_API_URL>/care-navigation/v1/appointments?patientId=care-nav-patient-casey"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/vaos/eps/get_appointments_200_empty_start_date.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/get_appointments_200_empty_start_date.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://veteran.apps.va.gov/vpg/v1/patients/1012846043V576341/appointments?end=2022-07-03T04:00:00Z&pageSize=0&start=2021-06-04T04:00:00Z
+      uri: <VAOS_CCRA_API_URL>/vpg/v1/patients/1012846043V576341/appointments?end=2022-07-03T04:00:00Z&pageSize=0&start=2021-06-04T04:00:00Z
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/support/vcr_cassettes/vaos/eps/get_appointments_empty_data.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/get_appointments_empty_data.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://veteran.apps.va.gov/vpg/v1/patients/1012846043V576341/appointments?end=2022-07-03T04:00:00Z&pageSize=0&start=2021-06-04T04:00:00Z
+      uri: <VAOS_CCRA_API_URL>/vpg/v1/patients/1012846043V576341/appointments?end=2022-07-03T04:00:00Z&pageSize=0&start=2021-06-04T04:00:00Z
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/support/vcr_cassettes/vaos/eps/get_drive_times/200.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/get_drive_times/200.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.wellhive.com/care-navigation/v1/drive-times
+    uri: <VAOS_EPS_API_URL>/care-navigation/v1/drive-times
     body:
       encoding: UTF-8
       string: '{"destinations":{"9mN718pH":{"latitude":28.08061,"longitude":-80.60322}},"origin":{"latitude":38.901,"longitude":-77.0347}}'

--- a/spec/support/vcr_cassettes/vaos/eps/get_drive_times/400_invalid_coords.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/get_drive_times/400_invalid_coords.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: post
-      uri: https://api.wellhive.com/care-navigation/v1/drive-times
+      uri: <VAOS_EPS_API_URL>/care-navigation/v1/drive-times
       body:
         encoding: UTF-8
         string: '{"destinations":{"9mN718pH":{"latitude":44.475883,"longitude":-73.212074}},"origin":{"latitude":91,"longitude":-74.006}}'

--- a/spec/support/vcr_cassettes/vaos/eps/get_eps_appointments_200.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/get_eps_appointments_200.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://api.wellhive.com/care-navigation/v1/appointments?patientId=1012846043V576341
+      uri: <VAOS_EPS_API_URL>/care-navigation/v1/appointments?patientId=1012846043V576341
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/support/vcr_cassettes/vaos/eps/get_provider_service/200.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/get_provider_service/200.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.wellhive.com/care-navigation/v1/provider-services/9mN718pH
+    uri: <VAOS_EPS_API_URL>/care-navigation/v1/provider-services/9mN718pH
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/vaos/eps/get_provider_service/404_unknown_provider.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/get_provider_service/404_unknown_provider.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.wellhive.com/care-navigation/v1/provider-services/9mN718pHa
+    uri: <VAOS_EPS_API_URL>/care-navigation/v1/provider-services/9mN718pHa
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/vaos/eps/get_provider_service/get_multiple_providers_200.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/get_provider_service/get_multiple_providers_200.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://api.wellhive.com/care-navigation/v1/provider-services?id=9mN71822&id=9mN718pH&id=DBKQ-123&id=DBKQ-456
+      uri: <VAOS_EPS_API_URL>/care-navigation/v1/provider-services?id=9mN71822&id=9mN718pH&id=DBKQ-123&id=DBKQ-456
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/support/vcr_cassettes/vaos/eps/get_provider_service/get_multiple_providers_200_v2.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/get_provider_service/get_multiple_providers_200_v2.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://api.wellhive.com/care-navigation/v1/provider-services?id=9mN71822&id=9mN718pH&id=DBKQ-123&id=DBKQ-456
+      uri: <VAOS_EPS_API_URL>/care-navigation/v1/provider-services?id=9mN71822&id=9mN718pH&id=DBKQ-123&id=DBKQ-456
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/support/vcr_cassettes/vaos/eps/get_provider_slots/200.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/get_provider_slots/200.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.wellhive.com/care-navigation/v1/provider-services/53mL4LAZ/slots?appointmentTypeId=ov&startBefore=2025-01-03T00:00:00Z&startOnOrAfter=2025-01-01T00:00:00Z
+    uri: <VAOS_EPS_API_URL>/care-navigation/v1/provider-services/53mL4LAZ/slots?appointmentTypeId=ov&startBefore=2025-01-03T00:00:00Z&startOnOrAfter=2025-01-01T00:00:00Z
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/vaos/eps/get_provider_slots/200_no_slots.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/get_provider_slots/200_no_slots.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.wellhive.com/care-navigation/v1/provider-services/9mN718pH/slots?appointmentTypeId=ov&startBefore=2025-01-03T00:00:00Z&startOnOrAfter=2025-01-01T00:00:00Z
+    uri: <VAOS_EPS_API_URL>/care-navigation/v1/provider-services/9mN718pH/slots?appointmentTypeId=ov&startBefore=2025-01-03T00:00:00Z&startOnOrAfter=2025-01-01T00:00:00Z
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/vaos/eps/get_vaos_appointments_200_with_merge.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/get_vaos_appointments_200_with_merge.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://veteran.apps.va.gov/vpg/v1/patients/1012846043V576341/appointments?end=2022-07-03T04:00:00Z&pageSize=0&start=2021-06-04T04:00:00Z
+      uri: <VAOS_CCRA_API_URL>/vpg/v1/patients/1012846043V576341/appointments?end=2022-07-03T04:00:00Z&pageSize=0&start=2021-06-04T04:00:00Z
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/support/vcr_cassettes/vaos/eps/providers/data_200.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/providers/data_200.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "https://api.wellhive.com/care-navigation/v1/provider-services/<%= provider_id %>"
+      uri: "<VAOS_EPS_API_URL>/care-navigation/v1/provider-services/<%= provider_id %>"
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/support/vcr_cassettes/vaos/eps/providers/data_401.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/providers/data_401.yml
@@ -1,7 +1,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "https://api.wellhive.com/care-navigation/v1/provider-services/<%= provider_id %>"
+      uri: "<VAOS_EPS_API_URL>/care-navigation/v1/provider-services/<%= provider_id %>"
     response:
       status:
         code: 401

--- a/spec/support/vcr_cassettes/vaos/eps/providers/data_500.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/providers/data_500.yml
@@ -1,7 +1,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "https://api.wellhive.com/care-navigation/v1/provider-services/<%= provider_id %>"
+      uri: "<VAOS_EPS_API_URL>/care-navigation/v1/provider-services/<%= provider_id %>"
     response:
       status:
         code: 500

--- a/spec/support/vcr_cassettes/vaos/eps/providers/data_Aq7wgAux_200.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/providers/data_Aq7wgAux_200.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "https://api.wellhive.com/care-navigation/v1/provider-services/Aq7wgAux"
+      uri: "<VAOS_EPS_API_URL>/care-navigation/v1/provider-services/Aq7wgAux"
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/support/vcr_cassettes/vaos/eps/search_provider_services/200.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/search_provider_services/200.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.wellhive.com/care-navigation/v1/provider-services?npi=7894563210
+    uri: <VAOS_EPS_API_URL>/care-navigation/v1/provider-services?npi=7894563210
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/vaos/eps/search_provider_services/empty_200.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/search_provider_services/empty_200.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.wellhive.com/care-navigation/v1/provider-services?npi=9mN718pHa
+    uri: <VAOS_EPS_API_URL>/care-navigation/v1/provider-services?npi=9mN718pHa
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Updated VCR URLs for EPS and CCRA tests to use settings. This makes it so we do not hard code URLs in the VCR cassettes.
- Team: UAE Check In

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/104226

## Testing done
Existing unit tests cover this change.

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

