### PR TITLE
VEBT-1933 - remove name from spool file email list

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -364,7 +364,6 @@ edu:
       - noah.stern@va.gov
       - gregg.puhala@va.gov
       - kara.ciprich@va.gov
-      - napoleon.kernessant@govcio.com
       - vishnhav.ashok@va.gov
       - donna.saunders@va.gov
       - ariana.adili@govcio.com

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -364,7 +364,6 @@ edu:
       - noah.stern@va.gov
       - gregg.puhala@va.gov
       - kara.ciprich@va.gov
-      - napoleon.kernessant@govcio.com
       - vishnhav.ashok@va.gov
       - donna.saunders@va.gov
       - ariana.adili@govcio.com

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -363,7 +363,6 @@ edu:
       - noah.stern@va.gov
       - gregg.puhala@va.gov
       - kara.ciprich@va.gov
-      - napoleon.kernessant@govcio.com
       - vishnhav.ashok@va.gov
       - donna.saunders@va.gov
       - ariana.adili@govcio.com


### PR DESCRIPTION

## Summary

- *This work is behind a feature toggle (flipper): NO*
- remove name from spool file email list
- *(If bug, how to reproduce)* N/A
- VEBT

## Related issue(s)

- [VEBT-1933](https://jira.devops.va.gov/browse/VEBT-1933)
![vebt-1933](https://github.com/user-attachments/assets/bd68c753-8b6e-4257-a473-6a5c503f0cc5)


## Testing done

- [x] *New code is covered by unit tests*
- Napoleon on staging spool file email list
- submit form on staging, check distribution list when spool file email sent

## What areas of the site does it impact?
staging spool files

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)

