### PR TITLE
[Event Bus Gateway]: Create DB table for tracking sent notifications

### DIFF
--- a/db/migrate/20250717152023_create_event_bus_gateway_notification.rb
+++ b/db/migrate/20250717152023_create_event_bus_gateway_notification.rb
@@ -1,0 +1,10 @@
+class CreateEventBusGatewayNotification < ActiveRecord::Migration[7.2]
+  def change
+    create_table :event_bus_gateway_notifications do |t|
+      t.references :user_account, null: false, foreign_key: true, type: :uuid
+      t.string :va_notify_id, null: false
+      t.string :template_id, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_14_141145) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_17_152023) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -845,6 +845,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_14_141145) do
     t.index ["needs_kms_rotation"], name: "index_education_stem_automated_decisions_on_needs_kms_rotation"
     t.index ["user_account_id"], name: "index_education_stem_automated_decisions_on_user_account_id"
     t.index ["user_uuid"], name: "index_education_stem_automated_decisions_on_user_uuid"
+  end
+
+  create_table "event_bus_gateway_notifications", force: :cascade do |t|
+    t.uuid "user_account_id", null: false
+    t.string "va_notify_id", null: false
+    t.string "template_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_account_id"], name: "index_event_bus_gateway_notifications_on_user_account_id"
   end
 
   create_table "evidence_submissions", force: :cascade do |t|
@@ -2104,6 +2113,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_14_141145) do
   add_foreign_key "deprecated_user_accounts", "user_verifications"
   add_foreign_key "digital_dispute_submissions", "user_accounts"
   add_foreign_key "education_stem_automated_decisions", "user_accounts"
+  add_foreign_key "event_bus_gateway_notifications", "user_accounts"
   add_foreign_key "evidence_submissions", "user_accounts"
   add_foreign_key "evss_claims", "user_accounts"
   add_foreign_key "form526_submission_remediations", "form526_submissions"


### PR DESCRIPTION
We would like to implement code [in our callback](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/sidekiq/event_bus_gateway/va_notify_email_status_callback.rb) that retries `temporary-failure` Notifications.

We will use the VA Notify Notification ID in the callback to look up this object, which will include the template ID and the user account. We can then go through the user account to retrieve the participant ID (or ICN) and send it over to Notify alongside the template ID to be retried.