### PR TITLE
Update source_app_middleware.rb

### DIFF
--- a/lib/source_app_middleware.rb
+++ b/lib/source_app_middleware.rb
@@ -134,6 +134,7 @@ class SourceAppMiddleware
     'secure-messaging-pilot',
     'sign-in-changes',
     'Survivor and Dependent Benefits 22-5490',
+    'survivor-dependent-education-benefit-22-5490',
     'static-pages',
     'submitted-appeal',
     'terms-of-use',


### PR DESCRIPTION
Adding app name 'survivor-depedent-education-benefit-22-5490' to fix un-mapped source app 


## Related issue(s)

[DataDog Alert](https://vagov.ddog-gov.com/logs?query=%22Unrecognized%20value%20for%20HTTP_SOURCE_APP_NAME%20request%20header%22%20service%3Avets-api%20env%3Aeks-prod&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZdGPtT1N78gXgAAABhBWmRHUHRkSkFBRHUtWlEwUm94OFJRUEUAAAAkMDE5NzQ2M2UtZWIxMC00MGNlLWFjZjUtODMzODlmZTJjYTRlAAA8yQ&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1740494857565&to_ts=1740509257565&live=true)

[Slack on-call alert](https://dsva.slack.com/archives/C30LCU8S3/p1749229541094289) 


## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
![image](https://github.com/user-attachments/assets/fe8cc606-8671-4aaf-9142-11c187d4aa77)

![image](https://github.com/user-attachments/assets/63771504-9d12-4bdb-9d4c-c2c94feafbc9)


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
