### PR TITLE
1690: add log_eligible_benefits feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1070,6 +1070,10 @@ features:
     actor_type: user
     description: Lighthouse Benefits Claims API uses MPI birls_id as filenumber parameter to BDS search
     enable_in_development: true
+  log_eligible_benefits:
+    actor_type: user
+    description: Allows log_eligible_benefits_job.rb to run in background.
+    enable_in_development: true
   loop_pages:
     actor_type: user
     description: Enable new list loop pattern


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- Creates a new feature flag for running a background job

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-iir/issues/1690

## Testing done

None. Just adding a feature flag.

## Screenshots

## What areas of the site does it impact?

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
