### PR TITLE
111272 - Change PDF validation to a GET request

### DIFF
--- a/app/controllers/v0/my_va/submission_pdf_urls_controller.rb
+++ b/app/controllers/v0/my_va/submission_pdf_urls_controller.rb
@@ -19,7 +19,7 @@ module V0
 
         # Check to make sure the returned URL is found in S3
         Faraday::Connection.new do |conn|
-          response = conn.head(url)
+          response = conn.get(url)
           raise Common::Exceptions::RecordNotFound, request_params[:submission_guid] if response.status != 200
         end
         render json: { url: }

--- a/spec/support/vcr_cassettes/my_va/submission_pdf_urls.yml
+++ b/spec/support/vcr_cassettes/my_va/submission_pdf_urls.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: head
+    method: get
     uri: https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf
     body:
       encoding: US-ASCII

--- a/spec/support/vcr_cassettes/my_va/submission_pdf_urls_404.yml
+++ b/spec/support/vcr_cassettes/my_va/submission_pdf_urls_404.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: head
+    method: get
     uri: https://example.com/file1.pdf
     body:
       encoding: US-ASCII


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- The previous validation check attempted to use a HEAD request to avoid downloading the whole file.
- This now changes to using a GET request to validate the file's presence before having the browser attempt to download it.
- Authenticated Experience Team Authentiknights

## Related issue(s)

- Current: https://github.com/department-of-veterans-affairs/va.gov-team/issues/111272
- Previous: https://github.com/department-of-veterans-affairs/va.gov-team/issues/109295

## Testing done

- [x] *New code is covered by unit tests*
- Requests in running environments are failing because they're a HEAD request. GET should work from testing in the rails console on dev.
- Use the download PDF button on a My VA page that has a submitted form within the last 60 days.

## Screenshots
N/A

## What areas of the site does it impact?
*Just the My VA dashboard page.*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback