### PR TITLE
API-48039-add-missing-field-to-read-all-gather

### DIFF
--- a/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/data_mapper/read_all_veteran_representative_data_mapper.rb
+++ b/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/data_mapper/read_all_veteran_representative_data_mapper.rb
@@ -31,6 +31,7 @@ module ClaimsApi
             claimant_relationship: data['claimantRelationship'],
             poa_code: data['poaCode'],
             organization_name: data['organizationName'],
+            representativeLawFirmOrAgencyName: data['representativeLawFirmOrAgencyName'],
             representative_first_name: data['representativeFirstName'],
             representative_last_name: data['representativeLastName'],
             representative_title: data['representativeTitle'],

--- a/modules/claims_api/spec/services/power_of_attorney_request_service/data_mapper/read_all_veteran_representative_data_mapper_spec.rb
+++ b/modules/claims_api/spec/services/power_of_attorney_request_service/data_mapper/read_all_veteran_representative_data_mapper_spec.rb
@@ -56,6 +56,7 @@ describe ClaimsApi::PowerOfAttorneyRequestService::DataMapper::ReadAllVeteranRep
       claimant_relationship: nil,
       poa_code: '083',
       organization_name: 'DISABLED AMERICAN VETERANS',
+      representativeLawFirmOrAgencyName: nil,
       representative_first_name: 'John',
       representative_last_name: 'Doe',
       representative_title: nil,


### PR DESCRIPTION
## Summary
* When building out the readAll data gathering I missed a field called `representativeLawFirmOrAgencyName`, this just adds it in to the data mapper and related test

## Related issue(s)
[API-48039](https://jira.devops.va.gov/browse/API-48039)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/services/claims_api/power_of_attorney_request_service/data_mapper/read_all_veteran_representative_data_mapper.rb
	modified:   modules/claims_api/spec/services/power_of_attorney_request_service/data_mapper/read_all_veteran_representative_data_mapper_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
