### PR TITLE
BUG - Update Claim Letters Documents adapter to check for empty data object

### DIFF
--- a/modules/mobile/app/models/mobile/v0/adapters/claim_letter_documents.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/claim_letter_documents.rb
@@ -5,7 +5,8 @@ module Mobile
     module Adapters
       class ClaimLetterDocuments
         def self.parse(documents_response)
-          return [] unless documents_response
+          # Benefits Documents Service will pass back an empty data object if no documents are present
+          return [] if documents_response['data'].empty?
 
           documents = documents_response.dig('data', 'documents')
 


### PR DESCRIPTION
It has been verified that the GET `claim-letters/search` endpoint from the LH Benefits Documents Service will return an empty data object (ie `{ "data" => {} }` when the user has no documents to return. This was not being checked for originally (it was assumed, according to their docs that either nothing is returned or an empty "documents" list is returned). This change fixes that check.

## Summary

- *This work is behind a feature toggle (flipper): ~~YES~~/NO*
- *(Summarize the changes that have been made to the platform)*
Update Mobile Claim Letter Documents adapter to account for empty data object.
- *(If bug, how to reproduce)*
Make a request on staging to the mobile GET `claim-letters/documents` endpoint with a user with no documents. It will currently return a 500
- *(What is the solution, why is this the solution?)*
The solution is described above... it will now properly handle a user without any documents.
- *(Which team do you work for, does your team own the maintenance of this component?)*
VA Mobille App team
- ~~*(If introducing a flipper, what is the success criteria being targeted?)*~~

## Related issue(s)

- ~~*Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*~~
- ~~*Link to previous change of the code/bug (if applicable)*~~
- ~~*Link to epic if not included in ticket*~~

## Testing done

- [x] *New code is covered by unit tests*
- ~~*Describe what the old behavior was prior to the change*~~
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
Merge into staging and test with a user without documents (ie user 42)
- ~~*If this work is behind a flipper:*~~
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
None other than the claim-letters documents section for mobile app

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback
