### PR TITLE
Validate betamocks config in all non-prod envs

### DIFF
--- a/config/initializers/betamocks.rb
+++ b/config/initializers/betamocks.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
-unless Rails.env.production?
+unless Settings.vsp_environment == 'production'
   begin
     ERB.new(File.read(Settings.betamocks.services_config)).result
-  rescue NoMethodError
-    raise ArgumentError, 'betamocks services_config error, check that vars from settings.yml are interpolated correctly'
+  rescue NoMethodError, ArgumentError
+    raise ArgumentError,
+          "Betamocks services_config error. Values in settings.yml aren't being interpolated correctly " \
+          'for a betamocks configuration in config/betamocks/services_config.yml'
   end
 end
 

--- a/config/initializers/betamocks.rb
+++ b/config/initializers/betamocks.rb
@@ -6,7 +6,7 @@ unless Settings.vsp_environment == 'production'
   rescue NoMethodError, ArgumentError
     raise ArgumentError,
           "Betamocks services_config error. Values in settings.yml aren't being interpolated correctly " \
-          'for a betamocks configuration in config/betamocks/services_config.yml'
+          "for a betamocks configuration in #{Settings.betamocks.services_config}"
   end
 end
 

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -319,7 +319,7 @@ dmc:
   fsr_payment_window: 30
   mock_debts: false
   mock_fsr: false
-  # url: https://fwdproxy-dev.vfs.va.gov:4465/api/v1/digital-services/
+  url: https://fwdproxy-dev.vfs.va.gov:4465/api/v1/digital-services/
 dogstatsd:
   enabled: false
 edu:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -319,7 +319,7 @@ dmc:
   fsr_payment_window: 30
   mock_debts: false
   mock_fsr: false
-  url: https://fwdproxy-dev.vfs.va.gov:4465/api/v1/digital-services/
+  # url: https://fwdproxy-dev.vfs.va.gov:4465/api/v1/digital-services/
 dogstatsd:
   enabled: false
 edu:


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper):* NO

This PR changes the betamocks validation so it runs in all envs except prod (local, CI, dev, staging, and sandbox). There was an incident in May that would have been caught earlier is this was in place. This PR also changes the error handling so the custom error is reported. When this error happened in May, the error was:
```
bad argument (expected URI object or URI string) (ArgumentError)
```
It took some digging 🔬 to figure out where the true error was coming from. This PR rescues that `ArgumentError` and returns a more precise error. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/109200

## Testing done

1. comment out `Settings.dmc.url` in test.yml. Expected result: CI should fail on startup. ✅ This happened. The [test output](https://github.com/department-of-veterans-affairs/vets-api/actions/runs/16271141850/job/45938813304?pr=23079) shows the `"Betamocks services_config error..."` in the **Setup Database** portion of the test setup, so the tests don't even run. 

## Screenshots
New error message:
<img width="754" height="127" alt="Image" src="https://github.com/user-attachments/assets/d42e417a-af42-4cf1-8252-1ce316bab759" />

## What areas of the site does it impact?
This run the betamocks validation on startup in all envs except production.

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  I added a screenshot of the developed feature

## Requested Feedback

Is there a reason we don't run this validation check in production?
