### PR TITLE
Refactor: Rename `declination_reason` param to `key` for decision declnations to align with FE

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_request_decisions_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_request_decisions_controller.rb
@@ -46,14 +46,14 @@ module AccreditedRepresentativePortal
       end
 
       def process_declination
-        declination_reason = decision_params[:declination_reason]
+        declination_key = decision_params[:key]
 
-        if declination_reason.blank?
+        if declination_key.blank?
           render json: { errors: ["Validation failed: Declination reason can't be blank"] }, status: :bad_request
           return
         end
 
-        @poa_request.mark_declined!(creator, declination_reason)
+        @poa_request.mark_declined!(creator, declination_key)
         send_declination_email(@poa_request)
         track_declination_metrics
 
@@ -72,7 +72,7 @@ module AccreditedRepresentativePortal
       end
 
       def decision_params
-        params.require(:decision).permit(:type, :declination_reason)
+        params.require(:decision).permit(:type, :declinationReason, :key)
       end
 
       def creator

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_request_decisions_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_request_decisions_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestDecisio
         )
       end
 
-      it 'complains about a missing declination_reason for a declination' do
+      it 'complains about a missing key for a declination' do
         post "/accredited_representative_portal/v0/power_of_attorney_requests/#{poa_request.id}/decision",
              params: { decision: { type: 'declination' } }
 
@@ -135,14 +135,14 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestDecisio
           .to eq('PowerOfAttorneyRequestAcceptance')
       end
 
-      it 'creates a declination decision with both declination_reason and no free-form reason' do
+      it 'creates a declination decision with both key and no free-form reason' do
         expect(AccreditedRepresentativePortal::PowerOfAttorneyRequestEmailJob)
           .to receive(:perform_async)
 
         post "/accredited_representative_portal/v0/power_of_attorney_requests/#{poa_request.id}/decision",
              params: { decision: {
                type: 'declination',
-               declination_reason: 'DECLINATION_HEALTH_RECORDS_WITHHELD'
+               key: 'DECLINATION_HEALTH_RECORDS_WITHHELD'
              } }
 
         expect(response).to have_http_status(:ok)
@@ -160,7 +160,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestDecisio
         post "/accredited_representative_portal/v0/power_of_attorney_requests/#{poa_request.id}/decision",
              params: { decision: {
                type: 'declination',
-               declination_reason: 'DECLINATION_NOT_ACCEPTING_CLIENTS'
+               key: 'DECLINATION_NOT_ACCEPTING_CLIENTS'
              } }
 
         expect(response).to have_http_status(:ok)
@@ -218,7 +218,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestDecisio
         post "/accredited_representative_portal/v0/power_of_attorney_requests/#{poa_request.id}/decision",
              params: { decision: {
                type: 'declination',
-               declination_reason: 'DECLINATION_NOT_ACCEPTING_CLIENTS'
+               key: 'DECLINATION_NOT_ACCEPTING_CLIENTS'
              } }
 
         expect(response).to have_http_status(:unprocessable_entity)


### PR DESCRIPTION

- Updated controller to use `key` instead of `declination_reason`
- Adjusted strong params and validation logic accordingly
- Updated specs to use `key` in request payloads
- Improved naming clarity to align with declination option keys

Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/112923

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
