### PR TITLE
Fix api_key bug in next_steps_email_controller

### DIFF
--- a/modules/representation_management/app/controllers/representation_management/v0/next_steps_email_controller.rb
+++ b/modules/representation_management/app/controllers/representation_management/v0/next_steps_email_controller.rb
@@ -18,6 +18,7 @@ module RepresentationManagement
           VANotify::EmailJob.perform_async(
             data.email_address,
             template_id,
+            nil,
             email_personalisation(data),
             email_callback_options(data)
           )

--- a/modules/representation_management/spec/requests/v0/next_steps_email_spec.rb
+++ b/modules/representation_management/spec/requests/v0/next_steps_email_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe 'NextStepsEmailController', type: :request do
         expect(VANotify::EmailJob).to receive(:perform_async).with(
           params[:next_steps_email][:email_address],
           'appoint_a_representative_confirmation_email_template_id', # This is the actual value from the settings file
+          nil,
           {
             # The first_name is the only key here that has an underscore.
             # That is intentional.  All the keys here match the keys in the
@@ -70,6 +71,7 @@ RSpec.describe 'NextStepsEmailController', type: :request do
         expect(VANotify::EmailJob).to receive(:perform_async).with(
           params[:next_steps_email][:email_address],
           'appoint_a_representative_confirmation_email_template_id',
+          nil,
           {
             'first_name' => 'First',
             'form name' => 'Form Name',


### PR DESCRIPTION
## Summary

- Updated the `NextStepsEmailController#create` method to correctly pass `callback_options` to `VANotify::EmailJob` by explicitly inserting `nil` for the `api_key` argument, ensuring the callback lands in the correct fifth parameter slot.
- *If bug, how to reproduce*: When the `accredited_representative_portal_email_delivery_callback` Flipper flag is enabled, callback metadata was being silently ignored because it was incorrectly passed as the fourth argument (`api_key`) instead of the fifth (`callback_options`).
- *What is the solution, why is this the solution?*: The fix explicitly passes `nil` for the `api_key` argument to preserve argument order, allowing `callback_options` to be properly received and logged by the job. This ensures reliable handling of email delivery status tracking.
- *Which team do you work for, does your team own the maintenance of this component?*: FAR, no.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/106452

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
