### PR TITLE
Add Blank and Nil Checks for presence of File attachments

### DIFF
--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/inquiry_payload.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/inquiry_payload.rb
@@ -104,7 +104,9 @@ module AskVAApi
         end
 
         def list_of_attachments
-          return if inquiry_params[:files].first[:file_name].nil?
+          # To try and resolve Exception InquiriesCreatorError: undefined method `[]' for nil
+          return if inquiry_params[:files].blank?
+          return if inquiry_params[:files].first.nil? || inquiry_params[:files].first[:file_name].nil?
 
           inquiry_params[:files].map do |file|
             file_name = normalize_file_name(file[:file_name])


### PR DESCRIPTION
Datadog Stack Trace shows that the error is happening because the file structure may be nil or empty. This puts defensive checks to ensure the inquiry can proceed if there are no file attachments. This may have been preventing Inquiries from being submitted.

`AskVAApi::Inquiries::InquiriesCreatorError: InquiriesCreatorError: undefined method `[]' for nil`

## Summary

- *This work is behind a feature toggle (flipper): NO*
- *(Summarize the changes that have been made to the platform)*
   -- In ask VA, there is a `undefined method `[]' for nil` error. The source of the error points to this line.
- *(If bug, how to reproduce)* N/A
- *(What is the solution, why is this the solution?)*
   -- Added additional nil checks in the structure.
- *(Which team do you work for, does your team own the maintenance of this component?)*
   -- Watchtower
- *(If introducing a flipper, what is the success criteria being targeted?)* - N/A

## Related issue(s)
N/A

## Screenshots
![image](https://github.com/user-attachments/assets/eb90d7d0-334f-4359-ae75-cb6c81cee121)

## What areas of the site does it impact?
ASK-VA

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature