### PR TITLE
[Event Bus Gateway] More iteration on letter-sending job

### DIFF
--- a/app/controllers/v0/event_bus_gateway_controller.rb
+++ b/app/controllers/v0/event_bus_gateway_controller.rb
@@ -12,9 +12,9 @@ module V0
     def send_email
       if Flipper.enabled?(:event_bus_gateway_emails_enabled)
         EventBusGateway::LetterReadyEmailJob.perform_async(
-          participant_id:,
-          template_id: send_email_params[:template_id],
-          personalisation: send_email_params[:personalisation]
+          participant_id,
+          send_email_params[:template_id],
+          send_email_params[:personalisation]
         )
       end
       head :ok

--- a/app/sidekiq/event_bus_gateway/letter_ready_email_job.rb
+++ b/app/sidekiq/event_bus_gateway/letter_ready_email_job.rb
@@ -11,7 +11,7 @@ module EventBusGateway
     NOTIFY_SETTINGS = Settings.vanotify.services.benefits_management_tools
     MAILER_TEMPLATE_ID = NOTIFY_SETTINGS.template_id.decision_letter_ready_email
 
-    def perform(participant_id:, template_id:, personalisation:)
+    def perform(participant_id, template_id, personalisation)
       notify_client.send_email(
         recipient_identifier: { id_value: participant_id, id_type: 'PID' },
         template_id:,

--- a/app/sidekiq/event_bus_gateway/letter_ready_email_job.rb
+++ b/app/sidekiq/event_bus_gateway/letter_ready_email_job.rb
@@ -9,13 +9,15 @@ module EventBusGateway
 
     sidekiq_options retry: 0
     NOTIFY_SETTINGS = Settings.vanotify.services.benefits_management_tools
-    MAILER_TEMPLATE_ID = NOTIFY_SETTINGS.template_id.decision_letter_ready_email
 
-    def perform(participant_id, template_id, personalisation)
+    def perform(participant_id, template_id, personalisation_params)
       notify_client.send_email(
         recipient_identifier: { id_value: participant_id, id_type: 'PID' },
         template_id:,
-        personalisation:
+        personalisation: personalisation_params.merge({
+                                                        host: Settings.hostname,
+                                                        first_name: get_first_name_from_participant_id(participant_id)
+                                                      })
       )
     rescue => e
       record_email_send_failure(e)
@@ -27,11 +29,20 @@ module EventBusGateway
       VaNotify::Service.new(NOTIFY_SETTINGS.api_key)
     end
 
+    def get_first_name_from_participant_id(participant_id)
+      bgs = BGS::Services.new(external_uid: participant_id, external_key: participant_id)
+      person = bgs.people.find_person_by_ptcpnt_id(participant_id)
+      if person
+        person[:first_nm].capitalize
+      else
+        record_email_send_failure(OpenStruct.new(message: 'Participant ID cannot be found in BGS'))
+      end
+    end
+
     def record_email_send_failure(error)
       error_message = 'LetterReadyEmailJob VANotify errored'
       ::Rails.logger.error(error_message, { message: error.message })
       StatsD.increment('event_bus_gateway', tags: ['service:event-bus-gateway', "function: #{error_message}"])
-      log_exception_to_sentry(error)
     end
   end
 end

--- a/spec/controllers/v0/event_bus_gateway_controller_spec.rb
+++ b/spec/controllers/v0/event_bus_gateway_controller_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe V0::EventBusGatewayController, type: :request do
       end
 
       it 'invokes the email-sending job' do
-        expected_args = { participant_id: '1234', template_id: '5678', personalisation: nil }
-        expect(EventBusGateway::LetterReadyEmailJob).to receive(:perform_async).with(expected_args)
+        expect(EventBusGateway::LetterReadyEmailJob).to receive(:perform_async).with('1234', '5678', nil)
         post v0_event_bus_gateway_send_email_path(params:), headers: service_account_auth_header
         expect(response).to have_http_status(:ok)
       end

--- a/spec/sidekiq/event_bus_gateway/letter_ready_email_job_spec.rb
+++ b/spec/sidekiq/event_bus_gateway/letter_ready_email_job_spec.rb
@@ -23,7 +23,14 @@ RSpec.describe EventBusGateway::LetterReadyEmailJob, type: :job do
   context 'when an error does not occur' do
     it 'sends an email using VA Notify' do
       allow(VaNotify::Service).to receive(:new).and_return(va_notify_service)
-      expect(va_notify_service).to receive(:send_email)
+      expect_any_instance_of(BGS::PersonWebService)
+        .to receive(:find_person_by_ptcpnt_id).and_return({ first_nm: 'Joe' })
+      expected_args = {
+        recipient_identifier: { id_value: participant_id, id_type: 'PID' },
+        template_id:,
+        personalisation: { host: Settings.hostname, first_name: 'Joe' }
+      }
+      expect(va_notify_service).to receive(:send_email).with(expected_args)
       subject.new.perform(participant_id, template_id, personalisation)
     end
   end

--- a/spec/sidekiq/event_bus_gateway/letter_ready_email_job_spec.rb
+++ b/spec/sidekiq/event_bus_gateway/letter_ready_email_job_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe EventBusGateway::LetterReadyEmailJob, type: :job do
     it 'sends an email using VA Notify' do
       allow(VaNotify::Service).to receive(:new).and_return(va_notify_service)
       expect(va_notify_service).to receive(:send_email)
-      subject.new.perform(participant_id:, template_id:, personalisation:)
+      subject.new.perform(participant_id, template_id, personalisation)
     end
   end
 
@@ -44,7 +44,7 @@ RSpec.describe EventBusGateway::LetterReadyEmailJob, type: :job do
         .to receive(:error)
         .with(error_message, { message: 'StandardError' })
       expect(StatsD).to receive(:increment).with('event_bus_gateway', tags:)
-      subject.new.perform(participant_id:, template_id:, personalisation:)
+      subject.new.perform(participant_id, template_id, personalisation)
     end
   end
 end


### PR DESCRIPTION
1. Abandon named keyword arguments in redis jobs. `#perform(named:, named_two:)` works but `#perform_async(named:, named_two:)` breaks. I think I should have known this from the beginning, probably something to do with how the job is serialized? It isn't a coincidence that the jobs in vets-api avoid keyword args.
2. In the call to VA Notify, we now build out a default `personalisation` object. It includes a `host`, defined as `Settings.hostname`, and `first_name`, which is the first name of the person retrieved from BGS via the passed-in `participant_id`. As best I could tell, this is the first time we are getting a user's first name only via their participant ID. I see many examples of getting info via the MPI service with ICN, but not Participant ID.
3. Remove `MAILER_TEMPLATE_ID` constant from the job, since this template ID will be sent over from the Gateway.
4. Remove `log_exception_to_sentry` because sentry is being deprecated. Right?