### PR TITLE
fix: remove draft PR workflow failures

### DIFF
--- a/.github/workflows/ready_for_review.yml
+++ b/.github/workflows/ready_for_review.yml
@@ -110,10 +110,6 @@ jobs:
           number: ${{ steps.get_pr_data.outputs.pr_number }}
           labels: ready-for-review
 
-      - name: Fail if draft
-        if: steps.get_pr_data.outputs.pr_draft == 'true'
-        run: exit 1
-
   check-workflow-status:
     name: Check Workflow Statuses
     needs: [get-pr-data]

--- a/.github/workflows/require_be_approval.yml
+++ b/.github/workflows/require_be_approval.yml
@@ -244,13 +244,17 @@ jobs:
           number: ${{ env.pr_number }}
           labels: exempt-be-review
 
-      - name: Fail if draft or failures
+      - name: Backend approval still required
         if: steps.verify_approval.outputs.approval_status == 'required'
-        run: exit 1
+        run: |
+          echo "Backend approval is still required but not failing the check."
+          echo "This allows the PR to remain mergeable while waiting for approval."
 
-      - name: Fail if backend approval not confirmed
+      - name: Backend approval not confirmed
         if: steps.verify_approval.outputs.approval_status == 'not_confirmed'
-        run: exit 1
+        run: |
+          echo "Backend approval not confirmed but not failing the check."
+          echo "This allows the PR to remain mergeable while waiting for approval."
 
       - name: Exit for non backend approvals
         if: steps.verify_approval.outputs.backend_approval_required == 'false'

--- a/.github/workflows/require_be_approval.yml
+++ b/.github/workflows/require_be_approval.yml
@@ -86,6 +86,7 @@ jobs:
   fetch-pr-reviews:
     name: Succeed if backend approval is confirmed
     needs: [get-pr-data]
+    if: github.event_name == 'pull_request_review' || needs.get-pr-data.outputs.pr_draft == 'true'
     runs-on: ubuntu-latest
     permissions: write-all
     env:
@@ -244,17 +245,17 @@ jobs:
           number: ${{ env.pr_number }}
           labels: exempt-be-review
 
-      - name: Backend approval still required
+      - name: Fail if backend approval still required
         if: steps.verify_approval.outputs.approval_status == 'required'
         run: |
-          echo "Backend approval is still required but not failing the check."
-          echo "This allows the PR to remain mergeable while waiting for approval."
+          echo "Backend approval is still required."
+          exit 1
 
-      - name: Backend approval not confirmed
+      - name: Fail if backend approval not confirmed
         if: steps.verify_approval.outputs.approval_status == 'not_confirmed'
         run: |
-          echo "Backend approval not confirmed but not failing the check."
-          echo "This allows the PR to remain mergeable while waiting for approval."
+          echo "Backend approval not confirmed."
+          exit 1
 
       - name: Exit for non backend approvals
         if: steps.verify_approval.outputs.backend_approval_required == 'false'

--- a/.github/workflows/require_be_approval.yml
+++ b/.github/workflows/require_be_approval.yml
@@ -76,6 +76,13 @@ jobs:
           number: ${{ steps.get_pr_data.outputs.pr_number }}
           labels: final-review-confirmed
 
+      - name: Remove exempt-be-review label
+        if: steps.pr_data.outputs.pr_draft == 'true'
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          number: ${{ steps.get_pr_data.outputs.pr_number }}
+          labels: exempt-be-review
+
       - name: Skip backend approval for draft PR
         if: steps.pr_data.outputs.pr_draft == 'true'
         run: |

--- a/.github/workflows/require_be_approval.yml
+++ b/.github/workflows/require_be_approval.yml
@@ -3,6 +3,9 @@ on:
   pull_request_review:
     types: [submitted]
     branches: master
+  pull_request:
+    types: [opened, ready_for_review, converted_to_draft]
+    branches: master
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/require_be_approval.yml
+++ b/.github/workflows/require_be_approval.yml
@@ -4,7 +4,7 @@ on:
     types: [submitted]
     branches: master
   pull_request:
