### PR TITLE
replace email with opaque ID

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/token_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/token_client.rb
@@ -78,7 +78,7 @@ module TravelPay
 
       {
         'iss' => host,
-        'sub' => user.email,
+        'sub' => user.user_account_uuid,
         'aud' => "#{host}/v0/sign_in/token",
         'iat' => current_time,
         'exp' => current_time + 300,

--- a/modules/travel_pay/spec/services/token_client_spec.rb
+++ b/modules/travel_pay/spec/services/token_client_spec.rb
@@ -74,7 +74,7 @@ describe TravelPay::TokenClient do
     let(:assertion) do
       {
         'iss' => 'https://www.example.com',
-        'sub' => user.email,
+        'sub' => user.user_account_uuid,
         'aud' => 'https://www.example.com/v0/sign_in/token',
         'iat' => 1_634_745_556,
         'exp' => 1_634_745_856,


### PR DESCRIPTION


## Summary
Replace user.email with user.user_account_uuid to avoid emails in datadog. Refer to https://dsva.slack.com/archives/C05UTPZRZFY/p1750263931642559 for more information.

## Related issue(s)
closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/112568

## Testing done

- [x] *New code is covered by unit tests*
