### PR TITLE
110205: Add process_attachments

### DIFF
--- a/modules/income_and_assets/spec/controllers/income_and_assets/v0/claims_controller_spec.rb
+++ b/modules/income_and_assets/spec/controllers/income_and_assets/v0/claims_controller_spec.rb
@@ -76,6 +76,27 @@ RSpec.describe IncomeAndAssets::V0::ClaimsController, type: :request do
     end
   end
 
+  describe '#process_and_upload_to_lighthouse' do
+    let(:claim) { build(:income_and_assets_claim) }
+    let(:in_progress_form) { build(:in_progress_form) }
+
+    it 'returns a success' do
+      expect(claim).to receive(:process_attachments!)
+
+      subject.send(:process_and_upload_to_lighthouse, in_progress_form, claim)
+    end
+
+    it 'raises an error' do
+      allow(claim).to receive(:process_attachments!).and_raise(StandardError, 'mock error')
+      expect(monitor).to receive(:track_process_attachment_error).once
+      expect(IncomeAndAssets::BenefitsIntake::SubmitClaimJob).not_to receive(:perform_async)
+
+      expect do
+        subject.send(:process_and_upload_to_lighthouse, in_progress_form, claim)
+      end.to raise_error(StandardError, 'mock error')
+    end
+  end
+
   describe '#log_validation_error_to_metadata' do
     let(:claim) { build(:income_and_assets_claim) }
     let(:in_progress_form) { build(:in_progress_form) }


### PR DESCRIPTION
As a Veteran I want to upload documents that are required by VA in the 0969 process so that I can complete the benefits application or development process.

## Summary

- Add `process_attachment` to controller
- Update spec

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/110205

## Testing done

- [ ] *New code is covered by unit tests*
