### PR TITLE
add success logging, fix return value

### DIFF
--- a/app/services/form1010cg/service.rb
+++ b/app/services/form1010cg/service.rb
@@ -65,10 +65,7 @@ module Form1010cg
 
       result = CARMA::Client::MuleSoftClient.new.create_submission_v2(payload)
       self.class::AUDITOR.log_caregiver_request_duration(context: :process, event: :success, start_time:)
-      Rails.logger.info(
-        "[10-10CG] - CARMA submission complete; claim PDF path length: #{claim_pdf_path.length}",
-        { form: '10-10CG', claim_guid: claim.guid }
-      )
+      log_submission_complete(claim.guid, claim_pdf_path, poa_attachment_path)
 
       result
     rescue => e
@@ -161,6 +158,18 @@ module Form1010cg
     end
 
     private
+
+    def log_submission_complete(guid, claim_pdf_path, poa_attachment_path)
+      Rails.logger.info(
+        '[10-10CG] - CARMA submission complete',
+        {
+          form: '10-10CG',
+          claim_guid: guid,
+          claim_pdf_path_length: claim_pdf_path&.length,
+          poa_attachment_path_length: poa_attachment_path&.length
+        }
+      )
+    end
 
     def generate_records(claim_pdf_path, poa_attachment_path)
       [

--- a/spec/services/form1010cg/service_spec.rb
+++ b/spec/services/form1010cg/service_spec.rb
@@ -570,8 +570,8 @@ RSpec.describe Form1010cg::Service do
           { claim_guid: }
         )
         expect(Rails.logger).to receive(:info).with(
-          '[10-10CG] - CARMA submission complete; claim PDF path length: 68',
-          { form: '10-10CG', claim_guid: }
+          '[10-10CG] - CARMA submission complete',
+          { form: '10-10CG', claim_guid:, claim_pdf_path_length: 68, poa_attachment_path_length: nil }
         )
 
         response = subject


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Add logging of PDF directory on success
- Return CARMA response value instead of Auditor duration result
- Health Enrollment 10-10EZ/CG

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101080

## Testing done

- [x] *New code is covered by unit tests*
- Before: succeed silently, mistakenly return Logger Duration object instead of CARMA response
- After: log to Datadog on success, and return CARMA's response value

## What areas of the site does it impact?
Health Enrollment 10-10CG form

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
