### PR TITLE
Api 47787 seperate out decision classes

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -143,11 +143,9 @@ module ClaimsApi
         private
 
         def process_poa_decision(decision:, ptcpnt_id:, proc_id:, representative_id:)
-          if decision == 'declined'
-            ClaimsApi::PowerOfAttorneyRequestService::DecisionHandler.new(
-              ptcpnt_id:, proc_id:, representative_id:
-            ).call
-          end
+          ClaimsApi::PowerOfAttorneyRequestService::DecisionHandler.new(
+            decision:, ptcpnt_id:, proc_id:, representative_id:
+          ).call
         end
 
         def handle_get_poa_request(ptcpnt_id:, lighthouse_id:)

--- a/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/decision_handler.rb
+++ b/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/decision_handler.rb
@@ -1,61 +1,30 @@
 # frozen_string_literal: true
 
+require_relative 'declined_decision_handler'
+
 module ClaimsApi
   module PowerOfAttorneyRequestService
     class DecisionHandler
-      def initialize(ptcpnt_id:, proc_id:, representative_id:)
+      DECISION_HANDLERS = {
+        'declined' => ClaimsApi::PowerOfAttorneyRequestService::DeclinedDecisionHandler
+      }.freeze
+
+      def initialize(decision:, ptcpnt_id:, proc_id:, representative_id:)
+        @decision = decision
         @ptcpnt_id = ptcpnt_id
         @proc_id = proc_id
         @representative_id = representative_id
       end
 
       def call
-        poa_request = validate_ptcpnt_id!
-        first_name = poa_request['claimantFirstName'].presence || poa_request['vetFirstName'] if poa_request
+        handler_class = DECISION_HANDLERS[@decision]
+        return unless handler_class
 
-        send_declined_notification(ptcpnt_id: @ptcpnt_id, first_name:, representative_id: @representative_id)
-      end
-
-      private
-
-      def manage_representative_service
-        ClaimsApi::ManageRepresentativeService.new(external_uid: Settings.bgs.external_uid,
-                                                   external_key: Settings.bgs.external_key)
-      end
-
-      def validate_ptcpnt_id!
-        if @ptcpnt_id.blank?
-          raise ::Common::Exceptions::ParameterMissing.new('ptcpntId',
-                                                           detail: 'ptcpntId is required if decision is declined')
-        end
-
-        if @representative_id.blank?
-          raise ::Common::Exceptions::ParameterMissing
-            .new('representativeId', detail: 'representativeId is required if decision is declined')
-        end
-
-        res = manage_representative_service.read_poa_request_by_ptcpnt_id(ptcpnt_id: @ptcpnt_id)
-
-        raise ::Common::Exceptions::Lighthouse::BadGateway if res.blank?
-
-        poa_requests = Array.wrap(res['poaRequestRespondReturnVOList'])
-
-        matching_request = poa_requests.find { |poa_request| poa_request['procID'] == @proc_id }
-
-        detail = 'Participant ID/Process ID combination not found'
-        raise ::Common::Exceptions::ResourceNotFound.new(detail:) if matching_request.nil?
-
-        matching_request
-      end
-
-      def send_declined_notification(ptcpnt_id:, first_name:, representative_id:)
-        return unless Flipper.enabled?(:lighthouse_claims_api_v2_poa_va_notify)
-
-        lockbox = Lockbox.new(key: Settings.lockbox.master_key)
-        encrypted_ptcpnt_id = Base64.strict_encode64(lockbox.encrypt(ptcpnt_id))
-        encrypted_first_name = Base64.strict_encode64(lockbox.encrypt(first_name))
-
-        ClaimsApi::VANotifyDeclinedJob.perform_async(encrypted_ptcpnt_id, encrypted_first_name, representative_id)
+        handler_class.new(
+          ptcpnt_id: @ptcpnt_id,
+          proc_id: @proc_id,
+          representative_id: @representative_id
+        ).call
       end
     end
   end

