### PR TITLE
Add service_tag to datadog_action_controller

### DIFF
--- a/app/controllers/v0/datadog_action_controller.rb
+++ b/app/controllers/v0/datadog_action_controller.rb
@@ -2,6 +2,7 @@
 
 module V0
   class DatadogActionController < ApplicationController
+    service_tag 'datadog-metrics'
     skip_before_action :authenticate
 
     def create


### PR DESCRIPTION
## Summary

This **Unchanged files with check annotations** message has been showing up in PRs ever since https://github.com/department-of-veterans-affairs/vets-api/pull/22623 merged. That PR had an [Audit service failure](https://github.com/department-of-veterans-affairs/vets-api/actions/runs/15782557590/job/44491553211) with the error:
`Error: V0::DatadogActionController is missing a service tag. Please associate with a service catalog entry using the Traceable#service_tag method.`

## Related issue(s)
None. Saw while on support. 

## Testing done
- [ ] No **Unchanged files with check annotations** in this PR

## Screenshots
Message showing up in PRs:
![image](https://github.com/user-attachments/assets/e8ff6f59-fd2e-4fcb-b24d-be90457fc072)

A service tag gives you a Service in Datadog APM
![image](https://github.com/user-attachments/assets/9a6d600f-d70e-4909-8c33-bb306e465266)
