### PR TITLE
Added CCRA configuration to failing appointment spec unit tests

### DIFF
--- a/modules/vaos/spec/requests/vaos/v2/appointments_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/appointments_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
       api_url: 'https://api.wellhive.com',
       base_path: 'care-navigation/v1'
     )
+    allow(Settings.vaos.ccra).to receive_messages(
+      api_url: 'http://test.example.com',
+      base_path: 'vaos/v1/patients'
+    )
     sign_in_as(current_user)
     allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token')
-  end
-
-  after do
-    Rails.cache.clear
   end
 
   let(:described_class) { VAOS::V2::AppointmentsController }


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Some tests in `modules/vaos/spec/requests/vaos/v2/appointments_spec.rb` are failing randomly. We finally were able to replicate by running ALL the VAOS tests with the following command: `bundle exec rspec modules/vaos/spec/ --seed 123`. Note that running just the one test file will result in success. The issue turned out to be that the CCRA settings were not set.
- Team: UAE Check In

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/113647

## Testing done
N/A

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

