### PR TITLE
API-47550: Update Email Report Recipients for Lighthouse Decision Reviews and Benefits Intake APIs

### DIFF
--- a/modules/appeals_api/config/mailinglists/error_report_daily.yml
+++ b/modules/appeals_api/config/mailinglists/error_report_daily.yml
@@ -1,11 +1,11 @@
 common:
    - michael.hobson@adhocteam.us
-   - michel.mcdonald@adhocteam.us
    - kristen.brown@adhocteam.us
-   - matt.kelly@adhocteam.us
-   - gia.antoniades@adhocteam.us
+   - mmcdonald@technatomy.com
+   - pstevens@technatomy.com
 development:
 staging:
 sandbox:
 production:
   - matthew.self2@va.gov
+  - heather.roy@zerodelta365.com

--- a/modules/appeals_api/config/mailinglists/error_report_weekly.yml
+++ b/modules/appeals_api/config/mailinglists/error_report_weekly.yml
@@ -1,9 +1,8 @@
 common:
    - michael.hobson@adhocteam.us
-   - michel.mcdonald@adhocteam.us
    - kristen.brown@adhocteam.us
-   - matt.kelly@adhocteam.us
-   - gia.antoniades@adhocteam.us
+   - mmcdonald@technatomy.com
+   - pstevens@technatomy.com
 development:
 staging:
 sandbox:
@@ -11,3 +10,4 @@ production:
   - matthew.self2@va.gov
   - janet.coutinho@va.gov
   - drew.fisher@adhocteam.us
+  - heather.roy@zerodelta365.com

--- a/modules/appeals_api/config/mailinglists/report_daily.yml
+++ b/modules/appeals_api/config/mailinglists/report_daily.yml
@@ -1,9 +1,8 @@
 common:
-  - gia.antoniades@adhocteam.us
-  - kristen.brown@adhocteam.us
-  - matt.kelly@adhocteam.us
   - michael.hobson@adhocteam.us
-  - michel.mcdonald@adhocteam.us
+  - kristen.brown@adhocteam.us
+  - mmcdonald@technatomy.com
+  - pstevens@technatomy.com
 development:
 staging:
 sandbox:
@@ -17,3 +16,4 @@ production:
   - premal.shah@va.gov
   - steve.albers@va.gov
   - zachary.goldfine@va.gov
+  - heather.roy@zerodelta365.com

--- a/modules/appeals_api/config/mailinglists/report_weekly.yml
+++ b/modules/appeals_api/config/mailinglists/report_weekly.yml
@@ -1,9 +1,8 @@
 common:
   - michael.hobson@adhocteam.us
-  - michel.mcdonald@adhocteam.us
   - kristen.brown@adhocteam.us
-  - matt.kelly@adhocteam.us
-  - gia.antoniades@adhocteam.us
+  - mmcdonald@technatomy.com
+  - pstevens@technatomy.com
 development:
 staging:
 sandbox:
@@ -17,4 +16,5 @@ production:
   - premal.shah@va.gov
   - steve.albers@va.gov
   - zachary.goldfine@va.gov
+  - heather.roy@zerodelta365.com
 

--- a/modules/appeals_api/config/mailinglists/stats_report_monthly.yml
+++ b/modules/appeals_api/config/mailinglists/stats_report_monthly.yml
@@ -1,10 +1,10 @@
 common:
-  - michel.mcdonald@adhocteam.us
   - kristen.brown@adhocteam.us
-  - matt.kelly@adhocteam.us
-  - gia.antoniades@adhocteam.us
+  - mmcdonald@technatomy.com
+  - pstevens@technatomy.com
 development:
 staging:
 production:
   - drew.fisher@adhocteam.us
   - michael.hobson@adhocteam.us
+  - heather.roy@zerodelta365.com

--- a/modules/vba_documents/app/mailers/vba_documents/monthly_report_recipients.yml
+++ b/modules/vba_documents/app/mailers/vba_documents/monthly_report_recipients.yml
@@ -1,17 +1,15 @@
 common:
   - 'kristen.brown@adhocteam.us'
   - 'michael.hobson@adhocteam.us'
-  - 'michel.mcdonald@adhocteam.us'
-  - 'emily.goodrich@oddball.io'
-  - 'melinda.cuerda@adhocteam.us'
-  - 'heather.roy@adhocteam.us'
-  - 'matt.kelly@adhocteam.us'
-  - 'gia.antoniades@adhocteam.us'
+  - 'mmcdonald@technatomy.com'
+  - 'pstevens@technatomy.com'
 dev:
 staging:
 sandbox:
 prod:
   - 'drew.fisher@adhocteam.us'
+  - 'melinda.cuerda@adhocteam.us'
+  - 'heather.roy@zerodelta365.com'
   - 'david.mazik@va.gov'
   - 'stone_christopher@bah.com'
   - 'valerie.hase@va.gov'

--- a/modules/vba_documents/app/mailers/vba_documents/unsuccessful_report_recipients.yml
+++ b/modules/vba_documents/app/mailers/vba_documents/unsuccessful_report_recipients.yml
@@ -1,17 +1,15 @@
 common:
   - 'kristen.brown@adhocteam.us'
   - 'michael.hobson@adhocteam.us'
-  - 'michel.mcdonald@adhocteam.us'
-  - 'emily.goodrich@oddball.io'
-  - 'melinda.cuerda@adhocteam.us'
-  - 'heather.roy@adhocteam.us'
-  - 'matt.kelly@adhocteam.us'
-  - 'gia.antoniades@adhocteam.us'
+  - 'mmcdonald@technatomy.com'
+  - 'pstevens@technatomy.com'
 dev:
 staging:
 sandbox:
 prod:
   - 'drew.fisher@adhocteam.us'
+  - 'melinda.cuerda@adhocteam.us'
+  - 'heather.roy@zerodelta365.com'
   - 'david.mazik@va.gov'
   - 'stone_christopher@bah.com'
   - 'valerie.hase@va.gov'


### PR DESCRIPTION
## Summary
This work is behind a feature toggle (flipper): *NO*

This PR updates the email recipients list for the Lighthouse Decision Reviews and Benefits Intake API email reports, to adjust to recent changes to the Lighthouse staff.

My team (Lighthouse Banana Peels) owns the `appeals_api` and `vba_documents` modules.

## Related issue(s)
[API-47550](https://jira.devops.va.gov/browse/API-47550)

<img width="450" alt="Jira Ticket Screenshot" src="https://github.com/user-attachments/assets/e139aa44-54bd-4e14-a16c-b85c02b078e3" />

## Testing done
- [ ] *New code is covered by unit tests* – N/A, config change only, and tests for this feature are already present
- Prior to this change, the reporting emails for the Decision Reviews and Benefits Intake APIs were sent to a slightly different list of recipients.
- To roll out the change, we'll simply merge the PR and allow the updated recipients lists to take effect for the email reports going forward.

## Screenshots
None

## What areas of the site does it impact?
This PR impacts the `appeals_api` and `vba_documents` modules, and specifically the email reporting features for the Lighthouse Decision Reviews and Benefits Intake APIs.

## Acceptance criteria
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable). – N/A, config change only
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable) – N/A
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested for this PR.