### PR TITLE
Handle vvsKind value of MOBILE_GFE telehealth appointments

### DIFF
--- a/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointment.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointment.rb
@@ -42,9 +42,10 @@ module Mobile
 
         # ADHOC is a staging value used in place of MOBILE_ANY
         VIDEO_CODE = %w[
+          ADHOC
           MOBILE_ANY
           MOBILE_ANY_GROUP
-          ADHOC
+          MOBILE_GFE
         ].freeze
 
         # Only a subset of types of service that requires human readable conversion
@@ -300,7 +301,7 @@ module Mobile
 
           vvs_kind = appointment.dig(:telehealth, :vvs_kind)
           if VIDEO_CODE.include?(vvs_kind)
-            if appointment.dig(:extension, :patient_has_mobile_gfe)
+            if vvs_kind == 'MOBILE_GFE' || appointment.dig(:extension, :patient_has_mobile_gfe)
               APPOINTMENT_TYPES[:va_video_connect_gfe]
             else
               APPOINTMENT_TYPES[:va_video_connect_home]

--- a/modules/mobile/spec/models/adapters/appointments_vaos_v2_adapter_spec.rb
+++ b/modules/mobile/spec/models/adapters/appointments_vaos_v2_adapter_spec.rb
@@ -17,9 +17,10 @@ describe Mobile::V0::Adapters::VAOSV2Appointments, :aggregate_failures do
   let(:phone_va_id) { '53352' }
   let(:home_va_mobile_any_id) { '50094' }
   let(:atlas_va_id) { '50095' }
-  let(:home_gfe_id) { '50096' }
+  let(:home_mobile_any_gfe_id) { '50096' }
   let(:home_va_mobile_any_group_id) { '50098' }
   let(:home_va_adhoc_id) { '50099' }
+  let(:home_mobile_gfe_id) { '50100' }
   let(:past_request_date_appt_id) { '53360' }
   let(:future_request_date_appt_id) { '53359' }
   let(:telehealth_onsite_id) { '50097' }
@@ -56,7 +57,7 @@ describe Mobile::V0::Adapters::VAOSV2Appointments, :aggregate_failures do
 
   it 'returns a list of Mobile::V0::Appointments at the expected size' do
     adapted_appointments = subject.parse(appointment_data)
-    expect(adapted_appointments.size).to eq(15)
+    expect(adapted_appointments.size).to eq(16)
     expect(adapted_appointments.map(&:class).uniq).to match_array(Mobile::V0::Appointment)
   end
 
@@ -162,8 +163,13 @@ describe Mobile::V0::Adapters::VAOSV2Appointments, :aggregate_failures do
         expect(appt.appointment_type).to eq('VA_VIDEO_CONNECT_ATLAS')
       end
 
-      it 'sets GFE appointments to VA_VIDEO_CONNECT_GFE' do
-        appt = appointment_by_id(home_gfe_id)
+      it 'sets GFE MOBILE_ANY appointments to VA_VIDEO_CONNECT_GFE' do
+        appt = appointment_by_id(home_mobile_any_gfe_id)
+        expect(appt.appointment_type).to eq('VA_VIDEO_CONNECT_GFE')
+      end
+
+      it 'sets GFE MOBILE_GFE appointments to VA_VIDEO_CONNECT_GFE' do
+        appt = appointment_by_id(home_mobile_gfe_id)
         expect(appt.appointment_type).to eq('VA_VIDEO_CONNECT_GFE')
       end
 

--- a/modules/mobile/spec/support/fixtures/VAOS_v2_appointments.json
+++ b/modules/mobile/spec/support/fixtures/VAOS_v2_appointments.json
@@ -734,6 +734,67 @@
     }
   },
   {
+    "id": "50100",
+    "identifier": [
+      {
+        "system": "http://med.va.gov/fhir/urn/vaos/arsid",
+        "value": "8a487fd67ba6a62d017bc0cc86d80002"
+      }
+    ],
+    "kind": "telehealth",
+    "type": "VA",
+    "location": {
+      "id": "442",
+      "name": "Cheyenne VA Medical Center",
+      "time_zone": {
+        "time_zone_id": "America/Denver"
+      },
+      "physical_address": {
+        "type": "physical",
+        "line": [
+          "2360 East Pershing Boulevard"
+        ],
+        "city": "Cheyenne",
+        "state": "WY",
+        "postal_code": "82001-5356"
+      },
+      "lat": 41.148026,
+      "long": -104.786255,
+      "phone": {
+        "main": "307-778-7550"
+      },
+      "url": null,
+      "code": null
+    },
+    "status": "proposed",
+    "service_type": "PrimaryCare",
+    "patient_icn": "1012845331V153043",
+    "location_id": "983",
+    "reason": "Test_SM test (tele)",
+    "requested_periods": [
+      {
+        "start": "2021-09-08T12:00:00Z",
+        "end": "2021-09-08T23:59:59.999Z"
+      }
+    ],
+    "contact": {
+      "telecom": [
+        {
+          "type": "phone",
+          "value": "9999999992"
+        }
+      ]
+    },
+    "cancellation_reason": {
+      "code": "other"
+    },
+    "cancellable": true,
+    "telehealth": {
+      "vvs_kind": "MOBILE_GFE",
+      "url": "http://www.meeting.com"
+    }
+  },
+  {
     "id": "53359",
     "identifier": [
       {

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -944,7 +944,7 @@ module VAOS
           'vaVideoCareAtAnAtlasLocation'
         elsif %w[CLINIC_BASED STORE_FORWARD].include?(vvs_kind)
           'vaVideoCareAtAVaLocation'
-        elsif %w[MOBILE_ANY MOBILE_ANY_GROUP ADHOC].include?(vvs_kind)
+        elsif %w[ADHOC MOBILE_ANY MOBILE_ANY_GROUP MOBILE_GFE].include?(vvs_kind)
           'vaVideoCareAtHome'
         elsif vvs_kind.nil?
           vvs_video_appt = appointment.dig(:extension, :vvs_vista_video_appt)

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -2372,7 +2372,7 @@ describe VAOS::V2::AppointmentsService do
       expect(appt[:modality]).to eq('vaVideoCareAtAVaLocation')
     end
 
-    %w[MOBILE_ANY MOBILE_ANY_GROUP ADHOC].each do |input|
+    %w[ADHOC MOBILE_ANY MOBILE_ANY_GROUP MOBILE_GFE].each do |input|
       it "is vaVideoCareAtHome for #{input} vvsKind" do
         appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth).attributes
         appt[:telehealth][:vvs_kind] = input
@@ -2397,7 +2397,7 @@ describe VAOS::V2::AppointmentsService do
 
     it 'is nil for unrecognized vvsKind' do
       appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth).attributes
-      appt[:telehealth][:vvs_kind] = 'MOBILE_GFE'
+      appt[:telehealth][:vvs_kind] = 'MOBILE_UNKNOWN'
       subject.send(:set_modality, appt)
       expect(appt[:modality]).to be_nil
     end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- We discovered that we weren't handling telehealth appointments with vvsKind of MOBILE_GFE
- We confirmed that these types of appointments should be handled in the same way as telehealth appointments with vvsKind of MOBILE_ANY and patient_has_mobile_gfe=true in extensions
- Appointments FE Team

## Related issue(s)

- See detailed slack discussion [here](https://dsva.slack.com/archives/CMNQT72LX/p1751991838050649)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/113816

## Testing done

- [x] *New code is covered by unit tests*


## Screenshots
N/A

## What areas of the site does it impact?
Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature


