### PR TITLE
Enable 686c-674 PDF overflow tracking

### DIFF
--- a/app/models/saved_claim.rb
+++ b/app/models/saved_claim.rb
@@ -221,9 +221,6 @@ class SavedClaim < ApplicationRecord
   def pdf_overflow_tracking
     tags = ["form_id:#{form_id}"]
 
-    # TODO: 686C-674 will require special handling
-    return if form_id.start_with? '686C-674'
-
     form_class = PdfFill::Filler::FORM_CLASSES[form_id]
     unless form_class
       return Rails.logger.info("#{self.class} Skipping tracking PDF overflow", form_id:, saved_claim_id: id)

--- a/app/models/saved_claim/dependency_claim.rb
+++ b/app/models/saved_claim/dependency_claim.rb
@@ -284,6 +284,10 @@ class SavedClaim::DependencyClaim < CentralMailClaim
     monitor.track_send_received_email_failure(id, e, user&.user_account_uuid)
   end
 
+  def monitor
+    @monitor ||= Dependents::Monitor.new(use_v2 || form_id.include?('-V2'))
+  end
+
   private
 
   def partitioned_686_674_params
@@ -294,9 +298,5 @@ class SavedClaim::DependencyClaim < CentralMailClaim
     college_student_data = { 'dependents_application' => student_data.merge!(veteran_data) }
 
     { college_student_data:, dependent_data: }
-  end
-
-  def monitor
-    @monitor ||= Dependents::Monitor.new(use_v2 || form_id.include?('-V2'))
   end
 end

--- a/app/sidekiq/benefits_intake_status_job.rb
+++ b/app/sidekiq/benefits_intake_status_job.rb
@@ -155,9 +155,10 @@ class BenefitsIntakeStatusJob
               end
       if claim.present? && email.present?
         claim.send_failure_email(email)
-        Dependents::Monitor.new.log_silent_failure_no_confirmation(context, call_location:)
+        claim.monitor.log_silent_failure_no_confirmation(context, call_location:)
       else
-        Dependents::Monitor.new.log_silent_failure(context, call_location:)
+        monitor = claim.present? ? claim.monitor : Dependents::Monitor.new(false)
+        monitor.log_silent_failure(context, call_location:)
       end
     end
 

--- a/lib/dependents/monitor.rb
+++ b/lib/dependents/monitor.rb
@@ -98,5 +98,29 @@ module Dependents
       track_send_email_failure("'Received' email failure for claim #{claim_id}", "#{EMAIL_STATS_KEY}.received.failure",
                                claim_id, e, user_account_uuid)
     end
+
+    def track_to_pdf_failure(claim_id, e)
+      metric = "#{CLAIM_STATS_KEY}.to_pdf.failure"
+      metric = "#{metric}.v2" if @use_v2
+      payload = default_payload.merge({ statsd: metric, claim_id:, e: })
+
+      StatsD.increment(metric, tags:)
+      Rails.logger.error('SavedClaim::DependencyClaim#to_pdf error', payload)
+    end
+
+    def track_pdf_overflow_tracking_failure(claim_id, e)
+      metric = "#{CLAIM_STATS_KEY}.track_pdf_overflow.failure"
+      metric = "#{metric}.v2" if @use_v2
+      payload = default_payload.merge({ statsd: metric, claim_id:, e: })
+
+      StatsD.increment(metric, tags:)
+      Rails.logger.error('Error tracking PDF overflow', payload)
+    end
+
+    def track_pdf_overflow(form_id)
+      tags = ["form_id:#{form_id}"]
+      metric = 'saved_claim.pdf.overflow'
+      StatsD.increment(metric, tags:)
+    end
   end
 end

--- a/lib/dependents/notification_callback.rb
+++ b/lib/dependents/notification_callback.rb
@@ -11,7 +11,14 @@ module Dependents
     # the monitor to be used
     # @see Dependents::Monitor
     def monitor
