### PR TITLE
Migrate extend SentryLogging to Vets::SharedLogging

### DIFF
--- a/app/models/iam_user_identity.rb
+++ b/app/models/iam_user_identity.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require 'sentry_logging'
+require './lib/vets/shared_logging'
 
 # Subclasses the `UserIdentity` model. Adds a unique redis namespace for IAM user identities.
 # Like the it's base model it acts as an adapter for the attributes from the IAMSSOeOAuth::Service's
 # introspect endpoint.Adds IAM sourced versions of ICN, EDIPI, and SEC ID to pass to the IAMUser model.
 #
 class IAMUserIdentity < UserIdentity
-  extend SentryLogging
+  extend Vets::SharedLogging
   extend Identity::Parsers::GCIdsHelper
 
   PREMIUM_LOAS = [2, 3].freeze

--- a/app/models/iam_user_identity.rb
+++ b/app/models/iam_user_identity.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require './lib/vets/shared_logging'
+require 'vets/shared_logging'
 
 # Subclasses the `UserIdentity` model. Adds a unique redis namespace for IAM user identities.
 # Like the it's base model it acts as an adapter for the attributes from the IAMSSOeOAuth::Service's
@@ -84,6 +84,7 @@ class IAMUserIdentity < UserIdentity
     mhv_ids = mhv_ids&.split(',')&.uniq
     if mhv_ids&.size.to_i > 1
       log_message_to_sentry('OAuth: Multiple MHV IDs present', :warn, { mhv_ien: id_from_profile })
+      log_message_to_rails('OAuth: Multiple MHV IDs present', :warn, { mhv_ien: id_from_profile })
     end
     mhv_ids&.first
   end

--- a/app/sidekiq/evss/document_upload.rb
+++ b/app/sidekiq/evss/document_upload.rb
@@ -6,10 +6,11 @@ require 'logging/third_party_transaction'
 require 'evss/failure_notification'
 require 'lighthouse/benefits_documents/constants'
 require 'lighthouse/benefits_documents/utilities/helpers'
+require './lib/vets/shared_logging'
 
 class EVSS::DocumentUpload
   include Sidekiq::Job
-  extend SentryLogging
+  extend Vets::SharedLogging
   extend Logging::ThirdPartyTransaction::MethodWrapper
 
   DD_ZSF_TAGS = ['service:claim-status', 'function: evidence upload to EVSS'].freeze

--- a/app/sidekiq/evss/document_upload.rb
+++ b/app/sidekiq/evss/document_upload.rb
@@ -6,7 +6,7 @@ require 'logging/third_party_transaction'
 require 'evss/failure_notification'
 require 'lighthouse/benefits_documents/constants'
 require 'lighthouse/benefits_documents/utilities/helpers'
-require './lib/vets/shared_logging'
+require 'vets/shared_logging'
 
 class EVSS::DocumentUpload
   include Sidekiq::Job
@@ -119,6 +119,7 @@ class EVSS::DocumentUpload
                          { message: e.message })
     StatsD.increment('silent_failure', tags: DD_ZSF_TAGS)
     log_exception_to_sentry(e)
+    log_exception_to_rails(e)
   end
 
   # Update personalisation here since an evidence submission record was previously created

--- a/app/sidekiq/hca/ezr_submission_job.rb
+++ b/app/sidekiq/hca/ezr_submission_job.rb
@@ -2,7 +2,7 @@
 
 require 'hca/soap_parser'
 require 'form1010_ezr/service'
-require './lib/vets/shared_logging'
+require 'vets/shared_logging'
 
 module HCA
   class EzrSubmissionJob
@@ -79,6 +79,7 @@ module HCA
 
       Form1010Ezr::Service.log_submission_failure_to_sentry(parsed_form, '1010EZR failure', 'failure')
       self.class.log_exception_to_sentry(e)
+      self.class.log_exception_to_rails(e)
       self.class.send_failure_email(parsed_form) if Flipper.enabled?(:ezr_use_va_notify_on_submission_failure)
     rescue Ox::ParseError => e
       log_parse_error(parsed_form, e)

