### PR TITLE
RepresentativeFormUploadConcern::attachment_guids multiform compliant

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/concerns/accredited_representative_portal/v0/representative_form_upload_concern.rb
+++ b/modules/accredited_representative_portal/app/controllers/concerns/accredited_representative_portal/v0/representative_form_upload_concern.rb
@@ -12,7 +12,7 @@ module AccreditedRepresentativePortal
         guids << submit_params[:confirmationCode] if submit_params[:confirmationCode].present?
 
         if submit_params[:supportingDocuments].is_a?(Array)
-          guids += submit_params[:supportingDocuments].map { |doc| doc[:confirmationCode] }.compact
+          guids += submit_params[:supportingDocuments].pluck(:confirmationCode).compact
         end
 
         guids
@@ -101,7 +101,7 @@ module AccreditedRepresentativePortal
           param_filters = [
             :formName,
             :confirmationCode,
-            { supportingDocuments: [:name, :confirmationCode, :size, :isEncrypted] },
+            { supportingDocuments: %i[name confirmationCode size isEncrypted] },
             { formData: [
               :veteranSsn,
               :postalCode,
@@ -132,7 +132,7 @@ module AccreditedRepresentativePortal
             param_filters = [
               :confirmation_code,
               :form_name,
-              { supporting_documents: [:name, :confirmation_code, :size, :is_encrypted] },
+              { supporting_documents: %i[name confirmation_code size is_encrypted] },
               { form_data: [
                 :veteran_ssn,
                 :postal_code,

--- a/modules/accredited_representative_portal/app/controllers/concerns/accredited_representative_portal/v0/representative_form_upload_concern.rb
+++ b/modules/accredited_representative_portal/app/controllers/concerns/accredited_representative_portal/v0/representative_form_upload_concern.rb
@@ -7,10 +7,6 @@ module AccreditedRepresentativePortal
 
       private
 
-      ##
-      # TODO: Client will need to send us multiple attachment guids for multi-
-      # form upload.
-      #
       def attachment_guids
         [submit_params[:confirmationCode]]
       end

--- a/modules/accredited_representative_portal/app/controllers/concerns/accredited_representative_portal/v0/representative_form_upload_concern.rb
+++ b/modules/accredited_representative_portal/app/controllers/concerns/accredited_representative_portal/v0/representative_form_upload_concern.rb
@@ -8,7 +8,14 @@ module AccreditedRepresentativePortal
       private
 
       def attachment_guids
-        [submit_params[:confirmationCode]]
+        guids = []
+        guids << submit_params[:confirmationCode] if submit_params[:confirmationCode].present?
+
+        if submit_params[:supportingDocuments].is_a?(Array)
+          guids += submit_params[:supportingDocuments].map { |doc| doc[:confirmationCode] }.compact
+        end
+
+        guids
       end
 
       def claimant_representative
@@ -94,6 +101,7 @@ module AccreditedRepresentativePortal
           param_filters = [
             :formName,
             :confirmationCode,
+            { supportingDocuments: [:name, :confirmationCode, :size, :isEncrypted] },
             { formData: [
               :veteranSsn,
               :postalCode,
@@ -124,6 +132,7 @@ module AccreditedRepresentativePortal
             param_filters = [
               :confirmation_code,
               :form_name,
+              { supporting_documents: [:name, :confirmation_code, :size, :is_encrypted] },
               { form_data: [
                 :veteran_ssn,
                 :postal_code,

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/representative_form_uploads_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/representative_form_uploads_spec.rb
@@ -41,7 +41,9 @@ RSpec.describe AccreditedRepresentativePortal::V0::RepresentativeFormUploadContr
 
   describe '#submit' do
     let(:attachment_guid) { '743a0ec2-6eeb-49b9-bd70-0a195b74e9f3' }
+    let(:supporting_attachment_guid) { '743a0ec2-6eeb-49b9-bd70-0a195b74e9f2' }
     let!(:attachment) { PersistentAttachments::VAForm.create!(guid: attachment_guid, form_id: '21-686c') }
+    let!(:supporting_attachment) { PersistentAttachments::VAFormDocumentation.create!(guid: supporting_attachment_guid, form_id: '21-686c') }
     let(:representative_fixture_path) do
       Rails.root.join('modules', 'accredited_representative_portal', 'spec', 'fixtures', 'form_data',
                       'representative_form_upload_21_686c.json')
@@ -49,6 +51,19 @@ RSpec.describe AccreditedRepresentativePortal::V0::RepresentativeFormUploadContr
     let(:veteran_params) do
       JSON.parse(representative_fixture_path.read).tap do |memo|
         memo['representative_form_upload']['confirmationCode'] = attachment_guid
+      end
+    end
+
+    let(:multi_form_veteran_params) do
+      JSON.parse(representative_fixture_path.read).tap do |memo|
+        memo['representative_form_upload']['confirmationCode'] = attachment_guid
+        memo['representative_form_upload']['supportingDocuments'] = [
+          { 
+            'confirmationCode' => supporting_attachment_guid,
+            'name' => 'supporting_document.pdf',
+            'size' => 12345
+          }
+        ]
       end
     end
     let(:invalid_form_fixture_path) do
@@ -116,6 +131,11 @@ RSpec.describe AccreditedRepresentativePortal::V0::RepresentativeFormUploadContr
 
       it 'makes the veteran request' do
         post('/accredited_representative_portal/v0/submit_representative_form', params: veteran_params)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'makes the veteran request with multiple attachments' do
+        post('/accredited_representative_portal/v0/submit_representative_form', params: multi_form_veteran_params)
         expect(response).to have_http_status(:ok)
       end
 

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/representative_form_uploads_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/representative_form_uploads_spec.rb
@@ -43,7 +43,9 @@ RSpec.describe AccreditedRepresentativePortal::V0::RepresentativeFormUploadContr
     let(:attachment_guid) { '743a0ec2-6eeb-49b9-bd70-0a195b74e9f3' }
     let(:supporting_attachment_guid) { '743a0ec2-6eeb-49b9-bd70-0a195b74e9f2' }
     let!(:attachment) { PersistentAttachments::VAForm.create!(guid: attachment_guid, form_id: '21-686c') }
-    let!(:supporting_attachment) { PersistentAttachments::VAFormDocumentation.create!(guid: supporting_attachment_guid, form_id: '21-686c') }
+    let!(:supporting_attachment) do
+      PersistentAttachments::VAFormDocumentation.create!(guid: supporting_attachment_guid, form_id: '21-686c')
+    end
     let(:representative_fixture_path) do
       Rails.root.join('modules', 'accredited_representative_portal', 'spec', 'fixtures', 'form_data',
                       'representative_form_upload_21_686c.json')
@@ -58,10 +60,10 @@ RSpec.describe AccreditedRepresentativePortal::V0::RepresentativeFormUploadContr
       JSON.parse(representative_fixture_path.read).tap do |memo|
         memo['representative_form_upload']['confirmationCode'] = attachment_guid
         memo['representative_form_upload']['supportingDocuments'] = [
-          { 
+          {
             'confirmationCode' => supporting_attachment_guid,
             'name' => 'supporting_document.pdf',
-            'size' => 12345
+            'size' => 12_345
           }
         ]
       end


### PR DESCRIPTION
## Summary

- We are now submitting supporting evidence with a VA Form. Our service needs to find all associated attachments based on confirmation codes. This change handles multi attachment submissions

## Related issue(s)

- Front-end pr - https://github.com/department-of-veterans-affairs/vets-website/pull/37170

## What areas of the site does it impact?
/representative/representative-form-upload

## Acceptance criteria
- [ ] I added tests for the new code
- [ ]  No error nor warning in the console