### PR TITLE
Add toggle for MyVA new design #109868

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2210,3 +2210,6 @@ features:
   debt_deduction_code_filtering:
     actor_type: user
     description: Enables filtering of debts based on approved deduction codes and current amounts > 0.
+  my_va_auth_exp_redesign_enabled:
+    actor_type: user
+    description: When enabled, a user will see the redesigned experience of MyVA.


### PR DESCRIPTION
## Summary

- *This work IS a feature toggle (flipper):* `my_va_auth_exp_redesign_enabled`
- To begin the work for our MyVA Redesign we are adding the toggle that will show/hide the new design
- MyVA & Profile/Authenticated Experience Team
- When this toggle is enabled and changes are wrapped with this new toggle, the user will be able to experience the MyVA redesign

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/109868

## Testing done

- [ ] *New code is covered by unit tests*
  - Only adding the feature toggle itself so no changes to be tested
- *Describe what the old behavior was prior to the change*
  - The toggle was nor visible in Flipper UI 
- To see the new toggle:
    1️⃣  Checkout this branch
    2️⃣  start your rails server `rails s`
    3️⃣  Navigate to `http://localhost:3000/flipper/features`
    4️⃣  Cmd + F for `my_va_auth_exp_redesign_enabled`
    ⭐  You should see the new toggle in the Flipper UI

## Screenshots
![Screenshot 2025-05-20 at 09 33 51](https://github.com/user-attachments/assets/198a09ad-771a-4204-a49a-a2ad295ea0a2)


## What areas of the site does it impact?
MyVA

## Acceptance criteria

- [ ]  (N/A) I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  (N/A) Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated: https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity-personalization/my-va-3.0/README.md
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  (N/A) Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  (N/A) If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
