### PR TITLE
Add VA Profile cassette for CORE103 error case

### DIFF
--- a/spec/support/vcr_cassettes/va_profile/v2/contact_information/person_icn_no_vaprofile_id.yml
+++ b/spec/support/vcr_cassettes/va_profile/v2/contact_information/person_icn_no_vaprofile_id.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: <VETS360_URL>/contact-information-hub/contact-information/v2/2.16.840.1.113883.4.349/1012592963V937803%5ENI%5E200M%5EUSVHA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      X-Oneagent-Js-Injection:
+      - 'true'
+      - 'true'
+      Server-Timing:
+      - dtRpid;desc="1570547608", dtSInfo;desc="0"
+      - dtRpid;desc="712815789", dtSInfo;desc="0"
+      Vaprofiletxauditid:
+      - be8375cc-d074-49c2-851a-9089fe1a0e2c
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Frame-Options:
+      - DENY
+      Content-Security-Policy:
+      - 'default-src ''self'' ''unsafe-eval'' ''unsafe-inline'' data: filesystem:
+        about: blob: ws: wss:'
+      Date:
+      - Wed, 04 Jun 2025 14:18:36 GMT
+      Referrer-Policy:
+      - no-referrer
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"code":"CORE103","key":"_CUF_NOT_FOUND","text":"The ContactInformationBio
+        for id/criteria 2.16.840.1.113883.4.349/1012592963V937803^NI^200M^USVHA could
+        not be found. Please correct your request and try again!","severity":"ERROR"}],"txAuditId":"be8375cc-d074-49c2-851a-9089fe1a0e2c","status":"COMPLETED_FAILURE"}'
+  recorded_at: Wed, 04 Jun 2025 14:18:36 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
## Summary
This PR adds a cassette for tests that have yet to be written (ticket coming soon!).

During the PCIU migration, VA Profile told us that if a user tries to hit the GET contact-information/ endpoint with an ICN but _no_ a va profile id, they will hit a `CORE103` error. I was able to reproduce this with the test user with the ICN of `1012592963V937803`. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101375

## Testing done
None needed since this is only a cassette for using later. However, I'll paste a variation of the tests I was trying to get to pass (but kept getting this error saying the response didn't have the error in it)
Error:

       Expected exception-free block
       to raise a kind of RuntimeError with message "ContactInformationV2 - Missing User VAProfile_ID"

Failing tests:
```ruby
  describe '#get_person with icn when VA Profile id is null' do
    let(:verified_user) { build(:user, :loa3, vet360_id: nil) }

    it 'raises an error about missing VA Profile ID' do
      VCR.use_cassette('va_profile/v2/contact_information/person_icn_no_vaprofile_id', VCR::MATCH_EVERYTHING) do
        expect do
          subject.get_person
        end.to raise_error(RuntimeError, 'ContactInformationV2 - Missing User VAProfile_ID')
      end
    end

    it 'logs the error with appropriate context' do
      VCR.use_cassette('va_profile/v2/contact_information/person_icn_no_vaprofile_id', VCR::MATCH_EVERYTHING) do
        expect_any_instance_of(SentryLogging).to receive(:log_exception_to_sentry).with(
          instance_of(RuntimeError),
          { vet360_id: nil },
          { va_profile: :person_not_found },
          :warning
        )

        expect { subject.get_person }.to raise_error(RuntimeError)
      end
    end
  end
```

## Screenshots
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/d29b8ce2-c1cd-40e0-8895-ca06a0c43596" />
