### PR TITLE
VAOS Referral provider slot search uses start time in the present or future

### DIFF
--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -519,7 +519,7 @@ module VAOS
           provider.id,
           {
             appointmentTypeId: appointment_type_id,
-            startOnOrAfter: Date.parse(referral.referral_date).to_time(:utc).iso8601,
+            startOnOrAfter: [Date.parse(referral.referral_date), Date.current].max.to_time(:utc).iso8601,
             startBefore: Date.parse(referral.expiration_date).to_time(:utc).iso8601
           }
         )


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- VAOS Referral provider slot search uses start time in the present or future. The EPS service is not able to handle dates in the past. Although EPS will fix that, we will also provide a fix for consistency since we do not care about any appointment slots in the past.
- Team: UAE Check In

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/113457

## Testing done
- [x] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
VAOS Referral scheduling appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

