### PR TITLE
API-47680 Add more logging when POA not found

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
@@ -130,8 +130,7 @@ module ClaimsApi
       def handle_not_found(reps, poa_code)
         ClaimsApi::Logger.log 'poa_verification',
                               detail: "Found #{reps.size} reps for POA code #{poa_code}",
-                              level: :warn, poa_code:, rep_count: reps.size, current_users_uuid: @current_user.uuid,
-                              current_user_icn: @current_user.icn
+                              level: :warn, poa_code:, rep_count: reps.size, current_users_uuid: @current_user.uuid
         raise ::Common::Exceptions::UnprocessableEntity, detail: 'Ambiguous VSO Representative Results' if reps.size > 1
 
         # Intentionally does not raise in other cases. Doing so would break some shared behavior.

--- a/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
@@ -130,7 +130,8 @@ module ClaimsApi
       def handle_not_found(reps, poa_code)
         ClaimsApi::Logger.log 'poa_verification',
                               detail: "Found #{reps.size} reps for POA code #{poa_code}",
-                              level: :warn, poa_code:, rep_count: reps.size
+                              level: :warn, poa_code:, rep_count: reps.size, current_users_uuid: @current_user.uuid,
+                              current_user_icn: @current_user.icn
         raise ::Common::Exceptions::UnprocessableEntity, detail: 'Ambiguous VSO Representative Results' if reps.size > 1
 
         # Intentionally does not raise in other cases. Doing so would break some shared behavior.


### PR DESCRIPTION
## Summary

Adds some `current_user` details to logging when the POA verifier can't find (or finds too many) a representative in its search. This should let us more easily find the user by both login details and MPI details to see where things didn't match up. 

## Related issue(s)
[API-47680](https://jira.devops.va.gov/browse/API-47680)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature