### PR TITLE
Verify user before updating Contact Information

### DIFF
--- a/lib/va_profile/v2/contact_information/service.rb
+++ b/lib/va_profile/v2/contact_information/service.rb
@@ -321,7 +321,6 @@ module VAProfile
 
         def get_transaction_status(path, response_class)
           with_monitoring do
-            verify_user!
             raw_response = perform(:get, path)
             VAProfile::Stats.increment_transaction_results(raw_response)
 


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary
VET360_CORE103 errors increased when Contact InformationV2 was enabled in production. User ICN/VAProfile_ID should be verified before sending requests to the VAProfile Contact Information service. Contact Information V1 service does verify vet360_id before sending requests to the VAProfile Contact Information Service. _This will may not resolve all CORE103 errors._

The user's ICN/VAPRofile_ID will be verified before sending requests to VAProfile to modify data with the `verify_user! `private method:
```
        def post_or_put_data(method, model, path, response_class)
          with_monitoring do
            verify_user!
            request_path = "#{MPI::Constants::VA_ROOT_OID}/#{ERB::Util.url_encode(vaprofile_aaid)}" + "/#{path}"
            # in_json_v2 method should replace in_json after Contact Information V1 has depreciated
            if log_transaction_id?
              Rails.logger.info("ContactInformationV2 METHOD: #{method}, JSON: #{model.in_json_v2}")
            end
            raw_response = perform(method, request_path, model.in_json_v2)
            Rails.logger.info("ContactInformation RAW RESPONSE: #{raw_response}") if log_transaction_id?
            response_class.from(raw_response)
          end
        rescue => e
          handle_error(e)
        end
```

Contact Information V1 does verify if the user has a vet360_id by calling `vet360_id_present!`:
```
      def post_or_put_data(method, model, path, response_class)
        with_monitoring do
          vet360_id_present!
          raw_response = perform(method, path, model.in_json)

          response_class.from(raw_response)
        end
      rescue => e
        handle_error(e)
      end
```

## Related issue(s)

- department-of-veterans-affairs/va.gov-team/issues/111523
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- User IDs are verified before sending requests to VAProfile

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
