### PR TITLE
[393] restores user profile account serialization format & flipper check

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -453,7 +453,7 @@ class User < Common::RedisStore
   end
 
   def flipper_id
-    email&.downcase
+    email&.downcase || user_account_uuid
   end
 
   def relationships

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -9,7 +9,7 @@ class UserSerializer
 
   set_id { '' }
 
-  attributes :services, :user_account, :profile, :va_profile, :veteran_status,
+  attributes :services, :account, :profile, :va_profile, :veteran_status,
              :in_progress_forms, :prefills_available, :vet360_contact_information,
              :session, :onboarding
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -9,7 +9,7 @@ class UserSerializer
 
   set_id { '' }
 
-  attributes :services, :account, :profile, :va_profile, :veteran_status,
+  attributes :services, :user_account, :account, :profile, :va_profile, :veteran_status,
              :in_progress_forms, :prefills_available, :vet360_contact_information,
              :session, :onboarding
 end

--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -45,7 +45,7 @@ module Users
     end
 
     def fetch_and_serialize_profile
-      scaffold.user_account = user_account
+      scaffold.account = user_account
       scaffold.profile = profile
       scaffold.vet360_contact_information = vet360_contact_information
       scaffold.va_profile = mpi_profile
@@ -58,7 +58,7 @@ module Users
     end
 
     def user_account
-      { id: user.user_account_uuid }
+      { account_uuid: user.user_account_uuid }
     rescue => e
       scaffold.errors << Users::ExceptionHandler.new(e, 'UserAccount').serialize_error
       nil

--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -45,7 +45,8 @@ module Users
     end
 
     def fetch_and_serialize_profile
-      scaffold.account = user_account
+      scaffold.user_account = user_account
+      scaffold.account = account
       scaffold.profile = profile
       scaffold.vet360_contact_information = vet360_contact_information
       scaffold.va_profile = mpi_profile
@@ -58,9 +59,16 @@ module Users
     end
 
     def user_account
-      { account_uuid: user.user_account_uuid }
+      { id: user.user_account_uuid }
     rescue => e
       scaffold.errors << Users::ExceptionHandler.new(e, 'UserAccount').serialize_error
+      nil
+    end
+
+    def account
+      { account_uuid: user.user_account_uuid }
+    rescue => e
+      scaffold.errors << Users::ExceptionHandler.new(e, 'Account').serialize_error
       nil
     end
 

--- a/app/services/users/scaffold.rb
+++ b/app/services/users/scaffold.rb
@@ -8,9 +8,9 @@ module Users
   # and `status` second.
   #
   # rubocop:disable Style/StructInheritance
-  class Scaffold < Struct.new(:errors, :status, :services, :account, :profile, :va_profile, :veteran_status,
-                              :in_progress_forms, :prefills_available, :vet360_contact_information, :session,
-                              :onboarding)
+  class Scaffold < Struct.new(:errors, :status, :services, :user_account, :account, :profile, :va_profile,
+                              :veteran_status, :in_progress_forms, :prefills_available, :vet360_contact_information,
+                              :session, :onboarding)
   end
   # rubocop:enable Style/StructInheritance
 end

--- a/app/services/users/scaffold.rb
+++ b/app/services/users/scaffold.rb
@@ -8,7 +8,7 @@ module Users
   # and `status` second.
   #
   # rubocop:disable Style/StructInheritance
-  class Scaffold < Struct.new(:errors, :status, :services, :user_account, :profile, :va_profile, :veteran_status,
+  class Scaffold < Struct.new(:errors, :status, :services, :account, :profile, :va_profile, :veteran_status,
                               :in_progress_forms, :prefills_available, :vet360_contact_information, :session,
                               :onboarding)
   end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe UserSerializer do
     expect(attributes['services']).to eq pre_serialized_profile.services
   end
 
+  it 'returns serialized #user_account data' do
+    expect(attributes['user_account']).to eq JSON.parse(pre_serialized_profile.user_account.to_json)
+  end
+
   it 'returns serialized #account data' do
     expect(attributes['account']).to eq JSON.parse(pre_serialized_profile.account.to_json)
   end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe UserSerializer do
     expect(attributes['services']).to eq pre_serialized_profile.services
   end
 
-  it 'returns serialized #user_account data' do
-    expect(attributes['user_account']).to eq JSON.parse(pre_serialized_profile.user_account.to_json)
+  it 'returns serialized #account data' do
+    expect(attributes['account']).to eq JSON.parse(pre_serialized_profile.account.to_json)
   end
 
   it 'returns serialized #profile data' do

--- a/spec/support/schemas/user_loa1.json
+++ b/spec/support/schemas/user_loa1.json
@@ -76,13 +76,13 @@
                 null
               ]
             },
-            "user_account": {
+            "account": {
               "type": "object",
               "required": [
-                "id"
+                "account_uuid"
               ],
               "properties": {
-                "id": {
+                "account_uuid": {
                   "type": [
                     "string",
                     null

--- a/spec/support/schemas/user_loa1.json
+++ b/spec/support/schemas/user_loa1.json
@@ -76,6 +76,20 @@
                 null
               ]
             },
+            "user_account": {
+              "type": "object",
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": [
+                    "string",
+                    null
+                  ]
+                }
+              }
+            },
             "account": {
               "type": "object",
               "required": [

--- a/spec/support/schemas/user_loa3.json
+++ b/spec/support/schemas/user_loa3.json
@@ -80,13 +80,13 @@
                 null
               ]
             },
-            "user_account": {
+            "account": {
               "type": "object",
               "required": [
-                "id"
+                "account_uuid"
               ],
               "properties": {
-                "id": {
+                "account_uuid": {
                   "type": [
                     "string",
                     null

--- a/spec/support/schemas/user_loa3.json
+++ b/spec/support/schemas/user_loa3.json
@@ -80,6 +80,20 @@
                 null
               ]
             },
+            "user_account": {
+              "type": "object",
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": [
+                    "string",
+                    null
+                  ]
+                }
+              }
+            },
             "account": {
               "type": "object",
               "required": [

--- a/spec/support/schemas_camelized/user_loa1.json
+++ b/spec/support/schemas_camelized/user_loa1.json
@@ -76,13 +76,13 @@
                 null
               ]
             },
-            "userAccount": {
+            "account": {
               "type": "object",
               "required": [
-                "id"
+                "accountUuid"
               ],
               "properties": {
-                "id": {
+                "accountUuid": {
                   "type": [
                     "string",
                     null

--- a/spec/support/schemas_camelized/user_loa1.json
+++ b/spec/support/schemas_camelized/user_loa1.json
@@ -76,6 +76,20 @@
                 null
               ]
             },
+            "userAccount": {
+              "type": "object",
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": [
+                    "string",
+                    null
+                  ]
+                }
+              }
+            },
             "account": {
               "type": "object",
               "required": [

--- a/spec/support/schemas_camelized/user_loa3.json
+++ b/spec/support/schemas_camelized/user_loa3.json
@@ -80,13 +80,13 @@
                 null
               ]
             },
-            "userAccount": {
+            "account": {
               "type": "object",
               "required": [
-                "id"
+                "accountUuid"
               ],
               "properties": {
-                "id": {
+                "accountUuid": {
                   "type": [
                     "string",
                     null

--- a/spec/support/schemas_camelized/user_loa3.json
+++ b/spec/support/schemas_camelized/user_loa3.json
@@ -80,6 +80,20 @@
                 null
               ]
             },
+            "userAccount": {
+              "type": "object",
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": [
+                    "string",
+                    null
+                  ]
+                }
+              }
+            },
             "account": {
               "type": "object",
               "required": [


### PR DESCRIPTION
## Summary

- Updates to `Account` removal PR: https://github.com/department-of-veterans-affairs/vets-api/pull/21979.
- restores user profile `account` serialization, this will be removed after a `vets-website` update.
- restores user `flipper_id` function to also include `UserAccount` id.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/393

## Testing done

- Confirm user serialization change - both `account` and `user_account` should be present with an identical uuid
![image](https://github.com/user-attachments/assets/c5b40bb8-1f84-4fce-a447-4536dc5ddc53)
