### PR TITLE
[Event Bus Gateway]: Fixes permitted params in the Controller

### DIFF
--- a/app/controllers/v0/event_bus_gateway_controller.rb
+++ b/app/controllers/v0/event_bus_gateway_controller.rb
@@ -4,11 +4,6 @@ module V0
   class EventBusGatewayController < SignIn::ServiceAccountApplicationController
     service_tag 'event_bus_gateway'
 
-    EMAIL_PARAMS = %i[
-      template_id
-      personalisation
-    ].freeze
-
     def send_email
       if Flipper.enabled?(:event_bus_gateway_emails_enabled)
         EventBusGateway::LetterReadyEmailJob.perform_async(
@@ -27,7 +22,7 @@ module V0
     end
 
     def send_email_params
-      params.permit(EMAIL_PARAMS)
+      params.permit(:template_id, personalisation: {})
     end
   end
 end

--- a/app/sidekiq/event_bus_gateway/letter_ready_email_job.rb
+++ b/app/sidekiq/event_bus_gateway/letter_ready_email_job.rb
@@ -10,7 +10,7 @@ module EventBusGateway
     sidekiq_options retry: 0
     NOTIFY_SETTINGS = Settings.vanotify.services.benefits_management_tools
 
-    def perform(participant_id, template_id, personalisation_params)
+    def perform(participant_id, template_id, personalisation_params = {})
       notify_client.send_email(
         recipient_identifier: { id_value: participant_id, id_type: 'PID' },
         template_id:,


### PR DESCRIPTION
The `personalisation` param is an hash, which means it can't be permitted via a `%i` array, so let's revert to a simpler `params.permit`.

Secondly, modify the job to give `personalisation` a default value of `{}` so that it can be merged properly even if the client doesn't send anything over.