### PR TITLE
Update date of sentry logging deprecation

### DIFF
--- a/lib/sentry_logging.rb
+++ b/lib/sentry_logging.rb
@@ -3,7 +3,7 @@
 require 'sentry_logging'
 
 module SentryLogging
-  # WARNING: This module is deprecated, and will be removed in June 2025. Please use Vets::SharedLogging instead.
+  # WARNING: This module is deprecated, and will be removed in October 2025. Please use Vets::SharedLogging instead.
   # If your team currently uses this module, please see documentation for migrating to Vets::SharedLogging: TODO
   ActiveSupport::Deprecation
     .new.warn('SentryLogging is deprecated and will be removed in October 2025. Use Vets::SharedLogging instead.')


### PR DESCRIPTION
We missed this in https://github.com/department-of-veterans-affairs/vets-api/pull/22933