### PR TITLE
Arp/form upload/7

### DIFF
--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/claimant_representative.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/claimant_representative.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  class ClaimantRepresentative <
+    Data.define(
+      :claimant_id,
+      :power_of_attorney_holder_type,
+      :power_of_attorney_holder_poa_code,
+      :accredited_individual_registration_number
+    )
+
+    class << self
+      def find(&)
+        Finder.new.tap(&).perform
+      end
+    end
+
+    class Finder
+      Error = Class.new(RuntimeError)
+
+      def perform
+        unless [@claimant, @representative].all?(&:present?)
+          raise ArgumentError, <<~MSG.squish
+            all of `claimant' and `representative'
+            must be present
+          MSG
+        end
+
+        poa_holder = @claimant.power_of_attorney_holder
+        poa_holders = @representative.power_of_attorney_holders
+
+        poa_holders.each do |h|
+          ##
+          # Would be nice to be able to use `PowerOfAttorneyHolder#==` instead.
+          #
+          next unless h.poa_code == poa_holder.poa_code
+          next unless h.type == poa_holder.type
+
+          return build(h)
+        end
+
+        nil
+      rescue
+        raise Error
+      end
+
+      def for_claimant(...)
+        @claimant = Claimant.new(...)
+      end
+
+      def for_representative(...)
+        @representative = Representative.new(...)
+      end
+
+      private
+
+      def build(poa_holder)
+        ClaimantRepresentative.new(
+          claimant_id: @claimant.id,
+          power_of_attorney_holder_type: poa_holder.type,
+          power_of_attorney_holder_poa_code: poa_holder.poa_code,
+          accredited_individual_registration_number:
+            @representative.get_registration_number(
+              poa_holder.type
+            )
+        )
+      end
+    end
+
+    class Claimant
+      def initialize(id: nil, icn: nil)
+        unless [id, icn].one?(&:present?)
+          raise ArgumentError, <<~MSG.squish
+            exactly one of `id' or `icn'
+            must be present
+          MSG
+        end
+
+        @id = id
+        @icn = icn
+      end
+
+      delegate :id, to: :identifier
+
+      def power_of_attorney_holder
+        @power_of_attorney_holder ||= begin
+          service = BenefitsClaims::Service.new(identifier.icn)
+          response = service.get_power_of_attorney['data']
+
+          ##
+          # Also, the API does not fully distinguish types like we do. The value
+          # 'individual' is returned for both claims agents and attorneys.
+          #
+          response['type'] == 'organization' or
+            raise 'Unsupported power of attorney holder type'
+
+          PowerOfAttorneyHolder.new(
+            type: PowerOfAttorneyHolder::Types::VETERAN_SERVICE_ORGANIZATION,
+            poa_code: response.dig('attributes', 'code'),
+            can_accept_digital_poa_requests: nil
+          )
+        end
+      end
+
+      private
+
+      def identifier
+        @identifier ||=
+          if @icn.present?
+            IcnTemporaryIdentifier.find_or_create_by(icn: @icn)
+          else
+            IcnTemporaryIdentifier.find(@id)
+          end
+      end
+    end
+
+    class Representative
+      def initialize(icn:, email:)
+        @icn = icn
+        @email = email
+      end
+
+      delegate(
+        :get_registration_number,
+        to: :representative_user_account
+      )
+
+      def power_of_attorney_holders
+        ##
+        # TODO: Make this method public once the codebase is churning less.
+        #
+        representative_user_account.send(
+          :power_of_attorney_holders
+        )
+      end
+
+      private
+
+      def representative_user_account
+        @representative_user_account ||=
+          RepresentativeUserAccount.find_by!(icn: @icn).tap do |account|
+            account.set_email(@email)
+          end
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/claimant_representative.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/claimant_representative.rb
@@ -31,7 +31,8 @@ module AccreditedRepresentativePortal
 
         poa_holders.each do |h|
           ##
-          # Would be nice to be able to use `PowerOfAttorneyHolder#==` instead.
+          # Might be nice to instead have a `PowerOfAttorneyHolder#==` with a
+          # semantics that matches what is needed here.
           #
           next unless h.poa_code == poa_holder.poa_code
           next unless h.type == poa_holder.type
@@ -115,9 +116,10 @@ module AccreditedRepresentativePortal
     end
 
     class Representative
-      def initialize(icn:, email:)
+      def initialize(icn:, email:, all_emails:)
         @icn = icn
         @email = email
