### PR TITLE
Update outgoing error message and metrics tags for CC appts

### DIFF
--- a/modules/vaos/app/controllers/vaos/v2/eps_appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/eps_appointments_controller.rb
@@ -6,7 +6,6 @@ module VAOS
       STATSD_KEY = 'api.vaos.eps_appointment_detail.access'
 
       def show
-        StatsD.increment(STATSD_KEY, tags: ['Community Care Appointments'])
 
         appointment = appointment_service.get_appointment(
           appointment_id: eps_appointment_id,
@@ -14,6 +13,7 @@ module VAOS
         )
 
         response_object = assemble_appt_response_object(appointment)
+        StatsD.increment(STATSD_KEY, tags: ['Community Care Appointments'])
         render json: response_object
       end
 

--- a/modules/vaos/app/controllers/vaos/v2/eps_appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/eps_appointments_controller.rb
@@ -3,7 +3,11 @@
 module VAOS
   module V2
     class EpsAppointmentsController < VAOS::BaseController
+      STATSD_KEY = 'api.vaos.eps_appointment_detail.access'
+
       def show
+        StatsD.increment(STATSD_KEY, tags: ['Community Care Appointments'])
+
         appointment = appointment_service.get_appointment(
           appointment_id: eps_appointment_id,
           retrieve_latest_details: true

--- a/modules/vaos/app/controllers/vaos/v2/eps_appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/eps_appointments_controller.rb
@@ -6,7 +6,6 @@ module VAOS
       STATSD_KEY = 'api.vaos.eps_appointment_detail.access'
 
       def show
-
         appointment = appointment_service.get_appointment(
           appointment_id: eps_appointment_id,
           retrieve_latest_details: true

--- a/modules/vaos/app/services/eps/appointment_service.rb
+++ b/modules/vaos/app/services/eps/appointment_service.rb
@@ -95,7 +95,7 @@ module Eps
       redis_client.store_appointment_data(
         uuid: user.uuid,
         appointment_id:,
-        email: user.va_profile_email
+        email: user.email
       )
 
       # Enqueue worker with UUID and last 4 of appointment_id

--- a/modules/vaos/app/services/eps/appointment_status_notification_callback.rb
+++ b/modules/vaos/app/services/eps/appointment_status_notification_callback.rb
@@ -8,6 +8,11 @@ module Eps
   # through StatsD metrics and structured logging.
   class AppointmentStatusNotificationCallback
     STATSD_KEY = 'api.vaos.appointment_status_notification'
+    STATSD_NOTIFY_SILENT_FAILURE = 'silent_failure'
+    STATSD_CC_SILENT_FAILURE_TAGS = [
+      'service:vaos',
+      'function: Community Care Appointment Status Notification Failure'
+    ].freeze
     FAILURE_STATUSES = %w[permanent-failure temporary-failure technical-failure].freeze
     FAILURE_TYPE_MAP = {
       'permanent-failure' => 'permanent',
@@ -95,6 +100,7 @@ module Eps
     # @return [void]
     def self.handle_failure(notification, base_data)
       StatsD.increment("#{STATSD_KEY}.failure", tags: ['Community Care Appointments'])
+      StatsD.increment(STATSD_NOTIFY_SILENT_FAILURE, tags: STATSD_CC_SILENT_FAILURE_TAGS)
 
       failure_type = FAILURE_TYPE_MAP[notification.status&.downcase] || 'unknown'
       failure_data = base_data.merge(

--- a/modules/vaos/app/sidekiq/eps/appointment_status_email_job.rb
+++ b/modules/vaos/app/sidekiq/eps/appointment_status_email_job.rb
@@ -22,6 +22,11 @@ module Eps
     # is back up.
     sidekiq_options retry: 14
     STATSD_KEY = 'api.vaos.appointment_status_email_job'
+    STATSD_NOTIFY_SILENT_FAILURE = 'silent_failure'
+    STATSD_CC_SILENT_FAILURE_TAGS = [
+      'service:vaos',
+      'function: Community Care Appointment Status Notification Failure'
+    ].freeze
 
     ##
     # Main job execution method that processes appointment status email notifications.
@@ -87,6 +92,7 @@ module Eps
       if permanent
         StatsD.increment("#{STATSD_KEY}.failure",
                          tags: ["user_uuid:#{user_uuid}", "appointment_id_last4:#{appointment_id_last4}"])
+        StatsD.increment(STATSD_NOTIFY_SILENT_FAILURE, tags: STATSD_CC_SILENT_FAILURE_TAGS)
       else
         raise error
       end

--- a/modules/vaos/app/sidekiq/eps/appointment_status_email_job.rb
+++ b/modules/vaos/app/sidekiq/eps/appointment_status_email_job.rb
@@ -90,8 +90,7 @@ module Eps
       )
 
       if permanent
-        StatsD.increment("#{STATSD_KEY}.failure",
-                         tags: ["user_uuid:#{user_uuid}", "appointment_id_last4:#{appointment_id_last4}"])
+        StatsD.increment("#{STATSD_KEY}.failure", tags: ['Community Care Appointments'])
         StatsD.increment(STATSD_NOTIFY_SILENT_FAILURE, tags: STATSD_CC_SILENT_FAILURE_TAGS)
       else
         raise error

--- a/modules/vaos/app/sidekiq/eps/appointment_status_job.rb
+++ b/modules/vaos/app/sidekiq/eps/appointment_status_job.rb
@@ -110,7 +110,7 @@ module Eps
         handle_appointment_response(response, retry_count)
       rescue
         Rails.logger.error('Community Care Appointments: EpsAppointmentJob failed to get appointment status',
-                           { user_uuid: @user_uuid, appointment_id_last4: @appointment_id_last4})
+                           { user_uuid: @user_uuid, appointment_id_last4: @appointment_id_last4 })
         StatsD.increment("#{STATSD_PREFIX}.failure", tags: ['Community Care Appointments'])
         send_vanotify_message(error: ERROR_MESSAGE)
       end

--- a/modules/vaos/app/sidekiq/eps/appointment_status_job.rb
+++ b/modules/vaos/app/sidekiq/eps/appointment_status_job.rb
@@ -23,6 +23,8 @@ module Eps
     include Sidekiq::Worker
 
     STATSD_PREFIX = 'api.vaos.appointment_status_check'
+    ERROR_MESSAGE = 'Could not verify the booking status of your submitted appointment, ' \
+                    'please contact support'
     MAX_RETRIES = 3
 
     ##
@@ -86,10 +88,7 @@ module Eps
       Rails.logger.error('Community Care Appointments: EpsAppointmentJob missing or incomplete Redis data',
                          { user_uuid: @user_uuid, appointment_id_last4: @appointment_id_last4,
                            appointment_data: }.to_json)
-      StatsD.increment("#{STATSD_PREFIX}.failure",
-                       tags: ['Community Care Appointments',
-                              "user_uuid: #{@user_uuid}",
-                              "appointment_id_last4: #{@appointment_id_last4}"])
+      StatsD.increment("#{STATSD_PREFIX}.failure", tags: ['Community Care Appointments'])
     end
 
     ##
@@ -111,11 +110,9 @@ module Eps
         handle_appointment_response(response, retry_count)
       rescue
         Rails.logger.error('Community Care Appointments: EpsAppointmentJob failed to get appointment status',
-                           { user_uuid: @user_uuid,
-                             appointment_id_last4: @appointment_id_last4,
-                             appointment_id: })
-        send_vanotify_message(error: 'Could not verify the booking status of your submitted appointment, ' \
-                                     'please contact support')
+                           { user_uuid: @user_uuid, appointment_id_last4: @appointment_id_last4})
+        StatsD.increment("#{STATSD_PREFIX}.failure", tags: ['Community Care Appointments'])
+        send_vanotify_message(error: ERROR_MESSAGE)
       end
     end
 
@@ -132,11 +129,14 @@ module Eps
     #
     def handle_appointment_response(response, retry_count)
       if appointment_finished?(response)
-        # Appointment finished successfully, do nothing
+        StatsD.increment("#{STATSD_PREFIX}.success", tags: ['Community Care Appointments'])
       elsif retry_count < MAX_RETRIES
         self.class.perform_in(1.minute, @user_uuid, @appointment_id_last4, retry_count + 1)
       else
-        send_vanotify_message(error: 'Could not complete booking')
+        StatsD.increment("#{STATSD_PREFIX}.failure", tags: ['Community Care Appointments'])
+        Rails.logger.error('Community Care Appointments: EpsAppointmentJob could not confirm appointment booking',
+                           { user_uuid: @user_uuid, appointment_id_last4: @appointment_id_last4 })
+        send_vanotify_message(error: ERROR_MESSAGE)
       end
     end
 

--- a/modules/vaos/spec/requests/vaos/v2/eps_appointments_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/eps_appointments_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe 'VAOS::V2::EpsAppointments', :skip_mvi, type: :request do
           VCR.use_cassette('vaos/eps/token/token_200', match_requests_on: %i[method path]) do
             VCR.use_cassette('vaos/eps/get_appointment/booked_200', match_requests_on: %i[method path]) do
               VCR.use_cassette('vaos/eps/providers/data_Aq7wgAux_200', match_requests_on: %i[method path]) do
+                # expect(StatsD).to receive(:increment).with(
+                #   'api.vaos.eps_appointment_detail.access',
+                #   tags: ['Community Care Appointments']
+                # ).and_call_original
+                allow(StatsD).to receive(:increment).and_call_original
+
                 get '/vaos/v2/eps_appointments/qdm61cJ5', headers: inflection_header
 
                 expect(response).to have_http_status(:success)

--- a/modules/vaos/spec/requests/vaos/v2/eps_appointments_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/eps_appointments_spec.rb
@@ -63,10 +63,10 @@ RSpec.describe 'VAOS::V2::EpsAppointments', :skip_mvi, type: :request do
           VCR.use_cassette('vaos/eps/token/token_200', match_requests_on: %i[method path]) do
             VCR.use_cassette('vaos/eps/get_appointment/booked_200', match_requests_on: %i[method path]) do
               VCR.use_cassette('vaos/eps/providers/data_Aq7wgAux_200', match_requests_on: %i[method path]) do
-                # expect(StatsD).to receive(:increment).with(
-                #   'api.vaos.eps_appointment_detail.access',
-                #   tags: ['Community Care Appointments']
-                # ).and_call_original
+                expect(StatsD).to receive(:increment).with(
+                  'api.vaos.eps_appointment_detail.access',
+                  tags: ['Community Care Appointments']
+                ).and_call_original
                 allow(StatsD).to receive(:increment).and_call_original
 
                 get '/vaos/v2/eps_appointments/qdm61cJ5', headers: inflection_header

--- a/modules/vaos/spec/services/eps/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/eps/appointment_service_spec.rb
@@ -294,7 +294,7 @@ describe Eps::AppointmentService do
         expect(redis_client).to receive(:store_appointment_data).with(
           uuid: user.account_uuid,
           appointment_id:,
-          email: user.va_profile_email
+          email: user.email
         )
 
         expect(Eps::AppointmentStatusJob).to receive(:perform_async).with(

--- a/modules/vaos/spec/services/eps/appointment_status_notification_callback_spec.rb
+++ b/modules/vaos/spec/services/eps/appointment_status_notification_callback_spec.rb
@@ -59,6 +59,10 @@ RSpec.describe Eps::AppointmentStatusNotificationCallback, type: :service do
           "#{described_class::STATSD_KEY}.failure",
           tags: ['Community Care Appointments']
         )
+        expect(StatsD).to have_received(:increment).with(
+          described_class::STATSD_NOTIFY_SILENT_FAILURE,
+          tags: described_class::STATSD_CC_SILENT_FAILURE_TAGS
+        )
         expect(Rails.logger).to have_received(:error).with(
           'Community Care Appointments: Eps::AppointmentNotificationCallback delivery failed',
           {

--- a/modules/vaos/spec/sidekiq/eps/appointment_status_email_job_spec.rb
+++ b/modules/vaos/spec/sidekiq/eps/appointment_status_email_job_spec.rb
@@ -208,7 +208,11 @@ RSpec.describe Eps::AppointmentStatusEmailJob, type: :job do
   def check_statsd_failure_increment(uuid, last4)
     expect(StatsD).to have_received(:increment).with(
       "#{described_class::STATSD_KEY}.failure",
-      tags: ["user_uuid:#{uuid}", "appointment_id_last4:#{last4}"]
+      tags: ['Community Care Appointments']
+    )
+    expect(StatsD).to have_received(:increment).with(
+      described_class::STATSD_NOTIFY_SILENT_FAILURE,
+      tags: described_class::STATSD_CC_SILENT_FAILURE_TAGS
     )
   end
 end

--- a/modules/vaos/spec/sidekiq/eps/appointment_status_email_job_spec.rb
+++ b/modules/vaos/spec/sidekiq/eps/appointment_status_email_job_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Eps::AppointmentStatusEmailJob, type: :job do
         )
         allow(va_notify_service).to receive(:send_email)
         expect(va_notify_service).not_to have_received(:send_email)
-        check_statsd_failure_increment(user_uuid, appointment_id_last4)
+        check_statsd_failure_increment
       end
     end
 
@@ -130,7 +130,7 @@ RSpec.describe Eps::AppointmentStatusEmailJob, type: :job do
         )
         allow(va_notify_service).to receive(:send_email)
         expect(va_notify_service).not_to have_received(:send_email)
-        check_statsd_failure_increment(user_uuid, appointment_id_last4)
+        check_statsd_failure_increment
       end
     end
 
@@ -146,7 +146,7 @@ RSpec.describe Eps::AppointmentStatusEmailJob, type: :job do
           /upstream error - will not retry: 400/,
           { user_uuid:, appointment_id_last4: }
         )
