### PR TITLE
Skip flaky VAOS EPS referral tests

### DIFF
--- a/modules/vaos/spec/requests/vaos/v2/appointments_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/appointments_spec.rb
@@ -1222,7 +1222,7 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
     end
   end
 
-  context 'for eps referrals' do
+  context 'for eps referrals', skip: 'Flaky tests affecting CI stability since June 27th' do
     let(:current_user) { build(:user, :vaos, icn: 'care-nav-patient-casey') }
     let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
     let(:redis_token_expiry) { 59.minutes }


### PR DESCRIPTION
## Summary
- Skip consistently failing VAOS EPS referral tests that have been affecting CI stability since June 27th
- Tests are being temporarily skipped while the root cause is investigated

## Background
- VAOS EPS referral tests started failing consistently around June 27th
- 37+ master branch failures identified with identical 9-test failure patterns
- Timeline correlates with commit 8326d1b12d which added `Rails.cache.clear` to test suite
- Failures are blocking CI for multiple unrelated PRs

## Test Plan
- [x] Verify tests are properly skipped with `:skip` tag
- [x] Confirm CI passes without these flaky tests
- [ ] VFS-VAOS team to investigate root cause and re-enable tests

## Next Steps
@department-of-veterans-affairs/vfs-vaos team will investigate the root cause, likely related to the `Rails.cache.clear` addition in the test's `after` block.

Related files:
- `modules/vaos/spec/requests/vaos/v2/appointments_spec.rb:1225`
- Suspect commit: https://github.com/department-of-veterans-affairs/vets-api/commit/8326d1b12d33c3998acb545449f4321adc64e961