### PR TITLE
fix(workflows): handle null user login in jq approval parsing

### DIFF
--- a/.github/workflows/require_be_approval.yml
+++ b/.github/workflows/require_be_approval.yml
@@ -151,7 +151,7 @@ jobs:
             ]
             | sort_by(.submitted_at)
             | last
-            | .user.login
+            | .user.login // ""
           ' || true)
 
           echo "Approvals: $APPROVED"


### PR DESCRIPTION
## Summary
- Fix jq parsing error in require_be_approval workflow when PR reviews have null user data
- Add fallback to empty string using `// ""` operator to prevent parsing failures

## Test plan
- [x] Verified the jq syntax change handles null values correctly
- [ ] Test on a PR with problematic review data to ensure no parsing errors occur