### PR TITLE
arp/fix-to-withdrawn-poa-search-break

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/claimant_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/claimant_controller.rb
@@ -8,7 +8,7 @@ module AccreditedRepresentativePortal
       def search
         authorize nil, policy_class: ClaimantPolicy
 
-        poa_requests = policy_scope(PowerOfAttorneyRequest).joins(:claimant).where(claimant: { icn: })
+        poa_requests = policy_scope(PowerOfAttorneyRequest).joins(:claimant).where(claimant: { icn: }).not_withdrawn
         active_poa_codes = current_user.user_account.active_power_of_attorney_holders.map(&:poa_code)
         claimant = Claimant.new(search_result.try(:profile), poa_requests, active_poa_codes)
 

--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_request_decisions_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_request_decisions_controller.rb
@@ -4,6 +4,7 @@ module AccreditedRepresentativePortal
   module V0
     class PowerOfAttorneyRequestDecisionsController < ApplicationController
       include PowerOfAttorneyRequests
+      include AccreditedRepresentativePortal::V0::WithdrawalGuard
 
       before_action do
         authorize PowerOfAttorneyRequestDecision
@@ -13,13 +14,7 @@ module AccreditedRepresentativePortal
         before_action do
           id = params[:power_of_attorney_request_id]
           set_poa_request(id)
-
-          # Return 404 if withdrawn
-          if @poa_request.resolution&.resolving.is_a?(
-            AccreditedRepresentativePortal::PowerOfAttorneyRequestWithdrawal
-          )
-            render json: { errors: ['Record not found'] }, status: :not_found
-          end
+          render_404_if_withdrawn!(@poa_request)
         end
       end
 

--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_request_decisions_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_request_decisions_controller.rb
@@ -18,7 +18,7 @@ module AccreditedRepresentativePortal
           if @poa_request.resolution&.resolving.is_a?(
             AccreditedRepresentativePortal::PowerOfAttorneyRequestWithdrawal
           )
-            render json: { errors: ['Record not found'] }, status: :not_found and return
+            render json: { errors: ['Record not found'] }, status: :not_found
           end
         end
       end

--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_request_decisions_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_request_decisions_controller.rb
@@ -13,6 +13,13 @@ module AccreditedRepresentativePortal
         before_action do
           id = params[:power_of_attorney_request_id]
           set_poa_request(id)
+
+          # Return 404 if withdrawn
+          if @poa_request.resolution&.resolving.is_a?(
+            AccreditedRepresentativePortal::PowerOfAttorneyRequestWithdrawal
+          )
+            render json: { errors: ['Record not found'] }, status: :not_found and return
+          end
         end
       end
 

--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
@@ -4,6 +4,8 @@ module AccreditedRepresentativePortal
   module V0
     class PowerOfAttorneyRequestsController < ApplicationController
       include PowerOfAttorneyRequests
+      include AccreditedRepresentativePortal::V0::WithdrawalGuard
+
       before_action do
         authorize PowerOfAttorneyRequest
       end
@@ -11,13 +13,7 @@ module AccreditedRepresentativePortal
         before_action do
           id = params[:id]
           set_poa_request(id)
-
-          # Return 404 if withdrawn
-          if @poa_request.resolution&.resolving.is_a?(
-            AccreditedRepresentativePortal::PowerOfAttorneyRequestWithdrawal
-          )
-            render json: { errors: ['Record not found'] }, status: :not_found
-          end
+          render_404_if_withdrawn!(@poa_request)
         end
       end
 

--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/power_of_attorney_requests_controller.rb
@@ -16,7 +16,7 @@ module AccreditedRepresentativePortal
           if @poa_request.resolution&.resolving.is_a?(
             AccreditedRepresentativePortal::PowerOfAttorneyRequestWithdrawal
           )
-            render json: { errors: ['Record not found'] }, status: :not_found and return
+            render json: { errors: ['Record not found'] }, status: :not_found
           end
         end
       end

--- a/modules/accredited_representative_portal/app/controllers/concerns/accredited_representative_portal/v0/withdrawal_guard.rb
+++ b/modules/accredited_representative_portal/app/controllers/concerns/accredited_representative_portal/v0/withdrawal_guard.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module AccreditedRepresentativePortal
+  module V0
+    module WithdrawalGuard
+      extend ActiveSupport::Concern
+
+      included do
+        private
+
+        def render_404_if_withdrawn!(poa_request)
+          if poa_request.resolution&.resolving.is_a?(
+            PowerOfAttorneyRequestWithdrawal
+          )
+            render json: { errors: ['Record not found'] }, status: :not_found
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request.rb
@@ -111,9 +111,7 @@ module AccreditedRepresentativePortal
     scope :unredacted, -> { where(redacted_at: nil) }
     scope :redacted, -> { where.not(redacted_at: nil) }
 
