### PR TITLE
fix va callbacks

### DIFF
--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/email_delivery_status_callback.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/email_delivery_status_callback.rb
@@ -44,17 +44,17 @@ module AccreditedRepresentativePortal
     end
 
     def self.report_success(base_metric, tags)
-      StatsD.increment("#{base_metric}.delivered", **tags)
-      StatsD.increment('silent_failure_avoided', **tags)
+      StatsD.increment("#{base_metric}.delivered", tags:)
+      StatsD.increment('silent_failure_avoided', tags:)
     end
 
     def self.report_failure(notification, base_metric, tags)
-      StatsD.increment("#{base_metric}.#{notification.status}", **tags)
+      StatsD.increment("#{base_metric}.#{notification.status}", tags:)
       Rails.logger.error(build_log_payload(notification, tags).to_json)
     end
 
     def self.report_other(notification, base_metric, tags)
-      StatsD.increment("#{base_metric}.other", **tags)
+      StatsD.increment("#{base_metric}.other", tags:)
       Rails.logger.warn(build_log_payload(notification, tags).merge(message: 'Unhandled callback status').to_json)
     end
 


### PR DESCRIPTION
## Summary
Update bug with configuring ARP VA Notify email callbacks.

## Related issue(s)
- Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/114167

## Testing done
- Tests were updated.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
ARP VA Notify email callbacks

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
