### PR TITLE
hotfix vvs check

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -945,7 +945,7 @@ module VAOS
           'vaVideoCareAtHome'
         elsif vvs_kind.nil?
           vvs_video_appt = appointment.dig(:extension, :vvs_vista_video_appt)
-          vvs_video_appt == 'true' ? 'vaVideoCareAtHome' : 'vaInPerson'
+          vvs_video_appt.to_s.downcase == 'true' ? 'vaVideoCareAtHome' : 'vaInPerson'
         end
       end
 

--- a/modules/vaos/spec/factories/v2/appointment_forms.rb
+++ b/modules/vaos/spec/factories/v2/appointment_forms.rb
@@ -375,7 +375,7 @@ FactoryBot.define do
       telehealth
       extension do
         {
-          vvs_vista_video_appt: 'true'
+          vvs_vista_video_appt: true
         }
       end
     end
@@ -385,7 +385,7 @@ FactoryBot.define do
       telehealth
       extension do
         {
-          vvs_vista_video_appt: 'false'
+          vvs_vista_video_appt: false
         }
       end
     end


### PR DESCRIPTION
## Summary

- Hotfix for checking telehealth modality, adding conversion to string to cover booleans

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111669