### PR TITLE
[Event Bus Gateway] Adds callback class to the email-sending job

### DIFF
--- a/app/sidekiq/event_bus_gateway/letter_ready_email_job.rb
+++ b/app/sidekiq/event_bus_gateway/letter_ready_email_job.rb
@@ -29,7 +29,8 @@ module EventBusGateway
     private
 
     def notify_client
-      VaNotify::Service.new(NOTIFY_SETTINGS.api_key)
+      VaNotify::Service.new(NOTIFY_SETTINGS.api_key,
+                            { callback_klass: 'EventBusGateway::VANotifyEmailStatusCallback' })
     end
 
     def get_first_name_from_participant_id(participant_id)

--- a/app/sidekiq/event_bus_gateway/va_notify_email_status_callback.rb
+++ b/app/sidekiq/event_bus_gateway/va_notify_email_status_callback.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module EventBusGateway
+  class VANotifyEmailStatusCallback
+    def self.call(notification)
+      status = notification.status
+
+      add_metrics(status)
+      add_log(notification) if notification.status != 'delivered'
+    end
+
+    def self.add_log(notification)
+      context = {
+        notification_id: notification.notification_id,
+        source_location: notification.source_location,
+        status: notification.status,
+        status_reason: notification.status_reason,
+        notification_type: notification.notification_type
+      }
+
+      Rails.logger.error(name, context)
+    end
+
+    def self.add_metrics(status)
+      case status
+      when 'delivered'
+        StatsD.increment('api.vanotify.notifications.delivered')
+        StatsD.increment('callbacks.event_bus_gateway.va_notify.notifications.delivered')
+        tags = ['service:event-bus-gateway', 'function: Event Bus Gateway - VA Notify decision letter ready email']
+        StatsD.increment('silent_failure_avoided', tags:)
+      when 'permanent-failure'
+        StatsD.increment('api.vanotify.notifications.permanent_failure')
+        StatsD.increment('callbacks.event_bus_gateway.va_notify.notifications.permanent_failure')
+        tags = ['service:event-bus-gateway', 'function: Event Bus Gateway - VA Notify decision letter ready email']
+        StatsD.increment('silent_failure', tags:)
+      when 'temporary-failure'
+        StatsD.increment('api.vanotify.notifications.temporary_failure')
+        StatsD.increment('callbacks.event_bus_gateway.va_notify.notifications.temporary_failure')
+      else
+        StatsD.increment('api.vanotify.notifications.other')
+        StatsD.increment('callbacks.event_bus_gateway.va_notify.notifications.other')
+      end
+    end
+  end
+end

--- a/spec/sidekiq/event_bus_gateway/va_notify_email_status_callback_spec.rb
+++ b/spec/sidekiq/event_bus_gateway/va_notify_email_status_callback_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe EventBusGateway::VANotifyEmailStatusCallback do
+  describe '#call' do
+    context 'notification callback' do
+      let(:notification_type) { :error }
+      let(:callback_metadata) { { notification_type: } }
+
+      context 'permanent-failure' do
+        let!(:notification_record) do
+          build(:notification, status: 'permanent-failure', notification_id: SecureRandom.uuid, callback_metadata:)
+        end
+
+        it 'logs error and increments StatsD' do
+          allow(StatsD).to receive(:increment)
+          allow(Rails.logger).to receive(:error)
+          described_class.call(notification_record)
+          expect(Rails.logger).to have_received(:error).with(
+            'EventBusGateway::VANotifyEmailStatusCallback',
+            { notification_id: notification_record.notification_id,
+              source_location: notification_record.source_location,
+              status: notification_record.status,
+              status_reason: notification_record.status_reason,
+              notification_type: notification_record.notification_type }
+          )
+          expect(StatsD).to have_received(:increment)
+            .with('silent_failure',
+                  tags: ['service:event-bus-gateway',
+                         'function: Event Bus Gateway - VA Notify decision letter ready email'])
+          expect(StatsD).to have_received(:increment).with('api.vanotify.notifications.permanent_failure')
+          expect(StatsD).to have_received(:increment)
+            .with('callbacks.event_bus_gateway.va_notify.notifications.permanent_failure')
+        end
+      end
+
+      context 'delivered' do
+        let!(:notification_record) do
+          build(:notification, status: 'delivered', notification_id: SecureRandom.uuid)
+        end
+
+        it 'logs success and increments StatsD' do
+          allow(StatsD).to receive(:increment)
+          described_class.call(notification_record)
+          expect(StatsD).to have_received(:increment)
+            .with('silent_failure_avoided',
+                  tags: ['service:event-bus-gateway',
+                         'function: Event Bus Gateway - VA Notify decision letter ready email'])
+          expect(StatsD).to have_received(:increment).with('api.vanotify.notifications.delivered')
+          expect(StatsD).to have_received(:increment)
+            .with('callbacks.event_bus_gateway.va_notify.notifications.delivered')
+        end
+      end
+
+      context 'temporary-failure' do
+        let!(:notification_record) do
+          build(:notification, status: 'temporary-failure', notification_id: SecureRandom.uuid)
+        end
+
+        it 'logs error and increments StatsD' do
+          allow(StatsD).to receive(:increment)
+          allow(Rails.logger).to receive(:error)
+          described_class.call(notification_record)
+          expect(StatsD).to have_received(:increment).with('api.vanotify.notifications.temporary_failure')
+          expect(StatsD).to have_received(:increment)
+            .with('callbacks.event_bus_gateway.va_notify.notifications.temporary_failure')
+          expect(Rails.logger).to have_received(:error).with(
+            'EventBusGateway::VANotifyEmailStatusCallback',
+            { notification_id: notification_record.notification_id,
+              source_location: notification_record.source_location,
+              status: notification_record.status,
+              status_reason: notification_record.status_reason,
+              notification_type: notification_record.notification_type }
+          )
+        end
+      end
+
+      context 'other' do
+        let!(:notification_record) do
+          build(:notification, status: '', notification_id: SecureRandom.uuid)
+        end
+
+        it 'logs error and increments StatsD' do
+          allow(StatsD).to receive(:increment)
+          allow(Rails.logger).to receive(:error)
+          described_class.call(notification_record)
+          expect(StatsD).to have_received(:increment).with('api.vanotify.notifications.other')
+          StatsD.increment('callbacks.event_bus_gateway.va_notify.notifications.other')
+          expect(Rails.logger).to have_received(:error).with(
+            'EventBusGateway::VANotifyEmailStatusCallback',
+            { notification_id: notification_record.notification_id,
+              source_location: notification_record.source_location,
+              status: notification_record.status,
+              status_reason: notification_record.status_reason,
+              notification_type: notification_record.notification_type }
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implements a callback class for the Letter Ready Job to link back to
If VA Notify has a problem, it will pass the notification object back to this class for us to log information about it