### PR TITLE
API-46858 POA v1 active endpoint lookup expansion

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v1/forms/power_of_attorney_controller.rb
@@ -116,10 +116,14 @@ module ClaimsApi
         #
         # @return [JSON] Last POA change request through Claims API
         def active # rubocop:disable Metrics/MethodLength
-          validate_user_is_accredited! if header_request? && !token.client_credentials_token?
+          if header_request? && !token.client_credentials_token? && !verify_power_of_attorney!
+            claims_v1_logging 'poa_v1_active',
+                              level: :warn,
+                              message: "POA not found, poa: #{@power_of_attorney&.id}"
+          end
 
           unless power_of_attorney_verifier.current_poa_code
-            claims_v1_logging('poa_active', message: "POA not found, poa: #{@power_of_attorney&.id}")
+            claims_v1_logging('poa_v1_active', message: "POA not found, poa: #{@power_of_attorney&.id}")
             raise ::Common::Exceptions::ResourceNotFound.new(detail: 'POA not found')
           end
 

--- a/modules/claims_api/spec/concerns/claims_api/poa_verification_spec.rb
+++ b/modules/claims_api/spec/concerns/claims_api/poa_verification_spec.rb
@@ -98,7 +98,7 @@ describe FakeController do
         it 'raises "Ambiguous VSO Representative Results"' do
           expect do
             subject.valid_poa_code_for_current_user?(poa_code)
-          end.to raise_error(Common::Exceptions::Unauthorized)
+          end.to raise_error(Common::Exceptions::UnprocessableEntity)
         end
       end
     end

--- a/modules/claims_api/spec/requests/v1/forms/rswag_2122_spec.rb
+++ b/modules/claims_api/spec/requests/v1/forms/rswag_2122_spec.rb
@@ -734,11 +734,11 @@ Rspec.describe 'Power of Attorney', openapi_spec: 'modules/claims_api/app/swagge
 
           before do |example|
             stub_poa_verification
+            create(:representative, first_name: 'Abraham', last_name: 'Lincoln', poa_codes: %w[A01])
 
             mock_acg(scopes) do
               allow(BGS::PowerOfAttorneyVerifier).to receive(:new).and_return(bgs_poa_verifier)
-              allow(Veteran::Service::Representative).to receive(:for_user).and_return(true)
-              expect(bgs_poa_verifier).to receive(:current_poa_code).and_return('HelloWorld').exactly(3).times
+              expect(bgs_poa_verifier).to receive(:current_poa_code).and_return('A01').exactly(3).times
               expect(bgs_poa_verifier).to receive(:previous_poa_code).and_return(nil)
               expect_any_instance_of(
                 ClaimsApi::V1::Forms::PowerOfAttorneyController
@@ -806,7 +806,6 @@ Rspec.describe 'Power of Attorney', openapi_spec: 'modules/claims_api/app/swagge
             mock_acg(scopes) do
               allow(BGS::PowerOfAttorneyVerifier).to receive(:new).and_return(bgs_poa_verifier)
               allow(Veteran::Service::Representative).to receive(:for_user).and_return(true)
-              expect(bgs_poa_verifier).to receive(:current_poa_code).and_return(nil)
               submit_request(example.metadata)
             end
           end

--- a/modules/claims_api/spec/support/auth_helper.rb
+++ b/modules/claims_api/spec/support/auth_helper.rb
@@ -3,7 +3,7 @@
 def mock_acg(_scopes)
   VCR.use_cassette('claims_api/token_validation/v3/indicates_token_is_valid_sandbox') do
     VCR.use_cassette('claims_api/token_validation/v3/userinfo_sandbox') do
-      profile = build(:mpi_profile, given_names: %w[abraham], family_name: 'lincoln', ssn: '796111863')
+      profile = build(:mpi_profile, given_names: %w[abraham], family_name: 'lincoln', ssn: '796111863', suffix: 'IV')
       profile_response = build(:find_profile_response, profile:)
       allow_any_instance_of(MPI::Service).to receive(:find_profile_by_identifier).and_return(profile_response)
 


### PR DESCRIPTION
## Summary

Expands searching for representatives in cases where the Representative's name in OGC is different than what's stored in the login or MPI. It's the same search logic vetted in other existing endpoints, now added to the `active` POA v1 endpoint.

## Related issue(s)

* Marmoset originating ticket: [API-46858](https://jira.devops.va.gov/browse/API-46858)
* Subtask: [API-47081](https://jira.devops.va.gov/browse/API-47081)

## Testing done

- [x] New code is covered by unit tests

## What areas of the site does it impact?

Representatives looking to see a veteran's active POA will have a better chance of being recognized by the system as a valid viewer of that information.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature