### PR TITLE
Fix for NoMethodError in Sentry

### DIFF
--- a/app/controllers/concerns/sentry_controller_logging.rb
+++ b/app/controllers/concerns/sentry_controller_logging.rb
@@ -25,7 +25,7 @@ module SentryControllerLogging
   def tags_context
     { controller_name: }.tap do |tags|
       # Add defensive checks to avoid nil errors
-      sign_in = if current_user&.respond_to?(:identity) && current_user.identity&.sign_in.present?
+      sign_in = if current_user.respond_to(:identity) && current_user.identity&.sign_in.present?
                   current_user.identity.sign_in
                 elsif current_user&.sign_in.present?
                   current_user.sign_in

--- a/app/controllers/concerns/sentry_controller_logging.rb
+++ b/app/controllers/concerns/sentry_controller_logging.rb
@@ -25,7 +25,7 @@ module SentryControllerLogging
   def tags_context
     { controller_name: }.tap do |tags|
       # Add defensive checks to avoid nil errors
-      sign_in = if current_user.respond_to(:identity) && current_user.identity&.sign_in.present?
+      sign_in = if current_user&.respond_to?(:identity) && current_user.identity&.sign_in.present? # rubocop:disable Lint/RedundantSafeNavigation
                   current_user.identity.sign_in
                 elsif current_user&.sign_in.present?
                   current_user.sign_in

--- a/app/controllers/concerns/sentry_controller_logging.rb
+++ b/app/controllers/concerns/sentry_controller_logging.rb
@@ -24,8 +24,14 @@ module SentryControllerLogging
 
   def tags_context
     { controller_name: }.tap do |tags|
-      if current_user.present?
-        sign_in = current_user.respond_to?(:identity) ? current_user.identity.sign_in : current_user.sign_in
+      # Add defensive checks to avoid nil errors
+      sign_in = if current_user&.respond_to?(:identity) && current_user.identity&.sign_in.present?
+                  current_user.identity.sign_in
+                elsif current_user&.sign_in.present?
+                  current_user.sign_in
+                end
+
+      if sign_in.present?
         tags[:sign_in_method] = sign_in[:service_name]
         # account_type is filtered by sentry, becasue in other contexts it refers to a bank account type
         tags[:sign_in_acct_type] = sign_in[:account_type]


### PR DESCRIPTION
Updates UserIdentity guard clause in app/controllers/concerns/sentry_controller_logging.rb

Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): YES/NO* NO
- *(Summarize the changes that have been made to the platform)*
  -- Updates UserIdentity guard clause in app/controllers/concerns/sentry_controller_logging.rb
- *(If bug, how to reproduce)* N/A
- *(What is the solution, why is this the solution?)* 
   -- Implements defensive checks to avoid conditions under nil. 
- *(Which team do you work for, does your team own the maintenance of this component?)*
   -- Watchtower
- *(If introducing a flipper, what is the success criteria being targeted?)* N/A

> [!Note]
> There is a related issue whereby the [AccreditedRepresentativePortal::RepresentativeUser has sign_in](https://github.com/department-of-veterans-affairs/vets-api/blob/9e6def3ccf59fb82c27aac6424579a275b4ba6fa/modules/accredited_representative_portal/app/models/accredited_representative_portal/representative_user.rb#L21) directly off the model. The logging accounts for this condition as well. (i.e. checks whether `identity` method is there or not

## Related issue(s)

[Link to Datadog for the errors](https://vagov.ddog-gov.com/apm/traces?query=env%3Aeks-prod%20status%3Aerror%20%40error.type%3ANoMethodError%20%40error.file%3A%2Fapp%2Fapp%2Fcontrollers%2Fconcerns%2Fsentry_controller_logging.rb&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code%2C%40error.message%2C%40http.path_group%2C%40_span.count%2C%40_duration.by_service&fromUser=false&graphType=flamegraph&historicalData=true&messageDisplay=inline&query_translation_version=v0&refresh_mode=sliding&shouldShowLegend=true&sort=time&sort_by=%40duration&sort_order=desc&spanType=all&spanViewType=errors&step=auto&storage=hot&view=spans&viz=stream&start=1751414628819&end=1751501028819&paused=false)

## Related PR
https://github.com/department-of-veterans-affairs/vets-api/pull/22962