-      @monitor ||= Dependents::Monitor.new
+      begin
+        claim = SavedClaim::DependencyClaim.find(saved_claim_id)
+        monitor = claim.monitor
+      rescue => e
+        monitor = Dependents::Monitor.new(false)
+        Rails.logger.warn('Unable to find claim for DependentsNotification', e)
+      end
+      monitor
     end
   end
 end

--- a/lib/pdf_fill/forms/va21674.rb
+++ b/lib/pdf_fill/forms/va21674.rb
@@ -669,11 +669,14 @@ module PdfFill
           'did_attend_no' => select_checkbox(!did_attend)
         }
 
-        is_school_accredited = dependents_application['current_term_dates']['is_school_accredited']
-        dependents_application['current_term_dates']['is_school_accredited'] = {
-          'is_school_accredited_yes' => select_radio_button(is_school_accredited),
-          'is_school_accredited_no' => select_radio_button(!is_school_accredited)
-        }
+        current_term_dates = dependents_application['current_term_dates']
+        if current_term_dates.present?
+          is_school_accredited = current_term_dates['is_school_accredited']
+          dependents_application['current_term_dates']['is_school_accredited'] = {
+            'is_school_accredited_yes' => select_radio_button(is_school_accredited),
+            'is_school_accredited_no' => select_radio_button(!is_school_accredited)
+          }
+        end
       end
       # rubocop:enable Metrics/MethodLength
     end

--- a/lib/pdf_fill/forms/va21674v2.rb
+++ b/lib/pdf_fill/forms/va21674v2.rb
@@ -812,7 +812,7 @@ module PdfFill
       def merge_fields(options = {})
         created_at = options[:created_at] if options[:created_at].present?
         student = options[:student]
-        @form_data['dependents_application']['student_information'] = [student]
+        @form_data['dependents_application']['student_information'] = [student.deep_dup]
         expand_signature(@form_data['veteran_information']['full_name'], created_at&.to_date || Time.zone.today)
         @form_data['signature_date'] = split_date(@form_data['signatureDate'])
         veteran_contact_information = @form_data['dependents_application']['veteran_contact_information']

--- a/spec/factories/dependency_claim.rb
+++ b/spec/factories/dependency_claim.rb
@@ -230,6 +230,8 @@ FactoryBot.define do
   factory :dependency_claim_v2, class: 'SavedClaim::DependencyClaim' do
     form_id { '686C-674-V2' }
 
