### PR TITLE
112573: Fix incorrectly formulated BPDS request body for pension claims

### DIFF
--- a/lib/bpds/service.rb
+++ b/lib/bpds/service.rb
@@ -35,12 +35,9 @@ module BPDS
     # @return [String] The response body from the submission
     # @raise [StandardError] If an error occurs during submission.
     def submit_json(claim, participant_id = nil, file_number = nil)
-      payload = default_payload(claim)
-      payload.merge({ 'participantId' => participant_id }) if participant_id.present?
-      payload.merge({ 'fileNumber' => file_number }) if file_number.present?
+      payload = default_payload(claim, participant_id, file_number)
       response = perform(:post, '', payload.to_json, config.base_request_headers)
 
-      # TODO: store the bpds_uuid in the future
       response.body
     end
 
@@ -63,6 +60,8 @@ module BPDS
     # Generates the default payload for a given claim.
     #
     # @param claim [Object] The claim object containing the form data.
+    # @param participant_id [String, nil] The participant ID to be included in the payload (optional).
+    # @param file_number [String, nil] The file number to be included in the payload (optional).
     # @return [Hash, nil] A hash representing the default payload for the claim, or nil if the claim is nil.
     #
     # The returned hash has the following structure:
@@ -70,18 +69,24 @@ module BPDS
     #   'bpd' => {
     #     'sensitivityLevel' => Integer,
     #     'payloadNamespace' => String,
+    #     'participantId' => String, # Optional
+    #     'fileNumber' => String, # Optional
     #     'payload' => Hash
     #   }
     # }
     #
     # - 'sensitivityLevel' is currently set to 0. We may need to calculate this value in the future.
     # - 'payloadNamespace' is determined by the bpds_namespace method using the claim's form_id.
+    # - 'participantId' is included if provided, representing the participant's ID.
+    # - 'fileNumber' is included if provided, representing the participant's file number.
     # - 'payload' contains the parsed form data from the claim.
-    def default_payload(claim)
+    def default_payload(claim, participant_id = nil, file_number = nil)
       {
         'bpd' => {
           'sensitivityLevel' => 0,
           'payloadNamespace' => bpds_namespace(claim.form_id),
+          'participantId' => participant_id,
+          'fileNumber' => file_number,
           'payload' => claim.parsed_form
         }
       }

--- a/lib/bpds/service.rb
+++ b/lib/bpds/service.rb
@@ -77,8 +77,8 @@ module BPDS
     #
     # - 'sensitivityLevel' is currently set to 0. We may need to calculate this value in the future.
     # - 'payloadNamespace' is determined by the bpds_namespace method using the claim's form_id.
-    # - 'participantId' is included if provided, representing the participant's ID.
-    # - 'fileNumber' is included if provided, representing the participant's file number.
+    # - 'participantId' is included if provided, representing the user's participant ID.
+    # - 'fileNumber' is included if provided, representing the user's file number.
     # - 'payload' contains the parsed form data from the claim.
     def default_payload(claim, participant_id = nil, file_number = nil)
       {

--- a/spec/lib/bpds/service_spec.rb
+++ b/spec/lib/bpds/service_spec.rb
@@ -45,15 +45,40 @@ RSpec.describe BPDS::Service do
   end
 
   describe '#default_payload' do
-    it 'returns the default payload for a given claim' do
-      expected_payload = {
-        'bpd' => {
-          'sensitivityLevel' => 0,
-          'payloadNamespace' => "urn:vets_api:#{claim.form_id}:#{Settings.bpds.schema_version}",
-          'payload' => claim.parsed_form
+    context 'when a participant id is present' do
+      let(:participant_id) { '133663' }
+      let(:file_number) { nil }
+
+      it 'returns the default payload for a given claim with the participant id' do
+        expected_payload = {
+          'bpd' => {
+            'sensitivityLevel' => 0,
+            'payloadNamespace' => "urn:vets_api:#{claim.form_id}:#{Settings.bpds.schema_version}",
+            'participantId' => participant_id,
+            'fileNumber' => nil,
+            'payload' => claim.parsed_form
+          }
         }
-      }
-      expect(service.send(:default_payload, claim)).to eq(expected_payload)
+        expect(service.send(:default_payload, claim, participant_id, file_number)).to eq(expected_payload)
+      end
+    end
+
+    context 'when a file number is present' do
+      let(:participant_id) { nil }
+      let(:file_number) { '123456789' }
+
+      it 'returns the default payload for a given claim with the file number' do
+        expected_payload = {
+          'bpd' => {
+            'sensitivityLevel' => 0,
+            'payloadNamespace' => "urn:vets_api:#{claim.form_id}:#{Settings.bpds.schema_version}",
+            'participantId' => nil,
+            'fileNumber' => file_number,
+            'payload' => claim.parsed_form
+          }
+        }
+        expect(service.send(:default_payload, claim, participant_id, file_number)).to eq(expected_payload)
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES* `bpds_service_enabled`
- This updates the POST request body being sent to BPDS being incorrectly generated
- The bugs were that participant id and file number were added at the root level instead of in the `bpd` element, and the `.merge` calls were not changing the payload in-place so the final submitted payload wasn't including any identifier fields
- Owned by Pension Benefits team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/112573
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/109911

## Testing done

- [x] *New code is covered by unit tests*
- Tested manually locally and on staging

## What areas of the site does it impact?
* Requests to BPDS from the Pension ClaimsController

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
