### PR TITLE
Update user redis ttl so they are longer than session expiration

### DIFF
--- a/config/redis.yml
+++ b/config/redis.yml
@@ -9,13 +9,13 @@ development: &defaults
     each_ttl: 1800
   user_b_store:
     namespace: users_b
-    each_ttl: 1800
+    each_ttl: 2000
   representative_user_store:
     namespace: representative_users
-    each_ttl: 1800
+    each_ttl: 2000
   user_identity_store:
     namespace: user_identities
-    each_ttl: 1800
+    each_ttl: 2000
   # DO NOT CHANGE ABOVE TTL
   identifier_store:
     namespace: identifier_indexes


### PR DESCRIPTION
## Summary

- This PR updates `User`, `UserIdentity` and `RepresentativeUser` so their Redis retention is slightly longer than the session refresh. This is done in an attempt to mitigate potential issues about redis models expiring on session timeout thresholds