### PR TITLE
(DO NOT MERGE)Test transition off RedisStore and Virtus gem

### DIFF
--- a/app/models/sign_in/state_code.rb
+++ b/app/models/sign_in/state_code.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
+require 'common/redis_model'
+
 module SignIn
-  class StateCode < Common::RedisStore
+  class StateCode < Common::RedisModel
     redis_store REDIS_CONFIG[:sign_in_state_code][:namespace]
     redis_ttl REDIS_CONFIG[:sign_in_state_code][:each_ttl]
     redis_key :code
 
-    attribute :code, String
+    attribute :code, :string
 
-    validates(:code, presence: true)
+    validates :code, presence: true
+
+    computed_fallbacks code: 'hi emily'
   end
 end

--- a/app/models/user_identity.rb
+++ b/app/models/user_identity.rb
@@ -1,51 +1,69 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
-require 'common/models/redis_store'
-require 'saml/user'
+require 'common/redis_model'
 
 # Stores attributes used to identify a user. Serves as a set of inputs to an MVI lookup. Also serves
 # as the receiver of identity attributes received from alternative sources during the SSO flow.
-class UserIdentity < Common::RedisStore
+class UserIdentity < Common::RedisModel
   redis_store REDIS_CONFIG[:user_identity_store][:namespace]
   redis_ttl REDIS_CONFIG[:user_identity_store][:each_ttl]
   redis_key :uuid
 
   # identity attributes
-  attribute :uuid
-  attribute :email
-  attribute :first_name
-  attribute :middle_name
-  attribute :last_name
-  attribute :gender
-  attribute :birth_date
-  attribute :icn
-  attribute :ssn
-  attribute :loa
-  attribute :multifactor, Boolean # used by F/E to decision on whether or not to prompt user to add MFA
-  attribute :authn_context # used by F/E to handle various identity related complexities pending refactor
-  attribute :idme_uuid
-  attribute :logingov_uuid
-  attribute :verified_at # Login.gov IAL2 verification timestamp
-  attribute :sec_id
-  attribute :mhv_icn # only needed by B/E not serialized in user_serializer
-  attribute :mhv_credential_uuid
-  attribute :mhv_account_type # this is only available for MHV sign-in users
-  attribute :edipi # this is only available for dslogon users
-  attribute :sign_in, Hash # original sign_in (see sso_service#mergable_identity_attributes)
-  attribute :icn_with_aaid
-  attribute :search_token
+  attribute :uuid, :string
+  attribute :email, :string
+  attribute :first_name, :string
+  attribute :middle_name, :string
+  attribute :last_name, :string
+  attribute :gender, :string
+  attribute :birth_date, :string
+  attribute :icn, :string
+  attribute :ssn, :string
+  attribute :loa, :string
+  attribute :multifactor, :boolean # used by F/E to decision on whether or not to prompt user to add MFA
+  attribute :authn_context, :string # used by F/E to handle various identity related complexities pending refactor
+  attribute :idme_uuid, :string
+  attribute :logingov_uuid, :string
+  attribute :verified_at, :string # Login.gov IAL2 verification timestamp
+  attribute :sec_id, :string
+  attribute :mhv_icn, :string # only needed by B/E not serialized in user_serializer
+  attribute :mhv_credential_uuid, :string
+  attribute :mhv_account_type, :string # this is only available for MHV sign-in users
+  attribute :edipi, :string # this is only available for dslogon users
+  attribute :sign_in, :string # original sign_in (see sso_service#mergable_identity_attributes) (RedisStore note: using string and serializing manually)
+  attribute :icn_with_aaid, :string
+  attribute :search_token, :string
 
   validates :uuid, presence: true
   validates :loa, presence: true
-  validate  :loa_highest_present
+  validate :loa_highest_present
+
+  # I think we can technically define hash as a custom type with ActiveModel::Type
+  # as another solution instead of using string and serializing manually
+  def sign_in
+    @sign_in ||= JSON.parse(super || '{}')
+  end
+
+  def sign_in=(value)
+    super(value.to_json)
+    @sign_in = value
+  end
+
+  def loa
+    @loa ||= JSON.parse(super || '{}')
+  end
+
+  def loa=(value)
+    super(value.to_json)
+    @loa = value
+  end
 
   # LOA3 no longer just means ID.me FICAM LOA3.
   # It could also be DSLogon or MHV Premium users.
   # It could also be DSLogon or MHV NON PREMIUM users who have done ID.me FICAM LOA3.
   # Additionally, LOA3 does not automatically mean user has opted to have MFA.
   def loa3?
-    loa && loa[:current].try(:to_i) == LOA::THREE
+    loa && loa[:current].to_i == LOA::THREE
   end
 
   with_options if: :loa3? do

