### PR TITLE
Adds to breakers outage_exceptions

### DIFF
--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -115,4 +115,8 @@ Rails.application.reloader.to_prepare do
   Breakers.redis_prefix = ''
   Breakers.client = client
   Breakers.disabled = true if Settings.breakers_disabled
+
+  Breakers.config&.outage_exceptions += [
+    Common::Exceptions::BackendServiceException
+  ]
 end


### PR DESCRIPTION
## Summary

- Adds Common::Exceptions::BackendServiceException to outage_exceptions array so that Breakers will count this exception.

## Related issue(s)

- [issues/110190](https://github.com/department-of-veterans-affairs/va.gov-team/issues/110190)

It looks like the missing piece is that Breakers only “sees” failures when you raise one of the exceptions in its outage_exceptions list — and by default that list does not include the custom Common::Exceptions::BackendServiceException.

In your VAOS stack:

VAOS returns a 5xx (say, 503).

RaiseCustomError picks that up and raises Common::Exceptions::BackendServiceException.

Breakers’ middleware notices an exception, but unless that exception class is in Breakers.config.outage_exceptions, it won’t count as a failure and thus won’t trip the circuit or write the Redis key.

Other services you’ve got wired up (EVSS, etc.) probably raise Faraday timeouts or Common::Client::Errors::ClientError variants that are in the default list, so those circuits trip properly.