### PR TITLE
Remove dead code for VAOS EPS get appointment using referral data

### DIFF
--- a/modules/vaos/app/controllers/vaos/v2/eps_appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/eps_appointments_controller.rb
@@ -27,28 +27,10 @@ module VAOS
       # @param appointment_data [Hash] Raw appointment data from the EPS service
       # @return [Eps::EpsAppointmentSerializer] Serialized appointment with referral and provider data
       def assemble_appt_response_object(appointment)
-        referral = fetch_referral(appointment)
         provider = fetch_provider(appointment)
-        eps_appointment = VAOS::V2::EpsAppointment.new(appointment, referral, provider)
+        eps_appointment = VAOS::V2::EpsAppointment.new(appointment, provider)
 
         Eps::EpsAppointmentSerializer.new(eps_appointment)
-      end
-
-      ##
-      # Retrieves referral details from CCRA service for the given appointment if a referral number is present.
-      #
-      # @param appointment [Hash] The appointment data containing referral information
-      # @return [Ccra::ReferralDetail, nil] The referral details if found, nil otherwise
-      def fetch_referral(appointment)
-        referral_number = appointment.dig(:referral, :referral_number)
-        return nil if referral_number.blank?
-
-        begin
-          ccra_referral_service.get_referral(referral_number, current_user.icn)
-        rescue => e
-          Rails.logger.error "Failed to retrieve referral details: #{e.message}"
-          nil
-        end
       end
 
       ##
@@ -77,10 +59,6 @@ module VAOS
 
       def appointment_service
         @appointment_service ||= Eps::AppointmentService.new(current_user)
-      end
-
-      def ccra_referral_service
-        @ccra_referral_service ||= Ccra::ReferralService.new(current_user)
       end
 
       def provider

--- a/modules/vaos/app/models/vaos/v2/eps_appointment.rb
+++ b/modules/vaos/app/models/vaos/v2/eps_appointment.rb
@@ -6,9 +6,9 @@ module VAOS
       attr_reader :id, :status, :patient_icn, :created, :location_id, :clinic,
                   :start, :is_latest, :last_retrieved, :contact, :referral_id,
                   :referral, :provider_service_id, :provider_name,
-                  :provider, :type_of_care, :provider_phone, :referring_facility_details
+                  :provider
 
-      def initialize(appointment_data = {}, referral = nil, provider = nil)
+      def initialize(appointment_data = {}, provider = nil)
         appointment_details = appointment_data[:appointment_details]
         referral_details = appointment_data[:referral]
 
@@ -26,10 +26,6 @@ module VAOS
         @referral = { referral_number: referral_details[:referral_number]&.to_s }
         @provider_service_id = appointment_data[:provider_service_id]
         @provider_name = appointment_data.dig(:provider, :name).presence || 'unknown'
-
-        @type_of_care = referral&.category_of_care
-        @provider_phone = referral&.treating_facility_phone
-        @referring_facility_details = parse_referring_facility_details(referral)
         @provider = provider
       end
 
@@ -57,8 +53,7 @@ module VAOS
           id: provider.id,
           name: provider.provider_name,
           practice: provider.practice_name,
-          location: provider.location,
-          phone: provider_phone
+          location: provider.location
         }
 
         # Transform address fields if address exists
@@ -69,28 +64,6 @@ module VAOS
             city: provider.address[:city],
             state: provider.address[:state],
             zip: provider.address[:postal_code]
-          }.compact
-        end
-
-        result.compact
-      end
-
-      def parse_referring_facility_details(referral)
-        return {} if referral.nil?
-
-        result = {
-          name: referral.referring_facility_name,
-          phone: referral.referring_facility_phone
-        }
-
-        # Add address information if present
-        if referral.referring_facility_address.present?
-          result[:address] = {
-            street1: referral.referring_facility_address[:street1],
-            street2: referral.referring_facility_address[:street2],
-            city: referral.referring_facility_address[:city],
-            state: referral.referring_facility_address[:state],
-            zip: referral.referring_facility_address[:zip]
           }.compact
         end
 

--- a/modules/vaos/app/serializers/eps/eps_appointment_serializer.rb
+++ b/modules/vaos/app/serializers/eps/eps_appointment_serializer.rb
@@ -11,8 +11,6 @@ module Eps
 
     attribute :start, &:start
 
