### PR TITLE
Arp/form upload/2

### DIFF
--- a/app/models/persistent_attachments/va_form_attachment.rb
+++ b/app/models/persistent_attachments/va_form_attachment.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PersistentAttachments::VAFormAttachment < PersistentAttachment
-  include ::FormUpload::Uploader::Attachment.new(:file)
+  include ::ClaimDocumentation::Uploader::Attachment.new(:file)
 
   before_destroy(:delete_file)
 

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/saved_claim/benefits_intake.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/saved_claim/benefits_intake.rb
@@ -42,8 +42,8 @@ module AccreditedRepresentativePortal
 
       with_options(attachment_association_options) do
         ##
-        # TODO: Add some application-level validation that this claim has _only
-        # one_ `form_attachment`?
+        # TODO: Add some application-level validation or DB constraint that this
+        # claim has _only one_ `form_attachment`?
         #
         has_one(
           :form_attachment,

--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/saved_claim_service/attach.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/saved_claim_service/attach.rb
@@ -7,8 +7,15 @@ module AccreditedRepresentativePortal
       InvalidFileError = Class.new(Error)
 
       class << self
-        def perform(file)
-          PersistentAttachments::VAFormAttachment.new.tap do |attachment|
+        def perform(file, is_form:)
+          klass =
+            if is_form
+              PersistentAttachments::VAForm
+            else
+              PersistentAttachments::VAFormAttachment
+            end
+
+          klass.new.tap do |attachment|
             attachment.file = file
             validate_record!(attachment)
             validate_upstream!(attachment)

--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/saved_claim_service/attach.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/saved_claim_service/attach.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  module SavedClaimService
+    module Attach
+      Error = Class.new(RuntimeError)
+      InvalidFileError = Class.new(Error)
+
+      class << self
+        def perform(file)
+          PersistentAttachments::VAFormAttachment.new.tap do |attachment|
+            attachment.file = file
+            validate_record!(attachment)
+            validate_upstream!(attachment)
+
+            attachment.save
+          end
+
+        ##
+        # Expose a discrete set of known exceptions. Expose any remaining with a
+        # catch-all exception.
+        #
+        rescue InvalidFileError
+          raise
+        rescue
+          raise Error
+        end
+
+        private
+
+        def validate_record!(attachment)
+          attachment.validate!
+        rescue ActiveRecord::RecordInvalid => e
+          ##
+          # Present `ActiveRecord::RecordInvalid` as an `InvalidFileError` only
+          # if `file` is the only attribute in violation (likely(?) due to
+          # `shrine` validations).
+          #
+          e.record.errors.details.keys == [:file] and
+            raise InvalidFileError
+
+          raise
+        end
+
+        ##
+        # Duplicates the validations that run on attachments during ultimate
+        # claim submission, less the stamping that is applied first.
+        #
+        def validate_upstream!(attachment)
+          BenefitsIntakeService::Service.new.valid_document?(
+            document: attachment.to_pdf
+          )
+        rescue BenefitsIntakeService::Service::InvalidDocumentError
+          raise InvalidFileError
+        end
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/saved_claim_service/attach_spec.rb
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/saved_claim_service/attach_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 require 'benefits_intake_service/service'
 
 RSpec.describe AccreditedRepresentativePortal::SavedClaimService::Attach do
-  subject(:perform) { described_class.perform(file) }
+  subject(:perform) { described_class.perform(file, is_form:) }
+
+  let(:is_form) { false }
 
   context 'when record invalid' do
     let(:file) do
@@ -28,15 +30,19 @@ RSpec.describe AccreditedRepresentativePortal::SavedClaimService::Attach do
     # check.
     #
     before do
-      allow_any_instance_of(PersistentAttachments::VAFormAttachment).to(
+      allow_any_instance_of(PersistentAttachments::VAForm).to(
         receive(:file=)
       )
 
       allow_any_instance_of(PersistentAttachments::VAFormAttachment).to(
+        receive(:file=)
+      )
+
+      allow_any_instance_of(PersistentAttachment).to(
         receive(:validate!)
       )
 
-      allow_any_instance_of(PersistentAttachments::VAFormAttachment).to(
+      allow_any_instance_of(PersistentAttachment).to(
         receive(:to_pdf)
       )
     end
@@ -68,6 +74,16 @@ RSpec.describe AccreditedRepresentativePortal::SavedClaimService::Attach do
         expect(perform).to be_a(
           PersistentAttachments::VAFormAttachment
         )
+      end
+
+      context 'when attachment is the main form' do
+        let(:is_form) { true }
+
+        it 'returns a VAForm' do
+          expect(perform).to be_a(
+            PersistentAttachments::VAForm
+          )
+        end
       end
     end
   end

--- a/spec/fixtures/files/accredited_representative_portal/invalid.pdf
+++ b/spec/fixtures/files/accredited_representative_portal/invalid.pdf
@@ -1,0 +1,12 @@
+%PDF-1.0
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj 2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj 3 0 obj<</Type/Page/MediaBox[0 0 3 3]>>endobj
+xref
+0 4
+0000000000 65535 f
+0000000010 00000 n
+0000000053 00000 n
+0000000102 00000 n
+trailer<</Size 4/Root 1 0 R>>
+startxref
+149
+%EOF


### PR DESCRIPTION
Introduces a service, `SavedClaimService::Attach`, for creating attachments that can later be specified by ID as attachments to a Benefits Intake saved claim, `SavedClaim::BenefitsIntake`, upon submission. This mirrors the client-server relationship from Simple Forms products that we forked.

This has no callers yet.

Attachments have an attribute determining whether or not they are for the main form or for other documents, which in turn determines which attachment validations they receive:
- `VAForm` => `FormUpload::Uploader::Attachment`
- `VAFormAttachment` (later PR renames to `VAFormDocumentation`) => `ClaimDocumentation::Uploader::Attachment`

The service exercises two sets of validations of the attached file:
- `vets-api`'s local validations of `PersistentAttachment` subtypes
  - Mirroring Simple Forms usage of warnings upon upload
- Validations that are later run by Benefits Intake API upon submission (invoked w/ an API call to `/uploads/validate_document`)