### PR TITLE
VEBT-2000b - fix linting related typo

### DIFF
--- a/modules/vye/spec/controllers/vye/v1/pending_verification_scenarios/verifications_controller_implied_aed_spec.rb
+++ b/modules/vye/spec/controllers/vye/v1/pending_verification_scenarios/verifications_controller_implied_aed_spec.rb
@@ -45,13 +45,13 @@ RSpec.describe Vye::V1::VerificationsController, type: :controller do
         setup_award(award_begin_date: award_begin_date_2, award_end_date: award_end_date_2, payment_date:)
       end
 
-      # rubocop:disable Rspec/NoExpectationExample
+      # rubocop:disable RSpec/NoExpectationExample
       it 'creates a pending verification for the 1st row with an act end of 3/14' do
         Timecop.freeze(run_date) { subject.create }
         pv = Vye::Verification.first
         check_expectations_for(pv, award_begin_date, Date.new(2025, 3, 14), Date.new(2025, 4, 1), 'case5')
       end
-      # rubocop:enable Rspec/NoExpectationExample
+      # rubocop:enable RSpec/NoExpectationExample
     end
     # rubocop:enable Naming/VariableNumber
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- fix a typo in linting related command
- throws warning in CI
- fix typo
- VEBT

## Related issue(s)

- [VEBT-2000](https://devops.jira.va.gov/browse/VEBT-2000)

related Slack thread:
https://dsva.slack.com/archives/CE4304QPK/p1750695537150759

## Testing done

- [x] *New code is covered by unit tests*
- throws warning in CI
- to verify, check that it no longer throws a warning in CI

## What areas of the site does it impact?
vets-api CI

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

