### PR TITLE
Changed on_complete and on_success Sidekiq call backs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,17 +133,6 @@ PATH
     vye (0.1.0)
 
 GEM
-  remote: https://enterprise.contribsys.com/
-  specs:
-    sidekiq-ent (7.3.4)
-      einhorn (~> 1.0)
-      gserver
-      sidekiq (>= 7.3.7, < 8)
-      sidekiq-pro (>= 7.3.4, < 8)
-    sidekiq-pro (7.3.6)
-      sidekiq (>= 7.3.7, < 8)
-
-GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (2.0.1)
@@ -432,7 +421,6 @@ GEM
       dry-initializer (~> 3.2)
       dry-schema (~> 1.14)
       zeitwerk (~> 2.6)
-    einhorn (1.0.0)
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
@@ -568,7 +556,6 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    gserver (0.0.1)
     guard (2.18.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -1381,8 +1368,6 @@ DEPENDENCIES
   shoulda-matchers
   shrine
   sidekiq
-  sidekiq-ent!
-  sidekiq-pro!
   sign_in_service
   simple_forms_api!
   simplecov

--- a/modules/vye/app/sidekiq/vye/midnight_run/ingress_tims.rb
+++ b/modules/vye/app/sidekiq/vye/midnight_run/ingress_tims.rb
@@ -30,7 +30,7 @@ module Vye
         end
       end
 
-      def on_complete(status)
+      def on_complete(status, _options)
         message =
           if status.failures.zero?
             "#{self.class.name}: All chunks have ran for TIMS feed, there were no failures."
@@ -43,7 +43,7 @@ module Vye
         Rails.logger.info message
       end
 
-      def on_success(_status)
+      def on_success(_status, _options)
         Rails.logger.info "#{self.class.name}: Ingress completed successfully for TIMS feed"
       end
     end


### PR DESCRIPTION
Sidekiq jobs are failing with a message - wrong number of arguments (given 2, expected 1). This PR should fix this issue.

Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
   - NO
- *(Summarize the changes that have been made to the platform)*
   - Change Sidekiq job to accept 2 parameters instead of one to avoid the job failing in Sidekiq
- *(If bug, how to reproduce)*
    - See this [DD link](https://vagov.ddog-gov.com/apm/traces?query=env%3Aeks-prod%20%40peer.messaging.system%3Asidekiq%20%40sidekiq.job.id%3Aa90a2f4f0784d6603a05cf4e&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=flamegraph&historicalData=true&messageDisplay=inline&refresh_mode=sliding&shouldShowLegend=true&sort=time&spanID=1591464894165607188&spanType=all&storage=hot&timeHint=1747861624225&trace=AwAAAZb0q9WhnSfPQQAAABhBWmIwcS1xVEFBQ3RuU2hNamhLSzVWTTYAAAAkMDE5NmY1NDQtNjVhZS00MmJiLTk1ZWItOTU2YzgwOTNlODBjAAcehg&traceID=4202888878405648492&view=spans&start=1747858896311&end=1748031696311&paused=false) for an example
- *(What is the solution, why is this the solution?)*
   - Add a Second Parameter to the Callbacks
- *(Which team do you work for, does your team own the maintenance of this component?)*
   - Platform Watchtower
- *(If introducing a flipper, what is the success criteria being targeted?)*
   - Not Applicable
   


## Screenshots
### From Sidekiq dashboard

![image](https://github.com/user-attachments/assets/98ae838d-757a-4707-8d12-a07e72cac772)

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature