### PR TITLE
Use saved_claim_id to initialize Dependents:Monitor

### DIFF
--- a/app/models/saved_claim/dependency_claim.rb
+++ b/app/models/saved_claim/dependency_claim.rb
@@ -60,7 +60,7 @@ class SavedClaim::DependencyClaim < CentralMailClaim
     track_each_pdf_overflow(use_v2 ? '686C-674-V2' : '686C-674') if submittable_686?
     track_each_pdf_overflow(use_v2 ? '21-674-V2' : '21-674') if submittable_674?
   rescue => e
-    monitor.track_pdf_overflow_tracking_failure(id, e)
+    monitor.track_pdf_overflow_tracking_failure(e)
   end
 
   def track_each_pdf_overflow(subform_id)
@@ -198,7 +198,7 @@ class SavedClaim::DependencyClaim < CentralMailClaim
     self.form_id = form_id
     PdfFill::Filler.fill_form(self, nil, { created_at:, student: })
   rescue => e
-    monitor.track_to_pdf_failure(id, e)
+    monitor.track_to_pdf_failure(e)
     raise e
   ensure
     self.form_id = original_form_id
@@ -244,7 +244,7 @@ class SavedClaim::DependencyClaim < CentralMailClaim
 
     FORM674 if submittable_674?
   rescue => e
-    monitor.track_unknown_claim_type(id, e)
+    monitor.track_unknown_claim_type(e)
     nil
   end
 
@@ -261,9 +261,9 @@ class SavedClaim::DependencyClaim < CentralMailClaim
       # Combo or unknown form types use combo email
       Dependents::NotificationEmail.new(id, user).deliver(:submitted686c674)
     end
-    monitor.track_send_submitted_email_success(id, user&.user_account_uuid)
+    monitor.track_send_submitted_email_success(user&.user_account_uuid)
   rescue => e
-    monitor.track_send_submitted_email_failure(id, e, user&.user_account_uuid)
+    monitor.track_send_submitted_email_failure(e, user&.user_account_uuid)
   end
 
   ##
@@ -279,13 +279,13 @@ class SavedClaim::DependencyClaim < CentralMailClaim
       # Combo or unknown form types use combo email
       Dependents::NotificationEmail.new(id, user).deliver(:received686c674)
     end
-    monitor.track_send_received_email_success(id, user&.user_account_uuid)
+    monitor.track_send_received_email_success(user&.user_account_uuid)
   rescue => e
-    monitor.track_send_received_email_failure(id, e, user&.user_account_uuid)
+    monitor.track_send_received_email_failure(e, user&.user_account_uuid)
   end
 
   def monitor
-    @monitor ||= Dependents::Monitor.new(use_v2 || form_id.include?('-V2'))
+    @monitor ||= Dependents::Monitor.new(id)
   end
 
   private

--- a/app/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job.rb
+++ b/app/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job.rb
@@ -272,11 +272,12 @@ module Lighthouse
         claim = SavedClaim::DependencyClaim.find(saved_claim_id)
         email = claim.parsed_form.dig('dependents_application', 'veteran_contact_information', 'email_address') ||
                 user_struct.try(:va_profile_email)
-        claim.monitor.track_submission_exhaustion(msg, email)
+        Dependents::Monitor.new(claim.id).track_submission_exhaustion(msg, email)
         claim.send_failure_email(email)
       rescue => e
         # If we fail in the above failure events, this is a critical error and silent failure.
-        Rails.logger.error('Lighthouse::BenefitsIntake::SubmitCentralForm686cJob silent failure!', { e:, msg: })
+        v2 = claim&.use_v2
+        Rails.logger.error('Lighthouse::BenefitsIntake::SubmitCentralForm686cJob silent failure!', { e:, msg:, v2: })
         StatsD.increment("#{Lighthouse::BenefitsIntake::SubmitCentralForm686cJob::STATSD_KEY_PREFIX}}.silent_failure")
       end
 

--- a/lib/dependents/monitor.rb
+++ b/lib/dependents/monitor.rb
@@ -22,13 +22,27 @@ module Dependents
     # statsd key for email notifications
     EMAIL_STATS_KEY = 'dependents.email_notification'
 
-    def initialize(use_v2)
+    def initialize(claim_id)
+      @claim_id = claim_id
+      @claim = claim(claim_id)
       @use_v2 = use_v2
       super('dependents-application')
     end
 
+    def use_v2
+      return nil unless @claim
+
+      @claim&.use_v2 || @claim&.form_id&.include?('-V2')
+    end
+
+    def claim(claim_id)
+      SavedClaim::DependencyClaim.find(claim_id)
+    rescue => e
+      Rails.logger.warn('Unable to find claim for Dependents::Monitor', { claim_id:, e: })
+    end
+
     def default_payload
-      { service:, use_v2: @use_v2 }
+      { service:, use_v2: @use_v2, claim_id: @claim_id }
     end
 
     def tags
@@ -55,63 +69,63 @@ module Dependents
       )
     end
 
-    def track_unknown_claim_type(claim_id, e)
+    def track_unknown_claim_type(e)
       metric = "#{EMAIL_STATS_KEY}.unknown_type"
-      payload = default_payload.merge({ statsd: metric, claim_id:, e: })
+      payload = default_payload.merge({ statsd: metric, e: })
 
       StatsD.increment(metric, tags:)
-      Rails.logger.error("Unknown Dependents form type for claim #{claim_id}", payload)
+      Rails.logger.error("Unknown Dependents form type for claim #{@claim_id}", payload)
     end
 
-    def track_send_email_success(message, metric, claim_id, user_account_id = nil)
-      payload = default_payload.merge({ statsd: metric, claim_id:, user_account_id: })
+    def track_send_email_success(message, metric, user_account_id = nil)
+      payload = default_payload.merge({ statsd: metric, user_account_id: })
 
       StatsD.increment(metric, tags:)
       Rails.logger.info(message, payload)
     end
 
