### PR TITLE
issue-110193-resolve-dup-service-names-breakers-config

### DIFF
--- a/lib/search_gsa/configuration.rb
+++ b/lib/search_gsa/configuration.rb
@@ -27,7 +27,7 @@ module SearchGsa
     end
 
     def service_name
-      'Search/Results'
+      'SearchGsa/Results'
     end
   end
 end

--- a/lib/veteran_enrollment_system/base_configuration.rb
+++ b/lib/veteran_enrollment_system/base_configuration.rb
@@ -12,7 +12,7 @@ module VeteranEnrollmentSystem
     end
 
     def service_name
-      'VeteranEnrollmentSystem'
+      'VeteranEnrollmentSystem/BaseConfiguration'
     end
 
     # The base request headers required for any VES API call

--- a/spec/lib/search_gsa/configuration_spec.rb
+++ b/spec/lib/search_gsa/configuration_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe SearchGsa::Configuration do
   describe '#service_name' do
     it 'has the expected service name' do
-      expect(described_class.instance.service_name).to eq('Search/Results')
+      expect(described_class.instance.service_name).to eq('SearchGsa/Results')
     end
   end
 

--- a/spec/lib/veteran_enrollment_system/base_configuration_spec.rb
+++ b/spec/lib/veteran_enrollment_system/base_configuration_spec.rb
@@ -21,7 +21,7 @@ describe 'VeteranEnrollmentSystem::BaseConfiguration' do
 
   describe '#service_name' do
     it 'overrides service_name with a unique name' do
-      expect(subject.service_name).to eq('VeteranEnrollmentSystem')
+      expect(subject.service_name).to eq('VeteranEnrollmentSystem/BaseConfiguration')
     end
   end
 


### PR DESCRIPTION
## Summary

- Changes names of two dup services, and 
- changes the tests accordingly.

## Related issue(s)

- [issues/110193](https://github.com/department-of-veterans-affairs/va.gov-team/issues/110193)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   lib/search_gsa/configuration.rb
	modified:   lib/veteran_enrollment_system/base_configuration.rb
	modified:   spec/lib/search_gsa/configuration_spec.rb
	modified:   spec/lib/veteran_enrollment_system/base_configuration_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature