### PR TITLE
update GITHUB_TOKEN to github-token in GHA

### DIFF
--- a/.github/workflows/check_codeowners.yml
+++ b/.github/workflows/check_codeowners.yml
@@ -44,7 +44,7 @@ jobs:
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:
         message: 'Error: A file (or its parent directories) does not have a CODEOWNERS entry. Please update the .github/CODEOWNERS file and add the entry for the Offending file: ${{ env.offending_file }}'
-        GITHUB_TOKEN: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+        github-token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
 
     - name: Add Failure label
       uses: actions-ecosystem/action-add-labels@v1
@@ -96,7 +96,7 @@ jobs:
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:
         message: 'Error: A file (or its parent directories) was deleted but its reference still exists in CODEOWNERS. Please update the .github/CODEOWNERS file and delete the entry for the Offending file: ${{ env.offending_file }}'
-        GITHUB_TOKEN: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+        github-token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
 
     - name: Add Failure label
       uses: actions-ecosystem/action-add-labels@v1

--- a/app/controllers/v0/test/test.rb
+++ b/app/controllers/v0/test/test.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+def test
+  'This will be deleted'
+end

--- a/app/controllers/v0/test/test.rb
+++ b/app/controllers/v0/test/test.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-def test
-  'This will be deleted'
-end


### PR DESCRIPTION
## Summary

breaking change in an action we use: https://github.com/thollander/actions-comment-pull-request/blob/main/MIGRATION_GUIDE.md

## Testing done
Updated in https://github.com/department-of-veterans-affairs/vets-api/pull/22310 and the comments came through in the PR when this change was made:
![image](https://github.com/user-attachments/assets/df554e04-dfb4-4311-b639-b1291f84e63c)

https://github.com/department-of-veterans-affairs/vets-api/pull/22319#issuecomment-2897994270 (below)
![image](https://github.com/user-attachments/assets/e8a5d062-042f-4e47-8d24-15df9b696309)


## What areas of the site does it impact?
Codeowners Github action
