### PR TITLE
Remove setting veteranAddress data if no address submitted

### DIFF
--- a/app/models/saved_claim/veteran_readiness_employment_claim.rb
+++ b/app/models/saved_claim/veteran_readiness_employment_claim.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'sentry_logging'
 require 'res/ch31_form'
+require 'vets/shared_logging'
 
 class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
   include Vets::SharedLogging

--- a/app/sidekiq/vre/submit1900_job.rb
+++ b/app/sidekiq/vre/submit1900_job.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'vets/shared_logging'
 require 'vre/monitor'
 
 module VRE

--- a/lib/res/ch31_form.rb
+++ b/lib/res/ch31_form.rb
@@ -43,7 +43,6 @@ module RES
 
     def format_payload_for_res
       form_data = claim_form_hash
-
       res_payload = {
         useEva: form_data['useEva'],
         receiveElectronicCommunication: form_data['receiveElectronicCommunication'],
@@ -116,6 +115,8 @@ module RES
     end
 
     def mapped_address_hash(client_hash)
+      return nil unless client_hash
+
       {
         country: client_hash['country'],
         street: client_hash['street'],

--- a/spec/factories/veteran_readiness_employment_claim.rb
+++ b/spec/factories/veteran_readiness_employment_claim.rb
@@ -105,4 +105,25 @@ FactoryBot.define do
       }.to_json
     }
   end
+
+  factory :new_veteran_readiness_employment_claim_minimal, class: 'SavedClaim::VeteranReadinessEmploymentClaim' do
+    form_id { '28-1900-V2' }
+
+    form {
+      {
+        'email' => 'email@test.com',
+        'isMoving' => false,
+        'yearsOfEducation' => '10',
+        'veteranInformation' => {
+          'fullName' => {
+            'first' => 'First',
+            'middle' => 'Middle',
+            'last' => 'Last',
+            'suffix' => 'III'
+          },
+          'dob' => '1980-01-01'
+        }
+      }.to_json
+    }
+  end
 end

--- a/spec/factories/veteran_readiness_employment_claim.rb
+++ b/spec/factories/veteran_readiness_employment_claim.rb
@@ -117,9 +117,7 @@ FactoryBot.define do
         'veteranInformation' => {
           'fullName' => {
             'first' => 'First',
-            'middle' => 'Middle',
-            'last' => 'Last',
-            'suffix' => 'III'
+            'last' => 'Last'
           },
           'dob' => '1980-01-01'
         }

--- a/spec/lib/res/ch31_form_spec.rb
+++ b/spec/lib/res/ch31_form_spec.rb
@@ -6,9 +6,11 @@ require 'res/ch31_form'
 RSpec.describe RES::Ch31Form do
   let(:claim) { create(:veteran_readiness_employment_claim) }
   let(:claim_with_new_form) { create(:new_veteran_readiness_employment_claim) }
+  let(:claim_with_new_form_minimal) { create(:new_veteran_readiness_employment_claim_minimal) }
   let(:user) { create(:evss_user, :loa3) }
   let(:service) { RES::Ch31Form.new(user:, claim:) }
   let(:service_with_new_form) { RES::Ch31Form.new(user:, claim: claim_with_new_form) }
