### PR TITLE
remove ppiu config

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -363,14 +363,6 @@
       :uid_location: header
       :uid_locator: 'va_eauth_pnid'
 
-  # PPIU payment information
-  - :method: :get
-    :path: "/wss-ppiu-services-web/rest/ppiuServices/v1/paymentInformation"
-    :file_path: "evss/ppiu/payment_information"
-  - :method: :post
-    :path: "/wss-ppiu-services-web/rest/ppiuServices/v1/paymentInformation"
-    :file_path: "evss/ppiu/update_payment_information"
-
   # Intent To File
   - :method: :get
     :path: "/wss-intenttofile-services-web/rest/intenttofile/v1"
@@ -699,7 +691,7 @@
       :cache_multiple_responses:
         :uid_location: 'url'
         :uid_locator: '\/facilities\/v2\/facilities\/^[0-9]+$\/clinics\/^[0-9]+$'
-    
+
     # Get referral list
     - :method: :get
       :path: "/vaos/v1/patients/*/referrals"
@@ -938,12 +930,12 @@
       :cache_multiple_responses:
         :uid_location: url
         :uid_locator: '\/care-navigation\/v1\/provider-services\/(.+)'
-        
+
     # Get list of appointments
     - :method: :get
       :path: "/care-navigation/v1/appointments"
       :file_path: "vaos/eps/appointments/get_appointments/default"
-        
+
     # Get appointment details
     - :method: :get
       :path: "/care-navigation/v1/appointments/*"
@@ -951,7 +943,7 @@
       :cache_multiple_responses:
         :uid_location: url
         :uid_locator: '\/care-navigation\/v1\/appointments\/(.+)'
-        
+
     # Get provider service slots
     - :method: :get
       :path: "/care-navigation/v1/provider-services/*/slots"
@@ -959,7 +951,7 @@
       :cache_multiple_responses:
         :uid_location: url
         :uid_locator: '\/care-navigation\/v1\/provider-services\/(.+)\/slots'
-    
+
     # Create draft appointment
     - :method: :post
       :path: "/care-navigation/v1/appointments"
@@ -967,7 +959,7 @@
       :cache_multiple_responses:
         :uid_location: body
         :uid_locator: 'referralNumber":"(\w+)"'
-    
+
     # Submit appointment
     - :method: :post
       :path: "/care-navigation/v1/appointments/*/submit"

--- a/config/locales/exceptions.en.yml
+++ b/config/locales/exceptions.en.yml
@@ -2346,25 +2346,6 @@ en:
       detail: 'The upstream server returned an error code that is unmapped'
       code: 128
       status: 400
-    ppiu:
-      potential_fraud:
-        <<: *defaults
-        title: Potential Fraud
-        detail: 'Routing number related to potential fraud'
-        code: 135
-        status: 422
-      account_flagged:
-        <<: *defaults
-        title: Account Flagged
-        detail: 'The account has been flagged'
-        code: 136
-        status: 422
-      unprocessable_entity:
-        <<: *defaults
-        title: Unprocessable Entity
-        detail: 'One or more unprocessable user payment properties'
-        code: 126
-        status: 422
     intent_to_file:
       partner_service_error:
         <<: *defaults

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,9 +191,6 @@ Rails.application.routes.draw do
     get 'healthcheck', to: 'example#healthcheck', as: :healthcheck
     get 'startup_healthcheck', to: 'example#startup_healthcheck', as: :startup_healthcheck
 
-    get 'ppiu/payment_information', to: 'ppiu#index'
-    put 'ppiu/payment_information', to: 'ppiu#update'
-
     post 'event_bus_gateway/send_email', to: 'event_bus_gateway#send_email'
 
     resources :maintenance_windows, only: [:index]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -401,13 +401,10 @@ evss:
   mock_letters: <%= ENV['evss__mock_letters'] %>
   mock_pciu: <%= ENV['evss__mock_pciu'] %>
   mock_pciu_address: <%= ENV['evss__mock_pciu_address'] %>
-  mock_ppiu: <%= ENV['evss__mock_ppiu'] %>
   mock_vso_search: <%= ENV['evss__mock_vso_search'] %>
   pciu:
     timeout: 30
   pciu_address:
-    timeout: 30
-  ppiu:
     timeout: 30
   prefill: true
   root_cert_path: <%= ENV['evss__root_cert_path'] %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -400,13 +400,10 @@ evss:
   mock_letters: false
   mock_pciu: true
   mock_pciu_address: false
-  mock_ppiu: true
   mock_vso_search: false
   pciu:
     timeout: 30
   pciu_address:
-    timeout: 30
-  ppiu:
     timeout: 30
   prefill: true
   root_cert_path: ~

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -399,13 +399,10 @@ evss:
   mock_letters: false
   mock_pciu: true
   mock_pciu_address: false
-  mock_ppiu: true
   mock_vso_search: false
   pciu:
     timeout: 30
   pciu_address:
-    timeout: 30
-  ppiu:
     timeout: 30
   prefill: true
   root_cert_path: ~


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper):* NO

Remove EVSS PPIU config. EVSS turned off PPIU last year. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/105754

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

