### PR TITLE
[ARP] Always `BypassOliveBranch`. Once and for all

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -30,13 +30,6 @@ features:
     actor_type: user
     description: Enables the endpoints of the accredited representative portal intent to file
     enable_in_development: true
-  accredited_representative_portal_normalize_path:
-    actor_type: user
-    description: >
-      Enables the path that is passed in to the AccreditedRepresentativePortal::BypassOliveBranch.exclude_arp_route?() method to
-      use the function Rack::Attack::PathNormalizer.normalize_path() which removes trailing slashes and resolves redundant parts of the path.
-      NOTE: This should only be enabled in localhost and staging.
-    enable_in_development: true
   accredited_representative_portal_search:
     actor_type: user
     description: Enables the people search of the accredited representative portal

--- a/modules/accredited_representative_portal/app/controllers/concerns/accredited_representative_portal/v0/representative_form_upload_concern.rb
+++ b/modules/accredited_representative_portal/app/controllers/concerns/accredited_representative_portal/v0/representative_form_upload_concern.rb
@@ -2,7 +2,7 @@
 
 module AccreditedRepresentativePortal
   module V0
-    module RepresentativeFormUploadConcern # rubocop:disable Metrics/ModuleLength
+    module RepresentativeFormUploadConcern
       extend ActiveSupport::Concern
 
       private
@@ -93,72 +93,20 @@ module AccreditedRepresentativePortal
           end
       end
 
