### PR TITLE
112032 - Add resubmission metadata properties to form submissions - form 10-7959a

### DIFF
--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
@@ -33,7 +33,13 @@ module IvcChampva
         'uuid' => @uuid,
         'primaryContactInfo' => @data['primary_contact_info'],
         'primaryContactEmail' => @data.dig('primary_contact_info', 'email').to_s
-      }
+      }.merge(add_resubmission_properties)
+    end
+
+    def add_resubmission_properties
+      # TODO: When the frontend adds the actual PDI number field, add to this list
+      @data.slice('claim_status', 'pdi_or_claim_number', 'claim_type', 'provider_name', 'beginning_date_of_service',
+                  'end_date_of_service', 'medication_name', 'prescription_fill_date')
     end
 
     def desired_stamps

--- a/modules/ivc_champva/spec/models/vha_10_7959a_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959a_spec.rb
@@ -52,6 +52,54 @@ RSpec.describe IvcChampva::VHA107959a do
     end
   end
 
+  describe '#add_resubmission_properties' do
+    context 'when medical claim resubmission data is present' do
+      let(:medical_resubmission_data) do
+        # update data to reflect a resubmitted medical claim
+        data.merge(
+          {
+            'claim_status' => 'resubmission',
+            'pdi_or_claim_number' => 'PDI number',
+            'claim_type' => 'medical',
+            'provider_name' => 'BCBS',
+            'beginning_date_of_service' => '01-01-1999',
+            'end_date_of_service' => '01-02-1999'
+          }
+        )
+      end
+
+      let(:vha107959a_medical_resubmission) { described_class.new(medical_resubmission_data) }
+
+      it 'includes a key for each present resubmission property' do
+        res = vha107959a_medical_resubmission.add_resubmission_properties
+        expect(res.keys.include?('claim_status')).to be(true)
+        expect(res.keys.include?('pdi_or_claim_number')).to be(true)
+        expect(res.keys.include?('claim_type')).to be(true)
+        expect(res.keys.include?('provider_name')).to be(true)
+        expect(res.keys.include?('beginning_date_of_service')).to be(true)
+        expect(res.keys.include?('end_date_of_service')).to be(true)
+      end
+
+      it 'contains resubmission data' do
+        res = vha107959a_medical_resubmission.add_resubmission_properties
+        expect(res['claim_status']).to eq('resubmission')
+      end
+    end
+
+    context 'when resubmission properties are missing' do
+      it 'does not interfere with metadata creation' do
+        expect(vha_10_7959a.metadata.keys.include?('veteranFirstName')).to be(true)
+      end
+
+      it 'does not include resubmission property if there is no corresponding value' do
+        # vha_10_7959a was initialized with no resubmission values
+        res = vha_10_7959a.add_resubmission_properties
+        # this key will not be present even though `add_resubmission_properties` attempts to get it from the form data
+        expect(res.keys.include?('claim_status')).to be(false)
+      end
+    end
+  end
+
   describe '#track_email_usage' do
     let(:statsd_key) { 'api.ivc_champva_form.10_7959a' }
 


### PR DESCRIPTION
## Summary

This PR updates the metadata object created for form 10-7959a to indicate whether or not the submission is a resubmitted form.

It also adds basic unit tests

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/112032

## Testing done

- [X] *New code is covered by unit tests*
- Previously the metadata object didn't reflect any of the resubmission data properties
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots

NA

## What areas of the site does it impact?

IVC CHAMPVA form 10-7959a

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA