### PR TITLE
Remove orphaned validate_user_is_accredited! method

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
@@ -26,16 +26,6 @@ module ClaimsApi
       end
 
       #
-      # Validate @current_user is an accredited representative
-      #
-      # @raise [Common::Exceptions::Forbidden] if @current_user is not a representative
-      def validate_user_is_accredited!
-        representative = ::Veteran::Service::Representative.for_user(first_name: @current_user.first_name,
-                                                                     last_name: @current_user.last_name)
-        raise ::Common::Exceptions::Forbidden if representative.blank?
-      end
-
-      #
       # Validate poa code provided matches one of the poa codes associated with the @current_user
       # @param poa_code [String] poa code to match to @current_user
       #


### PR DESCRIPTION
## Summary

As it says on the tin. No call path uses this method, so it can be removed. Missed removing it while working on #22613

## Related issue(s)

https://jira.devops.va.gov/browse/API-47081

## Testing done

Ensured a clean test run & did a code sweep for the method. Its definition was the only place remaining.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature