### PR TITLE
Add comprehensive Datadog tracing to RepresentativeFormUploadController

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_form_upload_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_form_upload_controller.rb
@@ -19,48 +19,63 @@ module AccreditedRepresentativePortal
         upload_supporting_documents
       ]
 
+      # rubocop:disable Metrics/MethodLength
       def submit
-        service = SavedClaimService::Create
+        ar_monitoring.trace('ar.claims.form_upload.submit') do |span|
+          service = SavedClaimService::Create
+          current_form_number = metadata[:formNumber]
 
-        saved_claim = service.perform(
-          type: form_class,
-          metadata:, attachment_guids:,
-          claimant_representative:
-        )
+          # Tags for tracing
+          span.set_tag('form_id', current_form_number)
+          Datadog::Tracing.active_trace&.set_tag('form_id', current_form_number)
 
-        render json: {
-          confirmationNumber:
-            saved_claim.latest_submission_attempt.benefits_intake_uuid,
-          status: '200'
-        }
-      rescue service::RecordInvalidError => e
-        raise Common::Exceptions::ValidationErrors, e.record
-      rescue service::WrongAttachmentsError => e
-        raise Common::Exceptions::UnprocessableEntity,
-              detail: e.message
+          saved_claim = service.perform(
+            type: form_class,
+            metadata:,
+            attachment_guids:,
+            claimant_representative:
+          )
 
-      ##
-      # Once we have a uniform strategy for handling errors in our controllers,
-      # we may be comfortable allowing parent code to handle these generic
-      # errors for us implicitly.
-      #
-      rescue service::UnknownError => e
-        # Is there any particular reason to prefer `e.cause` over `e`?
-        raise Common::Exceptions::InternalServerError, e.cause
+          confirmation_number = saved_claim
+                                  .latest_submission_attempt
+                                  .benefits_intake_uuid
+
+          span.set_tag('form_submission.status', '200')
+          span.set_tag('form_submission.confirmation_number', confirmation_number)
+
+          render json: {
+            confirmationNumber: confirmation_number,
+            status: '200'
+          }
+        rescue service::RecordInvalidError => e
+          span.set_tag('error.specific_reason', 'record_invalid')
+          raise Common::Exceptions::ValidationErrors, e.record
+        rescue service::WrongAttachmentsError => e
+          span.set_tag('error.specific_reason', 'wrong_attachments')
+          raise Common::Exceptions::UnprocessableEntity, detail: e.message
+        rescue service::UnknownError => e
+          span.set_tag('error.specific_reason', 'unknown_error')
+          raise Common::Exceptions::InternalServerError, e.cause
+        end
       end
+      # rubocop:enable Metrics/MethodLength
 
       def upload_scanned_form
-        handle_attachment_upload(
-          PersistentAttachments::VAForm,
-          PersistentAttachmentVAFormSerializer
-        )
+        ar_monitoring.trace('ar.claims.form_upload.upload_scanned_form') do |_span|
+          handle_attachment_upload(
+            PersistentAttachments::VAForm,
+            PersistentAttachmentVAFormSerializer
+          )
+        end
       end
 
       def upload_supporting_documents
-        handle_attachment_upload(
-          PersistentAttachments::VAFormDocumentation,
-          PersistentAttachmentSerializer
-        )
+        ar_monitoring.trace('ar.claims.form_upload.upload_supporting_documents') do |_span|
+          handle_attachment_upload(
+            PersistentAttachments::VAFormDocumentation,
+            PersistentAttachmentSerializer
+          )
+        end
       end
 
       private
@@ -78,44 +93,60 @@ module AccreditedRepresentativePortal
       end
 
       def authorize_submission
-        claimant_icn.present? or
-          raise Common::Exceptions::RecordNotFound, <<~MSG.squish
-            Could not lookup claimant with given information.
-          MSG
+        ar_monitoring.trace('ar.claims.form_upload.authorize_submission') do |_span|
+          claimant_icn.present? or
+            raise Common::Exceptions::RecordNotFound,
+                  'Could not lookup claimant with given information.'
 
-        authorize(
-          claimant_representative,
-          policy_class: RepresentativeFormUploadPolicy
-        )
+          authorize(
+            claimant_representative,
+            policy_class: RepresentativeFormUploadPolicy
+          )
+        end
       end
 
+      # rubocop:disable Metrics/MethodLength
       def handle_attachment_upload(model_klass, serializer_klass)
-        service = SavedClaimService::Attach
+        ar_monitoring.trace('ar.claims.form_upload.handle_attachment_upload') do |span|
+          service = SavedClaimService::Attach
 
-        attachment = service.perform(
-          model_klass, file: params[:file], form_id: form_class::PROPER_FORM_ID
-        )
+          attachment = service.perform(
+            model_klass,
+            file: params[:file],
+            form_id: form_class::PROPER_FORM_ID
+          )
 
-        json = serializer_klass.new(attachment).as_json
-        json = json.deep_transform_keys do |key|
-          key.camelize(:lower)
+          # Trace tags
+          span.set_tag('form_upload.form_id', attachment.form_id)
+          span.set_tag('form_upload.attachment_type', model_klass.name)
+          if params['file'].respond_to?(:original_filename)
+            span.set_tag('form_upload.file_name', params['file'].original_filename)
+          end
+          span.set_tag('form_upload.file_size', params['file'].size) if params['file'].respond_to?(:size)
+
+          json = serializer_klass.new(attachment).as_json.deep_transform_keys(&:camelize).deep_transform_keys! do |key|
+            key.camelize(:lower)
+          end
+
+          render json:
+        rescue service::RecordInvalidError => e
+          span.set_tag('error.specific_reason', 'record_invalid')
+          raise Common::Exceptions::ValidationErrors, e.record
+        rescue service::UpstreamInvalidError => e
+          span.set_tag('error.specific_reason', 'upstream_invalid')
+          raise Common::Exceptions::UpstreamUnprocessableEntity, detail: e.message
+        rescue service::UnknownError => e
+          span.set_tag('error.specific_reason', 'unknown_error')
+          raise Common::Exceptions::InternalServerError, e.cause
         end
