### PR TITLE
Replace Virtus with Vets::Model - Pension21p527ez

### DIFF
--- a/lib/pension_21p527ez/pension_military_information.rb
+++ b/lib/pension_21p527ez/pension_military_information.rb
@@ -3,13 +3,14 @@
 require 'va_profile/prefill/military_information'
 require 'claims_api/service_branch_mapper'
 require 'form_profile'
+require 'vets/model'
 
 module Pension21p527ez
   ##
   # extends FormMilitaryInformation to add additional military information fields to Pension prefill.
   # @see app/models/form_profile.rb FormMilitaryInformation
   class PensionFormMilitaryInformation < FormMilitaryInformation
-    include Virtus.model
+    include Vets::Model
 
     attribute :first_uniformed_entry_date, String
     attribute :last_active_discharge_date, String


### PR DESCRIPTION
## Summary

- Virtus is being replace with `Vets::Model`. Differences include:
    - There's no hash access for attributes `form[:attribute]` only dot notation `form.attribute`
    - Syntax change for Array attributes
    - Sorting uses a class method: `default_sort_by`
    - booleans are temporarily `Bool`, until Virtus is completely gone
- This PR replaces `Virtus.model` with `Vets::Model` and updates the _attributes_ and _implementation_ accordingly. 
- This change should not affect any functionality.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/110066

## Testing done

- [x] Manual testing for similar output

## Acceptance criteria

- [x] Virtus models are now Vets::Model
- [x] No functional change