--- a/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/declined_decision_handler.rb
+++ b/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/declined_decision_handler.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module ClaimsApi
+  module PowerOfAttorneyRequestService
+    class DeclinedDecisionHandler
+      def initialize(ptcpnt_id:, proc_id:, representative_id:)
+        @ptcpnt_id = ptcpnt_id
+        @proc_id = proc_id
+        @representative_id = representative_id
+      end
+
+      def call
+        poa_request = fetch_and_validate_ptcpnt_request!
+        first_name = extract_first_name(poa_request)
+
+        send_declined_notification(ptcpnt_id: @ptcpnt_id, first_name:, representative_id: @representative_id)
+      end
+
+      private
+
+      def fetch_and_validate_ptcpnt_request!
+        validate_params!
+
+        res = read_poa_request_by_ptcpnt_id
+        validate_response!(res)
+
+        matching_request = find_matching_request(res)
+        raise_resource_not_found unless matching_request
+
+        matching_request
+      end
+
+      def validate_params!
+        raise_if_blank(@ptcpnt_id, 'ptcpntId')
+        raise_if_blank(@representative_id, 'representativeId')
+      end
+
+      def raise_if_blank(value, name)
+        return if value.present?
+
+        raise ::Common::Exceptions::ParameterMissing.new(
+          name, detail: "#{name} is required if decision is declined"
+        )
+      end
+
+      def read_poa_request_by_ptcpnt_id
+        manage_representative_service.read_poa_request_by_ptcpnt_id(ptcpnt_id: @ptcpnt_id)
+      end
+
+      def validate_response!(res)
+        raise ::Common::Exceptions::Lighthouse::BadGateway if res.blank?
+      end
+
+      def find_matching_request(res)
+        poa_requests = Array.wrap(res['poaRequestRespondReturnVOList'])
+        poa_requests.find { |poa| poa['procID'] == @proc_id }
+      end
+
+      def raise_resource_not_found
+        detail = 'Participant ID/Process ID combination not found'
+        raise ::Common::Exceptions::ResourceNotFound.new(detail:)
+      end
+
+      def extract_first_name(poa_request)
+        poa_request['claimantFirstName'].presence || poa_request['vetFirstName']
+      end
+
+      def manage_representative_service
+        ClaimsApi::ManageRepresentativeService.new(external_uid: Settings.bgs.external_uid,
+                                                   external_key: Settings.bgs.external_key)
+      end
+
+      def send_declined_notification(ptcpnt_id:, first_name:, representative_id:)
+        return unless Flipper.enabled?(:lighthouse_claims_api_v2_poa_va_notify)
+
+        lockbox = Lockbox.new(key: Settings.lockbox.master_key)
+        encrypted_ptcpnt_id = Base64.strict_encode64(lockbox.encrypt(ptcpnt_id))
+        encrypted_first_name = Base64.strict_encode64(lockbox.encrypt(first_name))
+
+        ClaimsApi::VANotifyDeclinedJob.perform_async(encrypted_ptcpnt_id, encrypted_first_name, representative_id)
+      end
+    end
+  end
+end

--- a/modules/claims_api/spec/services/power_of_attorney_request_service/decision_handler_spec.rb
+++ b/modules/claims_api/spec/services/power_of_attorney_request_service/decision_handler_spec.rb
@@ -1,45 +1,18 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'bgs_service/manage_representative_service'
 
 describe ClaimsApi::PowerOfAttorneyRequestService::DecisionHandler do
-  subject { described_class.new(ptcpnt_id:, proc_id:, representative_id:) }
+  subject { described_class.new(decision:, ptcpnt_id:, proc_id:, representative_id:) }
 
+  let(:decision) { 'declined' }
   let(:ptcpnt_id) { '600043284' }
   let(:proc_id) { '12345' }
   let(:representative_id) { '11' }
 
