### PR TITLE
Arp/form upload/5

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -259,7 +259,7 @@ app/models/persistent_attachment.rb  @department-of-veterans-affairs/benefits-no
 app/models/persistent_attachments/dependency_claim.rb @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/persistent_attachments/lgy_claim.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/persistent_attachments/pension_burial.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/pension-and-burials @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
-app/models/persistent_attachments/va_form_attachment.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
+app/models/persistent_attachments/va_form_documentation.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/persistent_attachments/va_form.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/personal_information_log.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group
 app/models/power_of_attorney.rb @department-of-veterans-affairs/va-api-engineers @department-of-veterans-affairs/backend-review-group

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,10 +74,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 6b084fbc87a7c3bc403b1e3dc4a15a3387784b68
+  revision: a7d433e62ccc94f2d13a3d8704ff48806f515c42
   branch: master
   specs:
-    vets_json_schema (24.15.1)
+    vets_json_schema (24.15.2)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 

--- a/app/models/persistent_attachments/va_form_documentation.rb
+++ b/app/models/persistent_attachments/va_form_documentation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PersistentAttachments::VAFormAttachment < PersistentAttachment
+class PersistentAttachments::VAFormDocumentation < PersistentAttachment
   include ::ClaimDocumentation::Uploader::Attachment.new(:file)
 
   before_destroy(:delete_file)

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/saved_claim/benefits_intake.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/saved_claim/benefits_intake.rb
@@ -7,9 +7,9 @@ module AccreditedRepresentativePortal
         ##
         # Types of Benefits Intake API claims differ only by the value of a
         # couple attributes. `::define_claim_type` is a narrow & rigid interface
-        # for defining new claim types. It discourages bespoke customization and
-        # encourages a thoughtful pause in the case that some new requirement
-        # presents friction.
+        # for defining new claim types. This interface discourages bespoke
+        # customization and encourages a thoughtful pause in the case that some
+        # new requirement presents friction for it.
         #
         def define_claim_type(form_id:, business_line:)
           Class.new(self) do
@@ -33,6 +33,10 @@ module AccreditedRepresentativePortal
           business_line: BusinessLines::COMPENSATION
         )
 
+      ##
+      # Needed to interoperate with the form schema validations performed by the
+      # parent class.
+      #
       FORM = 'BENEFITS-INTAKE'
 
       attachment_association_options = {
@@ -41,10 +45,6 @@ module AccreditedRepresentativePortal
       }
 
       with_options(attachment_association_options) do
-        ##
-        # TODO: Add some application-level validation or DB constraint that this
-        # claim has _only one_ `form_attachment`?
-        #
         has_one(
           :form_attachment,
           -> { where(type: PersistentAttachments::VAForm) },

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/saved_claim/benefits_intake.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/saved_claim/benefits_intake.rb
@@ -54,7 +54,7 @@ module AccreditedRepresentativePortal
 
         has_many(
           :persistent_attachments,
-          -> { where(type: PersistentAttachments::VAFormAttachment) }
+          -> { where(type: PersistentAttachments::VAFormDocumentation) }
         )
       end
 

--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/saved_claim_service/attach.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/saved_claim_service/attach.rb
@@ -12,7 +12,7 @@ module AccreditedRepresentativePortal
             if is_form
               PersistentAttachments::VAForm
             else
-              PersistentAttachments::VAFormAttachment
+              PersistentAttachments::VAFormDocumentation
             end
 
           klass.new.tap do |attachment|

--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/saved_claim_service/create.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/saved_claim_service/create.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  module SavedClaimService
+    module Create
+      Error = Class.new(RuntimeError)
+      WrongAttachmentsError = Class.new(Error)
+
+      class << self
+        def perform(metadata:, attachment_guids:, type:)
+          type.new.tap do |claim|
+            claim.form = metadata.to_json
+
+            ##
+            # TODO: More robust (DB) constraints of the invariants expressed in
+            # `organize_attachments!`? I.e., number of types & no re-parenting.
+            # Ideally something more atomic with no gap between checking and
+            # persisting.
+            #
+            attachments = organize_attachments!(attachment_guids)
+
+            ##
+            # Figuring out when to set `form_id` for claim and attachment
+            # records, or what they're even used for, is complicated. It might
+            # be nice to easily detect distribution of abandoned attachments.
+            # But there is a complexity cost of needing these assignments to
+            # agree over time, rather than being set at only one final moment.
+            #
+            claim.form_attachment = attachments[:form]
+            claim.form_attachment.form_id = claim.form_id
+
+            attachments[:documentations].each do |attachment|
+              claim.persistent_attachments << attachment
+            end
+
+            claim.save!
+          end
+
+        ##
+        # Expose a discrete set of known exceptions. Expose any remaining with a
+        # catch-all exception.
+        #
+        rescue WrongAttachmentsError
+          raise
+        ##
+        # Errors resulting from schema validations of metadata seem like a fair
+        # target for exposing distinctly.
+        #
+        rescue
+          raise Error
+        end
+
+        def organize_attachments!(guids)
+          attachments =
+            PersistentAttachment.where(guid: guids).to_a
+
+          ##
+          # No re-parenting allowed.
+          #
+          attachments.none?(&:saved_claim_id) or
+            raise WrongAttachmentsError
+
+          groups = attachments.group_by(&:class)
+          forms = groups.delete(PersistentAttachments::VAForm).to_a
+          documentations = groups.delete(PersistentAttachments::VAFormDocumentation).to_a
+
+          ##
+          # Must be 1 form, 0+ documentations, 0 extraneous.
+          #
+          (forms.one? && groups.empty?) or
+            raise WrongAttachmentsError
+
+          {
+            form: forms.first,
+            documentations:
+          }
+        end
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/models/accredited_representative_portal/saved_claim/benefits_intake_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representative_portal/saved_claim/benefits_intake_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe AccreditedRepresentativePortal::SavedClaim::BenefitsIntake, type:
 
       it 'raises `ActiveModel::StrictValidationFailed` when validated' do
         expect { claim.valid? }.to raise_error(
-          ActiveModel::StrictValidationFailed
+          ActiveModel::StrictValidationFailed,
+          'Form is not included in the list'
         )
       end
     end

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/saved_claim_service/attach_spec.rb
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/saved_claim_service/attach_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe AccreditedRepresentativePortal::SavedClaimService::Attach do
         receive(:file=)
       )
 
