### PR TITLE
Add page auth, page unauth and cta auth param to operation type

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -32,7 +32,10 @@ module V1
                        INTERSTITIAL_VERIFY = 'interstitial_verify',
                        INTERSTITIAL_SIGNUP = 'interstitial_signup',
                        MHV_EXCEPTION = 'mhv_exception',
-                       MYHEALTHEVET_TEST_ACCOUNT = 'myhealthevet_test_account'].freeze
+                       MYHEALTHEVET_TEST_ACCOUNT = 'myhealthevet_test_account',
+                       VERIFY_CTA_AUTHENTICATED = 'verify_cta_authenticated',
+                       VERIFY_PAGE_AUTHENTICATED = 'verify_page_authenticated',
+                       VERIFY_PAGE_UNAUTHENTICATED = 'verify_page_unauthenticated'].freeze
     CERNER_ELIGIBLE_COOKIE_NAME = 'CERNER_ELIGIBLE'
 
     # Collection Action: auth is required for certain types of requests

--- a/app/services/sign_in/constants/auth.rb
+++ b/app/services/sign_in/constants/auth.rb
@@ -29,7 +29,10 @@ module SignIn
       OPERATION_TYPES = [SIGN_UP = 'sign_up',
                          AUTHORIZE = 'authorize',
                          INTERSTITIAL_VERIFY = 'interstitial_verify',
-                         INTERSTITIAL_SIGNUP = 'interstitial_signup'].freeze
+                         INTERSTITIAL_SIGNUP = 'interstitial_signup',
+                         VERIFY_CTA_AUTHENTICATED = 'verify_cta_authenticated',
+                         VERIFY_PAGE_AUTHENTICATED = 'verify_page_authenticated',
+                         VERIFY_PAGE_UNAUTHENTICATED = 'verify_page_unauthenticated'].freeze
       GRANT_TYPES = [AUTH_CODE_GRANT = 'authorization_code',
                      JWT_BEARER_GRANT = Urn::JWT_BEARER_GRANT_TYPE,
                      TOKEN_EXCHANGE_GRANT = Urn::TOKEN_EXCHANGE_GRANT_TYPE].freeze

--- a/spec/controllers/v0/sign_in_controller_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_spec.rb
@@ -444,6 +444,27 @@ RSpec.describe V0::SignInController, type: :controller do
 
           it_behaves_like 'an idme service interface with appropriate operation'
         end
+
+        context 'and the operation param is verify_cta_authenticated' do
+          let(:operation_value) { SignIn::Constants::Auth::VERIFY_CTA_AUTHENTICATED }
+          let(:expected_op_value) { '' }
+
+          it_behaves_like 'an idme service interface with appropriate operation'
+        end
+
+        context 'and the operation param is verify_page_authenticated' do
+          let(:operation_value) { SignIn::Constants::Auth::VERIFY_PAGE_AUTHENTICATED }
+          let(:expected_op_value) { '' }
+
+          it_behaves_like 'an idme service interface with appropriate operation'
+        end
+
+        context 'and the operation param is verify_page_unauthenticated' do
+          let(:operation_value) { SignIn::Constants::Auth::VERIFY_PAGE_UNAUTHENTICATED }
+          let(:expected_op_value) { '' }
+
+          it_behaves_like 'an idme service interface with appropriate operation'
+        end
       end
 
       shared_context 'an idme service interface with appropriate operation' do


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): NO*
- We are adding 3 operation param types to `operationType`: `VERIFY_CTA_AUTHENTICATED`, `VERIFY_PAGE_AUTHENTICATED` and `VERIFY_PAGE_UNAUTHENTICATED`
- *(If bug, how to reproduce)* not a bug
- *(What is the solution, why is this the solution?)* Adding more operation types for FE use
- *(Which team do you work for, does your team own the maintenance of this component?)* Identity
- *(If introducing a flipper, what is the success criteria being targeted?)* No flipper

## Related issue(s)

- [GH ticket](https://github.com/orgs/department-of-veterans-affairs/projects/1646/views/2?pane=issue&itemId=113714077&issue=department-of-veterans-affairs%7Cidentity-documentation%7C376)

## Testing done
- In the `new` action of `app/controllers/v1/sessions_controller.rb` add this logger line to test: `Rails.logger.info("Operation: #{operation} | Type: #{type} | Client ID: #{client_id}")`
- open a rails console with `bin/rails c` and set `controller = V1::SessionsController.new`
- test `verify_cta_authenticated`:
```
params = { type: 'idme_verified', operation: 'verify_cta_authenticated', client_id: 'vaweb' }
controller.params = params
controller.new
```
- Check log for =>  `2025-06-13 12:00:52.373069 I [38783:11800 sessions_controller.rb:51] Rails -- Operation: verify_cta_authenticated | Type: idme_verified | Client ID: vaweb`
- test `verify_page_authenticated`
```
params = { type: 'idme_verified', operation: 'verify_page_authenticated', client_id: 'vaweb' }
controller.params = params
controller.new
```
- Check log for => `2025-06-13 12:05:25.175046 I [38783:11800 sessions_controller.rb:51] Rails -- Operation: verify_page_authenticated | Type: idme_verified | Client ID: vaweb`
- test `verify_page_unauthenticated`
```
params = { type: 'idme_verified', operation: 'verify_page_unauthenticated', client_id: 'vaweb' }
controller.params = params
controller.new
```
- Check log for => `2025-06-13 12:05:46.963089 I [38783:11800 sessions_controller.rb:51] Rails -- Operation: verify_page_unauthenticated | Type: idme_verified | Client ID: vaweb`

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
