### PR TITLE
104657: Add monitoring to track validation error

### DIFF
--- a/modules/income_and_assets/app/controllers/income_and_assets/v0/claims_controller.rb
+++ b/modules/income_and_assets/app/controllers/income_and_assets/v0/claims_controller.rb
@@ -43,6 +43,7 @@ module IncomeAndAssets
         claim.form_start_date = in_progress_form.created_at if in_progress_form
 
         unless claim.save
+          monitor.track_create_validation_error(in_progress_form, claim, current_user)
           log_validation_error_to_metadata(in_progress_form, claim)
           raise Common::Exceptions::ValidationErrors, claim.errors
         end

--- a/modules/income_and_assets/spec/controllers/income_and_assets/v0/claims_controller_spec.rb
+++ b/modules/income_and_assets/spec/controllers/income_and_assets/v0/claims_controller_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe IncomeAndAssets::V0::ClaimsController, type: :request do
     sign_in_as(user)
     allow(IncomeAndAssets::Monitor).to receive(:new).and_return(monitor)
     allow(monitor).to receive_messages(track_show404: nil, track_show_error: nil, track_create_attempt: nil,
-                                       track_create_error: nil, track_create_success: nil)
+                                       track_create_error: nil, track_create_success: nil,
+                                       track_create_validation_error: nil)
   end
 
   describe '#create' do
@@ -27,6 +28,7 @@ RSpec.describe IncomeAndAssets::V0::ClaimsController, type: :request do
 
       expect(monitor).to receive(:track_create_attempt).once
       expect(monitor).to receive(:track_create_error).once
+      expect(monitor).to receive(:track_create_validation_error).once
       expect(IncomeAndAssets::BenefitsIntake::SubmitClaimJob).not_to receive(:perform_async)
 
       post '/income_and_assets/v0/claims', params: { param_name => { form: claim.form } }


### PR DESCRIPTION
Add monitoring to validation error

## Summary

- Add monitor to controller when validation fails
- Update spec

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/104657

## Testing done

- [ ] *New code is covered by unit tests*