### PR TITLE
Removed debug logging from referral service

### DIFF
--- a/modules/vaos/app/services/ccra/referral_service.rb
+++ b/modules/vaos/app/services/ccra/referral_service.rb
@@ -20,13 +20,6 @@ module Ccra
           request_headers
         )
 
-        # Log the response body for debugging purposes, will remove upon completion of staging testing
-        body_preview = response.body.is_a?(String) ? response.body : response.body.inspect
-        Rails.logger.info("CCRA Referral List - Req headers: #{request_headers}")
-        Rails.logger.info("CCRA Referral List - Params: #{params}")
-        Rails.logger.info("CCRA Referral List - Content-Type: #{response.response_headers['Content-Type']}, " \
-                          "Body Class: #{response.body.class}, Body Preview: #{body_preview}...")
-
         ReferralListEntry.build_collection(response.body)
       end
     end
@@ -46,13 +39,6 @@ module Ccra
           params,
           request_headers
         )
-
-        # Log the response body for debugging purposes, will remove upon completion of staging testing
-        body_preview = response.body.is_a?(String) ? response.body[0..100] : response.body.inspect[0..100]
-        Rails.logger.info("CCRA Referral Detail - Req headers: #{request_headers}")
-        Rails.logger.info("CCRA Referral Detail - Params: #{params}")
-        Rails.logger.info("CCRA Referral Detail - Content-Type: #{response.request_headers['Content-Type']}, " \
-                          "Body Class: #{response.body.class}, Body Preview: #{body_preview}...")
 
         referral = ReferralDetail.new(response.body)
         cache_referral_data(referral)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Removed debug logging from referral service
- Team: UAE Check In

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/109247

## Testing done
N/A

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback