### PR TITLE
[324] removes account from user serialization

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -9,7 +9,7 @@ class UserSerializer
 
   set_id { '' }
 
-  attributes :services, :user_account, :account, :profile, :va_profile, :veteran_status,
+  attributes :services, :user_account, :profile, :va_profile, :veteran_status,
              :in_progress_forms, :prefills_available, :vet360_contact_information,
              :session, :onboarding
 end

--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -46,7 +46,6 @@ module Users
 
     def fetch_and_serialize_profile
       scaffold.user_account = user_account
-      scaffold.account = account
       scaffold.profile = profile
       scaffold.vet360_contact_information = vet360_contact_information
       scaffold.va_profile = mpi_profile
@@ -62,13 +61,6 @@ module Users
       { id: user.user_account_uuid }
     rescue => e
       scaffold.errors << Users::ExceptionHandler.new(e, 'UserAccount').serialize_error
-      nil
-    end
-
-    def account
-      { account_uuid: user.user_account_uuid }
-    rescue => e
-      scaffold.errors << Users::ExceptionHandler.new(e, 'Account').serialize_error
       nil
     end
 

--- a/app/services/users/scaffold.rb
+++ b/app/services/users/scaffold.rb
@@ -8,7 +8,7 @@ module Users
   # and `status` second.
   #
   # rubocop:disable Style/StructInheritance
-  class Scaffold < Struct.new(:errors, :status, :services, :user_account, :account, :profile, :va_profile,
+  class Scaffold < Struct.new(:errors, :status, :services, :user_account, :profile, :va_profile,
                               :veteran_status, :in_progress_forms, :prefills_available, :vet360_contact_information,
                               :session, :onboarding)
   end

--- a/spec/support/schemas/user_loa1.json
+++ b/spec/support/schemas/user_loa1.json
@@ -76,20 +76,6 @@
                 null
               ]
             },
-            "account": {
-              "type": "object",
-              "required": [
-                "account_uuid"
-              ],
-              "properties": {
-                "account_uuid": {
-                  "type": [
-                    "string",
-                    null
-                  ]
-                }
-              }
-            },
             "user_account": {
               "type": "object",
               "required": [

--- a/spec/support/schemas/user_loa3.json
+++ b/spec/support/schemas/user_loa3.json
@@ -80,20 +80,6 @@
                 null
               ]
             },
-            "account": {
-              "type": "object",
-              "required": [
-                "account_uuid"
-              ],
-              "properties": {
-                "account_uuid": {
-                  "type": [
-                    "string",
-                    null
-                  ]
-                }
-              }
-            },
             "user_account": {
               "type": "object",
               "required": [

--- a/spec/support/schemas_camelized/user_loa1.json
+++ b/spec/support/schemas_camelized/user_loa1.json
@@ -76,20 +76,6 @@
                 null
               ]
             },
-            "account": {
-              "type": "object",
-              "required": [
-                "accountUuid"
-              ],
-              "properties": {
-                "accountUuid": {
-                  "type": [
-                    "string",
-                    null
-                  ]
-                }
-              }
-            },
             "userAccount": {
               "type": "object",
               "required": [

--- a/spec/support/schemas_camelized/user_loa3.json
+++ b/spec/support/schemas_camelized/user_loa3.json
@@ -80,20 +80,6 @@
                 null
               ]
             },
-            "account": {
-              "type": "object",
-              "required": [
-                "accountUuid"
-              ],
-              "properties": {
-                "accountUuid": {
-                  "type": [
-                    "string",
-                    null
-                  ]
-                }
-              }
-            },
             "userAccount": {
               "type": "object",
               "required": [


### PR DESCRIPTION
## Summary

- Removes `account` from User serialization.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/324
- https://github.com/department-of-veterans-affairs/identity-documentation/issues/393

## Testing done

- [x] *New code is covered by unit tests*
- Verify `account` attribute is no longer present at `localhost:3000/v0/user`

## Screenshots
### Current serialization
![Screenshot from 2025-06-26 12-43-26](https://github.com/user-attachments/assets/eaaabf60-8cf0-45c8-97ea-02cf3e68527e)

### After change
![Screenshot from 2025-06-26 12-42-44](https://github.com/user-attachments/assets/f8fbb4cf-5580-4578-b731-c4300efcb92b)