### PR TITLE
[Event Bus Gateway] Creates basic object for tracking EBG notifications

### DIFF
--- a/db/migrate/20250716020033_create_event_bus_gateway_notifications.rb
+++ b/db/migrate/20250716020033_create_event_bus_gateway_notifications.rb
@@ -1,0 +1,14 @@
+class CreateEventBusGatewayNotifications < ActiveRecord::Migration[7.2]
+  def change
+    create_table :event_bus_gateway_notifications, if_not_exists: true do |t|
+      t.string :job_id
+      t.string :job_class
+      t.references :user_account, null: false, foreign_key: true, type: :uuid
+      t.string :va_notify_id, null: false
+      t.string :va_notify_status
+      t.datetime :va_notify_date
+      t.string :error_message
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
### Immediate question
This table I'm creating is pretty boilerplate. It basically exists to track a VA Notify Notification being sent out, update its status, and associate it with a user account. The goal is to use this object in the [Event Bus Gateway VA Notify Callback](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/sidekiq/event_bus_gateway/va_notify_email_status_callback.rb) to attempt to retry `temporary-failure` Notifications.

**Does this functionality already exist?** If so, where? Should I be using it instead?
More broadly, **is it actually not a good idea to retry `temporary-failure` notifications?**

### Table Info
name: `event_bus_gateway_notifications` -- I think this is fine?
`job_id`: could be useful for looking the job up in redis
`job_class`: for now this will always be `EventBusGateway::LetterReadyEmailJob` but that may not always be true forever
`user_account` reference feels like a good idea
`va_notify_id`: for looking up more information on the Notify side
`va_notify_status`: enum. maybe not worth storing on the vets-api side but could be helpful for metrics?
`va_notify_date`: the date on which the notification went out
`error_message`: the error we receive from the VA Notify callback