### PR TITLE
Reduced VES timeout to 45s to allow for two retries

### DIFF
--- a/modules/ivc_champva/lib/ves_api/configuration.rb
+++ b/modules/ivc_champva/lib/ves_api/configuration.rb
@@ -7,8 +7,8 @@ module IvcChampva
   module VesApi
     class Configuration < Common::Client::Configuration::REST
       # Override the default timeouts from lib/common/client/configuration/base.rb
-      self.open_timeout = 60
-      self.read_timeout = 60
+      self.open_timeout = 45
+      self.read_timeout = 45
 
       def settings
         Settings.ivc_champva_ves_api


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- This work is behind a feature toggle (flipper): YES - The entire VES integration feature is behind a toggle
- Reduced the VES timeout from 60s to 45s to allow enough time for two retries
- I work for the IVC Forms team and we own this module

## Related issue(s)

[Related ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/110262)

## Testing done

- [x] New code is covered by unit tests
- Prior to this change, calls to VES used a 60s timeout
- Verification requires the associated forward proxy configuration to be broken, and there is a potential fix scheduled to be deployed on Friday 6/6.  If this fix does not work then verification can be done by submitting form 1010d and checking timestamps in datadog logs.  If this fix does work then there is no easy way to verify, but this is a simple and low risk change.

## Screenshots
None

## What areas of the site does it impact?
This only impacts form 1010d in staging while the send to VES toggle is enabled.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
None
