### PR TITLE
Feature toggles: ignore authentication [proof-of-concept]

### DIFF
--- a/app/controllers/concerns/authentication_and_sso_concerns.rb
+++ b/app/controllers/concerns/authentication_and_sso_concerns.rb
@@ -59,9 +59,9 @@ module AuthenticationAndSSOConcerns # rubocop:disable Metrics/ModuleLength
     @current_user.present?
   end
 
-  def load_user(skip_terms_check: false)
+  def load_user(skip_terms_check: false, skip_expiration_check: false)
     if cookies[SignIn::Constants::Auth::ACCESS_TOKEN_COOKIE_NAME]
-      super()
+      super(skip_expiration_check:)
     else
       set_session_object
       set_current_user(skip_terms_check)

--- a/app/controllers/v0/feature_toggles_controller.rb
+++ b/app/controllers/v0/feature_toggles_controller.rb
@@ -5,7 +5,12 @@ module V0
     service_tag 'feature-flag'
     # the feature toggle does not require authentication, but if a user is logged we might use @current_user
     skip_before_action :authenticate
-    before_action :load_user
+    before_action do
+      load_user(
+        skip_expiration_check: true,
+        skip_terms_check: true
+      )
+    end
 
     def index
       if params[:features].present?


### PR DESCRIPTION
Catches up feature toggles' purported lack of authentication requirement to account for modern authentication logic?