### PR TITLE
[Event Bus]: Adds mapping for hostname to remove api prefix

### DIFF
--- a/app/sidekiq/event_bus_gateway/letter_ready_email_job.rb
+++ b/app/sidekiq/event_bus_gateway/letter_ready_email_job.rb
@@ -9,12 +9,18 @@ module EventBusGateway
 
     sidekiq_options retry: 0
     NOTIFY_SETTINGS = Settings.vanotify.services.benefits_management_tools
+    HOSTNAME_MAPPING = {
+      'dev-api.va.gov' => 'dev.va.gov',
+      'staging-api.va.gov' => 'staging.va.gov',
+      'api.va.gov' => 'va.gov'
+    }.freeze
 
     def perform(participant_id, template_id)
       notify_client.send_email(
         recipient_identifier: { id_value: participant_id, id_type: 'PID' },
         template_id:,
-        personalisation: { host: Settings.hostname, first_name: get_first_name_from_participant_id(participant_id) }
+        personalisation: { host: HOSTNAME_MAPPING[Settings.hostname] || Settings.hostname,
+                           first_name: get_first_name_from_participant_id(participant_id) }
       )
     rescue => e
       record_email_send_failure(e)


### PR DESCRIPTION
In the email being sent via VA Notify, there are links. But those links should refer to the non-api host, not the api host. So this does that. I could do this with a regexp but I find the hash to be more direct.

For environments that aren't in the mapping (local), we don't need to alter it.