### PR TITLE
Remove va_online_scheduling_convert_slots_to_utc feature toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -33,7 +33,7 @@ features:
   accredited_representative_portal_normalize_path:
     actor_type: user
     description: >
-      Enables the path that is passed in to the AccreditedRepresentativePortal::BypassOliveBranch.exclude_arp_route?() method to 
+      Enables the path that is passed in to the AccreditedRepresentativePortal::BypassOliveBranch.exclude_arp_route?() method to
       use the function Rack::Attack::PathNormalizer.normalize_path() which removes trailing slashes and resolves redundant parts of the path.
       NOTE: This should only be enabled in localhost and staging.
     enable_in_development: true
@@ -1865,10 +1865,6 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle to use API response as the source of truth in FE for Video at VA, Video at ATLAS, Video at Home modalities.
-  va_online_scheduling_convert_slots_to_utc:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle for for converting the start & end times in slots fetch to UTC.
   vaos_appointment_notification_callback:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
## Summary

- Removing fully released feature toggles
- Appointments FE Team
- This PR should be merged only after the vets-website PR is merged and deployed.
  - https://github.com/department-of-veterans-affairs/vets-website/pull/37475

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/113241

## Testing done

N/A

## Screenshots
N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
