### PR TITLE
[ARP] Benefits Intake API configuration workaround

### DIFF
--- a/modules/accredited_representative_portal/app/sidekiq/accredited_representative_portal/submit_benefits_intake_claim_job.rb
+++ b/modules/accredited_representative_portal/app/sidekiq/accredited_representative_portal/submit_benefits_intake_claim_job.rb
@@ -2,6 +2,46 @@
 
 module AccreditedRepresentativePortal
   class SubmitBenefitsIntakeClaimJob < Lighthouse::SubmitBenefitsIntakeClaim
+    ##
+    # TODO: Remove this parent class override.
+    #
+    # This is a temporary workaround while there is configuration inconsistency
+    # between two Benefits Intake API Ruby clients in `vets-api`'s staging
+    # environment. The inconsistency between these Ruby clients matters because
+    # we use both of them in different parts of claims' lifecycles:
+    #
+    # - `BenefitsIntakeService::Service`
+    #   - Points to Lighthouse's staging environment
+    #   - Used to submit claims initially
+    # - `BenefitsIntake::Service`
+    #   - Points to Lighthouse's sandbox environment
+    #   - Used to check claims' statuses afterwards
+    #
+    def init(saved_claim_id)
+      @claim =
+        ::SavedClaim.find(saved_claim_id)
+
+      @lighthouse_service =
+        ##
+        # Rather than:
+        # ```
+        # BenefitsIntakeService::Service.new(with_upload_location: true)
+        # ```
+        #
+        BenefitsIntakeService::Service.new.tap do |service|
+          service.define_singleton_method(:config) do
+            BenefitsIntake::Service.configuration
+          end
+
+          upload = service.get_location_and_uuid
+          service.instance_variable_set(:@uuid, upload[:uuid])
+          service.instance_variable_set(:@location, upload[:location])
+        end
+    end
+
+    ##
+    # Overrides parent class.
+    #
     def generate_metadata
       veteran = @claim.parsed_form['veteran']
       veteran_name = veteran['name']
@@ -17,6 +57,9 @@ module AccreditedRepresentativePortal
       )
     end
 
+    ##
+    # Overrides parent class.
+    #
     def stamp_pdf(record)
       case record
       when PersistentAttachments::VAFormDocumentation

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -56,10 +56,10 @@ VCR.configure do |c|
     Settings.lighthouse.benefits_education.client_id
   end
   c.filter_sensitive_data('<LIGHTHOUSE_BENEFITS_INTAKE_API_KEY>') do
-    Settings.benefits_intake_service.api_key
+    Settings.lighthouse.benefits_intake.api_key
   end
   c.filter_sensitive_data('<LIGHTHOUSE_BENEFITS_INTAKE_URL>') do
-    Settings.benefits_intake_service.url
+    BenefitsIntake::Service.configuration.service_path
   end
   c.filter_sensitive_data('<VEIS_AUTH_URL>') { Settings.travel_pay.veis.auth_url }
   c.filter_sensitive_data('<CONTENTION_CLASSIFICATION_API_URL>') { Settings.contention_classification_api.url }

--- a/spec/support/vcr_cassettes/accredited_representative_portal/sidekiq/accredited_representative_portal/submit_benefits_intake_claim_job_spec/performs.yml
+++ b/spec/support/vcr_cassettes/accredited_representative_portal/sidekiq/accredited_representative_portal/submit_benefits_intake_claim_job_spec/performs.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<LIGHTHOUSE_BENEFITS_INTAKE_URL>uploads"
+    uri: "<LIGHTHOUSE_BENEFITS_INTAKE_URL>/uploads"
     body:
       encoding: UTF-8
       string: "{}"
@@ -75,7 +75,7 @@ http_interactions:
   recorded_at: Tue, 17 Jun 2025 07:19:31 GMT
 - request:
     method: post
-    uri: "<LIGHTHOUSE_BENEFITS_INTAKE_URL>uploads/validate_document"
+    uri: "<LIGHTHOUSE_BENEFITS_INTAKE_URL>/uploads/validate_document"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -155,7 +155,7 @@ http_interactions:
   recorded_at: Tue, 17 Jun 2025 07:19:33 GMT
 - request:
     method: post
-    uri: "<LIGHTHOUSE_BENEFITS_INTAKE_URL>uploads/validate_document"
+    uri: "<LIGHTHOUSE_BENEFITS_INTAKE_URL>/uploads/validate_document"
     body:
       encoding: ASCII-8BIT
       string: !binary |-


### PR DESCRIPTION
This is a temporary workaround while there is configuration inconsistency between two Benefits Intake API Ruby clients in `vets-api`'s staging environment. The inconsistency between these Ruby clients matters because we use both of them in different parts of claims' lifecycles:

- `BenefitsIntakeService::Service`
  - Points to Lighthouse's staging environment
  - Used to submit claims initially
- `BenefitsIntake::Service`
  - Points to Lighthouse's sandbox environment
  - Used to check claims' statuses afterwards
