### PR TITLE
[ARP] Surface Benefits Intake UUID

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_form_upload_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_form_upload_controller.rb
@@ -29,7 +29,8 @@ module AccreditedRepresentativePortal
         )
 
         render json: {
-          confirmationNumber: saved_claim.confirmation_number,
+          confirmationNumber:
+            saved_claim.latest_submission_attempt.benefits_intake_uuid,
           status: '200'
         }
       rescue service::RecordInvalidError => e

--- a/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/saved_claim_claimant_representative_serializer.rb
+++ b/modules/accredited_representative_portal/app/serializers/accredited_representative_portal/saved_claim_claimant_representative_serializer.rb
@@ -27,7 +27,9 @@ module AccreditedRepresentativePortal
       object.persistent_attachments.any?
     end
 
-    attribute :confirmation_number, &:guid
+    attribute :confirmation_number do |object|
+      object.latest_submission_attempt.benefits_intake_uuid
+    end
 
     attribute :vbms_status do |object|
       STATUSES[object.latest_submission_attempt&.aasm_state]

--- a/modules/accredited_representative_portal/spec/factories/saved_claim.rb
+++ b/modules/accredited_representative_portal/spec/factories/saved_claim.rb
@@ -18,7 +18,10 @@ FactoryBot.define do
           class: 'AccreditedRepresentativePortal::SavedClaim::BenefitsIntake::DependencyClaim' do
     guid { SecureRandom.uuid }
     form_attachment { create(:va_form_pdf) }
-
     form { form_data.to_json }
+
+    form_submissions do
+      create_list(:form_submission, 1, :pending)
+    end
   end
 end

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/claim_submissions_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/claim_submissions_spec.rb
@@ -21,14 +21,14 @@ RSpec.describe AccreditedRepresentativePortal::V0::ClaimSubmissionsController, t
              poa_codes: [poa_code])
     end
     let!(:vso) { create(:organization, poa: poa_code, can_accept_digital_poa_requests: false) }
-    let!(:saved_claim_claimant_representative) { create(:saved_claim_claimant_representative) }
-    let!(:saved_claim_claimant_representative2) { create(:saved_claim_claimant_representative) }
+    let!(:saved_claim_claimant_representative_a) { create(:saved_claim_claimant_representative) }
+    let!(:saved_claim_claimant_representative_b) { create(:saved_claim_claimant_representative) }
     # different PoA code
-    let!(:saved_claim_claimant_representative3) do
+    let!(:saved_claim_claimant_representative_c) do
       create(:saved_claim_claimant_representative, power_of_attorney_holder_poa_code: '002')
     end
     # different registration number
-    let!(:saved_claim_claimant_representative4) do
+    let!(:saved_claim_claimant_representative_d) do
       create(:saved_claim_claimant_representative, accredited_individual_registration_number: '987675')
     end
 
@@ -39,20 +39,48 @@ RSpec.describe AccreditedRepresentativePortal::V0::ClaimSubmissionsController, t
     end
 
     describe 'GET /accredited_representative_portal/v0/claims_submissions' do
-      let(:expected_meta) do
-        { 'page' => { 'number' => 1, 'size' => 10, 'total' => 2, 'totalPages' => 1 } }
-      end
-
       it 'returns only claims submissions that the rep is allowed to view' do
         get '/accredited_representative_portal/v0/claim_submissions'
         expect(response).to have_http_status(:ok)
-        saved_claim_ids = [
-          saved_claim_claimant_representative.id,
-          saved_claim_claimant_representative2.id
-        ]
-        parsed_response = JSON.parse(response.body)
-        expect(parsed_response['data'].map { |obj| obj['id'] }).to eq saved_claim_ids
-        expect(parsed_response['meta']).to eq expected_meta
+
+        expect(parsed_response).to eq(
+          {
+            'data' => [
+              {
+                'submittedDate' => '2025-07-02',
+                'firstName' => 'John',
+                'lastName' => 'Doe',
+                'formType' => '21-686c',
+                'packet' => false,
+                'confirmationNumber' =>
+                  saved_claim_claimant_representative_a.saved_claim.latest_submission_attempt.benefits_intake_uuid,
+                'vbmsStatus' => 'awaiting_receipt',
+                'vbmsReceivedDate' => nil,
+                'id' => saved_claim_claimant_representative_a.id
+              },
+              {
+                'submittedDate' => '2025-07-02',
+                'firstName' => 'John',
+                'lastName' => 'Doe',
+                'formType' => '21-686c',
+                'packet' => false,
+                'confirmationNumber' =>
+                  saved_claim_claimant_representative_b.saved_claim.latest_submission_attempt.benefits_intake_uuid,
+                'vbmsStatus' => 'awaiting_receipt',
+                'vbmsReceivedDate' => nil,
+                'id' => saved_claim_claimant_representative_b.id
+              }
+            ],
+            'meta' => {
+              'page' => {
+                'number' => 1,
+                'size' => 10,
+                'total' => 2,
+                'totalPages' => 1
+              }
+            }
+          }
+        )
       end
 
       context 'rep does not have any valid PoA codes' do


### PR DESCRIPTION
Rather than our own internal ID, for claim submissions. We learned that representative do have help resources where this ID is actually useful. Apparently Central Mail Portal operators are able to make use of Benefits Intake UUID as well as Central Mail's Packet ID. And the help resources available to representatives can make contact with those operators directly or indirectly.

This ties into a UX concern. It would potentially be better UX for a length claim submission to happen asynchronously such that this ID would not be available immediately to display on the form submission confirmation.

For now, we're going to do synchronous submission.

We're going to surface Benefits Intake UUID in both the confirmation page and the claim submission history page.