### PR TITLE
Handle vvsKind value of MOBILE_ANY_GROUP telehealth appointments

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -941,7 +941,7 @@ module VAOS
           'vaVideoCareAtAnAtlasLocation'
         elsif %w[CLINIC_BASED STORE_FORWARD].include?(vvs_kind)
           'vaVideoCareAtAVaLocation'
-        elsif %w[MOBILE_ANY ADHOC].include?(vvs_kind)
+        elsif %w[MOBILE_ANY MOBILE_ANY_GROUP ADHOC].include?(vvs_kind)
           'vaVideoCareAtHome'
         elsif vvs_kind.nil?
           vvs_video_appt = appointment.dig(:extension, :vvs_vista_video_appt)

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -2321,7 +2321,7 @@ describe VAOS::V2::AppointmentsService do
       expect(appt[:modality]).to eq('vaVideoCareAtAVaLocation')
     end
 
-    %w[MOBILE_ANY ADHOC].each do |input|
+    %w[MOBILE_ANY MOBILE_ANY_GROUP ADHOC].each do |input|
       it "is vaVideoCareAtHome for #{input} vvsKind" do
         appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth).attributes
         appt[:telehealth][:vvs_kind] = input


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- We discovered that we weren't handling telehealth appointments with vvsKind of MOBILE_ANY_GROUP
- We confirmed that these types of appointments should be handled in the same way as telehealth appointments with vvsKind of MOBILE_ANY
- Appointments FE Team

## Related issue(s)

- See detailed slack discussion [here](https://dsva.slack.com/archives/CMNQT72LX/p1751991838050649)

## Testing done

- [x] *New code is covered by unit tests*


## Screenshots
N/A

## What areas of the site does it impact?
Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature


