### PR TITLE
fix(ci): Remove ECR driver options to fix Docker cache

### DIFF
--- a/.github/workflows/audit_service_tags.yml
+++ b/.github/workflows/audit_service_tags.yml
@@ -53,18 +53,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: image=${{ steps.ecr-login.outputs.registry }}/moby/buildkit:buildx-stable-1
-
-      - name: Restore Docker cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ github.head_ref || github.ref_name }}-
-            ${{ runner.os }}-buildx-master-
-            ${{ runner.os }}-buildx-
 
       - name: Build Docker Image
         uses: docker/build-push-action@v6
@@ -78,8 +66,8 @@ jobs:
           push: false
           load: true
           tags: vets-api
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Setup Database
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -118,18 +118,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: image=${{ steps.ecr-login.outputs.registry }}/moby/buildkit:buildx-stable-1
-
-      - name: Restore Docker cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ github.head_ref || github.ref_name }}-
-            ${{ runner.os }}-buildx-master-
-            ${{ runner.os }}-buildx-
 
       - name: Build Docker Image
         uses: docker/build-push-action@v6
@@ -143,8 +131,8 @@ jobs:
           push: false
           load: true
           tags: vets-api
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Setup Database
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2

--- a/.github/workflows/gh-env-cleanup.yml
+++ b/.github/workflows/gh-env-cleanup.yml
@@ -65,27 +65,6 @@ jobs:
             puts "\nDone."
           EOF
 
-      - name: Clean up old caches
-        run: |
-          echo "Cleaning up caches older than 7 days..."
-          
-          # Get current timestamp and calculate 7 days ago
-          SEVEN_DAYS_AGO=$(date -v-7d +%Y-%m-%dT%H:%M:%SZ)
-          echo "Deleting caches last accessed before: $SEVEN_DAYS_AGO"
-          
-          # Delete old caches
-          gh api repos/${{ github.repository }}/actions/caches --paginate | \
-            jq -r ".actions_caches[] | select(.last_accessed_at < \"${SEVEN_DAYS_AGO}\") | .id" | \
-            while read -r cache_id; do
-              if [ -n "$cache_id" ]; then
-                echo "Deleting old cache ID: $cache_id"
-                gh api --method DELETE repos/${{ github.repository }}/actions/caches/$cache_id || true
-              fi
-            done
-          
-          echo "Old cache cleanup completed"
-        env:
-          GH_TOKEN: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
 
   # PR-close cleanup job
   pr-close-cleanup:
@@ -129,21 +108,3 @@ jobs:
             fi
           done
 
-      - name: Delete branch cache
-        run: |
-          BRANCH_NAME="${{ github.head_ref }}"
-          echo "Cleaning up caches for deleted branch: $BRANCH_NAME"
-          
-          # Delete caches using proper iteration over lines
-          gh api repos/${{ github.repository }}/actions/caches --paginate | \
-            jq -r ".actions_caches[] | select(.ref == \"refs/heads/${BRANCH_NAME}\" or (.key | contains(\"buildx-${BRANCH_NAME}-\"))) | .id" | \
-            while read -r cache_id; do
-              if [ -n "$cache_id" ]; then
-                echo "Deleting cache ID: $cache_id"
-                gh api --method DELETE repos/${{ github.repository }}/actions/caches/$cache_id || true
-              fi
-            done
-          
-          echo "Cache cleanup completed for branch: $BRANCH_NAME"
-        env:
-          GH_TOKEN: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
This PR tests a simpler approach to [fixing Docker cache issues](https://github.com/department-of-veterans-affairs/vets-api/pull/23021) by removing the ECR driver options from the Docker Buildx setup.

## Changes
- Removed `driver-opts: image=${{ steps.ecr-login.outputs.registry }}/moby/buildkit:buildx-stable-1` from both workflows
- Reverted to original GitHub Actions cache (`type=gha`) instead of local cache
- Removed cache cleanup logic that was added in the previous approach

## Test Plan
- [ ] Monitor CI build times to see if they return to 1-2 minutes
- [ ] Verify cache hits are working properly
- [x] Confirm ECR authentication still works for avoiding Docker Hub rate limits

This tests whether the ECR driver options were the root cause of cache misses without the complexity of the previous caching solution.