### PR TITLE
111669 updated telehealth modality

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -944,7 +944,8 @@ module VAOS
         elsif %w[MOBILE_ANY ADHOC].include?(vvs_kind)
           'vaVideoCareAtHome'
         elsif vvs_kind.nil?
-          'vaInPerson'
+          vvs_video_appt = appointment.dig(:extension, :vvs_vista_video_appt)
+          vvs_video_appt == 'true' ? 'vaVideoCareAtHome' : 'vaInPerson'
         end
       end
 

--- a/modules/vaos/spec/factories/v2/appointment_forms.rb
+++ b/modules/vaos/spec/factories/v2/appointment_forms.rb
@@ -369,5 +369,25 @@ FactoryBot.define do
         }
       end
     end
+
+    trait :vistaVideoTrue do
+      va_proposed_base
+      telehealth
+      extension do
+        {
+          vvs_vista_video_appt: 'true'
+        }
+      end
+    end
+
+    trait :vistaVideoFalse do
+      va_proposed_base
+      telehealth
+      extension do
+        {
+          vvs_vista_video_appt: 'false'
+        }
+      end
+    end
   end
 end

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -2331,7 +2331,7 @@ describe VAOS::V2::AppointmentsService do
     end
 
     it 'is vaInPerson for nil vvsKind and false vvsVistaVideoAppt' do
-      appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth).attributes
+      appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth, :vistaVideoFalse).attributes
       appt[:telehealth][:vvs_kind] = nil
       subject.send(:set_modality, appt)
       expect(appt[:modality]).to eq('vaInPerson')
@@ -2345,7 +2345,7 @@ describe VAOS::V2::AppointmentsService do
     end
 
     it 'is nil for unrecognized vvsKind' do
-      appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth, :vistaVideoFalse).attributes
+      appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth).attributes
       appt[:telehealth][:vvs_kind] = 'MOBILE_GFE'
       subject.send(:set_modality, appt)
       expect(appt[:modality]).to be_nil

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -2330,15 +2330,22 @@ describe VAOS::V2::AppointmentsService do
       end
     end
 
-    it 'is vaInPerson for nil vvsKind' do
+    it 'is vaInPerson for nil vvsKind and false vvsVistaVideoAppt' do
       appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth).attributes
       appt[:telehealth][:vvs_kind] = nil
       subject.send(:set_modality, appt)
       expect(appt[:modality]).to eq('vaInPerson')
     end
 
+    it 'is vaVideoCareAtHome for nil vvsKind and true vvsVistaVideoAppt' do
+      appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth, :vistaVideoTrue).attributes
+      appt[:telehealth][:vvs_kind] = nil
+      subject.send(:set_modality, appt)
+      expect(appt[:modality]).to eq('vaVideoCareAtHome')
+    end
+
     it 'is nil for unrecognized vvsKind' do
-      appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth).attributes
+      appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth, :vistaVideoFalse).attributes
       appt[:telehealth][:vvs_kind] = 'MOBILE_GFE'
       subject.send(:set_modality, appt)
       expect(appt[:modality]).to be_nil


### PR DESCRIPTION
## Summary

- This work is to update the logic for determining telehealth modality. From the original ticket, here is the logic we now follow:
```
If appointment.kind === "telehealth" and vvsKind is not present:

Check appointment.extension.vvsVistaVideoAppt

If true, set telehealth modality to vaVideoCareAtHome.

If false, set modality to vaInPerson.

If vvsKind is present, continue using existing logic.
```

We are assuming that `vvsVistaVideoAppt` will always exist & return a boolean value

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111669

## Testing done

- Unit tests to cover new scenarios
- Regression tested
