### PR TITLE
Update config so we can set up maintenance windows for Decision Reviews

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -781,6 +781,7 @@ maintenance:
     caseflow: <%= ENV['maintenance__services__caseflow'] %>
     cie: <%= ENV['maintenance__services__cie'] %>
     coe: <%= ENV['maintenance__services__coe'] %>
+    decision_reviews: PT2SZGW
     dmc: <%= ENV['maintenance__services__dmc'] %>
     dslogon: <%= ENV['maintenance__services__dslogon'] %>
     es: <%= ENV['maintenance__services__es'] %>
@@ -812,6 +813,7 @@ maintenance:
     search: PRG8HJI
     ssoe: <%= ENV['maintenance__services__ssoe'] %>
     ssoe_oauth: <%= ENV['maintenance__services__ssoe_oauth'] %>
+    staging_decision_reviews: PHR6FGV
     staging_mdot: PGT74RC
     tc: <%= ENV['maintenance__services__tc'] %>
     tims: <%= ENV['maintenance__services__tims'] %>


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- As part of the work to update the 4142 form being generated by the Supplemental Claim flow to the latest version of the PDF, we will need to handle in-progress forms for impacted users to ensure they see the updated legalese for authorizing the VA to retrieve their private medical records. We will need some time to run the [rake task](https://github.com/department-of-veterans-affairs/va.gov-team/issues/111445) to handle the in-progress forms and want to make sure no users are in-progress when we do the release.
  - More specifically: if a user happens to have progressed past the authorization screen, and is in the middle of completing the 4142 sub flow while we are turning the feature flags on in production, we will generate the newer version of the 4142 PDF for them without having shown them the updated legalese.

## Related issue(s)

- Tracking [issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/112080)
- Related PRs: [Feature/add form 4142 template support department-of-veterans-affairs/vets-api#22527](https://github.com/department-of-veterans-affairs/vets-api/pull/22527), [refactor 4142 processors](https://github.com/department-of-veterans-affairs/vets-api/pull/22538)
- Link to [epic](https://github.com/department-of-veterans-affairs/va.gov-team/issues/105771)

## Testing done
- Created two services in PagerDuty with one test maintenance window each (one for [staging](https://dsva.pagerduty.com/service-directory/PHR6FGV/activity), one for [prod](https://dsva.pagerduty.com/service-directory/PT2SZGW/activity))
- Grabbed PagerDuty API key from staging and verified locally (see screenshots below)

## Screenshots
![Screenshot 2025-06-13 at 4 12 41 PM](https://github.com/user-attachments/assets/fc68b108-e532-4345-90d1-d8212367d04e)

## What areas of the site does it impact?
This will help us set up [downtime notifications](https://depo-platform-documentation.scrollhelp.site/developer-docs/downtime-notifications) for the Decision Reviews portion of VA.gov to facilitate the release of the 4142 changes.

## Acceptance criteria

- [ ]  ~~I fixed|updated|added unit tests and integration tests for each feature (if applicable).~~ N/A
- [ ]  No error nor warning in the console.
- [ ]  ~~Events are being sent to the appropriate logging solution~~ N/A
- [ ]  ~~Documentation has been updated (link to documentation)~~ N/A
- [ ]   ~~No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs)~~ N/A
- [ ]   ~~Feature/bug has a monitor built into Datadog (if applicable))~~ N/A
- [ ]   ~~If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected)~~ N/A
- [ ]  I added a screenshot of the developed feature)~~ N/A