+  let(:service_with_new_form_minimal) { RES::Ch31Form.new(user:, claim: claim_with_new_form_minimal) }
   let(:new_address_hash) do
     {
       newAddress: {
@@ -40,20 +42,23 @@ RSpec.describe RES::Ch31Form do
 
       it 'adds a new address if the user is moving within 30 days' do
         expect(service).to receive(:new_address) { new_address_hash }
-
         service.submit
       end
     end
 
     context 'with a successful new form submission' do
-      before do
-        allow(service_with_new_form).to receive(:send_to_res).and_return(success_message)
-      end
-
       it 'adds a new address if the user is moving within 30 days' do
+        allow(service_with_new_form).to receive(:send_to_res).and_return(success_message)
         expect(service_with_new_form).to receive(:new_address) { new_address_hash }
 
         service_with_new_form.submit
+      end
+
+      it 'accepts only required fields' do
+        allow(service_with_new_form_minimal).to receive(:send_to_res).and_return(success_message)
+        expect(service_with_new_form_minimal).to receive(:mapped_address_hash).and_return(nil)
+
+        service_with_new_form_minimal.submit
       end
     end
 
@@ -61,7 +66,6 @@ RSpec.describe RES::Ch31Form do
       context 'with old form' do
         it 'does not successfully send to RES' do
           allow(service).to receive(:send_to_res).and_return(OpenStruct.new(body: { 'error' => 'Error' }))
-
           expect { service.submit }.to raise_error(Ch31Error)
         end
       end
@@ -69,14 +73,12 @@ RSpec.describe RES::Ch31Form do
       context 'with new form' do
         it 'does not successfully send to RES' do
           allow(service_with_new_form).to receive(:send_to_res).and_return(OpenStruct.new(body: { 'error' => 'Error' }))
-
           expect { service_with_new_form.submit }.to raise_error(Ch31Error)
         end
       end
 
       it 'handles nil claim' do
         nil_claim_service = RES::Ch31Form.new(user:, claim: nil)
-
         expect { nil_claim_service.submit }.to raise_error(Ch31NilClaimError)
       end
     end

--- a/spec/lib/res/ch31_form_spec.rb
+++ b/spec/lib/res/ch31_form_spec.rb
@@ -62,6 +62,83 @@ RSpec.describe RES::Ch31Form do
       end
     end
 
+    context 'when all fields are supplied' do
+      it 'forms params with matching supplied data' do
+        payload = {
+          useEva: nil,
+          receiveElectronicCommunication: nil,
+          useTelecounseling: nil,
+          appointmentTimePreferences: nil,
+          yearsOfEducation: '10',
+          isMoving: true,
+          mainPhone: '2222222222',
+          cellNumber: '3333333333',
+          internationalNumber: '+4444444444',
+          email: 'email@test.com',
+          documentId: nil,
+          receivedDate: claim_with_new_form.created_at.iso8601,
+          veteranAddress: {
+            country: 'USA',
+            street: '12 usa street',
+            city: 'New York',
+            state: 'NY',
+            postalCode: '10001'
+          },
+          veteranInformation: {
+            fullName: {
+              first: 'First',
+              middle: 'Middle',
+              last: 'Last',
+              suffix: 'III'
+            },
+            dob: '1980-01-01',
+            regionalOffice: nil
+          },
+          newAddress: {
+            country: 'USA',
+            street: '13 usa street',
+            city: 'New York',
+            state: 'NY',
+            postalCode: '10001'
+          }
+        }.to_json
+        expect_any_instance_of(RES::Service).to receive(:send_to_res).with(payload:).and_return(success_message)
+
+        service_with_new_form.submit
+      end
+    end
+
+    context 'when only required fields are supplied' do
+      it 'forms params with null data attributes' do
+        payload = {
+          useEva: nil,
+          receiveElectronicCommunication: nil,
+          useTelecounseling: nil,
+          appointmentTimePreferences: nil,
+          yearsOfEducation: '10',
+          isMoving: false,
+          mainPhone: nil,
+          cellNumber: nil,
+          internationalNumber: nil,
+          email: 'email@test.com',
+          documentId: nil,
+          receivedDate: claim_with_new_form_minimal.created_at.iso8601,
+          veteranAddress: nil,
+          veteranInformation: {
+            fullName: {
+              first: 'First',
+              last: 'Last'
+            },
+            dob: '1980-01-01',
+            regionalOffice: nil
+          },
+        }.to_json
+        expect_any_instance_of(RES::Service).to receive(:send_to_res).with(payload:).and_return(success_message)
+
+        service_with_new_form_minimal.submit
+      end
+    end
+
     context 'with an unsuccessful submission' do
       context 'with old form' do
         it 'does not successfully send to RES' do

--- a/spec/lib/res/ch31_form_spec.rb
+++ b/spec/lib/res/ch31_form_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe RES::Ch31Form do
             },
             dob: '1980-01-01',
             regionalOffice: nil
-          },
+          }
         }.to_json
         expect_any_instance_of(RES::Service).to receive(:send_to_res).with(payload:).and_return(success_message)
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This change handles forming the RES Service payload if no `veteranAddress` is submitted, setting it to `nil` instead of trying to access data that is not present. `veteranAddress` is an optional field on the form, and was not being treated as such, causing the form submission to fail on staging. My team is implementing a new version of the form in vets-website. This is not behind a feature toggle because the new form is not reachable in production.
- I work on the IIR Product team and we currently own the VR&E (Ch 31) form

## Related issue(s)

- [1843](https://github.com/department-of-veterans-affairs/va-iir/issues/1843)

## Testing done

- [x] *New code is covered by unit tests*
- This is all new functionality, supporting a new version of the Ch. 31 form.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
This only impacts the new Ch. 31 form RES Service submission.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
