### PR TITLE
[ARP] `routing_error`

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/application_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/application_controller.rb
@@ -34,6 +34,10 @@ module AccreditedRepresentativePortal
       routing_error unless Flipper.enabled?(:accredited_representative_portal_submissions, @current_user)
     end
 
+    def routing_error
+      raise Common::Exceptions::RoutingError, params[:path]
+    end
+
     def track_unique_session
       if @current_user.present?
         arp_session_key = :arp_session_started_for_user


### PR DESCRIPTION
@ojbucao `routing_error` wasn't defined in our controllers. Did you try running or testing the code during [this change](https://github.com/department-of-veterans-affairs/vets-api/commit/1c6f86308602844526c47ad55da6d04b1ca29d70#diff-5ed68ed17c221f4bd20344340241973151763adc6675894fc96a111d182db5c9R34)?