### PR TITLE
[ID-246] - Add metrics for logingov RISC events

### DIFF
--- a/app/services/sign_in/logingov/risc_event_handler.rb
+++ b/app/services/sign_in/logingov/risc_event_handler.rb
@@ -5,6 +5,8 @@ require 'sign_in/logingov/risc_event'
 module SignIn
   module Logingov
     class RiscEventHandler
+      STATSD_KEY = 'api.sign_in.logingov.risc_event'
+
       attr_reader :payload
 
       def initialize(payload:)
@@ -26,8 +28,17 @@ module SignIn
       private
 
       def handle_event(risc_event)
+        log_event(risc_event)
+        increment_metric(risc_event)
+      end
+
+      def log_event(risc_event)
         Rails.logger.info('[SignIn][Logingov][RiscEventHandler] risc_event received',
                           risc_event: risc_event.to_h_masked)
+      end
+
+      def increment_metric(risc_event)
+        StatsD.increment(STATSD_KEY, tags: ["event_type:#{risc_event.event_type}"])
       end
     end
   end


### PR DESCRIPTION
## Summary

- Add StatsD metrics for easier monitoring and anomaly detection in datadog
- Metrics are retained longer than logs which give more accurate historical trends

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/246

## Testing 
- change [lib/sign_in/logingov/service.rb#98](https://github.com/department-of-veterans-affairs/vets-api/blob/db39231d4c34167e279b71e8d45023c9c9c541c1/lib/sign_in/logingov/service.rb#L98) to:
  ```ruby
   { verify_expiration:, algorithm: config.jwt_decode_algorithm, jwks: FactoryBot.create(:logingov_risc_event_jwks) }
  ```
- Generate a JWT in the rails console -
   ```ruby
   FactoryBot.create(:logingov_risc_event_payload, :encoded)
   ```
- start rails server and make request with the JWT in the body
   ```bash
   curl --request POST \
  --url http://localhost:3000/sign_in/webhooks/logingov/risc \
  --header 'accept: application/json' \
  --header 'content-type: application/secevent+jwt' \
  --data eyJ0eXAiOiJzZWNldmVudCtqd3QiLCJhbGciOiJSUzI1NiIsImtpZCI6InNvbWUta2lkIn0.eyJpc3MiOiJodHRwczovL2lkcC5pbnQuaWRlbnRpdHlzYW5kYm94LmdvdiIsImp0aSI6ImU0NjAwNjYxLWRkZDUtNDdkZS1hNGVjLTNmZWMwMjMxNTVmYyIsImlhdCI6MTc0ODYzOTY5MSwiYXVkIjoiaHR0cHM6Ly92YS5nb3YiLCJldmVudHMiOnsiaHR0cHM6Ly9zY2hlbWFzLm9wZW5pZC5uZXQvc2VjZXZlbnQvcmlzYy9ldmVudC10eXBlL2FjY291bnQtZGlzYWJsZWQiOnsic3ViamVjdCI6eyJzdWJqZWN0X3R5cGUiOiJpc3Mtc3ViIiwiaXNzIjoiaHR0cHM6Ly9pZHAuaW50LmlkZW50aXR5c2FuZGJveC5nb3YiLCJlbWFpbCI6ImNoZXJ5X2hvd2VAb2tlZWZlLnRlc3QiLCJzdWIiOiI0OWFhZTEzMy1lMjkxLTQwZWUtYjczOC0wMTY1MTg4YWZhYmIifSwicmVhc29uIjpudWxsLCJldmVudF9vY2N1cnJlZF9hdCI6bnVsbH19fQ.l1ySreGmF4XJISKCf9h7hLk3KDDkJF_53E0C98c5kmfoy1TAxEvrzZTHV36bnuR3iYOoWR_gw4zlsLW1WDYJraf3bYIEuVZ2ZZKNE49Mgr5NSDDsDqDJkGZfWqz96s8VSfMhvy8oAKmcpiaAJQhuGjaHEGPaDB_5_srbgAoLLNrlDfUrsraPPhs75LTc5lQdCkKgGJ-m-cT0598QFI90cB_46LVk2sq_iHgzRS_3D8v-or24oDIOx6NMoYI5X6EXhzdDCdg2IYzrUBZgEee9lYqFC_GDohR2FN_MrzMCppUqyiUg7Ky95LGYtrnWblFbu3VUauuaYOQKDqynaMkkBw
   ```
  - You should get a `202 Accepted` with no body
  - In `log/statsd.log` you should see a metric log like:
    ```ruby
    DEBUG -- : [StatsD] api_sign_in_logingov_risc_event:1|c|#event_type:account_disabled
    ```

## What areas of the site does it impact?
logingov RISC event

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
