### PR TITLE
Remove va_online_scheduling_mhv_route_guards feature toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1811,10 +1811,6 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle to use API response as the source of truth in FE for Video at VA, Video at ATLAS, Video at Home modalities.
-  va_online_scheduling_mhv_route_guards:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle for adopting MHV route guards for the appointment tool.
   va_online_scheduling_convert_slots_to_utc:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
## Summary

- Remove a VAOS feature toggle `va_online_scheduling_mhv_route_guards`
- Note that this PR should only be merged once the associated vets-website PR is merged.
- Appointments Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/109697

## Testing done

- N/A

## Screenshots
N/A

## What areas of the site does it impact?
Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