-    attribute :type_of_care, &:type_of_care
-
     attribute :is_latest, &:is_latest
 
     attribute :last_retrieved, &:last_retrieved
@@ -26,6 +24,8 @@ module Eps
 
     attribute :provider, &:provider_details
 
-    attribute :referring_facility, &:referring_facility_details
+    attribute :referring_facility do |_object|
+      {}
+    end
   end
 end

--- a/modules/vaos/app/serializers/eps/eps_appointment_serializer.rb
+++ b/modules/vaos/app/serializers/eps/eps_appointment_serializer.rb
@@ -23,9 +23,5 @@ module Eps
     end
 
     attribute :provider, &:provider_details
-
-    attribute :referring_facility do |_object|
-      {}
-    end
   end
 end

--- a/modules/vaos/spec/requests/vaos/v2/eps_appointments_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/eps_appointments_spec.rb
@@ -21,11 +21,6 @@ RSpec.describe 'VAOS::V2::EpsAppointments', :skip_mvi, type: :request do
     Rails.cache.write(Eps::BaseService::REDIS_TOKEN_KEY, access_token)
 
     Settings.vaos ||= OpenStruct.new
-    Settings.vaos.ccra ||= OpenStruct.new
-    Settings.vaos.ccra.tap do |ccra|
-      ccra.api_url = 'http://ccra.api.example.com'
-      ccra.base_path = 'vaos/v1/patients'
-    end
     Settings.vaos.eps ||= OpenStruct.new
     Settings.vaos.eps.tap do |eps|
       eps.api_url = 'https://api.wellhive.com'
@@ -45,7 +40,6 @@ RSpec.describe 'VAOS::V2::EpsAppointments', :skip_mvi, type: :request do
               'id' => 'qdm61cJ5',
               'status' => 'booked',
               'start' => '2024-11-21T18:00:00Z',
-              'typeOfCare' => nil,
               'isLatest' => true,
               'lastRetrieved' => '2025-02-10T14:35:44Z',
               'modality' => 'OV',
@@ -111,70 +105,6 @@ RSpec.describe 'VAOS::V2::EpsAppointments', :skip_mvi, type: :request do
               get '/vaos/v2/eps_appointments/qdm61cJ5', headers: inflection_header
 
               expect(response).to have_http_status(:not_found)
-            end
-          end
-        end
-      end
-
-      context 'with referral detail data' do
-        let(:provider_phone) { '555-123-4567' }
-        let(:referring_facility_phone) { '555-123-0000' }
-        let(:referring_facility_name) { 'Test Referring Facility' }
-        let(:referring_facility_street1) { '123 Main St' }
-        let(:referring_facility_street2) { 'Suite 456' }
-        let(:referring_facility_city) { 'Anytown' }
-        let(:referring_facility_state) { 'CA' }
-        let(:referring_facility_zip) { '12345' }
-
-        it 'includes referral detail data in response when available' do
-          VCR.use_cassette('vaos/eps/token/token_200', match_requests_on: %i[method path]) do
-            VCR.use_cassette('vaos/eps/get_appointment/booked_200', match_requests_on: %i[method path]) do
-              VCR.use_cassette('vaos/eps/providers/data_Aq7wgAux_200', match_requests_on: %i[method path]) do
-                VCR.use_cassette('vaos/ccra/post_get_referral_with_phone', match_requests_on: %i[method path]) do
-                  get '/vaos/v2/eps_appointments/qdm61cJ5', headers: inflection_header
-
-                  expect(response).to have_http_status(:success)
-
-                  # Check that the phone number is in the response
-                  body = JSON.parse(response.body)
-
-                  expect(body['data']['attributes']['provider']['phone']).to eq(provider_phone)
-                  expect(body['data']['attributes']['referringFacility']['phone']).to eq(referring_facility_phone)
-                  expect(body['data']['attributes']['referringFacility']['name']).to eq(referring_facility_name)
-
-                  # Check referring facility address fields
-                  if body['data']['attributes']['referringFacility'].key?('address')
-                    address = body['data']['attributes']['referringFacility']['address']
-                    expect(address['street1']).to eq(referring_facility_street1)
-                    expect(address['street2']).to eq(referring_facility_street2)
-                    expect(address['city']).to eq(referring_facility_city)
-                    expect(address['state']).to eq(referring_facility_state)
-                    expect(address['zip']).to eq(referring_facility_zip)
-                  end
-                end
-              end
-            end
-          end
-        end
-
-        it 'handles errors from referral service gracefully' do
-          VCR.use_cassette('vaos/eps/token/token_200', match_requests_on: %i[method path]) do
-            VCR.use_cassette('vaos/eps/get_appointment/booked_200', match_requests_on: %i[method path]) do
-              VCR.use_cassette('vaos/eps/providers/data_Aq7wgAux_200', match_requests_on: %i[method path]) do
-                VCR.use_cassette('vaos/ccra/post_get_referral_error', match_requests_on: %i[method path]) do
-                  # We still need to verify logging is happening
-                  allow(Rails.logger).to receive(:error)
-                  expect(Rails.logger).to receive(:error).with(/Failed to retrieve referral details/)
-
-                  get '/vaos/v2/eps_appointments/qdm61cJ5', headers: inflection_header
-
-                  expect(response).to have_http_status(:success)
-
-                  # Check that the response doesn't have the phone number
-                  body = JSON.parse(response.body)
-                  expect(body['data']['attributes']['provider']).not_to have_key('phone')
-                end
-              end
             end
           end
         end

