### PR TITLE
VAOS referral provider slot search must paginate even if no slots present

### DIFF
--- a/modules/vaos/app/services/eps/provider_service.rb
+++ b/modules/vaos/app/services/eps/provider_service.rb
@@ -92,7 +92,7 @@ module Eps
         all_slots.concat(current_response[:slots]) if current_response[:slots].present?
 
         next_token = current_response[:next_token]
-        break if next_token.blank? || current_response[:slots].blank?
+        break if next_token.blank?
       end
 
       combined_response = { slots: all_slots, count: all_slots.length }

--- a/modules/vaos/spec/services/eps/provider_service_spec.rb
+++ b/modules/vaos/spec/services/eps/provider_service_spec.rb
@@ -374,7 +374,7 @@ describe Eps::ProviderService do
           expect(result.slots.map { |slot| slot[:id] }).to include(
             'page1-slot1|2025-01-02T09:00:00Z',
             'page1-slot2|2025-01-02T10:00:00Z',
-            'page2-slot1|2025-01-02T14:00:00Z'
+            'page3-slot1|2025-01-02T14:00:00Z'
           )
           expect(result.to_h).not_to have_key(:next_token)
         end

--- a/spec/support/vcr_cassettes/vaos/eps/get_provider_slots/200_with_pagination.yml
+++ b/spec/support/vcr_cassettes/vaos/eps/get_provider_slots/200_with_pagination.yml
@@ -92,6 +92,53 @@ http_interactions:
         - 94c8947f4410568bdca331053536b04f
     body:
       encoding: UTF-8
-      string: '{"count":1,"slots":[{"id":"page2-slot1|2025-01-02T14:00:00Z","providerServiceId":"TEST123","appointmentTypeId":"ov","start":"2025-01-02T14:00:00Z","remaining":1}]}'
+      string: '{"count":0,"slots":[],"next_token":"page3_token"}'
+  recorded_at: Sat, 11 Jan 2025 23:00:45 GMT
+- request:
+    method: get
+    uri: <VAOS_EPS_API_URL>/care-navigation/v1/provider-services/TEST123/slots?nextToken=page3_token
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+        - application/json
+      Content-Type:
+        - application/json
+      User-Agent:
+        - Vets.gov Agent
+      Authorization: Bearer <TOKEN>
+      X-Request-Id:
+        - 2b7d2bc2-cb28-42f8-900c-4ba0fdfd93d7
+      Accept-Encoding:
+        - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+        - Sat, 11 Jan 2025 23:00:45 GMT
+      Content-Type:
+        - application/json
+      Transfer-Encoding:
+        - chunked
+      Connection:
+        - keep-alive
+      Content-Security-Policy:
+        - frame-ancestors 'none'
+      Strict-Transport-Security:
+        - max-age=6307200; includeSubDomains; preload
+      Traceparent:
+        - 00-94c8947f4410568bdca331053536b04f-f282e870e6d5fa60-01
+      X-Content-Type-Options:
+        - nosniff
+      X-Request-Id:
+        - 2b7d2bc2-cb28-42f8-900c-4ba0fdfd93d7
+      X-Wellhive-Trace-Id:
+        - 94c8947f4410568bdca331053536b04f
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"slots":[{"id":"page3-slot1|2025-01-02T14:00:00Z","providerServiceId":"TEST123","appointmentTypeId":"ov","start":"2025-01-02T14:00:00Z","remaining":1}]}'
   recorded_at: Sat, 11 Jan 2025 23:00:45 GMT
 recorded_with: VCR 6.3.1 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Referral provider slot search must paginate even if no slots present. We had a gate that stopped paginating if no slots are found on the response even when a nextToken is provided. Nate form EPS has stated that we still have to paginate in those cases.
- Team: UAE Check In

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/113478

## Testing done
Changed the pagination test to have one page with no slots.

## Screenshots
N/A

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

