### PR TITLE
Remove caregiver_carma_submitted_at feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -120,9 +120,6 @@ features:
   caregiver_browser_monitoring_enabled:
     actor_type: user
     description: Enables Datadog Real Time User Monitoring
-  caregiver_carma_submitted_at:
-    actor_type: user
-    description: Enables sending CARMA the current time as a metadata submitted_at value
   caregiver_request_duration_monitoring:
     actor_type: user
     description: Enables logging of 10-10CG request durations to StatsD

--- a/lib/carma/models/submission.rb
+++ b/lib/carma/models/submission.rb
@@ -19,18 +19,12 @@ module CARMA
       # @return [CARMA::Models::Submission] A CARMA Submission model object
       #
       def self.from_claim(claim, metadata = {})
-        submitted_at = if Flipper.enabled?(:caregiver_carma_submitted_at)
-                         Time.now.utc.iso8601
-                       else
-                         claim.created_at&.iso8601
-                       end
-
         new(
           data: claim.parsed_form,
           metadata: metadata.merge(
             claim_id: claim.id,
             claim_guid: claim.guid,
-            submitted_at:
+            submitted_at: Time.now.utc.iso8601
           )
         )
       end

--- a/spec/lib/carma/models/submission_spec.rb
+++ b/spec/lib/carma/models/submission_spec.rb
@@ -164,117 +164,59 @@ RSpec.describe CARMA::Models::Submission, type: :model do
   end
 
   describe '::from_claim' do
-    context 'when :caregiver_carma_submitted_at is enabled' do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:caregiver_carma_submitted_at).and_return(true)
-      end
+    it 'transforms a CaregiversAssistanceClaim to a new CARMA::Model::Submission' do
+      submitted_at = DateTime.now - 1.second
+      allow(Time).to receive(:now).and_return(submitted_at)
+      claim = build(:caregivers_assistance_claim, created_at: DateTime.now)
 
-      it 'transforms a CaregiversAssistanceClaim to a new CARMA::Model::Submission' do
-        submitted_at = DateTime.now - 1.second
-        allow(Time).to receive(:now).and_return(submitted_at)
-        claim = build(:caregivers_assistance_claim, created_at: DateTime.now)
+      submission = described_class.from_claim(claim)
 
-        submission = described_class.from_claim(claim)
+      expect(submission).to be_instance_of(described_class)
+      expect(submission.data).to eq(claim.parsed_form)
+      expect(submission.carma_case_id).to be_nil
 
-        expect(submission).to be_instance_of(described_class)
-        expect(submission.data).to eq(claim.parsed_form)
-        expect(submission.carma_case_id).to be_nil
-
-        expect(submission.metadata).to be_instance_of(CARMA::Models::Metadata)
-        expect(submission.metadata.claim_id).to eq(claim.id)
-        expect(submission.metadata.claim_guid).to eq(claim.guid)
-        expect(submission.metadata.submitted_at).to eq(submitted_at.utc.iso8601)
-      end
-
-      it 'overrides :claim_id when passed in metadata and use claim.id instead' do
-        created_at = DateTime.now
-        claim = build(:caregivers_assistance_claim, created_at:)
-        submitted_at = created_at + 1.second
-        allow(Time).to receive(:now).and_return(submitted_at)
-
-        submission = described_class.from_claim(claim, claim_id: 99)
-
-        expect(submission).to be_instance_of(described_class)
-        expect(submission.data).to eq(claim.parsed_form)
-        expect(submission.carma_case_id).to be_nil
-        expect(submission.submitted_at).to be_nil
-
-        expect(submission.metadata).to be_instance_of(CARMA::Models::Metadata)
-        expect(submission.metadata.claim_id).to eq(claim.id)
-        expect(submission.metadata.submitted_at).to eq(submitted_at.utc.iso8601)
-        # expect(submission.metadata.submitted_at).to eq(claim.created_at.iso8601)
-      end
-
-      it 'overrides :claim_guid when passed in metadata and use claim.guid instead' do
-        created_at = DateTime.now
-        claim = build(:caregivers_assistance_claim, created_at:)
-        submitted_at = created_at + 1.second
-        allow(Time).to receive(:now).and_return(submitted_at)
-
-        submission = described_class.from_claim(claim, claim_guid: 'not-this-claims-guid')
-
-        expect(submission).to be_instance_of(described_class)
-        expect(submission.data).to eq(claim.parsed_form)
-        expect(submission.carma_case_id).to be_nil
-        expect(submission.submitted_at).to be_nil
-
-        expect(submission.metadata).to be_instance_of(CARMA::Models::Metadata)
-        expect(submission.metadata.claim_guid).not_to eq('not-this-claims-guid')
-        expect(submission.metadata.claim_guid).to eq(claim.guid)
-        expect(submission.metadata.submitted_at).to eq(submitted_at.utc.iso8601)
-      end
+      expect(submission.metadata).to be_instance_of(CARMA::Models::Metadata)
+      expect(submission.metadata.claim_id).to eq(claim.id)
+      expect(submission.metadata.claim_guid).to eq(claim.guid)
+      expect(submission.metadata.submitted_at).to eq(submitted_at.utc.iso8601)
     end
 
