### PR TITLE
[Event Bus] BGS fail to find now raises exception so VA Notify is not hit

### DIFF
--- a/app/sidekiq/event_bus_gateway/letter_ready_email_job.rb
+++ b/app/sidekiq/event_bus_gateway/letter_ready_email_job.rb
@@ -38,12 +38,12 @@ module EventBusGateway
       if person
         person[:first_nm].capitalize
       else
-        record_email_send_failure(OpenStruct.new(message: 'Participant ID cannot be found in BGS'))
+        raise StandardError, 'Participant ID cannot be found in BGS'
       end
     end
 
     def record_email_send_failure(error)
-      error_message = 'LetterReadyEmailJob VANotify errored'
+      error_message = 'LetterReadyEmailJob errored'
       ::Rails.logger.error(error_message, { message: error.message })
       StatsD.increment('event_bus_gateway', tags: ['service:event-bus-gateway', "function: #{error_message}"])
     end


### PR DESCRIPTION
Prior to this change, if BGS could not find a user for a given Participant ID, the job would continue to execute and we'd get an error from VA Notify.

This change makes the BGS fail-to-find raise an error so that **that** stops execution of the code and the error is caught and logged earlier.