### PR TITLE
108930: Update ITF metrics to be consistent with prefix

### DIFF
--- a/lib/lighthouse/benefits_claims/intent_to_file/monitor.rb
+++ b/lib/lighthouse/benefits_claims/intent_to_file/monitor.rb
@@ -138,21 +138,21 @@ module BenefitsClaims
 
       def track_missing_user_icn_itf_controller(method, form_id, itf_type, user_uuid, error)
         tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "method:#{method}"]
-        StatsD.increment('user.icn.blank', tags:)
+        StatsD.increment("#{STATSD_KEY_PREFIX}.user.icn.blank", tags:)
         context = { error:, method:, form_id:, itf_type:, user_uuid: }
         Rails.logger.info('V0 IntentToFilesController ITF user.icn is blank', context)
       end
 
       def track_missing_user_pid_itf_controller(method, form_id, itf_type, user_uuid, error)
         tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "method:#{method}"]
-        StatsD.increment('user.participant_id.blank', tags:)
+        StatsD.increment("#{STATSD_KEY_PREFIX}.user.participant_id.blank", tags:)
         context = { error:, method:, form_id:, itf_type:, user_uuid: }
         Rails.logger.info('V0 IntentToFilesController ITF user.participant_id is blank', context)
       end
 
       def track_invalid_itf_type_itf_controller(method, form_id, itf_type, user_uuid, error)
         tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "method:#{method}"]
-        StatsD.increment('itf.type.invalid', tags:)
+        StatsD.increment("#{STATSD_KEY_PREFIX}.itf.type.invalid", tags:)
         context = { error:, method:, form_id:, itf_type:, user_uuid: }
         Rails.logger.info('V0 IntentToFilesController ITF invalid ITF type', context)
       end

--- a/spec/lib/lighthouse/benefits_claims/intent_to_file/monitor_spec.rb
+++ b/spec/lib/lighthouse/benefits_claims/intent_to_file/monitor_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
           user_uuid: current_user.uuid
         }
 
-        expect(StatsD).to receive(:increment).with('user.icn.blank', tags:)
+        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.user.icn.blank", tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_missing_user_icn_itf_controller('post', '21P-527EZ', 'pension', current_user.uuid, 'error')
@@ -250,7 +250,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
           user_uuid: current_user.uuid
         }
 
-        expect(StatsD).to receive(:increment).with('user.participant_id.blank', tags:)
+        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.user.participant_id.blank", tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_missing_user_pid_itf_controller('post', '21P-527EZ', 'pension', current_user.uuid, 'error')
@@ -269,7 +269,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
           user_uuid: current_user.uuid
         }
 
-        expect(StatsD).to receive(:increment).with('itf.type.invalid', tags:)
+        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.itf.type.invalid", tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_invalid_itf_type_itf_controller('post', '21P-527EZ', 'pension', current_user.uuid, 'error')


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
This updates the ITF controller metrics to all use the statsd prefix defined in the monitor class.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108930

## Testing done
- [x] *New code is covered by unit tests*
- Specs test and locally tested

## What areas of the site does it impact?
* StatsD metrics for ITF requests

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