+      end
+      # rubocop:enable Metrics/MethodLength
 
-        render json:
-      rescue service::RecordInvalidError => e
-        raise Common::Exceptions::ValidationErrors, e.record
-      rescue service::UpstreamInvalidError => e
-        raise Common::Exceptions::UpstreamUnprocessableEntity,
-              detail: e.message
-
-      ##
-      # Once we have a uniform strategy for handling errors in our controllers,
-      # we may be comfortable allowing parent code to handle these generic
-      # errors for us implicitly.
-      #
-      rescue service::UnknownError => e
-        # Is there any particular reason to prefer `e.cause` over `e`?
-        raise Common::Exceptions::InternalServerError, e.cause
+      def ar_monitoring
+        @ar_monitoring ||= AccreditedRepresentativePortal::Monitoring.new(
+          AccreditedRepresentativePortal::Monitoring::NAME,
+          default_tags: ["controller:#{controller_name}", "action:#{action_name}"]
+        )
       end
 
       def form_class

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/monitoring_spec.rb
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/monitoring_spec.rb
@@ -41,6 +41,64 @@ RSpec.describe AccreditedRepresentativePortal::Monitoring do
     end
   end
 
+  describe '#trace' do
+    let(:span_name) { 'test.span' }
+    let(:initial_span_tags) { { initial_tag: 'initial_value' } }
+    let(:dynamic_span_tag) { { dynamic_tag: 'dynamic_value' } }
+    let(:mock_span) { instance_double(Datadog::Tracing::Span) }
+
+    before do
+      allow(Datadog::Tracing).to receive(:trace).and_yield(mock_span)
+      allow(mock_span).to receive(:set_tag)
+    end
+
+    it 'calls Datadog::Tracing.trace with the correct span name and service' do
+      expect(Datadog::Tracing).to receive(:trace).with(span_name, service: service_name)
+      subject.trace(span_name) { 'block_executed' }
+    end
+
+    it 'sets initial tags on the span' do
+      initial_span_tags.each do |key, value|
+        expect(mock_span).to receive(:set_tag).with(key, value)
+      end
+      subject.trace(span_name, tags: initial_span_tags) { 'block_executed' }
+    end
+
+    it 'yields the span to the block' do
+      expect do |b|
+        subject.trace(span_name, &b)
+      end.to yield_with_args(mock_span)
+    end
+
+    it 'allows dynamic tags to be set within the block' do
+      expect(mock_span).to receive(:set_tag).with(dynamic_span_tag.keys.first, dynamic_span_tag.values.first)
+      subject.trace(span_name) do |span|
+        span.set_tag(dynamic_span_tag.keys.first, dynamic_span_tag.values.first)
+      end
+    end
+
+    context 'when an exception occurs in the block' do
+      let(:error_message) { 'Something went wrong!' }
+      let(:test_error) { StandardError.new(error_message) }
+
+      it 'sets error tags on the span' do
+        expect(mock_span).to receive(:set_tag).with('error', true)
+        expect(mock_span).to receive(:set_tag).with('error.type', test_error.class.name)
+        expect(mock_span).to receive(:set_tag).with('error.message', error_message)
+
+        expect do
+          subject.trace(span_name) { raise test_error }
+        end.to raise_error(test_error) # Ensure the original error is re-raised
+      end
+
+      it 're-raises the original exception' do
+        expect do
+          subject.trace(span_name) { raise test_error }
+        end.to raise_error(test_error)
+      end
+    end
+  end
+
   describe '#merge_tags' do
     it 'combines custom tags with default service tags and removes duplicates' do
       merged_tags = subject.send(:merge_tags, custom_tags)


### PR DESCRIPTION
Background

To improve observability and troubleshooting of form upload flows in the Accredited Representative Portal, we need to capture detailed spans and contextual metadata around each major step. This includes the initial submission, scanned-form upload, PDF stamping, upload to Benefits Intake, database persistence, and ICN lookup.

⸻

What’s Changed
	1.	New Monitoring Service
	•	Introduced AccreditedRepresentativePortal::Monitoring#trace_method to wrap arbitrary code blocks in a Datadog span, automatically tagging and capturing errors.
	2.	Controller Instrumentation
	•	Required the new monitoring service in RepresentativeFormUploadController.
	•	Wrapped the following methods in ar_monitoring.trace_method blocks, setting rich tags on each span:
	•	submit
	•	upload_scanned_form (including file name, size, and upload category)
	•	upload_response (entire form submission flow)
	•	upload_pdf (upload to Benefits Intake API)
	•	prepare_for_upload (pre-upload request)
	•	create_form_submission_attempt and create_form_submission (database transactions)
	•	perform_pdf_upload (actual API call)
	•	get_icn (MPI lookup)
	3.	Span Tagging
	•	Tags include form IDs, file metadata, API response statuses, UUIDs, file sizes, database flags, and error details.
	•	Ensures that each trace contains enough context to diagnose failures or performance issues in isolation.
	4.	Logging & Error Capture
	•	On exceptions within a traced block, the span is marked as an error and includes the exception type and message before re-raising.
	•	Existing Rails logs remain intact for backward compatibility.


## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/108639

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
