### PR TITLE
[ARP] Fix claim submission response

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_form_upload_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_form_upload_controller.rb
@@ -14,7 +14,7 @@ module AccreditedRepresentativePortal
         authorize(get_icn, policy_class: RepresentativeFormUploadPolicy)
         Datadog::Tracing.active_trace&.set_tag('form_id', form_data[:formNumber])
         status, confirmation_number = upload_response
-        render json: { status:, confirmation_number: }
+        render json: { status:, confirmationNumber: confirmation_number }
       end
 
       def upload_scanned_form


### PR DESCRIPTION
We've standardized on camel key responses.

This change will play nicely with the backend's key casing middleware, whether or not it runs, since that makes camel key responses too.