-      def submit_params # rubocop:disable Metrics/MethodLength
-        @submit_params ||= begin
-          unwrapped_params =
-            params.require(:representative_form_upload)
-
-          param_filters = [
-            :formName,
-            :confirmationCode,
-            { supportingDocuments: %i[name confirmationCode size isEncrypted] },
-            { formData: [
-              :veteranSsn,
-              :postalCode,
-              :veteranDateOfBirth,
-              :formNumber,
-              :email,
-              :claimantDateOfBirth,
-              :claimantSsn,
-              :vaFileNumber,
-              { claimantFullName: %i[first last] },
-              { veteranFullName: %i[first last] }
-            ] }
-          ]
-
-          ##
-          # TODO: Remove. This is a workaround while we're in the situation that
-          # OliveBranch modifies our params on staging but not on localhost.
-          # We'll have fixed that bug when it leaves our params alone in both
-          # environments.
-          #
-          # This `blank?` check approach should suffice to target this situation
-          # without causing some other breakage.
-          #
-          if unwrapped_params[:formData].blank?
-            ##
-            # Manual snakification of `param_filters`. Not done programmatically
-            # because the algorithm would be too long for throwaway code.
-            #
-            param_filters = [
-              :confirmation_code,
-              :form_name,
-              { supporting_documents: %i[name confirmation_code size is_encrypted] },
-              { form_data: [
-                :veteran_ssn,
-                :postal_code,
-                :veteran_date_of_birth,
-                :form_number,
-                :email,
-                :claimant_date_of_birth,
-                :claimant_ssn,
-                :va_file_number,
-                { claimant_full_name: %i[first last] },
-                { veteran_full_name: %i[first last] }
+      def submit_params
+        @submit_params ||=
+          params.require(:representative_form_upload).permit(
+            [
+              :formName, :confirmationCode,
+              { supportingDocuments: %i[name confirmationCode size isEncrypted] },
+              { formData: [
+                :veteranSsn, :postalCode, :veteranDateOfBirth, :formNumber,
+                :email, :claimantDateOfBirth, :claimantSsn, :vaFileNumber,
+                { claimantFullName: %i[first last] },
+                { veteranFullName: %i[first last] }
               ] }
             ]
-          end
-
-          ##
-          # TODO: Remove. This is a part of the same workaround above. Once we
-          # have a fix, this transformation will be purely redundant.
-          #
-          unwrapped_params
-            .permit(*param_filters)
-            .deep_transform_keys do |k|
-              k.camelize(:lower)
-            end
-        end
+          )
       end
     end
   end

--- a/modules/accredited_representative_portal/config/initializers/bypass_olive_branch.rb
+++ b/modules/accredited_representative_portal/config/initializers/bypass_olive_branch.rb
@@ -29,6 +29,11 @@ module AccreditedRepresentativePortal
     PATH_NORMALIZER = ::ActionDispatch::Journey::Router::Utils
 
     def exclude_arp_route?(env)
+      ##
+      # Our reverse proxy for deployed environments prepends an extra slash at
+      # the beginning. Offending nginx conf here:
+      # https://github.com/department-of-veterans-affairs/devops/blob/c84a83696357b84e155c8ec849934af3019da769/ansible/deployment/config/revproxy-vagov/templates/nginx_api_server.conf.j2#L121
+      #
       path_info = PATH_NORMALIZER.normalize_path(env['PATH_INFO']).to_s
       path_info.start_with?(ARP_PATH_INFO_PREFIX)
     end

--- a/modules/accredited_representative_portal/config/initializers/bypass_olive_branch.rb
+++ b/modules/accredited_representative_portal/config/initializers/bypass_olive_branch.rb
@@ -26,20 +26,11 @@ module AccreditedRepresentativePortal
     private
 
     ARP_PATH_INFO_PREFIX = '/accredited_representative_portal'
+    PATH_NORMALIZER = ::ActionDispatch::Journey::Router::Utils
 
     def exclude_arp_route?(env)
-      if env_check && Flipper.enabled?(:accredited_representative_portal_normalize_path)
-        # Chose the function Rack::Attack::PathNormalizer.normalize_path() since our middlewares
-        # uses this later [here](https://github.com/department-of-veterans-affairs/vets-api/blob/934424f5fe986befc33645cfc7b0a3156f3f7ae3/config/application.rb#L88).
-        # Need to use this since the Staging path includes an extra hash EX: '//accredited_representative_portal'
-        Rack::Attack::PathNormalizer.normalize_path(env['PATH_INFO']).to_s.start_with?(ARP_PATH_INFO_PREFIX)
-      else
-        env['PATH_INFO'].to_s.start_with?(ARP_PATH_INFO_PREFIX)
-      end
-    end
-
-    def env_check
-      %w[test localhost development staging].include?(Settings.vsp_environment)
+      path_info = PATH_NORMALIZER.normalize_path(env['PATH_INFO']).to_s
+      path_info.start_with?(ARP_PATH_INFO_PREFIX)
     end
   end
 end

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/bypass_olive_branch_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/bypass_olive_branch_spec.rb
@@ -26,115 +26,38 @@ RSpec.describe AccreditedRepresentativePortal::BypassOliveBranch, type: :request
     Rails.application.reload_routes!
   end
 
-  context 'the request is in development and accredited_representative_portal_normalize_path is disabled' do
-    before do
-      allow(Settings).to receive(:vsp_environment).and_return('development')
-      allow(Flipper).to receive(:enabled?).with(:accredited_representative_portal_normalize_path).and_return(false)
-    end
+  context 'when the request is for an accredited representative portal route' do
+    let(:path_prefix) { '/accredited_representative_portal' }
 
-    context 'when the request is for an accredited representative portal route' do
-      let(:path_prefix) { '/accredited_representative_portal' }
-
-      it 'bypasses OliveBranch processing' do
-        expect(OliveBranch::Transformations).not_to receive(:underscore_params)
-        expect(OliveBranch::Transformations).not_to receive(:transform)
-        subject
-      end
-    end
-
-    context 'when the request is for a normal route' do
-      let(:path_prefix) { '' }
-
-      it 'applies OliveBranch processing' do
-        expect(OliveBranch::Transformations).to receive(:underscore_params)
-        expect(OliveBranch::Transformations).to receive(:transform)
-        subject
-      end
+    it 'bypasses OliveBranch processing' do
+      expect(OliveBranch::Transformations).not_to receive(:underscore_params)
+      expect(OliveBranch::Transformations).not_to receive(:transform)
+      subject
     end
   end
 
-  context 'the request is in development and accredited_representative_portal_normalize_path is enabled' do
-    before do
-      allow(Settings).to receive(:vsp_environment).and_return('development')
-      allow(Flipper).to receive(:enabled?).with(:accredited_representative_portal_normalize_path).and_return(true)
-    end
+  ##
+  # Our reverse proxy for deployed environments prepends an extra slash at the
+  # beginning. Ouch. Offending nginx conf here:
+  # https://github.com/department-of-veterans-affairs/devops/blob/c84a83696357b84e155c8ec849934af3019da769/ansible/deployment/config/revproxy-vagov/templates/nginx_api_server.conf.j2#L121
+  #
+  context 'when the request is for an accredited representative portal route with an extra slash prepended' do
+    let(:path_prefix) { '//accredited_representative_portal' }
 
-    context 'when the request is for an accredited representative portal route' do
-      let(:path_prefix) { '/accredited_representative_portal' }
-
-      it 'bypasses OliveBranch processing' do
-        expect(OliveBranch::Transformations).not_to receive(:underscore_params)
-        expect(OliveBranch::Transformations).not_to receive(:transform)
-        subject
-      end
-    end
-
-    context 'when the request is for a normal route' do
-      let(:path_prefix) { '' }
-
-      it 'applies OliveBranch processing' do
-        expect(OliveBranch::Transformations).to receive(:underscore_params)
-        expect(OliveBranch::Transformations).to receive(:transform)
-        subject
-      end
+    it 'bypasses OliveBranch processing' do
+      expect(OliveBranch::Transformations).not_to receive(:underscore_params)
+      expect(OliveBranch::Transformations).not_to receive(:transform)
+      subject
     end
   end
 
-  context 'the request is in staging and accredited_representative_portal_normalize_path is disabled' do
-    before do
-      allow(Settings).to receive(:vsp_environment).and_return('staging')
-      allow(Flipper).to receive(:enabled?).with(:accredited_representative_portal_normalize_path).and_return(false)
-    end
+  context 'when the request is for a normal route' do
+    let(:path_prefix) { '' }
 
-    # Staging path includes an extra hash EX: '//accredited_representative_portal'
-    context 'when the request is for an accredited representative portal route' do
-      let(:path_prefix) { '//accredited_representative_portal' }
-
-      it 'bypasses OliveBranch processing' do
-        # This is true because the Staging path includes an extra hash EX: '//accredited_representative_portal'
-        # and when not normalized the extra hash is not removed.
-        expect(OliveBranch::Transformations).to receive(:underscore_params)
-        expect(OliveBranch::Transformations).to receive(:transform)
-        subject
-      end
-    end
-
-    context 'when the request is for a normal route' do
-      let(:path_prefix) { '' }
-
-      it 'applies OliveBranch processing' do
-        expect(OliveBranch::Transformations).to receive(:underscore_params)
-        expect(OliveBranch::Transformations).to receive(:transform)
-        subject
-      end
-    end
-  end
-
-  context 'the request is in staging and accredited_representative_portal_normalize_path is enabled' do
-    before do
-      allow(Settings).to receive(:vsp_environment).and_return('staging')
-      allow(Flipper).to receive(:enabled?).with(:accredited_representative_portal_normalize_path).and_return(true)
-    end
-
-    # Staging path includes an extra hash EX: '//accredited_representative_portal'
-    context 'when the request is for an accredited representative portal route' do
-      let(:path_prefix) { '//accredited_representative_portal' }
-
-      it 'bypasses OliveBranch processing' do
-        expect(OliveBranch::Transformations).not_to receive(:underscore_params)
-        expect(OliveBranch::Transformations).not_to receive(:transform)
-        subject
-      end
-    end
-
-    context 'when the request is for a normal route' do
-      let(:path_prefix) { '' }
-
-      it 'applies OliveBranch processing' do
-        expect(OliveBranch::Transformations).to receive(:underscore_params)
-        expect(OliveBranch::Transformations).to receive(:transform)
-        subject
-      end
+    it 'applies OliveBranch processing' do
+      expect(OliveBranch::Transformations).to receive(:underscore_params)
+      expect(OliveBranch::Transformations).to receive(:transform)
+      subject
     end
   end
 end

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/bypass_olive_branch_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/bypass_olive_branch_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe AccreditedRepresentativePortal::BypassOliveBranch, type: :request
 
   ##
   # Our reverse proxy for deployed environments prepends an extra slash at the
-  # beginning. Ouch. Offending nginx conf here:
+  # beginning. Offending nginx conf here:
   # https://github.com/department-of-veterans-affairs/devops/blob/c84a83696357b84e155c8ec849934af3019da769/ansible/deployment/config/revproxy-vagov/templates/nginx_api_server.conf.j2#L121
   #
   context 'when the request is for an accredited representative portal route with an extra slash prepended' do


### PR DESCRIPTION
After adding new path normalization logic and observing that we won't break anything by bypassing for all existing client invocations in all environments.

Just some mess to get out of our hair before it languishes forever!