### PR TITLE
Create 0009-adding-user-identifier-to-bpds-request.md

### DIFF
--- a/lib/bpds/documentation/adr/0009-adding-user-identifier-to-bpds-request.md
+++ b/lib/bpds/documentation/adr/0009-adding-user-identifier-to-bpds-request.md
@@ -1,0 +1,32 @@
+# 9. Adding user identifier to BPDS submission
+
+Date: 2025-06-02
+
+## Status
+
+Accepted
+
+## Context
+
+As part of the data submitted to BPDS by the Sidekiq job, we need logic to retrieve a unique identifier that can be used to associate the user with the submission in BPDS. These identifiers are PII and cannot be logged or stored unecrypted.
+
+## Decision
+
+We implemented logic to determine the appropriate user identifier (participant id or file number) and included this association with the request to BPDS. As we do not want PII identifiers to be exposed due to being used for Sidekiq job parameters, the identifiers are encrypted during processing.
+
+The logic is as follows:
+1) If the user is LOA3, we use the user's ICN to look up the user in MPI and obtain their profile. The MPI profile contains `participant_id`. If there is a `participant_id`, we send it to BPDS.
+
+2) If the user is LOA1, we use BGS to look up the user information.
+  * If `participant_id` is present in the response, we send it to BPDS.
+  * If `participant_id` is not present in the response, we check if `file_number` is present and include `file_number` in the request to BPDS instead.
+
+3) If the user is unauthenticated, we use BGS to look up the user.
+  * If `participant_id` is present in the response, we send it to BPDS.
+  * If `participant_id` is not present in the response, we check if `file_number` is present and include `file_number` in the request to BPDS instead.
+
+4) If no available identifiers are present, we log that no identifier was found for the saved claim and skip the BPDS job.
+
+## Consequences
+
+This change allows user identifiers to be included in the submission to BPDS when a user submits a form. Logging and metrics have been added to a dashboard for monitoring purposes.


### PR DESCRIPTION
## Summary
- *This work is behind a feature toggle (flipper): NO*
Add new ADR for BPDS work related to user identifier association

## Related issue(s)
* https://github.com/department-of-veterans-affairs/va.gov-team/issues/111438

## Testing done
Documentation only 

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
