### PR TITLE
Added some logging to debug why education requests are being submitted as Unauthenticated to CRM

### DIFF
--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/inquiry_payload.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/inquiry_payload.rb
@@ -36,6 +36,19 @@ module AskVAApi
             DependentFirstName: family_member_field(:first)
           }.merge(additional_payload_fields)
 
+          # Add debug logging to determine root cause for https://github.com/department-of-veterans-affairs/ask-va/issues/1872
+          # Level of Authentication is a misnomer. it doesn't contain any PII and the two possible values are:
+          # 1. 'Business' - for authenticated users
+          # 2. 'Personal' - for unauthenticated users
+          if user.nil? && inquiry_detail&.education_benefits?
+            Rails.logger.warn("Unauthenticated Education inquiry submitted. - Category: #{inquiry_detail.category},
+              Topic: #{inquiry_detail.topic},
+              Level of Authentication: #{inquiry_details.level_of_authentication}")
+          end
+
+          # Also log user's LOA if available (to verify that it didn't get downgraded for any reason)
+          Rails.logger.info("User LOA: #{user&.loa&.current&.fetch(:current, nil)}") if user
+
           payload[:LevelOfAuthentication] = UNAUTHENTICATE_ID if user.nil?
 
           payload


### PR DESCRIPTION
This additional logging is to narrow down the root cause for the [ticket related to ask-va](https://github.com/department-of-veterans-affairs/ask-va/issues/1872).

No other functional change is being made

## Summary

- *This work is behind a feature toggle (flipper): No*
- *(Summarize the changes that have been made to the platform)*
   -- Added some logging to get to the root cause of an issue documented in the above mentioned ticket.
- *(If bug, how to reproduce)* : N/A
- *(What is the solution, why is this the solution?)* : This is for Debugging purposes only. No functional change is being introduced.
- *(Which team do you work for, does your team own the maintenance of this component?)* Watchtower
- *(If introducing a flipper, what is the success criteria being targeted?)* N/A

## Related issue(s)

- [*Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*](https://github.com/department-of-veterans-affairs/ask-va/issues/1872)


## Testing done
N/A

## What areas of the site does it impact?
ASK-VA

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature