### PR TITLE
[Income & Assets] change feature toggle to correct one

### DIFF
--- a/modules/income_and_assets/app/controllers/income_and_assets/v0/claims_controller.rb
+++ b/modules/income_and_assets/app/controllers/income_and_assets/v0/claims_controller.rb
@@ -73,7 +73,7 @@ module IncomeAndAssets
       def process_and_upload_to_lighthouse(in_progress_form, claim)
         claim.process_attachments!
 
-        IncomeAndAssets::BenefitsIntake::SubmitClaimJob.perform(claim.id, current_user&.user_account_uuid)
+        IncomeAndAssets::BenefitsIntake::SubmitClaimJob.perform_async(claim.id, current_user&.user_account_uuid)
       rescue => e
         monitor.track_process_attachment_error(in_progress_form, claim, current_user)
         raise e


### PR DESCRIPTION
## Summary
The controller actions are behind a `before_action` that checks if a particular feature toggle is enabled. We are using the wrong feature toggle, so updating the controller to use the correct one. Also fixing an issue where we are passing the ID of an in progress form instead of the whole thing, which is not expected by the code

- *This work is behind a feature toggle (flipper): YES*
- *(Summarize the changes that have been made to the platform)*
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)*
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/112763

## Testing done
Tests still pass

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
