### PR TITLE
pass nil to postal_cd and prvnc_nm if foreign address

### DIFF
--- a/app/models/bgs_dependents_v2/base.rb
+++ b/app/models/bgs_dependents_v2/base.rb
@@ -168,7 +168,6 @@ module BGSDependentsV2
         frgn_postal_code = address['postal_code']
         state = nil
       end
-      state = 
       {
         efctv_dt: Time.current.iso8601,
         vnp_ptcpnt_id: participant_id,
@@ -185,7 +184,7 @@ module BGSDependentsV2
         mlty_postal_type_cd: address['military_postal_code'],
         mlty_post_office_type_cd: address['military_post_office_type_code'],
         zip_prefix_nbr: address['postal_code'],
-        prvnc_nm: state,
+        prvnc_nm: address['state'],
         email_addrs_txt: payload['email_address']
       }
     end

--- a/app/models/bgs_dependents_v2/base.rb
+++ b/app/models/bgs_dependents_v2/base.rb
@@ -161,11 +161,14 @@ module BGSDependentsV2
     # rubocop:disable Metrics/MethodLength
     def create_address_params(proc_id, participant_id, payload)
       address = generate_address(payload)
-      frgn_postal_code = if address['military_postal_code'].present? || address['country'] == 'USA'
-                           nil
-                         else
-                           address['postal_code']
-                         end
+      if address['military_postal_code'].present? || address['country'] == 'USA'
+        frgn_postal_code = nil
+        state = address['state']
+      else
+        frgn_postal_code = address['postal_code']
+        state = nil
+      end
+      state = 
       {
         efctv_dt: Time.current.iso8601,
         vnp_ptcpnt_id: participant_id,
@@ -177,12 +180,12 @@ module BGSDependentsV2
         addrs_three_txt: address['address_line3'],
         city_nm: address['city'],
         cntry_nm: address['country'],
-        postal_cd: address['state'],
+        postal_cd: state,
         frgn_postal_cd: frgn_postal_code,
         mlty_postal_type_cd: address['military_postal_code'],
         mlty_post_office_type_cd: address['military_post_office_type_code'],
         zip_prefix_nbr: address['postal_code'],
-        prvnc_nm: address['state'],
+        prvnc_nm: state,
         email_addrs_txt: payload['email_address']
       }
     end

--- a/spec/models/bgs_dependents_v2/base_spec.rb
+++ b/spec/models/bgs_dependents_v2/base_spec.rb
@@ -102,6 +102,20 @@ RSpec.describe BGSDependentsV2::Base do
         base.adjust_country_name_for!(address:)
         expect(address['country']).to eq('Italy')
       end
+
+      it 'receives nil for state in the address' do
+        address = sample_v2_dependent_application['veteran_contact_information']['veteran_address']
+        address['country'] = 'ITA'
+        address['international_postal_code'] = '12345'
+        address['state'] = 'Tuscany'
+        base.dependent_address(
+          dependents_application: sample_v2_dependent_application,
+          lives_with_vet: true,
+          alt_address: nil
+        )
+        expect(address['postal_cd']).to eq(nil)
+        expect(address['prvnc_nm']).to eq(nil)
+      end
     end
   end
 end

--- a/spec/models/bgs_dependents_v2/base_spec.rb
+++ b/spec/models/bgs_dependents_v2/base_spec.rb
@@ -108,13 +108,9 @@ RSpec.describe BGSDependentsV2::Base do
         address['country'] = 'ITA'
         address['international_postal_code'] = '12345'
         address['state'] = 'Tuscany'
-        base.dependent_address(
-          dependents_application: sample_v2_dependent_application,
-          lives_with_vet: true,
-          alt_address: nil
-        )
-        expect(address['postal_cd']).to eq(nil)
-        expect(address['prvnc_nm']).to eq(nil)
+        params = base.create_address_params('1', '1', address)
+        expect(params[:postal_cd]).to be_nil
+        expect(params[:prvnc_nm]).to eq('Tuscany')
       end
     end
   end


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
- Pass nil to postal_cd where previously 'state' would have been passed, if the address is international. In V1, there was a Province field for international addresses and state was just passed as nil. However in V2, international addresses use the state field. State will still be passed to prvnc_nm after confirming that the field could take a longer string.
- assign state to nil before passing through bgs for the postal_cd field. 
- VA Lifestage Dependents
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114609

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
