### PR TITLE
Revert "Skip Form21a flaky tests"

### DIFF
--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/form21a_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/form21a_spec.rb
@@ -55,9 +55,7 @@ RSpec.describe 'AccreditedRepresentativePortal::V0::Form21a', type: :request do
     context 'with valid JSON' do
       let!(:in_progress_form) { create(:in_progress_form, form_id: '21a', user_uuid: representative_user.uuid) }
 
-      it 'logs success and destroys in-progress form',
-         skip: 'Test has been flaky - see: ' \
-               'https://github.com/department-of-veterans-affairs/va.gov-team/issues/102880' do
+      it 'logs success and destroys in-progress form' do
         get('/accredited_representative_portal/v0/in_progress_forms/21a')
         expect(response).to have_http_status(:ok)
         expect(parsed_response.keys).to contain_exactly('formData', 'metadata')
@@ -125,9 +123,7 @@ RSpec.describe 'AccreditedRepresentativePortal::V0::Form21a', type: :request do
     end
 
     context 'when service returns a blank response' do
-      it 'logs and returns no content',
-         skip: 'Test has been flaky - see: ' \
-               'https://github.com/department-of-veterans-affairs/va.gov-team/issues/102880' do
+      it 'logs and returns no content' do
         allow(AccreditationService).to receive(:submit_form21a).and_return(
           instance_double(Faraday::Response, success?: false, body: nil, status: 204)
         )


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#22961

These failures were related to a schema issue. See [Slack thread](https://dsva.slack.com/archives/C06ABHUNBRS/p1751469809273359?thread_ts=1738956153.238539&cid=C06ABHUNBRS) for more info.