### PR TITLE
109911: Add identifiers for BPDS submissions

### DIFF
--- a/lib/bpds/service.rb
+++ b/lib/bpds/service.rb
@@ -25,17 +25,19 @@ module BPDS
     # Submits a JSON payload for a given claim.
     #
     # This method tracks the submission process, including success and failure events.
-    # It constructs a payload from the claim, optionally includes a participant ID,
+    # It constructs a payload from the claim, optionally includes a participant ID or file number,
     # and performs a POST request with the payload. If an error occurs, it tracks the failure
     # and re-raises the exception.
     #
     # @param claim [SavedClaim] The claim object to be submitted.
     # @param participant_id [String, nil] The participant ID to be included in the payload (optional).
+    # @param file_number [String, nil] The file number to be included in the payload (optional).
     # @return [String] The response body from the submission
     # @raise [StandardError] If an error occurs during submission.
-    def submit_json(claim, participant_id = nil)
+    def submit_json(claim, participant_id = nil, file_number = nil)
       payload = default_payload(claim)
       payload.merge({ 'participantId' => participant_id }) if participant_id.present?
+      payload.merge({ 'fileNumber' => file_number }) if file_number.present?
       response = perform(:post, '', payload.to_json, config.base_request_headers)
 
       # TODO: store the bpds_uuid in the future


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES* `bpds_service_enabled`
- This adds identifiers to BPDS submissions in the Pension ClaimsController
- Owned by Pensions Benefits team

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/109911

## Testing done

- [x] *New code is covered by unit tests*
- Tested locally and spec tests

## What areas of the site does it impact?
* Pension ClaimsController requests to BPDS

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
