### PR TITLE
111974 - Add feature flag for VAOS Mental Health History Filtering

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2256,3 +2256,7 @@ features:
   my_va_display_all_lighthouse_benefits_intake_forms:
     actor_type: user
     description: When enabled, a user will see all submitted Lighthouse Benefits Intake forms in My VA for form status.
+  va_online_scheduling_mental_health_history_filtering:
+    actor_type: user
+    enable_in_development: true
+    description: When enabled, allows past visit filtering for Mental Health


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO* No - Adds flipper
- *Adds flipper va_online_scheduling_mental_health_history_filtering *
- *Appointments and Check-in Experience*
- *Flipper will allow for vets-website to build and enable past MH visit filtering*

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111974

## Testing done

- [ ] *New code is covered by unit tests* (N/A)
- *Describe what the old behavior was prior to the change* -- Just adds new flipper `va_online_scheduling_mental_health_history_filtering`

## Screenshots
N/A

## What areas of the site does it impact?
Nothing impacted since no vets-website usage yet

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable). (N/A)
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated ([Flippers for VAOS](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/va-online-scheduling/product/feature_toggles.md))
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (N/A)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature (N/A)

## Requested Feedback

Check that flipper is created