-    def track_send_email_error(message, metric, claim_id, e, user_account_uuid = nil)
-      payload = default_payload.merge({ statsd: metric, claim_id:, e:, user_account_uuid: })
+    def track_send_email_error(message, metric, e, user_account_uuid = nil)
+      payload = default_payload.merge({ statsd: metric, e:, user_account_uuid: })
 
       StatsD.increment(metric, tags:)
       Rails.logger.error(message, payload)
     end
 
-    def track_send_submitted_email_success(claim_id, user_account_uuid = nil)
-      track_send_email_success("'Submitted' email success for claim #{claim_id}",
+    def track_send_submitted_email_success(user_account_uuid = nil)
+      track_send_email_success("'Submitted' email success for claim #{@claim_id}",
                                "#{EMAIL_STATS_KEY}.submitted.success",
-                               claim_id, user_account_uuid)
+                               user_account_uuid)
     end
 
-    def track_send_submitted_email_failure(claim_id, e, user_account_uuid = nil)
-      track_send_email_error("'Submitted' email failure for claim #{claim_id}",
+    def track_send_submitted_email_failure(e, user_account_uuid = nil)
+      track_send_email_error("'Submitted' email failure for claim #{@claim_id}",
                              "#{EMAIL_STATS_KEY}.submitted.failure",
-                             claim_id, e, user_account_uuid)
+                             e, user_account_uuid)
     end
 
-    def track_send_received_email_success(claim_id, user_account_uuid = nil)
-      track_send_email_success("'Received' email success for claim #{claim_id}", "#{EMAIL_STATS_KEY}.received.success",
-                               claim_id, user_account_uuid)
+    def track_send_received_email_success(user_account_uuid = nil)
+      track_send_email_success("'Received' email success for claim #{@claim_id}", "#{EMAIL_STATS_KEY}.received.success",
+                               user_account_uuid)
     end
 
-    def track_send_received_email_failure(claim_id, e, user_account_uuid = nil)
-      track_send_email_failure("'Received' email failure for claim #{claim_id}", "#{EMAIL_STATS_KEY}.received.failure",
-                               claim_id, e, user_account_uuid)
+    def track_send_received_email_failure(e, user_account_uuid = nil)
+      track_send_email_failure("'Received' email failure for claim #{@claim_id}", "#{EMAIL_STATS_KEY}.received.failure",
+                               e, user_account_uuid)
     end
 
-    def track_to_pdf_failure(claim_id, e)
+    def track_to_pdf_failure(e)
       metric = "#{CLAIM_STATS_KEY}.to_pdf.failure"
       metric = "#{metric}.v2" if @use_v2
-      payload = default_payload.merge({ statsd: metric, claim_id:, e: })
+      payload = default_payload.merge({ statsd: metric, e: })
 
       StatsD.increment(metric, tags:)
       Rails.logger.error('SavedClaim::DependencyClaim#to_pdf error', payload)
     end
 
-    def track_pdf_overflow_tracking_failure(claim_id, e)
+    def track_pdf_overflow_tracking_failure(e)
       metric = "#{CLAIM_STATS_KEY}.track_pdf_overflow.failure"
       metric = "#{metric}.v2" if @use_v2
-      payload = default_payload.merge({ statsd: metric, claim_id:, e: })
+      payload = default_payload.merge({ statsd: metric, e: })
 
       StatsD.increment(metric, tags:)
       Rails.logger.error('Error tracking PDF overflow', payload)

--- a/spec/lib/dependents/monitor_spec.rb
+++ b/spec/lib/dependents/monitor_spec.rb
@@ -4,11 +4,12 @@ require 'rails_helper'
 require 'dependents/monitor'
 
 RSpec.describe Dependents::Monitor do
-  let(:monitor_v1) { described_class.new(false) }
-  let(:monitor_v2) { described_class.new(true) }
+  let(:claim) { create(:dependency_claim) }
+  let(:claim_v2) { create(:dependency_claim_v2) }
+  let(:monitor_v1) { described_class.new(claim.id) }
+  let(:monitor_v2) { described_class.new(claim_v2.id) }
   let(:claim_stats_key) { described_class::CLAIM_STATS_KEY }
   let(:submission_stats_key) { described_class::SUBMISSION_STATS_KEY }
-  let(:claim) { create(:dependency_claim) }
   let(:user) { create(:evss_user, :loa3) }
 
   let(:vet_info) do

--- a/spec/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job_spec.rb
+++ b/spec/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job_spec.rb
@@ -495,7 +495,7 @@ RSpec.describe Lighthouse::BenefitsIntake::SubmitCentralForm686cJob, :uploader_h
   describe 'sidekiq_retries_exhausted block with dependents_trigger_action_needed_email flipper on' do
     before do
       allow(SavedClaim::DependencyClaim).to receive(:find).and_return(claim)
-      allow(claim).to receive(:monitor).and_return(monitor)
+      allow(Dependents::Monitor).to receive(:new).and_return(monitor)
       allow(monitor).to receive :track_submission_exhaustion
       allow(Flipper).to receive(:enabled?).with(:dependents_trigger_action_needed_email).and_return(true)
     end


### PR DESCRIPTION
## Summary

- First piece of https://github.com/department-of-veterans-affairs/va.gov-team/issues/110120
- Updates the Dependents::Monitor to take saved_claim_id as a parameter at creation (instead of v2) to allow safer and more consistent calculation of whether a claim is v2 for monitoring purposes. This will also make removing v2 from the monitors after full release simpler. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/110120

## Testing done

- [ ] *New code is covered by unit tests*

## What areas of the site does it impact?
Dependents

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