+    use_v2 { true }
+
     form {
       {
         'view:selectable686_options': {

--- a/spec/models/saved_claim/dependency_claim_spec.rb
+++ b/spec/models/saved_claim/dependency_claim_spec.rb
@@ -242,10 +242,23 @@ RSpec.describe SavedClaim::DependencyClaim do
 
     before do
       allow(Flipper).to receive(:enabled?).with(:va_dependents_v2).and_return(true)
+      allow(Flipper).to receive(:enabled?).with(:saved_claim_pdf_overflow_tracking).and_return(true)
     end
 
     it 'has a form id of 686C-674-V2' do
       expect(subject.form_id).to eq('686C-674-V2')
+    end
+
+    context 'after create' do
+      it 'tracks pdf overflow' do
+        allow(Flipper).to receive(:enabled?).with(:saved_claim_pdf_overflow_tracking).and_return(true)
+        allow(StatsD).to receive(:increment)
+        subject.save!
+
+        tags = ['form_id:686C-674-V2']
+        expect(StatsD).to have_received(:increment).with('saved_claim.pdf.overflow', { tags: })
+        expect(StatsD).to have_received(:increment).with('saved_claim.create', { tags: })
+      end
     end
   end
 end

--- a/spec/models/saved_claim/dependency_claim_spec.rb
+++ b/spec/models/saved_claim/dependency_claim_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe SavedClaim::DependencyClaim do
     end
 
     context 'va_dependents_v2 is enabled' do
-      subject { described_class.new(form: all_flows_payload_v2.to_json) }
+      subject { described_class.new(form: all_flows_payload_v2.to_json, use_v2: true) }
 
       before do
         allow(Flipper).to receive(:enabled?).with(:va_dependents_v2).and_return(true)
@@ -181,7 +181,7 @@ RSpec.describe SavedClaim::DependencyClaim do
     end
 
     context 'va_dependents_v2 is enabled' do
-      subject { described_class.new(form: form_674_only_v2.to_json) }
+      subject { described_class.new(form: form_674_only_v2.to_json, use_v2: true) }
 
       before do
         allow(Flipper).to receive(:enabled?).with(:va_dependents_v2).and_return(true)
@@ -217,7 +217,7 @@ RSpec.describe SavedClaim::DependencyClaim do
     end
 
     context 'va_dependents_v2 is enabled' do
-      subject { described_class.new(form: adopted_child_v2.to_json) }
+      subject { described_class.new(form: adopted_child_v2.to_json, use_v2: true) }
 
       before do
         allow(Flipper).to receive(:enabled?).with(:va_dependents_v2).and_return(true)

--- a/spec/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job_spec.rb
+++ b/spec/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job_spec.rb
@@ -495,7 +495,7 @@ RSpec.describe Lighthouse::BenefitsIntake::SubmitCentralForm686cJob, :uploader_h
   describe 'sidekiq_retries_exhausted block with dependents_trigger_action_needed_email flipper on' do
     before do
       allow(SavedClaim::DependencyClaim).to receive(:find).and_return(claim)
-      allow(Dependents::Monitor).to receive(:new).and_return(monitor)
+      allow(claim).to receive(:monitor).and_return(monitor)
       allow(monitor).to receive :track_submission_exhaustion
       allow(Flipper).to receive(:enabled?).with(:dependents_trigger_action_needed_email).and_return(true)
     end

--- a/spec/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job_spec.rb
+++ b/spec/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe Lighthouse::BenefitsIntake::SubmitCentralForm686cJob, :uploader_h
 
   context 'with va_dependents_v2 disabled' do
     before do
+      allow(Flipper).to receive(:enabled?).with(:saved_claim_pdf_overflow_tracking).and_return(true)
       allow(Flipper).to receive(:enabled?).with(:va_dependents_v2).and_return(false)
     end
 
@@ -267,7 +268,7 @@ RSpec.describe Lighthouse::BenefitsIntake::SubmitCentralForm686cJob, :uploader_h
   context 'with va_dependents_v2 enabled' do
     before do
       allow(Flipper).to receive(:enabled?).with(anything).and_call_original
-      allow(Flipper).to receive(:enabled?).with(:saved_claim_pdf_overflow_tracking).and_return(false)
+      allow(Flipper).to receive(:enabled?).with(:saved_claim_pdf_overflow_tracking).and_return(true)
       allow(Flipper).to receive(:enabled?).with(:va_dependents_v2).and_return(true)
     end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): Partially*

The primary purpose of this PR is to add overflow PDF tracking for the 686c-674 form (v1 and v2), but this involved resolving a significant number of related bugs and issues.
- The Dependents monitor needed to be updated to differentiate between v1 and v2 claims
- Updates to locations using the monitor to pass new v2 flag
- The V2 flag wasn't getting set correctly in tests, so tests needed to be updated
- Once the V2 flag was set, V2 tests began failing. I discovered that `SavedClaim.form_data` was getting overwritten with each call to `to_pdf` for 21-674-V2, causing errors on all calls after the first. This has been fixed. 
- As part of debugging, I added an additional monitoring call to `to_pdf`.
- One test broke for v1 when current_term_dates was missing, because the presence of current_term_dates is checked in one location but not another. This case has been handled. 
- And of course, PRF overflow tracking has been added for 686c-674. The overflow tracking distinguishes between 686c, 686c-v2, 674, and 674-v2 so that we can provide stakeholders with distinct overflow counts for each. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108402

## Testing done

- [ ] *New code is covered by unit tests*
- [ ] Manual testing in rails console of claim creation (which triggers the tracking)

## What areas of the site does it impact?
Dependents

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
