### PR TITLE
Add location name to veterans health immunizations

### DIFF
--- a/lib/lighthouse/veterans_health/models/immunization.rb
+++ b/lib/lighthouse/veterans_health/models/immunization.rb
@@ -13,6 +13,7 @@ module Lighthouse
         attribute :dose_number, String
         attribute :dose_series, String
         attribute :group_name, String
+        attribute :location, String
         attribute :location_id, String
         attribute :manufacturer, String
         attribute :note, String

--- a/lib/lighthouse/veterans_health/serializers/immunization_serializer.rb
+++ b/lib/lighthouse/veterans_health/serializers/immunization_serializer.rb
@@ -47,6 +47,7 @@ module Lighthouse
           attrs.dose_number = extract_dose_number(protocol_applied)
           attrs.dose_series = extract_dose_series(protocol_applied)
           attrs.group_name = group_name
+          attrs.location = extract_location_display(resource['location'])
           attrs.location_id = extract_location_id(resource['location'])
           attrs.manufacturer = extract_manufacturer(resource, group_name)
           attrs.note = extract_note(resource['note'])
@@ -157,6 +158,12 @@ module Lighthouse
           return nil if location.nil?
 
           location['reference'].split('/').last if location.is_a?(Hash) && location['reference']
+        end
+
+        def self.extract_location_display(location)
+          return nil if location.nil?
+
+          location['display'] if location.is_a?(Hash) && location['display']
         end
       end
     end

--- a/modules/my_health/spec/requests/my_health/v2/immunizations_spec.rb
+++ b/modules/my_health/spec/requests/my_health/v2/immunizations_spec.rb
@@ -49,6 +49,23 @@ RSpec.describe 'MyHealth::V2::ImmunizationsController', :skip_json_api_validatio
           get path, headers: { 'X-Key-Inflection' => 'camel' }, params: default_params
         end
       end
+
+      it 'includes location information in immunization data' do
+        json_response = JSON.parse(response.body)
+        
+        # Verify that immunizations have location data
+        expect(json_response['data']).to be_an(Array)
+        expect(json_response['data']).not_to be_empty
+        
+        # Check that each immunization includes location data
+        json_response['data'].each do |immunization|
+          expect(immunization['attributes']).to have_key('location')
+          expect(immunization['attributes']).to have_key('locationId')
+        end
+
+        # Verify the location name for the first immunization
+        expect(json_response['data'][0]['attributes']['location']).to eq('TEST VA FACILITY')
+      end
     end
 
     context 'error cases' do

--- a/modules/my_health/spec/requests/my_health/v2/immunizations_spec.rb
+++ b/modules/my_health/spec/requests/my_health/v2/immunizations_spec.rb
@@ -52,11 +52,11 @@ RSpec.describe 'MyHealth::V2::ImmunizationsController', :skip_json_api_validatio
 
       it 'includes location information in immunization data' do
         json_response = JSON.parse(response.body)
-        
+
         # Verify that immunizations have location data
         expect(json_response['data']).to be_an(Array)
         expect(json_response['data']).not_to be_empty
-        
+
         # Check that each immunization includes location data
         json_response['data'].each do |immunization|
           expect(immunization['attributes']).to have_key('location')


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): NO*

This PR adds the human-readable location display name to the veterans health immunizations endpoint. The location information is sourced from the `immunization.location.display` field in the LH FHIR response.

## Testing done

- [x] *New code is covered by unit tests*
