### PR TITLE
[111946] adds email index to tud_accounts

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_18_203044) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_24_162553) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -1618,6 +1618,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_18_203044) do
     t.uuid "logingov_uuid"
     t.text "id_types", default: [], array: true
     t.uuid "user_account_id"
+    t.index ["email"], name: "index_test_user_dashboard_tud_accounts_on_email", unique: true
     t.index ["user_account_id"], name: "index_test_user_dashboard_tud_accounts_on_user_account_id"
   end
 

--- a/modules/test_user_dashboard/db/migrate/20250624162553_add_index_to_tud_account_emails.rb
+++ b/modules/test_user_dashboard/db/migrate/20250624162553_add_index_to_tud_account_emails.rb
@@ -1,7 +1,11 @@
 class AddIndexToTudAccountEmails < ActiveRecord::Migration[7.2]
   disable_ddl_transaction!
 
-  def change
+  def up
     add_index :test_user_dashboard_tud_accounts, :email, unique: true, algorithm: :concurrently, name: 'index_test_user_dashboard_tud_accounts_on_email'
+  end
+
+  def down
+    remove_index :test_user_dashboard_tud_accounts, name: 'index_test_user_dashboard_tud_accounts_on_email'
   end
 end

--- a/modules/test_user_dashboard/db/migrate/20250624162553_add_index_to_tud_account_emails.rb
+++ b/modules/test_user_dashboard/db/migrate/20250624162553_add_index_to_tud_account_emails.rb
@@ -1,0 +1,7 @@
+class AddIndexToTudAccountEmails < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :test_user_dashboard_tud_accounts, :email, unique: true, algorithm: :concurrently, name: 'index_test_user_dashboard_tud_accounts_on_email'
+  end
+end


### PR DESCRIPTION
## Summary

- adds `email` index to `test_user_dashboard_tud_accounts` table.
- necessary for TUD `email` uniqueness validation to be Rubocop-compliant.

## Related issue(s)

- TUD rubocop update: https://github.com/department-of-veterans-affairs/vets-api/pull/22842
- https://github.com/orgs/department-of-veterans-affairs/projects/1646/views/2?filterQuery=label%3Abackend+-status%3AINTAKE%2CDiscovery%2C%22Shape+Work+%26+Prioritize%22%2CDesign%2C%22Active+Research%22%2C%22Super+Epics%22%2CEpics%2C%22Launch+%26+Monitor%22%2C%22Discover+%26+Define%22%2C%22Deliver%21+Iterate%21%22+type%3ATask+assignee%3A%40me&pane=issue&itemId=115002077&issue=department-of-veterans-affairs%7Cva.gov-team%7C111946