-    context 'when :caregiver_carma_submitted_at is disabled' do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:caregiver_carma_submitted_at).and_return(false)
-      end
+    it 'overrides :claim_id when passed in metadata and use claim.id instead' do
+      created_at = DateTime.now
+      claim = build(:caregivers_assistance_claim, created_at:)
+      submitted_at = created_at + 1.second
+      allow(Time).to receive(:now).and_return(submitted_at)
 
-      it 'transforms a CaregiversAssistanceClaim to a new CARMA::Model::Submission' do
-        claim = build(:caregivers_assistance_claim, created_at: DateTime.now)
+      submission = described_class.from_claim(claim, claim_id: 99)
 
-        submission = described_class.from_claim(claim)
+      expect(submission).to be_instance_of(described_class)
+      expect(submission.data).to eq(claim.parsed_form)
+      expect(submission.carma_case_id).to be_nil
+      expect(submission.submitted_at).to be_nil
 
-        expect(submission).to be_instance_of(described_class)
-        expect(submission.data).to eq(claim.parsed_form)
-        expect(submission.carma_case_id).to be_nil
+      expect(submission.metadata).to be_instance_of(CARMA::Models::Metadata)
+      expect(submission.metadata.claim_id).to eq(claim.id)
+      expect(submission.metadata.submitted_at).to eq(submitted_at.utc.iso8601)
+      # expect(submission.metadata.submitted_at).to eq(claim.created_at.iso8601)
+    end
 
-        expect(submission.metadata).to be_instance_of(CARMA::Models::Metadata)
-        expect(submission.metadata.claim_id).to eq(claim.id)
-        expect(submission.metadata.claim_guid).to eq(claim.guid)
-        expect(submission.metadata.submitted_at).to eq(claim.created_at.iso8601)
-      end
+    it 'overrides :claim_guid when passed in metadata and use claim.guid instead' do
+      created_at = DateTime.now
+      claim = build(:caregivers_assistance_claim, created_at:)
+      submitted_at = created_at + 1.second
+      allow(Time).to receive(:now).and_return(submitted_at)
 
-      it 'overrides :claim_id when passed in metadata and use claim.id instead' do
-        claim = build(:caregivers_assistance_claim, created_at: DateTime.now)
+      submission = described_class.from_claim(claim, claim_guid: 'not-this-claims-guid')
 
-        submission = described_class.from_claim(claim, claim_id: 99)
+      expect(submission).to be_instance_of(described_class)
+      expect(submission.data).to eq(claim.parsed_form)
+      expect(submission.carma_case_id).to be_nil
+      expect(submission.submitted_at).to be_nil
 
-        expect(submission).to be_instance_of(described_class)
-        expect(submission.data).to eq(claim.parsed_form)
-        expect(submission.carma_case_id).to be_nil
-        expect(submission.submitted_at).to be_nil
-
-        expect(submission.metadata).to be_instance_of(CARMA::Models::Metadata)
-        expect(submission.metadata.claim_id).to eq(claim.id)
-        expect(submission.metadata.submitted_at).to eq(claim.created_at.iso8601)
-      end
-
-      it 'overrides :claim_guid when passed in metadata and use claim.guid instead' do
-        claim = build(:caregivers_assistance_claim, created_at: DateTime.now)
-
-        submission = described_class.from_claim(claim, claim_guid: 'not-this-claims-guid')
-
-        expect(submission).to be_instance_of(described_class)
-        expect(submission.data).to eq(claim.parsed_form)
-        expect(submission.carma_case_id).to be_nil
-        expect(submission.submitted_at).to be_nil
-
-        expect(submission.metadata).to be_instance_of(CARMA::Models::Metadata)
-        expect(submission.metadata.claim_guid).not_to eq('not-this-claims-guid')
-        expect(submission.metadata.claim_guid).to eq(claim.guid)
-        expect(submission.metadata.submitted_at).to eq(claim.created_at.iso8601)
-      end
+      expect(submission.metadata).to be_instance_of(CARMA::Models::Metadata)
+      expect(submission.metadata.claim_guid).not_to eq('not-this-claims-guid')
+      expect(submission.metadata.claim_guid).to eq(claim.guid)
+      expect(submission.metadata.submitted_at).to eq(submitted_at.utc.iso8601)
     end
   end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Remove `caregiver_carma_submitted_at` feature flag now that it's confirmed stable in production

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111162

## Testing done

- [x] *New code is covered by unit tests*
  - *What is the testing plan for rolling out the feature?* after deploy to production, delete the feature flag from all environments via Argo:
  - [x] production
  - [x] staging
  - [x] dev
  - [x] sandbox

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
