### PR TITLE
EPS draft appointments don't 404

### DIFF
--- a/modules/vaos/app/controllers/vaos/v2/eps_appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/eps_appointments_controller.rb
@@ -9,8 +9,6 @@ module VAOS
           retrieve_latest_details: true
         )
 
-        raise Common::Exceptions::RecordNotFound, message: 'Record not found' if appointment[:state] == 'draft'
-
         response_object = assemble_appt_response_object(appointment)
         render json: response_object
       end

--- a/modules/vaos/app/models/vaos/v2/eps_appointment.rb
+++ b/modules/vaos/app/models/vaos/v2/eps_appointment.rb
@@ -13,17 +13,17 @@ module VAOS
         referral_details = appointment_data[:referral]
 
         @id = appointment_data[:id]&.to_s
-        @status = determine_status(appointment_details[:status])
+        @status = determine_status(appointment_details&.dig(:status))
         @patient_icn = appointment_data[:patient_id]
-        @created = appointment_details[:last_retrieved]
+        @created = appointment_details&.dig(:last_retrieved)
         @location_id = appointment_data[:network_id]
         @clinic = appointment_data[:provider_service_id]
-        @start = appointment_data.dig(:appointment_details, :start)
-        @is_latest = appointment_data.dig(:appointment_details, :is_latest)
-        @last_retrieved = appointment_data.dig(:appointment_details, :last_retrieved)
+        @start = appointment_details&.dig(:start)
+        @is_latest = appointment_details&.dig(:is_latest)
+        @last_retrieved = appointment_details&.dig(:last_retrieved)
         @contact = appointment_data[:contact]
-        @referral_id = referral_details[:referral_number]
-        @referral = { referral_number: referral_details[:referral_number]&.to_s }
+        @referral_id = referral_details&.dig(:referral_number)
+        @referral = { referral_number: referral_details&.dig(:referral_number)&.to_s }
         @provider_service_id = appointment_data[:provider_service_id]
         @provider_name = appointment_data.dig(:provider, :name).presence || 'unknown'
         @provider = provider
@@ -32,7 +32,7 @@ module VAOS
       def serializable_hash
         {
           id: @id,
-          status: determine_status(@status),
+          status: @status,
           patient_icn: @patient_icn,
           created: @created,
           location_id: @location_id,

--- a/modules/vaos/spec/requests/vaos/v2/eps_appointments_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/eps_appointments_spec.rb
@@ -103,7 +103,8 @@ RSpec.describe 'VAOS::V2::EpsAppointments', :skip_mvi, type: :request do
             VCR.use_cassette('vaos/eps/get_appointment/draft_200', match_requests_on: %i[method path]) do
               get '/vaos/v2/eps_appointments/qdm61cJ5', headers: inflection_header
 
-              expect(response).to have_http_status(:not_found)
+              expect(response).to have_http_status(:success)
+              expect(JSON.parse(response.body)['data']['attributes']['status']).to eq('proposed')
             end
           end
         end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- EPS draft appointments don't 404. We were returning a 404 when an appointment had a state of draft, but this is not really a 404 as the appointment was found. We now just return the data.
- Team: UAE Check In

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/110958

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

