### PR TITLE
Updating MHV Prescriptions Policy to bypass cache if it does not exist

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,8 +145,8 @@ class User < Common::RedisStore
     mpi_mhv_correlation_id if active_mhv_ids&.one?
   end
 
-  def mhv_user_account
-    @mhv_user_account ||= MHV::UserAccount::Creator.new(user_verification:, from_cache_only: true).perform
+  def mhv_user_account(from_cache_only: true)
+    @mhv_user_account ||= MHV::UserAccount::Creator.new(user_verification:, from_cache_only:).perform
   rescue => e
     log_mhv_user_account_error(e.message)
     nil

--- a/app/policies/mhv_prescriptions_policy.rb
+++ b/app/policies/mhv_prescriptions_policy.rb
@@ -7,13 +7,17 @@ MHVPrescriptionsPolicy = Struct.new(:user, :mhv_prescriptions) do
 
   def access?
     if Flipper.enabled?(:mhv_medications_new_policy, user)
-      user.mhv_user_account&.patient || user.mhv_user_account&.champ_va
+      user.loa3? && (mhv_user_account&.patient || mhv_user_account&.champ_va)
     else
       default_access_check
     end
   end
 
   private
+
+  def mhv_user_account
+    user.mhv_user_account(from_cache_only: false)
+  end
 
   def default_access_check
     service_name = user.identity.sign_in[:service_name]

--- a/spec/policies/mhv_prescriptions_policy_spec.rb
+++ b/spec/policies/mhv_prescriptions_policy_spec.rb
@@ -4,26 +4,25 @@ require 'rails_helper'
 require 'flipper'
 require 'ostruct'
 require 'mhv_prescriptions_policy'
+require 'mhv/account_creation/service'
 
 describe MHVPrescriptionsPolicy do
   let(:mhv_prescriptions) { double('mhv_prescriptions') }
-  let(:user) do
-    u = OpenStruct.new(
-      mhv_user_account: OpenStruct.new(patient: true, champ_va: true),
-      mhv_account_type: 'Premium',
-      va_patient: true,
-      va_treatment_facility_ids: ['123'],
-      mhv_correlation_id: '456',
-      identity: OpenStruct.new(sign_in: { service_name: 'idme' })
-    )
-    def u.va_patient?
-      va_patient
-    end
-    u
+  let(:mhv_response) do
+    {
+      user_profile_id: '12345678',
+      premium: true,
+      champ_va:,
+      patient:,
+      sm_account_created: true,
+      message: 'some-message'
+    }
   end
+  let(:patient) { false }
+  let(:champ_va) { false }
 
-  def set_va_patient(user, value)
-    user.va_patient = value
+  before do
+    allow_any_instance_of(MHV::AccountCreation::Service).to receive(:create_account).and_return(mhv_response)
   end
 
   context 'when Flipper flag is enabled' do
@@ -31,54 +30,125 @@ describe MHVPrescriptionsPolicy do
       allow(Flipper).to receive(:enabled?).with(:mhv_medications_new_policy, user).and_return(true)
     end
 
-    it 'returns true if user is a patient' do
-      user.mhv_user_account.champ_va = false
-      expect(described_class.new(user, mhv_prescriptions).access?).to be(true)
+    context 'and user is verified' do
+      let(:user) { create(:user, :loa3, :with_terms_of_use_agreement) }
+
+      context 'and user is a patient' do
+        let(:patient) { true }
+
+        it 'returns true' do
+          expect(described_class.new(user, mhv_prescriptions).access?).to be(true)
+        end
+      end
+
+      context 'and user is champ_va eligible' do
+        let(:champ_va) { true }
+
+        it 'returns true' do
+          expect(described_class.new(user, mhv_prescriptions).access?).to be(true)
+        end
+      end
+
+      context 'and user is not a patient or champ_va eligible' do
+        let(:patient) { false }
+        let(:champ_va) { false }
+
+        it 'returns false' do
+          expect(described_class.new(user, mhv_prescriptions).access?).to be(false)
+        end
+      end
     end
 
-    it 'returns true if user is champ_va' do
-      user.mhv_user_account.patient = false
-      expect(described_class.new(user, mhv_prescriptions).access?).to be(true)
-    end
+    context 'and user is not verified' do
+      let(:user) { create(:user, :loa1) }
 
-    it 'returns false if user is not a patient or champ_va' do
-      user.mhv_user_account.patient = false
-      user.mhv_user_account.champ_va = false
-      expect(described_class.new(user, mhv_prescriptions).access?).to be(false)
+      it 'returns false' do
+        expect(described_class.new(user, mhv_prescriptions).access?).to be(false)
+      end
     end
   end
 
   context 'when Flipper flag is disabled' do
