### PR TITLE
109762 ves outage spec

### DIFF
--- a/modules/ivc_champva/spec/services/uploads_controller_failure_scenarios_spec.rb
+++ b/modules/ivc_champva/spec/services/uploads_controller_failure_scenarios_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'pega_api/client'
+
+RSpec.describe 'IVC CHAMPVA Integration Failure Scenarios', type: :request do
+  let(:user) { create(:user, :loa3) }
+  let(:simple_form_data) do
+    {
+      'form_number' => '10-10D',
+      'certifier_role' => 'applicant',
+      'primary_contact_info' => {
+        'name' => { 'first' => 'Test', 'last' => 'User' },
+        'email' => 'test@example.com'
+      },
+      'veteran' => {
+        'full_name' => { 'first' => 'Veteran', 'last' => 'Name' },
+        'ssn_or_tin' => '123456789',
+        'date_of_birth' => '1980-01-01'
+      },
+      'applicants' => [
+        {
+          'applicant_name' => { 'first' => 'Applicant', 'last' => 'Name' },
+          'ssn_or_tin' => '987654321',
+          'applicant_dob' => '1985-01-01',
+          'vet_relationship' => 'spouse'
+        }
+      ],
+      'certification' => {
+        'first_name' => 'Test',
+        'last_name' => 'User',
+        'date' => '2024-01-01'
+      },
+      'statement_of_truth_signature' => 'Test User'
+    }
+  end
+
+  before do
+    sign_in(user)
+    # Mock AWS to avoid real S3 calls
+    Aws.config.update(stub_responses: true)
+
+    # Ensure we're in non-production environment for VES integration
+    allow(Settings).to receive(:vsp_environment).and_return('staging')
+
+    # Mock VES data validation to bypass form validation errors
+    ves_request = instance_double(IvcChampva::VesRequest,
+                                  transaction_uuid: 'test-uuid',
+                                  application_uuid: 'app-uuid',
+                                  to_json: '{"test": "data"}')
+    allow(ves_request).to receive(:transaction_uuid=)
+    allow(IvcChampva::VesDataFormatter).to receive(:format_for_request)
+      .and_return(ves_request)
+
+    # Mock PDF generation and stamping to avoid file system dependencies
+    allow(IvcChampva::PdfFiller).to receive(:new).and_return(
+      instance_double(IvcChampva::PdfFiller, generate: '/tmp/test.pdf')
+    )
+    allow(IvcChampva::PdfStamper).to receive(:stamp_pdf).and_return(true)
+
+    # Mock S3 operations to return success by default
+    allow_any_instance_of(IvcChampva::S3).to receive(:put_object)
+      .and_return({ success: true, etag: 'test-etag' })
+  end
+
+  describe 'VES Integration Failure Scenarios' do
+    context 'when VES API fails' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:champva_send_to_ves, user).and_return(true)
+        # Mock VES to fail with any error (connection, HTTP, timeout, etc.)
+        stub_request(:post, %r{.*/ves-vfmp-app-svc/champva-applications})
+          .to_raise(Faraday::ConnectionFailed.new('Connection refused'))
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it 'logs VES error but allows form submission to succeed (graceful degradation)' do
+        post '/ivc_champva/v1/forms', params: simple_form_data
+
+        # Verify the VES request was attempted and failed (may retry once)
+        expect(WebMock).to have_requested(:post, %r{.*/ves-vfmp-app-svc/champva-applications}).at_least_once
+
+        # Verify VES error was logged (retry mechanism logs the error)
+        expect(Rails.logger).to have_received(:error)
+          .with(a_string_matching(/Ignoring error when submitting to VES.*Connection refused/)).at_least(:once)
+
+        # Verify form submission still succeeded despite VES failure
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to be_a(Hash)
+      end
+    end
+
+    context 'when VES API returns HTTP error' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:champva_send_to_ves, user).and_return(true)
+        stub_request(:post, %r{.*/ves-vfmp-app-svc/champva-applications})
+          .to_return(status: 500, body: 'Internal Server Error')
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it 'handles VES HTTP errors gracefully' do
+        post '/ivc_champva/v1/forms', params: simple_form_data
+
+        # Verify the VES request was attempted and failed (may retry once)
+        expect(WebMock).to have_requested(:post, %r{.*/ves-vfmp-app-svc/champva-applications}).at_least_once
+
+        # Verify VES error was logged with the response code
+        expect(Rails.logger).to have_received(:error)
+          .with(a_string_matching(/Ignoring error when submitting to VES.*response code: 500/))
+          .at_least(:once)
+
+        # Form submission should still succeed despite VES failure
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to be_a(Hash)
+      end
+    end
+
+    context 'when VES feature flag is disabled' do
+      before do
+        # Reset WebMock to clear any previous stubs
+        WebMock.reset!
+        # Explicitly disable the VES feature flag
+        allow(Flipper).to receive(:enabled?).with(:champva_send_to_ves, user).and_return(false)
+        allow(Flipper).to receive(:enabled?).with(:champva_send_to_ves, anything).and_return(false)
+      end
+
+      it 'does not attempt VES submission and form succeeds normally' do
+        post '/ivc_champva/v1/forms', params: simple_form_data
+
+        # Should not make any VES requests
+        expect(WebMock).not_to have_requested(:post, %r{.*/ves-vfmp-app-svc/champva-applications})
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to be_a(Hash)
+      end
+    end
+  end
+
+  describe 'Pega Infrastructure Failure Scenarios' do
+    # NOTE: Pega integration is asynchronous via S3 pickup, not direct API calls during form submission.
+    # These tests cover infrastructure failures that prevent Pega from receiving form data.
+
+    context 'when database insertion fails during form submission' do
+      before do
+        # Mock database insertion to fail - prevents IvcChampvaForm record creation
+        allow(IvcChampvaForm).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(IvcChampvaForm.new))
+      end
+
+      it 'returns 500 error when database record creation fails' do
+        post '/ivc_champva/v1/forms', params: simple_form_data
+
+        # Database failure prevents form tracking records from being created
+        # Impact: No form records in database, no tracking for Pega processing
+        expect(response).to have_http_status(:internal_server_error)
+        expect(response.parsed_body).to have_key('error_message')
+        expect(response.parsed_body['error_message']).to match(/An unknown error occurred while uploading document/)
+      end
+    end
+
+    context 'when S3 upload fails' do
+      before do
+        # Mock S3 upload to fail - prevents files and metadata from reaching S3 bucket
+        allow_any_instance_of(IvcChampva::FileUploader).to receive(:upload)
+          .and_return([500, 'S3 connection failed'])
+      end
+
+      it 'returns 500 error when S3 upload fails' do
+        post '/ivc_champva/v1/forms', params: simple_form_data
+
+        # S3 failure prevents metadata JSON upload that triggers Pega lambda
+        # Impact: Pega cannot process form (nothing in S3 bucket to pick up)
+        expect(response).to have_http_status(:internal_server_error)
+        expect(response.parsed_body).to have_key('error_message')
+        expect(response.parsed_body['error_message']).to match(/An unknown error occurred while uploading document/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper):NO*
- Add an integration test to verify behavior when Pega and/or VES are down.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/109762

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated [link to documentation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/champva/engineering/failure_scenarios_analysis.md)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
