### PR TITLE
Require the  vet360_id for GET Person VAProfile requests

### DIFF
--- a/lib/va_profile/v2/contact_information/service.rb
+++ b/lib/va_profile/v2/contact_information/service.rb
@@ -34,9 +34,9 @@ module VAProfile
         # @return [VAProfile::V2::ContactInformation::PersonResponse] wrapper around an person object
         def get_person
           with_monitoring do
-            verify_user!
+            verify_vet360_id!
 
-            raw_response = perform(:get, "#{MPI::Constants::VA_ROOT_OID}/#{ERB::Util.url_encode(vaprofile_aaid)}")
+            raw_response = perform(:get, "#{MPI::Constants::VA_ROOT_OID}/#{ERB::Util.url_encode(vet360_aaid)}")
             PersonResponse.from(raw_response)
           end
         rescue Common::Client::Errors::ClientError => e
@@ -217,6 +217,10 @@ module VAProfile
 
         private
 
+        def verify_vet360_id!
+          raise 'ContactInformationV2 - Missing User VAProfile_ID' if @user&.vet360_id.blank?
+        end
+
         def verify_user!
           unless @user&.vet360_id.present? || @user&.icn.present?
             raise 'ContactInformationV2 - Missing User ICN and VAProfile_ID'
@@ -226,8 +230,12 @@ module VAProfile
             VAProfile Verified? #{@user&.vet360_id.present?}")
         end
 
+        def vet360_aaid
+          "#{@user.vet360_id}^PI^200VETS^USDVA"
+        end
+
         def vaprofile_aaid
-          return "#{@user.vet360_id}^PI^200VETS^USDVA" if @user.vet360_id.present?
+          return vet360_aaid if @user.vet360_id.present?
 
           "#{@user.icn}^NI^200M^USVHA" # AAID for VAProfile Requests ONLY
         end


### PR DESCRIPTION
## Summary

The vet360_id is required for `/GET` person VAProfile requests.

This is behind the `remove_pciu` flipper, which is on in staging and off in prod.

## Related issue(s)

- https://dsva.slack.com/archives/C06JM7UUHE3/p1748455143817789
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101375

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*
  
## What areas of the site does it impact?
This impacts the calls to VA Profile for the base contact information endpoint.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature