### PR TITLE
Removed pagination from VAOS check referral usage method call

### DIFF
--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -555,7 +555,7 @@ module VAOS
       #
       # TODO: pass in date from cached referral data to use as range for CCRA appointments call
       def check_referral_usage(referral_id)
-        check = appointments_service.referral_appointment_already_exists?(referral_id, pagination_params)
+        check = appointments_service.referral_appointment_already_exists?(referral_id)
 
         if check[:error]
           { success: false, json: { message: "Error checking appointments: #{check[:failures]}" },

--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -518,8 +518,8 @@ module VAOS
           provider_id,
           {
             appointmentTypeId: referral_data[:appointment_type_id],
-            startOnOrAfter: referral_data[:start_date],
-            startBefore: referral_data[:end_date]
+            startOnOrAfter: Date.parse(referral_data[:start_date]).to_time.utc.iso8601,
+            startBefore: Date.parse(referral_data[:end_date]).to_time.utc.iso8601
           }
         )
       end
@@ -555,7 +555,7 @@ module VAOS
       #
       # TODO: pass in date from cached referral data to use as range for CCRA appointments call
       def check_referral_usage(referral_id)
-        check = appointments_service.referral_appointment_already_exists?(referral_id)
+        check = appointments_service.referral_appointment_already_exists?(referral_id, pagination_params)
 
         if check[:error]
           { success: false, json: { message: "Error checking appointments: #{check[:failures]}" },


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
- Removed pagination from VAOS check referral usage method call. This was causing an exception since the pagination object as missing data. We don't need this.
- Formatted dates as needed by API
- Team: UAE Check In

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/106405

## Testing done
- [x] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