+        @all_emails = all_emails
       end
 
       delegate(
@@ -140,6 +142,7 @@ module AccreditedRepresentativePortal
         @representative_user_account ||=
           RepresentativeUserAccount.find_by!(icn: @icn).tap do |account|
             account.set_email(@email)
+            account.set_all_emails(@all_emails)
           end
       end
     end

--- a/modules/accredited_representative_portal/spec/models/accredited_representative_portal/claimant_representative_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representative_portal/claimant_representative_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccreditedRepresentativePortal::ClaimantRepresentative, type: :model do
+  describe '.find' do
+    context 'without all required arguments' do
+      subject do
+        described_class.find {}
+      end
+
+      it 'raises Finder::Error' do
+        expect { subject }.to raise_error(
+          described_class::Finder::Error
+        )
+      end
+    end
+
+    context 'with all required arguments' do
+      subject do
+        described_class.find do |finder|
+          finder.for_claimant(
+            icn: claimant_icn
+          )
+
+          finder.for_representative(
+            icn: representative_icn,
+            email: representative_email
+          )
+        end
+      end
+
+      context 'with a representative belonging to 2 VSOs' do
+        before do
+          vso_a = create(:organization, poa: 'PAA')
+          vso_b = create(:organization, poa: 'PBB')
+
+          representative =
+            create(
+              :representative, :vso,
+              poa_codes: [vso_a.poa, vso_b.poa]
+            )
+
+          create(
+            :user_account_accredited_individual,
+            user_account_email: representative_email,
+            user_account_icn: representative_icn,
+            accredited_individual_registration_number:
+              representative.representative_id
+          )
+
+          create(
+            :user_account,
+            icn: representative_icn
+          )
+        end
+
+        let(:representative_icn) { Faker::Number.unique.number(digits: 10) }
+        let(:representative_email) { Faker::Internet.email }
+        let(:claimant_icn) { Faker::Number.unique.number(digits: 10) }
+
+        context '`BenefitsClaims::Service` does raise' do
+          before do
+            allow_any_instance_of(BenefitsClaims::Service).to(
+              receive(:get_power_of_attorney).and_raise(
+                Common::Exceptions::ResourceNotFound
+              )
+            )
+          end
+
+          it 'raises Finder::Error' do
+            expect { subject }.to raise_error(
+              described_class::Finder::Error
+            )
+          end
+        end
+
+        context '`BenefitsClaims::Service` does not raise' do
+          before do
+            allow_any_instance_of(BenefitsClaims::Service).to(
+              receive(:get_power_of_attorney).and_return(
+                JSON.parse(
+                  <<~JSON
+                    {
+                      "data": {
+                        "type": "organization",
+                        "attributes": {
+                          "code": "#{claimant_poa_code}"
+                        }
+                      }
+                    }
+                  JSON
+                )
+              )
+            )
+          end
+
+          context 'and a claimant that has poa with one of them' do
+            let(:claimant_poa_code) { 'PAA' }
+
+            it 'returns a `ClaimantRepresentative`' do
+              expect(subject).to have_attributes(
+                claimant_id: be_a(String),
+                accredited_individual_registration_number: be_a(String),
+                power_of_attorney_holder_poa_code: claimant_poa_code,
+                power_of_attorney_holder_type:
+                  AccreditedRepresentativePortal::PowerOfAttorneyHolder::Types::
+                    VETERAN_SERVICE_ORGANIZATION
+              )
+            end
+          end
+
+          context 'and a claimant that does not have poa with one of them' do
+            let(:claimant_poa_code) { 'ZZZ' }
+
+            it 'returns nil' do
+              expect(subject).to be_nil
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/models/accredited_representative_portal/claimant_representative_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representative_portal/claimant_representative_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe AccreditedRepresentativePortal::ClaimantRepresentative, type: :mo
 
           finder.for_representative(
             icn: representative_icn,
-            email: representative_email
+            email: representative_email,
+            all_emails: [representative_email]
           )
         end
       end
@@ -38,7 +39,8 @@ RSpec.describe AccreditedRepresentativePortal::ClaimantRepresentative, type: :mo
           representative =
             create(
               :representative, :vso,
-              poa_codes: [vso_a.poa, vso_b.poa]
+              poa_codes: [vso_a.poa, vso_b.poa],
+              email: representative_email
             )
 
           create(


### PR DESCRIPTION
Introduces `ClaimantRepresentative` for encapsulating checking for and returning a POA holder relationship involving a claimant and representative.

(In near future state, representative's POA holders are sourced from OGC data while claimant's current general POA is sourced from CorpDB via BGS via Lighthouse)

**Note:** This is knowingly duplicative of some existing code, and can motivate consolidation into some module if we can find the consolidation.