### PR TITLE
[ARP] OliveBranch debugging

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_form_upload_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_form_upload_controller.rb
@@ -121,11 +121,16 @@ module AccreditedRepresentativePortal
         # TODO: Remove. This is for temporary debugging into different behavior
         # observed between localhost and staging.
         #
-        if Settings.vsp_environment != 'eks-prod'
+        if Settings.vsp_environment != 'production'
           log_value = { ssn:, first_name:, last_name:, birth_date: }
-          Rails.logger.error(log_value.deep_transform_values do |v|
+          log_value = log_value.deep_transform_values do |v|
             { class: v.class, size: v.try(:size) }
-          end)
+          end
+
+          Rails.logger.error(
+            'arp_olive_branch_debugging',
+            log_value
+          )
         end
 
         mpi = MPI::Service.new.find_profile_by_attributes(ssn:, first_name:, last_name:, birth_date:)

--- a/modules/accredited_representative_portal/app/controllers/concerns/accredited_representative_portal/v0/representative_form_upload_concern.rb
+++ b/modules/accredited_representative_portal/app/controllers/concerns/accredited_representative_portal/v0/representative_form_upload_concern.rb
@@ -36,15 +36,23 @@ module AccreditedRepresentativePortal
           # TODO: Remove. This is for temporary debugging into different behavior
           # observed between localhost and staging.
           #
-          log_value = params.to_unsafe_h
-          Rails.logger.error(log_value.deep_transform_values do |v|
-            { class: v.class, size: v.try(:size) }
-          end)
-          form_params_list
+          if Settings.vsp_environment != 'production'
+            log_value = params.to_unsafe_h
+            log_value = log_value.deep_transform_values do |v|
+              { class: v.class, size: v.try(:size) }
+            end
+
+            Rails.logger.error(
+              'arp_olive_branch_debugging',
+              log_value
+            )
+          end
+
+          get_form_params
         end
       end
 
-      def form_params_list
+      def get_form_params
         params.require(:representative_form_upload).permit(
           :confirmationCode,
           :location,

--- a/modules/accredited_representative_portal/config/initializers/bypass_olive_branch.rb
+++ b/modules/accredited_representative_portal/config/initializers/bypass_olive_branch.rb
@@ -28,6 +28,26 @@ module AccreditedRepresentativePortal
     ARP_PATH_INFO_PREFIX = '/accredited_representative_portal'
 
     def exclude_arp_route?(env)
+      if Settings.vsp_environment != 'production'
+        req = Rack::Request.new(env)
+        exclude =
+          req.path.starts_with?(
+            ARP_PATH_INFO_PREFIX
+          )
+
+        log_value = {
+          PATH_INFO: env['PATH_INFO'],
+          SCRIPT_NAME: env['SCRIPT_NAME'],
+          path: req.path,
+          exclude:
+        }
+
+        Rails.logger.error(
+          'arp_olive_branch_debugging',
+          log_value
+        )
+      end
+
       env['PATH_INFO'].to_s.start_with?(ARP_PATH_INFO_PREFIX)
     end
   end


### PR DESCRIPTION
We saw that we're bypassing the `OliveBranch` middleware on localhost but not in other envs. This led to an unexpected error in staging for our claims submission endpoint.

### Investigation
#### Comparing with similar code in `vets-api`
- The `Rack::Attack` middleware [performs path matches for engine routes](https://github.com/department-of-veterans-affairs/vets-api/blob/82599dc730c0f03a364960d2e9c305885f8dbefb/config/initializers/rack_attack.rb#L48)
- It does this using `Rack::Request::Helpers#path`
  - Which equates to `env['SCRIPT_NAME'] + env['PATH_INFO']`
  - And _might_ indicate that `env['PATH_INFO']` alone wasn't good enough
    - ARP path prefix is in `PATH_INFO` in localhost
    - But is in `SCRIPT_NAME` in staging???

#### Quick local experiment
- [x] Breakpoint in `Rack::Attack` for an engine route
- [x] And dig into `Rack::Request::Helpers#path` internals