### PR TITLE
Adding check for presence of user.identity to SSO auth

### DIFF
--- a/app/controllers/concerns/authentication_and_sso_concerns.rb
+++ b/app/controllers/concerns/authentication_and_sso_concerns.rb
@@ -151,7 +151,9 @@ module AuthenticationAndSSOConcerns # rubocop:disable Metrics/ModuleLength
     return unless @session_object
 
     user = User.find(@session_object.uuid)
-    @current_user = user if (skip_terms_check || !user&.needs_accepted_terms_of_use) && !user&.credential_lock
+    if (skip_terms_check || !user&.needs_accepted_terms_of_use) && !user&.credential_lock && user&.identity
+      @current_user = user
+    end
   end
 
   def sso_cookie_content


### PR DESCRIPTION
## Summary

- This PR adds an additional check to SSO auth that insures the `user.identity` redis exists before allowing authentication. And authenticated SSOe user should always have both a `user` redis record that is retrievable, and a `user.identity` record

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/477

## Testing done

- [ ] Authenticated
- [ ] In rails console, `user.identity.destroy` with my authenticated user model
- [ ] Click anywhere on page, confirm I am logged out

## What areas of the site does it impact?
Authenticated routes

## Acceptance criteria

- [ ] Authenticate
- [ ] In rails console, find `User` for authenticated user, then `user.identity.destroy` with authenticated user model
- [ ] Click anywhere on page, confirm you are logged out