-  let(:poa_request_response) do
-    {
-      'poaRequestRespondReturnVOList' => [
-        {
-          'procID' => proc_id,
-          'claimantFirstName' => 'John',
-          'poaCode' => '123'
-        }
-      ]
-    }
-  end
-
-  context 'VANotify Job' do
-    before do
-      service_double = instance_double(ClaimsApi::ManageRepresentativeService)
-      allow(ClaimsApi::ManageRepresentativeService).to receive(:new).with(any_args)
-                                                                    .and_return(service_double)
-      allow(service_double).to receive(:read_poa_request_by_ptcpnt_id).with(any_args).and_return(poa_request_response)
-    end
-
-    it 'queues when the job when the feature flag is enabled' do
-      allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_v2_poa_va_notify).and_return(true)
-      expect(ClaimsApi::VANotifyDeclinedJob).to receive(:perform_async)
-
-      subject.call
-    end
-
-    it 'does not enqueue the job when the feature flag is disabled' do
-      allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_v2_poa_va_notify).and_return(false)
-      expect(ClaimsApi::VANotifyDeclinedJob).not_to receive(:perform_async)
+  context "When the decision is 'Declined'" do
+    it 'calls the declined decision service handler' do
+      expect_any_instance_of(ClaimsApi::PowerOfAttorneyRequestService::DeclinedDecisionHandler).to receive(:call)
 
       subject.call
     end

--- a/modules/claims_api/spec/services/power_of_attorney_request_service/declined_decision_handler_spec.rb
+++ b/modules/claims_api/spec/services/power_of_attorney_request_service/declined_decision_handler_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'bgs_service/manage_representative_service'
+
+describe ClaimsApi::PowerOfAttorneyRequestService::DeclinedDecisionHandler do
+  subject { described_class.new(ptcpnt_id:, proc_id:, representative_id:) }
+
+  let(:ptcpnt_id) { '600043284' }
+  let(:proc_id) { '12345' }
+  let(:representative_id) { '11' }
+
+  let(:poa_request_response) do
+    {
+      'poaRequestRespondReturnVOList' => [
+        {
+          'procID' => proc_id,
+          'claimantFirstName' => 'John',
+          'poaCode' => '123'
+        }
+      ]
+    }
+  end
+
+  context 'VANotify Job' do
+    before do
+      service_double = instance_double(ClaimsApi::ManageRepresentativeService)
+      allow(ClaimsApi::ManageRepresentativeService).to receive(:new).with(any_args)
+                                                                    .and_return(service_double)
+      allow(service_double).to receive(:read_poa_request_by_ptcpnt_id).with(any_args).and_return(poa_request_response)
+    end
+
+    it 'queues when the job when the feature flag is enabled' do
+      allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_v2_poa_va_notify).and_return(true)
+      expect(ClaimsApi::VANotifyDeclinedJob).to receive(:perform_async)
+
+      subject.call
+    end
+
+    it 'does not enqueue the job when the feature flag is disabled' do
+      allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_v2_poa_va_notify).and_return(false)
+      expect(ClaimsApi::VANotifyDeclinedJob).not_to receive(:perform_async)
+
+      subject.call
+    end
+  end
+end


### PR DESCRIPTION
## Summary
* Moves the decsion handling part of the `decide` method out into a service
* Moves one test that was checking for the notify job queue.  Since this now gets queued up from the service and not in the controller those 2 tests needed to be moved.  Nothing added in thisrefactor, but those two tests moved and adjusted
* This refactor is setting up the following parent ticket, but as a stand alone refactor probably does not make the most sense, but we will see multiple paths once 'accepted' gets built out.

## Related issue(s)
[API-47787](https://jira.devops.va.gov/browse/API-47787)
[API-43735](https://jira.devops.va.gov/browse/API-43735) (Parent ticket this is setting up for)

## Testing done
- This is a refactor so no new functionality to test.  Some tests where moved in order to cover the changes but nothing new was added functionality-wise in this refactor.
- [x] *Code is covered by unit tests*

## Screenshots


## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
	modified:   modules/claims_api/app/services/claims_api/power_of_attorney_request_service/decision_handler.rb
	modified:   modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
	new file:   modules/claims_api/spec/services/power_of_attorney_request_service/decision_handler_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

Please feel free to share any opinions on changes or better approaches.  Totally open to changing things up here or trying a different approach for keeping the `declined` & (u[coming)  `accepted` workflows clean and amangeable.
