### PR TITLE
Add statement to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,4 @@
-**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.
-
+Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests and linting pass CI. See [these tips]() on how to avoid common delays in getting your PR merged.
 
 ## Summary
 


### PR DESCRIPTION
## Summary
Based on feedback the Platform has received from the Platform surveys and Backend Community of Practice meetings, I'd like to add this blurb at the top of the PR template for the vets-api repo. I'm attempting to make it clear when the "clock" starts for getting a Platform review. And also, provide tips on common things that can hold up a PR getting merged. This doc isn't on the platform website yet, but **I'll link it before merging this PR.** 

## What areas of the site does it impact?
PR template
