### PR TITLE
Remove certificates from config factories

### DIFF
--- a/spec/factories/sign_in/client_configs.rb
+++ b/spec/factories/sign_in/client_configs.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
     authentication { SignIn::Constants::Auth::API }
     anti_csrf { false }
     pkce { true }
-    certificates { [] }
     redirect_uri { Faker::Internet.url }
     logout_redirect_uri { Faker::Internet.url }
     access_token_duration { SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES }

--- a/spec/factories/sign_in/service_account_configs.rb
+++ b/spec/factories/sign_in/service_account_configs.rb
@@ -8,7 +8,6 @@ FactoryBot.define do
     access_token_audience { SecureRandom.hex }
     access_token_duration { SignIn::Constants::ServiceAccountAccessToken::VALIDITY_LENGTH_SHORT_MINUTES }
     access_token_user_attributes { [] }
-    certificates { [] }
 
     trait :with_certificates do
       ignore do


### PR DESCRIPTION
## Summary

- Remove `certificates` from `ClientConfig` and `ServiceAccountConfig` factories
- need to remove before we drop the columns - https://github.com/department-of-veterans-affairs/vets-api/pull/22712

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-api/pull/22712

## Testing done

- specs using factories should pass

## What areas of the site does it impact
ClientConfigs, ServiceAccountConfigs

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

