### PR TITLE
Potential fix for code scanning alert no. 852: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/base_controller.rb
@@ -186,10 +186,10 @@ module ClaimsApi
         end
 
         def header_md5
-          @header_md5 ||= Digest::MD5.hexdigest(auth_headers.except('va_eauth_authenticationauthority',
-                                                                    'va_eauth_service_transaction_id',
-                                                                    'va_eauth_issueinstant',
-                                                                    'Authorization').to_json)
+          @header_md5 ||= Digest::SHA256.hexdigest(auth_headers.except('va_eauth_authenticationauthority',
+                                                                      'va_eauth_service_transaction_id',
+                                                                      'va_eauth_issueinstant',
+                                                                      'Authorization').to_json)
         end
 
         def header_hash


### PR DESCRIPTION
Potential fix for [https://github.com/department-of-veterans-affairs/vets-api/security/code-scanning/852](https://github.com/department-of-veterans-affairs/vets-api/security/code-scanning/852)

MD5 is widely regarded as insecure due to its vulnerability to collision attacks, meaning two different inputs can produce the same hash. This makes it unsuitable for any application that relies on cryptographic security or integrity guarantees.

To fix the issue, replace the use of the MD5 hashing algorithm in the `header_md5` method with a stronger cryptographic hash function. Since the `header_hash` method already uses SHA-256, we can align the `header_md5` method to use SHA-256 as well. This ensures consistency and improves security.

**Steps to fix:**
1. Replace `Digest::MD5` with `Digest::SHA256` in the `header_md5` method.
2. Ensure that the functionality of the `header_md5` method remains unchanged, except for the stronger hashing algorithm.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