+    let(:user) { create(:user, :loa3, :with_terms_of_use_agreement, va_patient:, authn_context:) }
+    let(:mhv_account_type) { 'some-mhv-account-type' }
+    let(:authn_context) { LOA::IDME_MHV_LOA1 }
+    let(:va_patient) { true }
+
     before do
       allow(Flipper).to receive(:enabled?).with(:mhv_medications_new_policy, user).and_return(false)
+      allow_any_instance_of(MHVAccountTypeService).to receive(:mhv_account_type).and_return(mhv_account_type)
     end
 
-    it 'returns true for Premium/Advanced account and va_patient' do
-      user.mhv_account_type = 'Premium'
-      set_va_patient(user, true)
-      expect(described_class.new(user, mhv_prescriptions).access?).to be(true)
+    context 'and user is mhv_account_type premium' do
+      let(:mhv_account_type) { 'Premium' }
+
+      context 'and user is a va patient' do
+        let(:va_patient) { true }
+
+        it 'returns true' do
+          expect(described_class.new(user, mhv_prescriptions).access?).to be(true)
+        end
+      end
+
+      context 'and user is not a va patient' do
+        let(:va_patient) { false }
+
+        context 'and user has logged in with MHV credential' do
+          let(:authn_context) { LOA::IDME_MHV_LOA1 }
+
+          it 'returns true' do
+            expect(described_class.new(user, mhv_prescriptions).access?).to be(true)
+          end
+        end
+
+        context 'and user has not logged in with MHV credential' do
+          let(:authn_context) { LOA::IDME_LOA1_VETS }
+
+          it 'returns true' do
+            expect(described_class.new(user, mhv_prescriptions).access?).to be(false)
+          end
+        end
+      end
     end
 
-    it 'returns true for Premium/Advanced account and MHV sign in' do
-      user.mhv_account_type = 'Advanced'
-      set_va_patient(user, false)
-      user.identity.sign_in[:service_name] = 'myhealthevet'
-      stub_const('SignIn::Constants::Auth::MHV', 'myhealthevet')
-      expect(described_class.new(user, mhv_prescriptions).access?).to be(true)
+    context 'and user is mhv_account_type advanced' do
+      let(:mhv_account_type) { 'Advanced' }
+
+      context 'and user is a va patient' do
+        let(:va_patient) { true }
+
+        it 'returns true' do
+          expect(described_class.new(user, mhv_prescriptions).access?).to be(true)
+        end
+      end
+
+      context 'and user is not a va patient' do
+        let(:va_patient) { false }
+
+        context 'and user has logged in with MHV credential' do
+          let(:authn_context) { LOA::IDME_MHV_LOA1 }
+
+          it 'returns true' do
+            expect(described_class.new(user, mhv_prescriptions).access?).to be(true)
+          end
+        end
+
+        context 'and user has not logged in with MHV credential' do
+          let(:authn_context) { LOA::IDME_LOA1_VETS }
+
+          it 'returns true' do
+            expect(described_class.new(user, mhv_prescriptions).access?).to be(false)
+          end
+        end
+      end
     end
 
-    it 'returns false for Basic account' do
-      user.mhv_account_type = 'Basic'
-      set_va_patient(user, true)
-      expect(described_class.new(user, mhv_prescriptions).access?).to be(false)
-    end
+    context 'and user mhv_account_type is arbitrary' do
+      let(:mhv_account_type) { 'some-mhv-account-type' }
 
-    it 'returns false for Premium/Advanced account but not va_patient and not MHV sign in' do
-      user.mhv_account_type = 'Premium'
-      set_va_patient(user, false)
-      user.identity.sign_in[:service_name] = 'idme'
-      stub_const('SignIn::Constants::Auth::MHV', 'myhealthevet')
-      expect(described_class.new(user, mhv_prescriptions).access?).to be(false)
+      it 'returns false' do
+        expect(described_class.new(user, mhv_prescriptions).access?).to be(false)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- This PR updates the MHV Prescriptions Policy so that it will call out to MHV Account Creation API if the cached response does not already exist

## Testing done

- [ ] Logged in and noted ICN I logged in with
- [ ] Delete MHV Account Creation API cached record in rails console with `Rails.cache.destroy('mhv_account_creation_<my_icn>')`
- [ ] Refreshed page and confirmed MHV Account Creation API was called on the backend, and a new response was generated and cached

## What areas of the site does it impact?
MHV Services

## Acceptance criteria

- [ ] Logged in and note ICN 
- [ ] Delete MHV Account Creation API cached record in rails console with `Rails.cache.destroy('mhv_account_creation_<my_icn>')`
- [ ] Refresh page and confirm MHV Account Creation API is called, confirm prescriptions service authorization is responding as expected