--- a/lib/common/redis_model.rb
+++ b/lib/common/redis_model.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'active_model'
+require 'oj'
+
+module Common
+  class RedisModel
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include ActiveModel::Validations
+    include ActiveModel::Serialization
+
+    # rubocop:disable ThreadSafety/ClassAndModuleAttributes
+    class_attribute :redis_namespace, instance_writer: false
+    class_attribute :redis_ttl, instance_writer: false
+    class_attribute :redis_key, instance_writer: false
+    class_attribute :computed_fallback, instance_writer: false, default: {}
+    # rubocop:enable ThreadSafety/ClassAndModuleAttributes
+
+    class << self
+      def redis_store(namespace)
+        self.redis_namespace = Redis::Namespace.new(namespace, redis: $redis)
+      end
+
+      def redis_ttl(ttl)
+        self.redis_ttl = ttl
+      end
+
+      def redis_key(field)
+        self.redis_key = field.to_s
+      end
+
+      def computed_fallbacks(hash = nil)
+        if hash
+          self.computed_fallback = hash.transform_keys(&:to_sym)
+        else
+          computed_fallback
+        end
+      end
+
+      def find(key)
+        raw = redis_namespace.get(key)
+        return nil if raw.blank?
+
+        attrs = Oj.load(raw)
+        new(attrs.merge(redis_key => key))
+      end
+
+      def create(attrs)
+        new(attrs).tap(&:save)
+      end
+
+      def delete(key)
+        redis_namespace.del(key)
+      end
+
+      delegate :exists?, :keys, to: :redis_namespace
+    end
+
+    attr_reader :persisted
+
+    def initialize(attrs = {})
+      super(attrs)
+      @persisted = false
+    end
+
+    def redis_key
+      send(self.class.redis_key)
+    end
+
+    def save
+      return false unless valid?
+      return false if redis_key.blank?
+
+      self.class.redis_namespace.set(redis_key, Oj.dump(serializable_hash))
+      self.class.redis_namespace.expire(redis_key, self.class.redis_ttl) if self.class.redis_ttl
+      @persisted = true
+    end
+
+    def save!
+      raise ActiveModel::ValidationError, self unless save
+    end
+
+    def update(attrs)
+      assign_attributes(attrs)
+      save
+    end
+
+    def destroy
+      self.class.redis_namespace.del(redis_key)
+      @destroyed = true
+      freeze
+    end
+
+    def persisted?
+      !!@persisted
+    end
+
+    def destroyed?
+      !!@destroyed
+    end
+
+    def computed(attr_name)
+      value = public_send(attr_name)
+      value.presence || self.class.computed_fallback[attr_name.to_sym]
+    end
+
+    def serializable_hash(*)
+      base_hash = super
+      computed_hash = self.class.computed_fallback.keys.index_with { |attr| computed(attr) }
+      base_hash.merge(computed_hash)
+    end
+  end
+end

--- a/spec/models/sign_in/state_code_spec.rb
+++ b/spec/models/sign_in/state_code_spec.rb
@@ -3,21 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe SignIn::StateCode, type: :model do
-  let(:state_code) { create(:state_code, code:) }
-  let(:code) { SecureRandom.hex }
-
   describe 'validations' do
-    describe '#code' do
-      subject { state_code.code }
+    context 'when code is nil' do
+      subject(:state_code) { described_class.new(code: nil) }
 
-      context 'when code is nil' do
-        let(:code) { nil }
-        let(:expected_error) { Common::Exceptions::ValidationErrors }
-        let(:expected_error_message) { 'Validation error' }
+      it 'is invalid' do
+        expect(state_code).not_to be_valid
+        expect(state_code.errors[:code]).to include("can't be blank")
+      end
 
-        it 'raises validation error' do
-          expect { subject }.to raise_error(expected_error, expected_error_message)
-        end
+      it 'raises ActiveModel::ValidationError on save!' do
+        expect { state_code.save! }.to raise_error(ActiveModel::ValidationError)
       end
     end
   end


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
- *(Summarize the changes that have been made to the platform)*
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)*
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- [GH spike ticket](https://github.com/orgs/department-of-veterans-affairs/projects/1646/views/2?pane=issue&itemId=111816013&issue=department-of-veterans-affairs%7Cidentity-documentation%7C317)

## Testing done

Testing `app/models/sign_in/state_code.rb` transition:
- [ ] Open a rails console and create a new `state_code` and test methods
```
state_code = SignIn::StateCode.new(code: "abc123")
```
- [ ] Test these methods `state_code.valid?` `state_code.save` `state_code.persisted?` (should all be `true`)
- [ ] Test `find` by running `SignIn::StateCode.find("abc123")`.
- [ ] Let's test `nil` now. We can set a new variable `state_code_nil = SignIn::StateCode.new`
- [ ] We can check if the `state_code_nil` object was able to hit the attribute fallback for `code`. We should see something like `state_code_nil.code => "hi emily"`
- [ ] Test `state_code_nil.serializable_hash` => `{"code"=>"hi emily", :code=>"hi emily"}` just making sure that the computed attribute saves if the value is not provided.

Testing `app/models/user_identity.rb` transition:
- [ ] Open a rails console and create a new `user_identity` and test methods
```
user_identity = UserIdentity.new(
  uuid: SecureRandom.uuid,
  email: "test@example.com",
  first_name: "Jane",
  last_name: "Doe",
  loa: { current: LOA::THREE, highest: LOA::THREE },
  ssn: "123456789",
  gender: "F",
  multifactor: true,
  sign_in: { provider: "idme" }
)
```
We should get the following results for these methods that are defined in the RedisModel:
- [ ] `user_identity.valid?` => `true`
- [ ] `user_identity.errors.full_messages` => `[]` should be empty
- [ ] `user_identity.save` => `true`

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
