### PR TITLE
API-47905-fix-missing-error-var

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
@@ -83,7 +83,7 @@ module ClaimsApi
         valid_poa_code_for_current_user?(poa_code_to_verify)
       rescue ::Common::Exceptions::UnprocessableEntity
         raise
-      rescue
+      rescue => e
         ClaimsApi::Logger.log 'poa_verification', level: :error, detail: e.message, error_class: e.class.name
         raise ::Common::Exceptions::Unauthorized, detail: 'Cannot validate Power of Attorney'
       end


### PR DESCRIPTION
## Summary
* Sets missing error variable
	* This was causing 500s to be thrown when the rescue got hit

## Related issue(s)
[API-47905](https://jira.devops.va.gov/browse/API-47905)

Related [DD logs](https://vagov.ddog-gov.com/monitors/195768?event_id=AwAAAZftOLzAiRqkpwAAABhBWmZ0T2hfckFBQzRmUlNiMV9remFIeVEAAAAkMDE5N2VkNTctMWUxOC00ZTEwLThkZmYtYTI3ZTJhZGJhZDY2AACrtQ&link_source=monitor_notif&from_ts=1752030708000&to_ts=1752031908000&live=false)

## Testing done

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
modified:   modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
