### PR TITLE
Add profile_contact_info_page_ui_refresh flag to features.yml

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1324,12 +1324,12 @@ features:
       Toggle for the entire pre-entry covid 19 self-screener available at /covid19screener and to be used by visitors
       to VHA facilities in lieu of manual screening with a VHA employee.
       This toggle is owned by Patrick B. and the rest of the CTO Health Products team.
-  profile_contact_info_page_ui_refresh:
-    actor_type: user
-    description: Display updated UI/UX for the profile Contact Information page.
   profile_ppiu_reject_requests:
     actor_type: user
     description: When enabled, requests to the PPIU controller will return a routing error.
+  profile_contact_info_page_ui_refresh:
+    actor_type: user
+    description: Display updated UI/UX for the profile Contact Information page.
   profile_enhanced_military_info:
     actor_type: user
     description: When enabled, /v1/profile/military_info endpoint will return all military information for a user.

--- a/config/features.yml
+++ b/config/features.yml
@@ -1324,6 +1324,9 @@ features:
       Toggle for the entire pre-entry covid 19 self-screener available at /covid19screener and to be used by visitors
       to VHA facilities in lieu of manual screening with a VHA employee.
       This toggle is owned by Patrick B. and the rest of the CTO Health Products team.
+  profile_contact_info_page_ui_refresh:
+    actor_type: user
+    description: Display updated UI/UX for the profile Contact Information page.
   profile_ppiu_reject_requests:
     actor_type: user
     description: When enabled, requests to the PPIU controller will return a routing error.


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): NO*
- This change adds the `profile_contact_info_page_ui_refresh` ahead of UI updates to the Profile Contact Info page in vets-website. This flipper will be removed once the UI updates are complete and have been validated by our team.
- Team: Authenticated Experience

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/111396

## Testing done

Verified the flag shows in features/flipper in my local environment

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
