### PR TITLE
Revert "Bump datadog from 2.15.0 to 2.16.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -365,13 +365,13 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    datadog (2.16.0)
-      datadog-ruby_core_source (~> 3.4, >= 3.4.1)
+    datadog (2.15.0)
+      datadog-ruby_core_source (~> 3.4)
       libdatadog (~> 16.0.1.1.0)
       libddwaf (~> 1.22.0.0.2)
       logger
       msgpack
-    datadog-ruby_core_source (3.4.1)
+    datadog-ruby_core_source (3.4.0)
     date (3.4.1)
     date (3.4.1-java)
     date_time_precision (0.8.1)


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#22342

https://dsva.slack.com/archives/C30LCU8S3/p1747999195998519

Added in 2.16:
> Add warning when `on_error` handler is not a Proc ([#4611](https://github.com/DataDog/dd-trace-rb/pull/4611))

Causing lots of vets-api errors:
```
W, [2025-05-23T13:24:19.916260 #103]  WARN -- datadog: [datadog] on_error argument to SpanOperation ignored because is not a Proc: #<Method: Net::HTTP(Datadog::Tracing::Contrib::HTTP::Instrumentation::InstanceMethods)#annotate_span_with_error!(span, error) /usr/local/bundle/cache/ruby/3.3.0/gems/datadog-2.16.0/lib/datadog/tracing/contrib/http/instrumentation.rb:115>
```