### PR TITLE
ActiveModel::PrettyInspect

### DIFF
--- a/lib/identity/model/inspect.rb
+++ b/lib/identity/model/inspect.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Identity
+  module Model
+    module Inspect
+      def inspect
+        return super unless respond_to?(:attribute_names)
+
+        inspection = attribute_names.map do |name|
+          "#{name}: #{public_send(name).inspect}"
+        end.join(', ')
+
+        "#<#{self.class} #{inspection}>"
+      end
+
+      def pretty_print(pp)
+        return super unless respond_to?(:attributes)
+
+        names = attributes.keys.sort
+
+        pp.object_address_group(self) do
+          pp.seplist(names, proc { pp.text ',' }) do |name|
+            val = attributes[name]
+            pp.breakable ' '
+            pp.group(1) do
+              pp.text name
+              pp.text ':'
+              pp.breakable
+              pp.pp val
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mpi/models/mvi_profile.rb
+++ b/lib/mpi/models/mvi_profile.rb
@@ -4,12 +4,14 @@ require_relative 'mvi_profile_address'
 require_relative 'mvi_profile_identity'
 require_relative 'mvi_profile_ids'
 require_relative 'mvi_profile_relationship'
+require 'identity/model/inspect'
 
 module MPI
   module Models
     class MviProfile
       include ActiveModel::Model
       include ActiveModel::Attributes
+      include Identity::Model::Inspect
       include MviProfileIdentity
       include MviProfileIds
 

--- a/lib/mpi/models/mvi_profile_address.rb
+++ b/lib/mpi/models/mvi_profile_address.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
+require 'identity/model/inspect'
+
 module MPI
   module Models
     class MviProfileAddress
       include ActiveModel::Model
       include ActiveModel::Attributes
+      include Identity::Model::Inspect
 
       attribute :street,      :string
       attribute :street2,     :string

--- a/lib/mpi/models/mvi_profile_relationship.rb
+++ b/lib/mpi/models/mvi_profile_relationship.rb
@@ -2,12 +2,14 @@
 
 require_relative 'mvi_profile_identity'
 require_relative 'mvi_profile_ids'
+require 'identity/model/inspect'
 
 module MPI
   module Models
     class MviProfileRelationship
       include ActiveModel::Model
       include ActiveModel::Attributes
+      include Identity::Model::Inspect
       include MviProfileIdentity
       include MviProfileIds
     end

--- a/spec/lib/identity/model/inspect_spec.rb
+++ b/spec/lib/identity/model/inspect_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'identity/model/inspect'
+
+class TestInspect
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include Identity::Model::Inspect
+
+  attribute :attr1, :string
+  attribute :attr2, :integer
+  attribute :attr3, :boolean
+  attribute :attr4, :float
+end
+
+RSpec.describe Identity::Model::Inspect do
+  let(:model) { TestInspect.new(attr1: 'value1', attr2: 42, attr3: true, attr4: 3.14) }
+  let(:expected_inspect_output) do
+    '#<TestInspect attr1: "value1", attr2: 42, attr3: true, attr4: 3.14>'
+  end
+
+  let(:expected_pretty_print_output) do
+    /\A#<TestInspect:0x[0-9a-f]+\n\s*attr1: "value1",\n\s*attr2: 42,\n\s*attr3: true,\n\s*attr4: 3\.14>\n\z/
+  end
+
+  describe '#inspect' do
+    it 'returns a formatted string representation of the model' do
+      expect(model.inspect).to eq(expected_inspect_output)
+    end
+  end
+
+  describe '#pretty_print' do
+    it 'returns a formatted string representation of the model' do
+      output = StringIO.new
+      PP.pp(model, output)
+      expect(output.string).to match(expected_pretty_print_output)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Create  `inspect` and `pretty_print` for `ActiveModel` objects
- Mimic ActiveRecord functions

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/478

## Testing 
- Test with MPI Profile Object
```ruby
MPI::Service.new.find_profile_by_identifier(identifier: some_icn, identifier_type: MPI::Constants::ICN)&.profile
```
This should print out to the console like this:
<img width="1382" height="838" alt="Screenshot 2025-07-11 at 10 28 53 AM" src="https://github.com/user-attachments/assets/c70a78c6-a0e6-47fa-be33-7f9ecb78e71e" />


## What areas of the site does it impact?
`MPI::Models::MviProfile` console output

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
