### PR TITLE
Add Support for Lab Result Comparators

### DIFF
--- a/lib/unified_health_data/service.rb
+++ b/lib/unified_health_data/service.rb
@@ -225,7 +225,7 @@ module UnifiedHealthData
 
     def fetch_observation_value(obs)
       type, text = if obs['valueQuantity']
-                     ['quantity', "#{obs['valueQuantity']['value']} #{obs['valueQuantity']['unit']}"]
+                     ['quantity', format_quantity_value(obs['valueQuantity'])]
                    elsif obs['valueCodeableConcept']
                      ['codeable-concept', obs['valueCodeableConcept']['text']]
                    elsif obs['valueString']
@@ -241,6 +241,19 @@ module UnifiedHealthData
                      [nil, nil]
                    end
       { text:, type: }
+    end
+
+    def format_quantity_value(value_quantity)
+      value = value_quantity['value']
+      unit = value_quantity['unit']
+      comparator = value_quantity['comparator']
+
+      result_text = ''
+      result_text += comparator.to_s if comparator.present?
+      result_text += value.to_s
+      result_text += " #{unit}" if unit.present?
+
+      result_text
     end
 
     def fetch_ordered_by(record)

--- a/spec/lib/unified_health_data/service_spec.rb
+++ b/spec/lib/unified_health_data/service_spec.rb
@@ -127,6 +127,31 @@ describe UnifiedHealthData::Service, type: :service do
       expect(service.send(:fetch_observation_value, obs)).to eq({ type: 'quantity', text: '5 mg' })
     end
 
+    it 'includes the less-than comparator in the text result when present' do
+      obs = { 'valueQuantity' => { 'value' => 50, 'comparator' => '<', 'unit' => 'mmol/L' } }
+      expect(service.send(:fetch_observation_value, obs)).to eq({ type: 'quantity', text: '<50 mmol/L' })
+    end
+
+    it 'includes the greater-than comparator in the text result when present' do
+      obs = { 'valueQuantity' => { 'value' => 120, 'comparator' => '>', 'unit' => 'mg/dL' } }
+      expect(service.send(:fetch_observation_value, obs)).to eq({ type: 'quantity', text: '>120 mg/dL' })
+    end
+
+    it 'includes the less-than-or-equal comparator in the text result when present' do
+      obs = { 'valueQuantity' => { 'value' => 6.5, 'comparator' => '<=', 'unit' => '%' } }
+      expect(service.send(:fetch_observation_value, obs)).to eq({ type: 'quantity', text: '<=6.5 %' })
+    end
+
+    it 'handles valueQuantity with no unit correctly' do
+      obs = { 'valueQuantity' => { 'value' => 10, 'comparator' => '>' } }
+      expect(service.send(:fetch_observation_value, obs)).to eq({ type: 'quantity', text: '>10' })
+    end
+
+    it 'handles empty or nil comparator gracefully' do
+      obs = { 'valueQuantity' => { 'value' => 75, 'comparator' => '', 'unit' => 'pg/mL' } }
+      expect(service.send(:fetch_observation_value, obs)).to eq({ type: 'quantity', text: '75 pg/mL' })
+    end
+
     it 'returns codeable-concept type and text' do
       obs = { 'valueCodeableConcept' => { 'text' => 'POS' } }
       expect(service.send(:fetch_observation_value, obs)).to eq({ type: 'codeable-concept', text: 'POS' })

--- a/spec/lib/unified_health_data/service_spec.rb
+++ b/spec/lib/unified_health_data/service_spec.rb
@@ -142,6 +142,16 @@ describe UnifiedHealthData::Service, type: :service do
       expect(service.send(:fetch_observation_value, obs)).to eq({ type: 'quantity', text: '<=6.5 %' })
     end
 
+    it 'includes the greater-than-or-equal comparator in the text result when present' do
+      obs = { 'valueQuantity' => { 'value' => 8.0, 'comparator' => '>=', 'unit' => 'ng/mL' } }
+      expect(service.send(:fetch_observation_value, obs)).to eq({ type: 'quantity', text: '>=8.0 ng/mL' })
+    end
+
+    it 'includes the "sufficient to achieve" (ad) comparator in the text result when present' do
+      obs = { 'valueQuantity' => { 'value' => 12.3, 'comparator' => 'ad', 'unit' => 'mol/L' } }
+      expect(service.send(:fetch_observation_value, obs)).to eq({ type: 'quantity', text: 'ad12.3 mol/L' })
+    end
+
     it 'handles valueQuantity with no unit correctly' do
       obs = { 'valueQuantity' => { 'value' => 10, 'comparator' => '>' } }
       expect(service.send(:fetch_observation_value, obs)).to eq({ type: 'quantity', text: '>10' })


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

This PR adds support for displaying comparator values (e.g., "<", ">", "<=") in lab results. Previously, lab results with comparators would only show the value and unit (e.g., "50 mmol/L"). Now, if a comparator is present in the data, it will be displayed correctly (e.g., "<50 mmol/L").

### Changes
- Updated `fetch_observation_value` method to include comparators when present
- Extracted a helper method `format_quantity_value` to handle formatting of quantity values
- Added comprehensive test cases for different comparator scenarios

### Testing
- Added unit tests for the following scenarios:
  - Less-than comparator (`<`)
  - Greater-than comparator (`>`)
  - Less-than-or-equal comparator (`<=`)
  - Values with comparator but no unit
  - Empty comparator fields