### PR TITLE
add overflow handling for OTHER field in Q11

### DIFF
--- a/lib/pdf_fill/forms/va210781v2.rb
+++ b/lib/pdf_fill/forms/va210781v2.rb
@@ -758,8 +758,20 @@ module PdfFill
       def process_unlisted_reports(unlisted_reports, extras_redesign)
         return if unlisted_reports.empty?
 
-        @form_data['reportsDetails']['other'] = unlisted_reports.join('; ')
-        @form_data['reportsDetails']['otherOverflow'] = unlisted_reports if extras_redesign
+        joined = unlisted_reports.join('; ')
+        @form_data['reportsDetails']['other'] = joined
+
+        limit = KEY['reportsDetails']['other'][:limit] || 0
+
+        if extras_redesign && (joined.length > limit || police_report_overflowing?)
+          @form_data['reportsDetails']['otherOverflow'] = unlisted_reports
+        end
+      end
+
+      def police_report_overflowing?
+        police = @form_data.dig('reportsDetails', 'police')
+        limit = KEY['reportsDetails']['police'][:limit] || 0
+        police && police.length > limit
       end
 
       def process_treatment_dates


### PR DESCRIPTION
## Summary

- **This work is behind a feature toggle (flipper):** ✅ YES
- Adds overflow handling for OTHER field in Q11 to:
  - Overflow when the field exceeds its 194 character limit
  - Overflow when other Q11 fields (like police report) overflow
  - Maintain proper overflow behavior in the redesigned overflow generator

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#114552
Issue: Question 11: The only box checked is "Other" and the Veteran entered additional text into the details box, which is printed in it's entirety on the paper form. However, this content shows up again on the overflow page. If this is the only box checked and the additional text fits into the paper form, it should not overflow.
## Testing done

- Added test cases to verify overflow behavior:
  - OTHER field overflows when exceeding 194 character limit
  - OTHER field overflows when police report overflows
  - OTHER field doesn't overflow when under limit and no other fields overflow

## Screenshots
#### Before: `OTHER` field incorrectly overflows when under character limit
| Form | Overflow |
|  ------ | ----- |
| <img width="753" alt="Screenshot 2025-05-29 at 1 05 15 PM" src="https://github.com/user-attachments/assets/303f4f4b-9a49-45e4-adc3-2ff5c8f0c485" />     |  <img width="620" alt="Screenshot 2025-05-28 at 10 50 04 AM" src="https://github.com/user-attachments/assets/97e2d42d-393d-4a91-963b-a9a8b425d03f" />    |

#### After: `OTHER` field correctly overflows only when exceeding 194 character limit
| Form | Overflow |
|  ------ | ----- |
| <img width="753" alt="Screenshot 2025-05-29 at 1 04 13 PM" src="https://github.com/user-attachments/assets/fcd72aa3-cbcd-41bd-a94e-bab27c8a0a5e" />     |  <img width="849" alt="Screenshot 2025-05-29 at 1 04 21 PM" src="https://github.com/user-attachments/assets/9c4ce0af-ff47-4299-ab62-4c5f2949d5b2" />   |

#### Maintained: `OTHER` field overflows when police report overflows, regardless of its own length
| Form | Overflow |
|  ------ | ----- |
| <img width="599" alt="Screenshot 2025-05-30 at 9 10 46 AM" src="https://github.com/user-attachments/assets/305b9429-fafe-4420-8210-a917d22c2542" />    |  <img width="668" alt="Screenshot 2025-05-30 at 9 11 13 AM" src="https://github.com/user-attachments/assets/c679bf27-1a9c-4749-8085-320fdbb33214" />   |



## What areas of the site does it impact?

- PDF generation for form 21-0781v2, specifically the overflow handling of the OTHER field in question 11.

## Acceptance criteria

- [x] No error nor warning in the console.
- [x] Events are not affected by this form change.
- [x] No sensitive information is hardcoded or logged.
- [x] Form tested locally in authenticated context.
- [x] Overflow behavior works correctly in both legacy and redesigned overflow generators.
- [x] Tests cover all overflow scenarios for the OTHER field.