### PR TITLE
LSS 109337 Claim Evidence docType

### DIFF
--- a/app/controllers/v0/claim_documents_controller.rb
+++ b/app/controllers/v0/claim_documents_controller.rb
@@ -18,7 +18,7 @@ module V0
     def create
       uploads_monitor.track_document_upload_attempt(form_id, current_user)
 
-      @attachment = klass&.new(form_id:)
+      @attachment = klass&.new(form_id:, doctype:)
       # add the file after so that we have a form_id and guid for the uploader to use
       @attachment.file = unlock_file(params['file'], params['password'])
 
@@ -59,6 +59,10 @@ module V0
 
     def form_id
       params[:form_id].upcase
+    end
+
+    def doctype
+      params[:doctype] || 10 # Unknown
     end
 
     def unlock_file(file, file_password)

--- a/app/models/saved_claim/dependency_claim.rb
+++ b/app/models/saved_claim/dependency_claim.rb
@@ -174,7 +174,7 @@ class SavedClaim::DependencyClaim < CentralMailClaim
     uploader = ClaimsApi::VBMSUploader.new(
       filepath: path,
       file_number: parsed_form['veteran_information']['va_file_number'] || parsed_form['veteran_information']['ssn'],
-      doc_type:
+      doc_type: doc_type.to_s
     )
 
     uploader.upload! unless Rails.env.development?

--- a/app/sidekiq/vbms/submit_dependents_pdf_job.rb
+++ b/app/sidekiq/vbms/submit_dependents_pdf_job.rb
@@ -54,7 +54,9 @@ module VBMS
           File.rename(file_path, "#{file_path}#{file_extension}")
           file_path = "#{file_path}#{file_extension}"
 
-          claim.upload_to_vbms(path: file_path, doc_type: get_doc_type(attachment.guid, claim.parsed_form))
+          doc_type = attachment.doctype || get_doc_type(attachment.guid, claim.parsed_form)
+
+          claim.upload_to_vbms(path: file_path, doc_type:)
           Common::FileHelpers.delete_file_if_exists(file_path)
         end
         attachment.update(completed_at: Time.zone.now)

--- a/app/sidekiq/vbms/submit_dependents_pdf_v2_job.rb
+++ b/app/sidekiq/vbms/submit_dependents_pdf_v2_job.rb
@@ -54,7 +54,9 @@ module VBMS
           File.rename(file_path, "#{file_path}#{file_extension}")
           file_path = "#{file_path}#{file_extension}"
 
-          claim.upload_to_vbms(path: file_path, doc_type: get_doc_type(attachment.guid, claim.parsed_form))
+          doc_type = attachment.doctype || get_doc_type(attachment.guid, claim.parsed_form)
+
+          claim.upload_to_vbms(path: file_path, doc_type:)
           Common::FileHelpers.delete_file_if_exists(file_path)
         end
         attachment.update(completed_at: Time.zone.now)

--- a/modules/claims_evidence_api/documentation/claims-evidence-openapi.json
+++ b/modules/claims_evidence_api/documentation/claims-evidence-openapi.json
@@ -1,0 +1,10541 @@
+{
+  "openapi" : "3.0.0",
+  "info" : {
+    "description" : "The Claim Evidence Application Programming Interface (API) is file service for handling the storage and management of files supporting VA benefit claims. It serves as a modernized point of entry to files previously only accessible through VBMS eFolder. It is designed for easier implementation by consuming systems, but also with the ability to eventually replace the eFolder logic within VBMS.",
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+    },
+    "termsOfService" : "https://developer.va.gov/terms-of-service",
+    "title" : "Claim Evidence API.",
+    "version" : "0.0.1-SNAPSHOT"
+  },
+  "servers" : [ {
+    "url" : "/api/v1/rest"
+  } ],
+  "security" : [ {
+    "bearer-key" : [ ]
+  } ],
+  "tags" : [ {
+    "description" : "BIP",
+    "name" : "PRODUCT_SCOPE"
+  }, {
+    "description" : "C&P",
+    "name" : "PRODUCT_LINE_SCOPE"
+  }, {
+    "description" : "BAM",
+    "name" : "PORTFOLIO_SCOPE"
+  } ],
+  "paths" : {
+    "/folders/files:search" : {
+      "post" : {
+        "description" : "### Searches files by provided FolderIdentifier, and search request filers.",
+        "operationId" : "searchFiles",
+        "parameters" : [ {
+          "description" : "The Folder Identifier that the file will be associated to. The example provided is for identifying a veteran.<br><br>**Header Format**: folder-type:identifier-type:ID<br><br>**Valid Folder-Types**:<br> <br>* VETERAN - Allows: FILENUMBER, SSN, PARTICIPANT_ID, SEARCH, and EDIPI <br>* PERSON - Allows: PARTICIPANT_ID, SEARCH <br> <br> For search identifiers as a type, the ssn, date of birth, last name, and first name must be supplied on the ID field as query params encoded.",
+          "example" : "VETERAN:FILENUMBER:987267855",
+          "in" : "header",
+          "name" : "X-Folder-URI",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/searchFileRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFileResponse"
+                }
+              },
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFileResponse"
+                }
+              }
+            },
+            "description" : "Search was successful given provided search request."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Search Files",
+        "tags" : [ "Folder" ]
+      }
+    },
+    "/files" : {
+      "post" : {
+        "description" : "### Upload a file.\n This endpoint when given a file and associated data returns a UUID which can be used to retrieve back the latest data provided. Information on how to properly create a payload object for this endpoint is available in the schema section <a href=\"#model-payload\">here</a>. (Upload Payload)",
+        "operationId" : "upload",
+        "parameters" : [ {
+          "description" : "The Folder Identifier that the file will be associated to. The example provided is for identifying a veteran.<br><br>**Header Format**: folder-type:identifier-type:ID<br><br>**Valid Folder-Types**:<br> <br>* VETERAN - Allows: FILENUMBER, SSN, PARTICIPANT_ID, SEARCH, ICN and EDIPI <br>* PERSON - Allows: PARTICIPANT_ID, SEARCH <br> <br> For search identifiers as a type, the ssn, date of birth, last name, and first name must be supplied on the ID field as query params encoded.",
+          "example" : "VETERAN:FILENUMBER:987267855",
+          "in" : "header",
+          "name" : "X-Folder-URI",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "multipart/form-data" : {
+              "encoding" : {
+                "file" : {
+                  "contentType" : "image/png, image/jpeg"
+                }
+              },
+              "schema" : {
+                "$ref" : "#/components/schemas/uploadRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/uploadResponse"
+                }
+              }
+            },
+            "description" : "Response containing the file UUID, the owner, and the calculated MD5 Hash. As well as conversion information if the document has been converted."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/upload_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource"
+          },
+          "415" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/upload_415_response"
+                }
+              }
+            },
+            "description" : "Unsupported Media Type. This is common when uploading an unacceptable file type."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/upload_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Upload a file with associated provider data",
+        "tags" : [ "File" ]
+      }
+    },
+    "/files/{uuid}/" : {
+      "post" : {
+        "description" : "### Update a file.\n This endpoint when given a file and associated data returns a UUID which can be used to retrieve back the latest data provided. Information on how to properly create a payload object for this endpoint is available in the schema section <a href=\"#model-payload_2\">here</a>. (Update Payload)",
+        "operationId" : "update",
+        "parameters" : [ {
+          "description" : "The UUID of the file.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        }, {
+          "description" : "The Folder Identifier that the file will be associated to. The example provided is for identifying a veteran.<br><br>**Header Format**: folder-type:identifier-type:ID<br><br>**Valid Folder-Types**:<br> <br>* VETERAN - Allows: FILENUMBER, SSN, PARTICIPANT_ID, SEARCH, and EDIPI <br>* PERSON - Allows: PARTICIPANT_ID, SEARCH <br> <br> For search identifiers as a type, the ssn, date of birth, last name, and first name must be supplied on the ID field as query params encoded.",
+          "example" : "VETERAN:FILENUMBER:987267855",
+          "in" : "header",
+          "name" : "X-Folder-URI",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "multipart/form-data" : {
+              "encoding" : {
+                "file" : {
+                  "contentType" : "image/png, image/jpeg"
+                }
+              },
+              "schema" : {
+                "$ref" : "#/components/schemas/updateRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/updateResponse"
+                }
+              }
+            },
+            "description" : "Response containing the file UUID, the owner, as well as conversion information if the document has been converted."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/update_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource"
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Resource Not Found"
+          },
+          "415" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/upload_415_response"
+                }
+              }
+            },
+            "description" : "Unsupported Media Type. This is common when uploading an unacceptable file type."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/update_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Update a file with associated provider data",
+        "tags" : [ "File" ]
+      }
+    },
+    "/files/{uuid}/data" : {
+      "get" : {
+        "description" : "Retrieve file data.",
+        "operationId" : "getData",
+        "parameters" : [ {
+          "description" : "The UUID of the file data.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        }, {
+          "description" : "Optional param to include or exclude raw text data associated with the current version of the document in the response. Default behavior is exclusion. Providers must implement processing of this flag in their corresponding handler chain in order to utilize this addition to the default response. Valid values for this query parameter are \"0\"/\"1\" or \"false\"/\"true\"; anything else will result in a 400 Bad Request response.",
+          "in" : "query",
+          "name" : "includeRawTextData",
+          "schema" : {
+            "default" : false,
+            "type" : "boolean"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getData_200_response"
+                }
+              }
+            },
+            "description" : "File data is returned. If includeRawTextData is true, then raw text data associated with the file data will also be included in the response."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getData_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieve file data.",
+        "tags" : [ "File" ]
+      },
+      "put" : {
+        "description" : "### Update File Data.\n This endpoint when given data returns a status success or error message. Information on how to properly creae a payload object for this endpoint is available in the schema section.",
+        "operationId" : "updateData",
+        "parameters" : [ {
+          "description" : "The UUID of the file data.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/updateDataRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Response indicating a successful data update."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/update_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource"
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Resource Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/updateData_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Update a file with associated provider data",
+        "tags" : [ "File" ]
+      }
+    },
+    "/files/{uuid}/data/ocr" : {
+      "get" : {
+        "description" : "### Retrieve File OCR Data\nRetrieve OCR data (text content and geometry) for an existing file.",
+        "operationId" : "retrieveOcrData",
+        "parameters" : [ {
+          "description" : "The UUID of the file.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ocrDataResponse"
+                }
+              }
+            },
+            "description" : "Response indicating a successful OCR data retrieval"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource"
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/retrieveOcrData_404_response"
+                }
+              }
+            },
+            "description" : "Resource Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/retrieveOcrData_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieve OCR data related to a file",
+        "tags" : [ "File" ]
+      },
+      "post" : {
+        "description" : "### Upload File OCR Data\nUploads OCR data (text content and geometry) for an existing file, and indexes the file's text content to make it available for full-text search.",
+        "operationId" : "uploadOcrData",
+        "parameters" : [ {
+          "description" : "The UUID of the file.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ocrDataRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Response indicating a successful OCR data upload"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/updateOcrData_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource"
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Resource Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/updateOcrData_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Upload OCR data related to a file",
+        "tags" : [ "File" ]
+      },
+      "put" : {
+        "description" : "### Update File OCR Data\nUpdates OCR data (text content and/or geometry) to an existing OCR data file, and indexes the file's text content to make it available for full-text search.",
+        "operationId" : "updateOcrData",
+        "parameters" : [ {
+          "description" : "The UUID of the file.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ocrDataRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Response indicating a successful OCR data update"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/updateOcrData_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource"
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/retrieveOcrData_404_response"
+                }
+              }
+            },
+            "description" : "Resource Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/updateOcrData_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Updates OCR data to an existing OCR data file",
+        "tags" : [ "File" ]
+      }
+    },
+    "/files/{uuid}/content" : {
+      "get" : {
+        "description" : "Downloads file content.",
+        "operationId" : "getContent",
+        "parameters" : [ {
+          "description" : "UUID of the file you wish to download",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/pdf" : { }
+            },
+            "description" : "File content is returned."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/retrieveOcrData_404_response"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getContent_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Downloads file content",
+        "tags" : [ "File" ]
+      }
+    },
+    "/files/{uuid}/annotations" : {
+      "get" : {
+        "description" : "Retrieves File Annotation Objects.",
+        "operationId" : "getAnnotations",
+        "parameters" : [ {
+          "description" : "The UUID of the file data.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/annotationResponseModel"
+                }
+              }
+            },
+            "description" : "annotations are returned."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getData_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves annotations.",
+        "tags" : [ "File" ]
+      },
+      "post" : {
+        "description" : "### Add annotations.\n This endpoint when given data returns a status success or error message. The annotation object schema is listed at the bottom of this swagger page.",
+        "operationId" : "addAnnotations",
+        "parameters" : [ {
+          "description" : "The UUID of the file data.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Annotation_Request"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Save_Annotation_Response"
+                }
+              }
+            },
+            "description" : "Response indicating a successful annotation save"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/addAnnotations_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource"
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Resource Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/addAnnotations_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Add annotations on content.",
+        "tags" : [ "File" ]
+      }
+    },
+    "/files/{uuid}/bookmarks" : {
+      "delete" : {
+        "description" : "Deletes File Bookmarks keyed by Type.",
+        "operationId" : "deleteBookmarks",
+        "parameters" : [ {
+          "description" : "The UUID of the file data.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        }, {
+          "description" : "The Folder Identifier that the file will be associated to. The example provided is for identifying a veteran.<br><br>**Header Format**: folder-type:identifier-type:ID<br><br>**Valid Folder-Types**:<br> <br>* VETERAN - Allows: FILENUMBER, SSN, PARTICIPANT_ID, SEARCH, and EDIPI <br>* PERSON - Allows: PARTICIPANT_ID, SEARCH <br> <br> For search identifiers as a type, the ssn, date of birth, last name, and first name must be supplied on the ID field as query params encoded.",
+          "example" : "VETERAN:FILENUMBER:987267855",
+          "in" : "header",
+          "name" : "X-Folder-URI",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/deleteBookmarksRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/bookmarkResponseModel"
+                }
+              }
+            },
+            "description" : "Successfully deleted the Bookmark(s). Return the saved file query."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/deleteBookmarks_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource"
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Resource Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/saveBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Delete Bookmarks",
+        "tags" : [ "File" ]
+      },
+      "get" : {
+        "description" : "Retrieves File Bookmarks keyed by Realm.",
+        "operationId" : "getBookmarks",
+        "parameters" : [ {
+          "description" : "The UUID of the file data.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarksResponseModel"
+                }
+              }
+            },
+            "description" : "bookmarks are returned."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves bookmarks.",
+        "tags" : [ "File" ]
+      },
+      "put" : {
+        "description" : "Saves File Bookmarks keyed by Type. Updates Comments of Existing Bookmarks.",
+        "operationId" : "saveBookmarks",
+        "parameters" : [ {
+          "description" : "The UUID of the file data.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        }, {
+          "description" : "The Folder Identifier that the file will be associated to. The example provided is for identifying a veteran.<br><br>**Header Format**: folder-type:identifier-type:ID<br><br>**Valid Folder-Types**:<br> <br>* VETERAN - Allows: FILENUMBER, SSN, PARTICIPANT_ID, SEARCH, and EDIPI <br>* PERSON - Allows: PARTICIPANT_ID, SEARCH <br> <br> For search identifiers as a type, the ssn, date of birth, last name, and first name must be supplied on the ID field as query params encoded.",
+          "example" : "VETERAN:FILENUMBER:987267855",
+          "in" : "header",
+          "name" : "X-Folder-URI",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/saveBookmarksRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/bookmarkResponseModel"
+                }
+              }
+            },
+            "description" : "Successfully saved the Bookmark(s). Return the saved file query."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/saveBookmarks_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource"
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Resource Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/saveBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Save and Update Bookmarks",
+        "tags" : [ "File" ]
+      }
+    },
+    "/files/{uuid}/annotations/{annotationUuid}" : {
+      "delete" : {
+        "description" : "Deletes an annotation.",
+        "operationId" : "deleteAnnotation",
+        "parameters" : [ {
+          "description" : "The UUID of the file data.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        }, {
+          "description" : "The UUID of the annotation.",
+          "in" : "path",
+          "name" : "annotationUuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The annotation was deleted successfully."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          }
+        },
+        "summary" : "Deletes an annotation.",
+        "tags" : [ "File" ]
+      },
+      "put" : {
+        "description" : "### Update annotations.\nUpdates annotation data on a document. The annotation object schema is listed at the bottom of this swagger page.",
+        "operationId" : "updateAnnotations",
+        "parameters" : [ {
+          "description" : "The UUID of the file data.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        }, {
+          "description" : "The UUID of the annotation data.",
+          "in" : "path",
+          "name" : "annotationUuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Update_Annotation_Request"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Empty response indicates a successful annotation save"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/updateOcrData_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource"
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Resource Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/updateAnnotations_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Update annotation on a document.",
+        "tags" : [ "File" ]
+      }
+    },
+    "/files/{uuid}/associations/claims" : {
+      "get" : {
+        "description" : "this endpoint retrieves the claim associations on a given document",
+        "operationId" : "getAssociation",
+        "parameters" : [ {
+          "description" : "The UUID of the file.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getAssociation_200_response"
+                }
+              }
+            },
+            "description" : "Response containing the file UUID, the owner, as well as conversion information if the document has been converted."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource"
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Resource Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "tags" : [ "Association" ]
+      },
+      "put" : {
+        "description" : "This endpoint when given a array of claim Ids compared the claim Ids to already associated ones and removes the missing claim associarions and adds the new ones.",
+        "operationId" : "associate",
+        "parameters" : [ {
+          "description" : "The UUID of the file.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/associate_request"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Response indicating a successful data update."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/associate_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource"
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Resource Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/saveBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Add/remove claim associations to a given document",
+        "tags" : [ "Association" ]
+      }
+    },
+    "/files/uuids:exchange" : {
+      "post" : {
+        "description" : "### Exchange UUIDs\n This endpoint, when given historical version uuids, exchanges them with the main file identifiers (uuid).",
+        "operationId" : "UUIDExchange",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "example" : {
+                "versionUuids" : [ "862809db-1d91-4727-95c1-c3a9f3836e7c", "1c28dd40-f8a0-4c8a-905a-01692b3683b5" ]
+              },
+              "schema" : {
+                "$ref" : "#/components/schemas/uuidExchangeRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "uuids" : {
+                    "862809db-1d91-4727-95c1-c3a9f3836e7c" : "5578e33c-0d52-40b7-bee0-d1aac49ae18b",
+                    "1c28dd40-f8a0-4c8a-905a-01692b3683b5" : "b4840322-5e32-49ab-b118-f2901f6c8825"
+                  }
+                },
+                "schema" : {
+                  "$ref" : "#/components/schemas/uuidExchangeResponse"
+                }
+              }
+            },
+            "description" : "Exchange of versionUUIDs for UUIDs was successful."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/vefsErrorResponse"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/vefsErrorResponse"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/vefsErrorResponse"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource"
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/vefsErrorResponse"
+                }
+              }
+            },
+            "description" : "Resource Not Found"
+          },
+          "405" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/vefsErrorResponse"
+                }
+              }
+            },
+            "description" : "Method Not Allowed"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/vefsErrorResponse"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/vefsErrorResponse"
+                }
+              }
+            },
+            "description" : "This request is not yet implemented."
+          }
+        },
+        "security" : [ {
+          "bearer-key" : [ ]
+        } ],
+        "summary" : "Map CurrentVersionUuids to UUIDs Endpoint",
+        "tags" : [ "File" ]
+      }
+    },
+    "/permissions/folders" : {
+      "get" : {
+        "description" : "Retrieves folder level permissions for the requesting user.",
+        "operationId" : "getFolderPermissions",
+        "parameters" : [ {
+          "description" : "The Folder Identifier that the file will be associated to. The example provided is for identifying a veteran.<br><br>**Header Format**: folder-type:identifier-type:ID<br><br>**Valid Folder-Types**:<br> <br>* VETERAN - Allows: FILENUMBER, SSN, PARTICIPANT_ID, SEARCH, and EDIPI <br>* PERSON - Allows: PARTICIPANT_ID, SEARCH <br> <br> For search identifiers as a type, the ssn, date of birth, last name, and first name must be supplied on the ID field as query params encoded.",
+          "example" : "VETERAN:FILENUMBER:987267855",
+          "in" : "header",
+          "name" : "X-Folder-URI",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/folderPermissionsResponse"
+                }
+              }
+            },
+            "description" : "permission info is returned"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/deleteBookmarks_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves folder level permissions.",
+        "tags" : [ "Permissions" ]
+      }
+    },
+    "/permissions/post/files" : {
+      "get" : {
+        "description" : "Retrieves upload permissions for the requesting user.",
+        "operationId" : "getUploadPermissions",
+        "parameters" : [ {
+          "description" : "The Folder Identifier that the file will be associated to. The example provided is for identifying a veteran.<br><br>**Header Format**: folder-type:identifier-type:ID<br><br>**Valid Folder-Types**:<br> <br>* VETERAN - Allows: FILENUMBER, SSN, PARTICIPANT_ID, SEARCH, and EDIPI <br>* PERSON - Allows: PARTICIPANT_ID, SEARCH <br> <br> For search identifiers as a type, the ssn, date of birth, last name, and first name must be supplied on the ID field as query params encoded.",
+          "example" : "VETERAN:FILENUMBER:987267855",
+          "in" : "header",
+          "name" : "X-Folder-URI",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/postPermissionsResponse"
+                }
+              }
+            },
+            "description" : "permission info is returned"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/deleteBookmarks_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves upload permissions.",
+        "tags" : [ "Permissions" ]
+      }
+    },
+    "/permissions/put/files/{uuid}/data" : {
+      "get" : {
+        "description" : "Retrieves update file data permissions for the requesting user.",
+        "operationId" : "getUpdateDataPermissions",
+        "parameters" : [ {
+          "description" : "The UUID of the file.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/putPermissionsResponse"
+                }
+              }
+            },
+            "description" : "permission info is returned"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves update file data permissions.",
+        "tags" : [ "Permissions" ]
+      }
+    },
+    "/permissions/post/folders/files:search" : {
+      "get" : {
+        "description" : "Retrieves file search permissions for the requesting user.",
+        "operationId" : "getSearchPermissions",
+        "parameters" : [ {
+          "description" : "The Folder Identifier that the file will be associated to. The example provided is for identifying a veteran.<br><br>**Header Format**: folder-type:identifier-type:ID<br><br>**Valid Folder-Types**:<br> <br>* VETERAN - Allows: FILENUMBER, SSN, PARTICIPANT_ID, SEARCH, and EDIPI <br>* PERSON - Allows: PARTICIPANT_ID, SEARCH <br> <br> For search identifiers as a type, the ssn, date of birth, last name, and first name must be supplied on the ID field as query params encoded.",
+          "example" : "VETERAN:FILENUMBER:987267855",
+          "in" : "header",
+          "name" : "X-Folder-URI",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/postPermissionsResponse"
+                }
+              }
+            },
+            "description" : "permission info is returned"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/deleteBookmarks_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves file search permissions.",
+        "tags" : [ "Permissions" ]
+      }
+    },
+    "/permissions/post/files/{fileUuid}/annotations" : {
+      "get" : {
+        "description" : "Retrieves create annotations permissions for the requesting user.",
+        "operationId" : "getCreateAnnotationsPermissions",
+        "parameters" : [ {
+          "description" : "The UUID of the file.",
+          "in" : "path",
+          "name" : "fileUuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/postPermissionsResponse"
+                }
+              }
+            },
+            "description" : "permission info is returned"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves create annotations permissions.",
+        "tags" : [ "Permissions" ]
+      }
+    },
+    "/permissions/put/files/{fileUuid}/annotations/{annotationUuid}" : {
+      "get" : {
+        "description" : "Retrieves update annotations permissions for the requesting user.",
+        "operationId" : "getUpdateAnnotationsPermissions",
+        "parameters" : [ {
+          "description" : "The UUID of the file.",
+          "in" : "path",
+          "name" : "fileUuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        }, {
+          "description" : "The UUID of the annotation.",
+          "in" : "path",
+          "name" : "annotationUuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/putPermissionsResponse"
+                }
+              }
+            },
+            "description" : "permission info is returned"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves update annotations permissions.",
+        "tags" : [ "Permissions" ]
+      }
+    },
+    "/permissions/delete/files/{fileUuid}/annotations/{annotationUuid}" : {
+      "get" : {
+        "description" : "Retrieves delete annotations permissions for the requesting user.",
+        "operationId" : "getDeleteAnnotationsPermissions",
+        "parameters" : [ {
+          "description" : "The UUID of the file.",
+          "in" : "path",
+          "name" : "fileUuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        }, {
+          "description" : "The UUID of the annotation.",
+          "in" : "path",
+          "name" : "annotationUuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/deletePermissionsResponse"
+                }
+              }
+            },
+            "description" : "permission info is returned"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves delete annotations permissions.",
+        "tags" : [ "Permissions" ]
+      }
+    },
+    "/permissions/notes" : {
+      "get" : {
+        "description" : "Retrieves note permissions for all the lines of business.",
+        "operationId" : "getNotePermissions",
+        "parameters" : [ {
+          "description" : "The Folder Identifier that the file will be associated to. The example provided is for identifying a veteran.<br><br>**Header Format**: folder-type:identifier-type:ID<br><br>**Valid Folder-Types**:<br> <br>* VETERAN - Allows: FILENUMBER, SSN, PARTICIPANT_ID, SEARCH, and EDIPI <br>* PERSON - Allows: PARTICIPANT_ID, SEARCH <br> <br> For search identifiers as a type, the ssn, date of birth, last name, and first name must be supplied on the ID field as query params encoded.",
+          "example" : "VETERAN:FILENUMBER:987267855",
+          "in" : "header",
+          "name" : "X-Folder-URI",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "example" : [ {
+                    "lineOfBusiness" : "VRE",
+                    "hasCreateAccess" : true,
+                    "hasAlertAccess" : false,
+                    "hasSearchAccess" : true,
+                    "hasArchiveAccess" : true
+                  }, {
+                    "lineOfBusiness" : "EDU",
+                    "hasCreateAccess" : false,
+                    "hasAlertAccess" : false,
+                    "hasSearchAccess" : true,
+                    "hasArchiveAccess" : false
+                  } ],
+                  "items" : {
+                    "$ref" : "#/components/schemas/notePermissionsResponse"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "description" : "Note permission info is returned for each line of business."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/deleteBookmarks_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves note permissions.",
+        "tags" : [ "Permissions" ]
+      }
+    },
+    "/permissions/patch/files:move" : {
+      "get" : {
+        "description" : "Retrieves unassociate and move permissions for the requesting user.",
+        "operationId" : "getMovePermissions",
+        "parameters" : [ {
+          "description" : "The Folder Identifier is the **source** file that wants to be moved. The example provided is for identifying a veteran.<br><br>**Header Format**: folder-type:identifier-type:ID<br><br>**Valid Folder-Types**:<br> <br>* **VETERAN** - Allows: FILENUMBER, SSN, PARTICIPANT_ID, SEARCH, and EDIPI <br>* **PERSON** - Allows: PARTICIPANT_ID <br>* **BIN** - Format: BIN:NAME:Unassociated <br>",
+          "example" : "VETERAN:FILENUMBER:987267855",
+          "in" : "header",
+          "name" : "X-Folder-URI",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/movePermissionsResponse"
+                }
+              }
+            },
+            "description" : "permission info is returned"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/deleteBookmarks_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves user move permissions.",
+        "tags" : [ "Permissions" ]
+      }
+    },
+    "/permissions/manage/saved-filters" : {
+      "get" : {
+        "description" : "### Retrieves a user's permission to publish saved filters.\n This endpoint returns a user's permission to publish saved filters.",
+        "operationId" : "getPublishSavedFiltersPermission",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/postPermissionsResponse"
+                }
+              }
+            },
+            "description" : "permission info is returned"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves a user's permission to publish saved filters.",
+        "tags" : [ "Permissions" ]
+      }
+    },
+    "/folders/lastreadbycurrentuser" : {
+      "get" : {
+        "description" : "Returns the UUID of the document last read by the user within the specified folder.",
+        "operationId" : "getLastReadDocumentId",
+        "parameters" : [ {
+          "description" : "The Folder Identifier being searched for last read document. The example provided is for identifying a veteran.<br><br>**Header Format**: folder-type:identifier-type:ID<br><br>**Valid Folder-Types**:<br> <br>* VETERAN - Allows: FILENUMBER, SSN, PARTICIPANT_ID, SEARCH, and EDIPI <br>* PERSON - Allows: PARTICIPANT_ID, SEARCH <br> <br> For identifiers as a type, the ssn, date of birth, last name, and first name must be supplied on the ID field as query params encoded.",
+          "example" : "VETERAN:FILENUMBER:987267855",
+          "in" : "header",
+          "name" : "X-Folder-URI",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/lastReadDocumentResponse"
+                }
+              },
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/lastReadDocumentResponse"
+                }
+              }
+            },
+            "description" : "Lookup was successful for the given folder identifier."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/deleteBookmarks_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Get Last Read Document",
+        "tags" : [ "Last Read" ]
+      }
+    },
+    "/documenttypes" : {
+      "get" : {
+        "description" : "Retrieves document types and alternative document types based on role.",
+        "operationId" : "getDocumentTypes",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getDocumentTypesResponse"
+                }
+              }
+            },
+            "description" : "document types and alternative document types are returned"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves document types and alternative document types.",
+        "tags" : [ "Document Types" ]
+      }
+    },
+    "/contentsources" : {
+      "get" : {
+        "description" : "Retrieves content sources for UI consumption.",
+        "operationId" : "getContentSources",
+        "parameters" : [ {
+          "description" : "The Folder Identifier that the file will be associated to. The example provided is for identifying a veteran.<br><br>**Header Format**: folder-type:identifier-type:ID<br><br>**Valid Folder-Types**:<br> <br>* VETERAN - Allows: FILENUMBER, SSN, PARTICIPANT_ID, SEARCH, and EDIPI <br>* PERSON - Allows: PARTICIPANT_ID, SEARCH <br> <br> For search identifiers as a type, the ssn, date of birth, last name, and first name must be supplied on the ID field as query params encoded.",
+          "example" : "VETERAN:FILENUMBER:987267855",
+          "in" : "header",
+          "name" : "X-Folder-URI",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getContentSourcesResponse"
+                }
+              }
+            },
+            "description" : "content sources are returned"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/deleteBookmarks_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves content sources.",
+        "tags" : [ "Content Sources" ]
+      }
+    },
+    "/folders/uploadsources" : {
+      "get" : {
+        "description" : "Retrieves upload sources for UI consumption.",
+        "operationId" : "getUploadSources",
+        "parameters" : [ {
+          "description" : "The Folder Identifier that the file will be associated to. The example provided is for identifying a veteran.<br><br>**Header Format**: folder-type:identifier-type:ID<br><br>**Valid Folder-Types**:<br> <br>* VETERAN - Allows: FILENUMBER, SSN, PARTICIPANT_ID, SEARCH, and EDIPI <br>* PERSON - Allows: PARTICIPANT_ID, SEARCH <br> <br> For search identifiers as a type, the ssn, date of birth, last name, and first name must be supplied on the ID field as query params encoded.",
+          "example" : "VETERAN:FILENUMBER:987267855",
+          "in" : "header",
+          "name" : "X-Folder-URI",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getUploadSourcesResponse"
+                }
+              }
+            },
+            "description" : "upload sources are returned"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/deleteBookmarks_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves upload sources.",
+        "tags" : [ "Upload Sources" ]
+      }
+    },
+    "/files/{uuid}/data/rawtext/ocr/raw" : {
+      "get" : {
+        "description" : "This endpoint will retrieve raw OCR data for the current version of a document represented by the UUID.",
+        "operationId" : "getOcrRaw",
+        "parameters" : [ {
+          "description" : "The UUID of the raw OCR data to retrieve.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "additionalProperties" : {
+                    "type" : "string"
+                  },
+                  "example" : {
+                    "ocrRaw" : "This is example text to demonstrate the format of the response from this endpoint. Any text can be stored and retrieved, but it will be treated as plain text for the response."
+                  },
+                  "maxProperties" : 1,
+                  "minProperties" : 1,
+                  "type" : "object"
+                }
+              }
+            },
+            "description" : "Raw OCR text for the current version of a document is returned."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getOcrRaw_404_response"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request. Response will contain a \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieve raw OCR data for the current version of a document",
+        "tags" : [ "OCR" ]
+      },
+      "post" : {
+        "description" : "Create raw OCR text for the current version of the given document UUID. If raw OCR text data already exists for the given UUID, an error will occur.",
+        "operationId" : "createOcrRaw",
+        "parameters" : [ {
+          "description" : "The UUID of the document on which to create OCR raw text.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "type" : "string"
+              }
+            }
+          },
+          "description" : "The raw OCR text to store for the current version of this document. This value will be treated as plain text.",
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "A response which indicates the raw OCR data was successfully created."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/vefsErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/updateOcrRaw_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request. Response will contain a \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Create raw OCR text for the current version of the given document UUID",
+        "tags" : [ "OCR" ]
+      },
+      "put" : {
+        "description" : "Update raw OCR text for the current version of the given document UUID. If raw OCR text data does not already exist for the given UUID in order to be updated, an error will occur.",
+        "operationId" : "updateOcrRaw",
+        "parameters" : [ {
+          "description" : "The UUID of the document on which to update OCR raw text.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "type" : "string"
+              }
+            }
+          },
+          "description" : "The raw OCR text to store for the current version of this document. This value will be treated as plain text.",
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "A response which indicates the raw OCR data was successfully updated."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/vefsErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/updateOcrRaw_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request. Response will contain a \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Update raw OCR text for the current version of the given document UUID",
+        "tags" : [ "OCR" ]
+      }
+    },
+    "/files/{uuid}/data/rawtext/ocr/perspective/{key}" : {
+      "get" : {
+        "description" : "This endpoint will retrieve an OCR perspective text for the current version of a document represented by the UUID, and identified by a given perspective key.",
+        "operationId" : "getOcrPerspective",
+        "parameters" : [ {
+          "description" : "The UUID of the OCR perspective data to retrieve.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        }, {
+          "description" : "The key of the OCR perspective data to retrieve.",
+          "in" : "path",
+          "name" : "key",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "additionalProperties" : {
+                    "type" : "string"
+                  },
+                  "example" : {
+                    "testPerspective" : "This is example text to demonstrate the format of the response from this endpoint. Any text can be stored and retrieved, but it will be treated as plain text for the response."
+                  },
+                  "maxProperties" : 1,
+                  "minProperties" : 1,
+                  "type" : "object"
+                }
+              }
+            },
+            "description" : "Requested OCR perspective text for the current version of a document is returned."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getOcrPerspective_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getOcrRaw_404_response"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/vefsErrorResponse"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request. Response will contain a \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieve OCR perspective text for the current version of a document by perspective key",
+        "tags" : [ "OCR" ]
+      },
+      "post" : {
+        "description" : "Creates an OCR perspective for the current version of the given document UUID. If the perspective key already exists for the given UUID, an error will occur.",
+        "operationId" : "createOcrPerspective",
+        "parameters" : [ {
+          "description" : "The UUID of the document on which to create OCR perspective data.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        }, {
+          "description" : "The key of the OCR perspective data to create.",
+          "in" : "path",
+          "name" : "key",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "example" : "This is example text to demonstrate the format of the request body for this endpoint. Any text format can be stored and retrieved, but it will be treated as plain text.",
+                "minLength" : 1,
+                "type" : "string"
+              }
+            }
+          },
+          "description" : "Plain text data to store under the OCR perspective key in the current version of a document.",
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "A response which indicates the OCR perspective data was successfully updated."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/vefsErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/updateOcrRaw_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request. Response will contain a \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Create an OCR perspective for the current version of the given document UUID",
+        "tags" : [ "OCR" ]
+      },
+      "put" : {
+        "description" : "Updates an OCR perspective for the current version of the given document UUID. If the perspective key does not exist for the given UUID, an error will occur.",
+        "operationId" : "updateOcrPerspective",
+        "parameters" : [ {
+          "description" : "The UUID of the document on which to update OCR perspective data.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        }, {
+          "description" : "The key of the OCR perspective data to update.",
+          "in" : "path",
+          "name" : "key",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "text/plain" : {
+              "schema" : {
+                "example" : "This is example text to demonstrate the format of the request body for this endpoint. Any text format can be stored and retrieved, but it will be treated as plain text.",
+                "minLength" : 1,
+                "type" : "string"
+              }
+            }
+          },
+          "description" : "Plain text data to store under the OCR perspective key in the current version of a document.",
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "A response which indicates the OCR perspective data was successfully updated."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/vefsErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/updateOcrRaw_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request. Response will contain a \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Update an OCR perspective for the current version of the given document UUID",
+        "tags" : [ "OCR" ]
+      }
+    },
+    "/ocr/reprocess/file" : {
+      "post" : {
+        "description" : "### Upload a file.\n This endpoint when given a csv file containing existing textract job ids is able to reanalyze those jobs",
+        "operationId" : "upload",
+        "requestBody" : {
+          "content" : {
+            "multipart/form-data" : {
+              "encoding" : {
+                "file" : {
+                  "contentType" : "text/csv"
+                }
+              },
+              "schema" : {
+                "$ref" : "#/components/schemas/ocrReanalyze"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ocrReanalyzeResponse"
+                }
+              }
+            },
+            "description" : "Returns json obect containing duplicates, totalProcessed, failed counts and a UUID"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/upload_500_response_1"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request. Response will contain a \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Upload a csv file with textract job ids to be reprocessed",
+        "tags" : [ "OCR" ]
+      }
+    },
+    "/notes" : {
+      "post" : {
+        "description" : "### Create a new note.\n This endpoint allows a new note to be added for a Veteran",
+        "operationId" : "createNote",
+        "parameters" : [ {
+          "description" : "The Folder Identifier that the note will be associated to. The example provided is for identifying a veteran.<br><br>**Header Format**: folder-type:identifier-type:ID<br><br>**Valid Folder Types**:<br><br>* VETERAN<br><br>**Valid Identifier Types**:<br><br>* FILENUMBER<br>* SSN<br>* PARTICIPANT_ID<br>* EDIPI",
+          "example" : "VETERAN:FILENUMBER:987267855",
+          "in" : "header",
+          "name" : "X-Folder-URI",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/createNoteRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/createNoteResponse"
+                }
+              }
+            },
+            "description" : "Response containing the newly created note UUID."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/saveBookmarks_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/createNote_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Create a new note",
+        "tags" : [ "Notes" ]
+      }
+    },
+    "/notes:search" : {
+      "post" : {
+        "description" : "### Searches Notes by provided FolderIdentifier, and search request filers.",
+        "operationId" : "searchNotes",
+        "parameters" : [ {
+          "description" : "The Folder Identifier that the file will be associated to. The example provided is for identifying a veteran.<br><br>**Header Format**: folder-type:identifier-type:ID<br><br>**Valid Folder-Types**:<br> <br>* VETERAN - Allows: FILENUMBER, SSN, PARTICIPANT_ID, SEARCH, and EDIPI <br>* PERSON - Allows: PARTICIPANT_ID, SEARCH <br> <br> For search identifiers as a type, the ssn, date of birth, last name, and first name must be supplied on the ID field as query params encoded.",
+          "example" : "VETERAN:FILENUMBER:987267855",
+          "in" : "header",
+          "name" : "X-Folder-URI",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/searchNotesRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchNotesResponse"
+                }
+              },
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchNotesResponse"
+                }
+              }
+            },
+            "description" : "Search was successful given provided search request."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchNotes_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchNotes_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Search Notes",
+        "tags" : [ "Notes" ]
+      }
+    },
+    "/notes/{uuid}" : {
+      "delete" : {
+        "description" : "Archives a note.",
+        "operationId" : "archiveNote",
+        "parameters" : [ {
+          "description" : "The UUID of the note.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Note has been Archived"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getContent_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Archive a note.",
+        "tags" : [ "Notes" ]
+      }
+    },
+    "/migrate/note" : {
+      "post" : {
+        "description" : "### Migrate a new note.\n This endpoint allows a note to be migrated from an external system for a Veteran.\n It mirrors the creation endpoint with the ability to also send in existing audit information.",
+        "operationId" : "migrateNote",
+        "parameters" : [ {
+          "description" : "The Folder Identifier that the file will be associated to. The example provided is for identifying a veteran.<br><br>**Header Format**: folder-type:identifier-type:ID<br><br>**Valid Folder-Types**:<br> <br>* VETERAN - Allows: FILENUMBER, SSN, PARTICIPANT_ID, SEARCH, and EDIPI <br>* PERSON - Allows: PARTICIPANT_ID, SEARCH <br> <br> For search identifiers as a type, the ssn, date of birth, last name, and first name must be supplied on the ID field as query params encoded.",
+          "example" : "VETERAN:FILENUMBER:987267855",
+          "in" : "header",
+          "name" : "X-Folder-URI",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "items" : {
+                  "$ref" : "#/components/schemas/migrateNoteRequest"
+                },
+                "type" : "array"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/migrateNoteResponse"
+                }
+              }
+            },
+            "description" : "Response containing the newly created note UUID."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/migrateNote_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Migrates a note",
+        "tags" : [ "Notes" ]
+      }
+    },
+    "/publishedfilters" : {
+      "get" : {
+        "description" : "### Get Published and Active Filters.\nThis endpoint will retrieve all the published file filters that are currently active.",
+        "operationId" : "getPublishedFilters",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ResponseObject"
+                }
+              }
+            },
+            "description" : "Successfully returns the list of published active filters."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized. Please verify credentials used in the request."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieve the list of published file filters",
+        "tags" : [ "Saved Filter" ]
+      }
+    },
+    "/savedfilters" : {
+      "get" : {
+        "description" : "### Get Saved Subscribed and Personal Filters. \nThis endpoint will return a list containing both a users saved subscribed filters\nas well as their saved personal filters.",
+        "operationId" : "retrieveSavedFilters",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ResponseObject_1"
+                }
+              }
+            },
+            "description" : "Successfully returns the list of both subscribed and personal filters for the requesting user."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized. Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RESOURCE_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Resource Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_USER"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/retrieveSavedFilters_501_response"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieve list of user saved filters",
+        "tags" : [ "Saved Filter" ]
+      },
+      "post" : {
+        "description" : "### Save and Publish a Filter.  \nAllows admin to save and publish a filter.",
+        "operationId" : "saveAndPublishFilter",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/FilterRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/saveAndPublishFilter_200_response"
+                }
+              }
+            },
+            "description" : "Successfully saves and publishes filter."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/associate_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence action is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized. Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RESOURCE_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Resource Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/saveBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Save and publish a filter.",
+        "tags" : [ "Saved Filter" ]
+      }
+    },
+    "/savedfilters/{id}" : {
+      "patch" : {
+        "description" : "### Edit Existing Personal Filter. \nAllows the requesting user to edit the name and content of personal filters.\nIf requesting user is a NWQ admin then they will also be able to edit the published\nstatus of the filter.",
+        "operationId" : "updateSavedFilter",
+        "parameters" : [ {
+          "description" : "The id of the filter to be amended.",
+          "in" : "path",
+          "name" : "id",
+          "required" : true,
+          "schema" : {
+            "type" : "integer"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/updateSavedFilter_200_response"
+                }
+              }
+            },
+            "description" : "Successfully edit the chosen filter."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/associate_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized. Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RESOURCE_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Resource Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Allows user to edit existing filter",
+        "tags" : [ "Saved Filter" ]
+      }
+    },
+    "/publishedfilters/{id}/subscribe" : {
+      "post" : {
+        "description" : "### Subscribe to Published Filter.  \nAllows the requesting user to subscribe to a published filter which will be added\nto their list of saved subscribed filters.",
+        "operationId" : "subscribeToPublishedSavedFilter",
+        "parameters" : [ {
+          "description" : "The id of the filter user wishes to subscribe to.",
+          "in" : "path",
+          "name" : "id",
+          "required" : true,
+          "schema" : {
+            "type" : "integer"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/subscribeToPublishedSavedFilter_200_response"
+                }
+              }
+            },
+            "description" : "Successfully returns the newly created record in VBMSUI.SAVED_FILTER_SUBSCRIPTION."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized. Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RESOURCE_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Resource Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Allows user to subscribe to a published filter",
+        "tags" : [ "Saved Filter" ]
+      }
+    },
+    "/publishedfilters/{id}/unsubscribe" : {
+      "post" : {
+        "description" : "### Unsubscribe to a Filter. \nAllows the requesting user to unsubscribe to a published filter which will then\nremove this filter from their list of saved subscribed filters.",
+        "operationId" : "unsubscribeFromPublishedSavedFilter",
+        "parameters" : [ {
+          "description" : "The id of the filter to which the user wants to unsubscribe",
+          "in" : "path",
+          "name" : "id",
+          "required" : true,
+          "schema" : {
+            "type" : "integer"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/unsubscribeFromPublishedSavedFilter_200_response"
+                }
+              }
+            },
+            "description" : "Successfully unsubscribes to user filter and removes it from their subscribed list of filters."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized. Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RESOURCE_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Resource Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Allows user to unsubscribe to a published filter",
+        "tags" : [ "Saved Filter" ]
+      }
+    },
+    "/manage/queries/{id}" : {
+      "delete" : {
+        "description" : "### Deletes a saved file query.\n This endpoint allows a user to delete a saved file query using an id.",
+        "operationId" : "deleteSavedFileQuery",
+        "parameters" : [ {
+          "description" : "id of the saved file query you wish to delete.",
+          "in" : "path",
+          "name" : "queryId",
+          "required" : true,
+          "schema" : {
+            "type" : "integer"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/deleteSavedFileQuery_200_response"
+                }
+              }
+            },
+            "description" : "Saved file query for the matching id is deleted."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource"
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RESOURCE_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Resource Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Delete a saved file query",
+        "tags" : [ "File Queries" ]
+      }
+    },
+    "/folders/notifications/move" : {
+      "delete" : {
+        "description" : "Updates notification to be acknowledged.",
+        "operationId" : "deleteMoveNotifications",
+        "parameters" : [ {
+          "description" : "The Folder Identifier is the **source** file that wants to be moved. The example provided is for identifying a veteran.<br><br>**Header Format**: folder-type:identifier-type:ID<br><br>**Valid Folder-Types**:<br> <br>* **VETERAN** - Allows: FILENUMBER, SSN, PARTICIPANT_ID, SEARCH, and EDIPI <br>* **PERSON** - Allows: PARTICIPANT_ID <br>* **BIN** - Format: BIN:NAME:Unassociated <br>",
+          "example" : "VETERAN:FILENUMBER:987267855",
+          "in" : "header",
+          "name" : "X-Folder-URI",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Notification Dismissal was successful"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/deleteBookmarks_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Deletes move notifications.",
+        "tags" : [ "Move Notifications" ]
+      },
+      "get" : {
+        "description" : "Retrieves all the move notifications.",
+        "operationId" : "getMoveNotifications",
+        "parameters" : [ {
+          "description" : "The Folder Identifier is the **source** file that wants to be moved. The example provided is for identifying a veteran.<br><br>**Header Format**: folder-type:identifier-type:ID<br><br>**Valid Folder-Types**:<br> <br>* **VETERAN** - Allows: FILENUMBER, SSN, PARTICIPANT_ID, SEARCH, and EDIPI <br>* **PERSON** - Allows: PARTICIPANT_ID <br>* **BIN** - Format: BIN:NAME:Unassociated <br>",
+          "example" : "VETERAN:FILENUMBER:987267855",
+          "in" : "header",
+          "name" : "X-Folder-URI",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/moveNotificationsResponse"
+                }
+              }
+            },
+            "description" : "Response indicates a successful move notification retrieval"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/deleteBookmarks_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves move notifications.",
+        "tags" : [ "Move Notifications" ]
+      }
+    },
+    "/files/{uuid}/periodOfService" : {
+      "get" : {
+        "description" : "### Retrieves the Period of Service Documents of a Veteran. This includes information such as EOD, RAD, Verified/Vads Verified Status.\n This endpoint allows to get the Period of Service Information.",
+        "operationId" : "getPeriodOfServiceInfo",
+        "parameters" : [ {
+          "description" : "The UUID of the file data.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/periodOfServiceDocumentsResponse"
+                }
+              }
+            },
+            "description" : "Successfully retrieved the Period of Service Documents"
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves Period Of Service Documents",
+        "tags" : [ "Period Of Service" ]
+      }
+    },
+    "/files/{uuid}/{versionuuid}/content" : {
+      "get" : {
+        "description" : "Retrieves content based on file UUID and version UUID",
+        "operationId" : "getVersionContent",
+        "parameters" : [ {
+          "description" : "The UUID of the file data.",
+          "in" : "path",
+          "name" : "uuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        }, {
+          "description" : "Version uuid of the file data.",
+          "in" : "path",
+          "name" : "versionUuid",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/pdf" : { }
+            },
+            "description" : "Content for specified version file is returned."
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/INVALID_JWT"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "JWT contains claims which indicate the consumer is not authorized to access the resource."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UNAUTHORIZED"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getContent_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves file content for given version UUID",
+        "tags" : [ "Version Content" ]
+      }
+    },
+    "/manifest" : {
+      "post" : {
+        "operationId" : "uploadManifest",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/uploadRequest_1"
+              }
+            }
+          },
+          "description" : "File upload manifest request with associated document identifiers to upload"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/uploadResponse_1"
+                }
+              }
+            },
+            "description" : "Successful creation of the manifest"
+          }
+        },
+        "summary" : "Create a new file upload manifest with a list of associated documents",
+        "tags" : [ "Manifest" ]
+      }
+    },
+    "/manifest/{fileNumber}/manifest/{manifestId}" : {
+      "get" : {
+        "description" : "Retrieves the manifest data from the database.",
+        "operationId" : "getManifestById",
+        "parameters" : [ {
+          "description" : "The file number associated with the manifest.",
+          "in" : "path",
+          "name" : "fileNumber",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "description" : "The manifest ID.",
+          "in" : "path",
+          "name" : "manifestId",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getManifestResponse"
+                }
+              }
+            },
+            "description" : "Successful retrieval of the manifest"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/deleteBookmarks_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves the manifest using manifest id.",
+        "tags" : [ "Manifest" ]
+      },
+      "patch" : {
+        "description" : "Updates a manifest by adding documents or setting a claim ID.",
+        "operationId" : "updateManifest",
+        "parameters" : [ {
+          "description" : "The file number associated with the manifest.",
+          "in" : "path",
+          "name" : "fileNumber",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "description" : "The manifest ID.",
+          "in" : "path",
+          "name" : "manifestId",
+          "required" : true,
+          "schema" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/manifestPatchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "description" : "Standard VEFS response indicating a successful operation",
+                  "type" : "object"
+                }
+              }
+            },
+            "description" : "Successful update of the manifest"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/deleteBookmarks_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used invefsResponse.yml the request."
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "description" : "Standard VEFS response indicating the manifest was not found",
+                  "type" : "object"
+                }
+              }
+            },
+            "description" : "The requested manifest was not found."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Updates an existing manifest.",
+        "tags" : [ "Manifest" ]
+      }
+    },
+    "/manifest/{fileNumber}/claim/{claimId}" : {
+      "get" : {
+        "description" : "Retrieves the manifest data from the database.",
+        "operationId" : "getManifestByClaimId",
+        "parameters" : [ {
+          "description" : "The file number associated with the manifest.",
+          "in" : "path",
+          "name" : "fileNumber",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "description" : "The claim ID.",
+          "in" : "path",
+          "name" : "claimId",
+          "required" : true
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getManifestResponse"
+                }
+              }
+            },
+            "description" : "Successful retrieval of the manifest"
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/deleteBookmarks_400_response"
+                }
+              }
+            },
+            "description" : "Server was unable to understand the request. This may come back as an empty response if the json is malformed or not understood by the server."
+          },
+          "401" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/noJwtResponse"
+                }
+              }
+            },
+            "description" : "The authentication mechanism failed and hence access is forbidden."
+          },
+          "403" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/searchFiles_403_response"
+                }
+              }
+            },
+            "description" : "The request is not authorized.  Please verify credentials used in the request."
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/getBookmarks_500_response"
+                }
+              }
+            },
+            "description" : "There was an error encountered processing the Request.  Response will contain a  \"messages\" element that will provide further information on the error.  Please retry.  If problem persists, please contact support with a copy of the Response."
+          },
+          "501" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+                }
+              }
+            },
+            "description" : "This endpoint is not enabled."
+          }
+        },
+        "summary" : "Retrieves the manifest using claim id.",
+        "tags" : [ "Manifest" ]
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "searchFileRequest" : {
+        "description" : "Request containing search filters, sorting information, and paging information. The filter block is required, but the individual filters are optional.",
+        "properties" : {
+          "pageRequest" : {
+            "$ref" : "#/components/schemas/pageRequest"
+          },
+          "filters" : {
+            "$ref" : "#/components/schemas/Filters"
+          },
+          "sorts" : {
+            "$ref" : "#/components/schemas/Sorts"
+          }
+        },
+        "required" : [ "filters", "pageRequest" ],
+        "title" : "Search Files Request",
+        "type" : "object"
+      },
+      "Filters" : {
+        "properties" : {
+          "providerData.documentTypeId" : {
+            "$ref" : "#/components/schemas/documentTypeIdFilter"
+          },
+          "providerData.documentCategoryId" : {
+            "$ref" : "#/components/schemas/documentCategoryIdFilter"
+          },
+          "providerData.subject" : {
+            "$ref" : "#/components/schemas/subjectFilter"
+          },
+          "systemData.contentName" : {
+            "$ref" : "#/components/schemas/contentNameFilter"
+          },
+          "providerData.contentSource" : {
+            "$ref" : "#/components/schemas/contentSourceFilter"
+          },
+          "providerData.dateVaReceivedDocument" : {
+            "$ref" : "#/components/schemas/dateVaReceivedDocumentFilter"
+          },
+          "providerData.endProductCode" : {
+            "$ref" : "#/components/schemas/endProductCodeFilter"
+          },
+          "providerData.associatedClaimId" : {
+            "$ref" : "#/components/schemas/associatedClaimId"
+          },
+          "providerData.associationDateTime" : {
+            "$ref" : "#/components/schemas/associationDateTimeFilter"
+          },
+          "systemData.uploadedDateTime" : {
+            "$ref" : "#/components/schemas/associationDateTimeFilter"
+          },
+          "systemData.mimeType" : {
+            "$ref" : "#/components/schemas/mimeTypeFilter"
+          },
+          "systemData.uploadSource" : {
+            "$ref" : "#/components/schemas/uploadSourceFilter"
+          },
+          "providerData.claimantFirstName" : {
+            "$ref" : "#/components/schemas/claimantFirstNameFilter"
+          },
+          "providerData.claimantLastName" : {
+            "$ref" : "#/components/schemas/claimantLastNameFilter"
+          },
+          "providerData.claimantMiddleInitial" : {
+            "$ref" : "#/components/schemas/claimantMiddleInitialFilter"
+          },
+          "providerData.claimantSsn" : {
+            "$ref" : "#/components/schemas/claimantSsnFilter"
+          },
+          "providerData.claimantDateOfBirth" : {
+            "$ref" : "#/components/schemas/claimantDateOfBirthFilter"
+          },
+          "providerData.benefitTypeId" : {
+            "$ref" : "#/components/schemas/benefitTypeIdFilter"
+          },
+          "rawTextData.ocrPerspective" : {
+            "$ref" : "#/components/schemas/ocrPerspectiveFilter"
+          },
+          "providerData.payeeCode" : {
+            "$ref" : "#/components/schemas/payeeCodeFilter"
+          },
+          "providerData.regionalProcessingOffice" : {
+            "$ref" : "#/components/schemas/regionalProcessingOfficeFilter"
+          },
+          "providerData.facilityCode" : {
+            "$ref" : "#/components/schemas/facilityCodeFilter"
+          },
+          "providerData.claimantParticipantId" : {
+            "$ref" : "#/components/schemas/claimantParticipantIdFilter"
+          },
+          "providerData.lineOfBusinessId" : {
+            "$ref" : "#/components/schemas/lineOfBusinessIdFilter"
+          },
+          "providerData.duplicateInformation.groupId" : {
+            "$ref" : "#/components/schemas/duplicateGroupIdFilter"
+          },
+          "providerData.textSearchable" : {
+            "$ref" : "#/components/schemas/textSearchableFilter"
+          },
+          "providerData.hasAnnotations" : {
+            "$ref" : "#/components/schemas/hasAnnotationsFilter"
+          },
+          "providerData.annotationType" : {
+            "$ref" : "#/components/schemas/annotationTypeFilter"
+          },
+          "providerData.annotationKeyword" : {
+            "$ref" : "#/components/schemas/annotationKeywordFilter"
+          },
+          "providerData.hasNotes" : {
+            "$ref" : "#/components/schemas/hasNotesFilter"
+          },
+          "providerData.ocrStatus" : {
+            "$ref" : "#/components/schemas/ocrStatusFilter"
+          },
+          "textContent" : {
+            "$ref" : "#/components/schemas/textContentFilter"
+          }
+        }
+      },
+      "Sorts" : {
+        "items" : { },
+        "type" : "array"
+      },
+      "searchFileResponse" : {
+        "description" : "Response containing results from search with applied filters.",
+        "properties" : {
+          "page" : {
+            "$ref" : "#/components/schemas/pageResponse"
+          },
+          "files" : {
+            "items" : {
+              "$ref" : "#/components/schemas/currentFileDataComposition"
+            },
+            "type" : "array"
+          }
+        },
+        "title" : "Search File Response",
+        "type" : "object"
+      },
+      "INVALID_JWT" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR40009" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "JWT provided does not contain expected claims, or contains invalid claim value(s)." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "INVALID_REQUEST" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR40010" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Invalid request data." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "INVALID_X_EFOLDER_URI" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR40008" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Header X-EFOLDER-URI contained invalid value %s" ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "UNABLE_TO_VERIFY_FOLDER" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR50014" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Unable to confirm validity of folder with Type %s using Identifier Type %s." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "DOES_NOT_CONFORM_TO_SCHEMA" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR40001" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Error message" ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "VALIDATE_INVALID_VALUE" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR40003" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Key: %s contained invalid value(s) %s" ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "noJwtResponse" : {
+        "description" : "Error response when no JWT is present on the request",
+        "properties" : {
+          "messages" : {
+            "items" : {
+              "$ref" : "#/components/schemas/noJwtResponse_messages_inner"
+            },
+            "type" : "array"
+          }
+        },
+        "title" : "Vefs No JWT Error Response",
+        "type" : "object"
+      },
+      "UNABLE_TO_RETRIEVE_PERSON" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR40302" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Unable to retrieve folder of Type: %s using Identifier: %s." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "UNABLE_TO_RETRIEVE_VETERAN" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR40302" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Unable to retrieve folder of Type: %s using Identifier: %s." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "UNAUTHORIZED" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR40301" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Unauthorized." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "UNABLE_TO_RETRIEVE_USER" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR50006" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Unknown error encountered retrieving user information." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "NO_RESULTS_RETURNED" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR50006" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "No results returned for %s." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "INVALID_EVALUATION_TYPE" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR50015" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Error encountered processing - %s is not a valid filter evaluation type for %s" ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "NULL_RESPONSE" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR50051" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Null response found on payload." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "UNKNOWN_ERROR" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR50009" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Unknown system error occurred." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "JSON_DESERIALIZATION" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR50011" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "JSON deserialization error." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "JSON_SERIALIZATION" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR50010" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "JSON serialization error." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "OPERATION_NOT_ENABLED" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR50102" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Operation not enabled." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "uploadRequest" : {
+        "description" : "Upload request containing the file binary and upload payload data",
+        "properties" : {
+          "payload" : {
+            "$ref" : "#/components/schemas/payload"
+          },
+          "file" : {
+            "format" : "binary",
+            "type" : "string"
+          }
+        },
+        "required" : [ "file", "payload" ],
+        "title" : "Upload Request",
+        "type" : "object"
+      },
+      "uploadResponse" : {
+        "properties" : {
+          "uuid" : {
+            "description" : "UUID representing the file as a whole. This is used for all primary VEFS-Operations.",
+            "example" : "c30626c9-954d-4dd1-9f70-1e38756d9d97",
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "currentVersionUuid" : {
+            "description" : "UUID representing the single point-in-time version of the document.",
+            "example" : "c30626c9-954d-4dd1-9f70-1e38756d9d98",
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "conversionInformation" : {
+            "$ref" : "#/components/schemas/conversionInformation"
+          }
+        },
+        "title" : "Upload Response",
+        "type" : "object"
+      },
+      "DUPLICATE_PROVIDERDATA_KEYS" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR40002" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Duplicate key: providerData contained duplicate keys %s" ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "DISABLED_IDENTIFER" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR40059" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Identifier %s is not enabled" ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "INVALID_MIMETYPE" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR41501" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "File binary content contained magic bytes indicates mime type: %s which does not match accepted mime types: %s" ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "WRONG_MIMETYPE_EXTENSION" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR41502" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "File binary content contained magic bytes indicates mime type: %s which does not match filename extension: %s" ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "UNABLE_TO_DETERMINE_MIMETYPE" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR50001" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "File binary content's mime type was unable to be determined. Accepted Type(s): %s" ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "UNABLE_TO_UPLOAD_DOCUMENT_CONTENT" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR50002" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Unknown error encountered uploading content." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "UNABLE_TO_PERSIST_DATA" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR50003" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Unknown error encountered saving data." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "UNABLE_TO_CONVERT" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR50012" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Unable to convert document from mime type %s to mime type %s" ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "updateRequest" : {
+        "description" : "Request containing the updated file binary and payload data",
+        "properties" : {
+          "payload" : {
+            "$ref" : "#/components/schemas/payload_1"
+          },
+          "file" : {
+            "format" : "binary",
+            "type" : "string"
+          }
+        },
+        "required" : [ "file", "payload" ],
+        "title" : "Update File Request",
+        "type" : "object"
+      },
+      "updateResponse" : {
+        "properties" : {
+          "uuid" : {
+            "description" : "UUID representing the file as a whole. This is used for all primary  Operations.",
+            "example" : "c30626c9-954d-4dd1-9f70-1e38756d9d97",
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "currentVersionUuid" : {
+            "description" : "UUID representing the single point-in-time version of the document.",
+            "example" : "c30626c9-954d-4dd1-9f70-1e38756d9d98",
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "conversionInformation" : {
+            "$ref" : "#/components/schemas/conversionInformation"
+          }
+        },
+        "title" : "Update File Response",
+        "type" : "object"
+      },
+      "CURRENT_VERSION_NOT_FOUND" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR40402" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Current Version not found for UUID %s." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "UNABLE_TO_REMEDIATE_DATA" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR50013" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Unknown error encountered remediating data." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "currentFileDataComposition" : {
+        "description" : "Schema for the response data for getFileData and search endpoints.",
+        "properties" : {
+          "owner" : {
+            "$ref" : "#/components/schemas/folderIdentifier"
+          },
+          "uuid" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "currentVersionUuid" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "currentVersion" : {
+            "$ref" : "#/components/schemas/versionComposition"
+          }
+        },
+        "title" : "Current File Data Response",
+        "type" : "object"
+      },
+      "currentFileDataCompositionWithRawTextData" : {
+        "description" : "Schema for the response data for getFileData and search endpoints that contains raw text data.",
+        "properties" : {
+          "owner" : {
+            "$ref" : "#/components/schemas/folderIdentifier"
+          },
+          "uuid" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "currentVersionUuid" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "currentVersion" : {
+            "$ref" : "#/components/schemas/versionCompositionWithRawTextData"
+          }
+        },
+        "title" : "Current File Data Response including Raw Text Data",
+        "type" : "object"
+      },
+      "INVALID_RESPONSE" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR50050" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Invalid response found on payload." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "updateDataRequest" : {
+        "description" : "Request containing the provider data for the update file data endpoint.",
+        "properties" : {
+          "providerData" : {
+            "$ref" : "#/components/schemas/updateDataProviderData"
+          }
+        },
+        "title" : "Update File Data Request",
+        "type" : "object"
+      },
+      "ocrDataResponse" : {
+        "description" : "Response containing OCR data for a file",
+        "properties" : {
+          "processingInformation" : {
+            "$ref" : "#/components/schemas/processingInformation"
+          },
+          "file" : {
+            "$ref" : "#/components/schemas/file"
+          }
+        },
+        "required" : [ "file", "processingInformation" ],
+        "title" : "OCR Data Response",
+        "type" : "object"
+      },
+      "RESOURCE_NOT_FOUND" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "description" : "Enumerated Error Code indicating the error classification.",
+              "enum" : [ "VEFSERR40401" ],
+              "title" : "Error Code",
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Expected resource not found." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "ocrDataRequest" : {
+        "description" : "Request containing OCR data for a file",
+        "properties" : {
+          "processingInformation" : {
+            "$ref" : "#/components/schemas/processingInformation"
+          },
+          "file" : {
+            "$ref" : "#/components/schemas/file"
+          }
+        },
+        "required" : [ "file", "processingInformation" ],
+        "title" : "OCR Data Request",
+        "type" : "object"
+      },
+      "PAYLOAD_VALIDATION" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR50008" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Payload invalid." ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "annotationResponseModel" : {
+        "description" : "Annotations for UI consumption.",
+        "properties" : {
+          "rectangles" : {
+            "items" : {
+              "$ref" : "#/components/schemas/basic"
+            },
+            "type" : "array"
+          },
+          "ovals" : {
+            "items" : {
+              "$ref" : "#/components/schemas/basic"
+            },
+            "type" : "array"
+          },
+          "lines" : {
+            "items" : {
+              "$ref" : "#/components/schemas/lines"
+            },
+            "type" : "array"
+          },
+          "callout" : {
+            "items" : {
+              "$ref" : "#/components/schemas/callout"
+            },
+            "type" : "array"
+          },
+          "freetext" : {
+            "items" : {
+              "$ref" : "#/components/schemas/freetext"
+            },
+            "type" : "array"
+          },
+          "icons" : {
+            "items" : {
+              "$ref" : "#/components/schemas/notes"
+            },
+            "type" : "array"
+          },
+          "stamps" : {
+            "items" : {
+              "$ref" : "#/components/schemas/stamps"
+            },
+            "type" : "array"
+          },
+          "highlights" : {
+            "items" : {
+              "$ref" : "#/components/schemas/textSelection"
+            },
+            "type" : "array"
+          },
+          "underlines" : {
+            "items" : {
+              "$ref" : "#/components/schemas/textSelection"
+            },
+            "type" : "array"
+          },
+          "strikeouts" : {
+            "items" : {
+              "$ref" : "#/components/schemas/textSelection"
+            },
+            "type" : "array"
+          }
+        },
+        "title" : "Annotation Response Model",
+        "type" : "object"
+      },
+      "basicAnnotationRequest" : {
+        "additionalProperties" : false,
+        "description" : "Schema for circle and square type annotations.",
+        "properties" : {
+          "type" : {
+            "$ref" : "#/components/schemas/basicAnnotations"
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "pageNumber" : {
+            "example" : 1,
+            "type" : "integer"
+          },
+          "position" : {
+            "$ref" : "#/components/schemas/position"
+          },
+          "size" : {
+            "$ref" : "#/components/schemas/annotationSize"
+          }
+        },
+        "required" : [ "pageNumber", "position", "size", "title", "type" ],
+        "title" : "Basic Annotation Save Request",
+        "type" : "object"
+      },
+      "lineAnnotationRequest" : {
+        "properties" : {
+          "type" : {
+            "example" : "line",
+            "type" : "string"
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "pageNumber" : {
+            "example" : 1,
+            "type" : "integer"
+          },
+          "points" : {
+            "$ref" : "#/components/schemas/points"
+          }
+        },
+        "required" : [ "Points", "pageNumber", "title", "type" ],
+        "title" : "Line Annotation Save Request",
+        "type" : "object"
+      },
+      "calloutAnnotationRequest" : {
+        "additionalProperties" : false,
+        "properties" : {
+          "type" : {
+            "example" : "callout",
+            "type" : "string"
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "pageNumber" : {
+            "example" : 1,
+            "type" : "integer"
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "tailDirection" : {
+            "$ref" : "#/components/schemas/tailDirection"
+          },
+          "position" : {
+            "$ref" : "#/components/schemas/position"
+          },
+          "size" : {
+            "$ref" : "#/components/schemas/annotationSize"
+          }
+        },
+        "required" : [ "pageNumber", "position", "size", "tailDirection", "title", "type" ],
+        "title" : "Callout Annotation Save Request",
+        "type" : "object"
+      },
+      "freetextAnnotationRequest" : {
+        "additionalProperties" : false,
+        "properties" : {
+          "type" : {
+            "example" : "freetext",
+            "type" : "string"
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "pageNumber" : {
+            "example" : 1,
+            "type" : "integer"
+          },
+          "position" : {
+            "$ref" : "#/components/schemas/position"
+          },
+          "size" : {
+            "$ref" : "#/components/schemas/annotationSize"
+          }
+        },
+        "required" : [ "pageNumber", "position", "size", "title", "type" ],
+        "title" : "Freetext Annotation Request",
+        "type" : "object"
+      },
+      "noteAnnotationRequest" : {
+        "additionalProperties" : false,
+        "properties" : {
+          "type" : {
+            "example" : "icon",
+            "type" : "string"
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "pageNumber" : {
+            "example" : 1,
+            "type" : "integer"
+          },
+          "position" : {
+            "$ref" : "#/components/schemas/position"
+          },
+          "size" : {
+            "$ref" : "#/components/schemas/annotationSize"
+          },
+          "icon" : {
+            "$ref" : "#/components/schemas/icon"
+          }
+        },
+        "required" : [ "icon", "pageNumber", "position", "size", "title", "type" ],
+        "title" : "Icon Annotation Request",
+        "type" : "object"
+      },
+      "stampAnnotationRequest" : {
+        "additionalProperties" : false,
+        "properties" : {
+          "type" : {
+            "example" : "stamp",
+            "type" : "string"
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "pageNumber" : {
+            "example" : 1,
+            "type" : "integer"
+          },
+          "position" : {
+            "$ref" : "#/components/schemas/position"
+          },
+          "size" : {
+            "$ref" : "#/components/schemas/annotationSize"
+          },
+          "image" : {
+            "$ref" : "#/components/schemas/stamp"
+          }
+        },
+        "required" : [ "image", "pageNumber", "position", "size", "title", "type" ],
+        "title" : "Stamp Annotation Request",
+        "type" : "object"
+      },
+      "textSelectionRequest" : {
+        "properties" : {
+          "type" : {
+            "$ref" : "#/components/schemas/textSelectionAnnotations"
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "pageNumber" : {
+            "example" : 1,
+            "type" : "integer"
+          },
+          "selectedAreas" : {
+            "$ref" : "#/components/schemas/selectedAreas"
+          }
+        },
+        "required" : [ "pageNumber", "selectedAreas", "title", "type" ],
+        "title" : "Text Selection Annotation Request",
+        "type" : "object"
+      },
+      "getBookmarksResponseModel" : {
+        "description" : "Bookmarks for UI consumption.",
+        "properties" : {
+          "VBA" : {
+            "$ref" : "#/components/schemas/bookmarkRealmResponseModel"
+          },
+          "VRO" : {
+            "$ref" : "#/components/schemas/bookmarkRealmResponseModel"
+          },
+          "BVA" : {
+            "$ref" : "#/components/schemas/bookmarkRealmResponseModel"
+          }
+        },
+        "title" : "Get Bookmarks Response Model",
+        "type" : "object"
+      },
+      "saveBookmarksRequest" : {
+        "additionalProperties" : false,
+        "properties" : {
+          "appeals" : {
+            "$ref" : "#/components/schemas/saveBookmarksRequest_appeals"
+          },
+          "workingNotes" : {
+            "$ref" : "#/components/schemas/saveBookmarksRequest_workingNotes"
+          },
+          "medical" : {
+            "$ref" : "#/components/schemas/saveBookmarksRequest_medical"
+          },
+          "deferral" : {
+            "$ref" : "#/components/schemas/saveBookmarksRequest_deferral"
+          },
+          "dependency" : {
+            "$ref" : "#/components/schemas/saveBookmarksRequest_dependency"
+          },
+          "peerReview" : {
+            "$ref" : "#/components/schemas/saveBookmarksRequest_peerReview"
+          }
+        },
+        "title" : "Save Bookmark Request",
+        "type" : "object"
+      },
+      "bookmarkResponseModel" : {
+        "properties" : {
+          "type" : {
+            "example" : "WORKING_NOTES",
+            "type" : "string"
+          },
+          "uuid" : {
+            "example" : "00000000-0000-0000-0000-00000229ece2",
+            "type" : "string"
+          },
+          "created" : {
+            "$ref" : "#/components/schemas/bookmarkResponseModel_created"
+          },
+          "updated" : {
+            "$ref" : "#/components/schemas/bookmarkResponseModel_created"
+          },
+          "comment" : {
+            "example" : "Comments are optional",
+            "type" : "string"
+          },
+          "fileNumber" : {
+            "example" : "03232015",
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "deleteBookmarksRequest" : {
+        "additionalProperties" : false,
+        "properties" : {
+          "types" : {
+            "example" : "[\"appeals\", \"dependency\" ]",
+            "items" : {
+              "enum" : [ "appeals", "medical", "peerReview", "workingNotes", "dependency", "deferral" ],
+              "type" : "string"
+            },
+            "maxItems" : 6,
+            "minItems" : 1,
+            "type" : "array",
+            "uniqueItems" : true
+          }
+        },
+        "title" : "Delete Bookmark Request",
+        "type" : "object"
+      },
+      "basicAnnotationUpdateRequest" : {
+        "additionalProperties" : false,
+        "description" : "Schema for basic annotation update. This supports updates for oval, rectangle, icon, freetext, callout, and stamp annotations",
+        "properties" : {
+          "title" : {
+            "type" : "string"
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "position" : {
+            "$ref" : "#/components/schemas/position"
+          },
+          "size" : {
+            "$ref" : "#/components/schemas/annotationSize"
+          }
+        },
+        "title" : "Basic Annotation Update Request",
+        "type" : "object"
+      },
+      "lineAnnotationUpdateRequest" : {
+        "properties" : {
+          "title" : {
+            "type" : "string"
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "points" : {
+            "$ref" : "#/components/schemas/points"
+          }
+        },
+        "title" : "Line Annotation Update Request",
+        "type" : "object"
+      },
+      "uuidExchangeRequest" : {
+        "properties" : {
+          "versionUuids" : {
+            "description" : "A list of version UUIDs to exchange.",
+            "items" : {
+              "format" : "uuid",
+              "type" : "string"
+            },
+            "type" : "array"
+          }
+        },
+        "required" : [ "versionUuids" ],
+        "title" : "VersionUuidsRequest",
+        "type" : "object"
+      },
+      "uuidExchangeResponse" : {
+        "properties" : {
+          "exchangeUuids" : {
+            "additionalProperties" : {
+              "format" : "uuid",
+              "type" : "string"
+            },
+            "description" : "A map where the key is the document ID (version UUID) and the value is the UUID.",
+            "type" : "object"
+          }
+        },
+        "required" : [ "exchangeUuids" ],
+        "title" : "UuidExchangeResponse",
+        "type" : "object"
+      },
+      "vefsErrorResponse" : {
+        "additionalProperties" : false,
+        "description" : "The root schema comprises generic File Store Errors.",
+        "properties" : {
+          "uuid" : {
+            "description" : "UUID used to trace the error response",
+            "format" : "uuid",
+            "title" : "Error UUID",
+            "type" : "string"
+          },
+          "code" : {
+            "description" : "Enumerated Error Code indicating the error classification.",
+            "title" : "Error Code",
+            "type" : "string"
+          },
+          "message" : {
+            "description" : "The message describing the error.",
+            "title" : "The message schema",
+            "type" : "string"
+          }
+        },
+        "title" : "Vefs Error Response",
+        "type" : "object"
+      },
+      "folderPermissionsResponse" : {
+        "description" : "Responses contain permission information for the folder permission endpoint",
+        "properties" : {
+          "update_data" : {
+            "$ref" : "#/components/schemas/folderPermission"
+          },
+          "upload" : {
+            "$ref" : "#/components/schemas/folderPermission"
+          },
+          "bookmarks" : {
+            "$ref" : "#/components/schemas/bookmarkPermissions"
+          },
+          "priorityOcr" : {
+            "$ref" : "#/components/schemas/folderPermission"
+          },
+          "newMail" : {
+            "$ref" : "#/components/schemas/folderPermission"
+          },
+          "pendingScanning" : {
+            "$ref" : "#/components/schemas/pendingScanningPermissions"
+          },
+          "bvaNotes" : {
+            "$ref" : "#/components/schemas/bvaNotesPermissions"
+          },
+          "importEvidence" : {
+            "$ref" : "#/components/schemas/folderPermission"
+          },
+          "militaryServiceInfo" : {
+            "$ref" : "#/components/schemas/militaryServiceInfoPermission"
+          }
+        },
+        "title" : "Folder Permissions Response",
+        "type" : "object"
+      },
+      "postPermissionsResponse" : {
+        "description" : "Responses contain permission information for the endpoint by POST verb",
+        "properties" : {
+          "post" : {
+            "$ref" : "#/components/schemas/verbPermission"
+          }
+        },
+        "title" : "Post Permissions Response",
+        "type" : "object"
+      },
+      "putPermissionsResponse" : {
+        "description" : "Responses contain permission information for the endpoint by PUT verb",
+        "properties" : {
+          "put" : {
+            "$ref" : "#/components/schemas/verbPermission"
+          }
+        },
+        "title" : "Put Permissions Response",
+        "type" : "object"
+      },
+      "deletePermissionsResponse" : {
+        "description" : "Responses contain permission information for the endpoint by DELETE verb",
+        "properties" : {
+          "delete" : {
+            "$ref" : "#/components/schemas/verbPermission"
+          }
+        },
+        "title" : "Delete Permissions Response",
+        "type" : "object"
+      },
+      "notePermissionsResponse" : {
+        "description" : "Note permission response that indicates what functions a line of business is permitted to perform.",
+        "properties" : {
+          "lineOfBusiness" : {
+            "$ref" : "#/components/schemas/lineOfBusiness"
+          },
+          "hasSearchAccess" : {
+            "type" : "boolean"
+          },
+          "hasCreateAccess" : {
+            "type" : "boolean"
+          },
+          "hasAlertAccess" : {
+            "type" : "boolean"
+          },
+          "hasArchiveAccess" : {
+            "type" : "boolean"
+          }
+        },
+        "title" : "Note Permissions Response",
+        "type" : "object"
+      },
+      "movePermissionsResponse" : {
+        "description" : "Responses contain permission information for the endpoint by PATCH verb",
+        "properties" : {
+          "patch" : {
+            "$ref" : "#/components/schemas/patchVerbPermission"
+          }
+        },
+        "title" : "PATCH Permissions Response",
+        "type" : "object"
+      },
+      "lastReadDocumentResponse" : {
+        "additionalProperties" : false,
+        "properties" : {
+          "lastReadDocumentId" : {
+            "description" : "The UUID of the document last read by the user within the folder specified.",
+            "format" : "uuid",
+            "type" : "string"
+          }
+        },
+        "title" : "Last Read Document",
+        "type" : "object"
+      },
+      "getDocumentTypesResponse" : {
+        "description" : "Get document types and alternative document types response object.",
+        "properties" : {
+          "documentTypes" : {
+            "items" : {
+              "$ref" : "#/components/schemas/documentType"
+            },
+            "type" : "array"
+          },
+          "alternativeDocumentTypes" : {
+            "items" : {
+              "$ref" : "#/components/schemas/alternativeDocumentType"
+            },
+            "type" : "array"
+          }
+        },
+        "title" : "Get Document Types Response",
+        "type" : "object"
+      },
+      "getContentSourcesResponse" : {
+        "description" : "Get content sources UI consumption.",
+        "properties" : {
+          "contentSources" : {
+            "items" : {
+              "$ref" : "#/components/schemas/contentSource"
+            },
+            "type" : "array"
+          }
+        },
+        "title" : "Get Content Sources Response",
+        "type" : "object"
+      },
+      "getUploadSourcesResponse" : {
+        "description" : "Get upload sources for UI consumption. The array containing the upload sources available for the folder specified on the request header.",
+        "properties" : {
+          "uploadSources" : {
+            "items" : {
+              "$ref" : "#/components/schemas/uploadSource"
+            },
+            "type" : "array"
+          }
+        },
+        "title" : "Get Upload Sources Response",
+        "type" : "object"
+      },
+      "DATA_NOT_FOUND_FOR_CURRENT_VERSION" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/baseErrorResponse"
+        }, {
+          "properties" : {
+            "code" : {
+              "enum" : [ "VEFSERR40403" ],
+              "type" : "string"
+            },
+            "message" : {
+              "description" : "The message describing the error.",
+              "enum" : [ "Requested data could not be found for current version of UUID %s" ],
+              "title" : "The message schema",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "ocrReanalyze" : {
+        "description" : "Reprocessing of existing textract job ids",
+        "title" : "OCR Reanalysis",
+        "type" : "object"
+      },
+      "ocrReanalyzeResponse" : {
+        "description" : "Response for OCR Reanalyze List",
+        "properties" : {
+          "failed" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "duplicates" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "totalProcessed" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "UUID" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        },
+        "title" : "OCR Reanalyze List",
+        "type" : "object"
+      },
+      "createNoteRequest" : {
+        "additionalProperties" : false,
+        "description" : "Create note request containing the note data",
+        "properties" : {
+          "text" : {
+            "description" : "The content of the note.",
+            "example" : "This is a note.",
+            "maxLength" : 4000,
+            "pattern" : "^[a-zA-Z0-9\\s.\\-_|\\Q\\\\E@#~=%,;?!'\"`():$+*^\\[\\]&<>{}\\Q/\\E]*$",
+            "title" : "Note Text",
+            "type" : "string"
+          },
+          "alert" : {
+            "default" : false,
+            "description" : "Indicator of whether or not this note should be shown as an alert banner on the UI.",
+            "type" : "boolean"
+          },
+          "noteData" : {
+            "$ref" : "#/components/schemas/createNoteRequest_noteData"
+          }
+        },
+        "required" : [ "text" ],
+        "title" : "Create Note Request",
+        "type" : "object"
+      },
+      "createNoteResponse" : {
+        "properties" : {
+          "uuid" : {
+            "description" : "UUID associated with the note that has been created.",
+            "example" : "a851b030-e70b-4564-a400-250a51a4ec28",
+            "format" : "uuid",
+            "type" : "string"
+          }
+        },
+        "title" : "Create Note Response",
+        "type" : "object"
+      },
+      "searchNotesRequest" : {
+        "description" : "Request containing search filters, sorting information, and paging information. The filter block is required, but the individual filters are optional.",
+        "properties" : {
+          "pageRequest" : {
+            "$ref" : "#/components/schemas/notePageRequest"
+          },
+          "filters" : {
+            "$ref" : "#/components/schemas/NoteFilters"
+          },
+          "sorts" : {
+            "$ref" : "#/components/schemas/NoteSorts"
+          }
+        },
+        "required" : [ "filters", "pageRequest" ],
+        "title" : "Search Notes Request",
+        "type" : "object"
+      },
+      "NoteFilters" : {
+        "properties" : {
+          "noteData.alert" : {
+            "$ref" : "#/components/schemas/alertFilter"
+          },
+          "noteData.archived" : {
+            "$ref" : "#/components/schemas/archivedFilter"
+          },
+          "noteData.claimantParticipantId" : {
+            "$ref" : "#/components/schemas/claimantParticipantIdFilter_1"
+          },
+          "noteData.createdBy" : {
+            "$ref" : "#/components/schemas/createdByFilter"
+          },
+          "noteData.lineOfBusiness" : {
+            "$ref" : "#/components/schemas/lineOfBusinessFilter"
+          }
+        }
+      },
+      "NoteSorts" : {
+        "items" : { },
+        "type" : "array"
+      },
+      "searchNotesResponse" : {
+        "description" : "Response containing results from search with applied filters.",
+        "properties" : {
+          "page" : {
+            "$ref" : "#/components/schemas/notePageResponse"
+          },
+          "folderNotes" : {
+            "items" : {
+              "$ref" : "#/components/schemas/currentNoteDataComposition"
+            },
+            "type" : "array"
+          }
+        },
+        "title" : "Search File Response",
+        "type" : "object"
+      },
+      "migrateNoteRequest" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/createNoteRequest"
+        }, {
+          "properties" : {
+            "createdBy" : {
+              "example" : "jbezos",
+              "type" : "string"
+            },
+            "createdDateTime" : {
+              "example" : "2022-03-23T14:35:44",
+              "type" : "string"
+            },
+            "archivedBy" : {
+              "example" : "emusk",
+              "type" : "string"
+            },
+            "archivedDateTime" : {
+              "example" : "2021-12-15T01:13:57",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ],
+        "description" : "Migrate note request containing the existing note data",
+        "title" : "Migrate Note Request",
+        "type" : "object"
+      },
+      "migrateNoteResponse" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/createNoteResponse"
+        } ],
+        "title" : "Migrate Note Response",
+        "type" : "object"
+      },
+      "ResponseObject" : {
+        "properties" : {
+          "published" : {
+            "items" : {
+              "$ref" : "#/components/schemas/FilterObject"
+            },
+            "type" : "array"
+          }
+        },
+        "type" : "object"
+      },
+      "ResponseObject_1" : {
+        "properties" : {
+          "subscribed" : {
+            "items" : {
+              "$ref" : "#/components/schemas/FilterObject"
+            },
+            "type" : "array"
+          },
+          "personal" : {
+            "items" : {
+              "$ref" : "#/components/schemas/FilterObject"
+            },
+            "type" : "array"
+          }
+        },
+        "type" : "object"
+      },
+      "FilterRequest" : {
+        "properties" : {
+          "name" : {
+            "example" : "filterName",
+            "type" : "string"
+          },
+          "publish" : {
+            "example" : true,
+            "type" : "boolean"
+          },
+          "filters" : {
+            "$ref" : "#/components/schemas/FilterRequest_filters"
+          }
+        },
+        "required" : [ "filters", "name", "publish" ],
+        "type" : "object"
+      },
+      "moveNotificationsResponse" : {
+        "description" : "Move Notifications Response Object Containing Information about the Move",
+        "properties" : {
+          "sent" : {
+            "items" : {
+              "$ref" : "#/components/schemas/moveNotificationsResponse_sent_inner"
+            },
+            "type" : "array"
+          },
+          "received" : {
+            "items" : {
+              "$ref" : "#/components/schemas/moveNotificationsResponse_received_inner"
+            },
+            "type" : "array"
+          }
+        },
+        "title" : "GET Move Notification Response",
+        "type" : "object"
+      },
+      "periodOfServiceDocumentsResponse" : {
+        "description" : "Schema for the periodOfService block in the response object for the getPeriodOfServiceInfo endpoint.",
+        "properties" : {
+          "periodOfServiceInformationList" : {
+            "items" : {
+              "$ref" : "#/components/schemas/periodOfServiceDocumentsResponse_periodOfServiceInformationList_inner"
+            },
+            "type" : "array"
+          }
+        },
+        "title" : "Period Of Service Response",
+        "type" : "object"
+      },
+      "uploadRequest_1" : {
+        "description" : "Upload manifest request containing the document upload manifest data",
+        "properties" : {
+          "uploads" : {
+            "items" : {
+              "$ref" : "#/components/schemas/uploadRequest_1_uploads_inner"
+            },
+            "type" : "array"
+          },
+          "fileNumber" : {
+            "description" : "The file number related to the manifest",
+            "type" : "string"
+          },
+          "claimId" : {
+            "description" : "The claim ID associated with this manifest",
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "automationTrigger" : {
+            "description" : "The type of automation trigger for the manifest (e.g., NONE, AUTOMATED_DELIVERY_SYSTEM, AUTOMATED_DELIVERY_SYSTEM_WITH_4142)",
+            "enum" : [ "NONE", "AUTOMATED_DELIVERY_SYSTEM", "AUTOMATED_DELIVERY_SYSTEM_WITH_4142" ],
+            "type" : "string"
+          }
+        },
+        "required" : [ "automationTrigger", "fileNumber", "uploads" ],
+        "title" : "Upload Manifest Request",
+        "type" : "object"
+      },
+      "uploadResponse_1" : {
+        "description" : "A response containing the manifest ID upon successful creation of the manifest",
+        "properties" : {
+          "manifestId" : {
+            "description" : "The UUID of the created manifest",
+            "example" : "123e4567-e89b-12d3-a456-426614174000",
+            "format" : "uuid",
+            "type" : "string"
+          }
+        },
+        "title" : "Upload Manifest Response",
+        "type" : "object"
+      },
+      "getManifestResponse" : {
+        "description" : "Response object for Manifest for the getManifestById and getManifestByClaimId endpoints.",
+        "properties" : {
+          "id" : {
+            "description" : "manifest identification",
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "fileNumber" : {
+            "description" : "file number",
+            "type" : "string"
+          },
+          "claimId" : {
+            "description" : "claim identification",
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "status" : {
+            "description" : "the status of the manifest",
+            "enum" : [ "NEW", "RECEIVING", "FULFILLED" ],
+            "type" : "string"
+          },
+          "automationTrigger" : {
+            "description" : "the automation type of the manifest",
+            "enum" : [ "NONE", "AUTOMATED_DELIVERY_SYSTEM" ],
+            "type" : "string"
+          },
+          "documentUploadResponses" : {
+            "description" : "a list of document upload responses",
+            "items" : {
+              "$ref" : "#/components/schemas/getManifestResponse_documentUploadResponses_inner"
+            },
+            "type" : "array"
+          }
+        },
+        "title" : "Manifest Response",
+        "type" : "object"
+      },
+      "manifestPatchRequest" : {
+        "anyOf" : [ {
+          "required" : [ "uploads" ],
+          "type" : "object"
+        }, {
+          "required" : [ "claimId" ],
+          "type" : "object"
+        } ],
+        "description" : "Request object for updating an existing Manifest.",
+        "properties" : {
+          "uploads" : {
+            "description" : "A list of documents to add to the manifest",
+            "items" : {
+              "properties" : {
+                "documentId" : {
+                  "description" : "The unique identifier of the document to add",
+                  "format" : "uuid",
+                  "type" : "string"
+                },
+                "title" : {
+                  "description" : "Optional title for the document",
+                  "type" : "string"
+                }
+              },
+              "required" : [ "documentId" ],
+              "type" : "object"
+            },
+            "type" : "array"
+          },
+          "claimId" : {
+            "description" : "The claim ID to set (only if not already set)",
+            "format" : "int64",
+            "type" : "integer"
+          }
+        },
+        "title" : "Manifest Patch Request",
+        "type" : "object"
+      },
+      "pageRequest" : {
+        "description" : "Paging request from user.",
+        "properties" : {
+          "resultsPerPage" : {
+            "example" : 10,
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "page" : {
+            "example" : 1,
+            "format" : "int32",
+            "type" : "integer"
+          }
+        },
+        "title" : "Paging Request",
+        "type" : "object"
+      },
+      "documentTypeIdFilter" : {
+        "description" : "Filters results on DocumentTypeId.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "description" : "This is a stringified json array of integers",
+            "example" : "\"[131]\"",
+            "type" : "string"
+          }
+        },
+        "title" : "Document Type Id Filter Request",
+        "type" : "object"
+      },
+      "documentCategoryIdFilter" : {
+        "description" : "Filters results on DocumentCategoryId.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "description" : "This is a stringified json array of integers",
+            "example" : "\"[14]\"",
+            "type" : "string"
+          }
+        },
+        "title" : "Document Category Id Filter Request",
+        "type" : "object"
+      },
+      "subjectFilter" : {
+        "description" : "Filters results on Subject.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "CONTAINS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "description" : "This is a stringified json array of strings.",
+            "example" : "\"[\\\"subject\\\", \\\"subject1\\\"]\"",
+            "type" : "string"
+          }
+        },
+        "title" : "Subject Filter Request",
+        "type" : "object"
+      },
+      "contentNameFilter" : {
+        "description" : "Filters results on ContentName.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "testFileName0.12713919732752.pdf",
+            "type" : "string"
+          }
+        },
+        "title" : "Content Name Filter Request",
+        "type" : "object"
+      },
+      "contentSourceFilter" : {
+        "description" : "Filters results based on ContentSource.",
+        "properties" : {
+          "evluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "VISTA",
+            "type" : "string"
+          }
+        },
+        "title" : "Content Source Filter Request",
+        "type" : "object"
+      },
+      "dateVaReceivedDocumentFilter" : {
+        "description" : "Filters results on range for DateVaReceivedDocument.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "BETWEEN" ],
+            "type" : "string"
+          },
+          "value" : {
+            "description" : "This is a stringified json array of dates",
+            "example" : "\"[\\\"2020-10-09\\\",\\\"2020-10-11\\\"]\"",
+            "type" : "string"
+          }
+        },
+        "title" : "Date Va Received Document Filter Request",
+        "type" : "object"
+      },
+      "endProductCodeFilter" : {
+        "description" : "Filters results on EndProductCode.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "030BGR",
+            "type" : "string"
+          }
+        },
+        "title" : "End Product Code Filter Request",
+        "type" : "object"
+      },
+      "associatedClaimId" : {
+        "description" : "Filter based on the claims associated to the documents.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "description" : "This is a stringified json array of integers",
+            "example" : "\"[137,12837]\"",
+            "type" : "string"
+          }
+        },
+        "title" : "Associated Claim ID Request",
+        "type" : "object"
+      },
+      "associationDateTimeFilter" : {
+        "description" : "Filters results on range for AssociationDateTime.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "BETWEEN" ],
+            "type" : "string"
+          },
+          "value" : {
+            "description" : "This is a stringified json array of dates",
+            "example" : "\"[\\\"2020-10-09\\\",\\\"2020-10-11\\\"]\"",
+            "type" : "string"
+          }
+        },
+        "title" : "Document Association Date Filter Request",
+        "type" : "object"
+      },
+      "mimeTypeFilter" : {
+        "description" : "Filters results on MimeType.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "description" : "This is a stringified json array of mime types",
+            "example" : "\"[\\\"application/pdf\\\", \\\"image/tiff\\\"]\"",
+            "type" : "string"
+          }
+        },
+        "title" : "Mime Type Filter Request",
+        "type" : "object"
+      },
+      "uploadSourceFilter" : {
+        "description" : "Filters results on uploadSource.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "VBMS-UI",
+            "type" : "string"
+          }
+        },
+        "title" : "Upload Source Filter Request",
+        "type" : "object"
+      },
+      "claimantFirstNameFilter" : {
+        "description" : "Filters results on claimant's first name.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "John",
+            "type" : "string"
+          }
+        },
+        "title" : "Claimant First Name Filter Request",
+        "type" : "object"
+      },
+      "claimantLastNameFilter" : {
+        "description" : "Filters results on claimant's last name.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "Smith",
+            "type" : "string"
+          }
+        },
+        "title" : "Claimant Last Name Filter Request",
+        "type" : "object"
+      },
+      "claimantMiddleInitialFilter" : {
+        "description" : "Filters results on claimant's middle initial.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "M",
+            "type" : "string"
+          }
+        },
+        "title" : "Claimant Middle Initial Filter Request",
+        "type" : "object"
+      },
+      "claimantSsnFilter" : {
+        "description" : "Filters results on claimant's Ssn.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "123456789",
+            "type" : "string"
+          }
+        },
+        "title" : "Claimant Ssn Filter Request",
+        "type" : "object"
+      },
+      "claimantDateOfBirthFilter" : {
+        "description" : "Filters results on range for claimantDobFilter.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "description" : "This is the claimant DOB",
+            "example" : "2020-10-09",
+            "type" : "string"
+          }
+        },
+        "title" : "Claimant DOB Filter Request",
+        "type" : "object"
+      },
+      "benefitTypeIdFilter" : {
+        "description" : "Filters results on Benefit Type Id. This filter only accepts string numbers 0-9",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "\"12\"",
+            "type" : "string"
+          }
+        },
+        "title" : "Benefit Type Id Filter Request",
+        "type" : "object"
+      },
+      "ocrPerspectiveFilter" : {
+        "description" : "Filters results on OCR perspective.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "persp1",
+            "type" : "string"
+          }
+        },
+        "title" : "OCR Perspective Filter Request",
+        "type" : "object"
+      },
+      "payeeCodeFilter" : {
+        "description" : "Filters results on payee code.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "01",
+            "type" : "string"
+          }
+        },
+        "title" : "Payee Code Filter Request",
+        "type" : "object"
+      },
+      "regionalProcessingOfficeFilter" : {
+        "description" : "Filters results on regional processing office.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "Buffalo",
+            "type" : "string"
+          }
+        },
+        "title" : "Regional Processing Office Filter Request",
+        "type" : "object"
+      },
+      "facilityCodeFilter" : {
+        "description" : "Filters results on facility code.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "Facility",
+            "type" : "string"
+          }
+        },
+        "title" : "Facility Code Filter Request",
+        "type" : "object"
+      },
+      "claimantParticipantIdFilter" : {
+        "description" : "Filters results on claimant participant Id.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "00000000",
+            "type" : "string"
+          }
+        },
+        "title" : "Claimant Participant Id Filter Request",
+        "type" : "object"
+      },
+      "lineOfBusinessIdFilter" : {
+        "description" : "Filters results based on documents that are associated with the provided line of business through their type or content source",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "VRE",
+            "type" : "string"
+          }
+        },
+        "title" : "Line of Business Id Filter Request",
+        "type" : "object"
+      },
+      "duplicateGroupIdFilter" : {
+        "description" : "Filters results based on the duplicate group they belong to",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "2",
+            "type" : "string"
+          }
+        },
+        "title" : "Duplicate Group Filter Request",
+        "type" : "object"
+      },
+      "textSearchableFilter" : {
+        "description" : "Filters results based on the text searchable status of a document",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : true,
+            "type" : "boolean"
+          }
+        },
+        "title" : "Text Searchable Filter Request",
+        "type" : "object"
+      },
+      "hasAnnotationsFilter" : {
+        "description" : "Filters results based on the existence of annotations for a document",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : true,
+            "type" : "boolean"
+          }
+        },
+        "title" : "Has Annotations Filter Request",
+        "type" : "object"
+      },
+      "annotationTypeFilter" : {
+        "description" : "Filters results based on the annotation types associated with the document",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "[\"FREETEXT\",\"CALLOUT\",\"CONTENTION\",\"NOTE\"]",
+            "type" : "string"
+          }
+        },
+        "title" : "Annotation Type Filter Request",
+        "type" : "object"
+      },
+      "annotationKeywordFilter" : {
+        "description" : "Filters results based on keywords in the title and comments of associated annotations",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "CONTAINS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "[\"keyword1\",\"keyword2\"]",
+            "type" : "string"
+          }
+        },
+        "title" : "Annotation Keyword Filter Request",
+        "type" : "object"
+      },
+      "hasNotesFilter" : {
+        "description" : "Filters results based on the notes",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "true",
+            "type" : "string"
+          }
+        },
+        "title" : "Notes Filter Request",
+        "type" : "object"
+      },
+      "ocrStatusFilter" : {
+        "description" : "Filters results based on the ocr status of a document",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "['Searchable', 'Not Searchable', 'Failure to Process']",
+            "type" : "string"
+          }
+        },
+        "title" : "Ocr Status Filter Request",
+        "type" : "object"
+      },
+      "textContentFilter" : {
+        "description" : "Filters results based on text search content in the documents",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "galaxy",
+            "type" : "string"
+          }
+        },
+        "title" : "Text search Filter Request",
+        "type" : "object"
+      },
+      "pageResponse" : {
+        "description" : "Information on paging of results.",
+        "properties" : {
+          "totalPages" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "requestedResultsPerPage" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "currentPage" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "totalResults" : {
+            "format" : "int32",
+            "type" : "integer"
+          }
+        },
+        "title" : "Page Response",
+        "type" : "object"
+      },
+      "baseErrorResponse" : {
+        "description" : "The root schema comprises generic File Store Errors.",
+        "properties" : {
+          "uuid" : {
+            "description" : "UUID used to trace the error response",
+            "format" : "uuid",
+            "title" : "Error UUID",
+            "type" : "string"
+          }
+        },
+        "title" : "Vefs Error Response",
+        "type" : "object"
+      },
+      "payload" : {
+        "description" : "Payload containing content name and the provider specific data. <a href=\"#model-payload\">Schema can be found here.</a>",
+        "properties" : {
+          "contentName" : {
+            "$ref" : "#/components/schemas/contentName"
+          },
+          "providerData" : {
+            "$ref" : "#/components/schemas/uploadProviderDataRequest"
+          },
+          "ocr" : {
+            "$ref" : "#/components/schemas/ocrDataRequest"
+          }
+        },
+        "required" : [ "contentName", "providerData" ],
+        "title" : "Upload Payload",
+        "type" : "object"
+      },
+      "conversionInformation" : {
+        "description" : "Details about a file's conversion. This is optional, and will only be present on responses where the file has been converted.",
+        "properties" : {
+          "preprocessed" : {
+            "$ref" : "#/components/schemas/conversionMetadata"
+          },
+          "converted" : {
+            "$ref" : "#/components/schemas/conversionMetadata"
+          }
+        },
+        "title" : "Conversion Information",
+        "type" : "object"
+      },
+      "payload_1" : {
+        "description" : "Payload containing content name and the provider specific data. <a href=\"#model-payload_2\">Schema can be found here.</a>",
+        "properties" : {
+          "providerData" : {
+            "$ref" : "#/components/schemas/uploadProviderDataRequest"
+          }
+        },
+        "required" : [ "providerData" ],
+        "title" : "Update File Payload",
+        "type" : "object"
+      },
+      "folderIdentifier" : {
+        "description" : "Details on the owner associated to the file.",
+        "properties" : {
+          "type" : {
+            "enum" : [ "VETERAN", "PARTICIPANT", "ORGANIZATION", "BIN", "ANY", "UNSUPPORTED" ],
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          }
+        },
+        "title" : "Folder Identifier",
+        "type" : "object"
+      },
+      "versionComposition" : {
+        "description" : "Response data containing the system and provider data for a file. This will always be a response containing the latest information for the file.",
+        "properties" : {
+          "systemData" : {
+            "$ref" : "#/components/schemas/systemDataComposition"
+          },
+          "providerData" : {
+            "$ref" : "#/components/schemas/providerData"
+          }
+        },
+        "title" : "Current Version Response",
+        "type" : "object"
+      },
+      "versionCompositionWithRawTextData" : {
+        "description" : "Response data containing the system, provider and raw text data for a file. This response will always contain the latest information for the file.",
+        "properties" : {
+          "systemData" : {
+            "$ref" : "#/components/schemas/systemDataComposition"
+          },
+          "providerData" : {
+            "$ref" : "#/components/schemas/providerData"
+          },
+          "rawTextData" : {
+            "$ref" : "#/components/schemas/rawTextData"
+          }
+        },
+        "title" : "Current Version Response including Raw Text Data",
+        "type" : "object"
+      },
+      "updateDataProviderData" : {
+        "additionalProperties" : false,
+        "description" : "Claim Evidence API Update Provider Data. This endpoint accepts any of the following properties, if you are only updating one property, it is possible to make the call with just one of them. For example if you wanted to just update subject, the request can be made with only the subject property in the providerData object on the request.",
+        "properties" : {
+          "contentSource" : {
+            "description" : "String field designating the originating source of the content being uploaded. This must match a valid content source from the /contentSources endpoint. This can only be updated by a limited subset of users.",
+            "example" : "VISTA",
+            "maximum" : 500,
+            "minimum" : 1,
+            "pattern" : "^[a-zA-Z0-9\\'\\,\\s.\\-\\_\\|\\/@\\(\\)]*$",
+            "title" : "Document content source",
+            "type" : "string"
+          },
+          "claimantFirstName" : {
+            "description" : "String field designating the Claimant's first name.",
+            "example" : "John",
+            "maxLength" : 64,
+            "pattern" : "^[a-zA-Z0-9\\\\'\\\\,\\\\s.\\\\-\\\\_\\\\|\\\\/@\\\\(\\\\)]*$",
+            "title" : "Claimant First Name",
+            "type" : "string"
+          },
+          "claimantMiddleInitial" : {
+            "description" : "String field designating the Claimant's middle initial.",
+            "example" : "M",
+            "maxLength" : 4,
+            "pattern" : "^[a-zA-Z]*$",
+            "title" : "Claimant Middle Initial",
+            "type" : "string"
+          },
+          "claimantLastName" : {
+            "description" : "String field designating the Claimant's last name.",
+            "example" : "Smith",
+            "maxLength" : 64,
+            "pattern" : "^[a-zA-Z0-9\\\\'\\\\,\\\\s.\\\\-\\\\_\\\\|\\\\/@\\\\(\\\\)]*$",
+            "title" : "Claimant Last Name",
+            "type" : "string"
+          },
+          "claimantSsn" : {
+            "description" : "String field designating the Claimant's SSN. Only accepts exactly 9 characters.",
+            "example" : "123456789",
+            "maxLength" : 9,
+            "pattern" : "^[0-9]*$",
+            "title" : "Claimant SSN",
+            "type" : "string"
+          },
+          "benefitTypeId" : {
+            "description" : "Number field designating the Benefit Type ID.",
+            "example" : 10,
+            "minimum" : 0,
+            "title" : "Benefit Type ID",
+            "type" : "integer"
+          },
+          "documentTypeId" : {
+            "description" : "Number field correlating to a Claim Evidence document type ID. Document types primary use is loosely categorizing their contents.",
+            "example" : 131,
+            "minimum" : 1,
+            "title" : "Document Type ID",
+            "type" : "integer"
+          },
+          "dateVaReceivedDocument" : {
+            "description" : "Date field indicating the date the VA received the document. This can be any date in format of YYYY-MM-DD from 1900 until today",
+            "example" : "2022-01-01",
+            "format" : "string",
+            "maxLength" : 10,
+            "minLength" : 10,
+            "pattern" : "([12]\\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01]))",
+            "title" : "Date VA Received Document",
+            "type" : "string"
+          },
+          "subject" : {
+            "description" : "Free text describing the document. This is primarily notes used to assist claim developers.",
+            "maxLength" : 256,
+            "pattern" : "^[a-zA-Z0-9\\s.\\-_|\\Q\\\\E@#~=%,;?!'\"`():$+*^\\[\\]&<>{}\\Q/\\E]*$",
+            "title" : "Subject",
+            "type" : "string"
+          },
+          "alternativeDocumentTypeIds" : {
+            "description" : "List of integers which relate to an alternative document type Id. This must match a valid alternative document type Id from the /documentTypes endpoint.",
+            "example" : [ 1 ],
+            "items" : {
+              "minimum" : 0,
+              "type" : "integer"
+            },
+            "minItems" : 1,
+            "title" : "Alternative Document Type Ids",
+            "type" : "array",
+            "uniqueItems" : true
+          },
+          "actionable" : {
+            "default" : false,
+            "description" : "Boolean true/false for if the document is considered 'actionable' or whether claim action can be taken based on the content.",
+            "title" : "Actionable",
+            "type" : "boolean"
+          },
+          "certified" : {
+            "default" : false,
+            "description" : "Boolean true/false for if the document is considered 'certified'.",
+            "title" : "Actionable",
+            "type" : "boolean"
+          },
+          "endProductCode" : {
+            "description" : "Free text describing the document. This is primarily notes used to assist claim developers. This field must match a valid known end product code.",
+            "example" : "130DPNDCY",
+            "maxLength" : 64,
+            "minLength" : 1,
+            "pattern" : "^[a-zA-Z0-9\\s.\\\\\\-\\_\\|\\/@&><\\(\\))\\'\\+\\,\\$]*$",
+            "title" : "Subject",
+            "type" : "string"
+          },
+          "notes" : {
+            "description" : "Notes to describe the document.",
+            "example" : "[This is a note for a document, These replace editing the document summary]",
+            "maxLength" : 100,
+            "pattern" : "^[a-zA-Z0-9\\s.\\-_|\\Q\\\\E@#~=%,;?!'\"`():$+*^\\[\\]&<>{}\\Q/\\E]*$",
+            "title" : "Document Notes",
+            "type" : "string"
+          },
+          "sourceComment" : {
+            "description" : "String field containing any comments from the source of the document",
+            "example" : "source comment",
+            "maxLength" : 1200,
+            "pattern" : "^[a-zA-Z0-9\\s.\\-_|\\Q\\\\E@#~=%,;?!'\"`():$+*^\\[\\]&<>{}\\Q/\\E]*$",
+            "title" : "Source comment",
+            "type" : "string"
+          },
+          "payeeCode" : {
+            "description" : "String field designating the Payee Code. Only accepts 2 digits as a string with leading 0 if below 10.",
+            "example" : "00",
+            "maxLength" : 2,
+            "minLength" : 2,
+            "pattern" : "^[0-9]*$",
+            "title" : "Payee Code",
+            "type" : "string"
+          },
+          "regionalProcessingOffice" : {
+            "description" : "String field designating the regional processing office.",
+            "example" : "Buffalo",
+            "maxLength" : 15,
+            "minLength" : 3,
+            "pattern" : "^[a-zA-Z0-9\\'\\,\\s.\\-\\_\\|\\/@\\(\\)]*$",
+            "title" : "Regional Processing Office",
+            "type" : "string"
+          },
+          "facilityCode" : {
+            "description" : "String field designating the Facility Code.",
+            "example" : "Facility",
+            "maxLength" : 8,
+            "pattern" : "^[a-zA-Z0-9\\'\\,\\s.\\-\\_\\|\\/@\\(\\)]*$",
+            "title" : "Facility Code",
+            "type" : "string"
+          },
+          "claimantParticipantId" : {
+            "description" : "String field designating the claimant participant Id.",
+            "example" : "000000000",
+            "maxLength" : 15,
+            "pattern" : "^[0-9]*$",
+            "title" : "Claimant Participant Id",
+            "type" : "string"
+          },
+          "claimantDateOfBirth" : {
+            "description" : "Date field indicating the date the claimant was born. This can be any date in format of YYYY-MM-DD from 1900 until today",
+            "example" : "2022-01-01",
+            "format" : "string",
+            "maxLength" : 10,
+            "pattern" : "([12]\\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01]))",
+            "title" : "Claimant Date of Birth",
+            "type" : "string"
+          },
+          "newMail" : {
+            "default" : false,
+            "description" : "Boolean true/false for if the document is considered 'new mail'",
+            "example" : false,
+            "title" : "New Mail",
+            "type" : "boolean"
+          },
+          "periodOfServiceInformationList" : {
+            "description" : "List of Period of Service Information",
+            "example" : {
+              "enteredOnDutyDate" : "2023-01-01",
+              "releasedActiveDuty" : "2024-01-01",
+              "linkageTypes" : [ "STR", "OMPF", "Service Verification" ]
+            },
+            "items" : {
+              "$ref" : "#/components/schemas/Period_Of_Service_Information_List_inner"
+            },
+            "title" : "Period Of Service Information List",
+            "type" : "array"
+          }
+        },
+        "title" : "Update File Provider Data",
+        "type" : "object"
+      },
+      "processingInformation" : {
+        "description" : "Information describing the OCR processing that occured to generate the OCR data.",
+        "properties" : {
+          "ocrDateTime" : {
+            "example" : "2022-01-11T02:37:14",
+            "format" : "string",
+            "pattern" : "^(?:[1-9]\\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(\\.\\d{1,3})?$",
+            "type" : "string"
+          }
+        },
+        "title" : "OCR Data Processing Information",
+        "type" : "object"
+      },
+      "file" : {
+        "description" : "OCR data describing the file",
+        "properties" : {
+          "text" : {
+            "type" : "string"
+          },
+          "pages" : {
+            "items" : {
+              "$ref" : "#/components/schemas/page"
+            },
+            "type" : "array"
+          },
+          "totalPages" : {
+            "example" : 3,
+            "minimum" : 1,
+            "type" : "integer"
+          }
+        },
+        "required" : [ "pages", "text", "totalPages" ],
+        "title" : "OCR Data File",
+        "type" : "object"
+      },
+      "basic" : {
+        "properties" : {
+          "uuid" : {
+            "type" : "string"
+          },
+          "type" : {
+            "$ref" : "#/components/schemas/basicAnnotations"
+          },
+          "created" : {
+            "$ref" : "#/components/schemas/audit"
+          },
+          "modified" : {
+            "$ref" : "#/components/schemas/audit"
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "pageNumber" : {
+            "example" : 1,
+            "type" : "integer"
+          },
+          "position" : {
+            "$ref" : "#/components/schemas/position"
+          },
+          "size" : {
+            "$ref" : "#/components/schemas/annotationSize"
+          },
+          "border" : {
+            "$ref" : "#/components/schemas/border"
+          },
+          "color" : {
+            "example" : "#000000",
+            "type" : "string"
+          }
+        },
+        "title" : "Basic Annotation Response",
+        "type" : "object"
+      },
+      "lines" : {
+        "properties" : {
+          "uuid" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string"
+          },
+          "created" : {
+            "$ref" : "#/components/schemas/audit"
+          },
+          "modified" : {
+            "$ref" : "#/components/schemas/audit"
+          },
+          "rawXfdf" : {
+            "type" : "string"
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "pageNumber" : {
+            "type" : "integer"
+          },
+          "thickness" : {
+            "type" : "integer"
+          },
+          "points" : {
+            "$ref" : "#/components/schemas/points"
+          },
+          "color" : {
+            "example" : "#000000",
+            "type" : "string"
+          }
+        },
+        "title" : "Line Annotation Response",
+        "type" : "object"
+      },
+      "callout" : {
+        "properties" : {
+          "uuid" : {
+            "type" : "string"
+          },
+          "type" : {
+            "example" : "callout",
+            "type" : "string"
+          },
+          "created" : {
+            "$ref" : "#/components/schemas/audit"
+          },
+          "modified" : {
+            "$ref" : "#/components/schemas/audit"
+          },
+          "rawXfdf" : {
+            "type" : "string"
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "pageNumber" : {
+            "example" : 1,
+            "type" : "integer"
+          },
+          "tailDirection" : {
+            "$ref" : "#/components/schemas/tailDirection"
+          },
+          "position" : {
+            "$ref" : "#/components/schemas/position"
+          },
+          "size" : {
+            "$ref" : "#/components/schemas/annotationSize"
+          },
+          "text" : {
+            "$ref" : "#/components/schemas/text"
+          },
+          "color" : {
+            "example" : "#000000",
+            "type" : "string"
+          }
+        },
+        "title" : "Callout Annotation Response",
+        "type" : "object"
+      },
+      "freetext" : {
+        "properties" : {
+          "uuid" : {
+            "type" : "string"
+          },
+          "type" : {
+            "example" : "freetext",
+            "type" : "string"
+          },
+          "created" : {
+            "$ref" : "#/components/schemas/audit"
+          },
+          "modified" : {
+            "$ref" : "#/components/schemas/audit"
+          },
+          "rawXfdf" : {
+            "type" : "string"
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "pageNumber" : {
+            "example" : 1,
+            "type" : "integer"
+          },
+          "position" : {
+            "$ref" : "#/components/schemas/position"
+          },
+          "size" : {
+            "$ref" : "#/components/schemas/annotationSize"
+          },
+          "text" : {
+            "$ref" : "#/components/schemas/text"
+          },
+          "color" : {
+            "example" : "#000000",
+            "type" : "string"
+          }
+        },
+        "title" : "Free Text Annotation Response",
+        "type" : "object"
+      },
+      "notes" : {
+        "properties" : {
+          "uuid" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string"
+          },
+          "created" : {
+            "$ref" : "#/components/schemas/audit"
+          },
+          "modified" : {
+            "$ref" : "#/components/schemas/audit"
+          },
+          "rawXfdf" : {
+            "type" : "string"
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "pageNumber" : {
+            "type" : "integer"
+          },
+          "size" : {
+            "$ref" : "#/components/schemas/annotationSize"
+          },
+          "position" : {
+            "$ref" : "#/components/schemas/position"
+          },
+          "icon" : {
+            "$ref" : "#/components/schemas/icon"
+          },
+          "color" : {
+            "example" : "#000000",
+            "type" : "string"
+          }
+        },
+        "title" : "Icon Annotation Response",
+        "type" : "object"
+      },
+      "stamps" : {
+        "properties" : {
+          "uuid" : {
+            "type" : "string"
+          },
+          "type" : {
+            "example" : "stamp",
+            "type" : "string"
+          },
+          "created" : {
+            "$ref" : "#/components/schemas/audit"
+          },
+          "modified" : {
+            "$ref" : "#/components/schemas/audit"
+          },
+          "rawXfdf" : {
+            "type" : "string"
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "pageNumber" : {
+            "example" : 1,
+            "type" : "integer"
+          },
+          "size" : {
+            "$ref" : "#/components/schemas/annotationSize"
+          },
+          "position" : {
+            "$ref" : "#/components/schemas/position"
+          },
+          "image" : {
+            "$ref" : "#/components/schemas/stamp"
+          }
+        },
+        "title" : "Stamp Annotation Response",
+        "type" : "object"
+      },
+      "textSelection" : {
+        "properties" : {
+          "uuid" : {
+            "type" : "string"
+          },
+          "type" : {
+            "$ref" : "#/components/schemas/textSelectionAnnotations"
+          },
+          "created" : {
+            "$ref" : "#/components/schemas/audit"
+          },
+          "modified" : {
+            "$ref" : "#/components/schemas/audit"
+          },
+          "rawXfdf" : {
+            "type" : "string"
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "pageNumber" : {
+            "example" : 1,
+            "type" : "integer"
+          },
+          "selectedAreas" : {
+            "$ref" : "#/components/schemas/selectedAreas"
+          },
+          "color" : {
+            "type" : "string"
+          }
+        },
+        "title" : "Text Selection Annotation Response",
+        "type" : "object"
+      },
+      "basicAnnotations" : {
+        "enum" : [ "rectangle", "oval" ],
+        "title" : "Basic Annotation Enum",
+        "type" : "string"
+      },
+      "position" : {
+        "additionalProperties" : false,
+        "description" : "bottom and left coordinate from bottom left corner of page.",
+        "properties" : {
+          "bottom" : {
+            "description" : "Number of pixels from bottom of the page.",
+            "example" : 75,
+            "minimum" : 0,
+            "title" : "Bottom",
+            "type" : "integer"
+          },
+          "left" : {
+            "description" : "Number of pixels from left of the page.",
+            "example" : 50,
+            "minimum" : 0,
+            "title" : "Left",
+            "type" : "integer"
+          }
+        },
+        "required" : [ "bottom", "left" ],
+        "title" : "Position (Annotation)",
+        "type" : "object"
+      },
+      "annotationSize" : {
+        "additionalProperties" : false,
+        "description" : "Width and height of annotation.",
+        "properties" : {
+          "width" : {
+            "description" : "Number of pixels wide the annotation appears.",
+            "example" : 150,
+            "minimum" : 0,
+            "title" : "Width",
+            "type" : "integer"
+          },
+          "height" : {
+            "description" : "Number of pixels tall thhe annotation appears.",
+            "example" : 100,
+            "minimum" : 0,
+            "title" : "Height",
+            "type" : "integer"
+          }
+        },
+        "required" : [ "height", "width" ],
+        "title" : "Size (Annotation)",
+        "type" : "object"
+      },
+      "points" : {
+        "properties" : {
+          "startX" : {
+            "example" : 50,
+            "type" : "integer"
+          },
+          "startY" : {
+            "example" : 75,
+            "type" : "integer"
+          },
+          "endX" : {
+            "example" : 100,
+            "type" : "integer"
+          },
+          "endY" : {
+            "example" : 75,
+            "type" : "integer"
+          }
+        },
+        "required" : [ "endX", "endY", "startX", "startY" ],
+        "title" : "Points (Annotation)",
+        "type" : "object"
+      },
+      "tailDirection" : {
+        "enum" : [ "up", "down", "right", "left" ],
+        "title" : "Tail Direction Enum",
+        "type" : "string"
+      },
+      "icon" : {
+        "enum" : [ "callout", "check", "circle", "comment", "cross", "help", "insert", "key", "newparagraph", "note", "paragraph", "star", "rightpointer", "rightarrow", "upleftarrow", "uparrow" ],
+        "title" : "Icon Type Enum",
+        "type" : "string"
+      },
+      "stamp" : {
+        "enum" : [ "Certified", "BestCopy", "Original" ],
+        "title" : "Stamp Type Enum",
+        "type" : "string"
+      },
+      "textSelectionAnnotations" : {
+        "enum" : [ "underline", "strikeout", "highlight" ],
+        "title" : "Text Selection Annotation Enum",
+        "type" : "string"
+      },
+      "selectedAreas" : {
+        "items" : {
+          "$ref" : "#/components/schemas/selectedAreas_inner"
+        },
+        "title" : "Selected Areas (Annotation)",
+        "type" : "array"
+      },
+      "bookmarkRealmResponseModel" : {
+        "properties" : {
+          "isDefaultRealm" : {
+            "type" : "boolean"
+          },
+          "appeals" : {
+            "$ref" : "#/components/schemas/bookmarkResponseModel"
+          },
+          "medical" : {
+            "$ref" : "#/components/schemas/bookmarkResponseModel"
+          },
+          "peerReview" : {
+            "$ref" : "#/components/schemas/bookmarkResponseModel"
+          },
+          "workingNotes" : {
+            "$ref" : "#/components/schemas/bookmarkResponseModel"
+          },
+          "deferral" : {
+            "$ref" : "#/components/schemas/bookmarkResponseModel"
+          },
+          "dependency" : {
+            "$ref" : "#/components/schemas/bookmarkResponseModel"
+          }
+        },
+        "type" : "object"
+      },
+      "folderPermission" : {
+        "description" : "Contains permission information",
+        "properties" : {
+          "hasAccess" : {
+            "description" : "flag indicating whether the requesting user has access to the endpoint",
+            "type" : "boolean"
+          }
+        },
+        "title" : "Folder Permission",
+        "type" : "object"
+      },
+      "bookmarkPermissions" : {
+        "properties" : {
+          "create" : {
+            "$ref" : "#/components/schemas/folderPermission"
+          },
+          "update" : {
+            "$ref" : "#/components/schemas/folderPermission"
+          },
+          "deferralAccess" : {
+            "$ref" : "#/components/schemas/folderPermission"
+          }
+        },
+        "title" : "Bookmark Permissions",
+        "type" : "object"
+      },
+      "pendingScanningPermissions" : {
+        "properties" : {
+          "listItems" : {
+            "$ref" : "#/components/schemas/folderPermission"
+          },
+          "scanningStatus" : {
+            "$ref" : "#/components/schemas/folderPermission"
+          },
+          "mangeEvidence" : {
+            "$ref" : "#/components/schemas/folderPermission"
+          }
+        },
+        "title" : "Pending Scanning Permissions",
+        "type" : "object"
+      },
+      "bvaNotesPermissions" : {
+        "properties" : {
+          "view" : {
+            "$ref" : "#/components/schemas/folderPermission"
+          },
+          "create" : {
+            "$ref" : "#/components/schemas/folderPermission"
+          },
+          "edit" : {
+            "$ref" : "#/components/schemas/folderPermission"
+          }
+        },
+        "title" : "BVA Notes Permissions",
+        "type" : "object"
+      },
+      "militaryServiceInfoPermission" : {
+        "properties" : {
+          "view" : {
+            "$ref" : "#/components/schemas/folderPermission"
+          },
+          "update" : {
+            "$ref" : "#/components/schemas/folderPermission"
+          }
+        },
+        "title" : "Military Service Information Permissions",
+        "type" : "object"
+      },
+      "verbPermission" : {
+        "description" : "Contains permission information for an endpoint based on the HTTP verb",
+        "properties" : {
+          "hasAccess" : {
+            "description" : "flag indicating whether the requesting user has access to the endpoint",
+            "type" : "boolean"
+          },
+          "systemData" : {
+            "description" : "array of strings indicating which system data fields are accessible. For Upload and update endpoints this block is not available. This block is also unavailable on annotation endpoints.",
+            "example" : [ "systemDataField1", "systemDataField2" ],
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "providerData" : {
+            "description" : "array of strings indicating which provider data fields are accessible. For some endpoints this may be empty due to the endpoint not returning or requesting data.",
+            "example" : [ "providerDataField1", "providerDataField2" ],
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          }
+        },
+        "title" : "Verb Permission",
+        "type" : "object"
+      },
+      "lineOfBusiness" : {
+        "description" : "The various lines of business known by CE.",
+        "example" : "EDU",
+        "title" : "Line of Business",
+        "type" : "string"
+      },
+      "patchVerbPermission" : {
+        "description" : "Contains permission information for an endpoint based on the HTTP verb",
+        "properties" : {
+          "Unassociate" : {
+            "$ref" : "#/components/schemas/Unassociate_Permission"
+          },
+          "Move" : {
+            "$ref" : "#/components/schemas/Move_Permission"
+          }
+        },
+        "required" : [ "user jwt" ],
+        "title" : "Verb Permission",
+        "type" : "object"
+      },
+      "documentType" : {
+        "description" : "Response object for Document Types from the Get Document Types endpoint.",
+        "properties" : {
+          "id" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "isUpdateSubjectRestricted" : {
+            "type" : "boolean"
+          },
+          "createDateTime" : {
+            "type" : "string"
+          },
+          "modifiedDateTime" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "isUserUploadable" : {
+            "type" : "boolean"
+          },
+          "is526" : {
+            "type" : "boolean"
+          },
+          "documentCategory" : {
+            "$ref" : "#/components/schemas/documentCategory"
+          }
+        },
+        "title" : "Document Type Response",
+        "type" : "object"
+      },
+      "alternativeDocumentType" : {
+        "description" : "Response object for Alternative Document Type as returned by the documentTypes endpoint.",
+        "properties" : {
+          "id" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "createDateTime" : {
+            "type" : "string"
+          },
+          "modifiedDateTime" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "categoryDescription" : {
+            "type" : "string"
+          }
+        },
+        "title" : "Alternative Document Type Response",
+        "type" : "object"
+      },
+      "contentSource" : {
+        "description" : "Content sources for UI consumption.",
+        "properties" : {
+          "id" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "createDateTime" : {
+            "example" : "2011-09-20T04:00:00",
+            "type" : "string"
+          },
+          "name" : {
+            "example" : "VBMS",
+            "type" : "string"
+          }
+        },
+        "title" : "Content Source",
+        "type" : "object"
+      },
+      "uploadSource" : {
+        "description" : "Upload sources response object.",
+        "properties" : {
+          "name" : {
+            "example" : "VBMS-UI",
+            "type" : "string"
+          }
+        },
+        "title" : "Upload Source Response",
+        "type" : "object"
+      },
+      "notePageRequest" : {
+        "description" : "Paging request from user.",
+        "properties" : {
+          "resultsPerPage" : {
+            "example" : 10,
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "page" : {
+            "example" : 1,
+            "format" : "int32",
+            "type" : "integer"
+          }
+        },
+        "title" : "Paging Request",
+        "type" : "object"
+      },
+      "alertFilter" : {
+        "description" : "Filters results on alert.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : true,
+            "type" : "boolean"
+          }
+        },
+        "title" : "Alert Indicator Filter Request",
+        "type" : "object"
+      },
+      "archivedFilter" : {
+        "description" : "Filters results on archived.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "EQUALS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "example" : false,
+            "type" : "boolean"
+          }
+        },
+        "title" : "Archived Indicator Filter Request",
+        "type" : "object"
+      },
+      "claimantParticipantIdFilter_1" : {
+        "description" : "Filters results on claimant participant Id.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "CONTAINS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "description" : "This is a stringified JSON array of strings.",
+            "example" : "\"[\\\"83941120\\\", \\\"659432892\\\"]\"",
+            "type" : "string"
+          }
+        },
+        "title" : "Claimant Participant Id Filter Request",
+        "type" : "object"
+      },
+      "createdByFilter" : {
+        "description" : "Filters results on creator username.",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "CONTAINS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "description" : "This is a stringified JSON array of strings.",
+            "example" : "\"[\\\"PAULL_EDUVCE\\\", \\\"STANLEYP_EDUCC\\\"]\"",
+            "type" : "string"
+          }
+        },
+        "title" : "Created By Filter Request",
+        "type" : "object"
+      },
+      "lineOfBusinessFilter" : {
+        "description" : "Filters results based on notes that are associated with the provided line of business through their type or content source",
+        "properties" : {
+          "evaluationType" : {
+            "enum" : [ "CONTAINS" ],
+            "type" : "string"
+          },
+          "value" : {
+            "description" : "This is a stringified JSON array of strings.",
+            "example" : "\"[\\\"EDU\\\", \\\"VHA\\\", \\\"VBA\\\"]\"",
+            "type" : "string"
+          }
+        },
+        "title" : "Line of Business Filter Request",
+        "type" : "object"
+      },
+      "notePageResponse" : {
+        "description" : "Information on paging of results.",
+        "properties" : {
+          "totalPages" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "requestedResultsPerPage" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "currentPage" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "totalResults" : {
+            "format" : "int32",
+            "type" : "integer"
+          }
+        },
+        "title" : "Page Response",
+        "type" : "object"
+      },
+      "currentNoteDataComposition" : {
+        "description" : "Schema for the response data for note search endpoints.",
+        "properties" : {
+          "alert" : {
+            "type" : "boolean"
+          },
+          "text" : {
+            "example" : "This is a note that we created.",
+            "type" : "string"
+          },
+          "uuid" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "noteData" : {
+            "$ref" : "#/components/schemas/noteData"
+          }
+        },
+        "title" : "Current Note Data Response",
+        "type" : "object"
+      },
+      "FilterObject" : {
+        "properties" : {
+          "id" : {
+            "example" : 1111,
+            "type" : "integer"
+          },
+          "name" : {
+            "example" : "filterName",
+            "type" : "string"
+          },
+          "filter" : {
+            "$ref" : "#/components/schemas/FilterObject_filter"
+          },
+          "published" : {
+            "example" : true,
+            "type" : "boolean"
+          }
+        },
+        "type" : "object"
+      },
+      "contentName" : {
+        "description" : "The content name of the document being uploaded. This must be unique for the folder being uploaded to. For instance the document \"pdf.pdf\" cannot be uploaded twice for fileNumber 987654321. The acceptable file extensions are png, pdf, tif, tiff, txt, jpg, jpeg, and bmp.",
+        "example" : "filename.pdf",
+        "maxLength" : 256,
+        "minLength" : 4,
+        "pattern" : "^[a-zA-Z0-9 Q`'~=+#^@$&-_.(){};[]E]+.[a-zA-Z]{3,4}$",
+        "title" : "Content Name",
+        "type" : "string"
+      },
+      "uploadProviderDataRequest" : {
+        "additionalProperties" : false,
+        "description" : "Claim Evidence API Provider Data.",
+        "properties" : {
+          "contentSource" : {
+            "description" : "String field designating the originating source of the content being uploaded.",
+            "example" : "VBMS",
+            "maximum" : 500,
+            "minimum" : 1,
+            "pattern" : "^[a-zA-Z0-9\\'\\,\\s.\\-\\_\\|\\/@\\(\\)]*$",
+            "title" : "Document content source",
+            "type" : "string"
+          },
+          "claimantFirstName" : {
+            "description" : "String field designating the Claimant's first name.",
+            "example" : "John",
+            "maxLength" : 64,
+            "pattern" : "^[a-zA-Z0-9\\\\'\\\\,\\\\s.\\\\-\\\\_\\\\|\\\\/@\\\\(\\\\)]*$",
+            "title" : "Claimant First Name",
+            "type" : "string"
+          },
+          "claimantMiddleInitial" : {
+            "description" : "String field designating the Claimant's middle initial.",
+            "example" : "M",
+            "maxLength" : 4,
+            "pattern" : "^[a-zA-Z]*$",
+            "title" : "Claimant Middle Initial",
+            "type" : "string"
+          },
+          "claimantLastName" : {
+            "description" : "String field designating the Claimant's last name.",
+            "example" : "Smith",
+            "maxLength" : 64,
+            "pattern" : "^[a-zA-Z0-9\\\\'\\\\,\\\\s.\\\\-\\\\_\\\\|\\\\/@\\\\(\\\\)]*$",
+            "title" : "Claimant Last Name",
+            "type" : "string"
+          },
+          "claimantSsn" : {
+            "description" : "String field designating the Claimant's SSN. Only accepts exactly 9 characters.",
+            "example" : "123456789",
+            "maxLength" : 9,
+            "pattern" : "^[0-9]*$",
+            "title" : "Claimant SSN",
+            "type" : "string"
+          },
+          "benefitTypeId" : {
+            "description" : "Number field designating the Benefit Type ID.",
+            "example" : 10,
+            "minimum" : 0,
+            "title" : "Benefit Type ID",
+            "type" : "integer"
+          },
+          "documentTypeId" : {
+            "description" : "Number field correlating to a Claim Evidence document type ID. Document types primary use is loosely categorizing their contents.",
+            "example" : 131,
+            "minimum" : 1,
+            "title" : "Document Type ID",
+            "type" : "integer"
+          },
+          "dateVaReceivedDocument" : {
+            "description" : "Date field indicating the date the VA received the document. This can be any date in format of YYYY-MM-DD from 1900 until today",
+            "example" : "2022-02-01",
+            "format" : "string",
+            "maxLength" : 10,
+            "minLength" : 10,
+            "pattern" : "([12]\\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01]))",
+            "title" : "Date VA Received Document",
+            "type" : "string"
+          },
+          "subject" : {
+            "description" : "Free text describing the document. This is primarily notes used to assist claim developers.",
+            "example" : "subject",
+            "maxLength" : 256,
+            "pattern" : "^[a-zA-Z0-9\\s.\\-_|\\Q\\\\E@#~=%,;?!'\"`():$+*^\\[\\]&<>{}\\Q/\\E]*$",
+            "title" : "Subject",
+            "type" : "string"
+          },
+          "contentions" : {
+            "description" : "list of contentions by name associated to the document. This is only available for files where the documentType is 526 as evidenced by the is526 property on the /DocumentTypes endpoint response. If there are no contentions supplied, this key should not be on the request.",
+            "example" : "[\"contention1\"]",
+            "items" : {
+              "maxLength" : 128,
+              "minLength" : 1,
+              "pattern" : "^[a-zA-Z0-9\\s.\\-_|\\Q\\\\E@#~=%,;?!'\"`():$+*^\\[\\]&<>{}\\Q/\\E]*$",
+              "type" : "string"
+            },
+            "title" : "Contentions",
+            "type" : "array"
+          },
+          "alternativeDocumentTypeIds" : {
+            "description" : "list of associated document type Ids.",
+            "example" : "[1]",
+            "items" : {
+              "minimum" : 0,
+              "type" : "integer"
+            },
+            "title" : "Alternative Document Type Ids",
+            "type" : "array"
+          },
+          "actionable" : {
+            "default" : false,
+            "description" : "Boolean true/false for if the document is considered 'actionable' or whether claim action can be taken based on the content.",
+            "title" : "Actionable",
+            "type" : "boolean"
+          },
+          "manifestId" : {
+            "description" : "UUID that uniquely identifies the manifest",
+            "example" : "550e8400-e29b-41d4-a716-446655440000",
+            "maxLength" : 36,
+            "minLength" : 36,
+            "pattern" : "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+            "title" : "Manifest Id",
+            "type" : "string"
+          },
+          "documentId" : {
+            "description" : "UUID that uniquely identifies the document",
+            "example" : "550e8400-e29b-41d4-a716-446655440001",
+            "maxLength" : 36,
+            "minLength" : 36,
+            "pattern" : "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+            "title" : "Document Id",
+            "type" : "string"
+          },
+          "associatedClaimIds" : {
+            "description" : "list of associated claim ids.",
+            "example" : "[\"1\"]",
+            "items" : {
+              "maxLength" : 128,
+              "minLength" : 1,
+              "pattern" : "^[a-zA-Z0-9\\s.\\-_|\\Q\\\\E@#~=%,;?!'\"`():$+*^\\[\\]&<>{}\\Q/\\E]*$",
+              "type" : "string"
+            },
+            "title" : "Associated Claim Ids",
+            "type" : "array"
+          },
+          "notes" : {
+            "description" : "Notes to describe the document.",
+            "example" : "[This is a note for a document, These replace editing the document summary]",
+            "maxLength" : 100,
+            "pattern" : "^[a-zA-Z0-9\\s.\\-_|\\Q\\\\E@#~=%,;?!'\"`():$+*^\\[\\]&<>{}\\Q/\\E]*$",
+            "title" : "Document Notes",
+            "type" : "string"
+          },
+          "payeeCode" : {
+            "description" : "String field designating the Payee Code. Only accepts 2 digits as a string with leading 0 if below 10.",
+            "example" : "00",
+            "maxLength" : 2,
+            "minLength" : 2,
+            "pattern" : "^[0-9]*$",
+            "title" : "Payee Code",
+            "type" : "string"
+          },
+          "endProductCode" : {
+            "description" : "Free text describing the document. This is primarily notes used to assist claim developers. This field must match a valid known end product code.",
+            "example" : "130DPNDCY",
+            "maxLength" : 64,
+            "minLength" : 1,
+            "pattern" : "^[a-zA-Z0-9\\s.\\\\\\-\\_\\|\\/@&><\\(\\))\\'\\+\\,\\$]*$",
+            "title" : "Subject",
+            "type" : "string"
+          },
+          "regionalProcessingOffice" : {
+            "description" : "String field designating the regional processing office.",
+            "example" : "Buffalo",
+            "maxLength" : 15,
+            "minLength" : 3,
+            "pattern" : "^[a-zA-Z0-9\\'\\,\\s.\\-\\_\\|\\/@\\(\\)]*$",
+            "title" : "Regional Processing Office",
+            "type" : "string"
+          },
+          "facilityCode" : {
+            "description" : "String field designating the Facility Code.",
+            "example" : "Facility",
+            "maxLength" : 8,
+            "pattern" : "^[a-zA-Z0-9\\'\\,\\s.\\-\\_\\|\\/@\\(\\)]*$",
+            "title" : "Facility Code",
+            "type" : "string"
+          },
+          "claimantParticipantId" : {
+            "description" : "String field designating the claimant participant Id.",
+            "example" : "000000000",
+            "maxLength" : 15,
+            "pattern" : "^[0-9]*$",
+            "title" : "Claimant Participant Id",
+            "type" : "string"
+          },
+          "sourceComment" : {
+            "description" : "String field containing any comments from the source of the document",
+            "example" : "source comment",
+            "maxLength" : 1200,
+            "pattern" : "^[a-zA-Z0-9\\s.\\-_|\\Q\\\\E@#~=%,;?!'\"`():$+*^\\[\\]&<>{}\\Q/\\E]*$",
+            "title" : "Source comment",
+            "type" : "string"
+          },
+          "claimantDateOfBirth" : {
+            "description" : "Date field indicating the date the claimant was born. This can be any date in format of YYYY-MM-DD from 1900 until today",
+            "example" : "2022-01-01",
+            "format" : "string",
+            "maxLength" : 10,
+            "pattern" : "([12]\\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01]))",
+            "title" : "Claimant Date of Birth",
+            "type" : "string"
+          },
+          "newMail" : {
+            "default" : false,
+            "description" : "Boolean true/false for if the document is considered 'new mail'",
+            "example" : false,
+            "title" : "New Mail",
+            "type" : "boolean"
+          },
+          "documentControlSheet" : {
+            "$ref" : "#/components/schemas/Document_Control_Sheet"
+          }
+        },
+        "required" : [ "contentSource", "dateVaReceivedDocument", "documentTypeId" ],
+        "title" : "Upload / Update Provider Data",
+        "type" : "object"
+      },
+      "conversionMetadata" : {
+        "description" : "Information only present if the document has been converted. Details the previous version mime type, md5, and time of file conversion.",
+        "properties" : {
+          "versionUuid" : {
+            "description" : "UUID identifying the particular version.",
+            "format" : "uuid",
+            "title" : "Version Uuid",
+            "type" : "string"
+          },
+          "mimeType" : {
+            "description" : "Mime Type of the indicated versionUuid.",
+            "title" : "Mime Type",
+            "type" : "string"
+          },
+          "uploadedDateTime" : {
+            "description" : "Date and time the document was uploaded.",
+            "title" : "Uploaded Date Time",
+            "type" : "string"
+          }
+        },
+        "title" : "Conversion Meta-data",
+        "type" : "object"
+      },
+      "systemDataComposition" : {
+        "description" : "Schema for the systemData block in the response object of the getFileData and search endpoints.",
+        "properties" : {
+          "uploadedDateTime" : {
+            "example" : "2022-03-22T15:24:24",
+            "type" : "string"
+          },
+          "contentName" : {
+            "example" : "bf52e49f-5351-4211-b1db-734e3d3c5b64.pdf",
+            "type" : "string"
+          },
+          "contentSize" : {
+            "example" : 1234567,
+            "type" : "integer"
+          },
+          "mimeType" : {
+            "example" : "application/pdf",
+            "type" : "string"
+          },
+          "uploadSource" : {
+            "example" : "VBMS-UI",
+            "type" : "string"
+          }
+        },
+        "title" : "System Data Response",
+        "type" : "object"
+      },
+      "providerData" : {
+        "description" : "Schema for the providerData block in the response object of the getFileData and search endpoints.",
+        "properties" : {
+          "modifiedDateTime" : {
+            "example" : "2022-03-22T15:24:49",
+            "type" : "string"
+          },
+          "dateVaReceivedDocument" : {
+            "example" : "2020-02-20",
+            "type" : "string"
+          },
+          "actionable" : {
+            "type" : "boolean"
+          },
+          "certified" : {
+            "type" : "boolean"
+          },
+          "claimantFirstName" : {
+            "type" : "string"
+          },
+          "claimantMiddleInitial" : {
+            "type" : "string"
+          },
+          "claimantLastName" : {
+            "type" : "string"
+          },
+          "claimantSsn" : {
+            "example" : "123-45-6789",
+            "type" : "string"
+          },
+          "contentSource" : {
+            "example" : "VISTA",
+            "type" : "string"
+          },
+          "benefitTypeId" : {
+            "example" : 13,
+            "type" : "integer"
+          },
+          "regionalProcessingOffice" : {
+            "example" : "Buffalo",
+            "type" : "string"
+          },
+          "payeeCode" : {
+            "example" : "00",
+            "type" : "string"
+          },
+          "facilityCode" : {
+            "example" : "Facility",
+            "type" : "string"
+          },
+          "claimantParticipantId" : {
+            "example" : "000000000",
+            "type" : "string"
+          },
+          "documentTypeId" : {
+            "example" : 137,
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "documentCategoryId" : {
+            "example" : 14,
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "endProductCode" : {
+            "example" : "130DPNDCY",
+            "type" : "string"
+          },
+          "subject" : {
+            "example" : "File contains evidence related to the claim.",
+            "type" : "string"
+          },
+          "systemSource" : {
+            "example" : "VBMS-UI",
+            "type" : "string"
+          },
+          "veteranFirstName" : {
+            "type" : "string"
+          },
+          "veteranLastName" : {
+            "type" : "string"
+          },
+          "veteranMiddleName" : {
+            "type" : "string"
+          },
+          "veteranSuffix" : {
+            "type" : "string"
+          },
+          "claimantDateOfBirth" : {
+            "example" : "2020-02-20",
+            "type" : "string"
+          },
+          "newMail" : {
+            "example" : true,
+            "type" : "boolean"
+          },
+          "readByCurrentUser" : {
+            "example" : false,
+            "type" : "boolean"
+          },
+          "lastOpenedDocument" : {
+            "example" : false,
+            "type" : "boolean"
+          },
+          "duplicateInformation" : {
+            "$ref" : "#/components/schemas/providerData_duplicateInformation"
+          },
+          "ocrStatus" : {
+            "example" : "Searchable",
+            "type" : "string"
+          },
+          "isAnnotated" : {
+            "example" : true,
+            "type" : "boolean"
+          },
+          "hasContentionAnnotation" : {
+            "example" : true,
+            "type" : "boolean"
+          },
+          "notes" : {
+            "example" : "This is a note.",
+            "type" : "string"
+          },
+          "bookmarks" : {
+            "$ref" : "#/components/schemas/providerData_bookmarks"
+          }
+        },
+        "title" : "Provider Data Response",
+        "type" : "object"
+      },
+      "rawTextData" : {
+        "description" : "Schema for the rawTextData block in the response object of the getFileData and search endpoints. (Schema is not currently defined.)",
+        "example" : {
+          "rawOcrData" : "sample text",
+          "ocrDataPerspectives" : {
+            "watson" : "sample text processed by ibm",
+            "other" : "sample text processed by other"
+          }
+        },
+        "title" : "Raw Text Data Response",
+        "type" : "object"
+      },
+      "page" : {
+        "description" : "Object representing OCR data for a page within a file.",
+        "properties" : {
+          "text" : {
+            "type" : "string"
+          },
+          "lines" : {
+            "items" : {
+              "$ref" : "#/components/schemas/line"
+            },
+            "type" : "array"
+          },
+          "pageNumber" : {
+            "minimum" : 1,
+            "type" : "integer"
+          }
+        },
+        "required" : [ "pageNumber" ],
+        "title" : "OCR Data Page",
+        "type" : "object"
+      },
+      "audit" : {
+        "properties" : {
+          "dateTime" : {
+            "example" : "2022-03-23T14:35:44",
+            "type" : "string"
+          },
+          "userId" : {
+            "example" : 269300,
+            "type" : "integer"
+          },
+          "userName" : {
+            "type" : "string"
+          }
+        },
+        "title" : "Audit Info (Annotation)",
+        "type" : "object"
+      },
+      "border" : {
+        "description" : "Informatiom on the border of the annotation.",
+        "properties" : {
+          "width" : {
+            "description" : "Number of pixels wide border appears.",
+            "example" : 1,
+            "minimum" : 0,
+            "title" : "Border width",
+            "type" : "integer"
+          },
+          "color" : {
+            "description" : "Hex color of border. (#XXXXXX) format",
+            "example" : "#000000",
+            "title" : "Border color",
+            "type" : "string"
+          }
+        },
+        "title" : "Border (Annotation)",
+        "type" : "object"
+      },
+      "text" : {
+        "properties" : {
+          "size" : {
+            "example" : 14,
+            "type" : "integer"
+          },
+          "font" : {
+            "example" : "Courier-Oblique",
+            "type" : "string"
+          },
+          "alignment" : {
+            "example" : "left",
+            "type" : "string"
+          },
+          "color" : {
+            "example" : "#000000",
+            "type" : "string"
+          }
+        },
+        "title" : "Text (Annotation)",
+        "type" : "object"
+      },
+      "documentCategory" : {
+        "description" : "Document type category information for UI consumption.",
+        "properties" : {
+          "id" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "createDateTime" : {
+            "type" : "string"
+          },
+          "modifiedDateTime" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "subDescription" : {
+            "type" : "string"
+          }
+        },
+        "title" : "Document Type Category",
+        "type" : "object"
+      },
+      "noteData" : {
+        "description" : "Schema for the noteData block in the response object of the search endpoints.",
+        "properties" : {
+          "archivedBy" : {
+            "example" : "jtimbers",
+            "type" : "string"
+          },
+          "archivedDateTime" : {
+            "example" : "2022-03-22T15:24:24",
+            "type" : "string"
+          },
+          "claimantParticipantId" : {
+            "example" : "192874623",
+            "type" : "string"
+          },
+          "createdDateTime" : {
+            "example" : "2022-03-22T15:24:24",
+            "type" : "string"
+          },
+          "createdBy" : {
+            "example" : "pmetin",
+            "type" : "string"
+          },
+          "lineOfBusiness" : {
+            "example" : "EDU",
+            "type" : "string"
+          }
+        },
+        "title" : "Note Data Response",
+        "type" : "object"
+      },
+      "bookmarkSearchResponseModel" : {
+        "properties" : {
+          "comment" : {
+            "example" : "Comment",
+            "type" : "string"
+          },
+          "realm" : {
+            "example" : "VBA",
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "bookmarkRealmSearchResponseModel" : {
+        "properties" : {
+          "isDefaultRealm" : {
+            "type" : "boolean"
+          },
+          "appeals" : {
+            "$ref" : "#/components/schemas/bookmarkSearchResponseModel"
+          },
+          "medical" : {
+            "$ref" : "#/components/schemas/bookmarkSearchResponseModel"
+          },
+          "peerReview" : {
+            "$ref" : "#/components/schemas/bookmarkSearchResponseModel"
+          },
+          "workingNotes" : {
+            "$ref" : "#/components/schemas/bookmarkSearchResponseModel"
+          },
+          "deferral" : {
+            "$ref" : "#/components/schemas/bookmarkSearchResponseModel"
+          },
+          "dependency" : {
+            "$ref" : "#/components/schemas/bookmarkSearchResponseModel"
+          }
+        },
+        "type" : "object"
+      },
+      "line" : {
+        "description" : "Object representing OCR data for a line within a page.",
+        "properties" : {
+          "text" : {
+            "type" : "string"
+          },
+          "words" : {
+            "items" : {
+              "$ref" : "#/components/schemas/word"
+            },
+            "type" : "array"
+          },
+          "geometry" : {
+            "$ref" : "#/components/schemas/geometry"
+          },
+          "pageNumber" : {
+            "minimum" : 1,
+            "type" : "integer"
+          }
+        },
+        "required" : [ "geometry", "pageNumber", "text", "words" ],
+        "title" : "OCR Data Line",
+        "type" : "object"
+      },
+      "word" : {
+        "description" : "Object representing OCR data for a word within a line.",
+        "properties" : {
+          "text" : {
+            "type" : "string"
+          },
+          "confidence" : {
+            "format" : "float",
+            "type" : "number"
+          },
+          "geometry" : {
+            "$ref" : "#/components/schemas/geometry"
+          },
+          "pageNumber" : {
+            "minimum" : 1,
+            "type" : "integer"
+          }
+        },
+        "required" : [ "geometry", "pageNumber", "text" ],
+        "title" : "OCR Data Word",
+        "type" : "object"
+      },
+      "geometry" : {
+        "description" : "Object describing the geometry (location) of an object (line or word) on a page",
+        "properties" : {
+          "top" : {
+            "format" : "float",
+            "type" : "number"
+          },
+          "left" : {
+            "format" : "float",
+            "type" : "number"
+          },
+          "width" : {
+            "format" : "float",
+            "type" : "number"
+          },
+          "height" : {
+            "format" : "float",
+            "type" : "number"
+          }
+        },
+        "required" : [ "height", "left", "top", "width" ],
+        "title" : "OCR Data - Geometry",
+        "type" : "object"
+      },
+      "searchFiles_400_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/INVALID_JWT"
+        }, {
+          "$ref" : "#/components/schemas/INVALID_REQUEST"
+        }, {
+          "$ref" : "#/components/schemas/INVALID_X_EFOLDER_URI"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_VERIFY_FOLDER"
+        }, {
+          "$ref" : "#/components/schemas/DOES_NOT_CONFORM_TO_SCHEMA"
+        }, {
+          "$ref" : "#/components/schemas/VALIDATE_INVALID_VALUE"
+        } ]
+      },
+      "searchFiles_403_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_PERSON"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_VETERAN"
+        }, {
+          "$ref" : "#/components/schemas/UNAUTHORIZED"
+        } ]
+      },
+      "searchFiles_500_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_USER"
+        }, {
+          "$ref" : "#/components/schemas/NO_RESULTS_RETURNED"
+        }, {
+          "$ref" : "#/components/schemas/INVALID_EVALUATION_TYPE"
+        }, {
+          "$ref" : "#/components/schemas/NULL_RESPONSE"
+        }, {
+          "$ref" : "#/components/schemas/UNKNOWN_ERROR"
+        }, {
+          "$ref" : "#/components/schemas/JSON_DESERIALIZATION"
+        }, {
+          "$ref" : "#/components/schemas/JSON_SERIALIZATION"
+        } ]
+      },
+      "upload_400_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/INVALID_JWT"
+        }, {
+          "$ref" : "#/components/schemas/INVALID_REQUEST"
+        }, {
+          "$ref" : "#/components/schemas/INVALID_X_EFOLDER_URI"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_VERIFY_FOLDER"
+        }, {
+          "$ref" : "#/components/schemas/DOES_NOT_CONFORM_TO_SCHEMA"
+        }, {
+          "$ref" : "#/components/schemas/VALIDATE_INVALID_VALUE"
+        }, {
+          "$ref" : "#/components/schemas/DUPLICATE_PROVIDERDATA_KEYS"
+        }, {
+          "$ref" : "#/components/schemas/DISABLED_IDENTIFER"
+        } ]
+      },
+      "upload_415_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/INVALID_MIMETYPE"
+        }, {
+          "$ref" : "#/components/schemas/WRONG_MIMETYPE_EXTENSION"
+        } ]
+      },
+      "upload_500_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/UNABLE_TO_DETERMINE_MIMETYPE"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_USER"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_UPLOAD_DOCUMENT_CONTENT"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_PERSIST_DATA"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_CONVERT"
+        }, {
+          "$ref" : "#/components/schemas/UNKNOWN_ERROR"
+        }, {
+          "$ref" : "#/components/schemas/JSON_DESERIALIZATION"
+        }, {
+          "$ref" : "#/components/schemas/JSON_SERIALIZATION"
+        } ]
+      },
+      "update_400_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/INVALID_JWT"
+        }, {
+          "$ref" : "#/components/schemas/INVALID_REQUEST"
+        }, {
+          "$ref" : "#/components/schemas/INVALID_X_EFOLDER_URI"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_VERIFY_FOLDER"
+        }, {
+          "$ref" : "#/components/schemas/DOES_NOT_CONFORM_TO_SCHEMA"
+        }, {
+          "$ref" : "#/components/schemas/VALIDATE_INVALID_VALUE"
+        }, {
+          "$ref" : "#/components/schemas/DUPLICATE_PROVIDERDATA_KEYS"
+        } ]
+      },
+      "update_500_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/UNABLE_TO_DETERMINE_MIMETYPE"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_USER"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_UPLOAD_DOCUMENT_CONTENT"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_PERSIST_DATA"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_REMEDIATE_DATA"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_CONVERT"
+        }, {
+          "$ref" : "#/components/schemas/UNKNOWN_ERROR"
+        }, {
+          "$ref" : "#/components/schemas/JSON_DESERIALIZATION"
+        } ]
+      },
+      "getData_200_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/currentFileDataComposition"
+        }, {
+          "$ref" : "#/components/schemas/currentFileDataCompositionWithRawTextData"
+        } ]
+      },
+      "getData_500_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_USER"
+        }, {
+          "$ref" : "#/components/schemas/INVALID_RESPONSE"
+        }, {
+          "$ref" : "#/components/schemas/NULL_RESPONSE"
+        }, {
+          "$ref" : "#/components/schemas/UNKNOWN_ERROR"
+        }, {
+          "$ref" : "#/components/schemas/JSON_SERIALIZATION"
+        } ]
+      },
+      "updateData_500_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_USER"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_PERSIST_DATA"
+        }, {
+          "$ref" : "#/components/schemas/UNKNOWN_ERROR"
+        }, {
+          "$ref" : "#/components/schemas/JSON_DESERIALIZATION"
+        } ]
+      },
+      "retrieveOcrData_404_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/RESOURCE_NOT_FOUND"
+        }, {
+          "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+        } ]
+      },
+      "retrieveOcrData_500_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_USER"
+        }, {
+          "$ref" : "#/components/schemas/NULL_RESPONSE"
+        }, {
+          "$ref" : "#/components/schemas/UNKNOWN_ERROR"
+        } ]
+      },
+      "updateOcrData_400_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/INVALID_JWT"
+        }, {
+          "$ref" : "#/components/schemas/DOES_NOT_CONFORM_TO_SCHEMA"
+        }, {
+          "$ref" : "#/components/schemas/VALIDATE_INVALID_VALUE"
+        } ]
+      },
+      "updateOcrData_500_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_USER"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_PERSIST_DATA"
+        }, {
+          "$ref" : "#/components/schemas/UNKNOWN_ERROR"
+        }, {
+          "$ref" : "#/components/schemas/JSON_DESERIALIZATION"
+        }, {
+          "$ref" : "#/components/schemas/JSON_SERIALIZATION"
+        } ]
+      },
+      "getContent_500_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_USER"
+        }, {
+          "$ref" : "#/components/schemas/PAYLOAD_VALIDATION"
+        }, {
+          "$ref" : "#/components/schemas/UNKNOWN_ERROR"
+        } ]
+      },
+      "Annotation_Request" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/basicAnnotationRequest"
+        }, {
+          "$ref" : "#/components/schemas/lineAnnotationRequest"
+        }, {
+          "$ref" : "#/components/schemas/calloutAnnotationRequest"
+        }, {
+          "$ref" : "#/components/schemas/freetextAnnotationRequest"
+        }, {
+          "$ref" : "#/components/schemas/noteAnnotationRequest"
+        }, {
+          "$ref" : "#/components/schemas/stampAnnotationRequest"
+        }, {
+          "$ref" : "#/components/schemas/textSelectionRequest"
+        } ],
+        "title" : "Annotation Request",
+        "type" : "object"
+      },
+      "Save_Annotation_Response" : {
+        "properties" : {
+          "uuid" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        },
+        "title" : "Save Annotation Response",
+        "type" : "object"
+      },
+      "addAnnotations_400_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/DOES_NOT_CONFORM_TO_SCHEMA"
+        }, {
+          "$ref" : "#/components/schemas/VALIDATE_INVALID_VALUE"
+        }, {
+          "$ref" : "#/components/schemas/INVALID_JWT"
+        } ]
+      },
+      "addAnnotations_500_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_USER"
+        }, {
+          "$ref" : "#/components/schemas/NULL_RESPONSE"
+        }, {
+          "$ref" : "#/components/schemas/UNKNOWN_ERROR"
+        }, {
+          "$ref" : "#/components/schemas/JSON_DESERIALIZATION"
+        } ]
+      },
+      "getBookmarks_500_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_USER"
+        }, {
+          "$ref" : "#/components/schemas/UNKNOWN_ERROR"
+        } ]
+      },
+      "saveBookmarks_400_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/INVALID_JWT"
+        }, {
+          "$ref" : "#/components/schemas/INVALID_REQUEST"
+        }, {
+          "$ref" : "#/components/schemas/INVALID_X_EFOLDER_URI"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_VERIFY_FOLDER"
+        }, {
+          "$ref" : "#/components/schemas/DOES_NOT_CONFORM_TO_SCHEMA"
+        } ]
+      },
+      "saveBookmarks_500_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_USER"
+        }, {
+          "$ref" : "#/components/schemas/UNKNOWN_ERROR"
+        }, {
+          "$ref" : "#/components/schemas/JSON_DESERIALIZATION"
+        } ]
+      },
+      "deleteBookmarks_400_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/INVALID_JWT"
+        }, {
+          "$ref" : "#/components/schemas/INVALID_REQUEST"
+        }, {
+          "$ref" : "#/components/schemas/INVALID_X_EFOLDER_URI"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_VERIFY_FOLDER"
+        } ]
+      },
+      "Update_Annotation_Request" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/basicAnnotationUpdateRequest"
+        }, {
+          "$ref" : "#/components/schemas/lineAnnotationUpdateRequest"
+        } ],
+        "title" : "Update Annotation Request",
+        "type" : "object"
+      },
+      "updateAnnotations_500_response" : {
+        "oneOf" : [ {
+          "type" : "object"
+        }, {
+          "$ref" : "#/components/schemas/UNKNOWN_ERROR"
+        }, {
+          "$ref" : "#/components/schemas/JSON_DESERIALIZATION"
+        }, {
+          "$ref" : "#/components/schemas/JSON_SERIALIZATION"
+        } ]
+      },
+      "getAssociation_200_response" : {
+        "properties" : {
+          "associatedClaimIds" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          }
+        },
+        "type" : "object"
+      },
+      "associate_request" : {
+        "properties" : {
+          "asssociatedClaimIds" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          }
+        },
+        "type" : "object"
+      },
+      "associate_400_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/INVALID_JWT"
+        }, {
+          "$ref" : "#/components/schemas/DOES_NOT_CONFORM_TO_SCHEMA"
+        } ]
+      },
+      "getOcrRaw_404_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/DATA_NOT_FOUND_FOR_CURRENT_VERSION"
+        }, {
+          "$ref" : "#/components/schemas/CURRENT_VERSION_NOT_FOUND"
+        } ]
+      },
+      "updateOcrRaw_500_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_USER"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_PERSIST_DATA"
+        }, {
+          "$ref" : "#/components/schemas/UNKNOWN_ERROR"
+        } ]
+      },
+      "getOcrPerspective_400_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/INVALID_JWT"
+        } ]
+      },
+      "upload_500_response_1" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_USER"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_DETERMINE_MIMETYPE"
+        }, {
+          "$ref" : "#/components/schemas/UNKNOWN_ERROR"
+        } ]
+      },
+      "createNote_500_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_USER"
+        }, {
+          "$ref" : "#/components/schemas/PAYLOAD_VALIDATION"
+        }, {
+          "$ref" : "#/components/schemas/INVALID_RESPONSE"
+        }, {
+          "$ref" : "#/components/schemas/NULL_RESPONSE"
+        }, {
+          "$ref" : "#/components/schemas/UNKNOWN_ERROR"
+        }, {
+          "$ref" : "#/components/schemas/JSON_DESERIALIZATION"
+        } ]
+      },
+      "searchNotes_400_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/INVALID_JWT"
+        }, {
+          "$ref" : "#/components/schemas/INVALID_REQUEST"
+        }, {
+          "$ref" : "#/components/schemas/INVALID_X_EFOLDER_URI"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_VERIFY_FOLDER"
+        }, {
+          "$ref" : "#/components/schemas/DOES_NOT_CONFORM_TO_SCHEMA"
+        }, {
+          "$ref" : "#/components/schemas/VALIDATE_INVALID_VALUE"
+        }, {
+          "$ref" : "#/components/schemas/INVALID_RESPONSE"
+        }, {
+          "$ref" : "#/components/schemas/NULL_RESPONSE"
+        } ]
+      },
+      "searchNotes_500_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_USER"
+        }, {
+          "$ref" : "#/components/schemas/NO_RESULTS_RETURNED"
+        }, {
+          "$ref" : "#/components/schemas/PAYLOAD_VALIDATION"
+        }, {
+          "$ref" : "#/components/schemas/UNKNOWN_ERROR"
+        }, {
+          "$ref" : "#/components/schemas/JSON_DESERIALIZATION"
+        }, {
+          "$ref" : "#/components/schemas/JSON_SERIALIZATION"
+        } ]
+      },
+      "migrateNote_500_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/UNABLE_TO_RETRIEVE_USER"
+        }, {
+          "$ref" : "#/components/schemas/NO_RESULTS_RETURNED"
+        }, {
+          "$ref" : "#/components/schemas/UNABLE_TO_UPLOAD_DOCUMENT_CONTENT"
+        }, {
+          "$ref" : "#/components/schemas/UNKNOWN_ERROR"
+        }, {
+          "$ref" : "#/components/schemas/JSON_DESERIALIZATION"
+        } ]
+      },
+      "retrieveSavedFilters_501_response" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/OPERATION_NOT_ENABLED"
+        }, {
+          "$ref" : "#/components/schemas/UNKNOWN_ERROR"
+        } ]
+      },
+      "saveAndPublishFilter_200_response_filter_providerData_keyword" : {
+        "properties" : {
+          "evaluationType" : {
+            "example" : "CONTAINS",
+            "type" : "string"
+          },
+          "value" : {
+            "example" : "[\"filter\",\"two\"]",
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "saveAndPublishFilter_200_response_filter_textContent_query" : {
+        "properties" : {
+          "includesAll" : {
+            "example" : [ "includes all example", "includes all example 2" ],
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "excludes" : {
+            "items" : {
+              "example" : "[excludes criteria]",
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "includesAtLeastOne" : {
+            "items" : {
+              "example" : "[color]",
+              "type" : "string"
+            },
+            "type" : "array"
+          }
+        },
+        "type" : "object"
+      },
+      "saveAndPublishFilter_200_response_filter_textContent" : {
+        "properties" : {
+          "evaluationType" : {
+            "example" : "QUERY",
+            "type" : "string"
+          },
+          "query" : {
+            "$ref" : "#/components/schemas/saveAndPublishFilter_200_response_filter_textContent_query"
+          }
+        },
+        "type" : "object"
+      },
+      "saveAndPublishFilter_200_response_filter" : {
+        "properties" : {
+          "providerData.keyword" : {
+            "$ref" : "#/components/schemas/saveAndPublishFilter_200_response_filter_providerData_keyword"
+          },
+          "textContent" : {
+            "$ref" : "#/components/schemas/saveAndPublishFilter_200_response_filter_textContent"
+          }
+        },
+        "type" : "object"
+      },
+      "saveAndPublishFilter_200_response" : {
+        "properties" : {
+          "id" : {
+            "example" : 1111111,
+            "type" : "integer"
+          },
+          "name" : {
+            "example" : "filterName",
+            "type" : "string"
+          },
+          "filter" : {
+            "$ref" : "#/components/schemas/saveAndPublishFilter_200_response_filter"
+          },
+          "published" : {
+            "example" : true,
+            "type" : "boolean"
+          }
+        },
+        "type" : "object"
+      },
+      "updateSavedFilter_200_response_filter_textContent_query" : {
+        "properties" : {
+          "includesAtLeastOne" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          }
+        },
+        "type" : "object"
+      },
+      "updateSavedFilter_200_response_filter_textContent" : {
+        "properties" : {
+          "evaluationType" : {
+            "example" : "QUERY",
+            "type" : "string"
+          },
+          "query" : {
+            "$ref" : "#/components/schemas/updateSavedFilter_200_response_filter_textContent_query"
+          }
+        },
+        "type" : "object"
+      },
+      "updateSavedFilter_200_response_filter" : {
+        "properties" : {
+          "textContent" : {
+            "$ref" : "#/components/schemas/updateSavedFilter_200_response_filter_textContent"
+          }
+        },
+        "type" : "object"
+      },
+      "updateSavedFilter_200_response" : {
+        "properties" : {
+          "id" : {
+            "example" : 1019,
+            "type" : "integer"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "filter" : {
+            "$ref" : "#/components/schemas/updateSavedFilter_200_response_filter"
+          },
+          "published" : {
+            "type" : "boolean"
+          }
+        },
+        "type" : "object"
+      },
+      "subscribeToPublishedSavedFilter_200_response_savedFilterSubscription" : {
+        "properties" : {
+          "id" : {
+            "example" : 100,
+            "type" : "integer"
+          },
+          "vbmsUserId" : {
+            "example" : 111111,
+            "type" : "integer"
+          },
+          "filterId" : {
+            "example" : 1003,
+            "type" : "integer"
+          }
+        },
+        "type" : "object"
+      },
+      "subscribeToPublishedSavedFilter_200_response" : {
+        "properties" : {
+          "savedFilterSubscription" : {
+            "$ref" : "#/components/schemas/subscribeToPublishedSavedFilter_200_response_savedFilterSubscription"
+          }
+        },
+        "type" : "object"
+      },
+      "unsubscribeFromPublishedSavedFilter_200_response_savedFilterSubscription" : {
+        "properties" : {
+          "id" : {
+            "example" : 111111,
+            "type" : "integer"
+          },
+          "vbmsUserId" : {
+            "example" : 222222,
+            "type" : "integer"
+          },
+          "filterId" : {
+            "example" : 9999999,
+            "type" : "integer"
+          }
+        },
+        "type" : "object"
+      },
+      "unsubscribeFromPublishedSavedFilter_200_response" : {
+        "properties" : {
+          "savedFilterSubscription" : {
+            "$ref" : "#/components/schemas/unsubscribeFromPublishedSavedFilter_200_response_savedFilterSubscription"
+          }
+        },
+        "type" : "object"
+      },
+      "deleteSavedFileQuery_200_response_savedFilter" : {
+        "properties" : {
+          "id" : {
+            "example" : 2800103,
+            "type" : "integer"
+          },
+          "queryName" : {
+            "example" : "portals Savings e83d87d7-6f63-4442-8f01-1d41a9f0f78e",
+            "type" : "string"
+          },
+          "userId" : {
+            "example" : 1126900,
+            "type" : "integer"
+          },
+          "published" : {
+            "example" : false,
+            "type" : "boolean"
+          },
+          "queryContent" : {
+            "example" : "{\"filters\":{\"providerData.keyword\":{\"evaluationType\":\"CONTAINS\",\"value\":\"[\\\"doc\\\",\\\"type\\\"]\"},\"textContent\":{\"evaluationType\":\"QUERY\",\"query\":{\"includesAll\":[\"includes all example\",\"includes all example 2\"]}}}}",
+            "type" : "string"
+          },
+          "active" : {
+            "example" : false,
+            "type" : "boolean"
+          }
+        },
+        "type" : "object"
+      },
+      "deleteSavedFileQuery_200_response" : {
+        "properties" : {
+          "savedFilter" : {
+            "$ref" : "#/components/schemas/deleteSavedFileQuery_200_response_savedFilter"
+          }
+        },
+        "type" : "object"
+      },
+      "noJwtResponse_messages_inner" : {
+        "properties" : {
+          "timestamp" : {
+            "example" : "2024-05-20T15:53:29.389",
+            "type" : "string"
+          },
+          "key" : {
+            "enum" : [ "UNAUTHORIZED" ],
+            "type" : "string"
+          },
+          "severity" : {
+            "enum" : [ "ERROR" ],
+            "type" : "string"
+          },
+          "status" : {
+            "enum" : [ "401" ],
+            "type" : "string"
+          },
+          "text" : {
+            "enum" : [ "No JWT Token in Header." ],
+            "type" : "string"
+          },
+          "httpStatus" : {
+            "enum" : [ "UNAUTHORIZED" ],
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "saveBookmarksRequest_appeals" : {
+        "properties" : {
+          "comment" : {
+            "example" : "Comments have a max of 100 characters",
+            "maxLength" : 100,
+            "pattern" : "^[a-zA-Z0-9\\\\s.\\\\-_|\\\\Q\\\\\\\\E@#~=%,;?!'\\\"`():$+*^\\\\[\\\\]&<>{}\\\\Q/\\\\E]*$",
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "saveBookmarksRequest_workingNotes" : {
+        "properties" : {
+          "comment" : {
+            "example" : "Can have some special characters and Numbers {}>>?",
+            "maxLength" : 100,
+            "pattern" : "^[a-zA-Z0-9\\\\s.\\\\-_|\\\\Q\\\\\\\\E@#~=%,;?!'\\\"`():$+*^\\\\[\\\\]&<>{}\\\\Q/\\\\E]*$",
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "saveBookmarksRequest_medical" : {
+        "properties" : {
+          "comment" : {
+            "example" : "Comments are not required, with the exception of deferral bookmark types",
+            "maxLength" : 100,
+            "pattern" : "^[a-zA-Z0-9\\\\s.\\\\-_|\\\\Q\\\\\\\\E@#~=%,;?!'\\\"`():$+*^\\\\[\\\\]&<>{}\\\\Q/\\\\E]*$",
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "saveBookmarksRequest_deferral" : {
+        "properties" : {
+          "comment" : {
+            "example" : "Need at least one character in comment for this bookmark type",
+            "maxLength" : 100,
+            "minLength" : 1,
+            "pattern" : "^\\\\S[a-zA-Z0-9\\\\s.\\\\-_|\\\\Q\\\\\\\\E@#~=%,;?!'\\\"`():$+*^\\\\[\\\\]&<>{}\\\\Q/\\\\E]*$",
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "saveBookmarksRequest_dependency" : {
+        "properties" : {
+          "comment" : {
+            "example" : "Only one instance of each bookmark type is allowed per file",
+            "maxLength" : 100,
+            "pattern" : "^[a-zA-Z0-9\\\\s.\\\\-_|\\\\Q\\\\\\\\E@#~=%,;?!'\\\"`():$+*^\\\\[\\\\]&<>{}\\\\Q/\\\\E]*$",
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "saveBookmarksRequest_peerReview" : {
+        "properties" : {
+          "comment" : {
+            "example" : "Comments will update when resending a bookmark type",
+            "maxLength" : 100,
+            "pattern" : "^[a-zA-Z0-9\\\\s.\\\\-_|\\\\Q\\\\\\\\E@#~=%,;?!'\\\"`():$+*^\\\\[\\\\]&<>{}\\\\Q/\\\\E]*$",
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "bookmarkResponseModel_created" : {
+        "properties" : {
+          "dateTime" : {
+            "example" : "2022-04-26T22:41:16",
+            "type" : "string"
+          },
+          "userName" : {
+            "example" : "jim *han",
+            "type" : "string"
+          },
+          "userId" : {
+            "example" : 132050,
+            "format" : "int32",
+            "type" : "integer"
+          }
+        },
+        "type" : "object"
+      },
+      "createNoteRequest_noteData" : {
+        "properties" : {
+          "claimantParticipantId" : {
+            "description" : "String field designating the claimant participant Id.",
+            "example" : "000000000",
+            "maxLength" : 15,
+            "pattern" : "^[0-9]*$",
+            "title" : "Claimant Participant Id",
+            "type" : "string"
+          },
+          "lineOfBusiness" : {
+            "example" : "EDU",
+            "pattern" : "^[a-zA-Z0-9\\s.\\-_|\\Q\\\\E@#~=%,;?!'\"`():$+*^\\[\\]&<>{}\\Q/\\E]*$",
+            "title" : "Line of Business",
+            "type" : "string"
+          }
+        },
+        "required" : [ "claimantParticipantId", "lineOfBusiness" ],
+        "type" : "object"
+      },
+      "FilterRequest_filters_textContent_query" : {
+        "properties" : {
+          "includesAll" : {
+            "example" : [ "includes all example", "includes all example 2" ],
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          }
+        },
+        "type" : "object"
+      },
+      "FilterRequest_filters_textContent" : {
+        "properties" : {
+          "evaluationType" : {
+            "example" : "QUERY",
+            "type" : "string"
+          },
+          "query" : {
+            "$ref" : "#/components/schemas/FilterRequest_filters_textContent_query"
+          }
+        },
+        "type" : "object"
+      },
+      "FilterRequest_filters" : {
+        "properties" : {
+          "providerData.keyword" : {
+            "$ref" : "#/components/schemas/saveAndPublishFilter_200_response_filter_providerData_keyword"
+          },
+          "textContent" : {
+            "$ref" : "#/components/schemas/FilterRequest_filters_textContent"
+          }
+        },
+        "type" : "object"
+      },
+      "moveNotificationsResponse_sent_inner_documentType" : {
+        "properties" : {
+          "id" : {
+            "type" : "integer"
+          },
+          "description" : {
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "moveNotificationsResponse_sent_inner" : {
+        "properties" : {
+          "uuid" : {
+            "type" : "string"
+          },
+          "documentType" : {
+            "$ref" : "#/components/schemas/moveNotificationsResponse_sent_inner_documentType"
+          },
+          "destination" : {
+            "$ref" : "#/components/schemas/moveNotificationsResponse_sent_inner_documentType"
+          },
+          "destinationName" : {
+            "type" : "string"
+          },
+          "date" : {
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "moveNotificationsResponse_received_inner" : {
+        "properties" : {
+          "uuid" : {
+            "type" : "string"
+          },
+          "documentType" : {
+            "$ref" : "#/components/schemas/moveNotificationsResponse_sent_inner_documentType"
+          },
+          "source" : {
+            "$ref" : "#/components/schemas/moveNotificationsResponse_sent_inner_documentType"
+          },
+          "sourceName" : {
+            "type" : "string"
+          },
+          "date" : {
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "periodOfServiceDocumentsResponse_periodOfServiceInformationList_inner" : {
+        "properties" : {
+          "enteredOnDutyDt" : {
+            "example" : "13/03/2022",
+            "type" : "string"
+          },
+          "releasedActiveDutyDt" : {
+            "example" : "21/04/2024",
+            "type" : "string"
+          },
+          "verified" : {
+            "type" : "boolean"
+          },
+          "veteransAssistanceDischargeSystemVerified" : {
+            "type" : "boolean"
+          },
+          "linkageTypes" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          }
+        },
+        "type" : "object"
+      },
+      "uploadRequest_1_uploads_inner" : {
+        "description" : "List of documents to upload, each with a document ID and title",
+        "properties" : {
+          "documentId" : {
+            "description" : "The UUID of the document",
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "title" : {
+            "description" : "The title of the document",
+            "type" : "string"
+          }
+        },
+        "required" : [ "documentId" ],
+        "type" : "object"
+      },
+      "getManifestResponse_documentUploadResponses_inner" : {
+        "properties" : {
+          "documentId" : {
+            "description" : "document identification",
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "documentUploadDataId" : {
+            "description" : "document upload data identification",
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "documentTitle" : {
+            "description" : "document title",
+            "type" : "string"
+          },
+          "completed" : {
+            "description" : "whether the document has been completed",
+            "type" : "boolean"
+          }
+        },
+        "type" : "object"
+      },
+      "Period_Of_Service_Information_List_inner" : {
+        "properties" : {
+          "enteredOnDutyDt" : {
+            "example" : "13/03/2022",
+            "type" : "string"
+          },
+          "releasedActiveDutyDt" : {
+            "example" : "21/04/2024",
+            "type" : "string"
+          },
+          "linkageTypes" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          }
+        },
+        "type" : "object"
+      },
+      "selectedAreas_inner" : {
+        "properties" : {
+          "topLeftX" : {
+            "example" : 50,
+            "type" : "integer"
+          },
+          "topLeftY" : {
+            "example" : 100,
+            "type" : "integer"
+          },
+          "topRightX" : {
+            "example" : 100,
+            "type" : "integer"
+          },
+          "topRightY" : {
+            "example" : 100,
+            "type" : "integer"
+          },
+          "bottomLeftX" : {
+            "example" : 100,
+            "type" : "integer"
+          },
+          "bottomLeftY" : {
+            "example" : 50,
+            "type" : "integer"
+          },
+          "bottomRightX" : {
+            "example" : 50,
+            "type" : "integer"
+          },
+          "bottomRightY" : {
+            "example" : 50,
+            "type" : "integer"
+          }
+        },
+        "type" : "object"
+      },
+      "Unassociate_Permission" : {
+        "description" : "Flag indicating whether the requesting user has permission to unassociate file.",
+        "properties" : {
+          "hasAccess" : {
+            "example" : true,
+            "title" : "the value of the unassoicate permission",
+            "type" : "boolean"
+          }
+        },
+        "title" : "Unassociate Permission",
+        "type" : "object"
+      },
+      "Move_Permission" : {
+        "description" : "Flag indicating whether the requesting user has permission to move file",
+        "properties" : {
+          "hasAccess" : {
+            "example" : true,
+            "title" : "the value of the move permission",
+            "type" : "boolean"
+          }
+        },
+        "title" : "Move Permission",
+        "type" : "object"
+      },
+      "FilterObject_filter_textContent_query" : {
+        "properties" : {
+          "includesAll" : {
+            "items" : {
+              "example" : "[\"swelling\",\"bruised\"]",
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "excludes" : {
+            "items" : {
+              "example" : "[\"leg\"]",
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "includesAtLeastOne" : {
+            "items" : {
+              "example" : "[\"discolored\"]",
+              "type" : "string"
+            },
+            "type" : "array"
+          }
+        },
+        "type" : "object"
+      },
+      "FilterObject_filter_textContent" : {
+        "properties" : {
+          "evaluationType" : {
+            "example" : "QUERY",
+            "type" : "string"
+          },
+          "query" : {
+            "$ref" : "#/components/schemas/FilterObject_filter_textContent_query"
+          }
+        },
+        "type" : "object"
+      },
+      "FilterObject_filter" : {
+        "properties" : {
+          "textContent" : {
+            "$ref" : "#/components/schemas/FilterObject_filter_textContent"
+          }
+        },
+        "type" : "object"
+      },
+      "Document_Control_Sheet" : {
+        "description" : "Object contains document sheet id and status",
+        "properties" : {
+          "dcsId" : {
+            "description" : "Optional DCS id during upload",
+            "example" : "LZ8GEZK16F0D8P",
+            "maxLength" : 256,
+            "minimum" : 1,
+            "pattern" : "^[a-zA-Z0-9]{1,13}-?[a-zA-Z0-9]{1,6}$",
+            "title" : "DCS ID",
+            "type" : "string"
+          },
+          "dcsScanningComplete" : {
+            "default" : false,
+            "description" : "Boolean true/false for if this document completes its DCS set",
+            "example" : false,
+            "title" : "DCS has Completed Scanning",
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "dcsId" ],
+        "title" : "Document Control Sheet",
+        "type" : "object"
+      },
+      "providerData_duplicateInformation" : {
+        "properties" : {
+          "bestCopy" : {
+            "type" : "boolean"
+          },
+          "certifiedCopy" : {
+            "type" : "boolean"
+          },
+          "establishesDate" : {
+            "type" : "boolean"
+          },
+          "groupId" : {
+            "type" : "integer"
+          }
+        },
+        "type" : "object"
+      },
+      "providerData_bookmarks" : {
+        "properties" : {
+          "appeals" : {
+            "$ref" : "#/components/schemas/bookmarkSearchResponseModel"
+          },
+          "medical" : {
+            "$ref" : "#/components/schemas/bookmarkSearchResponseModel"
+          },
+          "peerReview" : {
+            "$ref" : "#/components/schemas/bookmarkSearchResponseModel"
+          },
+          "workingNotes" : {
+            "$ref" : "#/components/schemas/bookmarkSearchResponseModel"
+          },
+          "deferral" : {
+            "$ref" : "#/components/schemas/bookmarkSearchResponseModel"
+          },
+          "dependency" : {
+            "$ref" : "#/components/schemas/bookmarkSearchResponseModel"
+          },
+          "VBA" : {
+            "$ref" : "#/components/schemas/bookmarkRealmSearchResponseModel"
+          },
+          "VRO" : {
+            "$ref" : "#/components/schemas/bookmarkRealmSearchResponseModel"
+          },
+          "BVA" : {
+            "$ref" : "#/components/schemas/bookmarkRealmSearchResponseModel"
+          }
+        },
+        "type" : "object"
+      }
+    },
+    "securitySchemes" : {
+      "bearer-key" : {
+        "bearerFormat" : "JWT",
+        "scheme" : "bearer",
+        "type" : "http"
+      }
+    }
+  }
+}

--- a/modules/claims_evidence_api/documentation/doctypes.json
+++ b/modules/claims_evidence_api/documentation/doctypes.json
@@ -1,0 +1,17900 @@
+{
+    "documentTypes" : [
+        {
+            "id" : 211,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2018-02-26T17:58:09",
+            "name" : "L182",
+            "description" : "VA 21-555 Certificate of Legal Capacity",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 423,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2018-02-26T17:58:09",
+            "name" : "L423",
+            "description" : "VA 21-555a Designation of Payee",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 136,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2017-08-04T14:38:35",
+            "name" : "L127",
+            "description" : "VA 21-592 Request for Appointment of Fiduciary Custodian or Guardian",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 453,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2016-10-07T15:08:00",
+            "name" : "L453",
+            "description" : "VA 21-6798 Disability Award",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 25,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Awards / Disallowance"
+            }
+        },
+        {
+            "id" : 586,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2018-02-26T17:58:09",
+            "name" : "L586",
+            "description" : "VA 21-6898 Application for Amounts on Deposit for Deceased Veteran",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 20,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L009",
+            "description" : "Appeal Checklist",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 469,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L469",
+            "description" : "Appeal Process Request Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 470,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L470",
+            "description" : "Appeals Election Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 27,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L016",
+            "description" : "BVA Decision",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 28,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L017",
+            "description" : "CAVC Decision",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 471,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L471",
+            "description" : "DRO Process Explanation Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 479,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L479",
+            "description" : "Election DRO Process",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 480,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L480",
+            "description" : "Election Traditional Process",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 507,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L507",
+            "description" : "Hearing Request",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 73,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L063",
+            "description" : "Notice of Disagreement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 86,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L076",
+            "description" : "Remand BVA or CAVC",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 95,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L085",
+            "description" : "Statement of Case (SOC)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 97,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L087",
+            "description" : "Supplemental Statement of Case (SSOC)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 174,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L165",
+            "description" : "VA 646 Statement of Accredited Representative in Appealed Case",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 178,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L169",
+            "description" : "VA 8 Certification of Appeal",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 179,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L170",
+            "description" : "VA 9 Appeal to Board of Appeals",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 23,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L012",
+            "description" : "Audit Report",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 473,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L473",
+            "description" : "Financial Actions (waiver, requests, check replacement requests, check reissued, finance letters)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 52,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L041",
+            "description" : "Forfeiture Statements",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 164,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L155",
+            "description" : "VA 24-0296 Direct Deposit Enrollment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 572,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L572",
+            "description" : "VA 4472 Return Check Worksheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 461,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L461",
+            "description" : "VA 5285 Certificate of Indebtedness",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 460,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L460",
+            "description" : "VA 5602 Receipt for Returned Treasury Check",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 103,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L093",
+            "description" : "VA 5655 Financial Status Report (Submit with Waiver Request)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 560,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L560",
+            "description" : "Veterans Rate Month of Death Payment Confirmation",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 464,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L464",
+            "description" : "VA 24-1042a Referral Of Indebtedness To Committee on Waivers and Compromises",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 23,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions",
+                "subDescription" : "COW"
+            }
+        },
+        {
+            "id" : 531,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L531",
+            "description" : "VAF 4-661, Debt Management Center Referrals for Committee on Waivers and Compromises",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 23,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions",
+                "subDescription" : "COW"
+            }
+        },
+        {
+            "id" : 476,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L476",
+            "description" : "MES Invoice",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 24,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions",
+                "subDescription" : "Other"
+            }
+        },
+        {
+            "id" : 357,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L215",
+            "description" : "QTC Invoice",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 24,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions",
+                "subDescription" : "Other"
+            }
+        },
+        {
+            "id" : 465,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L465",
+            "description" : "VA 24-5243 Overpayment Flash Notice Of Termination",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 24,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions",
+                "subDescription" : "Other"
+            }
+        },
+        {
+            "id" : 360,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L220",
+            "description" : "VA 4-6698 Computer Sampling Extract - Fiscal Audit Worksheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 24,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions",
+                "subDescription" : "Other"
+            }
+        },
+        {
+            "id" : 159,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L150",
+            "description" : "VA 21-8947 Compensation and Pension Award",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 25,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Awards / Disallowance"
+            }
+        },
+        {
+            "id" : 508,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2015-08-11T22:01:57",
+            "name" : "L508",
+            "description" : "Award Print",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 25,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Awards / Disallowance"
+            }
+        },
+        {
+            "id" : 156,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L147",
+            "description" : "VA 21-8679 Eligibility Determination for Clothing Allowance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 26,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Awards / Disallowance",
+                "subDescription" : "Live Awards "
+            }
+        },
+        {
+            "id" : 384,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L224",
+            "description" : "VA 21-8768 Disability Pension Award attachment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 26,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Awards / Disallowance",
+                "subDescription" : "Live Awards "
+            }
+        },
+        {
+            "id" : 145,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L136",
+            "description" : "VA 21-6753 Original or Amended Dependency and Indemnity Compensation Award",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 27,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Awards / Disallowance",
+                "subDescription" : "Death Awards "
+            }
+        },
+        {
+            "id" : 383,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L223",
+            "description" : "VA 21-8767 Death Pension Award Attachment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 27,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Awards / Disallowance",
+                "subDescription" : "Death Awards "
+            }
+        },
+        {
+            "id" : 509,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L509",
+            "description" : "Care Expense Statement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 416,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L416",
+            "description" : "Civil Service Information",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 513,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L513",
+            "description" : "CWT Notice",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 49,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L038",
+            "description" : "Eligibility Verification Report",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 518,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L518",
+            "description" : "Income and Tax Statements",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 580,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L580",
+            "description" : "Non-Medical Expenses (e.g., living expenses)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 417,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L417",
+            "description" : "Railroad Retirement Information",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 189,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L179",
+            "description" : "SHARE Print Screens",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 93,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L083",
+            "description" : "SSA/SSI Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 413,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L413",
+            "description" : "User Calculations (Medical Expenses, Partial Year Adjustment)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 106,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L097",
+            "description" : "VA 21-0571 Application for Exclusion of Childrens Income",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 117,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L108",
+            "description" : "VA 21-4165 Pension Claim Questionnaire for Farm Income",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 123,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L114",
+            "description" : "VA 21-4185 Report of Income from Property or Business",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 149,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L140",
+            "description" : "VA 21-8049 Request for Details of Expenses",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 151,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L142",
+            "description" : "VA 21-8086 Request for Benefit Data",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 154,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L145",
+            "description" : "VA 21-8416 Request for Information concerning Medical, Legal or Other Expenses",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 557,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L557",
+            "description" : "VETSNET EVR Screens (Incomplete and Returned EVRs, Max Rate, etc)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 336,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L195",
+            "description" : "Administrative Decision",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 30,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Determinations"
+            }
+        },
+        {
+            "id" : 376,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L217",
+            "description" : "VA Memo",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 30,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Determinations"
+            }
+        },
+        {
+            "id" : 120,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L111",
+            "description" : "VA 21-4176 Report of Accidental Injury in Support of Claim for Compensation or Pension",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 31,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Determinations",
+                "subDescription" : "Line of Duty "
+            }
+        },
+        {
+            "id" : 21,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L010",
+            "description" : "Apportionment Decision",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 33,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Determinations",
+                "subDescription" : "Dependency Issues "
+            }
+        },
+        {
+            "id" : 12,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L001",
+            "description" : "Accident Reports",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 35,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Service Personnel Records"
+            }
+        },
+        {
+            "id" : 40,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L029",
+            "description" : "Certificate of Release or Discharge From Active Duty (e.g. DD 214, NOAA 56-16, PHS 1867)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 35,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Service Personnel Records"
+            }
+        },
+        {
+            "id" : 35,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L024",
+            "description" : "DD 1141 Record of Exposure to Ionizing Radiation",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 35,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Service Personnel Records"
+            }
+        },
+        {
+            "id" : 47,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L036",
+            "description" : "Discharge / Retirement or ETS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 35,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Service Personnel Records"
+            }
+        },
+        {
+            "id" : 701,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L701",
+            "description" : "DPRIS Response",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 35,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Service Personnel Records"
+            }
+        },
+        {
+            "id" : 60,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L050",
+            "description" : "Logbooks",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 35,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Service Personnel Records"
+            }
+        },
+        {
+            "id" : 45,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L034",
+            "description" : "Military Personnel Record",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 35,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Service Personnel Records"
+            }
+        },
+        {
+            "id" : 90,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L080",
+            "description" : "Service Record (SR)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 35,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Service Personnel Records"
+            }
+        },
+        {
+            "id" : 112,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L103",
+            "description" : "VA 21-3101 Request for Information",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 35,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Service Personnel Records"
+            }
+        },
+        {
+            "id" : 420,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L420",
+            "description" : "DD 214 Certified Original - Certificate of Release or Discharge From Active Duty",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 36,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Service Personnel Records",
+                "subDescription" : "DD Form 214 / 215 "
+            }
+        },
+        {
+            "id" : 41,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L030",
+            "description" : "DD 215 Corrected DD Form 214 Certificate of Release or Discharge From Active Duty",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 36,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Service Personnel Records",
+                "subDescription" : "DD Form 214 / 215 "
+            }
+        },
+        {
+            "id" : 79,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L069",
+            "description" : "Personnel Record",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 37,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Service Personnel Records",
+                "subDescription" : "OMPF File / PTSD Data "
+            }
+        },
+        {
+            "id" : 85,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L075",
+            "description" : "Power of Attorney (incl. VA 21-22, VA 22a)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 40,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Representation"
+            }
+        },
+        {
+            "id" : 15,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L004",
+            "description" : "Agent Fee Agreement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 41,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Representation",
+                "subDescription" : "Private Attorney/Attorney Fee Agreement "
+            }
+        },
+        {
+            "id" : 295,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L190",
+            "description" : "VA 21-22 Appointment of Veterans Serv. Org. as Claimant Rep",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 42,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Representation",
+                "subDescription" : "National Service Organization "
+            }
+        },
+        {
+            "id" : 494,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L494",
+            "description" : "VA 21-0845 Authorization to Disclose Personal Information to a Third Party",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 43,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Representation",
+                "subDescription" : "Other "
+            }
+        },
+        {
+            "id" : 356,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L214",
+            "description" : "C&P Exam",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 344,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L203",
+            "description" : "CAPRI",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 463,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L463",
+            "description" : "Medical Statement for Consideration of Aid & Attendance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 58,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L048",
+            "description" : "Medical Treatment Record - Government Facility",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 478,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L478",
+            "description" : "Medical Treatment Records - Furnished by SSA",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 80,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L070",
+            "description" : "Photographs",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 92,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L082",
+            "description" : "SF 502 Clinical Record - Narrative Summary",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 96,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L086",
+            "description" : "Summaries of Inpatient Treatment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 566,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L566",
+            "description" : "VA 21-0960A-1 Ischemic Heart Disease Disability Benefits Questionnaire",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 567,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L567",
+            "description" : "VA 21-0960B-1 Hairy Cell and other B-Cell Leukemias Disability Benefits Questionnaire",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 568,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L568",
+            "description" : "VA 21-0960C-1 Parkinsons Disease Disability Benefits Questionnaire",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 111,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L102",
+            "description" : "VA 21-2680 Examination for Housebound Status or Permanent Need for Regular Aid and Attendance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 316,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L194",
+            "description" : "VA Examination",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 16,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L005",
+            "description" : "VAMC Other Output / Reports",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 573,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L573",
+            "description" : "VHA Clarification",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 59,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L049",
+            "description" : "Medical Treatment Record - Non-Government Facility",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 45,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records",
+                "subDescription" : "Private (Separated by Source) "
+            }
+        },
+        {
+            "id" : 150,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L141",
+            "description" : "VA 21-8056 Request for Retirement Information from the Railroad Retirement Board and Certification of Information From Department of Veterans Affairs",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 152,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L143",
+            "description" : "VA 21-8358 Notice to Department of Veterans Affairs of Admission to Uniformed Services Hospital",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 153,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L144",
+            "description" : "VA 21-8359 Information Re Veteran in Uniformed Services Hospital or Dispensary",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 258,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L189",
+            "description" : "VA 21-8960 Certification of School Attendance or Termination",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 495,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L495",
+            "description" : "VA 5571 Authorization to Disclose a Record in the Presence of a Third Party",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 173,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L164",
+            "description" : "VA 572 Request for Change of Address / Cancellation of Direct Deposit",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 175,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L166",
+            "description" : "VA 70-3288 Request for and Consent to Release of Information from Claimants Records",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 176,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L167",
+            "description" : "VA 70-4535 Notice of Employment, Transfer, or Separation of Veteran",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 177,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L168",
+            "description" : "VA 70-7216a Request for and/or Notice of Transfer of Veterans Records / COVERS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 14,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L003",
+            "description" : "Affidavit",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 71,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence"
+            }
+        },
+        {
+            "id" : 505,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L505",
+            "description" : "Assisted-Living Information",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 71,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence"
+            }
+        },
+        {
+            "id" : 22,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L011",
+            "description" : "Audio / Video Tapes",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 71,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence"
+            }
+        },
+        {
+            "id" : 26,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L015",
+            "description" : "Buddy / Lay Statement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 71,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence"
+            }
+        },
+        {
+            "id" : 29,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L018",
+            "description" : "Civilian Police Reports",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 71,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence"
+            }
+        },
+        {
+            "id" : 31,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L020",
+            "description" : "Commercial Invoice - Automotive Grant",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 71,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence"
+            }
+        },
+        {
+            "id" : 57,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L047",
+            "description" : "Hearing Testimony",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 71,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence"
+            }
+        },
+        {
+            "id" : 407,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L407",
+            "description" : "Nursing Home Statement (General)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 71,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence"
+            }
+        },
+        {
+            "id" : 503,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L503",
+            "description" : "State Medicaid Information",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 71,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence"
+            }
+        },
+        {
+            "id" : 375,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L222",
+            "description" : "VA 21-0779 Request for Nursing Home Info In Connection with Claim for Aid and Attendance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 71,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence"
+            }
+        },
+        {
+            "id" : 381,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L228",
+            "description" : "VA 21-0781, Statement in Support of Claim for PTSD",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 71,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence"
+            }
+        },
+        {
+            "id" : 382,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2016-07-11T13:41:02",
+            "name" : "L229",
+            "description" : "VA 21-0781a, Statement in Support of Claim for PTSD Secondary to Personal Assault",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 71,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence"
+            }
+        },
+        {
+            "id" : 377,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L218",
+            "description" : "VA 21-4140 Employment Questionnaire",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 71,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence"
+            }
+        },
+        {
+            "id" : 386,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L226",
+            "description" : "VA 21-4140-1 Employment Questionnaire",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 71,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence"
+            }
+        },
+        {
+            "id" : 182,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L173",
+            "description" : "VA 4 Personal Exemption Worksheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 71,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence"
+            }
+        },
+        {
+            "id" : 181,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L172",
+            "description" : "Web / HTML Documents",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 71,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence"
+            }
+        },
+        {
+            "id" : 63,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L053",
+            "description" : "Medical Receipts",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 72,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence",
+                "subDescription" : "Live Evidence "
+            }
+        },
+        {
+            "id" : 124,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L115",
+            "description" : "VA 21-4192 Request for Employment Information in Connection with Claim for Disability",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 72,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence",
+                "subDescription" : "Live Evidence "
+            }
+        },
+        {
+            "id" : 125,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L116",
+            "description" : "VA 21-4193 Notice to Veterans Administration of Veteran or Beneficiary Incarcerated in Penal Institution",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 72,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence",
+                "subDescription" : "Live Evidence "
+            }
+        },
+        {
+            "id" : 141,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L132",
+            "description" : "VA 21-653 Notice of Change in Status of Beneficiary Receiving Hospital or Domicilliary Care",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 72,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence",
+                "subDescription" : "Live Evidence "
+            }
+        },
+        {
+            "id" : 24,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L013",
+            "description" : "Autopsy Report",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 73,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence",
+                "subDescription" : "Death Evidence "
+            }
+        },
+        {
+            "id" : 36,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L025",
+            "description" : "DD 1300 Report of Casualty",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 73,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence",
+                "subDescription" : "Death Evidence "
+            }
+        },
+        {
+            "id" : 38,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L027",
+            "description" : "DD 1515 Pay and Allotment Information--Deceased Member",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 73,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence",
+                "subDescription" : "Death Evidence "
+            }
+        },
+        {
+            "id" : 44,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L033",
+            "description" : "Death Certificate",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 73,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence",
+                "subDescription" : "Death Evidence "
+            }
+        },
+        {
+            "id" : 462,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L462",
+            "description" : "Funeral Bill/Expenses",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 73,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence",
+                "subDescription" : "Death Evidence "
+            }
+        },
+        {
+            "id" : 82,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L072",
+            "description" : "PHS 2709  Report of Death of Commissioned Officer",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 73,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence",
+                "subDescription" : "Death Evidence "
+            }
+        },
+        {
+            "id" : 32,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L021",
+            "description" : "Report of Death",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 73,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence",
+                "subDescription" : "Death Evidence "
+            }
+        },
+        {
+            "id" : 100,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L090",
+            "description" : "VA 10-2065 Funeral Arrangements",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 73,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence",
+                "subDescription" : "Death Evidence "
+            }
+        },
+        {
+            "id" : 114,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L105",
+            "description" : "VA 21-4103 Information from Remarried Widow/er",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 73,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence",
+                "subDescription" : "Death Evidence "
+            }
+        },
+        {
+            "id" : 163,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L154",
+            "description" : "VA 23-6547 Excerpts from Death Certificate",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 73,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence",
+                "subDescription" : "Death Evidence "
+            }
+        },
+        {
+            "id" : 180,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L171",
+            "description" : "Verdict of Coroners Jury",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 73,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence",
+                "subDescription" : "Death Evidence "
+            }
+        },
+        {
+            "id" : 10,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "UNKNOWN",
+            "description" : "UNKNOWN",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 74,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Pending Category Assignment"
+            }
+        },
+        {
+            "id" : 475,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L475",
+            "description" : "Third Party Correspondence",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 75,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2015-03-30T21:09:37",
+                "description" : "Correspondence",
+                "subDescription" : "Incoming"
+            }
+        },
+        {
+            "id" : 186,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L176",
+            "description" : "BDN Print Screens",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 77,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "BDN Screen Print"
+            }
+        },
+        {
+            "id" : 504,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L504",
+            "description" : "Provider Proof Correspondence & Receipts",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 78,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Provider Proof"
+            }
+        },
+        {
+            "id" : 459,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L459",
+            "description" : "VA 21-1838 Decision on Compromise Case",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 80,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Committee of Waivers"
+            }
+        },
+        {
+            "id" : 233,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L185",
+            "description" : "VA 4-1837 Decision of Waiver on Indebtedness",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 80,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Committee of Waivers"
+            }
+        },
+        {
+            "id" : 194,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L187",
+            "description" : "DMC - First Demand Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 88,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions",
+                "subDescription" : "DMC"
+            }
+        },
+        {
+            "id" : 193,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L188",
+            "description" : "DMC - Waiver Grant Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 88,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions",
+                "subDescription" : "DMC"
+            }
+        },
+        {
+            "id" : 298,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L193",
+            "description" : "Returned Mail",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 101,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Returned Mail"
+            }
+        },
+        {
+            "id" : 210,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L186",
+            "description" : "BDN/VETSNET Capture",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 110,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "BDN/VETSNET Capture"
+            }
+        },
+        {
+            "id" : 380,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L227",
+            "description" : "MAPD Contention Screen",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 110,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "BDN/VETSNET Capture"
+            }
+        },
+        {
+            "id" : 337,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L196",
+            "description" : "CAP Review Worksheet (Combined Assessment Program)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 121,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Special Projects"
+            }
+        },
+        {
+            "id" : 486,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L486",
+            "description" : "Audit Error Worksheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 122,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Worksheet"
+            }
+        },
+        {
+            "id" : 340,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L199",
+            "description" : "BDD Worksheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 122,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Worksheet"
+            }
+        },
+        {
+            "id" : 342,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L201",
+            "description" : "Compensation Worksheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 122,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Worksheet"
+            }
+        },
+        {
+            "id" : 484,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2021-06-01T15:25:44",
+            "name" : "L484",
+            "description" : "CRDP Excel Calculation",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 122,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Worksheet"
+            }
+        },
+        {
+            "id" : 449,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L449",
+            "description" : "DFAS Payment Worksheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 122,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Worksheet"
+            }
+        },
+        {
+            "id" : 558,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L558",
+            "description" : "Radiation Risk Activity Worksheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 122,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Worksheet"
+            }
+        },
+        {
+            "id" : 565,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L565",
+            "description" : "Rating Calculator Worksheets",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 122,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Worksheet"
+            }
+        },
+        {
+            "id" : 414,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L414",
+            "description" : "User Calculations (Retroactive Payment, etc.)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 122,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Worksheet"
+            }
+        },
+        {
+            "id" : 341,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L200",
+            "description" : "BDD Checklist",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 123,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Checklist"
+            }
+        },
+        {
+            "id" : 343,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L202",
+            "description" : "Compensation Checklist",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 123,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Checklist"
+            }
+        },
+        {
+            "id" : 506,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L506",
+            "description" : "DES Exit Interview Checklist",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 123,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Checklist"
+            }
+        },
+        {
+            "id" : 571,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L571",
+            "description" : "Nehmer Authorization SME Checklist",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 123,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Checklist"
+            }
+        },
+        {
+            "id" : 570,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L570",
+            "description" : "Nehmer Rating SME Checklist",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 123,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Checklist"
+            }
+        },
+        {
+            "id" : 585,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L583",
+            "description" : "VA 21-6530a Quality Improvement Review Worksheet Public Contact Activities",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 123,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Checklist"
+            }
+        },
+        {
+            "id" : 483,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L483",
+            "description" : "VCAA CheckList for Development",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 123,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Checklist"
+            }
+        },
+        {
+            "id" : 418,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L418",
+            "description" : "Court Documents - General",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 200,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Legal/Court Documents"
+            }
+        },
+        {
+            "id" : 523,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L523",
+            "description" : "Legal Will",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 200,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Legal/Court Documents"
+            }
+        },
+        {
+            "id" : 401,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L401",
+            "description" : "Prison/Convict Information",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 200,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Legal/Court Documents"
+            }
+        },
+        {
+            "id" : 405,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L405",
+            "description" : "CRSC Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 201,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "CRSC Letters"
+            }
+        },
+        {
+            "id" : 529,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L529",
+            "description" : "Mortgage Agreement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 202,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Loan Guaranty"
+            }
+        },
+        {
+            "id" : 467,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L467",
+            "description" : "VA 26-1833 Advice Regarding Indebtedness Of Obligors On Guaranteed Or Insured Loans",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 202,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Loan Guaranty"
+            }
+        },
+        {
+            "id" : 468,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L468",
+            "description" : "VA 26-8903 Notice For Election To Convey And/Or Invoice For Transfer Of Property",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 202,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Loan Guaranty"
+            }
+        },
+        {
+            "id" : 526,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L526",
+            "description" : "Social Security Card",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 203,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Social Security Administration Documents-All"
+            }
+        },
+        {
+            "id" : 527,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L527",
+            "description" : "SSA-24 Application for Survivors Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 203,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Social Security Administration Documents-All"
+            }
+        },
+        {
+            "id" : 55,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L045",
+            "description" : "SSA-828-U4 Request for Medical Information From Records of Department of Veterans Affairs",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 203,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Social Security Administration Documents-All"
+            }
+        },
+        {
+            "id" : 477,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L477",
+            "description" : "SSA-831 Disability Determination and Transmittal",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 203,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Social Security Administration Documents-All"
+            }
+        },
+        {
+            "id" : 56,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L046",
+            "description" : "SSA-L1103",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 203,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Social Security Administration Documents-All"
+            }
+        },
+        {
+            "id" : 488,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L488",
+            "description" : "DPRIS - DD 214 Certified Original - Certificate of Release or Discharge From Active Duty",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 204,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "DPRIS - Service Personnel Records - DD Form 214/215"
+            }
+        },
+        {
+            "id" : 487,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L487",
+            "description" : "DPRIS - DD 215 Corrected DD 214 Certificate of Release or Discharge From Active Duty",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 204,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "DPRIS - Service Personnel Records - DD Form 214/215"
+            }
+        },
+        {
+            "id" : 502,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L502",
+            "description" : "Review of FPOW Status",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 206,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Determinations - FPOW"
+            }
+        },
+        {
+            "id" : 563,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L563",
+            "description" : "CRSC/CRDP Election Archive 2009",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 207,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "CRSC/CRDP"
+            }
+        },
+        {
+            "id" : 564,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L564",
+            "description" : "CRSC/CRDP Election Archive 2010",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 207,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "CRSC/CRDP"
+            }
+        },
+        {
+            "id" : 515,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L515",
+            "description" : "CRSC/CRDP Enrollment Archive",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 207,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "CRSC/CRDP"
+            }
+        },
+        {
+            "id" : 514,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L514",
+            "description" : "CRSC/CRDP One-Time Payment Notification from DFAS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 207,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "CRSC/CRDP"
+            }
+        },
+        {
+            "id" : 587,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L587",
+            "description" : "Titles and Deeds",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 211,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Net Worth"
+            }
+        },
+        {
+            "id" : 588,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L588",
+            "description" : "Trust Documentation",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 211,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Net Worth"
+            }
+        },
+        {
+            "id" : 17,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L006",
+            "description" : "VAMC Report of Hospitalization",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 47,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records",
+                "subDescription" : "VAMC Inpatient"
+            }
+        },
+        {
+            "id" : 99,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L089",
+            "description" : "VA 10-1000 Hospital Summary and/or the Compensation and Pension Exam Report",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 49,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records",
+                "subDescription" : "VAX & AMIE - Request Worksheets "
+            }
+        },
+        {
+            "id" : 110,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L101",
+            "description" : "VA 21-2507a Request for Physical Examination",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 49,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records",
+                "subDescription" : "VAX & AMIE - Request Worksheets "
+            }
+        },
+        {
+            "id" : 18,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L007",
+            "description" : "VA Exam Worksheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 49,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records",
+                "subDescription" : "VAX & AMIE - Request Worksheets "
+            }
+        },
+        {
+            "id" : 62,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L052",
+            "description" : "Medical Evaluation Board Proceedings",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 83,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L073",
+            "description" : "Physical Evaluation Board Proceedings",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 89,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L079",
+            "description" : "STR",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 345,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L204",
+            "description" : "STR - Dental",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 450,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L450",
+            "description" : "STR - Dental - Photocopy",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 346,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L205",
+            "description" : "STR - Diagnostic Test",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 347,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L206",
+            "description" : "STR - Exam - Annual",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 348,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L207",
+            "description" : "STR - Exam - Entrance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 349,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L208",
+            "description" : "STR - Exam - Exit",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 350,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L209",
+            "description" : "STR - Exam - Flight",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 351,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L210",
+            "description" : "STR - Exam - MEB - PEB",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 352,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L211",
+            "description" : "STR - Lab",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 353,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L212",
+            "description" : "STR - Medical",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 451,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L451",
+            "description" : "STR - Medical - Photocopy",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 354,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L213",
+            "description" : "STR - Reserve STR",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 98,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L088",
+            "description" : "Surgeon Generals Office (SGO) Extracts",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 13,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L002",
+            "description" : "Adoption Decree",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 62,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Dependency "
+            }
+        },
+        {
+            "id" : 19,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L008",
+            "description" : "Annulment Decree",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 62,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Dependency "
+            }
+        },
+        {
+            "id" : 25,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L014",
+            "description" : "Birth Certificate",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 62,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Dependency "
+            }
+        },
+        {
+            "id" : 48,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L037",
+            "description" : "Divorce Decree",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 62,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Dependency "
+            }
+        },
+        {
+            "id" : 61,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L051",
+            "description" : "Marriage Certificate / License",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 62,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Dependency "
+            }
+        },
+        {
+            "id" : 520,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L520",
+            "description" : "VA 21-0537 Marital Status Questionnaire",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 62,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Dependency "
+            }
+        },
+        {
+            "id" : 411,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L411",
+            "description" : "VA 21-0788 Information Regarding Apportionment of Beneficiary Award",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 62,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Dependency "
+            }
+        },
+        {
+            "id" : 118,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L109",
+            "description" : "VA 21-4170 Statement of Marital Relationship",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 62,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Dependency "
+            }
+        },
+        {
+            "id" : 119,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L110",
+            "description" : "VA 21-4171 Supporting Statement Regarding Marriage",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 62,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Dependency "
+            }
+        },
+        {
+            "id" : 129,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L120",
+            "description" : "VA 21-509 Statement of Dependency of Parents",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 62,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Dependency "
+            }
+        },
+        {
+            "id" : 130,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L121",
+            "description" : "VA 21-524 Statement of Person Claiming to Have Stood in Relation of Parent",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 62,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Dependency "
+            }
+        },
+        {
+            "id" : 142,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L133",
+            "description" : "VA 21-674 Report of School Attendance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 62,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Dependency "
+            }
+        },
+        {
+            "id" : 143,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L134",
+            "description" : "VA 21-674b School Attendance Report",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 62,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Dependency "
+            }
+        },
+        {
+            "id" : 144,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L135",
+            "description" : "VA 21-674c Request for Approval of School Attendance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 62,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Dependency "
+            }
+        },
+        {
+            "id" : 148,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2019-11-08T18:58:22",
+            "name" : "L139",
+            "description" : "VA 21-686c Application Request To Add And/Or Remove Dependents",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 62,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Dependency "
+            }
+        },
+        {
+            "id" : 296,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L191",
+            "description" : "Bureau of Prisons / Fugitive Felon Information",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 63,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Audit Write-Outs"
+            }
+        },
+        {
+            "id" : 188,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L178",
+            "description" : "VA 20-6560 Notice of Benefit Payment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 63,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Audit Write-Outs"
+            }
+        },
+        {
+            "id" : 187,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L177",
+            "description" : "VA 20-8270 C&P Master Record Audit Writeout",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 63,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Audit Write-Outs"
+            }
+        },
+        {
+            "id" : 359,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L219",
+            "description" : "VA 20-8271 Notice of Exception",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 63,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Audit Write-Outs"
+            }
+        },
+        {
+            "id" : 147,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L138",
+            "description" : "Deferred Rating (e.g. VA Form 21-6789)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 64,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2018-07-26T15:27:03",
+                "description" : "Rating Decisions "
+            }
+        },
+        {
+            "id" : 492,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L492",
+            "description" : "Proposed Rating - Codesheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 64,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2018-07-26T15:27:03",
+                "description" : "Rating Decisions "
+            }
+        },
+        {
+            "id" : 493,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L493",
+            "description" : "Proposed Rating - Narrative",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 64,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2018-07-26T15:27:03",
+                "description" : "Rating Decisions "
+            }
+        },
+        {
+            "id" : 406,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L406",
+            "description" : "Rating - Under Review (VSO, Second Signature)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 64,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2018-07-26T15:27:03",
+                "description" : "Rating Decisions "
+            }
+        },
+        {
+            "id" : 338,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L197",
+            "description" : "Rating Decision - Codesheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 64,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2018-07-26T15:27:03",
+                "description" : "Rating Decisions "
+            }
+        },
+        {
+            "id" : 339,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L198",
+            "description" : "Rating Decision - Narrative",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 64,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2018-07-26T15:27:03",
+                "description" : "Rating Decisions "
+            }
+        },
+        {
+            "id" : 146,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L137",
+            "description" : "Rating Decision (e.g. VA Form 21-6796)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 64,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2018-07-26T15:27:03",
+                "description" : "Rating Decisions "
+            }
+        },
+        {
+            "id" : 297,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L192",
+            "description" : "Congressionals",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 34,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L023",
+            "description" : "Correspondence",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 559,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L559",
+            "description" : "Debtor Discovery Information Print",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 481,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L481",
+            "description" : "FOIA/Privacy Act Request",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 700,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L700",
+            "description" : "MAP-D Development Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 482,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L482",
+            "description" : "Status Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 582,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L582",
+            "description" : "VA 21-4107 Your Rights to Appeal Our Decision",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 555,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L555",
+            "description" : "VA 26-8937 - Verification Of VA Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 447,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L447",
+            "description" : "VCAA Notice Acknowledgement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 577,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2015-08-11T22:01:57",
+            "name" : "L577",
+            "description" : "VDC Claimant Submission",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 561,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L561",
+            "description" : "Witnessed Signature Form",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 184,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L175",
+            "description" : "Notification Letter (e.g. VA 20-8993, VA 21-0290, PCGL)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 67,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Notification Letters "
+            }
+        },
+        {
+            "id" : 408,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L408",
+            "description" : "VA Examination Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 67,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Notification Letters "
+            }
+        },
+        {
+            "id" : 472,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L472",
+            "description" : "VCAA/DTA Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 68,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Development Letters "
+            }
+        },
+        {
+            "id" : 579,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L579",
+            "description" : "Incompetency Notice Response",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 69,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Due Process "
+            }
+        },
+        {
+            "id" : 519,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L519",
+            "description" : "VA 10-10 Forms (10-10EZ, 10-10SH, Etc.)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 69,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Due Process "
+            }
+        },
+        {
+            "id" : 589,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L589",
+            "description" : "Change of Address/Direct Deposit Request",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 37,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L026",
+            "description" : "DD 149 Application for Correction of Military or Naval Record",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 39,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L028",
+            "description" : "DD 20-228-3 Request for VA Disability Rate Information Ref PL 96-402",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 42,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L031",
+            "description" : "DD 2168 Application for Discharge of Member or Survivor of Member of Group Certified To Have Performed Active Duty with the Armed Forces of the United States",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 43,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L032",
+            "description" : "DD 293 Application for Review of Discharge or Dismissal from the Armed Forces of the United States",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 522,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L522",
+            "description" : "Due Process Waiver",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 400,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L400",
+            "description" : "Email Correspondence",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 53,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L043",
+            "description" : "ES-973 Request to VA for Military Information for Unemployment Compensation Purposes-UCX",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 11,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "FAXCS",
+            "description" : "Fax Cover Sheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 419,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L419",
+            "description" : "Identification Materials",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 521,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L521",
+            "description" : "Improved Pension Election Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 485,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L485",
+            "description" : "IRIS Inquiry",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 68,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L058",
+            "description" : "Microfiche / Microfilm",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 474,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L474",
+            "description" : "Miscellaneous C&P Correspondence",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 70,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L060",
+            "description" : "NA 13055 Request for Information Needed to Reconstruct Medical Data",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 71,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L061",
+            "description" : "NA 13075 Questionnaire About Military Service",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 88,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L078",
+            "description" : "Request for Certification by Social Security Administration",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 516,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L516",
+            "description" : "Revocation of VA 21-0845",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 91,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L081",
+            "description" : "SF 180 Request Pertaining to Military Records",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 512,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L512",
+            "description" : "Third Party Release of Information",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 569,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L569",
+            "description" : "VA 10-3884A Exchange of Beneficiary Information & Request for Eligibility Data CHAMPVA",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 415,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L415",
+            "description" : "VA 10-5345 Request For and Authorization to Release Medical or Health Information",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 101,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L091",
+            "description" : "VA 10-7131 Exchange of Beneficiary Information and Request for Administrative and Adjudicative Action",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 191,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L180",
+            "description" : "VA 10-7132 Status Change",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 102,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L092",
+            "description" : "VA 119 Report of Contact",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 104,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L094",
+            "description" : "VA 21-0172 Certification of Permanent and Total Disability",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 496,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L496",
+            "description" : "VA 27-0820a Report of First Notice of Death",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 497,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L497",
+            "description" : "VA 27-0820b Report of Nursing Home or Assisted Living Information",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 498,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L498",
+            "description" : "VA 27-0820c Report of Defense Finance & Accounting Service (DFAS)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 499,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L499",
+            "description" : "VA 27-0820d Report of Non-Receipt of Payment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 500,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L500",
+            "description" : "VA 27-0820e Report of Incarceration",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 501,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L501",
+            "description" : "VA 27-0820f Report of Month of Death",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 115,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2021-05-17T14:57:04",
+            "name" : "L106",
+            "description" : "VA Form 21-4138 Statement In Support of Claim",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 116,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2021-05-17T14:57:04",
+            "name" : "L107",
+            "description" : "VA Form 21-4142 Authorization for Release of Information",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 121,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L112",
+            "description" : "VA 21-4180 Request for Certification by Social Security Administration",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 231,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L183",
+            "description" : "VA 21-5427 Corpus of Estate Determination",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 140,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L131",
+            "description" : "VA 21-651 Election of Compensation in Lieu of Retired Pay or Waiver of Retired Pay to Secure Compensation From Department of Veterans Affairs",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 562,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L562",
+            "description" : "Fully Developed Claim Memo (Compensation or Pension)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 10,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications"
+            }
+        },
+        {
+            "id" : 581,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L581",
+            "description" : "Government Life Insurance Forms",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 10,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications"
+            }
+        },
+        {
+            "id" : 489,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L489",
+            "description" : "Informal Claims",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 10,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications"
+            }
+        },
+        {
+            "id" : 517,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L517",
+            "description" : "PARDS Cover Memo",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 10,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications"
+            }
+        },
+        {
+            "id" : 131,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L122",
+            "description" : "VA 21-526 Veterans Application for Compensation or Pension",
+            "isUserUploadable" : true,
+            "is526" : true,
+            "documentCategory" : {
+                "id" : 10,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications"
+            }
+        },
+        {
+            "id" : 532,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L532",
+            "description" : "VA 21-526b, Veteran Supplemental Claim",
+            "isUserUploadable" : true,
+            "is526" : true,
+            "documentCategory" : {
+                "id" : 10,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications"
+            }
+        },
+        {
+            "id" : 530,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L530",
+            "description" : "VA 21-526c Pre-Discharge Compensation Claim",
+            "isUserUploadable" : true,
+            "is526" : true,
+            "documentCategory" : {
+                "id" : 11,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Original Claim"
+            }
+        },
+        {
+            "id" : 533,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L533",
+            "description" : "VA 21-526EZ, Fully Developed Claim (Compensation)",
+            "isUserUploadable" : true,
+            "is526" : true,
+            "documentCategory" : {
+                "id" : 11,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Original Claim"
+            }
+        },
+        {
+            "id" : 534,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L534",
+            "description" : "VA 21-527EZ, Fully Developed Claim (Pension)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 11,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Original Claim"
+            }
+        },
+        {
+            "id" : 158,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L149",
+            "description" : "VA 21-8940 Veterans Application for Increased Compensation Based on Unemployability",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 12,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Subsequent Compensation Claims"
+            }
+        },
+        {
+            "id" : 132,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L123",
+            "description" : "VA 21-527 Income-Net Worth and Employment Statement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 13,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Pension Claims"
+            }
+        },
+        {
+            "id" : 556,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L556",
+            "description" : "VA 21-0847 - Request for Substitution of Claimant Upon Death of Claimant",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 107,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L098",
+            "description" : "VA 21-121 Application for Burial Allowance and Accrued Amounts Payable as Reimbursement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 108,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L099",
+            "description" : "VA 27-2008 Application for United States Flag for Burial Purposes",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 122,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L113",
+            "description" : "VA 21-4182 Application for Dependency and Indemnity Compensation or Death Pension (Including Accrued Benefits)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 133,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L124",
+            "description" : "VA 21-530 Application for Burial Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 134,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L125",
+            "description" : "VA 21-534 Application for Dependency and Indemnity Compensation or Death Pension by a Surviving Spouse or Child",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 135,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L126",
+            "description" : "VA 21-535 Application for Dependency and Indemnity Compensation for Parents",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 137,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L128",
+            "description" : "VA 21-601 Application for Reimbursement from Accrued Amounts Due a Deceased Beneficiary",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 138,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L129",
+            "description" : "VA 21-609 Application for Amounts Due Estates of Persons Entitled to Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 139,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L130",
+            "description" : "VA 21-614 Application for Accrued Amounts of Veterans Benefits Payable to Widow, Widower, Child or Dependent Parents",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 554,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L554",
+            "description" : "VA 21-8834 - Application for Reimbursement of Headstone or Marker Expense",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 161,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L152",
+            "description" : "VA 22-5490 Application for Survivors and Dependents Educational Assistance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 553,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L553",
+            "description" : "VA 40-0247 Presidential Memorial Certificate Request Form",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 222,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "National Cemetery Association",
+                "subDescription" : "NCA - Applications"
+            }
+        },
+        {
+            "id" : 491,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L491",
+            "description" : "VA 40-1330 Application for Government Headstone or Marker",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 222,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "National Cemetery Association",
+                "subDescription" : "NCA - Applications"
+            }
+        },
+        {
+            "id" : 172,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2015-04-27T22:02:18",
+            "name" : "L163",
+            "description" : "VA 551 Application for Accrued Benefits by Veterans Spouse, Child or Dependent Parent",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 105,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L095",
+            "description" : "VA 21-0304 Application for Spina Biffida Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 16,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Other Special Claims"
+            }
+        },
+        {
+            "id" : 448,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L448",
+            "description" : "VA 21-0773 Operation Enduring Freedom/Operation Iraqi Freedom Seriously Injured/Ill Servicemember/Veteran Worksheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 16,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Other Special Claims"
+            }
+        },
+        {
+            "id" : 126,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L117",
+            "description" : "VA 21-4502 Application for Automobile or Other Conveyance and Adaptive Equipment Under 38 U.S.C. 3901-3904",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 16,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Other Special Claims"
+            }
+        },
+        {
+            "id" : 155,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L146",
+            "description" : "VA 21-8678 Application for Annual Clothing Allowance Under 38 U.S.C. 1162",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 16,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Other Special Claims"
+            }
+        },
+        {
+            "id" : 166,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L157",
+            "description" : "VA 26-1817 Request for Determination of Loan Guaranty Eligibility - Unremarried Surviving Spouses",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 16,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Other Special Claims"
+            }
+        },
+        {
+            "id" : 167,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L158",
+            "description" : "VA 26-1880 Request for Certificate of Eligibility for VA Home Loan Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 16,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Other Special Claims"
+            }
+        },
+        {
+            "id" : 168,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L159",
+            "description" : "VA 26-4555 Veterans Application in Acquiring Specially Adapted Housing or Special Home Adaptation Grant Under Title 38 U.S.C. 2101(a) or (b)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 16,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Other Special Claims"
+            }
+        },
+        {
+            "id" : 528,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L528",
+            "description" : "Diploma",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 358,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L216",
+            "description" : "Education - General",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 157,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L148",
+            "description" : "VA 21-8924 Application of Surviving Spouse or Child for REPS Benefits (Restored Entitlement Program for Survivors",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 578,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L578",
+            "description" : "VA 22-0830 Agreement for Release of VA Education Information to a Third Party",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 378,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L221",
+            "description" : "VA 22-1990 Application for Education Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 412,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L412",
+            "description" : "VA 22-1999b Notice of Change in Student Status",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 410,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L410",
+            "description" : "VA 22-1999c Certification of Affirmation of Enrollment Agreement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 409,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L409",
+            "description" : "VA 22-8945 Education Award",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 165,
+            "createDateTime" : "2012-01-25",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L156",
+            "description" : "VA 24-5281 Application for Refund of Educational Contributions (VEAP, Chapter 32, Title 38 U.S.C)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 654,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L654",
+            "description" : "Bureau of Prisons Match",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 63,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Audit Write-Outs"
+            }
+        },
+        {
+            "id" : 655,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L655",
+            "description" : "VA 21-534EZ Application for Dependency and Indemnity Compensation or Death Pension by a Surviving Spouse or Child",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 656,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2014-06-10T23:05:11",
+            "name" : "L656",
+            "description" : "VA 27-0820 Report of General Information",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 658,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L658",
+            "description" : "Appeal Notification Letter ",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 217,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2015-08-11T22:01:57",
+                "description" : "Correspondence",
+                "subDescription" : "Appeals"
+            }
+        },
+        {
+            "id" : 659,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2015-08-11T22:01:57",
+            "name" : "L659",
+            "description" : "Appellate Brief (VSO IHP; Post remand Brief; Attorney Brief)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 660,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L660",
+            "description" : "Hearing Related ",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 661,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L661",
+            "description" : "Hearing Transcript ",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 662,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L662",
+            "description" : "Translation Related",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 663,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L663",
+            "description" : "Medical Opinion",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 664,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L664",
+            "description" : "CUE Related",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 665,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L665",
+            "description" : "Motion to Advance on Docket",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 666,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L666",
+            "description" : "Motion for Reconsideration ",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 667,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L667",
+            "description" : "Extension Request",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 668,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L668",
+            "description" : "Ebert Temporary Transfers",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 669,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L669",
+            "description" : "STR-Original",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 670,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L670",
+            "description" : "STR-Duplicate",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 800,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L800",
+            "description" : "DD 2963 Service Treatment Record Transfer or Certification",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 801,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L801",
+            "description" : "VA 21-0960P-3 Review Post Traumatic Stress Disorder (PTSD) Disability Benefits Questionnaire",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 802,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L802",
+            "description" : "PTIVA Form",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 75,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2015-03-30T21:09:37",
+                "description" : "Correspondence",
+                "subDescription" : "Incoming"
+            }
+        },
+        {
+            "id" : 803,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-02-25T18:04:29",
+            "name" : "L803",
+            "description" : "Educational/Vocational Counseling (CH 36) reports",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 805,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-11-09T16:37:55",
+            "name" : "L805",
+            "description" : "Retired Pay Screen",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 806,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2018-01-26T23:28:02",
+            "name" : "L806",
+            "description" : "Physical Disability Board of Review Findings",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 671,
+            "createDateTime" : "2014-10-29",
+            "modifiedDateTime" : "2014-10-29T17:00:23",
+            "name" : "L671",
+            "description" : "CAVC Hold Sheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 672,
+            "createDateTime" : "2014-10-29",
+            "modifiedDateTime" : "2014-10-29T17:00:23",
+            "name" : "L672",
+            "description" : "BVA Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 708,
+            "createDateTime" : "2014-04-28",
+            "modifiedDateTime" : "2016-07-11T13:41:02",
+            "name" : "L708",
+            "description" : "099 request code Camp Lejeune",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 35,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Service Personnel Records"
+            }
+        },
+        {
+            "id" : 709,
+            "createDateTime" : "2014-04-28",
+            "modifiedDateTime" : "2014-04-28T14:44:52",
+            "name" : "L709",
+            "description" : "Signature page VDC submitted 21-526EZ",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 40,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Representation"
+            }
+        },
+        {
+            "id" : 827,
+            "createDateTime" : "2014-10-29",
+            "modifiedDateTime" : "2014-10-29T17:00:23",
+            "name" : "L827",
+            "description" : "VA 21-4142a General Release for Medical Provider Information",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 828,
+            "createDateTime" : "2014-10-29",
+            "modifiedDateTime" : "2020-02-20T21:01:33",
+            "name" : "L828",
+            "description" : "VA 21P-530a State Application for Interment Allowance under 38 U.S.C. Chapter 23",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 829,
+            "createDateTime" : "2014-10-29",
+            "modifiedDateTime" : "2014-10-29T17:00:23",
+            "name" : "L829",
+            "description" : "Report of Contact",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 590,
+            "createDateTime" : "2013-09-04",
+            "modifiedDateTime" : "2015-08-11T22:01:57",
+            "name" : "L590",
+            "description" : "Appeal Substitution Review",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 591,
+            "createDateTime" : "2013-09-04",
+            "modifiedDateTime" : "2015-08-11T22:01:57",
+            "name" : "L591",
+            "description" : "Pension Bank Statement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 592,
+            "createDateTime" : "2013-09-04",
+            "modifiedDateTime" : "2015-08-11T22:01:57",
+            "name" : "L592",
+            "description" : "VBMAP Evidence Summary",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 213,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2015-08-11T22:01:57",
+                "description" : "Special Projects",
+                "subDescription" : "VBMAP"
+            }
+        },
+        {
+            "id" : 710,
+            "createDateTime" : "2014-06-19",
+            "modifiedDateTime" : "2014-06-19T22:07:57",
+            "name" : "L710",
+            "description" : "Central Mail Envelope",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 75,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2015-03-30T21:09:37",
+                "description" : "Correspondence",
+                "subDescription" : "Incoming"
+            }
+        },
+        {
+            "id" : 593,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L593",
+            "description" : "VBMAP Medical Index Summary",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 213,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2015-08-11T22:01:57",
+                "description" : "Special Projects",
+                "subDescription" : "VBMAP"
+            }
+        },
+        {
+            "id" : 597,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L597",
+            "description" : "Radiation Exposure Compensation Act Memo",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 75,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2015-03-30T21:09:37",
+                "description" : "Correspondence",
+                "subDescription" : "Incoming"
+            }
+        },
+        {
+            "id" : 598,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L598",
+            "description" : "VA 5572 Accounting of Records/Information Disclosure Under Privacy Act",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 599,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2016-08-25T16:48:15",
+            "name" : "L599",
+            "description" : "VA 10-0137 VA Advance Directive, Durable Power of Attorney for Health Care and Living Will",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 40,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Representation"
+            }
+        },
+        {
+            "id" : 652,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2015-11-02T14:34:14",
+            "name" : "L652",
+            "description" : "VA 21-8951 Notice of Waiver of VA Compensation or Pension to Receive Military Pay and Allowances",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 71,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence"
+            }
+        },
+        {
+            "id" : 653,
+            "createDateTime" : "2014-01-07",
+            "modifiedDateTime" : "2015-11-02T14:34:14",
+            "name" : "L653",
+            "description" : "VA 21-8951-2 Notice of Waiver of VA Compensation or Pension to Receive Military Pay and Allowances",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 71,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence"
+            }
+        },
+        {
+            "id" : 831,
+            "createDateTime" : "2015-01-09",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L831",
+            "description" : "Fiduciary Requests",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 718,
+            "createDateTime" : "2015-06-19",
+            "modifiedDateTime" : "2015-06-19T13:03:27",
+            "name" : "L718",
+            "description" : "VA 21-0966 Intent to File",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 10,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications"
+            }
+        },
+        {
+            "id" : 712,
+            "createDateTime" : "2015-07-08",
+            "modifiedDateTime" : "2015-07-08T16:43:44",
+            "name" : "L712",
+            "description" : "Request for Application",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 761,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2015-11-02T14:34:13",
+            "name" : "L761",
+            "description" : "Fiscal Transaction (18A) Change Recurring Deduction-Change or Terminate Garnishment W/HING and SBP COLA",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 762,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2015-11-02T14:34:13",
+            "name" : "L762",
+            "description" : "VA Form 10-1394, Application for Adaptive Equipment Motor Vehicle",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 763,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2015-11-02T14:34:13",
+            "name" : "L763",
+            "description" : "Establish Recurring Deduction (18)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 714,
+            "createDateTime" : "2015-05-19",
+            "modifiedDateTime" : "2015-05-19T15:15:28",
+            "name" : "L714",
+            "description" : "Appeals: Request for Notice of Disagreement Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 717,
+            "createDateTime" : "2015-05-19",
+            "modifiedDateTime" : "2018-02-26T17:58:09",
+            "name" : "L717",
+            "description" : "Fiduciary - Facility License",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 702,
+            "createDateTime" : "2015-08-11",
+            "modifiedDateTime" : "2015-08-11T22:01:57",
+            "name" : "L702",
+            "description" : "Disability Benefits Questionnaire (DBQ) - Veteran Provided",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 703,
+            "createDateTime" : "2015-08-11",
+            "modifiedDateTime" : "2015-08-11T22:01:57",
+            "name" : "L703",
+            "description" : "Goldmann Perimetry Chart/Field Of Vision Chart",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 704,
+            "createDateTime" : "2015-08-11",
+            "modifiedDateTime" : "2017-01-26T13:56:52",
+            "name" : "L704",
+            "description" : "Standard 5103 Notice",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 705,
+            "createDateTime" : "2015-08-11",
+            "modifiedDateTime" : "2015-08-11T22:01:57",
+            "name" : "L705",
+            "description" : "5103 Notice Acknowledgement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 706,
+            "createDateTime" : "2015-08-11",
+            "modifiedDateTime" : "2015-08-11T22:01:57",
+            "name" : "L706",
+            "description" : "5103 / DTA Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 68,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Development Letters "
+            }
+        },
+        {
+            "id" : 707,
+            "createDateTime" : "2015-08-11",
+            "modifiedDateTime" : "2015-08-11T22:01:57",
+            "name" : "L707",
+            "description" : "5103 Checklist for Development",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 123,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Checklist"
+            }
+        },
+        {
+            "id" : 713,
+            "createDateTime" : "2015-08-11",
+            "modifiedDateTime" : "2015-08-11T22:01:57",
+            "name" : "L713",
+            "description" : "VA Form 21-0958 Notice of Disagreement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 719,
+            "createDateTime" : "2015-08-11",
+            "modifiedDateTime" : "2015-08-11T22:01:57",
+            "name" : "L719",
+            "description" : "Exam Request",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 720,
+            "createDateTime" : "2015-08-11",
+            "modifiedDateTime" : "2015-08-11T22:01:57",
+            "name" : "L720",
+            "description" : "Exam Request Modification",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 721,
+            "createDateTime" : "2015-08-11",
+            "modifiedDateTime" : "2015-08-11T22:01:57",
+            "name" : "L721",
+            "description" : "VA 21-0961 Electronic Signatures",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 64,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2018-07-26T15:27:03",
+                "description" : "Rating Decisions "
+            }
+        },
+        {
+            "id" : 730,
+            "createDateTime" : "2015-08-11",
+            "modifiedDateTime" : "2015-08-11T22:01:57",
+            "name" : "L730",
+            "description" : "Service Department Memo of Complete and Current Service Treatment Record",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 731,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L731",
+            "description" : "VA Form 28-1902b, Counseling Record-Narrative Report",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 732,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L732",
+            "description" : "VA Form 28-1902w Rehabilitation Needs Inventory (RNI)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 733,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L733",
+            "description" : "VA Form 28-1902n, Counseling Record-Narrative (Supplemental Sheet)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 734,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L734",
+            "description" : "VA Form 28-8872, Rehabilitation Plan",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 735,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L735",
+            "description" : "VA Form 28-8861, Request for medical Services Chapter 31",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 736,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L736",
+            "description" : "VR-42, Adverse Action Notice",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 737,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2016-07-11T13:41:02",
+            "name" : "L737",
+            "description" : "VA Form 28-1905, Authorization and Certification of Entrance or Reentrance into Rehabilitation and Certification",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 738,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2018-07-26T15:27:03",
+            "name" : "L738",
+            "description" : "VR-38 Interregional Transfer Request",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 739,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L739",
+            "description" : "VA Form 28-8606 Next Steps Form",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 740,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L740",
+            "description" : "VA Form 28-0588, Vocational Rehabilitation and Employment-Getting Ahead After You Get Out",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 743,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2021-05-03T15:15:06",
+            "name" : "L743",
+            "description" : "VAF 28-1905m - Request and Authorization for Supplies (Chapter 31 -Veteran Readiness and Employment)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 744,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L744",
+            "description" : "VA Form 28-0846, Employment Adjustment Allowance Authorization",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 745,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L745",
+            "description" : "VA Form 20-0968, Claim for Reimbursement of Travel Expenses",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 747,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L747",
+            "description" : "VR-39, Rehabilitation-Employment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 748,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L748",
+            "description" : "Academic Transcripts and Grade Reports",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 749,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L749",
+            "description" : "VR&E-General",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 750,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L750",
+            "description" : "VA Form 28-1905c, Monthly Record of Training and Wages",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 751,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2015-11-02T14:34:13",
+            "name" : "L751",
+            "description" : "BVA-General",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 754,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2015-11-02T14:34:13",
+            "name" : "L754",
+            "description" : "Attorney Fee Calculation Spreadsheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 755,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2015-11-02T14:34:13",
+            "name" : "L755",
+            "description" : "Attorney Fee Memo to Release Funds",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 756,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2015-11-02T14:34:13",
+            "name" : "L756",
+            "description" : "FAS All Transactions",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 757,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2015-11-02T14:34:13",
+            "name" : "L757",
+            "description" : "Fiscal Transaction (04E) Establish A/R, AEW Debt, Chargeback Debt",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 758,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2015-11-02T14:34:13",
+            "name" : "L758",
+            "description" : "Fiscal Transaction (06A) Limited Pay",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 759,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2015-11-02T14:34:13",
+            "name" : "L759",
+            "description" : "Fiscal Transaction (06A) EAJA Payment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 760,
+            "createDateTime" : "2015-11-02",
+            "modifiedDateTime" : "2015-11-02T14:34:13",
+            "name" : "L760",
+            "description" : "Fiscal Transaction (08E) Decrease A/R",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 858,
+            "createDateTime" : "2016-07-08",
+            "modifiedDateTime" : "2016-07-11T13:41:02",
+            "name" : "L858",
+            "description" : "Custom 5103 Notice",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 852,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L852",
+            "description" : "DD Form 2384 Notice of Basic Eligibility",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 853,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L853",
+            "description" : "Additional Contribution",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 854,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L854",
+            "description" : "Kicker Contract (Contract with the military indicating that applicant would get additional money for education)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 855,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L855",
+            "description" : "VA Form 27-0974 Veteran ID Card Application",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 10,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications"
+            }
+        },
+        {
+            "id" : 856,
+            "createDateTime" : "2016-05-13",
+            "modifiedDateTime" : "2016-05-13T18:51:05",
+            "name" : "L856",
+            "description" : "Notice of Disagreement (Non-Standard Form)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 857,
+            "createDateTime" : "2016-05-13",
+            "modifiedDateTime" : "2016-05-13T18:51:05",
+            "name" : "L857",
+            "description" : "Substantive Appeal (In Lieu of VA Form 9)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 867,
+            "createDateTime" : "2016-07-11",
+            "modifiedDateTime" : "2016-07-11T13:41:02",
+            "name" : "L867",
+            "description" : "Proposal to Reduce - Failure to Report for an Exam Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 868,
+            "createDateTime" : "2016-07-11",
+            "modifiedDateTime" : "2016-07-11T13:41:02",
+            "name" : "L868",
+            "description" : "Proposal to Reduce - School Child Verification Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 869,
+            "createDateTime" : "2016-07-11",
+            "modifiedDateTime" : "2016-07-11T13:41:02",
+            "name" : "L869",
+            "description" : "Informal Claim Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 870,
+            "createDateTime" : "2016-07-11",
+            "modifiedDateTime" : "2016-07-11T13:41:02",
+            "name" : "L870",
+            "description" : "Character of Discharge Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 871,
+            "createDateTime" : "2016-07-11",
+            "modifiedDateTime" : "2016-07-11T13:41:02",
+            "name" : "L871",
+            "description" : "Drill Pay Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 872,
+            "createDateTime" : "2016-07-11",
+            "modifiedDateTime" : "2016-07-11T13:41:02",
+            "name" : "L872",
+            "description" : "Proposal to Reduce Failure to Submit Dependency Questionnaire",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 873,
+            "createDateTime" : "2016-07-11",
+            "modifiedDateTime" : "2016-07-11T13:41:02",
+            "name" : "L873",
+            "description" : "SSA Profile and Benefit Data",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 203,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Social Security Administration Documents-All"
+            }
+        },
+        {
+            "id" : 764,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L764",
+            "description" : "C&P Master Record Status (M11)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 765,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L765",
+            "description" : "C&P Master Record Award Data (M12)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 766,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L766",
+            "description" : "CAROLS Screen",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 767,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L767",
+            "description" : "Deduction/Receivable/Balance Data (M01)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 768,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L768",
+            "description" : "DDForm 2891 Authorization for SBP Withholding",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 769,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L769",
+            "description" : "DFAS Letter Requesting SBP Adjustment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 770,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L770",
+            "description" : "Fiscal Authorization - C&P (F95)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 771,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L771",
+            "description" : "Fiscal Transaction (02C) Change Collection Status",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 772,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L772",
+            "description" : "Fiscal Transaction (04A) Trainee Tools Debt (60B)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 773,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L773",
+            "description" : "Fiscal Transaction (06B) Establish RFL",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 774,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L774",
+            "description" : "Fiscal Transaction (06B) Replace Fraud/Identity Payment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 775,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L775",
+            "description" : "Fiscal Transaction (07D) Write Off",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 776,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L776",
+            "description" : "Fiscal Transaction (08A) Cash Transfer",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 777,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L777",
+            "description" : "Fiscal Transaction (18) Establish Attorney Fee",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 778,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L778",
+            "description" : "Fiscal Transaction (18) Establish Garnishment W/HING",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 779,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L779",
+            "description" : "Fiscal Transaction (18) Establish SBP W/HING",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 780,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L780",
+            "description" : "Fiscal Transaction (75A, 75B, 75C) Proceeds Action",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 781,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L781",
+            "description" : "FL4-321 Response to Check Inquiry Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 782,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L782",
+            "description" : "Garnishment Order",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 783,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L783",
+            "description" : "Garnishment Notification Letter to the Veteran",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 784,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L784",
+            "description" : "Garnishment Withholding Letter to the State Support Enforcement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 785,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L785",
+            "description" : "Journal Voucher (Form 1017G) Assessment Fee",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 786,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L786",
+            "description" : "Journal Voucher (Form 1017G) Transfer Funds to DMC for Education Debt",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 787,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L787",
+            "description" : "Public Voucher (Form 1047) Attorney Fee Release",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 788,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L788",
+            "description" : "Public Voucher (Form 1047) Garnishment Payment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 789,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L789",
+            "description" : "Public Voucher (Form 1047) IPAC - SBP Overpayment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 790,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L790",
+            "description" : "Special Payments (F15)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 791,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L791",
+            "description" : "TINQ Payment History",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 792,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L792",
+            "description" : "Treasury Response Message",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 793,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L793",
+            "description" : "VETSNET Irregular Deductions Report - PAT Sheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 794,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L794",
+            "description" : "Garnishment Notification to requestor (denial of request)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 795,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L795",
+            "description" : "Suspension Letters",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 796,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L796",
+            "description" : "FMS3858 Claims Document",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 797,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L797",
+            "description" : "Income Withholding for Support",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 798,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:20",
+            "name" : "L798",
+            "description" : "Fiscal Authorization - CH31 (F95)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 799,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L799",
+            "description" : "Public Voucher for Refunds",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 832,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L832",
+            "description" : "VA Form 1100 Agreement to Pay Indebtedness",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 833,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L833",
+            "description" : "VA Form 20-8922 Limited Payability Cancellation",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 834,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L834",
+            "description" : "Other Garnishment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 835,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L835",
+            "description" : "Attorney Fee or Memo",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 836,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L836",
+            "description" : "Initial Notice of Indebtedness for Fiduciary Debts",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 837,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L837",
+            "description" : "30 Day Notice of Indebtedness for Fiduciary Debts",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 838,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L838",
+            "description" : "Notice of TOP Referral",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 839,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L839",
+            "description" : "Established Fiduciary Debts (CAATS)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 840,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L840",
+            "description" : "Accounts Receivable Adjustments (F25)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 841,
+            "createDateTime" : "2016-01-28",
+            "modifiedDateTime" : "2016-01-28T19:00:21",
+            "name" : "L841",
+            "description" : "VA Form 24-8618 Records of Payment for Automobile or Other Conveyance and Adaptive Equipment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 859,
+            "createDateTime" : "2016-07-11",
+            "modifiedDateTime" : "2016-07-11T13:41:02",
+            "name" : "L859",
+            "description" : "Subsequent Development Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 860,
+            "createDateTime" : "2016-07-11",
+            "modifiedDateTime" : "2016-07-11T13:41:02",
+            "name" : "L860",
+            "description" : "Federal Third Party Reserve or Guard unit records",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 861,
+            "createDateTime" : "2016-07-11",
+            "modifiedDateTime" : "2016-07-11T13:41:02",
+            "name" : "L861",
+            "description" : "Initial Federal 3rd Party Letter - PTSD request copy of Vet Center records",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 862,
+            "createDateTime" : "2016-07-11",
+            "modifiedDateTime" : "2016-07-11T13:41:02",
+            "name" : "L862",
+            "description" : "Initial Federal 3rd Party Letter - PTSD obtain investigative Reports",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 863,
+            "createDateTime" : "2016-07-11",
+            "modifiedDateTime" : "2016-07-11T13:41:02",
+            "name" : "L863",
+            "description" : "Initial Federal 3rd Party Letter - PTSD diagnosed, confirm stressor, to MC Historical",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 864,
+            "createDateTime" : "2016-07-11",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L864",
+            "description" : "General Records Request (Medical)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 865,
+            "createDateTime" : "2016-07-11",
+            "modifiedDateTime" : "2016-07-11T13:41:02",
+            "name" : "L865",
+            "description" : "Proposed Incompetency Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 866,
+            "createDateTime" : "2016-07-11",
+            "modifiedDateTime" : "2016-07-11T13:41:02",
+            "name" : "L866",
+            "description" : "Proposal to Reduce Service Connected Compensation",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 874,
+            "createDateTime" : "2016-10-07",
+            "modifiedDateTime" : "2016-10-07T15:08:00",
+            "name" : "L874",
+            "description" : "IDES Reconsideration Request",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 875,
+            "createDateTime" : "2016-10-07",
+            "modifiedDateTime" : "2016-10-07T15:08:00",
+            "name" : "L875",
+            "description" : "PEB Request Revision",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 876,
+            "createDateTime" : "2016-10-07",
+            "modifiedDateTime" : "2016-10-07T15:08:00",
+            "name" : "L876",
+            "description" : "VRE - Invoice",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 877,
+            "createDateTime" : "2016-10-07",
+            "modifiedDateTime" : "2016-10-07T15:08:00",
+            "name" : "L877",
+            "description" : "VRE - Receipt for Reimbursement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 878,
+            "createDateTime" : "2016-10-07",
+            "modifiedDateTime" : "2016-10-07T15:08:00",
+            "name" : "L878",
+            "description" : "VRE - Finance (General)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 879,
+            "createDateTime" : "2016-10-07",
+            "modifiedDateTime" : "2016-10-07T15:08:00",
+            "name" : "L879",
+            "description" : "VRE - Request to Reopen Case",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 882,
+            "createDateTime" : "2016-10-07",
+            "modifiedDateTime" : "2016-10-07T15:08:00",
+            "name" : "L882",
+            "description" : "Power of Attorney (POA) Coversheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 883,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L883",
+            "description" : "Initial Private 3rd Party Letter, 21-4192",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 884,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L884",
+            "description" : "FOIA Request Acknowledgement Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 885,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L885",
+            "description" : "Privacy Act Request Acknowledgement Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 886,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L886",
+            "description" : "VBA Clarification Response to VHA/VBA Vendor",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 887,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L887",
+            "description" : "Exam Rework Request",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 888,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L888",
+            "description" : "C&P Contention Cancellation",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 889,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L889",
+            "description" : "VR-03 Appointment Letter - Initial Evaluation with VRC",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 890,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L890",
+            "description" : "VR-04 Appointment Letter - Ed-Voc Counseling",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 891,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L891",
+            "description" : "VR-05 Appointment Letter - Initial Evaluation with Contractor",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 892,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L892",
+            "description" : "VR-06 Appointment Letter - After Initial Evaluation with Contractor",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 894,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L894",
+            "description" : "VR-09 Appointment Letter - Follow-up Evaluation and Planning",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 896,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L896",
+            "description" : "VR-15 10-Day Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 899,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L899",
+            "description" : "VR-24 Appointment Letter - Case Management",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 900,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2018-03-21T17:32:54",
+            "name" : "L900",
+            "description" : "VR-26 Missed Appointment Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 903,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2018-07-26T15:27:01",
+            "name" : "L903",
+            "description" : "VR-29 Apportionment Letter - Original - Guardian",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 904,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2018-07-26T15:27:01",
+            "name" : "L904",
+            "description" : "VR-30 Apportionment Letter - Reinstatement - Guardian",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 905,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L905",
+            "description" : "VR-31 Approved Tutor Contract Notification",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 906,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2018-07-26T15:27:01",
+            "name" : "L906",
+            "description" : "VR-32 IEAP Development Prior Completion of Training",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 907,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2018-07-26T15:27:01",
+            "name" : "L907",
+            "description" : "VR-33 Referral - Employment Services",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 915,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L915",
+            "description" : "VR-46 Statement of the Case Notification",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 916,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2019-06-03T23:13:25",
+            "name" : "L916",
+            "description" : "VR-47 Proposed Closure for Non-Pursuit of Claim",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 917,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2018-07-26T15:27:03",
+            "name" : "L917",
+            "description" : "VR-48 Proposed Discontinuance - Maximum Rehabilitation Gain",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 918,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2018-07-26T15:27:01",
+            "name" : "L918",
+            "description" : "VR-49 Proposed Rehabilitation Letter - Further Education",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 920,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2018-07-26T15:27:01",
+            "name" : "L920",
+            "description" : "VR-52 Follow Up - After Discontinuance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 924,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L924",
+            "description" : "VR-21 Appointment Letter - Counseling (Case Management)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 926,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L926",
+            "description" : "VR-02 Follow-up Letter - Interrupted",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 928,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L928",
+            "description" : "VR-44 Partial Payment (Supplies) Notification - Vendor",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 931,
+            "createDateTime" : "2017-04-12",
+            "modifiedDateTime" : "2017-04-12T15:57:01",
+            "name" : "L931",
+            "description" : "VR-01 Motivation Letter - Apply for VRE Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 932,
+            "createDateTime" : "2017-07-15",
+            "modifiedDateTime" : "2017-07-15T14:02:36",
+            "name" : "L932",
+            "description" : "Request for Application - Apportionment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 933,
+            "createDateTime" : "2017-07-15",
+            "modifiedDateTime" : "2017-07-15T14:02:36",
+            "name" : "L933",
+            "description" : "Investigation of Suspected Fraud",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 99,
+                "createDateTime" : "2017-06-06",
+                "modifiedDateTime" : "2017-06-06T04:00:00",
+                "description" : "Special Projects"
+            }
+        },
+        {
+            "id" : 934,
+            "createDateTime" : "2017-07-15",
+            "modifiedDateTime" : "2017-07-15T14:02:36",
+            "name" : "L934",
+            "description" : "National Cemetery Administration Appeal",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 935,
+            "createDateTime" : "2017-07-15",
+            "modifiedDateTime" : "2017-07-15T14:02:36",
+            "name" : "L935",
+            "description" : "Education Appeal",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1250,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1250",
+            "description" : "VA Form 10182 Notice of Disagreement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1251,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1251",
+            "description" : "Fiduciary Program's Version of Supplemental Claim",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 1252,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1252",
+            "description" : "FL 521 - Request for IL Extension",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1253,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1253",
+            "description" : "28-0794 - Self-Employment Plan Approval Request",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1254,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1254",
+            "description" : "28-0814 - Checklist for Independent Living Plan Approval",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1255,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1255",
+            "description" : "21-0819 - VA/DOD Joint Disability Evaluation Board Claim",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1256,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1256",
+            "description" : "28-0850 - Checklist for Proposed Rehabilitation",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1257,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1257",
+            "description" : "28-0853 - Checklist for Proposed Discontinuance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1258,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1258",
+            "description" : "28-0947 - Independent Living (IL) - Specially Adapted Housing Coordination Checklist",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1260,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1260",
+            "description" : "28-0957 - Vocational Rehabilitation Guidelines and Debt Prevention",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1261,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1261",
+            "description" : "28-0962 - Checklist for Proposed Self-Employment Rehabilitation",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1262,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1262",
+            "description" : "28-1905h - Trainee Request for Leave (Chapter 31, Title 38 U.S.C.)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1263,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1263",
+            "description" : "28-1905l - Disposition of Supplies (Chapter 31)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1264,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1264",
+            "description" : "28-1905n - Farm Survey and Overall Farm and Home Plan Self-Proprietor/Manager - Chapter 31, Title 38, U.S.C.",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1265,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1265",
+            "description" : "28-1905p - Annual Farm and Home Plan for Institutional On-Farm Course of Training (Chapter 31)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1266,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1266",
+            "description" : "4107VRE - Your Rights to Appeal our Decision",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1267,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1267",
+            "description" : "22-8794 - Designation of Certifying Official(s)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1268,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1268",
+            "description" : "20-8206 - Statement of Assurance of Compliance with Equal Opportunity Laws",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1269,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1269",
+            "description" : "10-0103 - Veterans Application for Assistance in Acquiring Home Improvement and Structural Alterations",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1270,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1270",
+            "description" : "Appendix AZ - Review Prior to Purchase of Firearms",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1271,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1271",
+            "description" : "Phone Inquiry",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 111,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "All Insurance"
+            }
+        },
+        {
+            "id" : 1272,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1272",
+            "description" : "Waiver of Premiums Development Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1274,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1274",
+            "description" : "Beneficiary of Record Requested",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1275,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1275",
+            "description" : "No Record Mail",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1276,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1276",
+            "description" : "Waiver",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1277,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1277",
+            "description" : "Reinstatement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1278,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1278",
+            "description" : "Special Ordinary Life",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1279,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1279",
+            "description" : "Supplemental RH",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1280,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1280",
+            "description" : "No Record Mail",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1281,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1281",
+            "description" : "Administrative 368d",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1282,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1282",
+            "description" : "Insurance Claims Decision (808)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1283,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1283",
+            "description" : "Underwriting Numerical Rating (4437)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1284,
+            "createDateTime" : "2019-01-14",
+            "modifiedDateTime" : "2019-01-14T16:38:27",
+            "name" : "L1284",
+            "description" : "VA Form 1018 - Your Rights To Seek Further Review Of Our Decision",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1285,
+            "createDateTime" : "2019-01-14",
+            "modifiedDateTime" : "2019-01-14T16:38:27",
+            "name" : "L1285",
+            "description" : "HLR - Informal Conference",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1286,
+            "createDateTime" : "2019-01-14",
+            "modifiedDateTime" : "2019-01-14T16:38:27",
+            "name" : "L1286",
+            "description" : "AMA Notification Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1287,
+            "createDateTime" : "2019-01-14",
+            "modifiedDateTime" : "2019-01-14T16:38:27",
+            "name" : "L1287",
+            "description" : "DMC - Estate Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 88,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions",
+                "subDescription" : "DMC"
+            }
+        },
+        {
+            "id" : 1288,
+            "createDateTime" : "2019-01-14",
+            "modifiedDateTime" : "2019-01-14T16:38:27",
+            "name" : "L1288",
+            "description" : "TCIS Payment Information",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 1289,
+            "createDateTime" : "2019-01-14",
+            "modifiedDateTime" : "2019-01-14T16:38:27",
+            "name" : "L1289",
+            "description" : "Review of Quality Instruments",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1290,
+            "createDateTime" : "2019-01-14",
+            "modifiedDateTime" : "2019-01-14T16:38:27",
+            "name" : "L1290",
+            "description" : "VA Form 10183 Appeal Rights",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1292,
+            "createDateTime" : "2019-03-11",
+            "modifiedDateTime" : "2019-03-11T13:52:10",
+            "name" : "L1292",
+            "description" : "VA 21P-0969 Income and Asset Statement in Support of Claim",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 29,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Income"
+            }
+        },
+        {
+            "id" : 1293,
+            "createDateTime" : "2019-03-11",
+            "modifiedDateTime" : "2019-03-11T13:52:10",
+            "name" : "L1293",
+            "description" : "Closure Statement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1294,
+            "createDateTime" : "2019-06-03",
+            "modifiedDateTime" : "2019-06-03T23:13:25",
+            "name" : "L1294",
+            "description" : "VA Form 28-0787 IL Needs Assessment and Planning Matrix",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1295,
+            "createDateTime" : "2019-06-03",
+            "modifiedDateTime" : "2019-06-03T23:13:25",
+            "name" : "L1295",
+            "description" : "VA Form 28-0795 Vocational Rehabilitation and Employment (VR&E) Business Plan Review Guide",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1296,
+            "createDateTime" : "2019-06-03",
+            "modifiedDateTime" : "2019-06-03T23:13:25",
+            "name" : "L1296",
+            "description" : "VA Form 28-8872a Rehabilitation Plan - Continuation Sheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1297,
+            "createDateTime" : "2019-06-03",
+            "modifiedDateTime" : "2019-06-03T23:13:25",
+            "name" : "L1297",
+            "description" : "VR-58 Decision Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1298,
+            "createDateTime" : "2019-06-03",
+            "modifiedDateTime" : "2019-06-03T23:13:25",
+            "name" : "L1298",
+            "description" : "VR-59 Disapproval - Ch31 Only Programs of Training or Courses",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1299,
+            "createDateTime" : "2019-06-03",
+            "modifiedDateTime" : "2019-06-03T23:13:25",
+            "name" : "L1299",
+            "description" : "VR-60 Notice of Suspension - Facility (Chapter 31 Only)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1300,
+            "createDateTime" : "2019-06-03",
+            "modifiedDateTime" : "2019-06-03T23:13:25",
+            "name" : "L1300",
+            "description" : "VR-61 Notice of Continuance - Facility (Ch31 Only)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 936,
+            "createDateTime" : "2017-07-15",
+            "modifiedDateTime" : "2017-07-15T14:02:36",
+            "name" : "L936",
+            "description" : "Vocational Rehabilitation and Employment Appeal",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 937,
+            "createDateTime" : "2017-07-15",
+            "modifiedDateTime" : "2017-07-15T14:02:36",
+            "name" : "L937",
+            "description" : "Loan Guaranty Appeal",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 938,
+            "createDateTime" : "2017-07-15",
+            "modifiedDateTime" : "2017-07-15T14:02:36",
+            "name" : "L938",
+            "description" : "Insurance Appeal",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 940,
+            "createDateTime" : "2017-07-15",
+            "modifiedDateTime" : "2017-07-15T14:02:36",
+            "name" : "L940",
+            "description" : "Office of General Counsel Appeal",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 941,
+            "createDateTime" : "2017-07-15",
+            "modifiedDateTime" : "2017-07-15T14:02:36",
+            "name" : "L941",
+            "description" : "Committee on Waivers and Compromises Appeal",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 950,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L950",
+            "description" : "RAMP Opt-In Notice",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 951,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L951",
+            "description" : "RAMP Opt-in Election",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 952,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L952",
+            "description" : "DRC Vendor Exam Recommendation",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 124,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Checklist",
+                "subDescription" : "Other Special Claims"
+            }
+        },
+        {
+            "id" : 953,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L953",
+            "description" : "DRC Exam Validation",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 124,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Checklist",
+                "subDescription" : "Other Special Claims"
+            }
+        },
+        {
+            "id" : 954,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L954",
+            "description" : "VA Form 10091 VA-FSC Vendor File Request Form",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 222,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "National Cemetery Association",
+                "subDescription" : "NCA - Applications"
+            }
+        },
+        {
+            "id" : 955,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L955",
+            "description" : "VA Form 40-1330M Claim for Government Medallion for Placement in a Private Cemetery",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 222,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "National Cemetery Association",
+                "subDescription" : "NCA - Applications"
+            }
+        },
+        {
+            "id" : 956,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L956",
+            "description" : "VA Form 40-10007 Application for Pre-Need Determination of Eligibility for Burial in a VA National Cemetery",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 222,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "National Cemetery Association",
+                "subDescription" : "NCA - Applications"
+            }
+        },
+        {
+            "id" : 957,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L957",
+            "description" : "NCA Denial Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 223,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "National Cemetery Association",
+                "subDescription" : "NCA - Correspondence"
+            }
+        },
+        {
+            "id" : 958,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L958",
+            "description" : "30-day suspense / VCAA DTA / Procedural Options Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 223,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "National Cemetery Association",
+                "subDescription" : "NCA - Correspondence"
+            }
+        },
+        {
+            "id" : 959,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L959",
+            "description" : "VA Form 40-10088 Request for Reimbursement of Casket/Urn",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 222,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "National Cemetery Association",
+                "subDescription" : "NCA - Applications"
+            }
+        },
+        {
+            "id" : 960,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L960",
+            "description" : "VA Form 20-0986 Eligibility Determination for Character of Discharge (COD) Request Form.",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 123,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Checklist"
+            }
+        },
+        {
+            "id" : 961,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L961",
+            "description" : "38CFR 3.12",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 962,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L962",
+            "description" : "Appeal Satisfaction Notice",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 963,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L963",
+            "description" : "Appeals Management Center Coversheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 964,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L964",
+            "description" : "Claim Exam Enclosure",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 965,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L965",
+            "description" : "Detailed Guide: GW UNDIAGNOSED ILLNESS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 966,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L966",
+            "description" : "Milwaukee RACC Coversheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 967,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L967",
+            "description" : "Nursing Home Questionnaire for Married Veteran",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 968,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L968",
+            "description" : "Philadelphia RACC Coversheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 969,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L969",
+            "description" : "Questionnaire for Claim for Aid and Attendance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 970,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L970",
+            "description" : "Routine Exam Enclosure",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 971,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L971",
+            "description" : "Sample Consent Form",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 972,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L972",
+            "description" : "St Paul RACC Coversheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 973,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L973",
+            "description" : "VA Form 21-0789 Your Rights to Representation and a Hearing",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 974,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L974",
+            "description" : "VA Form 21-0790 Your Rights to Representation and a Hearing (Possible Overpayment)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 975,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L975",
+            "description" : "VA Form 21-8760 Additional Overpayment for Veterans with Service-Connected Permanent and Total Disability",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 976,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L976",
+            "description" : "VA Form 21-8760a  Additional Information for Veterans with Service Connection Under 38 U.S.C 1151 for Permanent and Total Disability",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 977,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:05",
+            "name" : "L977",
+            "description" : "VA Form 21-8764 Disability Compensation Award Attachment Important Information",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 978,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L978",
+            "description" : "VA Form 21-8764a Disability Compensation Award Under 38 U.S.C 1151 Important Information",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 979,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L979",
+            "description" : "VA Form 21-8765 Service Connected Death Award Attachment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 980,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L980",
+            "description" : "VA Form 21P-0510 Eligibility Verification Report Instructions",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 981,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L981",
+            "description" : "VA Form 21P-0514-1 DIC Parent's Eligibility Verification Report",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 982,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L982",
+            "description" : "VA Form 21P-0516-1 Improved Pension Eligibility Verification Report (Veteran with No Children)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 983,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L983",
+            "description" : "VA Form 21P-0516-1(Spanish) Improved Pension Eligibility Verification Report (Veteran with No Children)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 984,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L984",
+            "description" : "VA Form 21P-0517-1 Improved Pension Eligibility Verification Report (Veteran with Children)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 985,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L985",
+            "description" : "VA Form 21P-0517-1(Spanish) Improved Pension Eligibility Verification Report (Veteran with Children)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 986,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L986",
+            "description" : "VA Form 21P-0518-1 Improved Pension Eligibility Verification Report (Surviving Spouse with No Children)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 987,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L987",
+            "description" : "VA Form 21P-0519C-1 Improved Pension Eligibility Verification Report (Child or Children)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 988,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L988",
+            "description" : "VA Form 21P-0519S-1 Improved Pension Eligibility Verification Report (Surviving Spouse with Children)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 989,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L989",
+            "description" : "VA Form 21P-8765a Service-Connected Death Award Under U.S.C. 1151",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 990,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L990",
+            "description" : "VA Form 24-0296a International Direct Deposit Enrollment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 991,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L991",
+            "description" : "VA Form 28-8890 Important Information About Vocational Rehabilitation Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 992,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L992",
+            "description" : "VA Form 4107 VHA Your Rights to Appeal Our Decision",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 993,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L993",
+            "description" : "VA Form 4107c Your Rights to Appeal Our Decision - Contested Claims",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 994,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L994",
+            "description" : "VBA-21-0510 (Spanish) Instrucciones Para el Reporte Verificacion de Elegibilidad",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 995,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:07",
+            "name" : "L995",
+            "description" : "Veteran's Service Organization Information",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 996,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L996",
+            "description" : "What Evidence Must Show",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 997,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L997",
+            "description" : "Where to Send Written Correspondence",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 998,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L998",
+            "description" : "VA Form 21-0972 Notice of Veteran/Claimant of VA Forms that May Accompany an Alternate Signer Certification Form",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 999,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L999",
+            "description" : "Reason Code Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 111,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "All Insurance"
+            }
+        },
+        {
+            "id" : 1001,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1001",
+            "description" : "Beneficiary Designation  Processing Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 111,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "All Insurance"
+            }
+        },
+        {
+            "id" : 1002,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1002",
+            "description" : "Beneficiary Designation Development Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 111,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "All Insurance"
+            }
+        },
+        {
+            "id" : 1003,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1003",
+            "description" : "Insurance Fax Cover Sheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 111,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "All Insurance"
+            }
+        },
+        {
+            "id" : 1004,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1004",
+            "description" : "Insurance Free Text Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 111,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "All Insurance"
+            }
+        },
+        {
+            "id" : 1005,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1005",
+            "description" : "VAF 29-336 Designation of Beneficiary",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 111,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "All Insurance"
+            }
+        },
+        {
+            "id" : 1006,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1006",
+            "description" : "VAF 29-4125 Claim For One Sum Payment Government Life Insurance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1007,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1007",
+            "description" : "VAF 29-4125A Claim For Monthly Payments National Service Life Insurance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1008,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1008",
+            "description" : "VAF 29-541 Certificate Showing Residence And Heir",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1010,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1010",
+            "description" : "Award Maintenance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1011,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1011",
+            "description" : "Death Claim Correspondence",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1012,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1012",
+            "description" : "Returned Mail",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1013,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1013",
+            "description" : "Award Red Folder",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1014,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1014",
+            "description" : "VAF 29-5851 Death Claims Award Statement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1016,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1016",
+            "description" : "Death Claims Development Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1017,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1017",
+            "description" : "Death Claims Direct Deposit Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1018,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1018",
+            "description" : "Death Claims Invite Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1019,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1019",
+            "description" : "Running Award Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1020,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1020",
+            "description" : "Running Award Address Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1021,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1021",
+            "description" : "Running Award Check Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1022,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1022",
+            "description" : "Running Award Direct Deposit Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1023,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1023",
+            "description" : "Death Claims Status Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1024,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1024",
+            "description" : "VAF 29-0568 Waiver of Premiums Notification - Domestic",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1025,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1025",
+            "description" : "VAF 29-0568 Waiver of Premiums Notification - Foreign",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1026,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1026",
+            "description" : "VAF 29-0188 SRH Application Only",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1027,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1027",
+            "description" : "VAF 29-0189 SRH Letter & Application",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1028,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1028",
+            "description" : "VAF 29-0563 Veterans Mortgage Life Insurance - Change of Address Statement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1029,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1029",
+            "description" : "VAF 29-328 Underwriting Worksheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1030,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1030",
+            "description" : "VAF 29-357 Claim For Disability Ins Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1031,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1031",
+            "description" : "VAF 29-4364 APPLICATION FOR SERVICE-DISABLED VETERANS INSURANCE",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1032,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1032",
+            "description" : "VAF 29-8485 Application For Ordinary Life Insurance - Replacement Insurance For RML at Age 65",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1033,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1033",
+            "description" : "VAF 29-8485A Application For Ordinary Life Insurance - Replacement Insurance For RML at Age 70",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1034,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1034",
+            "description" : "VAF 29-8636 Veterans Mortgage Life Insurance Statement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1035,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1035",
+            "description" : "RH Evidence",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1036,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1036",
+            "description" : "VMLI",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1037,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1037",
+            "description" : "VMLI Mail",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1038,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1038",
+            "description" : "RH Application Approval Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1039,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1039",
+            "description" : "RH Application Denial Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1040,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1040",
+            "description" : "Live Claims Award Claim Status Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1042,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1042",
+            "description" : "Live Claims Application Development Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1043,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1043",
+            "description" : "Outreach to Disabled Veteran Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1044,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1044",
+            "description" : "Waiver of Premiums Approval Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1045,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1045",
+            "description" : "Waiver of Premiums Denial Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1046,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1046",
+            "description" : "Waiver of Premiums Invite Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1047,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1047",
+            "description" : "S-DVI Web Application",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 942,
+            "createDateTime" : "2017-08-04",
+            "modifiedDateTime" : "2021-05-11T22:07:32",
+            "name" : "L942",
+            "description" : "Final Notification - Development Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1048,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1048",
+            "description" : "VAF 29-0568 Loan & Cash Values",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1049,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1049",
+            "description" : "VAF 5767 Mature Endowment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1050,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1050",
+            "description" : "VAF 8348S1 Mature Endowment - Notification",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1051,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1051",
+            "description" : "VAF 29-1561 Loan & Cash Values",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1052,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1052",
+            "description" : "VAF 29-0568 Dividend information for Div Option NETC - Domestic",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1053,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1053",
+            "description" : "VAF29-0568 Dividend information for Div Option NETL - Domestic",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1054,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1054",
+            "description" : "VAF 29-0568 Dividend information for Div Option NETP - Domestic",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1055,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1055",
+            "description" : "VAF 29-0568 Dividend information for Div Option NETC - Foreign",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1056,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1056",
+            "description" : "VAF 29-1461 Loan Payment Receipt - Domestic",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1057,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1057",
+            "description" : "VAF 29-1461 Loan Payment Receipt - Foreign",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1058,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1058",
+            "description" : "VAF 29-389 Notice of Lapse - Domestic",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1059,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1059",
+            "description" : "VAF 29-389 Notice of Lapse - Foreign",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1060,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1060",
+            "description" : "VAF 29-0579 No Payment Received over 31 Days - Domestic",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1061,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1061",
+            "description" : "VAF 29-0579 No Payment Received over 31 Days - Foreign",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1062,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1062",
+            "description" : "VAF 29-389C-1 Extended Insurance Letter Domestic",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1063,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1063",
+            "description" : "VAF 29-389C-1 Extended Insurance Letter Foreign",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1064,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1064",
+            "description" : "VAF 29-0568 Div Credit and Deposit Statement - Domestic",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1065,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1065",
+            "description" : "VAF 29-0568 Div Credit and Deposit Statement - Foreign",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1066,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1066",
+            "description" : "VAF 29-0568 Dividend Credit withdraw to Premiums - Domestic",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1068,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-04-05T16:18:15",
+            "name" : "L1068",
+            "description" : "VAF 29-0568 Dividend Deposit Withdraw - Domestic",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1071,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1071",
+            "description" : "VAF 29-568 Renewal Term Premiums Letter - Domestic",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1072,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1072",
+            "description" : "VAF 29-568 Renewal Term Premiums Letter - Foreign",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1073,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1073",
+            "description" : "VAF 5885 Premium Payment - Domestic",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1074,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1074",
+            "description" : "VAF 5885 Premium Payment - Foreign",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1075,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1075",
+            "description" : "VAF 8348 PUA Mature Endowment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1076,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1076",
+            "description" : "VAF 8343 Insurance Status (Loan Critical) - Domestic",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1077,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1077",
+            "description" : "VAF 8348 Premium Payment & Critical Date - Domestic",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1078,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1078",
+            "description" : "VAF 8348 Premium Payment & Critical Date - Foreign",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1080,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1080",
+            "description" : "VAF 29-0152 Application for Conversion",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1081,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1081",
+            "description" : "VAF 29-0165 VA Matic Enrollment/Change",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1082,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1082",
+            "description" : "VAF 29-0309 Direct Deposit Enrollment/Change",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1083,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1083",
+            "description" : "VAF 29-1546 Application for Loan/Cash Surrender",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1084,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1084",
+            "description" : "VAF 29-1550 Government Life Insurance Application For Change Of Permanent Plan (Non-Medical)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1085,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1085",
+            "description" : "VAF 29-266A Servicemembers Civil Relief Act Termination Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1086,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1086",
+            "description" : "VAF 29-320 Request For Calculation",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1087,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1087",
+            "description" : "VAF 29-352 Application For Rein/Lapsed 6+ Mos",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1088,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1088",
+            "description" : "VAF 29-353 APPLICATION FOR REINSTATEMENT",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1089,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1089",
+            "description" : "VAF 29-369 Notice of Payment Due - Manual",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1090,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1090",
+            "description" : "VAF 29-381 Report By Insurer (Under Servicemembers' Civil Relief Act)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1091,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1091",
+            "description" : "VAF 29-390 Notice of Dividends Authorized",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1092,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1092",
+            "description" : "VAF 29-586 Certification of Change or Correction of Name",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1093,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1093",
+            "description" : "VAF 29-615 Part 1 - Certification of Health",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1094,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1094",
+            "description" : "VAF 29-640B Notice of Termination of Policy Protection under Servicemembers Civil Relief Act (SCRA)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1095,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1095",
+            "description" : "VAF 29-663 Notice of Application for Policy Protection under Servicemembers' Civil Relief Act",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1096,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1096",
+            "description" : "VAF 29-8700 Application For Ordinary Life Insurance - Replacement Insurance For RML at Age 65",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 943,
+            "createDateTime" : "2017-10-12",
+            "modifiedDateTime" : "2017-10-12T16:42:28",
+            "name" : "L943",
+            "description" : "VETSNET Award Print",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 25,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Awards / Disallowance"
+            }
+        },
+        {
+            "id" : 944,
+            "createDateTime" : "2017-10-12",
+            "modifiedDateTime" : "2017-10-12T16:42:28",
+            "name" : "L944",
+            "description" : "DBQ - Photographs",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 945,
+            "createDateTime" : "2017-10-12",
+            "modifiedDateTime" : "2017-10-12T16:42:28",
+            "name" : "L945",
+            "description" : "DBQ - Imaging Reports",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 946,
+            "createDateTime" : "2017-10-12",
+            "modifiedDateTime" : "2017-10-12T16:42:28",
+            "name" : "L946",
+            "description" : "DBQ - Other Test Results",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 947,
+            "createDateTime" : "2017-10-12",
+            "modifiedDateTime" : "2017-10-12T16:42:28",
+            "name" : "L947",
+            "description" : "Photographs - Veteran Provided",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 948,
+            "createDateTime" : "2017-10-12",
+            "modifiedDateTime" : "2017-10-12T16:42:28",
+            "name" : "L948",
+            "description" : "Imaging Reports - Veteran Provided",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 949,
+            "createDateTime" : "2017-10-12",
+            "modifiedDateTime" : "2017-10-12T16:42:28",
+            "name" : "L949",
+            "description" : "Other Test Results - Veteran Provided",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 1097,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1097",
+            "description" : "VAF 29-8701 Application For Ordinary Life Insurance - Replacement Insurance For RML at Age 70",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1098,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1098",
+            "description" : "Policy Service Annuity Update request",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1099,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1099",
+            "description" : "Policy Service Automatic Surrender Letter response",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1100,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1100",
+            "description" : "Policy Service Awd Direct Deposit Verified",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1101,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1101",
+            "description" : "Congressional Controlled Correspondence",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1102,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1102",
+            "description" : "Policy Service Correspondence",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1103,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1103",
+            "description" : "Policy Service Critical Date Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1104,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1104",
+            "description" : "Policy Service Direct Deposit Prenotification",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1105,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1105",
+            "description" : "Policy Service Dividend Withdrawal - Web",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1106,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1106",
+            "description" : "Policy Service Extended Insurance Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1107,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1107",
+            "description" : "Policy Service File Mail",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1108,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1108",
+            "description" : "Policy Service Informal Loan Request",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1109,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1109",
+            "description" : "Policy Service Inforce Direct Deposit Verified",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1110,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1110",
+            "description" : "Policy Service Informal Surrender Request",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1111,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1111",
+            "description" : "Policy Service Inforce and Awards Limited Pay",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1112,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1112",
+            "description" : "Policy Service Limited Pay Notification",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1113,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1113",
+            "description" : "Policy Service No Record Mail",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1114,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1114",
+            "description" : "Policy Service Option 2 Payee",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1115,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1115",
+            "description" : "Policy Service Evidence",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1116,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1116",
+            "description" : "Policy Service Return Mail",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1117,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1117",
+            "description" : "Policy Service Special Admin",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1118,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1118",
+            "description" : "Policy Service Over Payment Payee",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1119,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1119",
+            "description" : "Policy Service Power Of Attorney",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1120,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1120",
+            "description" : "Policy Service PUA Matured Insurance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1121,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1121",
+            "description" : "Policy Service Surrender Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1122,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1122",
+            "description" : "Policy Service TermCap Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1123,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1123",
+            "description" : "Policy Service Loan EFT or Check Voucher",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1124,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1124",
+            "description" : "Policy Service Surr EFT or Check Voucher",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1125,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1125",
+            "description" : "Third Party Request Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1126,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1126",
+            "description" : "Claim Folder Request",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1127,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1127",
+            "description" : "Collections Payment Processing Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1129,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1129",
+            "description" : "Policy Conversion Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1130,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1130",
+            "description" : "Payment Encoding Error Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1131,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1131",
+            "description" : "Deduction Processing Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1132,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1132",
+            "description" : "Policy Service Application Development Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1133,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1133",
+            "description" : "Policy Service Direct Deposit Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1134,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1134",
+            "description" : "Dividend Information Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1135,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1135",
+            "description" : "Dividend Option Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1136,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1136",
+            "description" : "Matured Endowment Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1137,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1137",
+            "description" : "Policy General Information Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1138,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1138",
+            "description" : "Occupant Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1139,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1139",
+            "description" : "Reinstatement Requirements Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1140,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1140",
+            "description" : "Reinstatement Status Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1141,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1141",
+            "description" : "Policy Lien Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1142,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1142",
+            "description" : "Policy Loan Information",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1143,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1143",
+            "description" : "Policy Loan Approval Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1144,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1144",
+            "description" : "Policy Loan Disapproval Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1145,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1145",
+            "description" : "Policy Loan and Cash Values Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1146,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1146",
+            "description" : "Modified Life and Special Ordinary Life Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1147,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1147",
+            "description" : "Name Change Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1148,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1148",
+            "description" : "Date of Birth Change Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1149,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1149",
+            "description" : "No Record of Insurance or Insurance Not in Force Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1150,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1150",
+            "description" : "Pre-authorized Debit (PADS) Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1151,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1151",
+            "description" : "Policy Status Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1152,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1152",
+            "description" : "Premium Status Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1153,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1153",
+            "description" : "Insurance reduction Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1154,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1154",
+            "description" : "Cash Surrender Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1155,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1155",
+            "description" : "Total Disability Income Provision Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1156,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1156",
+            "description" : "Term Cap Reserve Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1157,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1157",
+            "description" : "Term Insurance Information Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1158,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1158",
+            "description" : "VAF 29-0577c VMLI Annual Statement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 115,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "VMLI"
+            }
+        },
+        {
+            "id" : 1159,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1159",
+            "description" : "VMLI Award Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 115,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "VMLI"
+            }
+        },
+        {
+            "id" : 1160,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1160",
+            "description" : "VMLI Development Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 115,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "VMLI"
+            }
+        },
+        {
+            "id" : 1161,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1161",
+            "description" : "VMLI Denial - Cancellation Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 115,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "VMLI"
+            }
+        },
+        {
+            "id" : 1162,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1162",
+            "description" : "VAF 70-2 Address Verification",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1164,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1164",
+            "description" : "VA Form 28-0851 Activities for Daily Living Checklist",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1165,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1165",
+            "description" : "VA Form 28-0852 Case Support Checklist",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1166,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1166",
+            "description" : "VA Form 28-0987, Election for Chapter 31 Subsistence Allowance (CH31SA) Rate or Chapter 31 Post-9/11 Subsistence Allowance (P911SA) Rate",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1167,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1167",
+            "description" : "VA Form 28-1900 Disabled Veterans Application for Vocational Rehabilitation",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1170,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1170",
+            "description" : "VA Form 28-1917 Monthly Statement of Wages paid to Trainee",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1171,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1171",
+            "description" : "VA Form 28-8739a Protection of Privacy",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1172,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2021-05-03T15:15:06",
+            "name" : "L1172",
+            "description" : "VAF 28-8832 - Personalized Career Planning and Guidance Application",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1173,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1173",
+            "description" : "VA Form 2237 Request, Turn in and Receipt for Property of Services-Purchase Request",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1174,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1174",
+            "description" : "VA Form 5655 Financial Status Report",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1175,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1175",
+            "description" : "VA Form 21-0304  Application for Benefits for Certain Children with Disabilities Born of Vietnam and Certain Korea Service Veterans",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1176,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1176",
+            "description" : "VA Form 22-1990 Application for VA Education Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1177,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1177",
+            "description" : "VA Form 22-1990e Application for Family Member to use Transferred Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1179,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1179",
+            "description" : "VA Form 22-5490 Dependents Application for VA Education Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1180,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1180",
+            "description" : "SF 1034 Public Voucher for Purchase-Direct Reimbursement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1181,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1181",
+            "description" : "SF 1442 Solicitation, Offer and Award",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1182,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1182",
+            "description" : "Statement of Work (SOW)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1183,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1183",
+            "description" : "Independent Government Cost Estimate (IGCE)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1184,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1184",
+            "description" : "Performance Work Statement (PWS)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1185,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1185",
+            "description" : "VA Handbook 6500.6 Appendix A Checklist",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1186,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1186",
+            "description" : "SEI Site Survey Report",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1187,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1187",
+            "description" : "Resume",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1188,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1188",
+            "description" : "Post-9/11 Certificate of Eligibility",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1189,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1189",
+            "description" : "DOL referral forms",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1190,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1190",
+            "description" : "LMI Packet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1191,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1191",
+            "description" : "Assessment Results",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1192,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1192",
+            "description" : "Comprehensive IL Assessment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1193,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1193",
+            "description" : "VR-55 Appointment Letter - Chapter 35 Evaluation",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1194,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2019-06-03T23:13:25",
+            "name" : "L1194",
+            "description" : "VR-56 Ch31 Only Programs of Training or Courses",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1196,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1196",
+            "description" : "Appendix AB - Election of Retroactive VR&E Chapter 31 Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1197,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1197",
+            "description" : "Appendix AK - Fugitive Felon Due Sample Letters",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1198,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1198",
+            "description" : "Appendix AV - VREO Concurrence - Chapter 33 Retroactive Reimbursement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1199,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1199",
+            "description" : "Appendix AY - Election of P911SA in Lieu of CH31 Subsistence Allowance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1200,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1200",
+            "description" : "Appendix BB - VRC Checklist Chapter 33 Retroactive Reimbursement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1201,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1201",
+            "description" : "Appendix BO - Veteran Checklist Chapter 33 Retroactive Reimbursement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1202,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1202",
+            "description" : "Appendix BV - Chapter 36 Checklist",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1203,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1203",
+            "description" : "Appendix C - Military Request for VA Vocational Rehabilitation and Employment (VR&E)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1204,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1204",
+            "description" : "Appendix CO - VRC CHECKLIST - CHAPTER 31 RETROACTIVE INDUCTION",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1205,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1205",
+            "description" : "Appendix CP - VREO CONCURRENCE - CHAPTER 31 RETROACTIVE INDUCTION",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1206,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:08",
+            "name" : "L1206",
+            "description" : "Appendix CQ - VETERAN CHECKLIST - CHAPTER 31 RETROACTIVE INDUCTION",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1207,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1207",
+            "description" : "Appendix G - Preliminary Evaluation Self-Employment Checklist",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1208,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1208",
+            "description" : "Appendix Q - Special Employer Incentive Arrangement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1209,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1209",
+            "description" : "Appendix R - SEI Payment Schedule",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1210,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1210",
+            "description" : "Higher Level Review",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 61,
+                "createDateTime" : "2018-06-25",
+                "modifiedDateTime" : "2018-06-25T04:00:00",
+                "description" : "Rating Decisions",
+                "subDescription" : "Appeals Modernization"
+            }
+        },
+        {
+            "id" : 1211,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1211",
+            "description" : "Supplemental Review",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 61,
+                "createDateTime" : "2018-06-25",
+                "modifiedDateTime" : "2018-06-25T04:00:00",
+                "description" : "Rating Decisions",
+                "subDescription" : "Appeals Modernization"
+            }
+        },
+        {
+            "id" : 1212,
+            "createDateTime" : "2018-01-18",
+            "modifiedDateTime" : "2018-01-18T16:15:06",
+            "name" : "L1212",
+            "description" : "EVVE Certification",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 73,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Non-Medical Evidence",
+                "subDescription" : "Death Evidence "
+            }
+        },
+        {
+            "id" : 1213,
+            "createDateTime" : "2018-03-21",
+            "modifiedDateTime" : "2018-03-21T17:32:54",
+            "name" : "L1213",
+            "description" : "DMC - Second Demand Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 88,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions",
+                "subDescription" : "DMC"
+            }
+        },
+        {
+            "id" : 1214,
+            "createDateTime" : "2018-03-21",
+            "modifiedDateTime" : "2018-03-21T17:32:54",
+            "name" : "L1214",
+            "description" : "DMC - Third Demand Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 88,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions",
+                "subDescription" : "DMC"
+            }
+        },
+        {
+            "id" : 1215,
+            "createDateTime" : "2018-03-21",
+            "modifiedDateTime" : "2018-03-21T17:32:54",
+            "name" : "L1215",
+            "description" : "DMC - Debt Increase Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 88,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions",
+                "subDescription" : "DMC"
+            }
+        },
+        {
+            "id" : 1216,
+            "createDateTime" : "2018-03-21",
+            "modifiedDateTime" : "2018-03-21T17:32:54",
+            "name" : "L1216",
+            "description" : "DMC - Disaster Resume Collection Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 88,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions",
+                "subDescription" : "DMC"
+            }
+        },
+        {
+            "id" : 1217,
+            "createDateTime" : "2018-03-21",
+            "modifiedDateTime" : "2018-03-21T17:32:54",
+            "name" : "L1217",
+            "description" : "DMC - Disaster Suspend Collection Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 88,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions",
+                "subDescription" : "DMC"
+            }
+        },
+        {
+            "id" : 1218,
+            "createDateTime" : "2018-03-21",
+            "modifiedDateTime" : "2018-03-21T17:32:54",
+            "name" : "L1218",
+            "description" : "Education - Returned Mail",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1219,
+            "createDateTime" : "2018-03-21",
+            "modifiedDateTime" : "2018-03-21T17:32:54",
+            "name" : "L1219",
+            "description" : "B&O",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 111,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "All Insurance"
+            }
+        },
+        {
+            "id" : 1220,
+            "createDateTime" : "2018-03-21",
+            "modifiedDateTime" : "2018-03-21T17:32:54",
+            "name" : "L1220",
+            "description" : "B&O Development",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 111,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "All Insurance"
+            }
+        },
+        {
+            "id" : 1221,
+            "createDateTime" : "2018-03-21",
+            "modifiedDateTime" : "2018-03-21T17:32:54",
+            "name" : "L1221",
+            "description" : "B&O Folder",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 111,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "All Insurance"
+            }
+        },
+        {
+            "id" : 1222,
+            "createDateTime" : "2018-03-21",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1222",
+            "description" : "Death Claim",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 112,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1223,
+            "createDateTime" : "2018-03-21",
+            "modifiedDateTime" : "2018-03-21T17:32:54",
+            "name" : "L1223",
+            "description" : "Outreach Evidence",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1224,
+            "createDateTime" : "2018-03-21",
+            "modifiedDateTime" : "2018-03-21T17:32:54",
+            "name" : "L1224",
+            "description" : "Outreach File Mail",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1225,
+            "createDateTime" : "2018-03-21",
+            "modifiedDateTime" : "2018-03-21T17:32:54",
+            "name" : "L1225",
+            "description" : "Outreach Return Mail",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1226,
+            "createDateTime" : "2018-03-21",
+            "modifiedDateTime" : "2018-03-21T17:32:54",
+            "name" : "L1226",
+            "description" : "Outreach RH Application",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1227,
+            "createDateTime" : "2018-03-21",
+            "modifiedDateTime" : "2018-03-21T17:32:54",
+            "name" : "L1227",
+            "description" : "Outreach Special Admin",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1228,
+            "createDateTime" : "2018-03-21",
+            "modifiedDateTime" : "2018-03-21T17:32:54",
+            "name" : "L1228",
+            "description" : "VAF 29-1549 Application for Change of Permanent Plan (Medical)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1229,
+            "createDateTime" : "2018-03-21",
+            "modifiedDateTime" : "2018-03-21T17:32:54",
+            "name" : "L1229",
+            "description" : "Policy Service Power Of Attorney-NT",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1230,
+            "createDateTime" : "2018-07-26",
+            "modifiedDateTime" : "2018-07-26T15:27:00",
+            "name" : "L1230",
+            "description" : "VA Form 21-0985 Decision Ready Claim (DRC) Exam Request",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 124,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Checklist",
+                "subDescription" : "Other Special Claims"
+            }
+        },
+        {
+            "id" : 1233,
+            "createDateTime" : "2018-07-26",
+            "modifiedDateTime" : "2018-07-26T15:27:00",
+            "name" : "L1233",
+            "description" : "DD 1172-2 Application for Identification Card/DEERS Enrollment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1234,
+            "createDateTime" : "2018-07-26",
+            "modifiedDateTime" : "2018-07-26T15:27:00",
+            "name" : "L1234",
+            "description" : "B&O Trans",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 111,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "All Insurance"
+            }
+        },
+        {
+            "id" : 1235,
+            "createDateTime" : "2018-07-26",
+            "modifiedDateTime" : "2018-07-26T15:27:00",
+            "name" : "L1235",
+            "description" : "SGLV 8714, Application for Veterans' Group Life Insurance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 111,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "All Insurance"
+            }
+        },
+        {
+            "id" : 1236,
+            "createDateTime" : "2018-07-26",
+            "modifiedDateTime" : "2018-07-26T15:27:00",
+            "name" : "L1236",
+            "description" : "SGLV 8715, Application for the Servicemembers' Group Life Insurance (SGLI) Disability Extension",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1237,
+            "createDateTime" : "2018-07-26",
+            "modifiedDateTime" : "2018-07-26T15:27:00",
+            "name" : "L1237",
+            "description" : "VAF 29-0975- Authorization to Disclose Personal Information to a Third Party (Insurance)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 113,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Live Claims"
+            }
+        },
+        {
+            "id" : 1238,
+            "createDateTime" : "2018-07-26",
+            "modifiedDateTime" : "2018-07-26T15:27:00",
+            "name" : "L1238",
+            "description" : "Insurance Appeals Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 111,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "All Insurance"
+            }
+        },
+        {
+            "id" : 1239,
+            "createDateTime" : "2018-07-26",
+            "modifiedDateTime" : "2018-07-26T15:27:00",
+            "name" : "L1239",
+            "description" : "General Insurance Correspondence",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 111,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "All Insurance"
+            }
+        },
+        {
+            "id" : 1240,
+            "createDateTime" : "2018-07-26",
+            "modifiedDateTime" : "2018-07-26T15:27:00",
+            "name" : "L1240",
+            "description" : "VAF 29-888 Insurance Deduction Authorization (For Deduction From Benefit Payments)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 114,
+                "createDateTime" : "2018-01-18",
+                "modifiedDateTime" : "2018-01-18T16:15:06",
+                "description" : "Insurance",
+                "subDescription" : "Policy Service"
+            }
+        },
+        {
+            "id" : 1241,
+            "createDateTime" : "2018-07-26",
+            "modifiedDateTime" : "2018-07-26T15:27:00",
+            "name" : "L1241",
+            "description" : "FMS 1133 Claim Against the United States for the Proceeds of a Government Check",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 1242,
+            "createDateTime" : "2018-07-26",
+            "modifiedDateTime" : "2018-07-26T15:27:00",
+            "name" : "L1242",
+            "description" : "VP-001-VRE Notification Letter - Overpayment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1246,
+            "createDateTime" : "2018-07-26",
+            "modifiedDateTime" : "2018-07-26T15:27:03",
+            "name" : "L1246",
+            "description" : "VRE Correspondence",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1248,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1248",
+            "description" : "VA Form 20-0996 Request for Higher-Level Review",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1249,
+            "createDateTime" : "2018-09-10",
+            "modifiedDateTime" : "2018-09-10T15:20:21",
+            "name" : "L1249",
+            "description" : "VA Form 20-0995 Supplemental Claim Application",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1413,
+            "createDateTime" : "2020-07-15",
+            "modifiedDateTime" : "2020-07-30T13:01:40",
+            "name" : "L1413",
+            "description" : "Negligence Payment Recoupment Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 1417,
+            "createDateTime" : "2020-07-15",
+            "modifiedDateTime" : "2020-07-30T13:01:40",
+            "name" : "L1417",
+            "description" : "Precontact - Judicial No Rating Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 1418,
+            "createDateTime" : "2020-07-15",
+            "modifiedDateTime" : "2020-07-30T13:01:40",
+            "name" : "L1418",
+            "description" : "Precontact - VA Rating Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 1425,
+            "createDateTime" : "2020-07-15",
+            "modifiedDateTime" : "2020-07-30T13:01:40",
+            "name" : "L1425",
+            "description" : "SR Notification Cover Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 1426,
+            "createDateTime" : "2020-07-15",
+            "modifiedDateTime" : "2020-07-30T13:01:40",
+            "name" : "L1426",
+            "description" : "SR Untimely Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 1427,
+            "createDateTime" : "2020-07-15",
+            "modifiedDateTime" : "2020-07-30T13:01:40",
+            "name" : "L1427",
+            "description" : "Untimely Form 9 Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 1428,
+            "createDateTime" : "2020-07-15",
+            "modifiedDateTime" : "2020-07-30T13:01:40",
+            "name" : "L1428",
+            "description" : "Untimely NOD Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 1337,
+            "createDateTime" : "2020-10-08",
+            "modifiedDateTime" : "2020-10-08T22:01:54",
+            "name" : "L1337",
+            "description" : "VA Form 26-8497 - Request for Verification of Employment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 202,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Loan Guaranty"
+            }
+        },
+        {
+            "id" : 1338,
+            "createDateTime" : "2020-10-08",
+            "modifiedDateTime" : "2020-10-08T22:01:54",
+            "name" : "L1338",
+            "description" : "VA Form 26-8497a - Request for Verification of Deposit",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 202,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Loan Guaranty"
+            }
+        },
+        {
+            "id" : 1339,
+            "createDateTime" : "2020-10-08",
+            "modifiedDateTime" : "2020-10-08T22:01:54",
+            "name" : "L1339",
+            "description" : "VA Form 26-8736 - Application For Authority To Close Loans On An Automatic Basis - Non Supervised Lenders",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 202,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Loan Guaranty"
+            }
+        },
+        {
+            "id" : 1340,
+            "createDateTime" : "2020-10-08",
+            "modifiedDateTime" : "2020-10-08T22:01:54",
+            "name" : "L1340",
+            "description" : "VA Form 26-8736A - Non Supervised Lender's Nomination and Recommendation of Credit Underwriter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 202,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Loan Guaranty"
+            }
+        },
+        {
+            "id" : 1341,
+            "createDateTime" : "2020-10-08",
+            "modifiedDateTime" : "2020-10-08T22:01:54",
+            "name" : "L1341",
+            "description" : "VA Form 26-6381 - Application For Assumption Approval And/Or Release From Personal Liability To The Government On A Home Loan",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 202,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Loan Guaranty"
+            }
+        },
+        {
+            "id" : 1342,
+            "createDateTime" : "2020-10-08",
+            "modifiedDateTime" : "2020-10-08T22:01:54",
+            "name" : "L1342",
+            "description" : "VA Form 26-6382 - Statement Of Purchaser Or Owner Assuming Seller's Loan",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 202,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Loan Guaranty"
+            }
+        },
+        {
+            "id" : 1343,
+            "createDateTime" : "2020-10-08",
+            "modifiedDateTime" : "2020-10-08T22:01:54",
+            "name" : "L1343",
+            "description" : "VA Form 26-8106 - Statement of Veteran Assuming GI Loan (Substitution of Entitlement)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 202,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Loan Guaranty"
+            }
+        },
+        {
+            "id" : 1344,
+            "createDateTime" : "2020-10-08",
+            "modifiedDateTime" : "2020-10-08T22:01:54",
+            "name" : "L1344",
+            "description" : "VA Form 26-8812 - VA Equal Opportunity Lender Certification",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 202,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Loan Guaranty"
+            }
+        },
+        {
+            "id" : 1345,
+            "createDateTime" : "2020-10-08",
+            "modifiedDateTime" : "2020-10-08T22:01:54",
+            "name" : "L1345",
+            "description" : "VA Form 26-8791 - VA Affirmative Marketing Certification",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 202,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Loan Guaranty"
+            }
+        },
+        {
+            "id" : 1346,
+            "createDateTime" : "2020-10-08",
+            "modifiedDateTime" : "2020-10-08T22:01:54",
+            "name" : "L1346",
+            "description" : "VA Form 26-1802a - HUD/VA Addendum to Uniform Residential Loan Application",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 202,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Loan Guaranty"
+            }
+        },
+        {
+            "id" : 1347,
+            "createDateTime" : "2020-10-08",
+            "modifiedDateTime" : "2020-10-08T22:01:54",
+            "name" : "L1347",
+            "description" : "Fannie Mae Form 1003/Freddie Mac Form 65 - Uniform Residential Loan Application",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 202,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Loan Guaranty"
+            }
+        },
+        {
+            "id" : 1348,
+            "createDateTime" : "2020-10-08",
+            "modifiedDateTime" : "2020-10-08T22:01:54",
+            "name" : "L1348",
+            "description" : "VA Form 26-8923 - Interest Rate Reduction Refinancing Loan Worksheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 202,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Loan Guaranty"
+            }
+        },
+        {
+            "id" : 1349,
+            "createDateTime" : "2020-10-08",
+            "modifiedDateTime" : "2020-10-08T22:01:54",
+            "name" : "L1349",
+            "description" : "VA Form 26-0785 - Lender's Staff Appraisal Reviewer (SAR) Application",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 202,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Loan Guaranty"
+            }
+        },
+        {
+            "id" : 1350,
+            "createDateTime" : "2020-10-08",
+            "modifiedDateTime" : "2020-10-08T22:01:54",
+            "name" : "L1350",
+            "description" : "VA Form 20-10206 - Freedom of Information Act (FOIA) or Privacy Act (PA) Request",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1351,
+            "createDateTime" : "2020-10-08",
+            "modifiedDateTime" : "2020-10-08T22:01:54",
+            "name" : "L1351",
+            "description" : "VA Form 20-10207 - Priority Processing Request",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1352,
+            "createDateTime" : "2020-10-08",
+            "modifiedDateTime" : "2020-10-08T22:01:54",
+            "name" : "L1352",
+            "description" : "VA Form 20-10208, Document/Evidence Submission",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1438,
+            "createDateTime" : "2020-10-22",
+            "modifiedDateTime" : "2020-10-22T20:56:41",
+            "name" : "L1438",
+            "description" : "IDES 21-526 EZ",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 11,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Original Claim"
+            }
+        },
+        {
+            "id" : 1439,
+            "createDateTime" : "2020-10-22",
+            "modifiedDateTime" : "2020-10-22T20:56:41",
+            "name" : "L1439",
+            "description" : "IDES Return to Duty Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 69,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Due Process "
+            }
+        },
+        {
+            "id" : 1440,
+            "createDateTime" : "2020-10-22",
+            "modifiedDateTime" : "2020-10-22T20:56:41",
+            "name" : "L1440",
+            "description" : "IDES Benefits Estimate Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 1441,
+            "createDateTime" : "2020-10-22",
+            "modifiedDateTime" : "2020-10-22T20:56:41",
+            "name" : "L1441",
+            "description" : "IDES Declined to File Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 1480,
+            "createDateTime" : "2021-11-19",
+            "modifiedDateTime" : "2021-11-19T19:33:10",
+            "name" : "L1480",
+            "description" : "VA Form 28-0791, Preliminary Independent Living (IL) Assessment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1481,
+            "createDateTime" : "2021-11-04",
+            "modifiedDateTime" : "2021-11-04T18:30:29",
+            "name" : "L1481",
+            "description" : "VA Form 28-10214 - Rehab Plan CMS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1482,
+            "createDateTime" : "2021-11-19",
+            "modifiedDateTime" : "2021-11-26T21:46:38",
+            "name" : "L1482",
+            "description" : "28-0953 - Executive Director's Checklist for Waiver of Veteran Readiness and Employment (VR&E) Housing Adaptation Grant Amount",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1479,
+            "createDateTime" : "2021-11-19",
+            "modifiedDateTime" : "2021-11-19T19:33:10",
+            "name" : "L1479",
+            "description" : "VA Form 28-0800, Vocational Readiness and Employment (VR&E) Program Orientation",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1494,
+            "createDateTime" : "2021-11-19",
+            "modifiedDateTime" : "2021-11-19T19:33:10",
+            "name" : "L1494",
+            "description" : "VA Form 21P-530 EZ",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1487,
+            "createDateTime" : "2022-01-24",
+            "modifiedDateTime" : "2022-01-24T13:45:46",
+            "name" : "L1487",
+            "description" : "Chart Search Application Treatment Record",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 1666,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1666",
+            "description" : "CHAPTER 33 RETURN PAYMENT DOCS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1667,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1667",
+            "description" : "FILE COPIES - AR",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1668,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1668",
+            "description" : "FILE COPY - ADJ",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1321,
+            "createDateTime" : "2019-11-08",
+            "modifiedDateTime" : "2019-11-08T18:58:21",
+            "name" : "L1321",
+            "description" : "VA Form 21-0307 Award Attachment for Certain Children With Disabilities Born Of Vietnam And Certain Korea Service Veterans",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1306,
+            "createDateTime" : "2019-11-08",
+            "modifiedDateTime" : "2020-01-21T23:01:35",
+            "name" : "L1306",
+            "description" : "Automobile Adaptive Equipment - VHA",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1307,
+            "createDateTime" : "2019-11-08",
+            "modifiedDateTime" : "2020-01-21T23:01:35",
+            "name" : "L1307",
+            "description" : "Beneficiary Travel - VHA",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1308,
+            "createDateTime" : "2019-11-08",
+            "modifiedDateTime" : "2020-01-21T23:01:35",
+            "name" : "L1308",
+            "description" : "Camp Lejeune - VHA",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1309,
+            "createDateTime" : "2019-11-08",
+            "modifiedDateTime" : "2020-01-21T23:01:35",
+            "name" : "L1309",
+            "description" : "CHAMPVA - VHA",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1310,
+            "createDateTime" : "2019-11-08",
+            "modifiedDateTime" : "2020-01-21T23:01:35",
+            "name" : "L1310",
+            "description" : "Clothing Allowance - VHA",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1311,
+            "createDateTime" : "2019-11-08",
+            "modifiedDateTime" : "2019-11-08T18:58:21",
+            "name" : "L1311",
+            "description" : "Eligibility & Enrollment - VHA",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1312,
+            "createDateTime" : "2019-11-08",
+            "modifiedDateTime" : "2020-01-21T23:01:35",
+            "name" : "L1312",
+            "description" : "Foreign Medical Program - VHA",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1313,
+            "createDateTime" : "2019-11-08",
+            "modifiedDateTime" : "2020-01-21T23:01:35",
+            "name" : "L1313",
+            "description" : "General Prosthetics - VHA",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1314,
+            "createDateTime" : "2019-11-08",
+            "modifiedDateTime" : "2020-01-21T23:01:35",
+            "name" : "L1314",
+            "description" : "Income Verification/Priority Group/Copays - VHA",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1315,
+            "createDateTime" : "2019-11-08",
+            "modifiedDateTime" : "2020-01-21T23:01:35",
+            "name" : "L1315",
+            "description" : "Medical Expense Reimbursement (1725/1725A/1728) - VHA",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1316,
+            "createDateTime" : "2019-11-08",
+            "modifiedDateTime" : "2020-01-21T23:01:35",
+            "name" : "L1316",
+            "description" : "Spina Bifida/Children of Women Vietnam Veterans - VHA",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1317,
+            "createDateTime" : "2019-11-08",
+            "modifiedDateTime" : "2019-11-08T18:58:21",
+            "name" : "L1317",
+            "description" : "VR-64 Chapter 31 Positive Decision Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1318,
+            "createDateTime" : "2019-11-08",
+            "modifiedDateTime" : "2019-11-08T18:58:21",
+            "name" : "L1318",
+            "description" : "VR-65 Chapters 18, 35 and 36 Decision Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1319,
+            "createDateTime" : "2019-11-08",
+            "modifiedDateTime" : "2019-11-08T18:58:21",
+            "name" : "L1319",
+            "description" : "VR-66 General Proposed Adverse Action Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1486,
+            "createDateTime" : "2022-01-10",
+            "modifiedDateTime" : "2022-02-10T14:54:12",
+            "name" : "L1486",
+            "description" : "VA Form 28-1904, On-The-Job Training Agreement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1483,
+            "createDateTime" : "2022-02-05",
+            "modifiedDateTime" : "2022-02-05T21:18:41",
+            "name" : "L1483",
+            "description" : "SF-95, Claim for Damage, Injury, or Death",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1554,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1554",
+            "description" : "Automated State Plot Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1555,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1555",
+            "description" : "Chapter 31 Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1556,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1556",
+            "description" : "Child School Attendance Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1557,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1557",
+            "description" : "COLA Offset and Due Process Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1558,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1558",
+            "description" : "COLA - Adjusted (C710)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1559,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1559",
+            "description" : "COLA - Adjusted (C717)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1560,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1560",
+            "description" : "Non-Adjustment Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1561,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1561",
+            "description" : "Dependent Verification - Compensation",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1562,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1562",
+            "description" : "Compensation End of Day Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1563,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1563",
+            "description" : "Compensation End of Day Letter - Bad Address",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1564,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1564",
+            "description" : "Spouse Verification - Compensation",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1565,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1565",
+            "description" : "DD 214 Request Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1566,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1566",
+            "description" : "Death Match Dependency Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1567,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1567",
+            "description" : "Direct Deposit Change Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1568,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1568",
+            "description" : "Drug Entitlement Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1569,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1569",
+            "description" : "FAS Auto Enrollment Direct Deposit Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1570,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1570",
+            "description" : "Fugitive Felon Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1571,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1571",
+            "description" : "Income Reminder Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1572,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1572",
+            "description" : "Individual Unemployment Annual Eligibility Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1573,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1573",
+            "description" : "Intent to File Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1574,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1574",
+            "description" : "Limited Payability Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1575,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1575",
+            "description" : "Month of Death Letter ",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1576,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1576",
+            "description" : "Month of Death Letter - NOK",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1577,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1577",
+            "description" : "Month of Death Letter - Spouse",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1578,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1578",
+            "description" : "Pension End of Day Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1579,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1579",
+            "description" : "Pension End of Day Letter -- Bad Address",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1580,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1580",
+            "description" : "Philippine Residency Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1581,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1581",
+            "description" : "Return to Active Duty Due Process Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1582,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1582",
+            "description" : "Return to Active Duty Termination Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1583,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1583",
+            "description" : "Returned Check Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1584,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1584",
+            "description" : "School Age 13,16,18 Letter ",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1585,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1585",
+            "description" : "Service Disability Insurance Letter ",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1586,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1586",
+            "description" : "SSA Death Match",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1587,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1587",
+            "description" : "Tax Abatement Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1588,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1588",
+            "description" : "Tax Abatement Letter -- Bad Address ",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1589,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1589",
+            "description" : "Loss of POA Accreditation",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1590,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1590",
+            "description" : "CRSC - Concurrent Retirement and Disability Pay Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1591,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1591",
+            "description" : "CRSC - Coast Guard Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1492,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1492",
+            "description" : "Character of Discharge Notification Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1493,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1493",
+            "description" : "Earlier Effective Date Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1432,
+            "createDateTime" : "2020-07-29",
+            "modifiedDateTime" : "2020-07-29T19:01:49",
+            "name" : "L1432",
+            "description" : "Negligence Determination Beneficiary NL",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 1495,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1495",
+            "description" : "Returned Mail Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1496,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1496",
+            "description" : "Request for Application AMA Review Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1497,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1497",
+            "description" : "Fugitive Felon Due Process Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1539,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1539",
+            "description" : "Withdrawal of Claim (Comp/Pension) Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1498,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1498",
+            "description" : "Request for Application Compensation Pension or DIC Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1499,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1499",
+            "description" : "Fugitive Felon Final Notification Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1500,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1500",
+            "description" : "Non-BDD Claim- Additional Contentions Submitted Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1501,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1501",
+            "description" : "Non-BDD Claim- Less than 90 Day Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1502,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1502",
+            "description" : "Non-BDD Claim- Request Resubmission Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1503,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1503",
+            "description" : "POA Not of Record Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1504,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1504",
+            "description" : "Third Party Authorization Incorrect Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1505,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1505",
+            "description" : "HLR Not Timely  Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1506,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1506",
+            "description" : "Decision Review Against Pending Claim Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1507,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1507",
+            "description" : "Decision Review Against Proposal Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1508,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1508",
+            "description" : "Clarification of Decision Review Request Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1509,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1509",
+            "description" : "Withdrawal of Appeal Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1510,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1510",
+            "description" : "SOC Opt-in Notification Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1511,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1511",
+            "description" : "Notice of Decision Not Timely Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1512,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1512",
+            "description" : "File Certified to BVA Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1513,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1513",
+            "description" : "Local Appeal Hearing Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1514,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1514",
+            "description" : "Travel Board Video Conference Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1515,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1515",
+            "description" : "Opt-in to AMA Ineligible Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1516,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1516",
+            "description" : "Form 9 Not Timely Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1517,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1517",
+            "description" : "Duplicate Documents Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1518,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1518",
+            "description" : "Decision Review Officer Process Explanation Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1519,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1519",
+            "description" : "Request for Application Dependency Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1520,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1520",
+            "description" : "Annual Clothing Allowance Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1521,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1521",
+            "description" : "Invalid Direct Deposit Update Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1522,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1522",
+            "description" : "Receipt of Unsolicited Evidence Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1523,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1523",
+            "description" : "Request for Application Helpless Child Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1524,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1524",
+            "description" : "NOD Against Proposal Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1525,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1525",
+            "description" : "Drill Pay-179 Plus Days Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1526,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1526",
+            "description" : "Dependency Claim Missing Information Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1527,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1527",
+            "description" : "Audit Error Worksheet Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1528,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1528",
+            "description" : "Summary of Case Fee Decision Notice Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1529,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1529",
+            "description" : "Attorney Revocation Letter to Veteran",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1530,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1530",
+            "description" : "Attorney Revocation Letter to Attorney",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1531,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1531",
+            "description" : "Invalid Fee Agreement Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1532,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1532",
+            "description" : "Debt to Veteran for Failure to Withhold Attorney Fee Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1533,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1533",
+            "description" : "Fee Recoupment Procedures-Final Notice Letter to Veteran Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1534,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1534",
+            "description" : "No Exclusive Contact to Veteran Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1535,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1535",
+            "description" : "Incorrectly Established Claim Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1536,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1536",
+            "description" : "IDES Return to Active Service Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1537,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1537",
+            "description" : "Exam Appointment Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1538,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1538",
+            "description" : "Active ITF Notification Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1333,
+            "createDateTime" : "2020-03-24",
+            "modifiedDateTime" : "2020-03-24T13:10:38",
+            "name" : "L1333",
+            "description" : "Records Research Center Response",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1442,
+            "createDateTime" : "2020-11-30",
+            "modifiedDateTime" : "2020-11-30T17:57:09",
+            "name" : "L1442",
+            "description" : "VA Form 21-10210 - Lay Witness Statement",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 70,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence",
+                "subDescription" : "Miscellaneous "
+            }
+        },
+        {
+            "id" : 1443,
+            "createDateTime" : "2020-11-30",
+            "modifiedDateTime" : "2020-12-17T21:46:27",
+            "name" : "L1443",
+            "description" : "VA Form 28-10212 - Chapter 31 Request for Assistance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1444,
+            "createDateTime" : "2020-11-30",
+            "modifiedDateTime" : "2020-11-30T17:57:09",
+            "name" : "L1444",
+            "description" : "VA Form 22-1999 - VA Enrollment Certification",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1445,
+            "createDateTime" : "2020-11-30",
+            "modifiedDateTime" : "2020-11-30T17:57:09",
+            "name" : "L1445",
+            "description" : "VA Form 22-1995 - Request for Change of Program or Place of Training",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1446,
+            "createDateTime" : "2020-11-30",
+            "modifiedDateTime" : "2020-11-30T17:57:09",
+            "name" : "L1446",
+            "description" : "VA Form 22-5495 - Dependents' Request for Change of Program or Place of Training (Under Provisions of Chapters 33 and 35, Title 38, U.S.C.)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1447,
+            "createDateTime" : "2020-11-30",
+            "modifiedDateTime" : "2020-11-30T17:57:09",
+            "name" : "L1447",
+            "description" : "VR-68 Chapter 36 Missed Appointment 10-Day Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1448,
+            "createDateTime" : "2020-11-30",
+            "modifiedDateTime" : "2020-11-30T17:57:09",
+            "name" : "L1448",
+            "description" : "VR-69 Chapter 36 Decision Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1449,
+            "createDateTime" : "2020-11-30",
+            "modifiedDateTime" : "2020-11-30T17:57:09",
+            "name" : "L1449",
+            "description" : "VR-70 Chapter 36 PCPG Appointment Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1489,
+            "createDateTime" : "2021-11-29",
+            "modifiedDateTime" : "2021-11-29T12:20:13",
+            "name" : "L1489",
+            "description" : "Automated Review Summary Document",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 1488,
+            "createDateTime" : "2021-11-29",
+            "modifiedDateTime" : "2021-11-29T12:20:13",
+            "name" : "L1488",
+            "description" : "Computable Medical Data File",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 44,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Medical Records"
+            }
+        },
+        {
+            "id" : 1592,
+            "createDateTime" : "2022-05-16",
+            "modifiedDateTime" : "2022-05-16T15:50:17",
+            "name" : "L1592",
+            "description" : "Personal Trauma Development Checklist",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 123,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Checklist"
+            }
+        },
+        {
+            "id" : 1593,
+            "createDateTime" : "2022-05-16",
+            "modifiedDateTime" : "2022-05-16T15:50:17",
+            "name" : "L1593",
+            "description" : "Personal Trauma Incident/Marker Worksheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 122,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Worksheet"
+            }
+        },
+        {
+            "id" : 1540,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1540",
+            "description" : "Suspension of Claim Due to Return to Active Duty Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1541,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1541",
+            "description" : "IDES Benefits Estimate Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1542,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1542",
+            "description" : "Pre-Determination Hearing Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1605,
+            "createDateTime" : "2022-05-31",
+            "modifiedDateTime" : "2022-05-31T14:28:58",
+            "name" : "L1605",
+            "description" : "General Records Request (Non-Medical)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1669,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1669",
+            "description" : "FILE COPIES - VSD",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1670,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1670",
+            "description" : "FRONT END TOOL-CH33",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1671,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1671",
+            "description" : "HARD COPY CLAIMS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1672,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1672",
+            "description" : "HARD COPY CHAPTER 33 CERTIFICATIONS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1673,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1673",
+            "description" : "HARD COPY NON-33 CERTIFICATIONS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1674,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1674",
+            "description" : "ORIGINAL TATU",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1675,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1675",
+            "description" : "TUITION ASSISTANCE TOP-UP",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1676,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1676",
+            "description" : "SUPPLEMENTAL (S1990)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1677,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1677",
+            "description" : "SUPPLEMENTAL (S1990E)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1678,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1678",
+            "description" : "VONAPP SIGNATURE (VSIGN)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1679,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1679",
+            "description" : "VRRAP - ORIGINAL APPLICATION (V1990S)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1680,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1680",
+            "description" : "VIS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1681,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1681",
+            "description" : "VA ON-LINE 1990N",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1682,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1682",
+            "description" : "VA ON-LINE 1990E",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1683,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1683",
+            "description" : "WAIVER REQUEST",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1684,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1684",
+            "description" : "WORK STUDY LETTERS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1685,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1685",
+            "description" : "OTHER DEPENDENCY",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1686,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1686",
+            "description" : "HARD COPY SCHOOL",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1687,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1687",
+            "description" : "VETERANS ASSISTANCE INQUIRY",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1688,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1688",
+            "description" : "MONTHLY CERTIFICATIONS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1689,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1689",
+            "description" : "EDU NOTICE OF EXCEPTION",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1690,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1690",
+            "description" : "COMPLIANCE SURVEY",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1691,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1691",
+            "description" : "TUTORIAL ASSISTANCE CLAIM",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1692,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1692",
+            "description" : "ORDERS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1693,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1693",
+            "description" : "APPEALS MODERNIZATION ACT BOARD OF VETERANS AFFAIRS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1694,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1694",
+            "description" : "Fully Automated Original Claim (1990A)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1695,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1695",
+            "description" : "Off-Ramped Original Claim (1990B)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1696,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1696",
+            "description" : "Bio Data Needs Review On An Automated Claim (1990G)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1698,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1698",
+            "description" : "VA Form 22-653c Monthly Certification of Flight Training",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1699,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1699",
+            "description" : "VA Form 22-653d Monthly Certification Of On-The-Job and Apprenticeship Training",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1700,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1700",
+            "description" : "CANNOT SEND OPT-IN TO UNSUBSCRIBED CLAIMANT",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 20,
+                "createDateTime" : "2022-06-14",
+                "modifiedDateTime" : "2022-06-14T16:46:22",
+                "description" : "Education",
+                "subDescription" : "EDU Messaging"
+            }
+        },
+        {
+            "id" : 1551,
+            "createDateTime" : "2022-09-07",
+            "modifiedDateTime" : "2022-09-07T16:36:16",
+            "name" : "L1551",
+            "description" : "PCAFC - Veteran",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1552,
+            "createDateTime" : "2022-09-07",
+            "modifiedDateTime" : "2022-09-07T16:36:16",
+            "name" : "L1552",
+            "description" : "PCAFC - Caregiver",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1553,
+            "createDateTime" : "2022-09-07",
+            "modifiedDateTime" : "2022-09-07T16:36:16",
+            "name" : "L1553",
+            "description" : "PCAFC - Other",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1491,
+            "createDateTime" : "2022-09-07",
+            "modifiedDateTime" : "2022-09-07T16:36:16",
+            "name" : "L1491",
+            "description" : "VA Form 10-306 Request for Information (PCAFC Decisions)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1490,
+            "createDateTime" : "2022-09-07",
+            "modifiedDateTime" : "2022-09-07T16:36:16",
+            "name" : "L1490",
+            "description" : "VA Form 10-307 Notice of Disagreement (PCAFC Decisions)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1471,
+            "createDateTime" : "2021-04-21",
+            "modifiedDateTime" : "2021-05-17T14:57:04",
+            "name" : "L1471",
+            "description" : "VA Form 20-0998 Your Right to Seek Further Review of Our Decision",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1472,
+            "createDateTime" : "2021-05-05",
+            "modifiedDateTime" : "2021-05-05T15:26:32",
+            "name" : "L1472",
+            "description" : "VA Form 22-8691 - Application for Work-Study Allowance",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1474,
+            "createDateTime" : "2021-05-17",
+            "modifiedDateTime" : "2021-05-17T14:57:04",
+            "name" : "L1474",
+            "description" : "Burial Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1475,
+            "createDateTime" : "2021-05-17",
+            "modifiedDateTime" : "2021-05-17T14:57:04",
+            "name" : "L1475",
+            "description" : "Survivor's Compensation (DIC) and Pension Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1543,
+            "createDateTime" : "2022-06-29",
+            "modifiedDateTime" : "2022-06-29T19:05:58",
+            "name" : "L1543",
+            "description" : "PA/FOIA Final Response Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1544,
+            "createDateTime" : "2022-06-29",
+            "modifiedDateTime" : "2022-06-29T19:05:58",
+            "name" : "L1544",
+            "description" : "PA/FOIA Acknowledgement Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1545,
+            "createDateTime" : "2022-06-29",
+            "modifiedDateTime" : "2022-06-29T19:05:58",
+            "name" : "L1545",
+            "description" : "PA/FOIA VA Exam Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1546,
+            "createDateTime" : "2022-06-29",
+            "modifiedDateTime" : "2022-06-29T19:05:58",
+            "name" : "L1546",
+            "description" : "PA/FOIA No Folder Established Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1547,
+            "createDateTime" : "2022-06-29",
+            "modifiedDateTime" : "2022-06-29T19:05:58",
+            "name" : "L1547",
+            "description" : "PA/FOIA No Judge Signature Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1548,
+            "createDateTime" : "2022-06-29",
+            "modifiedDateTime" : "2022-06-29T19:05:58",
+            "name" : "L1548",
+            "description" : "PA/FOIA No Record Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1549,
+            "createDateTime" : "2022-06-29",
+            "modifiedDateTime" : "2022-06-29T19:05:58",
+            "name" : "L1549",
+            "description" : "PA/FOIA No Signature Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1550,
+            "createDateTime" : "2022-06-29",
+            "modifiedDateTime" : "2022-06-29T19:05:58",
+            "name" : "L1550",
+            "description" : "FOIA Rejection PA Acknowledgement Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1738,
+            "createDateTime" : "2022-08-29",
+            "modifiedDateTime" : "2022-08-29T19:45:17",
+            "name" : "L1738",
+            "description" : "Application or Form - Incomplete, Unclear, or Outdated",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1320,
+            "createDateTime" : "2020-01-10",
+            "modifiedDateTime" : "2020-01-10T19:00:14",
+            "name" : "L1320",
+            "description" : "VA Form 20-0999 Higher-Level Review Return",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 19,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Appeals"
+            }
+        },
+        {
+            "id" : 1322,
+            "createDateTime" : "2020-01-10",
+            "modifiedDateTime" : "2020-01-10T19:00:14",
+            "name" : "L1322",
+            "description" : "VR-67 CH 31 Positive Decision Letter at Plan Development",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1323,
+            "createDateTime" : "2020-01-10",
+            "modifiedDateTime" : "2020-01-10T19:00:14",
+            "name" : "L1323",
+            "description" : "Appendix DE - VA Modernized Decision Review System SOC/SSOC Opt-In Fact Sheet",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1324,
+            "createDateTime" : "2020-01-10",
+            "modifiedDateTime" : "2020-01-10T19:00:14",
+            "name" : "L1324",
+            "description" : "Appendix DD Opt-In Process",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1325,
+            "createDateTime" : "2020-01-10",
+            "modifiedDateTime" : "2020-01-10T19:00:14",
+            "name" : "L1325",
+            "description" : "Appendix AH - CH33 Retroactive Reimbursement Calculator ",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1326,
+            "createDateTime" : "2020-01-10",
+            "modifiedDateTime" : "2020-01-10T19:00:14",
+            "name" : "L1326",
+            "description" : "VA 21P-10194 Legal Summary Non Service-Connected Pension for Veterans",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1327,
+            "createDateTime" : "2020-01-10",
+            "modifiedDateTime" : "2020-01-10T19:00:14",
+            "name" : "L1327",
+            "description" : "VA 21P-10195 Legal Summary Accrued Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1328,
+            "createDateTime" : "2020-01-10",
+            "modifiedDateTime" : "2020-01-10T19:00:14",
+            "name" : "L1328",
+            "description" : "VA 21P-10196 Legal Summary Burial Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1329,
+            "createDateTime" : "2020-01-10",
+            "modifiedDateTime" : "2020-01-10T19:00:14",
+            "name" : "L1329",
+            "description" : "VA 21P-10198 Legal Summary Survivors Pension",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1330,
+            "createDateTime" : "2020-01-10",
+            "modifiedDateTime" : "2020-01-10T19:00:14",
+            "name" : "L1330",
+            "description" : "VA 21P-10197 Legal Summary DIC",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1331,
+            "createDateTime" : "2020-01-10",
+            "modifiedDateTime" : "2020-01-10T19:00:14",
+            "name" : "L1331",
+            "description" : "VA 21P-10199 Legal Summary Survivors Pension, DIC and Accrued Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1332,
+            "createDateTime" : "2020-01-10",
+            "modifiedDateTime" : "2020-01-10T19:00:14",
+            "name" : "L1332",
+            "description" : "VA 21P-10202 Legal Summary Parents DIC Benefits",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1334,
+            "createDateTime" : "2020-05-04",
+            "modifiedDateTime" : "2020-05-04T22:01:39",
+            "name" : "L1334",
+            "description" : "Debt Disagreement/Dispute",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 88,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions",
+                "subDescription" : "DMC"
+            }
+        },
+        {
+            "id" : 1335,
+            "createDateTime" : "2020-05-04",
+            "modifiedDateTime" : "2020-05-04T22:01:39",
+            "name" : "L1335",
+            "description" : "VAF 28-1902f Feasibility Determination Narrative Report",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1336,
+            "createDateTime" : "2020-05-04",
+            "modifiedDateTime" : "2020-05-04T22:01:39",
+            "name" : "L1336",
+            "description" : "VAF 28-1905d Special Report of Training",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1451,
+            "createDateTime" : "2021-03-25",
+            "modifiedDateTime" : "2021-03-25T23:26:11",
+            "name" : "L1451",
+            "description" : "Proposal to reduce Pension - claimant in Medicaid approved NH",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1452,
+            "createDateTime" : "2021-03-25",
+            "modifiedDateTime" : "2021-03-25T23:26:11",
+            "name" : "L1452",
+            "description" : "Apportionment - notice to claimant",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1453,
+            "createDateTime" : "2021-03-25",
+            "modifiedDateTime" : "2021-03-25T23:26:11",
+            "name" : "L1453",
+            "description" : "Apportionment - notice to Veteran",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1454,
+            "createDateTime" : "2021-03-25",
+            "modifiedDateTime" : "2021-03-25T23:26:11",
+            "name" : "L1454",
+            "description" : "Proposal to remove A&A - discharge from NH",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1455,
+            "createDateTime" : "2021-03-25",
+            "modifiedDateTime" : "2021-03-25T23:26:11",
+            "name" : "L1455",
+            "description" : "Proposal to reduce Pension - claimant in domiciliary / NH",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1456,
+            "createDateTime" : "2021-03-25",
+            "modifiedDateTime" : "2021-03-25T23:26:11",
+            "name" : "L1456",
+            "description" : "Proposal to reduce - claimant no longer P&T",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1457,
+            "createDateTime" : "2021-03-25",
+            "modifiedDateTime" : "2021-03-25T23:26:11",
+            "name" : "L1457",
+            "description" : "Request final hospitalization and autopsy findings",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1458,
+            "createDateTime" : "2021-03-25",
+            "modifiedDateTime" : "2021-03-25T23:26:11",
+            "name" : "L1458",
+            "description" : "Request report of accident investigation - CPD",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1459,
+            "createDateTime" : "2021-03-25",
+            "modifiedDateTime" : "2021-03-25T23:26:11",
+            "name" : "L1459",
+            "description" : "Public record - request for certified copy",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1460,
+            "createDateTime" : "2021-03-25",
+            "modifiedDateTime" : "2021-03-25T23:26:12",
+            "name" : "L1460",
+            "description" : "Prison development - 21-4193",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1461,
+            "createDateTime" : "2021-03-25",
+            "modifiedDateTime" : "2021-03-25T23:26:12",
+            "name" : "L1461",
+            "description" : "1151 development to VAMC",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1462,
+            "createDateTime" : "2021-03-25",
+            "modifiedDateTime" : "2021-03-25T23:26:12",
+            "name" : "L1462",
+            "description" : "Request to finanical institution for current mailing address",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1463,
+            "createDateTime" : "2021-03-25",
+            "modifiedDateTime" : "2021-07-26T10:35:31",
+            "name" : "L1463",
+            "description" : "Proposal to Stop A/A for VAMC admission and Restore",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1464,
+            "createDateTime" : "2021-03-25",
+            "modifiedDateTime" : "2021-07-26T10:35:31",
+            "name" : "L1464",
+            "description" : "Proposal to stop A/A for VAMC admission and reduce for Domiciliary/Nursing Home",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 65,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Correspondence"
+            }
+        },
+        {
+            "id" : 1466,
+            "createDateTime" : "2021-06-01",
+            "modifiedDateTime" : "2021-06-01T15:25:44",
+            "name" : "L1466",
+            "description" : "JLV/MTF",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 51,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "STRs"
+            }
+        },
+        {
+            "id" : 1606,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1606",
+            "description" : "RECORD OF ATTENDANCE TEXT MESSAGE \"YES\" REPLY FROM CLAIMANT",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 20,
+                "createDateTime" : "2022-06-14",
+                "modifiedDateTime" : "2022-06-14T16:46:22",
+                "description" : "Education",
+                "subDescription" : "EDU Messaging"
+            }
+        },
+        {
+            "id" : 1607,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1607",
+            "description" : "RECORD OF ATTENDANCE TEXT \"NO\" REPLY FROM CLAIMANT",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 20,
+                "createDateTime" : "2022-06-14",
+                "modifiedDateTime" : "2022-06-14T16:46:22",
+                "description" : "Education",
+                "subDescription" : "EDU Messaging"
+            }
+        },
+        {
+            "id" : 1608,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1608",
+            "description" : "RECORD OF CLAIMANT'S LACK OF RESPONSE TO AN ATTENDANCE MESSAGE",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 20,
+                "createDateTime" : "2022-06-14",
+                "modifiedDateTime" : "2022-06-14T16:46:22",
+                "description" : "Education",
+                "subDescription" : "EDU Messaging"
+            }
+        },
+        {
+            "id" : 1609,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1609",
+            "description" : "RECORD OF TEXT MESSAGE SENT TO CLAIMANT",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 20,
+                "createDateTime" : "2022-06-14",
+                "modifiedDateTime" : "2022-06-14T16:46:22",
+                "description" : "Education",
+                "subDescription" : "EDU Messaging"
+            }
+        },
+        {
+            "id" : 1610,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1610",
+            "description" : "RECORD OF CLAIMANT'S STOP REQUEST",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 20,
+                "createDateTime" : "2022-06-14",
+                "modifiedDateTime" : "2022-06-14T16:46:22",
+                "description" : "Education",
+                "subDescription" : "EDU Messaging"
+            }
+        },
+        {
+            "id" : 1611,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1611",
+            "description" : "VA Form 22-653B Certificate of Lessons Completed",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1614,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1614",
+            "description" : "VETERAN EMPLOYMENT THROUGH TECHNOLOGY EDUCATION COURSES (V0994)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1615,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1615",
+            "description" : "STEM APPLICATION (STEM1995)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1616,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1616",
+            "description" : "OIF/OEF PAPER ORIGINAL CLAIMS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1617,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1617",
+            "description" : "OIF/OEF VONAPP ORIGINAL CLAIMS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1618,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1618",
+            "description" : "OIF/OEF PAPER CH35 ORIGINAL CLAIMS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1619,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1619",
+            "description" : "OIF/OEF VONAPP CH35 ORIGINAL CLAIMS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1620,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1620",
+            "description" : "CHAPTER 34 CONVERSION-C",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1621,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1621",
+            "description" : "CHAPTER 34 CONVERSION-A",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1622,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1622",
+            "description" : "CHAPTER 34 CONVERSION-D",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1623,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1623",
+            "description" : "EDUCATION GENERAL CERTIFICATION",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1624,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1624",
+            "description" : "BENEFIT PAYMENT INQUIRY",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1625,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1625",
+            "description" : "PENDING ISSUE",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1626,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1626",
+            "description" : "BACK END TOOL - CH33",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1627,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1627",
+            "description" : "FOLDER FLASH MESSAGE",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1628,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1628",
+            "description" : "NOTES - OLD FILENET FORMAT ",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1301,
+            "createDateTime" : "2019-06-03",
+            "modifiedDateTime" : "2019-06-03T23:13:25",
+            "name" : "L1301",
+            "description" : "VR-62 Notice of Withdrawal - Facility (Ch31 Only)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1302,
+            "createDateTime" : "2019-06-03",
+            "modifiedDateTime" : "2019-06-03T23:13:25",
+            "name" : "L1302",
+            "description" : "VR-63 Proposed Termination of SA - Participant (Ch31 Only)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1467,
+            "createDateTime" : "2021-05-03",
+            "modifiedDateTime" : "2021-05-03T15:15:06",
+            "name" : "L1467",
+            "description" : "SF1199A - Direct Deposit Enrollment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 22,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions"
+            }
+        },
+        {
+            "id" : 1468,
+            "createDateTime" : "2021-05-03",
+            "modifiedDateTime" : "2021-05-05T23:33:39",
+            "name" : "L1468",
+            "description" : "VA Form 4-1027, Field Service Receipt - General",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 24,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Financial Actions",
+                "subDescription" : "Other"
+            }
+        },
+        {
+            "id" : 1469,
+            "createDateTime" : "2021-05-03",
+            "modifiedDateTime" : "2021-05-07T03:29:56",
+            "name" : "L1469",
+            "description" : "VA Form 21P-534a, Application for Dependency and Indemnity Compensation by a Surviving Spouse or Child - In-Service Death Only (Fillable)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 14,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Applications",
+                "subDescription" : "Death Claims"
+            }
+        },
+        {
+            "id" : 1470,
+            "createDateTime" : "2021-05-03",
+            "modifiedDateTime" : "2021-05-05T23:33:39",
+            "name" : "L1470",
+            "description" : "VAF 28-1905r - Receipt of Supplies (Chapter 31 - Veteran Readiness and Employment)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1473,
+            "createDateTime" : "2021-09-07",
+            "modifiedDateTime" : "2021-09-20T13:13:53",
+            "name" : "L1473",
+            "description" : "VR-73 - Reduction for Subsistence Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1484,
+            "createDateTime" : "2022-02-10",
+            "modifiedDateTime" : "2022-02-10T14:54:12",
+            "name" : "L1484",
+            "description" : "VA Form 28-1903, Contract for Training and Employment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1485,
+            "createDateTime" : "2022-02-10",
+            "modifiedDateTime" : "2022-02-10T14:54:12",
+            "name" : "L1485",
+            "description" : "VA Form 28-1910, Application and Public Voucher for Advancement From the Revolving Fund",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 215,
+                "createDateTime" : "2014-01-15",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Vocational Rehabilitation and Employment Documents"
+            }
+        },
+        {
+            "id" : 1629,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1629",
+            "description" : "WEAMS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1630,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1630",
+            "description" : "WORK STUDY AWARD",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1631,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1631",
+            "description" : "RESTORATION FOR SECTION 109",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1632,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1632",
+            "description" : "SECTION 106 ELECTION FORM",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1450,
+            "createDateTime" : "2021-03-19",
+            "modifiedDateTime" : "2021-03-19T15:13:39",
+            "name" : "L1450",
+            "description" : "VA 21-0538 Mandatory Verification of Dependents",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 62,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Dependency "
+            }
+        },
+        {
+            "id" : 1465,
+            "createDateTime" : "2021-03-19",
+            "modifiedDateTime" : "2021-03-19T15:13:39",
+            "name" : "L1465",
+            "description" : "NGB Form 22 - NATIONAL GUARD REPORT OF SEPARATION AND RECORD OF SERVICE",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 36,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Service Personnel Records",
+                "subDescription" : "DD Form 214 / 215 "
+            }
+        },
+        {
+            "id" : 1633,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1633",
+            "description" : "EQUITABLE RELIEF CLAIM",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1634,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1634",
+            "description" : "VA FORM 22-0993 OPT OUT",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1635,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1635",
+            "description" : "1 TIME EQUITABLE RELIEF FOR HOUSING DUE TO 12/1 COLMERY RELEASE",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1636,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1636",
+            "description" : "EDUCATION DEVELOPMENT LETTER - RETURN MAIL WHICH REQUIRES DEVELOPMENT",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1637,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1637",
+            "description" : "EDUCATION DEVELOPMENT LETTER",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1638,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1638",
+            "description" : "SPECIAL PROJECT ONE - HIGHLIGHT CERTAIN CIRCUMSTANCES",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1639,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1639",
+            "description" : "SPECIAL PROJECT TWO - HIGHLIGHT CERTAIN CIRCUMSTANCES",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1640,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1640",
+            "description" : "APPLICATION FOR STEM SCHOLARSHIP (V10203)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1641,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1641",
+            "description" : "WORK STUDY CONTRACT - VA22-8692",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1642,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1642",
+            "description" : "WORK STUDY TIME RECORD - VA22-8690",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1643,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1643",
+            "description" : "SUPPLEMENTAL COMPLIANCE SURVEY (1999B-CS)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1644,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1644",
+            "description" : "COMPLIANCE SURVEY (1999-CS)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1645,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1645",
+            "description" : "ACCELERATED PAYMENT",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1646,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1646",
+            "description" : "LICENSING AND CERTIFICATION TESTS",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1647,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1647",
+            "description" : "NATIONAL TEST",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1648,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1648",
+            "description" : "DD-2366",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1649,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1649",
+            "description" : "DEA ELIGIBILITY WORKSHEET",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1650,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1650",
+            "description" : "DOD CALL SHEET",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1651,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1651",
+            "description" : "ADVANCE PAY ENROLLMENT CERT",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1652,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1652",
+            "description" : "EDU - CORRESPONDENCE - FIN",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1653,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1653",
+            "description" : "EDU - CORRESPONDENCE - ADJ",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1654,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1654",
+            "description" : "EDU - CORRESPONDENCE - VSD",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1655,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1655",
+            "description" : "EDUCATION PENDING ISSUE -PIF",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1656,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1656",
+            "description" : "EDUCATION CH35 ELIGIBILITY",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1657,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1657",
+            "description" : "SCHOOL CALENDAR",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1658,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1658",
+            "description" : "SCHOOL IS COOL",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1659,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1659",
+            "description" : "SENSITIVE FILE",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1660,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1660",
+            "description" : "CERTS PAID BY FIN",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1661,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1661",
+            "description" : "ELECTRONIC ENROLLMENT CERT",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1662,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1662",
+            "description" : "ELECTRONIC CHANGE CERT",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1663,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1663",
+            "description" : "APPLICATION FOR REIMBURSEMENT OF PREP COURSE FOR L/C TEST",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1664,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1664",
+            "description" : "NOTES",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1665,
+            "createDateTime" : "2022-06-14",
+            "modifiedDateTime" : "2022-06-14T16:46:22",
+            "name" : "L1665",
+            "description" : "AUTOMATED DENIAL OF THE 10203 APPLICATION SUBMISSION (10203DNY)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 17,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Education"
+            }
+        },
+        {
+            "id" : 1373,
+            "createDateTime" : "2020-07-15",
+            "modifiedDateTime" : "2020-07-30T13:01:40",
+            "name" : "L1373",
+            "description" : "Supervised Direct Pay Assessment",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 1377,
+            "createDateTime" : "2020-07-15",
+            "modifiedDateTime" : "2020-07-30T13:01:40",
+            "name" : "L1377",
+            "description" : "Debt Memo to Support Services Division (SSD)",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 1389,
+            "createDateTime" : "2020-07-15",
+            "modifiedDateTime" : "2020-07-30T13:01:40",
+            "name" : "L1389",
+            "description" : "HLR Evidence Received Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 1390,
+            "createDateTime" : "2020-07-15",
+            "modifiedDateTime" : "2020-07-30T13:01:40",
+            "name" : "L1390",
+            "description" : "HLR Incomplete Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 1391,
+            "createDateTime" : "2020-07-15",
+            "modifiedDateTime" : "2020-07-30T13:01:40",
+            "name" : "L1391",
+            "description" : "HLR Notification Cover Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 1392,
+            "createDateTime" : "2020-07-15",
+            "modifiedDateTime" : "2020-07-30T13:01:40",
+            "name" : "L1392",
+            "description" : "HLR Untimely Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 1404,
+            "createDateTime" : "2020-07-15",
+            "modifiedDateTime" : "2020-07-30T13:01:40",
+            "name" : "L1404",
+            "description" : "Misuse Notification Letter to Beneficiary",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        },
+        {
+            "id" : 1405,
+            "createDateTime" : "2020-07-15",
+            "modifiedDateTime" : "2020-07-30T13:01:40",
+            "name" : "L1405",
+            "description" : "Misuse Notification Letter to Beneficiary Reconsideration Letter",
+            "isUserUploadable" : true,
+            "is526" : false,
+            "documentCategory" : {
+                "id" : 18,
+                "createDateTime" : "2012-01-25",
+                "modifiedDateTime" : "2014-04-28T14:44:52",
+                "description" : "Fiduciary"
+            }
+        }
+    ],
+    "alternativeDocumentTypes" : [
+        {
+            "id" : 1,
+            "createDateTime" : "2016-04-13",
+            "modifiedDateTime" : "2016-04-13T04:00:00",
+            "description" : "Notice of Disagreement (NOD)",
+            "categoryDescription" : "Appeals",
+            "name" : "L1"
+        },
+        {
+            "id" : 2,
+            "createDateTime" : "2016-04-13",
+            "modifiedDateTime" : "2016-04-13T04:00:00",
+            "description" : "Substantive Appeal to Board of Veterans' Appeals",
+            "categoryDescription" : "Appeals",
+            "name" : "L2"
+        },
+        {
+            "id" : 3,
+            "createDateTime" : "2016-04-13",
+            "modifiedDateTime" : "2016-04-13T04:00:00",
+            "description" : "Statement of the Case (SOC)",
+            "categoryDescription" : "Appeals",
+            "name" : "L3"
+        },
+        {
+            "id" : 4,
+            "createDateTime" : "2016-04-13",
+            "modifiedDateTime" : "2016-04-13T04:00:00",
+            "description" : "Supplemental Statement of the Case (SSOC)",
+            "categoryDescription" : "Appeals",
+            "name" : "L4"
+        }
+    ]
+}

--- a/modules/claims_evidence_api/lib/claims_evidence_api.rb
+++ b/modules/claims_evidence_api/lib/claims_evidence_api.rb
@@ -6,5 +6,5 @@ require 'claims_evidence_api/engine'
 # https://claimevidence-api-test.dev.bip.va.gov/api/v1/rest/swagger-ui.html
 module ClaimsEvidenceApi
   # The module path
-  MODULE_PATH = 'modules/burials'
+  MODULE_PATH = 'modules/claims_evidence_api'
 end


### PR DESCRIPTION
## Summary

add docType attribute to PersistentAttachment records

## Related issue(s)

[Implement mapping of docType to evidence upload](https://github.com/department-of-veterans-affairs/va.gov-team/issues/109337)

## Testing done

- [x] *New code is covered by unit tests*
upload attachment for a form - view db record
create a PersistentAttachment in console - view db record

## What areas of the site does it impact?

any form using claim_documents_controller.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
