### PR TITLE
[111946] removes unused columns

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -392,10 +392,6 @@ Naming/PredicatePrefix:
     - app/models/concerns/kms_encrypted_model_patch.rb
     - app/models/preneeds/burial_form.rb
 
-Rails/UnusedIgnoredColumns:
-  Exclude: 
-    - modules/test_user_dashboard/app/models/test_user_dashboard/tud_account.rb
-
 Rails/InverseOf:
   Exclude:
     - modules/income_limits/app/models/std_state.rb
@@ -406,7 +402,3 @@ Rails/InverseOf:
 Lint/DuplicateMethods:
   Exclude:
     - modules/appeals_api/app/services/appeals_api/pdf_construction/supplemental_claim/v4/form_data.rb
-
-Rails/UniqueValidationWithoutIndex:
-  Exclude: 
-    - modules/test_user_dashboard/app/models/test_user_dashboard/tud_account.rb

--- a/modules/test_user_dashboard/app/models/test_user_dashboard/tud_account.rb
+++ b/modules/test_user_dashboard/app/models/test_user_dashboard/tud_account.rb
@@ -2,8 +2,6 @@
 
 module TestUserDashboard
   class TudAccount < ApplicationRecord
-    self.ignored_columns += %w[standard available account_type id_type]
-
     ID_PROVIDERS = %w[idme dslogon mhv logingov].freeze
 
     validates :first_name, :last_name, :email, :id_types, presence: true


### PR DESCRIPTION
## Summary

- removes ignored_columns for long-removed TUD database columns: `standard`, `available,` `account_type`, `id_type`.
- removed TUD files from `.rubocop.yml` ignore list.

## Related issue(s)

- TUD schema update: https://github.com/department-of-veterans-affairs/vets-api/pull/22841
- https://github.com/orgs/department-of-veterans-affairs/projects/1646/views/2?filterQuery=label%3Abackend+-status%3AINTAKE%2CDiscovery%2C%22Shape+Work+%26+Prioritize%22%2CDesign%2C%22Active+Research%22%2C%22Super+Epics%22%2CEpics%2C%22Launch+%26+Monitor%22%2C%22Discover+%26+Define%22%2C%22Deliver%21+Iterate%21%22+type%3ATask+assignee%3A%40me&pane=issue&itemId=115002077&issue=department-of-veterans-affairs%7Cva.gov-team%7C111946
