### PR TITLE
[Event Bus] Use PID as id_type since it is Participant ID

### DIFF
--- a/app/sidekiq/event_bus_gateway/letter_ready_email_job.rb
+++ b/app/sidekiq/event_bus_gateway/letter_ready_email_job.rb
@@ -13,7 +13,7 @@ module EventBusGateway
 
     def perform(participant_id:, template_id:, personalisation:)
       notify_client.send_email(
-        recipient_identifier: { id_value: participant_id, id_type: 'ICN' },
+        recipient_identifier: { id_value: participant_id, id_type: 'PID' },
         template_id:,
         personalisation:
       )


### PR DESCRIPTION
I want to credit @dysbo on this one because I think she specifically called this exact thing out earlier and I went " 🤷 "

Anyway we are using a Participant ID for finding the user, so we have to tell VA Notify that the key we're passing it is a Participant ID. Not an ICN.