--- a/modules/vaos/spec/requests/vaos/v2/eps_appointments_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/eps_appointments_spec.rb
@@ -52,8 +52,7 @@ RSpec.describe 'VAOS::V2::EpsAppointments', :skip_mvi, type: :request do
                   'longitude' => -80.032819,
                   'timezone' => 'America/New_York'
                 }
-              },
-              'referringFacility' => {}
+              }
             }
           }
         }

--- a/modules/vaos/spec/serializers/eps/eps_appointment_serializer_spec.rb
+++ b/modules/vaos/spec/serializers/eps/eps_appointment_serializer_spec.rb
@@ -96,11 +96,6 @@ RSpec.describe Eps::EpsAppointmentSerializer do
         }
       )
     end
-
-    it 'includes empty referring facility details' do
-      facility_data = serialized[:data][:attributes][:referringFacility]
-      expect(facility_data).to eq({})
-    end
   end
 
   describe 'edge cases' do

--- a/modules/vaos/spec/serializers/eps/eps_appointment_serializer_spec.rb
+++ b/modules/vaos/spec/serializers/eps/eps_appointment_serializer_spec.rb
@@ -33,8 +33,6 @@ RSpec.describe Eps::EpsAppointmentSerializer do
       start: '2024-11-21T18:00:00Z',
       is_latest: true,
       last_retrieved: '2023-10-01T12:00:00Z',
-      type_of_care: 'CARDIOLOGY',
-      provider_phone: '1234567890',
       provider:,
       provider_details: {
         id: 'test-provider-id',
@@ -51,21 +49,9 @@ RSpec.describe Eps::EpsAppointmentSerializer do
           timezone: 'America/New_York'
         },
         network_ids: ['sandbox-network-test'],
-        phone: '1234567890',
         address: {
           street1: '123 Main St',
           street2: 'Suite 456',
-          city: 'Anytown',
-          state: 'CA',
-          zip: '12345'
-        }
-      },
-      referring_facility_details: {
-        name: 'VA Test Facility',
-        phone: '555-123-4567',
-        address: {
-          street1: '123 VA Street',
-          street2: 'Building A',
           city: 'Anytown',
           state: 'CA',
           zip: '12345'
@@ -81,7 +67,6 @@ RSpec.describe Eps::EpsAppointmentSerializer do
       expect(serialized[:data][:attributes][:id]).to eq('qdm61cJ5')
       expect(serialized[:data][:attributes][:status]).to eq('booked')
       expect(serialized[:data][:attributes][:start]).to eq('2024-11-21T18:00:00Z')
-      expect(serialized[:data][:attributes][:typeOfCare]).to eq('CARDIOLOGY')
       expect(serialized[:data][:attributes][:modality]).to eq('OV')
     end
 
@@ -102,7 +87,6 @@ RSpec.describe Eps::EpsAppointmentSerializer do
           timezone: 'America/New_York'
         },
         network_ids: ['sandbox-network-test'],
-        phone: '1234567890',
         address: {
           street1: '123 Main St',
           street2: 'Suite 456',
@@ -113,22 +97,9 @@ RSpec.describe Eps::EpsAppointmentSerializer do
       )
     end
 
-    it 'includes referring facility details' do
+    it 'includes empty referring facility details' do
       facility_data = serialized[:data][:attributes][:referringFacility]
-      expect(facility_data).not_to be_nil
-      expect(facility_data).to include(
-        name: 'VA Test Facility',
-        phone: '555-123-4567'
-      )
-      if facility_data[:address].present?
-        expect(facility_data[:address]).to include(
-          street1: '123 VA Street',
-          street2: 'Building A',
-          city: 'Anytown',
-          state: 'CA',
-          zip: '12345'
-        )
-      end
+      expect(facility_data).to eq({})
     end
   end
 
@@ -142,104 +113,13 @@ RSpec.describe Eps::EpsAppointmentSerializer do
           start: '2024-11-21T18:00:00Z',
           is_latest: true,
           last_retrieved: '2023-10-01T12:00:00Z',
-          type_of_care: 'CARDIOLOGY',
-          provider_phone: '1234567890',
           provider: nil,
-          provider_details: nil,
-          referring_facility_details: {
-            name: 'VA Test Facility',
-            phone: '555-123-4567'
-          }
+          provider_details: nil
         )
       end
 
       it 'returns nil for provider' do
         expect(serialized[:data][:attributes][:provider]).to be_nil
-      end
-    end
-
-    context 'when type_of_care is nil' do
-      let(:eps_appointment) do
-        instance_double(
-          VAOS::V2::EpsAppointment,
-          id: 'qdm61cJ5',
-          status: 'booked',
-          start: '2024-11-21T18:00:00Z',
-          is_latest: true,
-          last_retrieved: '2023-10-01T12:00:00Z',
-          type_of_care: nil,
-          provider_phone: nil,
-          provider:,
-          provider_details: {
-            id: 'test-provider-id',
-            name: 'Timothy Bob',
-            is_active: true,
-            organization: {
-              name: 'test-provider-org-name'
-            },
-            location: {
-              name: 'Test Medical Complex',
-              address: '207 Davishill Ln',
-              latitude: 33.058736,
-              longitude: -80.032819,
-              timezone: 'America/New_York'
-            },
-            network_ids: ['sandbox-network-test']
-          },
-          referring_facility_details: {
-            name: 'VA Test Facility',
-            phone: '555-123-4567'
-          }
-        )
-      end
-
-      it 'has nil for type_of_care' do
-        expect(serialized[:data][:attributes][:typeOfCare]).to be_nil
-      end
-
-      it 'does not include phone in provider data' do
-        expect(serialized[:data][:attributes][:provider]).not_to have_key(:phone)
-      end
-    end
-
-    context 'when provider_phone is nil but provider details include phone' do
-      let(:eps_appointment) do
-        instance_double(
-          VAOS::V2::EpsAppointment,
-          id: 'qdm61cJ5',
-          status: 'booked',
-          start: '2024-11-21T18:00:00Z',
-          is_latest: true,
-          last_retrieved: '2023-10-01T12:00:00Z',
-          type_of_care: 'CARDIOLOGY',
-          provider_phone: nil,
-          provider:,
-          provider_details: {
-            id: 'test-provider-id',
-            name: 'Timothy Bob',
-            is_active: true,
-            organization: {
-              name: 'test-provider-org-name'
-            },
-            location: {
-              name: 'Test Medical Complex',
-              address: '207 Davishill Ln',
-              latitude: 33.058736,
-              longitude: -80.032819,
-              timezone: 'America/New_York'
-            },
-            network_ids: ['sandbox-network-test'],
-            phone: '555-123-4567'
-          },
-          referring_facility_details: {
-            name: 'VA Test Facility',
-            phone: '555-123-4567'
-          }
-        )
-      end
-
-      it 'includes provider_details phone in provider data' do
-        expect(serialized[:data][:attributes][:provider][:phone]).to eq('555-123-4567')
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Remove dead code for VAOS EPS get appointment using referral data. The EPS appointment data has the referral number, but we require the consult ID and hence cannot get the referral data. The UI already had the referral data, so this step is no longer needed and will make this call faster.
- Team: UAE Check In

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/110610

## Testing done
- [ ] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

