### PR TITLE
fix: move SentryLogging deprecation warning from boot to method usage

### DIFF
--- a/lib/sentry_logging.rb
+++ b/lib/sentry_logging.rb
@@ -5,11 +5,13 @@ require 'sentry_logging'
 module SentryLogging
   # WARNING: This module is deprecated, and will be removed in October 2025. Please use Vets::SharedLogging instead.
   # If your team currently uses this module, please see documentation for migrating to Vets::SharedLogging: TODO
-  ActiveSupport::Deprecation
-    .new.warn('SentryLogging is deprecated and will be removed in October 2025. Use Vets::SharedLogging instead.')
   extend self
 
+  DEPRECATION_MESSAGE = 'SentryLogging is deprecated and will be removed in October 2025. ' \
+                        'Use Vets::SharedLogging instead.'
+
   def log_message_to_sentry(message, level, extra_context = {}, tags_context = {})
+    ActiveSupport::Deprecation.new.warn(DEPRECATION_MESSAGE)
     level = normalize_level(level, nil)
     formatted_message = extra_context.empty? ? message : "#{message} : #{extra_context}"
     rails_logger(level, formatted_message)
@@ -21,6 +23,7 @@ module SentryLogging
   end
 
   def log_exception_to_sentry(exception, extra_context = {}, tags_context = {}, level = 'error')
+    ActiveSupport::Deprecation.new.warn(DEPRECATION_MESSAGE)
     level = normalize_level(level, exception)
 
     if Settings.sentry.dsn.present?

--- a/lib/sentry_logging.rb
+++ b/lib/sentry_logging.rb
@@ -9,9 +9,10 @@ module SentryLogging
 
   DEPRECATION_MESSAGE = 'SentryLogging is deprecated and will be removed in October 2025. ' \
                         'Use Vets::SharedLogging instead.'
+  DEPRECATION_INSTANCE = ActiveSupport::Deprecation.new
 
   def log_message_to_sentry(message, level, extra_context = {}, tags_context = {})
-    ActiveSupport::Deprecation.new.warn(DEPRECATION_MESSAGE)
+    DEPRECATION_INSTANCE.warn(DEPRECATION_MESSAGE)
     level = normalize_level(level, nil)
     formatted_message = extra_context.empty? ? message : "#{message} : #{extra_context}"
     rails_logger(level, formatted_message)
@@ -23,7 +24,7 @@ module SentryLogging
   end
 
   def log_exception_to_sentry(exception, extra_context = {}, tags_context = {}, level = 'error')
-    ActiveSupport::Deprecation.new.warn(DEPRECATION_MESSAGE)
+    DEPRECATION_INSTANCE.warn(DEPRECATION_MESSAGE)
     level = normalize_level(level, exception)
 
     if Settings.sentry.dsn.present?


### PR DESCRIPTION
## Summary

Fixes the SentryLogging deprecation warning that appears during Rails application boot by moving the warning from module load time to method usage time.

## Problem

Currently, the SentryLogging module shows a deprecation warning every time the application boots:

```
SentryLogging is deprecated and will be removed in October 2025. Use Vets::SharedLogging instead.
```

This creates noisy boot output and makes it harder to spot real issues during development.

## Solution

**Move deprecation warning from module load to method usage:**

- ❌ **Before**: Warning appears when the module is required (at boot time)
- ✅ **After**: Warning appears only when `log_message_to_sentry` or `log_exception_to_sentry` methods are actually called

## Related

This is the first step in the broader SentryLogging → Vets::SharedLogging migration effort. Follow-up PRs will migrate actual usage while maintaining this clean deprecation path.