### PR TITLE
API-prefactor-for-gathering-data-declined-workflow

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -64,7 +64,7 @@ module ClaimsApi
                  status: :ok
         end
 
-        def decide # rubocop:disable Metrics/MethodLength
+        def decide
           lighthouse_id = params[:id]
           decision = normalize(form_attributes['decision'])
           representative_id = form_attributes['representativeId']
@@ -152,7 +152,7 @@ module ClaimsApi
 
           send_declined_notification(ptcpnt_id:, first_name:, representative_id:)
         end
-  
+
         def find_poa_request!(lighthouse_id)
           request = ClaimsApi::PowerOfAttorneyRequest.find_by(id: lighthouse_id)
 

--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -84,18 +84,13 @@ module ClaimsApi
                                                                external_key: Settings.bgs.external_key)
 
           ptcpnt_id = fetch_ptcpnt_id(vet_icn)
-          if decision == 'declined'
-            poa_request = validate_ptcpnt_id!(ptcpnt_id:, proc_id:, representative_id:, service:)
-          end
 
-          first_name = poa_request['claimantFirstName'].presence || poa_request['vetFirstName'] if poa_request
+          handle_declined_decision(ptcpnt_id:, proc_id:, representative_id:, service:) if decision == 'declined'
 
           res = service.update_poa_request(proc_id:, secondary_status: decision,
                                            declined_reason: form_attributes['declinedReason'])
 
           raise Common::Exceptions::Lighthouse::BadGateway if res.blank?
-
-          send_declined_notification(ptcpnt_id:, first_name:, representative_id:) if decision == 'declined'
 
           service = ClaimsApi::PowerOfAttorneyRequestService::Show.new(ptcpnt_id)
           res = service.get_poa_request
@@ -155,6 +150,13 @@ module ClaimsApi
         end
 
         private
+
+        def handle_declined_decision(ptcpnt_id:, proc_id:, representative_id:, service:)
+          poa_request = validate_ptcpnt_id!(ptcpnt_id:, proc_id:, representative_id:, service:)
+          first_name = poa_request['claimantFirstName'].presence || poa_request['vetFirstName'] if poa_request
+
+          send_declined_notification(ptcpnt_id:, first_name:, representative_id:)
+        end
 
         def validate_country_code
           vet_cc = form_attributes.dig('veteran', 'address', 'countryCode')


### PR DESCRIPTION
## Summary
No regret refactor to help with the upcoming work for API-43735. Extracts method out to handle when a decision is 'declined'.

## Related issue(s)
[API-47706](https://jira.devops.va.gov/browse/API-47706)
[API-43735](https://jira.devops.va.gov/browse/API-43735) (Parent ticket)

## Testing done
- No behavior changes related to this refactor
- [x] *Related unit tests still 🟢 *

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
modified:   modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
