### PR TITLE
0969 | Fix issue with emails not sending when claimant is Veteran

### DIFF
--- a/modules/income_and_assets/lib/income_and_assets/notification_email.rb
+++ b/modules/income_and_assets/lib/income_and_assets/notification_email.rb
@@ -18,6 +18,15 @@ module IncomeAndAssets
       IncomeAndAssets::SavedClaim
     end
 
+    # Capture the first name of the claimant or veteran
+    # @return [String] the first name of the claimant or veteran
+    # If neither is available, defaults to 'Veteran'
+    def first_name
+      first = claim.claimant_first_name || claim.veteran_first_name
+
+      first&.titleize || 'Veteran'
+    end
+
     # @see VeteranFacingServices::NotificationEmail::SavedClaim#personalization
     # {
     #   'date_submitted' => claim.submitted_at,
@@ -28,7 +37,7 @@ module IncomeAndAssets
 
       template = {
         # confirmation, error
-        'first_name' => claim.claimant_first_name&.titleize,
+        'first_name' => first_name,
         # received
         'date_received' => claim.form_submissions&.last&.form_submission_attempts&.last&.lighthouse_updated_at
       }


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary
The code for setting the personalisation was assuming that the `claimant_first_name` field was always populated, which wasn't the case when the claimant type was `VETERAN`. This fixes that issue by falling back to `veteran_first_name` if `claimant_first_name` isn't populated

- *This work is behind a feature toggle (flipper): YES*

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/114298

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
