### PR TITLE
Skip VBMS upload in development

### DIFF
--- a/app/models/saved_claim/dependency_claim.rb
+++ b/app/models/saved_claim/dependency_claim.rb
@@ -177,7 +177,7 @@ class SavedClaim::DependencyClaim < CentralMailClaim
       doc_type:
     )
 
-    uploader.upload!
+    uploader.upload! unless Rails.env.development?
   end
 
   # temporarily commented out before v2 rolls out. will be updated before v2's release.


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- VBMS upload isn't configured for local development, which causes a 500 error on local Dependents submissions. Skip upload attempt in development.

## Testing done

- [ ] Confirmed line is skipped in development only

## What areas of the site does it impact?
Dependents

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
