### PR TITLE
1834: add 1095b api key to settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1650,6 +1650,8 @@ veteran_enrollment_system:
     api_key: <%= ENV['veteran_enrollment_system__associations__api_key'] %>
   ee_summary:
     api_key: ~
+  form1095b:
+    api_key: <%= ENV['veteran_enrollment_system__form1095b__api_key'] %>
   host: <%= ENV['veteran_enrollment_system__host'] %>
   open_timeout: 10
   port: <%= ENV['veteran_enrollment_system__port'] %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1671,6 +1671,8 @@ veteran_enrollment_system:
     api_key: ~
   ee_summary:
     api_key: ~
+  form1095b:
+    api_key: ~
   host: https://localhost
   open_timeout: 10
   port: 4430

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1670,6 +1670,8 @@ veteran_enrollment_system:
     api_key: ~
   ee_summary:
     api_key: ~
+  form1095b:
+    api_key: ~
   host: https://localhost
   open_timeout: 10
   port: 4430


### PR DESCRIPTION
## Summary

- Adds form1095b api key to settings.yml, development.yml, and test.yml
- *This work is behind a feature toggle (flipper): NO

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-iir/issues/1824

## Testing done

Not needed for adding to yml files.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
None.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
