### PR TITLE
Arp/form upload/8

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -368,6 +368,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_05_180405) do
     t.index ["redacted_at"], name: "index_ar_power_of_attorney_requests_on_redacted_at"
   end
 
+  create_table "ar_saved_claim_claimant_representatives", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.bigint "saved_claim_id", null: false
+    t.string "claimant_id", null: false
+    t.string "claimant_type", null: false
+    t.string "power_of_attorney_holder_type", null: false
+    t.string "power_of_attorney_holder_poa_code", null: false
+    t.string "accredited_individual_registration_number", null: false
+    t.datetime "created_at", null: false
+    t.index ["saved_claim_id"], name: "idx_on_saved_claim_id_f4f27623c2", unique: true
+  end
+
   create_table "ar_user_account_accredited_individuals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "accredited_individual_registration_number", null: false
     t.string "power_of_attorney_holder_type", null: false

--- a/modules/accredited_representative_portal/db/migrate/20250527050638_create_ar_saved_claim_claimant_representatives.rb
+++ b/modules/accredited_representative_portal/db/migrate/20250527050638_create_ar_saved_claim_claimant_representatives.rb
@@ -1,0 +1,20 @@
+class CreateArSavedClaimClaimantRepresentatives < ActiveRecord::Migration[7.2]
+  def change
+    create_table :ar_saved_claim_claimant_representatives, id: :uuid do |t|
+      t.belongs_to :saved_claim, null: false, index: { unique: true }
+
+      ##
+      # This and corresponding PK should have PG's `uuid` type?
+      #
+      t.string "claimant_id", null: false
+      t.string "claimant_type", null: false
+
+      t.string "power_of_attorney_holder_type", null: false
+      t.string "power_of_attorney_holder_poa_code", null: false
+
+      t.string "accredited_individual_registration_number", null: false
+
+      t.datetime "created_at", null: false
+    end
+  end
+end


### PR DESCRIPTION
Migration for `SavedClaimClaimantRepresentative` which associates a claim submitted in our tool to 3x relationship members:
```
claimant <==> poa_holder <==> representative
```