### PR TITLE
Add job schedule and rake reprocess task

### DIFF
--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -214,6 +214,8 @@ PERIODIC_JOBS = lambda { |mgr| # rubocop:disable Metrics/BlockLength
   mgr.register('0 3 * * *', 'Representatives::QueueUpdates')
   # Updates veteran organizations address attributes (including lat, long, location, address fields)
   mgr.register('0 3 * * *', 'Organizations::QueueUpdates')
+  # Updates all accredited entities (agents, attorneys, representatives, veteran service organizations)
+  mgr.register('0 4 * * *', 'RepresentationManagement::AccreditedEntitiesQueueUpdates')
 
   # Sends emails to power of attorney claimants whose request will expire in 30 days
   mgr.register('0 8 * * *', 'PowerOfAttorneyRequests::SendExpirationReminderEmailJob')

--- a/modules/representation_management/app/sidekiq/representation_management/accredited_individuals_update.rb
+++ b/modules/representation_management/app/sidekiq/representation_management/accredited_individuals_update.rb
@@ -1,0 +1,284 @@
+# frozen_string_literal: true
+
+require 'sidekiq'
+require 'va_profile/models/validation_address'
+require 'va_profile/address_validation/service'
+require 'va_profile/models/v3/validation_address'
+require 'va_profile/v3/address_validation/service'
+
+module RepresentationManagement
+  # Processes updates for AccreditedIndividual records based on provided JSON data.
+  # This class is designed to parse AccreditedIndividual data, validate addresses using an external service,
+  # and update records in the database accordingly.
+  class AccreditedIndividualsUpdate
+    include Sidekiq::Job
+
+    attr_accessor :slack_messages
+
+    def initialize
+      @slack_messages = []
+      @reps_update_data = []
+    end
+
+    # Processes each AccreditedIndividual's data provided in JSON format.
+    # This method parses the JSON, validates each AccreditedIndividual's address, and updates the database records.
+    # @param reps_json [String] JSON string containing an array of AccreditedIndividual data.
+    def perform(reps_json)
+      reps_data = JSON.parse(reps_json)
+      reps_data.each { |rep_data| process_rep_data(rep_data) }
+    rescue => e
+      log_error("Error processing job: #{e.message}", send_to_slack: true)
+    ensure
+      @slack_messages.unshift('RepresentationManagement::AccreditedIndividualsUpdate') if @slack_messages.any?
+      log_to_slack(@slack_messages.join("\n")) unless @slack_messages.empty?
+    end
+
+    private
+
+    # Processes individual AccreditedIndividual data, validates the address, and updates the record.
+    # If the address validation fails or an error occurs during the update, the error is logged and the process
+    # is halted for the current AccreditedIndividual.
+    # @param rep_data [Hash] The AccreditedIndividual data including id and address.
+    def process_rep_data(rep_data)
+      address_validation_api_response = nil
+
+      api_response = get_best_address_candidate(rep_data['address'])
+
+      # don't update the record if there is not a valid address with non-zero lat and long at this point
+      if api_response.nil?
+        return
+      else
+        address_validation_api_response = api_response
+      end
+
+      begin
+        update_rep_record(rep_data, address_validation_api_response)
+      rescue Common::Exceptions::BackendServiceException => e
+        log_error("Address validation failed for Rep id: #{rep_data['id']}: #{e.message}")
+        nil
+      rescue => e
+        log_error("Update failed for Rep id: #{rep_data['id']}: #{e.message}")
+        nil
+      end
+    end
+
+    # Constructs a validation address object from the provided address data.
+    # @param address [Hash] A hash containing the details of the AccreditedIndividual's address.
+    # @return [VAProfile::Models::ValidationAddress] A validation address object ready for address validation service.
+    def build_validation_address(address)
+      validation_model = if Flipper.enabled?(:remove_pciu)
+                           VAProfile::Models::V3::ValidationAddress
+                         else
+                           VAProfile::Models::ValidationAddress
+                         end
+
+      validation_model.new(
+        address_pou: address['address_pou'],
+        address_line1: address['address_line1'],
+        address_line2: address['address_line2'],
+        address_line3: address['address_line3'],
+        city: address['city'],
+        state_code: address['state']['state_code'],
+        zip_code: address['zip_code5'],
+        zip_code_suffix: address['zip_code4'],
+        country_code_iso3: address['country_code_iso3']
+      )
+    end
+
+    # Validates the given address using the VAProfile address validation service.
+    # @param candidate_address [VAProfile::Models::ValidationAddress] The address to be validated.
+    # @return [Hash] The response from the address validation service.
+    def validate_address(candidate_address)
+      validation_service = if Flipper.enabled?(:remove_pciu)
+                             VAProfile::V3::AddressValidation::Service.new
+                           else
+                             VAProfile::AddressValidation::Service.new
+                           end
+      validation_service.candidate(candidate_address)
+    end
+
+    # Checks if the address validation response is valid.
+    # @param response [Hash] The response from the address validation service.
+    # @return [Boolean] True if the address is valid, false otherwise.
+    def address_valid?(response)
+      response.key?('candidate_addresses') && !response['candidate_addresses'].empty?
+    end
+
+    # Updates the address record based on the rep_data and validation response.
+    # If the record cannot be found, logs an error to Datadog.
+    # @param rep_data [Hash] Original rep_data containing the address and other details.
+    # @param api_response [Hash] The response from the address validation service.
+    def update_rep_record(rep_data, api_response)
+      record =
+        AccreditedIndividual.find(rep_data['id'])
+      if record.nil?
+        raise StandardError, 'AccreditedIndividual not found.'
+      else
+        record.update(build_address_attributes(rep_data, api_response))
+      end
+    end
+
+    # Updates the given record with the new address and other relevant attributes.
+    # @param rep_data [Hash] Original rep_data containing the address and other details.
+    # @param api_response [Hash] The response from the address validation service.
+    def build_address_attributes(rep_data, api_response)
+      if Flipper.enabled?(:remove_pciu)
+        build_v3_address(api_response['candidate_addresses'].first)
+      else
+        address = api_response['candidate_addresses'].first['address']
+        geocode = api_response['candidate_addresses'].first['geocode']
+        meta = api_response['candidate_addresses'].first['address_meta_data']
+        build_address(address, geocode, meta).merge({ raw_address: rep_data['address'].to_json })
+      end
+    end
+
+    # Builds the attributes for the record update from the address, geocode, and metadata.
+    # @param address [Hash] Address details from the validation response.
+    # @param geocode [Hash] Geocode details from the validation response.
+    # @param meta [Hash] Metadata about the address from the validation response.
+    # @return [Hash] The attributes to update the record with.
+    def build_address(address, geocode, meta)
+      {
+        address_type: meta['address_type'],
+        address_line1: address['address_line1'],
+        address_line2: address['address_line2'],
+        address_line3: address['address_line3'],
+        city: address['city'],
+        province: address['state_province']['name'],
+        state_code: address['state_province']['code'],
+        zip_code: address['zip_code5'],
+        zip_suffix: address['zip_code4'],
+        country_code_iso3: address['country']['iso3_code'],
+        country_name: address['country']['name'],
+        county_name: address.dig('county', 'name'),
+        county_code: address.dig('county', 'county_fips_code'),
+        lat: geocode['latitude'],
+        long: geocode['longitude'],
+        location: "POINT(#{geocode['longitude']} #{geocode['latitude']})"
+      }
+    end
+
+    def build_v3_address(address)
+      {
+        address_type: address['address_type'],
+        address_line1: address['address_line1'],
+        address_line2: address['address_line2'],
+        address_line3: address['address_line3'],
+        city: address['city_name'],
+        province: address['state']['state_name'],
+        state_code: address['state']['state_code'],
+        zip_code: address['zip_code5'],
+        zip_suffix: address['zip_code4'],
+        country_code_iso3: address['country']['iso3_code'],
+        country_name: address['country']['country_name'],
+        county_name: address.dig('county', 'county_name'),
+        county_code: address.dig('county', 'county_code'),
+        lat: address['geocode']['latitude'],
+        long: address['geocode']['longitude'],
+        location: "POINT(#{address['geocode']['longitude']} #{address['geocode']['latitude']})"
+      }
+    end
+
+    # Logs an error to Datadog and adds an error to the array that will be logged to slack.
+    # @param error [Exception] The error string to be logged.
+    def log_error(error, send_to_slack: false)
+      message = "RepresentationManagement::AccreditedIndividualsUpdate: #{error}"
+      Rails.logger.error(message)
+      @slack_messages << "----- #{message}" if send_to_slack
+    end
+
+    # Checks if the latitude and longitude of an address are both set to zero, which are the default values
+    #   for DualAddressError warnings we see with some P.O. Box addresses the validator struggles with
+    # @param candidate_address [Hash] an address hash object returned by [VAProfile::AddressValidation::Service]
+    # @return [Boolean]
+    def lat_long_zero?(candidate_address)
+      address = candidate_address['candidate_addresses']&.first
+      return false if address.blank?
+
+      geocode = address['geocode']
+      return false if geocode.blank?
+
+      geocode['latitude']&.zero? && geocode['longitude']&.zero?
+    end
+
+    # Attempt to get valid address with non-zero coordinates by modifying the OGC address data
+    # @param address [Hash] the OGC address object
+    # @param retry_count [Integer] the current retry attempt which determines how the address object should be modified
+    # @return [Hash] the response from the address validation service
+    def modified_validation(address, retry_count)
+      address_attempt = address.dup
+      case retry_count
+      when 1 # only use the original address_line1
+      when 2 # set address_line1 to the original address_line2
+        address_attempt['address_line1'] = address['address_line2']
+      else # set address_line1 to the original address_line3
+        address_attempt['address_line1'] = address['address_line3']
+      end
+
+      address_attempt['address_line2'] = nil
+      address_attempt['address_line3'] = nil
+
+      validate_address(build_validation_address(address_attempt))
+    end
+
+    # An address validation attempt is retriable if the address is invalid OR the coordinates are zero
+    # @param response [Hash, Nil] the response from the address validation service
+    # @return [Boolean]
+    def retriable?(response)
+      return true if response.blank?
+
+      !address_valid?(response) || lat_long_zero?(response)
+    end
+
+    # Retry address validation
+    # @param rep_address [Hash] the address provided by OGC
+    # @return [Hash, Nil] the response from the address validation service
+    def retry_validation(rep_address)
+      # the address validation service requires at least one of address_line1, address_line2, and address_line3 to
+      #   exist. No need to run the retry if we know it will fail before attempting the api call.
+      api_response = modified_validation(rep_address, 1) if rep_address['address_line1'].present?
+
+      if retriable?(api_response) && rep_address['address_line2'].present?
+        api_response = modified_validation(rep_address, 2)
+      end
+
+      if retriable?(api_response) && rep_address['address_line3'].present?
+        api_response = modified_validation(rep_address, 3)
+      end
+
+      api_response
+    end
+
+    # Get the best address that the address validation api can provide with some retry logic added in
+    # @param rep_address [Hash] the address provided by OGC
+    # @return [Hash, Nil] the response from the address validation service
+    def get_best_address_candidate(rep_address)
+      candidate_address = build_validation_address(rep_address)
+      original_response = validate_address(candidate_address)
+      return nil unless address_valid?(original_response)
+
+      # retry validation if we get zero as the coordinates - this should indicate some warning with validation that
+      #   is typically seen with addresses that mix street addresses with P.O. Boxes
+      if lat_long_zero?(original_response)
+        retry_response = retry_validation(rep_address)
+
+        if retriable?(retry_response)
+          nil
+        else
+          retry_response
+        end
+      else
+        original_response
+      end
+    end
+
+    def log_to_slack(message)
+      return unless Settings.vsp_environment == 'production'
+
+      client = SlackNotify::Client.new(webhook_url: Settings.edu.slack.webhook_url,
+                                       channel: '#benefits-representation-management-notifications',
+                                       username: 'RepresentationManagement::AccreditedIndividualsUpdate Bot')
+      client.notify(message)
+    end
+  end
+end

--- a/modules/representation_management/lib/tasks/reprocess_accredited_entities.rake
+++ b/modules/representation_management/lib/tasks/reprocess_accredited_entities.rake
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+namespace :representation_management do
+  namespace :accreditation do
+    desc 'Manually reprocess specific Accredited Entity types after validation failure'
+    # Usage examples:
+    #   rails representation_management:accreditation:reprocess[agents]           # Process only claims agents
+    #   rails representation_management:accreditation:reprocess[attorneys]        # Process only attorneys
+    #   rails representation_management:accreditation:reprocess[agents,attorneys] # Process both types
+    task :reprocess, [:rep_types] => :environment do |_task, args|
+      unless args[:rep_types]
+        puts 'Error: Please specify representative types to reprocess'
+        puts 'Usage: rails representation_management:accreditation:reprocess[agents,attorneys]'
+        exit 1
+      end
+
+      rep_types = args[:rep_types].split(',').map(&:strip)
+      valid_types = %w[agents attorneys]
+
+      invalid_types = rep_types - valid_types
+      if invalid_types.any?
+        puts "Error: Invalid representative types: #{invalid_types.join(', ')}"
+        puts "Valid types are: #{valid_types.join(', ')}"
+        exit 1
+      end
+
+      puts "Starting manual reprocessing for: #{rep_types.join(', ')}"
+
+      begin
+        # Enqueue the job with force_update_types parameter
+        RepresentationManagement::AccreditedEntitiesQueueUpdates.perform_async(rep_types)
+        puts "Job enqueued successfully for #{rep_types.join(', ')}"
+        puts "Processing #{rep_types.join(', ')} will bypass count validation"
+      rescue => e
+        puts "Error scheduling reprocessing job: #{e.message}"
+        puts e.backtrace.first(10).join("\n")
+        exit 1
+      end
+    end
+  end
+end

--- a/modules/representation_management/spec/lib/tasks/reprocess_accredited_entities_rake_spec.rb
+++ b/modules/representation_management/spec/lib/tasks/reprocess_accredited_entities_rake_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'representation_management:accreditation:reprocess rake task', type: :task do
+  before do
+    # Provide both task name and directory to search
+    rake_file_path = Rails.root.join('modules', 'representation_management', 'lib', 'tasks')
+    Rake.application.rake_require('reprocess_accredited_entities', [rake_file_path])
+    Rake::Task.define_task(:environment)
+    task.reenable # Reset the task for each test
+  end
+
+  let(:task_path) { 'representation_management:accreditation:reprocess' }
+  let(:task) { Rake::Task[task_path] }
+
+  describe 'task arguments validation' do
+    it 'exits with error when no rep_types are provided' do
+      expect do
+        expect do
+          task.invoke
+        end.to output(/Error: Please specify representative types to reprocess/).to_stdout
+      end.to raise_error(SystemExit)
+    end
+
+    it 'exits with error when invalid representative types are provided' do
+      expect do
+        expect do
+          task.invoke('invalid_type')
+        end.to output(/Error: Invalid representative types: invalid_type/).to_stdout
+      end.to raise_error(SystemExit)
+    end
+
+    it 'validates multiple representative types' do
+      expect do
+        expect do
+          task.invoke('agents,invalid_type')
+        end.to output(/Error: Invalid representative types: invalid_type/).to_stdout
+      end.to raise_error(SystemExit)
+    end
+
+    it 'accepts valid representative types' do
+      valid_types = ['agents']
+
+      allow(RepresentationManagement::AccreditedEntitiesQueueUpdates).to receive(:perform_async).with(valid_types)
+
+      expect do
+        task.invoke('agents')
+      end.to output(/Starting manual reprocessing for: agents/).to_stdout
+    end
+
+    it 'accepts multiple valid representative types' do
+      valid_types = %w[agents attorneys]
+
+      allow(RepresentationManagement::AccreditedEntitiesQueueUpdates).to receive(:perform_async).with(valid_types)
+
+      expect do
+        task.invoke('agents,attorneys')
+      end.to output(/Starting manual reprocessing for: agents, attorneys/).to_stdout
+    end
+  end
+
+  describe 'job processing' do
+    it 'enqueues a job with the correct parameters for agents' do
+      expect(RepresentationManagement::AccreditedEntitiesQueueUpdates).to receive(:perform_async)
+        .with(['agents'])
+
+      expect do
+        task.invoke('agents')
+      end.to output(/Job enqueued successfully for agents/).to_stdout
+    end
+
+    it 'enqueues a job with the correct parameters for attorneys' do
+      expect(RepresentationManagement::AccreditedEntitiesQueueUpdates).to receive(:perform_async)
+        .with(['attorneys'])
+
+      expect do
+        task.invoke('attorneys')
+      end.to output(/Job enqueued successfully for attorneys/).to_stdout
+    end
+
+    it 'handles job enqueuing errors gracefully' do
+      allow(RepresentationManagement::AccreditedEntitiesQueueUpdates).to receive(:perform_async)
+        .and_raise(StandardError.new('Test error'))
+
+      expect do
+        expect do
+          task.invoke('agents')
+        end.to output(/Error scheduling reprocessing job: Test error/).to_stdout
+      end.to raise_error(SystemExit)
+    end
+  end
+
+  describe 'output messages' do
+    before do
+      allow(RepresentationManagement::AccreditedEntitiesQueueUpdates).to receive(:perform_async)
+        .with(['agents'])
+    end
+
+    it 'outputs confirmation that the job will bypass count validation' do
+      expect do
+        task.invoke('agents')
+      end.to output(/Processing agents will bypass count validation/).to_stdout
+    end
+  end
+end

--- a/modules/representation_management/spec/sidekiq/representation_management/accredited_individuals_update_spec.rb
+++ b/modules/representation_management/spec/sidekiq/representation_management/accredited_individuals_update_spec.rb
@@ -1,0 +1,745 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RepresentationManagement::AccreditedIndividualsUpdate do
+  def address_attributes
+    {
+      address_line1: '123 East Main St',
+      address_line2: 'Suite 1',
+      address_line3: 'Address Line 3',
+      city: 'My City',
+      state_code: 'ZZ',
+      zip_code: '12345',
+      zip_suffix: '6789',
+      country_code_iso3: 'USA',
+      country_name: 'United States of America',
+      province: 'A Province',
+      international_postal_code: '12345',
+      address_type: 'DOMESTIC'
+    }
+  end
+
+  def create_accredited_individual
+    create(:accredited_individual,
+           { id:,
+             first_name: 'Bob',
+             last_name: 'Law',
+             lat: '39',
+             long: '-75',
+             email: 'email@example.com',
+             location: 'POINT(-75 39)',
+             phone: '111-111-1111' }.merge(address_attributes))
+  end
+  describe '#perform' do
+    let(:json_data) do
+      [
+        {
+          id:,
+          address: {
+            address_pou: 'abc',
+            address_line1: 'abc',
+            address_line2: 'abc',
+            address_line3: 'abc',
+            city: 'abc',
+            state: {
+              state_code: 'abc'
+            },
+            zip_code5: 'abc',
+            zip_code4: 'abc',
+            country_code_iso3: 'abc'
+          },
+          email: 'test@example.com',
+          phone: '999-999-9999'
+        }
+      ].to_json
+    end
+    let(:api_response_v2) do
+      {
+        'candidate_addresses' => [
+          {
+            'address' => {
+              'county' => {
+                'name' => 'Kings',
+                'county_fips_code' => '36047'
+              },
+              'state_province' => {
+                'name' => 'New York',
+                'code' => 'NY'
+              },
+              'country' => {
+                'name' => 'United States',
+                'code' => 'USA',
+                'fips_code' => 'US',
+                'iso2_code' => 'US',
+                'iso3_code' => 'USA'
+              },
+              'address_line1' => '37N 1st St',
+              'city' => 'Brooklyn',
+              'zip_code5' => '11249',
+              'zip_code4' => '3939'
+            },
+            'geocode' => {
+              'calc_date' => '2020-01-23T03:15:47+00:00',
+              'location_precision' => 31.0,
+              'latitude' => 40.717029,
+              'longitude' => -73.964956
+            },
+            'address_meta_data' => {
+              'confidence_score' => 100.0,
+              'address_type' => 'Domestic',
+              'delivery_point_validation' => 'UNDELIVERABLE',
+              'validation_key' => -646_932_106
+            }
+          }
+        ]
+      }
+    end
+
+    before do
+      allow_any_instance_of(VAProfile::AddressValidation::Service).to receive(:candidate).and_return(api_response_v2)
+    end
+
+    context 'when JSON parsing fails' do
+      let(:invalid_json_data) { 'invalid json' }
+
+      it 'logs an error' do
+        expect(Rails.logger).to receive(:error).with(
+          'RepresentationManagement::AccreditedIndividualsUpdate: Error processing job: ' \
+          "unexpected character: 'invalid json' at line 1 column 1"
+        )
+
+        subject.perform(invalid_json_data)
+      end
+    end
+
+    context 'when the representative cannot be found' do
+      let(:id) { 'not_found' }
+
+      it 'logs an error' do
+        expect(Rails.logger).to receive(:error).with(
+          'RepresentationManagement::AccreditedIndividualsUpdate: Update failed for Rep id: not_found: ' \
+          "Couldn't find AccreditedIndividual with 'id'=not_found"
+        )
+
+        subject.perform(json_data)
+      end
+    end
+
+    context 'when changing address' do
+      let(:id) { SecureRandom.uuid }
+      let!(:representative) { create_accredited_individual }
+
+      it 'updates the address' do
+        subject.perform(json_data)
+        representative.reload
+
+        expect(representative.send('address_line1')).to eq('37N 1st St')
+      end
+    end
+
+    context 'address validation retries' do
+      let(:id) { SecureRandom.uuid }
+      let!(:representative) { create_accredited_individual }
+      let(:validation_stub) { instance_double(VAProfile::AddressValidation::Service) }
+      let(:api_response_with_zero_v2) do
+        {
+          'candidate_addresses' => [
+            {
+              'address' => {
+                'county' => {
+                  'name' => 'Kings',
+                  'county_fips_code' => '36047'
+                },
+                'state_province' => {
+                  'name' => 'New York',
+                  'code' => 'NY'
+                },
+                'country' => {
+                  'name' => 'United States',
+                  'code' => 'USA',
+                  'fips_code' => 'US',
+                  'iso2_code' => 'US',
+                  'iso3_code' => 'USA'
+                },
+                'address_line1' => '37N 1st St',
+                'city' => 'Brooklyn',
+                'zip_code5' => '11249',
+                'zip_code4' => '3939'
+              },
+              'geocode' => {
+                'calc_date' => '2020-01-23T03:15:47+00:00',
+                'location_precision' => 31.0,
+                'latitude' => 0,
+                'longitude' => 0
+              },
+              'address_meta_data' => {
+                'confidence_score' => 100.0,
+                'address_type' => 'Domestic',
+                'delivery_point_validation' => 'UNDELIVERABLE',
+                'validation_key' => -646_932_106
+              }
+            }
+          ]
+        }
+      end
+      let(:api_response1_v2) do
+        {
+          'candidate_addresses' => [
+            {
+              'address' => {
+                'county' => {
+                  'name' => 'Kings',
+                  'county_fips_code' => '36047'
+                },
+                'state_province' => {
+                  'name' => 'New York',
+                  'code' => 'NY'
+                },
+                'country' => {
+                  'name' => 'United States',
+                  'code' => 'USA',
+                  'fips_code' => 'US',
+                  'iso2_code' => 'US',
+                  'iso3_code' => 'USA'
+                },
+                'address_line1' => '37N 1st St',
+                'city' => 'Brooklyn',
+                'zip_code5' => '11249',
+                'zip_code4' => '3939'
+              },
+              'geocode' => {
+                'calc_date' => '2020-01-23T03:15:47+00:00',
+                'location_precision' => 31.0,
+                'latitude' => 40.717029,
+                'longitude' => -73.964956
+              },
+              'address_meta_data' => {
+                'confidence_score' => 100.0,
+                'address_type' => 'Domestic',
+                'delivery_point_validation' => 'UNDELIVERABLE',
+                'validation_key' => -646_932_106
+              }
+            }
+          ]
+        }
+      end
+      let(:api_response2_v2) do
+        {
+          'candidate_addresses' => [
+            {
+              'address' => {
+                'county' => {
+                  'name' => 'Kings',
+                  'county_fips_code' => '36047'
+                },
+                'state_province' => {
+                  'name' => 'New York',
+                  'code' => 'NY'
+                },
+                'country' => {
+                  'name' => 'United States',
+                  'code' => 'USA',
+                  'fips_code' => 'US',
+                  'iso2_code' => 'US',
+                  'iso3_code' => 'USA'
+                },
+                'address_line1' => '37N 2nd St',
+                'city' => 'Brooklyn',
+                'zip_code5' => '11249',
+                'zip_code4' => '3939'
+              },
+              'geocode' => {
+                'calc_date' => '2020-01-23T03:15:47+00:00',
+                'location_precision' => 31.0,
+                'latitude' => 40.717029,
+                'longitude' => -73.964956
+              },
+              'address_meta_data' => {
+                'confidence_score' => 100.0,
+                'address_type' => 'Domestic',
+                'delivery_point_validation' => 'UNDELIVERABLE',
+                'validation_key' => -646_932_106
+              }
+            }
+          ]
+        }
+      end
+      let(:api_response3_v2) do
+        {
+          'candidate_addresses' => [
+            {
+              'address' => {
+                'county' => {
+                  'name' => 'Kings',
+                  'county_fips_code' => '36047'
+                },
+                'state_province' => {
+                  'name' => 'New York',
+                  'code' => 'NY'
+                },
+                'country' => {
+                  'name' => 'United States',
+                  'code' => 'USA',
+                  'fips_code' => 'US',
+                  'iso2_code' => 'US',
+                  'iso3_code' => 'USA'
+                },
+                'address_line1' => '37N 3rd St',
+                'city' => 'Brooklyn',
+                'zip_code5' => '11249',
+                'zip_code4' => '3939'
+              },
+              'geocode' => {
+                'calc_date' => '2020-01-23T03:15:47+00:00',
+                'location_precision' => 31.0,
+                'latitude' => 40.717029,
+                'longitude' => -73.964956
+              },
+              'address_meta_data' => {
+                'confidence_score' => 100.0,
+                'address_type' => 'Domestic',
+                'delivery_point_validation' => 'UNDELIVERABLE',
+                'validation_key' => -646_932_106
+              }
+            }
+          ]
+        }
+      end
+
+      context 'when the first retry has non-zero coordinates' do
+        before do
+          allow(VAProfile::AddressValidation::Service).to receive(:new).and_return(validation_stub)
+          allow(validation_stub).to receive(:candidate).and_return(api_response_with_zero_v2, api_response1_v2)
+        end
+
+        it 'does not update the representative address' do
+          expect(representative.lat).to eq(39)
+          expect(representative.long).to eq(-75)
+          expect(representative.address_line1).to eq('123 East Main St')
+
+          subject.perform(json_data)
+          representative.reload
+
+          expect(representative.lat).to eq(40.717029)
+          expect(representative.long).to eq(-73.964956)
+          expect(representative.address_line1).to eq('37N 1st St')
+        end
+      end
+
+      context 'when the second retry has non-zero coordinates' do
+        before do
+          allow(VAProfile::AddressValidation::Service).to receive(:new).and_return(validation_stub)
+          allow(validation_stub).to receive(:candidate).and_return(api_response_with_zero_v2, api_response_with_zero_v2,
+                                                                   api_response2_v2)
+        end
+
+        it 'does not update the representative address' do
+          expect(representative.lat).to eq(39)
+          expect(representative.long).to eq(-75)
+          expect(representative.address_line1).to eq('123 East Main St')
+
+          subject.perform(json_data)
+          representative.reload
+
+          expect(representative.lat).to eq(40.717029)
+          expect(representative.long).to eq(-73.964956)
+          expect(representative.address_line1).to eq('37N 2nd St')
+        end
+      end
+
+      context 'when the third retry has non-zero coordinates' do
+        before do
+          allow(VAProfile::AddressValidation::Service).to receive(:new).and_return(validation_stub)
+          allow(validation_stub).to receive(:candidate).and_return(api_response_with_zero_v2, api_response_with_zero_v2,
+                                                                   api_response_with_zero_v2, api_response3_v2)
+        end
+
+        it 'updates the representative address' do
+          expect(representative.lat).to eq(39)
+          expect(representative.long).to eq(-75)
+          expect(representative.address_line1).to eq('123 East Main St')
+
+          subject.perform(json_data)
+          representative.reload
+
+          expect(representative.lat).to eq(40.717029)
+          expect(representative.long).to eq(-73.964956)
+          expect(representative.address_line1).to eq('37N 3rd St')
+        end
+      end
+
+      context 'when the retry coordinates are all zero' do
+        before do
+          allow(VAProfile::AddressValidation::Service).to receive(:new).and_return(validation_stub)
+          allow(validation_stub).to receive(:candidate).and_return(api_response_with_zero_v2, api_response_with_zero_v2,
+                                                                   api_response_with_zero_v2, api_response_with_zero_v2)
+        end
+
+        it 'does not update the representative address' do
+          expect(representative.lat).to eq(39)
+          expect(representative.long).to eq(-75)
+          expect(representative.address_line1).to eq('123 East Main St')
+
+          subject.perform(json_data)
+          representative.reload
+
+          expect(representative.lat).to eq(39)
+          expect(representative.long).to eq(-75)
+          expect(representative.address_line1).to eq('123 East Main St')
+        end
+      end
+    end
+  end
+
+  describe 'V3/AddressValidation' do
+    def create_accredited_individual
+      create(:accredited_individual,
+             { id:,
+               first_name: 'Bob',
+               last_name: 'Law',
+               lat: '39',
+               long: '-75',
+               email: 'email@example.com',
+               location: 'POINT(-75 39)',
+               phone: '111-111-1111' }.merge(address_attributes))
+    end
+    describe '#perform V3/AddressValidation' do
+      let(:json_data) do
+        [
+          {
+            id:,
+            address: {
+              address_pou: 'abc',
+              address_line1: 'abc',
+              address_line2: 'abc',
+              address_line3: 'abc',
+              city_name: 'abc',
+              state: {
+                state_code: 'abc'
+              },
+              zip_code5: 'abc',
+              zip_code4: 'abc',
+              country_code_iso3: 'abc'
+            },
+            email: 'test@example.com',
+            phone: '999-999-9999'
+          }
+        ].to_json
+      end
+      let(:api_response_v3) do
+        {
+          'candidate_addresses' => [
+            {
+              'county' => {
+                'county_name' => 'Kings',
+                'county_code' => '36047'
+              },
+              'state' => {
+                'state_name' => 'New York',
+                'state_code' => 'NY'
+              },
+              'country' => {
+                'country_name' => 'United States',
+                'county_code_fips' => 'US',
+                'country_code_iso2' => 'US',
+                'country_code_iso3' => 'USA'
+              },
+              'address_line1' => '37N 1st St',
+              'city_name' => 'Brooklyn',
+              'zip_code5' => '11249',
+              'zip_code4' => '3939',
+              'geocode' => {
+                'calc_date' => '2020-01-23T03:15:47+00:00',
+                'location_precision' => 31.0,
+                'latitude' => 40.717029,
+                'longitude' => -73.964956
+              },
+              'confidence' => 100.0,
+              'address_type' => 'Domestic',
+              'delivery_point_validation' => 'UNDELIVERABLE'
+            }
+          ]
+        }
+      end
+
+      before do
+        validation_service = VAProfile::V3::AddressValidation::Service
+        allow(Flipper).to receive(:enabled?).with(:remove_pciu).and_return(true)
+        allow_any_instance_of(validation_service).to receive(:candidate).and_return(api_response_v3)
+      end
+
+      context 'when JSON parsing fails' do
+        let(:invalid_json_data) { 'invalid json' }
+
+        it 'logs an error' do
+          expect(Rails.logger).to receive(:error).with(
+            'RepresentationManagement::AccreditedIndividualsUpdate: Error processing job: unexpected character: ' \
+            "'invalid json' at line 1 column 1"
+          )
+
+          subject.perform(invalid_json_data)
+        end
+      end
+
+      context 'when the representative cannot be found' do
+        let(:id) { 'not_found' }
+
+        it 'logs an error' do
+          expect(Rails.logger).to receive(:error).with(
+            'RepresentationManagement::AccreditedIndividualsUpdate: Update failed for Rep id: not_found: ' \
+            "Couldn't find AccreditedIndividual with 'id'=not_found"
+          )
+
+          subject.perform(json_data)
+        end
+      end
+
+      context 'when changing the address' do
+        let(:id) { SecureRandom.uuid }
+        let!(:representative) { create_accredited_individual }
+
+        it 'updates the address' do
+          subject.perform(json_data)
+          representative.reload
+
+          expect(representative.send('address_line1')).to eq('37N 1st St')
+        end
+      end
+
+      context 'address validation retries' do
+        let(:id) { SecureRandom.uuid }
+        let!(:representative) { create_accredited_individual }
+        let(:validation_stub) { instance_double(VAProfile::V3::AddressValidation::Service) }
+        let(:api_response_with_zero_v3) do
+          {
+            'candidate_addresses' => [
+              {
+                'county' => {
+                  'county_name' => 'Kings',
+                  'county_code' => '36047'
+                },
+                'state' => {
+                  'state_name' => 'New York',
+                  'state_code' => 'NY'
+                },
+                'country' => {
+                  'country_name' => 'United States',
+                  'country_code_fips' => 'US',
+                  'country_code_iso2' => 'US',
+                  'country_code_iso3' => 'USA'
+                },
+                'address_line1' => '37N 1st St',
+                'city_name' => 'Brooklyn',
+                'zip_code5' => '11249',
+                'zip_code4' => '3939',
+                'geocode' => {
+                  'calc_date' => '2020-01-23T03:15:47+00:00',
+                  'location_precision' => 31.0,
+                  'latitude' => 0,
+                  'longitude' => 0
+                },
+                'confidence' => 100.0,
+                'address_type' => 'Domestic',
+                'delivery_point_validation' => 'UNDELIVERABLE'
+              }
+            ]
+          }
+        end
+        let(:api_response1_v3) do
+          {
+            'candidate_addresses' => [
+              {
+                'county' => {
+                  'county_name' => 'Kings',
+                  'county_code' => '36047'
+                },
+                'state' => {
+                  'state_name' => 'New York',
+                  'state_code' => 'NY'
+                },
+                'country' => {
+                  'country_name' => 'United States',
+                  'country_code_fips' => 'US',
+                  'country_code_iso2' => 'US',
+                  'country_code_iso3' => 'USA'
+                },
+                'address_line1' => '37N 1st St',
+                'city_name' => 'Brooklyn',
+                'zip_code5' => '11249',
+                'zip_code4' => '3939',
+                'geocode' => {
+                  'calc_date' => '2020-01-23T03:15:47+00:00',
+                  'location_precision' => 31.0,
+                  'latitude' => 40.717029,
+                  'longitude' => -73.964956
+                },
+                'confidence' => 100.0,
+                'address_type' => 'Domestic',
+                'delivery_point_validation' => 'UNDELIVERABLE'
+              }
+            ]
+          }
+        end
+        let(:api_response2_v3) do
+          {
+            'candidate_addresses' => [
+              {
+                'county' => {
+                  'county_name' => 'Kings',
+                  'county_code' => '36047'
+                },
+                'state' => {
+                  'state_name' => 'New York',
+                  'state_code' => 'NY'
+                },
+                'country' => {
+                  'country_name' => 'United States',
+                  'country_code_fips' => 'US',
+                  'country_code_iso2' => 'US',
+                  'country_code_iso3' => 'USA'
+                },
+                'address_line1' => '37N 2nd St',
+                'city_name' => 'Brooklyn',
+                'zip_code5' => '11249',
+                'zip_code4' => '3939',
+                'geocode' => {
+                  'calc_date' => '2020-01-23T03:15:47+00:00',
+                  'location_precision' => 31.0,
+                  'latitude' => 40.717029,
+                  'longitude' => -73.964956
+                },
+                'confidence' => 100.0,
+                'address_type' => 'Domestic',
+                'delivery_point_validation' => 'UNDELIVERABLE'
+              }
+            ]
+          }
+        end
+        let(:api_response3_v3) do
+          {
+            'candidate_addresses' => [
+              {
+                'county' => {
+                  'county_name' => 'Kings',
+                  'county_code' => '36047'
+                },
+                'state' => {
+                  'state_name' => 'New York',
+                  'state_code' => 'NY'
+                },
+                'country' => {
+                  'country_name' => 'United States',
+                  'country_code_fips' => 'US',
+                  'country_code_iso2' => 'US',
+                  'country_code_iso3' => 'USA'
+                },
+                'address_line1' => '37N 3rd St',
+                'city_name' => 'Brooklyn',
+                'zip_code5' => '11249',
+                'zip_code4' => '3939',
+                'geocode' => {
+                  'calc_date' => '2020-01-23T03:15:47+00:00',
+                  'location_precision' => 31.0,
+                  'latitude' => 40.717029,
+                  'longitude' => -73.964956
+                },
+                'confidence' => 100.0,
+                'address_type' => 'Domestic',
+                'delivery_point_validation' => 'UNDELIVERABLE'
+              }
+            ]
+          }
+        end
+
+        context 'when the first retry has non-zero coordinates' do
+          before do
+            allow(VAProfile::V3::AddressValidation::Service).to receive(:new).and_return(validation_stub)
+            allow(validation_stub).to receive(:candidate).and_return(api_response_with_zero_v3, api_response1_v3)
+          end
+
+          it 'does not update the representative address' do
+            expect(representative.lat).to eq(39)
+            expect(representative.long).to eq(-75)
+            expect(representative.address_line1).to eq('123 East Main St')
+
+            subject.perform(json_data)
+            representative.reload
+
+            expect(representative.lat).to eq(40.717029)
+            expect(representative.long).to eq(-73.964956)
+            expect(representative.address_line1).to eq('37N 1st St')
+          end
+        end
+
+        context 'when the second retry has non-zero coordinates' do
+          before do
+            allow(VAProfile::V3::AddressValidation::Service).to receive(:new).and_return(validation_stub)
+            allow(validation_stub).to receive(:candidate).and_return(api_response_with_zero_v3,
+                                                                     api_response_with_zero_v3,
+                                                                     api_response2_v3)
+          end
+
+          it 'does not update the representative address' do
+            expect(representative.lat).to eq(39)
+            expect(representative.long).to eq(-75)
+            expect(representative.address_line1).to eq('123 East Main St')
+
+            subject.perform(json_data)
+            representative.reload
+
+            expect(representative.lat).to eq(40.717029)
+            expect(representative.long).to eq(-73.964956)
+            expect(representative.address_line1).to eq('37N 2nd St')
+          end
+        end
+
+        context 'when the third retry has non-zero coordinates' do
+          before do
+            allow(VAProfile::V3::AddressValidation::Service).to receive(:new).and_return(validation_stub)
+            allow(validation_stub).to receive(:candidate).and_return(api_response_with_zero_v3,
+                                                                     api_response_with_zero_v3,
+                                                                     api_response_with_zero_v3,
+                                                                     api_response3_v3)
+          end
+
+          it 'updates the representative address' do
+            expect(representative.lat).to eq(39)
+            expect(representative.long).to eq(-75)
+            expect(representative.address_line1).to eq('123 East Main St')
+
+            subject.perform(json_data)
+            representative.reload
+
+            expect(representative.lat).to eq(40.717029)
+            expect(representative.long).to eq(-73.964956)
+            expect(representative.address_line1).to eq('37N 3rd St')
+          end
+        end
+
+        context 'when the retry coordinates are all zero' do
+          before do
+            allow(VAProfile::V3::AddressValidation::Service).to receive(:new).and_return(validation_stub)
+            allow(validation_stub).to receive(:candidate).and_return(api_response_with_zero_v3,
+                                                                     api_response_with_zero_v3,
+                                                                     api_response_with_zero_v3,
+                                                                     api_response_with_zero_v3)
+          end
+
+          it 'does not update the representative address' do
+            expect(representative.lat).to eq(39)
+            expect(representative.long).to eq(-75)
+            expect(representative.address_line1).to eq('123 East Main St')
+
+            subject.perform(json_data)
+            representative.reload
+
+            expect(representative.lat).to eq(39)
+            expect(representative.long).to eq(-75)
+            expect(representative.address_line1).to eq('123 East Main St')
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): YES*
- *(Summarize the changes that have been made to the platform)*: This PR contains the code to schedule the Accreditation API update job and to reprocess the job manually if needed.  There is a small change to periodic jobs to schedule the daily job, a rake task that can manually enqueue the main processing job to override the data safety measures, and a test for that task.  The biggest chunk of code is a sidekiq job that takes accredited individual data in json and uses the Address Validation API to get better addresses along with a lat/long pair we use in Find A Rep.  That job has lots of retry logic built in to try to get the (user submitted) addresses to match with a real address within their data set.
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)*: FAR/ARM.  We own the maintenance.
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/110116
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*: There was no schedule to enqueue the job or way to reprocess it manually.
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*: Run the reprocess rake task and confirm it enqueues the job.
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*: Mostly the `RepresentationManagement` module plus a small change to `peridoc_jobs`.

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