-        check_statsd_failure_increment(user_uuid, appointment_id_last4)
+        check_statsd_failure_increment
       end
     end
 
@@ -179,7 +179,7 @@ RSpec.describe Eps::AppointmentStatusEmailJob, type: :job do
           /unexpected error: StandardError/,
           { user_uuid:, appointment_id_last4: }
         )
-        check_statsd_failure_increment(user_uuid, appointment_id_last4)
+        check_statsd_failure_increment
       end
     end
   end
@@ -201,11 +201,11 @@ RSpec.describe Eps::AppointmentStatusEmailJob, type: :job do
         /retries exhausted: VANotify::Error - Service unavailable/,
         { user_uuid:, appointment_id_last4: }
       )
-      check_statsd_failure_increment(user_uuid, appointment_id_last4)
+      check_statsd_failure_increment
     end
   end
 
-  def check_statsd_failure_increment(uuid, last4)
+  def check_statsd_failure_increment
     expect(StatsD).to have_received(:increment).with(
       "#{described_class::STATSD_KEY}.failure",
       tags: ['Community Care Appointments']

--- a/modules/vaos/spec/sidekiq/eps/appointment_status_job_spec.rb
+++ b/modules/vaos/spec/sidekiq/eps/appointment_status_job_spec.rb
@@ -59,10 +59,15 @@ RSpec.describe Eps::AppointmentStatusJob, type: :job do
       end
 
       it 'sends failure message after max retries' do
+        expect(StatsD).to receive(:increment).with(
+          'api.vaos.appointment_status_check.failure',
+          tags: ['Community Care Appointments']
+        )
+
         expect(Eps::AppointmentStatusEmailJob).to receive(:perform_async).with(
           user.uuid,
           appointment_id_last4,
-          'Could not complete booking'
+          Eps::AppointmentStatusJob::ERROR_MESSAGE
         )
         worker.perform(user.uuid, appointment_id_last4, Eps::AppointmentStatusJob::MAX_RETRIES)
       end
@@ -79,7 +84,7 @@ RSpec.describe Eps::AppointmentStatusJob, type: :job do
         expect(Eps::AppointmentStatusEmailJob).to receive(:perform_async).with(
           user.uuid,
           appointment_id_last4,
-          'Could not verify the booking status of your submitted appointment, please contact support'
+          Eps::AppointmentStatusJob::ERROR_MESSAGE
         )
         worker.perform(user.uuid, appointment_id_last4, Eps::AppointmentStatusJob::MAX_RETRIES)
       end
@@ -93,10 +98,18 @@ RSpec.describe Eps::AppointmentStatusJob, type: :job do
       end
 
       it 'sends failure message after max retries' do
+        expect(StatsD).to receive(:increment).with(
+          'api.vaos.appointment_status_check.failure',
+          tags: ['Community Care Appointments']
+        )
+        expect(Rails.logger).to receive(:error).with(
+          'Community Care Appointments: EpsAppointmentJob failed to get appointment status',
+          { user_uuid: user.uuid, appointment_id_last4: }
+        )
         expect(Eps::AppointmentStatusEmailJob).to receive(:perform_async).with(
           user.uuid,
           appointment_id_last4,
-          'Could not verify the booking status of your submitted appointment, please contact support'
+          Eps::AppointmentStatusJob::ERROR_MESSAGE
         )
         worker.perform(user.uuid, appointment_id_last4, Eps::AppointmentStatusJob::MAX_RETRIES)
       end
@@ -114,10 +127,8 @@ RSpec.describe Eps::AppointmentStatusJob, type: :job do
           { user_uuid: user.uuid, appointment_id_last4:, appointment_data: nil }.to_json
         )
         expect(StatsD).to receive(:increment).with(
-          "#{described_class::STATSD_PREFIX}.failure",
-          tags: ['Community Care Appointments',
-                 "user_uuid: #{user.uuid}",
-                 "appointment_id_last4: #{appointment_id_last4}"]
+          'api.vaos.appointment_status_check.failure',
+          tags: ['Community Care Appointments']
         )
         worker.perform(user.uuid, appointment_id_last4)
       end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- updates `Eps::AppointmentService#submit_appointment` to utilize `user.email` rather than `user.va_profile_email`
- Adds StatsD metric to track access of the appointment detail endpoint
- Updates error message in `Eps::AppointmentStatusJob` to be consistent
- Removes unnecessary tags from StatsD logging to avoid excessive cardinality
- Adds metric increment and error logging in `Eps::AppointmentStatusJob` for status check success / failure

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1323/views/35?pane=issue&itemId=117454991&issue=department-of-veterans-affairs%7Cva.gov-team%7C113087

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
