### PR TITLE
Handle nil veteran info

### DIFF
--- a/app/models/saved_claim/dependency_claim.rb
+++ b/app/models/saved_claim/dependency_claim.rb
@@ -198,7 +198,7 @@ class SavedClaim::DependencyClaim < CentralMailClaim
     self.form_id = form_id
     PdfFill::Filler.fill_form(self, nil, { created_at:, student: })
   rescue => e
-    monitor.track_to_pdf_failure(id, e)
+    monitor.track_to_pdf_failure(id, e, form_id)
     raise e
   ensure
     self.form_id = original_form_id

--- a/lib/dependents/monitor.rb
+++ b/lib/dependents/monitor.rb
@@ -99,10 +99,10 @@ module Dependents
                                claim_id, e, user_account_uuid)
     end
 
-    def track_to_pdf_failure(claim_id, e)
+    def track_to_pdf_failure(claim_id, e, form_id)
       metric = "#{CLAIM_STATS_KEY}.to_pdf.failure"
       metric = "#{metric}.v2" if @use_v2
-      payload = default_payload.merge({ statsd: metric, claim_id:, e: })
+      payload = default_payload.merge({ statsd: metric, claim_id:, e:, form_id: })
 
       StatsD.increment(metric, tags:)
       Rails.logger.error('SavedClaim::DependencyClaim#to_pdf error', payload)
@@ -114,7 +114,7 @@ module Dependents
       payload = default_payload.merge({ statsd: metric, claim_id:, e: })
 
       StatsD.increment(metric, tags:)
-      Rails.logger.error('Error tracking PDF overflow', payload)
+      Rails.logger.warn('Error tracking PDF overflow', payload)
     end
 
     def track_pdf_overflow(form_id)

--- a/lib/pdf_fill/forms/va21674.rb
+++ b/lib/pdf_fill/forms/va21674.rb
@@ -555,7 +555,13 @@ module PdfFill
 
       def merge_fields(options = {})
         created_at = options[:created_at] if options[:created_at].present?
+
+        unless @form_data['veteran_information']
+          @form_data['veteran_information'] = @form_data.dig('dependents_application', 'veteran_information')
+        end
+
         expand_signature(@form_data['veteran_information']['full_name'], created_at&.to_date || Time.zone.today)
+
         @form_data['signature_date'] = split_date(@form_data['signatureDate'])
 
         veteran_contact_information = @form_data['dependents_application']['veteran_contact_information']

--- a/lib/pdf_fill/forms/va21674v2.rb
+++ b/lib/pdf_fill/forms/va21674v2.rb
@@ -813,6 +813,9 @@ module PdfFill
         created_at = options[:created_at] if options[:created_at].present?
         student = options[:student]
         @form_data['dependents_application']['student_information'] = [student.deep_dup]
+        unless @form_data['veteran_information']
+          @form_data['veteran_information'] = @form_data.dig('dependents_application', 'veteran_information')
+        end
         expand_signature(@form_data['veteran_information']['full_name'], created_at&.to_date || Time.zone.today)
         @form_data['signature_date'] = split_date(@form_data['signatureDate'])
         veteran_contact_information = @form_data['dependents_application']['veteran_contact_information']

--- a/lib/pdf_fill/forms/va686c674.rb
+++ b/lib/pdf_fill/forms/va686c674.rb
@@ -1565,6 +1565,10 @@ module PdfFill
       private
 
       def merge_veteran_helpers
+        unless @form_data['veteran_information']
+          @form_data['veteran_information'] = @form_data.dig('dependents_application', 'veteran_information')
+        end
+
         veteran_information = @form_data['veteran_information']
         veteran_contact_information = @form_data['dependents_application']['veteran_contact_information']
 

--- a/lib/pdf_fill/forms/va686c674v2.rb
+++ b/lib/pdf_fill/forms/va686c674v2.rb
@@ -1536,6 +1536,10 @@ module PdfFill
       private
 
       def merge_veteran_helpers
+        unless @form_data['veteran_information']
+          @form_data['veteran_information'] = @form_data.dig('dependents_application', 'veteran_information')
+        end
+
         veteran_information = @form_data['veteran_information']
         veteran_contact_information = @form_data['dependents_application']['veteran_contact_information']
 


### PR DESCRIPTION
## Summary

- Sometimes `veteran_information` is undefined in form_data at the top level, but is present in dependents_application. While this is handled elsewhere in the code, to track PDF overflow it needs to be managed earlier in the process, during a PDF mapping of unprocessed data. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108402

## Testing done

- [ ] *New code is covered by unit tests*
- [ ] Used censored versions of real PDF tracking failures from prod to ensure the adjustment resulted in the tracking succeeding.

## What areas of the site does it impact?
Dependents

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

