### PR TITLE
Update appointment service to show schedule link for cc req but not cc appt

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -950,7 +950,8 @@ module VAOS
 
       # This should be called after set_type has been called
       def schedulable?(appointment)
-        return false if cerner?(appointment) || cnp?(appointment) || telehealth?(appointment) || cc?(appointment)
+        return false if cerner?(appointment) || cnp?(appointment) || telehealth?(appointment)
+        return appointment[:type] == APPOINTMENT_TYPES[:cc_request] if cc?(appointment)
         return true if appointment[:type] == APPOINTMENT_TYPES[:request]
         if appointment[:type] == APPOINTMENT_TYPES[:va] &&
            SCHEDULABLE_SERVICE_TYPES.include?(appointment[:service_type])

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -2584,11 +2584,18 @@ describe VAOS::V2::AppointmentsService do
       expect(subject.send(:schedulable?, appt)).to be(false)
     end
 
-    it 'returns false for cc appointments and requests' do
-      appt = build(:appointment_form_v2, :community_cares_base).attributes
+    it 'returns false for cc appointment' do
+      appt = build(:appointment_form_v2, :community_cares_no_request_dates).attributes
       appt[:id] = '1234'
       subject.send(:set_type, appt)
       expect(subject.send(:schedulable?, appt)).to be(false)
+    end
+
+    it 'returns true for cc request' do
+      appt = build(:appointment_form_v2, :community_cares_base).attributes
+      appt[:id] = '1234'
+      subject.send(:set_type, appt)
+      expect(subject.send(:schedulable?, appt)).to be(true)
     end
 
     it 'returns true for va requests' do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- We confirmed that we want to show schedule link for community care requests but not community care appointments so we want to update the appointments service to match this 
- Appointment FE Team

## Related issue(s)

- Pending

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