--- a/app/sidekiq/hca/ezr_submission_job.rb
+++ b/app/sidekiq/hca/ezr_submission_job.rb
@@ -2,11 +2,12 @@
 
 require 'hca/soap_parser'
 require 'form1010_ezr/service'
+require './lib/vets/shared_logging'
 
 module HCA
   class EzrSubmissionJob
     include Sidekiq::Job
-    extend SentryLogging
+    extend Vets::SharedLogging
 
     FORM_ID = '10-10EZR'
     VALIDATION_ERROR = HCA::SOAPParser::ValidationError

--- a/app/sidekiq/lighthouse/poll_form526_pdf.rb
+++ b/app/sidekiq/lighthouse/poll_form526_pdf.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'lighthouse/benefits_claims/service'
-require 'sentry_logging'
+require './lib/vets/shared_logging'
 require 'logging/third_party_transaction'
 require 'sidekiq/form526_job_status_tracker/job_tracker'
 require 'sidekiq/form526_job_status_tracker/metrics'
@@ -44,7 +44,7 @@ module Lighthouse
     include Sidekiq::Job
     include Sidekiq::Form526JobStatusTracker::JobTracker
     extend ActiveSupport::Concern
-    extend SentryLogging
+    extend Vets::SharedLogging
     extend Logging::ThirdPartyTransaction::MethodWrapper
 
     attr_accessor :submission_id

--- a/app/sidekiq/lighthouse/poll_form526_pdf.rb
+++ b/app/sidekiq/lighthouse/poll_form526_pdf.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'lighthouse/benefits_claims/service'
-require './lib/vets/shared_logging'
+require 'vets/shared_logging'
 require 'logging/third_party_transaction'
 require 'sidekiq/form526_job_status_tracker/job_tracker'
 require 'sidekiq/form526_job_status_tracker/metrics'
@@ -79,6 +79,7 @@ module Lighthouse
       )
     rescue => e
       log_exception_to_sentry(e)
+      log_exception_to_rails(e)
     end
     # :nocov:
 

--- a/lib/common/pdf_helpers.rb
+++ b/lib/common/pdf_helpers.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 require 'hexapdf'
-require './lib/sentry_logging'
+require './lib/vets/shared_logging'
 
 module Common
   module PdfHelpers
-    extend SentryLogging
+    extend Vets::SharedLogging
 
     def self.unlock_pdf(input_file, password, output_file)
       doc = HexaPDF::Document.open(input_file, decryption_opts: { password: })

--- a/lib/common/pdf_helpers.rb
+++ b/lib/common/pdf_helpers.rb
@@ -13,12 +13,14 @@ module Common
       doc.write(output_file)
     rescue HexaPDF::EncryptionError => e
       log_message_to_sentry(e.message, 'warn')
+      log_message_to_rails(e.message, 'warn')
       raise Common::Exceptions::UnprocessableEntity.new(
         detail: I18n.t('errors.messages.uploads.pdf.incorrect_password'),
         source: 'Common::PdfHelpers.unlock_pdf'
       )
     rescue HexaPDF::Error => e
       log_message_to_sentry(e.message, 'warn')
