### PR TITLE
Remove certificates column from sign in configs

### DIFF
--- a/db/migrate/20250616154520_remove_certificates_from_client_configs.rb
+++ b/db/migrate/20250616154520_remove_certificates_from_client_configs.rb
@@ -1,0 +1,7 @@
+class RemoveCertificatesFromClientConfigs < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured do
+      remove_column :client_configs, :certificates, :string, array: true, default: [], null: false
+    end
+  end
+end

--- a/db/migrate/20250616154537_remove_certificates_from_service_account_configs.rb
+++ b/db/migrate/20250616154537_remove_certificates_from_service_account_configs.rb
@@ -1,0 +1,7 @@
+class RemoveCertificatesFromServiceAccountConfigs < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured do
+      remove_column :service_account_configs, :certificates, :string, array: true, default: [], null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_10_160901) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_16_154537) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -676,7 +676,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_10_160901) do
     t.datetime "updated_at", null: false
     t.text "logout_redirect_uri"
     t.boolean "pkce"
-    t.string "certificates", default: [], array: true
     t.text "description"
     t.string "access_token_attributes", default: [], array: true
     t.text "terms_of_use_url"
@@ -1424,7 +1423,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_10_160901) do
     t.text "scopes", default: [], null: false, array: true
     t.string "access_token_audience", null: false
     t.interval "access_token_duration", null: false
-    t.string "certificates", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "access_token_user_attributes", default: [], array: true


### PR DESCRIPTION
## Summary

- Remove certificates column from `SignIn::ClientConfig`
- Remove certificates column from `SignIn::ServiceAccountConfig`

## Related issue(s)

- [*Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*](https://github.com/department-of-veterans-affairs/identity-documentation/issues/344)

## Testing 
- run migrations 
  ```bash
  rails db:migrate
  ```

## What areas of the site does it impact?
SignIn configurations 

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