-      allow_any_instance_of(PersistentAttachments::VAFormAttachment).to(
+      allow_any_instance_of(PersistentAttachments::VAFormDocumentation).to(
         receive(:file=)
       )
 
@@ -72,7 +72,7 @@ RSpec.describe AccreditedRepresentativePortal::SavedClaimService::Attach do
 
       it 'returns an attachment' do
         expect(perform).to be_a(
-          PersistentAttachments::VAFormAttachment
+          PersistentAttachments::VAFormDocumentation
         )
       end
 

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/saved_claim_service/create_spec.rb
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/saved_claim_service/create_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+def load_fixture(path_suffix)
+  dir = './create_spec/fixtures'
+  File.expand_path("#{dir}/#{path_suffix}", __dir__)
+      .then { |path| File.read(path) }
+      .then { |json| JSON.parse(json) }
+end
+
+dependent_claimant_form =
+  load_fixture('dependent_claimant_form.json')
+
+RSpec.describe AccreditedRepresentativePortal::SavedClaimService::Create do
+  subject(:perform) do
+    described_class.perform(
+      type: AccreditedRepresentativePortal::SavedClaim::BenefitsIntake::DependencyClaim,
+      attachment_guids: attachments.map(&:guid),
+      metadata:
+    )
+  end
+
+  describe 'with invalid metadata' do
+    let(:metadata) { {} }
+    let(:attachments) { [] }
+
+    it 'raises a generic `Error`' do
+      expect { perform }.to raise_error(
+        described_class::Error
+      )
+    end
+  end
+
+  describe 'with valid metadata' do
+    let(:metadata) { dependent_claimant_form }
+
+    describe 'attachment composition' do
+      let(:form_a) { create(:persistent_attachment_va_form) }
+      let(:form_b) { create(:persistent_attachment_va_form) }
+      let(:attachment_a) { create(:persistent_attachment_va_form_documentation) }
+      let(:attachment_b) { create(:persistent_attachment_va_form_documentation) }
+
+      let(:already_parented_attachment) do
+        create(
+          ##
+          # But of one of the expected types.
+          #
+          :persistent_attachment_va_form_documentation,
+          saved_claim: build(:burial_claim)
+        )
+      end
+
+      let(:extraneous_type_attachment) do
+        create(:persistent_attachment)
+      end
+
+      describe 'parenting' do
+        context 'one already parented' do
+          let(:attachments) { [form_a, already_parented_attachment] }
+
+          it 'raises `WrongAttachmentsError`' do
+            expect { perform }.to raise_error(
+              described_class::WrongAttachmentsError
+            )
+          end
+        end
+
+        context 'none already parented' do
+          let(:attachments) { [form_a] }
+
+          it 'returns a saved claim' do
+            expect(perform).to be_a(
+              AccreditedRepresentativePortal::SavedClaim::BenefitsIntake
+            )
+          end
+        end
+      end
+
+      describe 'composition' do
+        context 'with no main form' do
+          let(:attachments) { [attachment_a, attachment_b] }
+
+          it 'raises `WrongAttachmentsError`' do
+            expect { perform }.to raise_error(
+              described_class::WrongAttachmentsError
+            )
+          end
+        end
+
+        context 'with a main form' do
+          let(:attachments) { [form_a, attachment_a, attachment_b] }
+
+          it 'returns a saved claim' do
+            expect(perform).to be_a(
+              AccreditedRepresentativePortal::SavedClaim::BenefitsIntake
+            )
+          end
+
+          context 'with an extraneous attachment type' do
+            let(:attachments) { [form_a, extraneous_type_attachment] }
+
+            it 'raises `WrongAttachmentsError`' do
+              expect { perform }.to raise_error(
+                described_class::WrongAttachmentsError
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/saved_claim_service/create_spec/fixtures/dependent_claimant_form.json
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/saved_claim_service/create_spec/fixtures/dependent_claimant_form.json
@@ -1,0 +1,45 @@
+{
+  "veteran": {
+    "name": {
+      "first": "John",
+      "middle": "Middle",
+      "last": "Doe"
+    },
+    "address": {
+      "addressLine1": "123 Main St",
+      "addressLine2": "Apt 1",
+      "city": "Springfield",
+      "stateCode": "IL",
+      "country": "US",
+      "zipCode": "62704",
+      "zipCodeSuffix": "6789"
+    },
+    "ssn": "6789",
+    "vaFileNumber": "6789",
+    "dateOfBirth": "1980-12-31",
+    "serviceNumber": "123456789",
+    "serviceBranch": "ARMY",
+    "phone": "1234567890",
+    "email": "veteran@example.com"
+  },
+  "dependent": {
+    "name": {
+      "first": "John",
+      "middle": "Middle",
+      "last": "Doe"
+    },
+    "address": {
+      "addressLine1": "123 Main St",
+      "addressLine2": "Apt 1",
+      "city": "Springfield",
+      "stateCode": "IL",
+      "country": "US",
+      "zipCode": "62704",
+      "zipCodeSuffix": "6789"
+    },
+    "dateOfBirth": "1980-12-31",
+    "relationship": "Spouse",
+    "phone": "1234567890",
+    "email": "veteran@example.com"
+  }
+}

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/saved_claim_service/create_spec/fixtures/veteran_claimant_form.json
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/saved_claim_service/create_spec/fixtures/veteran_claimant_form.json
@@ -1,0 +1,25 @@
+{
+  "veteran": {
+    "name": {
+      "first": "John",
+      "middle": "Middle",
+      "last": "Doe"
+    },
+    "address": {
+      "addressLine1": "123 Main St",
+      "addressLine2": "Apt 1",
+      "city": "Springfield",
+      "stateCode": "IL",
+      "country": "US",
+      "zipCode": "62704",
+      "zipCodeSuffix": "6789"
+    },
+    "ssn": "6789",
+    "vaFileNumber": "6789",
+    "dateOfBirth": "1980-12-31",
+    "serviceNumber": "123456789",
+    "serviceBranch": "ARMY",
+    "phone": "1234567890",
+    "email": "veteran@example.com"
+  }
+}

--- a/spec/factories/persistent_attachments.rb
+++ b/spec/factories/persistent_attachments.rb
@@ -19,5 +19,13 @@ FactoryBot.define do
         attachment.file_data = uploaded_file.to_json
       end
     end
+
+    factory :persistent_attachment_va_form_documentation, class: 'PersistentAttachments::VAFormDocumentation' do
+      after(:build) do |attachment|
+        file = Rails.root.join('spec', 'fixtures', 'files', 'doctors-note.pdf').open('rb')
+        uploaded_file = Shrine.upload(file, :store)
+        attachment.file_data = uploaded_file.to_json
+      end
+    end
   end
 end


### PR DESCRIPTION
Spikes `SavedClaimService::Create` to be invoked upon submitting a Benefits Intake claim. In this first pass we only do the work of validating and attaching form and documentation attachments and saving the claim record.