-    scope :unresolved, lambda {
-      left_outer_joins(:resolution).where(resolution: { id: nil }) # rubocop:disable Rails/WhereMissing
-    }
+    scope :unresolved, -> { where.missing(:resolution) }
     scope :resolved, lambda {
       left_outer_joins(:resolution).where.not(resolution: { id: nil })
     }
@@ -128,7 +126,7 @@ module AccreditedRepresentativePortal
     }
 
     scope :not_withdrawn, lambda {
-      unresolved.or(
+      where.missing(:resolution).or(
         resolved.where.not(
           resolution: { resolving_type: PowerOfAttorneyRequestWithdrawal.to_s }
         )

--- a/modules/accredited_representative_portal/spec/models/accredited_representative_portal/power_of_attorney_request_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representative_portal/power_of_attorney_request_spec.rb
@@ -85,6 +85,39 @@ RSpec.describe AccreditedRepresentativePortal::PowerOfAttorneyRequest, type: :mo
         end
       end
     end
+
+    describe '.not_withdrawn' do
+      let!(:unresolved_request) { create(:power_of_attorney_request) }
+
+      let!(:withdrawn_request) do
+        create(:power_of_attorney_request).tap do |req|
+          req.mark_replaced!(create(:power_of_attorney_request))
+        end
+      end
+
+      let!(:accepted_request) do
+        create(:power_of_attorney_request, :with_acceptance)
+      end
+
+      let!(:declined_request) do
+        create(:power_of_attorney_request, :with_declination)
+      end
+
+      it 'includes unresolved requests' do
+        result = described_class.not_withdrawn
+        expect(result).to include(unresolved_request)
+      end
+
+      it 'includes resolved requests that are not withdrawals' do
+        result = described_class.not_withdrawn
+        expect(result).to include(accepted_request, declined_request)
+      end
+
+      it 'excludes resolved requests that are withdrawals' do
+        result = described_class.not_withdrawn
+        expect(result).not_to include(withdrawn_request)
+      end
+    end
   end
 
   describe 'redaction' do

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_request_decisions_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_request_decisions_spec.rb
@@ -73,6 +73,21 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestDecisio
       end
     end
 
+    context 'when POA request is withdrawn' do
+      let!(:withdrawn_request) do
+        resolution = create(:power_of_attorney_request_resolution, :replacement)
+        resolution.power_of_attorney_request
+      end
+
+      it 'returns 404 Not Found and does not process a decision' do
+        post "/accredited_representative_portal/v0/power_of_attorney_requests/#{withdrawn_request.id}/decision",
+             params: { decision: { type: 'acceptance' } }
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.parsed_body).to eq({ 'errors' => ['Record not found'] })
+      end
+    end
+
     context "when user's VSO does accept digital POAs but isn't associated" do
       it 'returns 404 Not Found' do
         post "/accredited_representative_portal/v0/power_of_attorney_requests/#{other_poa_request.id}/decision",

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_requests_spec.rb
@@ -622,6 +622,20 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestsContro
           expect(response).to have_http_status(:not_found)
         end
       end
+
+      context 'when POA request is withdrawn' do
+        let!(:withdrawn_request) do
+          resolution = create(:power_of_attorney_request_resolution, :replacement)
+          resolution.power_of_attorney_request
+        end
+
+        it 'returns 404 Not Found' do
+          get("/accredited_representative_portal/v0/power_of_attorney_requests/#{withdrawn_request.id}")
+
+          expect(response).to have_http_status(:not_found)
+          expect(response.parsed_body).to eq({ 'errors' => ['Record not found'] })
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

This PR resolves a bug in the Power of Attorney Request serializer, where withdrawn POA requests were incorrectly included in the serialized output.

It introduces a new .not_withdrawn scope on PowerOfAttorneyRequest and updates the controller to use it, ensuring only valid, non-withdrawn requests are returned in the list API.

Additionally, it refactors the existing .resolved scope to use consistent LEFT OUTER JOIN semantics, making them reusable and compatible with .or queries.

It also improves error handling by returning a 404 Not Found response when attempting to view or make a decision on a withdrawn POA request. This behavior has been added to:

PowerOfAttorneyRequestsController#show
PowerOfAttorneyRequestDecisionsController#create

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114300
https://github.com/orgs/department-of-veterans-affairs/projects/1471/views/43?filterQuery=milestone%3A%22ARF+Claimaint+Search+1.0%22+&pane=issue&itemId=120154976&issue=department-of-veterans-affairs%7Cva.gov-team%7C114477

## Testing done

- [ ] Added unit tests for the .not_withdrawn scope, verifying correct inclusion/exclusion of withdrawn requests.
- [ ] Confirmed correct behavior locally by running through the representative claimant search flow and inspecting results.

## Screenshots
error screen for 404 on POA request show

<img width="1025" height="234" alt="Screenshot 2025-07-16 at 7 22 01 PM" src="https://github.com/user-attachments/assets/8313bd15-338b-4181-9d13-195d07c1f75e" />

## What areas of the site does it impact?
representative/claimant-search
representative/poa-requests/poa-request-id

## Acceptance criteria

- [ ]  I added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.