### PR TITLE
[ARP] Debug log shape of values in claim submission code path

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_form_upload_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_form_upload_controller.rb
@@ -121,10 +121,12 @@ module AccreditedRepresentativePortal
         # TODO: Remove. This is for temporary debugging into different behavior
         # observed between localhost and staging.
         #
-        log_value = { ssn:, first_name:, last_name:, birth_date: }
-        Rails.logger.error(log_value.deep_transform_values do |v|
-          { class: v.class, size: v.try(:size) }
-        end)
+        if Settings.vsp_environment != 'eks-prod'
+          log_value = { ssn:, first_name:, last_name:, birth_date: }
+          Rails.logger.error(log_value.deep_transform_values do |v|
+            { class: v.class, size: v.try(:size) }
+          end)
+        end
 
         mpi = MPI::Service.new.find_profile_by_attributes(ssn:, first_name:, last_name:, birth_date:)
 

--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_form_upload_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_form_upload_controller.rb
@@ -117,6 +117,15 @@ module AccreditedRepresentativePortal
       end
 
       def get_icn
+        ##
+        # TODO: Remove. This is for temporary debugging into different behavior
+        # observed between localhost and staging.
+        #
+        log_value = { ssn:, first_name:, last_name:, birth_date: }
+        Rails.logger.error(log_value.deep_transform_values do |v|
+          { class: v.class, size: v.try(:size) }
+        end)
+
         mpi = MPI::Service.new.find_profile_by_attributes(ssn:, first_name:, last_name:, birth_date:)
 
         if mpi.profile&.icn

--- a/modules/accredited_representative_portal/app/controllers/concerns/accredited_representative_portal/v0/representative_form_upload_concern.rb
+++ b/modules/accredited_representative_portal/app/controllers/concerns/accredited_representative_portal/v0/representative_form_upload_concern.rb
@@ -40,26 +40,29 @@ module AccreditedRepresentativePortal
           Rails.logger.error(log_value.deep_transform_values do |v|
             { class: v.class, size: v.try(:size) }
           end)
-
-          params.require(:representative_form_upload).permit(
-            :confirmationCode,
-            :location,
-            :formNumber,
-            :formName,
-            formData: [
-              :veteranSsn,
-              :formNumber,
-              :postalCode,
-              :veteranDateOfBirth,
-              :email,
-              :postal_code,
-              :claimantDateOfBirth,
-              :claimantSsn,
-              { claimantFullName: %i[first last] },
-              { veteranFullName: %i[first last] }
-            ]
-          )
+          form_params_list
         end
+      end
+
+      def form_params_list
+        params.require(:representative_form_upload).permit(
+          :confirmationCode,
+          :location,
+          :formNumber,
+          :formName,
+          formData: [
+            :veteranSsn,
+            :formNumber,
+            :postalCode,
+            :veteranDateOfBirth,
+            :email,
+            :postal_code,
+            :claimantDateOfBirth,
+            :claimantSsn,
+            { claimantFullName: %i[first last] },
+            { veteranFullName: %i[first last] }
+          ]
+        )
       end
 
       def form_data

--- a/modules/accredited_representative_portal/app/controllers/concerns/accredited_representative_portal/v0/representative_form_upload_concern.rb
+++ b/modules/accredited_representative_portal/app/controllers/concerns/accredited_representative_portal/v0/representative_form_upload_concern.rb
@@ -31,24 +31,35 @@ module AccreditedRepresentativePortal
       end
 
       def form_params
-        params.require(:representative_form_upload).permit(
-          :confirmationCode,
-          :location,
-          :formNumber,
-          :formName,
-          formData: [
-            :veteranSsn,
+        @form_params ||= begin
+          ##
+          # TODO: Remove. This is for temporary debugging into different behavior
+          # observed between localhost and staging.
+          #
+          log_value = params.to_unsafe_h
+          Rails.logger.error(log_value.deep_transform_values do |v|
+            { class: v.class, size: v.try(:size) }
+          end)
+
+          params.require(:representative_form_upload).permit(
+            :confirmationCode,
+            :location,
             :formNumber,
-            :postalCode,
-            :veteranDateOfBirth,
-            :email,
-            :postal_code,
-            :claimantDateOfBirth,
-            :claimantSsn,
-            { claimantFullName: %i[first last] },
-            { veteranFullName: %i[first last] }
-          ]
-        )
+            :formName,
+            formData: [
+              :veteranSsn,
+              :formNumber,
+              :postalCode,
+              :veteranDateOfBirth,
+              :email,
+              :postal_code,
+              :claimantDateOfBirth,
+              :claimantSsn,
+              { claimantFullName: %i[first last] },
+              { veteranFullName: %i[first last] }
+            ]
+          )
+        end
       end
 
       def form_data


### PR DESCRIPTION
This PR is to troubleshoot an error that as the ARF team we are only encountering on staging -- when using the same exact params to search users on MPI (first & last name, dob, ssn), it works on local dev environments but when on staging, it _appears_ that these parameters are blanked out. This change allows us to print the length of each param, without defying the masking used in logging.