### PR TITLE
VAOS Referral appointments uses provider's appointment types

### DIFF
--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -522,7 +522,7 @@ module VAOS
           )
         end
 
-        appointment_type_id = provider.appointment_types.first.id
+        appointment_type_id = provider.appointment_types.first[:id]
         eps_provider_service.get_provider_slots(
           provider.id,
           {

--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -505,18 +505,28 @@ module VAOS
       #
       # @param referral [ReferralDetail] The referral object containing:
       #   - `provider_npi` [String] The provider's NPI.
-      #   - `appointment_type_id` [String] The appointment type.
       #   - `referral_date` [String] The earliest appointment date (ISO 8601).
       #   - `expiration_date` [String] The latest appointment date (ISO 8601).
-      # @param provider_id [String] The provider's ID.
+      # @param provider [Object] The provider object.
       #
       # @return [Array, nil] Available slots array or nil if error occurs
       #
-      def fetch_provider_slots(referral, provider_id)
+      def fetch_provider_slots(referral, provider)
+        # Validate provider appointment types data before accessing it
+        if provider.appointment_types.blank?
+          raise Common::Exceptions::BackendServiceException.new(
+            'PROVIDER_APPOINTMENT_TYPES_MISSING',
+            {},
+            502,
+            'Provider appointment types data is not available'
+          )
+        end
+
+        appointment_type_id = provider.appointment_types.first.id
         eps_provider_service.get_provider_slots(
-          provider_id,
+          provider.id,
           {
-            appointmentTypeId: referral.appointment_type_id,
+            appointmentTypeId: appointment_type_id,
             startOnOrAfter: Date.parse(referral.referral_date).to_time.utc.iso8601,
             startBefore: Date.parse(referral.expiration_date).to_time.utc.iso8601
           }
@@ -611,7 +621,6 @@ module VAOS
 
         required_attributes = {
           'provider_npi' => referral.provider_npi,
-          'appointment_type_id' => referral.appointment_type_id,
           'referral_date' => referral.referral_date,
           'expiration_date' => referral.expiration_date
         }
@@ -780,7 +789,7 @@ module VAOS
                                  address: referral.treating_facility_address)
         return { success: false, json: provider_not_found_error, status: :not_found } unless provider&.id
 
-        slots = fetch_provider_slots(referral, provider.id)
+        slots = fetch_provider_slots(referral, provider)
         draft = eps_appointment_service.create_draft_appointment(referral_id:)
         drive_time = fetch_drive_times(provider)
 

--- a/modules/vaos/app/models/ccra/referral_detail.rb
+++ b/modules/vaos/app/models/ccra/referral_detail.rb
@@ -10,7 +10,7 @@ module Ccra
                 :referring_facility_name,
                 :referring_facility_phone, :referring_facility_code,
                 :referring_facility_address, :has_appointments,
-                :referral_date, :station_id, :referral_consult_id, :appointment_type_id,
+                :referral_date, :station_id, :referral_consult_id,
                 :treating_facility_name, :treating_facility_code, :treating_facility_phone,
                 :treating_facility_address
     attr_accessor :uuid
@@ -32,9 +32,6 @@ module Ccra
       @station_id = attributes[:station_id]
       @uuid = nil # Will be set by controller
       @has_appointments = attributes[:appointments].present?
-      # NOTE: appointment_type_id defaulted to 'ov' for phase 1 implementation, needed for EPS provider
-      # slots fetching
-      @appointment_type_id = 'ov'
 
       # Parse provider and facility info
       parse_referring_facility_info(attributes[:referring_facility_info])
@@ -79,7 +76,6 @@ module Ccra
         'referral_date' => @referral_date,
         'station_id' => @station_id,
         'referral_consult_id' => @referral_consult_id,
-        'appointment_type_id' => @appointment_type_id,
         'uuid' => @uuid
       }
     end
@@ -111,7 +107,6 @@ module Ccra
       @station_id = hash['station_id']
       @has_appointments = hash['has_appointments']
       @referral_consult_id = hash['referral_consult_id']
-      @appointment_type_id = hash['appointment_type_id'] || 'ov'
       @uuid = hash['uuid']
     end
 

--- a/modules/vaos/spec/requests/vaos/v2/appointments_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/appointments_spec.rb
@@ -1240,7 +1240,6 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
         referral_number: 'ref-123',
         referral_consult_id: '123-123456',
         npi:,
-        appointment_type_id:,
         start_date:,
         end_date:,
         treating_facility_address: address
@@ -1258,7 +1257,6 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
       instance_double(Ccra::ReferralDetail,
                       provider_specialty: specialty,
                       referral_number: 'ref-123',
-                      appointment_type_id:,
                       expiration_date: end_date,
                       provider_npi: npi,
                       referral_date: start_date,
@@ -1585,7 +1583,6 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
             referral_data = {
               referral_number: 'ref-124',
               npi:,
-              appointment_type_id:,
               start_date:,
               end_date:
             }
@@ -1593,7 +1590,6 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
             # Set up the test referral for this test case
             specific_referral_detail = instance_double(Ccra::ReferralDetail,
                                                        referral_number: referral_data[:referral_number],
-                                                       appointment_type_id: referral_data[:appointment_type_id],
                                                        expiration_date: referral_data[:end_date],
                                                        provider_npi: referral_data[:npi],
                                                        referral_date: referral_data[:start_date])
@@ -1650,7 +1646,6 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
           referral_data = {
             referral_number: 'ref-126',
             npi:,
-            appointment_type_id:,
             start_date:,
             end_date:
           }
@@ -1658,7 +1653,6 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
           # Set up the test referral for this test case
           ref126_detail = instance_double(Ccra::ReferralDetail,
                                           referral_number: referral_data[:referral_number],
-                                          appointment_type_id: referral_data[:appointment_type_id],
                                           expiration_date: referral_data[:end_date],
                                           provider_npi: referral_data[:npi],
                                           referral_date: referral_data[:start_date])

--- a/modules/vaos/spec/services/ccra/redis_client_spec.rb
+++ b/modules/vaos/spec/services/ccra/redis_client_spec.rb
@@ -125,7 +125,6 @@ describe Ccra::RedisClient do
       # Parse the JSON string to verify the data
       parsed_data = JSON.parse(saved_data)
       expect(parsed_data['referral_number']).to eq(referral_number)
-      expect(parsed_data['appointment_type_id']).to eq('ov')
     end
   end
 
@@ -145,7 +144,6 @@ describe Ccra::RedisClient do
         result = subject.fetch_referral_data(id:, icn:)
         expect(result).to be_a(Ccra::ReferralDetail)
         expect(result.referral_number).to eq(referral_number)
-        expect(result.appointment_type_id).to eq('ov')
       end
     end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- The appointment type was originally hard coded to `ov` per instructions received, but it turns out that we need to get the appointment type from the provider's data itself and send it to the the slots search.
- Team: UAE Check In

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/112860

## Testing done
- [x] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
Unreleased VAOS referral appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

