### PR TITLE
VAOS Provider search returns the first provider

### DIFF
--- a/modules/vaos/app/services/eps/provider_service.rb
+++ b/modules/vaos/app/services/eps/provider_service.rb
@@ -119,12 +119,8 @@ module Eps
       response = perform(:get, "/#{config.base_path}/provider-services", query_params, request_headers)
       log_response(response, 'EPS Search Provider Services')
 
-      # NOTE: faraday converts keys to symbols
-      matching_provider = response.body[:provider_services]&.find do |provider|
-        provider[:individual_providers]&.any? { |individual| individual[:npi] == npi }
-      end
-
-      matching_provider ? OpenStruct.new(matching_provider) : nil
+      # NPIs are unique, so we expect either an empty array or an array with exactly one matching provider
+      response.body[:provider_services]&.first&.then { |provider| OpenStruct.new(provider) }
     end
 
     private

--- a/modules/vaos/spec/services/eps/provider_service_spec.rb
+++ b/modules/vaos/spec/services/eps/provider_service_spec.rb
@@ -354,47 +354,10 @@ describe Eps::ProviderService do
             .and_return(response)
         end
 
-        it 'returns an OpenStruct with the matching provider' do
+        it 'returns an OpenStruct with the first provider' do
           result = service.search_provider_services(npi:)
           expect(result).to be_a(OpenStruct)
           expect(result.id).to eq('53mL4LAZ')
-        end
-      end
-
-      context 'when no provider with matching NPI exists' do
-        let(:response_body) do
-          {
-            count: 1,
-            providerServices: [
-              {
-                id: '53mL4LAZ',
-                name: 'Dr. Monty Graciano @ FHA Kissimmee Medical Campus',
-                isActive: true,
-                individualProviders: [
-                  {
-                    name: 'Dr. Monty Graciano',
-                    npi: '1234567890' # Different NPI
-                  }
-                ]
-              }
-            ]
-          }
-        end
-
-        let(:response) do
-          double('Response', status: 200, body: response_body,
-                             response_headers: { 'Content-Type' => 'application/json' })
-        end
-
-        before do
-          allow_any_instance_of(VAOS::SessionService).to receive(:perform)
-            .with(:get, "/#{config.base_path}/provider-services", { npi: }, headers)
-            .and_return(response)
-        end
-
-        it 'returns nil' do
-          result = service.search_provider_services(npi:)
-          expect(result).to be_nil
         end
       end
 
@@ -402,7 +365,7 @@ describe Eps::ProviderService do
         let(:response_body) do
           {
             count: 0,
-            providerServices: []
+            provider_services: []
           }
         end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Provider search returns the first provider. There is no need for us to check the NPI since the search does that for us already.
- Team: UAE check in

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/106405

## Testing done
- [ ] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