+      log_message_to_rails(e.message, 'warn')
       raise Common::Exceptions::UnprocessableEntity.new(
         detail: I18n.t('errors.messages.uploads.pdf.invalid'),
         source: 'Common::PdfHelpers.unlock_pdf'

--- a/lib/common/pdf_helpers.rb
+++ b/lib/common/pdf_helpers.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'hexapdf'
-require './lib/vets/shared_logging'
+require 'vets/shared_logging'
 
 module Common
   module PdfHelpers

--- a/lib/form1010_ezr/service.rb
+++ b/lib/form1010_ezr/service.rb
@@ -8,7 +8,7 @@ require 'va1010_forms/utils'
 require 'hca/overrides_parser'
 require 'va1010_forms/enrollment_system/service'
 require 'form1010_ezr/veteran_enrollment_system/associations/service'
-require './lib/vets/shared_logging'
+require 'vets/shared_logging'
 
 module Form1010Ezr
   class Service < Common::Client::Base

--- a/lib/form1010_ezr/service.rb
+++ b/lib/form1010_ezr/service.rb
@@ -8,12 +8,13 @@ require 'va1010_forms/utils'
 require 'hca/overrides_parser'
 require 'va1010_forms/enrollment_system/service'
 require 'form1010_ezr/veteran_enrollment_system/associations/service'
+require './lib/vets/shared_logging'
 
 module Form1010Ezr
   class Service < Common::Client::Base
     include Common::Client::Concerns::Monitoring
     include VA1010Forms::Utils
-    extend SentryLogging
+    extend Vets::SharedLogging
 
     STATSD_KEY_PREFIX = 'api.1010ezr'
 

--- a/lib/lighthouse/service_exception.rb
+++ b/lib/lighthouse/service_exception.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
+require './lib/vets/shared_logging'
+
 module Lighthouse
   # Custom exception that maps Lighthouse API errors to controller ExceptionHandling-friendly format
   #
   class ServiceException
-    extend SentryLogging
+    extend Vets::SharedLogging
 
     # a map of the known Lighthouse errors based on the documentation
     # https://developer.va.gov/

--- a/lib/lighthouse/service_exception.rb
+++ b/lib/lighthouse/service_exception.rb
@@ -127,6 +127,7 @@ module Lighthouse
       tags_context = Sentry.set_tags(external_service: service_name)
 
       log_exception_to_sentry(error, extra_context, tags_context)
+      log_exception_to_rails(error)
     end
 
     def self.log_to_rails_logger(service_name, options)

--- a/lib/lighthouse/service_exception.rb
+++ b/lib/lighthouse/service_exception.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require './lib/vets/shared_logging'
+require 'vets/shared_logging'
 
 module Lighthouse
   # Custom exception that maps Lighthouse API errors to controller ExceptionHandling-friendly format

--- a/lib/va_profile/contact_information/transaction_response.rb
+++ b/lib/va_profile/contact_information/transaction_response.rb
@@ -112,6 +112,7 @@ module VAProfile
         end
       rescue => e
         log_exception_to_sentry(e)
+        log_exception_to_rails(e)
       end
     end
 
@@ -146,6 +147,7 @@ module VAProfile
         end
       rescue => e
         log_exception_to_sentry(e)
+        log_exception_to_rails(e)
       end
     end
 

--- a/lib/va_profile/contact_information/transaction_response.rb
+++ b/lib/va_profile/contact_information/transaction_response.rb
@@ -2,11 +2,12 @@
 
 require 'va_profile/models/transaction'
 require 'va_profile/response'
+require './lib/vets/shared_logging'
 
 module VAProfile
   module ContactInformation
     class TransactionResponse < VAProfile::Response
-      extend SentryLogging
+      extend Vets::SharedLogging
 
       REDACTED_KEYS = %w[
         source_system_user

--- a/lib/va_profile/contact_information/transaction_response.rb
+++ b/lib/va_profile/contact_information/transaction_response.rb
@@ -2,7 +2,7 @@
 
 require 'va_profile/models/transaction'
 require 'va_profile/response'
-require './lib/vets/shared_logging'
+require 'vets/shared_logging'
 
 module VAProfile
   module ContactInformation

--- a/lib/va_profile/v2/contact_information/transaction_response.rb
+++ b/lib/va_profile/v2/contact_information/transaction_response.rb
@@ -2,7 +2,7 @@
 
 require 'va_profile/models/transaction'
 require 'va_profile/response'
-require './lib/vets/shared_logging'
+require 'vets/shared_logging'
 
 # rubocop:disable ThreadSafety/ClassInstanceVariable
 module VAProfile

--- a/lib/va_profile/v2/contact_information/transaction_response.rb
+++ b/lib/va_profile/v2/contact_information/transaction_response.rb
@@ -115,6 +115,7 @@ module VAProfile
           end
         rescue => e
           log_exception_to_sentry(e)
+          log_exception_to_rails(e)
         end
       end
 
@@ -149,6 +150,7 @@ module VAProfile
           end
         rescue => e
           log_exception_to_sentry(e)
+          log_exception_to_rails(e)
         end
       end
 

--- a/lib/va_profile/v2/contact_information/transaction_response.rb
+++ b/lib/va_profile/v2/contact_information/transaction_response.rb
@@ -2,13 +2,14 @@
 
 require 'va_profile/models/transaction'
 require 'va_profile/response'
+require './lib/vets/shared_logging'
 
 # rubocop:disable ThreadSafety/ClassInstanceVariable
 module VAProfile
   module V2
     module ContactInformation
       class TransactionResponse < VAProfile::Response
-        extend SentryLogging
+        extend Vets::SharedLogging
 
         REDACTED_KEYS = %w[
           source_system_user

--- a/spec/lib/form1010_ezr/service_spec.rb
+++ b/spec/lib/form1010_ezr/service_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Form1010Ezr::Service do
 
   describe '#log_submission_failure_to_sentry' do
     it 'logs a failure message to sentry' do
-      expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(
+      expect_any_instance_of(Vets::SharedLogging).to receive(:log_message_to_sentry).with(
         '1010EZR failure',
         :error,
         {
@@ -357,7 +357,7 @@ RSpec.describe Form1010Ezr::Service do
                 allow(StatsD).to receive(:increment)
 
                 expect(StatsD).to receive(:increment).with('api.1010ezr.failed')
-                expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(
+                expect_any_instance_of(Vets::SharedLogging).to receive(:log_message_to_sentry).with(
                   '1010EZR failure',
                   :error,
                   {
@@ -390,7 +390,7 @@ RSpec.describe Form1010Ezr::Service do
             allow(StatsD).to receive(:increment)
 
             expect(StatsD).to receive(:increment).with('api.1010ezr.failed')
-            expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(
+            expect_any_instance_of(Vets::SharedLogging).to receive(:log_message_to_sentry).with(
               '1010EZR failure',
               :error,
               {

--- a/spec/sidekiq/hca/ezr_submission_job_spec.rb
+++ b/spec/sidekiq/hca/ezr_submission_job_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe HCA::EzrSubmissionJob, type: :job do
           described_class.within_sidekiq_retries_exhausted_block(msg) do
             allow(VANotify::EmailJob).to receive(:perform_async)
             expect(StatsD).to receive(:increment).with('api.1010ezr.failed_wont_retry')
-            expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(
+            expect_any_instance_of(Vets::SharedLogging).to receive(:log_message_to_sentry).with(
               '1010EZR total failure',
               :error,
               {
@@ -113,7 +113,7 @@ RSpec.describe HCA::EzrSubmissionJob, type: :job do
 
           described_class.within_sidekiq_retries_exhausted_block(msg) do
             expect(StatsD).to receive(:increment).with('api.1010ezr.failed_wont_retry')
-            expect_any_instance_of(SentryLogging).to receive(:log_message_to_sentry).with(
+            expect_any_instance_of(Vets::SharedLogging).to receive(:log_message_to_sentry).with(
               '1010EZR total failure',
               :error,
               {


### PR DESCRIPTION
## Summary

Migrates files that use `extend SentryLogging` to use `extend Vets::SharedLogging` instead. This is part of the broader effort to deprecate SentryLogging in favor of the newer SharedLogging implementation.

## Changes

- Updates `extend SentryLogging` to `extend Vets::SharedLogging`
- Updates require statements to import `vets/shared_logging`
- Updates corresponding test files to expect `Vets::SharedLogging` instead of `SentryLogging`

## Related

This follows the initial PR that fixed the boot-time deprecation warnings and is part of the phased migration from SentryLogging to Vets::SharedLogging.