### PR TITLE
[Event Bus Gateway]: VA Notify callback failures are not silent

### DIFF
--- a/app/sidekiq/event_bus_gateway/va_notify_email_status_callback.rb
+++ b/app/sidekiq/event_bus_gateway/va_notify_email_status_callback.rb
@@ -26,13 +26,9 @@ module EventBusGateway
       when 'delivered'
         StatsD.increment('api.vanotify.notifications.delivered')
         StatsD.increment('callbacks.event_bus_gateway.va_notify.notifications.delivered')
-        tags = ['service:event-bus-gateway', 'function: Event Bus Gateway - VA Notify decision letter ready email']
-        StatsD.increment('silent_failure_avoided', tags:)
       when 'permanent-failure'
         StatsD.increment('api.vanotify.notifications.permanent_failure')
         StatsD.increment('callbacks.event_bus_gateway.va_notify.notifications.permanent_failure')
-        tags = ['service:event-bus-gateway', 'function: Event Bus Gateway - VA Notify decision letter ready email']
-        StatsD.increment('silent_failure', tags:)
       when 'temporary-failure'
         StatsD.increment('api.vanotify.notifications.temporary_failure')
         StatsD.increment('callbacks.event_bus_gateway.va_notify.notifications.temporary_failure')

--- a/spec/sidekiq/event_bus_gateway/va_notify_email_status_callback_spec.rb
+++ b/spec/sidekiq/event_bus_gateway/va_notify_email_status_callback_spec.rb
@@ -25,10 +25,6 @@ describe EventBusGateway::VANotifyEmailStatusCallback do
               status_reason: notification_record.status_reason,
               notification_type: notification_record.notification_type }
           )
-          expect(StatsD).to have_received(:increment)
-            .with('silent_failure',
-                  tags: ['service:event-bus-gateway',
-                         'function: Event Bus Gateway - VA Notify decision letter ready email'])
           expect(StatsD).to have_received(:increment).with('api.vanotify.notifications.permanent_failure')
           expect(StatsD).to have_received(:increment)
             .with('callbacks.event_bus_gateway.va_notify.notifications.permanent_failure')
@@ -43,10 +39,6 @@ describe EventBusGateway::VANotifyEmailStatusCallback do
         it 'logs success and increments StatsD' do
           allow(StatsD).to receive(:increment)
           described_class.call(notification_record)
-          expect(StatsD).to have_received(:increment)
-            .with('silent_failure_avoided',
-                  tags: ['service:event-bus-gateway',
-                         'function: Event Bus Gateway - VA Notify decision letter ready email'])
           expect(StatsD).to have_received(:increment).with('api.vanotify.notifications.delivered')
           expect(StatsD).to have_received(:increment)
             .with('callbacks.event_bus_gateway.va_notify.notifications.delivered')


### PR DESCRIPTION
These particular emails are not prompted by any action taken by the user, they are not Silent Failures. Do not log them as such.