### PR TITLE
[515] Add key to header for MHV Account Creation API service

### DIFF
--- a/lib/mhv/account_creation/service.rb
+++ b/lib/mhv/account_creation/service.rb
@@ -66,7 +66,8 @@ module MHV
       def authenticated_header(icn:)
         {
           'Authorization' => "Bearer #{config.sts_token(user_identifier: icn)}",
-          'x-api-key' => config.access_key
+          'x-api-key' => config.access_key,
+          'mhvapi-idempotency-key' => icn
         }
       end
 


### PR DESCRIPTION
## Summary

- This PR adds a header to the MHV Account Creation API so that it caches the responses for a short period of time. This should prevent race conditions when calling the service

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/515

## Testing done

- Testing will have to be done in staging, this should have no impact that we can measure on localhost