### PR TITLE
[Event Bus] Removes personalisation from gateway controller params

### DIFF
--- a/app/controllers/v0/event_bus_gateway_controller.rb
+++ b/app/controllers/v0/event_bus_gateway_controller.rb
@@ -8,8 +8,7 @@ module V0
       if Flipper.enabled?(:event_bus_gateway_emails_enabled)
         EventBusGateway::LetterReadyEmailJob.perform_async(
           participant_id,
-          send_email_params[:template_id],
-          send_email_params[:personalisation]
+          send_email_params[:template_id]
         )
       end
       head :ok
@@ -22,7 +21,7 @@ module V0
     end
 
     def send_email_params
-      params.permit(:template_id, personalisation: {})
+      params.permit(:template_id)
     end
   end
 end

--- a/app/sidekiq/event_bus_gateway/letter_ready_email_job.rb
+++ b/app/sidekiq/event_bus_gateway/letter_ready_email_job.rb
@@ -10,14 +10,11 @@ module EventBusGateway
     sidekiq_options retry: 0
     NOTIFY_SETTINGS = Settings.vanotify.services.benefits_management_tools
 
-    def perform(participant_id, template_id, personalisation_params = {})
+    def perform(participant_id, template_id)
       notify_client.send_email(
         recipient_identifier: { id_value: participant_id, id_type: 'PID' },
         template_id:,
-        personalisation: personalisation_params.merge({
-                                                        host: Settings.hostname,
-                                                        first_name: get_first_name_from_participant_id(participant_id)
-                                                      })
+        personalisation: { host: Settings.hostname, first_name: get_first_name_from_participant_id(participant_id) }
       )
     rescue => e
       record_email_send_failure(e)

--- a/spec/controllers/v0/event_bus_gateway_controller_spec.rb
+++ b/spec/controllers/v0/event_bus_gateway_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe V0::EventBusGatewayController, type: :request do
   describe '#send_email' do
     let(:params) do
       {
-        template_id: '5678',
+        template_id: '5678'
       }
     end
 

--- a/spec/controllers/v0/event_bus_gateway_controller_spec.rb
+++ b/spec/controllers/v0/event_bus_gateway_controller_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe V0::EventBusGatewayController, type: :request do
     let(:params) do
       {
         template_id: '5678',
-        personalisation: {}
       }
     end
 
@@ -19,7 +18,7 @@ RSpec.describe V0::EventBusGatewayController, type: :request do
       end
 
       it 'invokes the email-sending job' do
-        expect(EventBusGateway::LetterReadyEmailJob).to receive(:perform_async).with('1234', '5678', nil)
+        expect(EventBusGateway::LetterReadyEmailJob).to receive(:perform_async).with('1234', '5678')
         post v0_event_bus_gateway_send_email_path(params:), headers: service_account_auth_header
         expect(response).to have_http_status(:ok)
       end

--- a/spec/sidekiq/event_bus_gateway/letter_ready_email_job_spec.rb
+++ b/spec/sidekiq/event_bus_gateway/letter_ready_email_job_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe EventBusGateway::LetterReadyEmailJob, type: :job do
 
   let(:participant_id) { '1234' }
   let(:template_id) { '5678' }
-  let(:personalisation) { {} }
 
   let(:notification_id) { SecureRandom.uuid }
   let(:va_notify_service) do
@@ -31,7 +30,7 @@ RSpec.describe EventBusGateway::LetterReadyEmailJob, type: :job do
         personalisation: { host: Settings.hostname, first_name: 'Joe' }
       }
       expect(va_notify_service).to receive(:send_email).with(expected_args)
-      subject.new.perform(participant_id, template_id, personalisation)
+      subject.new.perform(participant_id, template_id)
     end
   end
 
@@ -51,7 +50,7 @@ RSpec.describe EventBusGateway::LetterReadyEmailJob, type: :job do
         .to receive(:error)
         .with(error_message, { message: 'StandardError' })
       expect(StatsD).to receive(:increment).with('event_bus_gateway', tags:)
-      subject.new.perform(participant_id, template_id, personalisation)
+      subject.new.perform(participant_id, template_id)
     end
   end
 end


### PR DESCRIPTION
The Gateway will actually **not** ever send over additional `personalisation` parameters, so we do not need to care about them in vets-api. Put another way, all the `personalisation` params being sent to VA Notify will be found or calculated within vets-api.