### PR TITLE
feat(devcontainer): update Ruby ghcr reference

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
   },
 
   "features": {
-    "ghcr.io/devcontainers-contrib/features/ruby-asdf:0": {
+    "ghcr.io/devcontainers-extra/features/ruby-asdf:0": {
       "version": "3.3.6"
     },
     "ghcr.io/robbert229/devcontainer-features/postgresql-client:1": {


### PR DESCRIPTION
## Summary

Updates the reference to `ruby-asdf`. This dev container seems to have been moved. See screenshots about how it was discovered and solved.

## Related issue(s)

- [issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/111361)
- [slack thread](https://dsva.slack.com/archives/CBU0KDSB1/p1749142423452029)

## Testing done

- The dev who reported the issue was able to re-create their codespace and everthing worked.

## Screenshots
![image](https://github.com/user-attachments/assets/f1fbddf1-f841-4691-b813-a45cff265308)
![image](https://github.com/user-attachments/assets/ac796a16-7ff7-4f45-96e8-0c8ff460243e)