-    types: [opened, reopened, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
     branches: [master]
 permissions:
   id-token: write

--- a/.github/workflows/require_be_approval.yml
+++ b/.github/workflows/require_be_approval.yml
@@ -73,9 +73,11 @@ jobs:
           number: ${{ steps.get_pr_data.outputs.pr_number }}
           labels: final-review-confirmed
 
-      - name: Fail if draft or failures
+      - name: Skip backend approval for draft PR
         if: steps.pr_data.outputs.pr_draft == 'true'
-        run: exit 1
+        run: |
+          echo "PR is in draft mode. Skipping backend approval requirements."
+          echo "Labels have been removed. No further action needed."
 
   # Fetch approvals when required workflows are successful.
   fetch-pr-reviews:
@@ -102,6 +104,13 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+
+      - name: Skip backend approval check for draft PR
+        if: env.pr_draft == 'true'
+        run: |
+          echo "PR is in draft mode. Backend approval check not required."
+          echo "This job succeeds to satisfy branch protection requirements."
+          exit 0
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4.0.2

--- a/.github/workflows/require_be_approval.yml
+++ b/.github/workflows/require_be_approval.yml
@@ -4,8 +4,8 @@ on:
     types: [submitted]
     branches: master
   pull_request:
-    types: [opened, ready_for_review, converted_to_draft]
-    branches: master
+    types: [opened, reopened, ready_for_review, converted_to_draft]
+    branches: [master]
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/require_be_approval.yml
+++ b/.github/workflows/require_be_approval.yml
@@ -117,18 +117,21 @@ jobs:
           exit 0
 
       - name: Configure AWS Credentials
+        if: env.pr_draft == 'false'
         uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
           role-to-assume: ${{ vars.AWS_ASSUME_ROLE }}
           aws-region: "us-gov-west-1"
 
       - name: Get bot token from Parameter Store
+        if: env.pr_draft == 'false'
         uses: marvinpinto/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
       - name: Verify backend-review-group approval
+        if: env.pr_draft == 'false'
         id: verify_approval
         run: |
           approval_status=required
@@ -223,7 +226,7 @@ jobs:
           GITHUB_TOKEN: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
 
       - name: Remove ready-for-review label
-        if: steps.verify_approval.outputs.team_approval_status == 'confirmed'
+        if: env.pr_draft == 'false' && steps.verify_approval.outputs.team_approval_status == 'confirmed'
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           number: ${{ env.pr_number }}
@@ -231,38 +234,41 @@ jobs:
 
       - name: Remove ready-for-backend-review label
         if: |
-          steps.verify_approval.outputs.approval_status == 'confirmed' ||
-          steps.verify_approval.outputs.backend_approval_required == 'false'
+          env.pr_draft == 'false' && (
+            steps.verify_approval.outputs.approval_status == 'confirmed' ||
+            steps.verify_approval.outputs.backend_approval_required == 'false'
+          )
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           number: ${{ env.pr_number }}
           labels: ready-for-backend-review
 
       - name: Add exempt-be-review label
-        if: steps.verify_approval.outputs.exempt_be_review == 'true'
+        if: env.pr_draft == 'false' && steps.verify_approval.outputs.exempt_be_review == 'true'
         uses: actions-ecosystem/action-add-labels@v1
         with:
           number: ${{ env.pr_number }}
           labels: exempt-be-review
 
       - name: Fail if backend approval still required
-        if: steps.verify_approval.outputs.approval_status == 'required'
+        if: env.pr_draft == 'false' && steps.verify_approval.outputs.approval_status == 'required'
         run: |
           echo "Backend approval is still required."
           exit 1
 
       - name: Fail if backend approval not confirmed
-        if: steps.verify_approval.outputs.approval_status == 'not_confirmed'
+        if: env.pr_draft == 'false' && steps.verify_approval.outputs.approval_status == 'not_confirmed'
         run: |
           echo "Backend approval not confirmed."
           exit 1
 
       - name: Exit for non backend approvals
-        if: steps.verify_approval.outputs.backend_approval_required == 'false'
+        if: env.pr_draft == 'false' && steps.verify_approval.outputs.backend_approval_required == 'false'
         run: exit 0
 
       - name: Add ready-for-backend-review label
         if: |
+          env.pr_draft == 'false' &&
           steps.verify_approval.outputs.approval_status == 'required' &&
           steps.verify_approval.outputs.team_approval_status == 'confirmed'
         uses: actions-ecosystem/action-add-labels@v1
@@ -271,12 +277,12 @@ jobs:
           labels: ready-for-backend-review
 
       - name: Add final-review-confirmed label
-        if: steps.verify_approval.outputs.approval_status == 'confirmed'
+        if: env.pr_draft == 'false' && steps.verify_approval.outputs.approval_status == 'confirmed'
         uses: actions-ecosystem/action-add-labels@v1
         with:
           number: ${{ env.pr_number }}
           labels: final-review-confirmed
 
       - name: Backend Approval Confirmed
-        if: steps.verify_approval.outputs.approval_status == 'confirmed'
+        if: env.pr_draft == 'false' && steps.verify_approval.outputs.approval_status == 'confirmed'
         run: exit 0


### PR DESCRIPTION
Remove unnecessary exit 1 steps from GitHub Actions workflows when PR is in draft mode. Draft PRs now show green checkmarks instead of red X's while still properly removing review labels and skipping approval logic.

- [x] Verified all subsequent jobs have proper draft conditionals
- [x] Confirmed label removal logic remains intact
- [x] Checked git blame/PR history to understand original intent

Fixes issue where draft PRs showed red X's instead of green checkmarks, making the workflow status cleaner and less confusing.