### PR TITLE
Use LH claimant validation endpoint before attempting upload

### DIFF
--- a/lib/lighthouse/benefits_documents/configuration.rb
+++ b/lib/lighthouse/benefits_documents/configuration.rb
@@ -20,6 +20,7 @@ module BenefitsDocuments
     DOCUMENTS_STATUS_PATH = "#{BASE_PATH}/uploads/status".freeze
     CLAIMS_LETTERS_SEARCH_PATH = "#{BASE_PATH}/claim-letters/search".freeze
     CLAIMS_LETTER_DOWNLOAD_PATH = "#{BASE_PATH}/claim-letters/download".freeze
+    DOCUMENT_VALIDATE_CLAIMANT_PATH = "#{BASE_PATH}/validate/claimant".freeze
     TOKEN_PATH = 'oauth2/benefits-documents/system/v1/token'
     QA_TESTING_DOMAIN = Settings.lighthouse.benefits_documents.host
 
@@ -177,6 +178,31 @@ module BenefitsDocuments
         }
       }
       connection.post(CLAIMS_LETTER_DOWNLOAD_PATH, body, headers)
+    end
+
+    ##
+    # Validates that a claimant (via participant ID) can upload documents of the
+    # given document type for the provided claim ID
+    # 
+    # @return [Faraday::Response] response from POST request
+    #
+    def claimant_can_upload_document(document_data, lighthouse_client_id = nil, lighthouse_rsa_key_path = nil, options = {})
+      headers = { 'Authorization' => "Bearer #{
+          access_token(
+            lighthouse_client_id,
+            lighthouse_rsa_key_path,
+            options
+          )
+        }" }
+
+      body = {
+        'data' => {
+          'docType' => document_data.document_type,
+          'participantId' => document_data.participant_id,
+          'claimId' => document_data.claim_id
+        }
+      }
+      connection.post(DOCUMENT_VALIDATE_CLAIMANT_PATH, body, headers)
     end
 
     ##

--- a/lib/lighthouse/benefits_documents/service.rb
+++ b/lib/lighthouse/benefits_documents/service.rb
@@ -62,6 +62,12 @@ module BenefitsDocuments
       handle_error(e, nil, 'services/benefits-documents/v1/claim-letters/download')
     end
 
+    def validate_claimant_can_upload(document_data)
+      config.claimant_can_upload_document(document_data)
+    rescue Faraday::ClientError, Faraday::ServerError => e
+      handle_error(e, nil, 'services/benefits-documents/v1/documents/validate/claimant')
+    end
+
     private
 
     def submit_document(file, file_params, lighthouse_client_id = nil) # rubocop:disable Metrics/MethodLength
@@ -80,6 +86,8 @@ module BenefitsDocuments
       Rails.logger.info('participant_id present?', @user.participant_id.present?)
 
       raise Common::Exceptions::ValidationErrors, document_data unless document_data.valid?
+
+      validate_claimant_can_upload(document_data)
 
       uploader = LighthouseDocumentUploader.new(user_icn, document_data.uploader_ids)
       uploader.store!(document_data.file_obj)


### PR DESCRIPTION
There is a new `/benefits-documents/v1/documents/validate/claimant` endpoint in lighthouse [(docs here)](https://developer.va.gov/explore/api/benefits-documents/docs?version=current) that validates whether a given user can upload a file of a given doctype for a given claim.

[We are encountering an issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/111231) where people who are not authorized to upload documents -- e.g. in this instance, dependents of _living_ veterans -- are attempting uploads, having them fail, and not being shown an error message why. We'd like to make a request to that new LH endpoint before attempting the upload in order to catch this.

I'm making this PR to solicit early feedback and ensure I am following expected patterns for this sort of thing. I was considering adding this check to the validators on the `LighthouseDocument` model, but I was not sure that such an error would really belong in the same bucket as the other validations. I also didn't love having a model's validations dependent on an external service. So I defaulted to keeping it separate, but within the upload process.