### PR TITLE
[515] Adding MHV account creation api cache header in non production environments

### DIFF
--- a/lib/mhv/account_creation/service.rb
+++ b/lib/mhv/account_creation/service.rb
@@ -66,8 +66,9 @@ module MHV
       def authenticated_header(icn:)
         {
           'Authorization' => "Bearer #{config.sts_token(user_identifier: icn)}",
-          'x-api-key' => config.access_key
-        }
+          'x-api-key' => config.access_key,
+          'mhvapi-idempotency-key' => Settings.vsp_environment == 'production' ? nil : icn
+        }.compact
       end
 
       def normalize_response_body(response_body)


### PR DESCRIPTION
## Summary

- This PR adds a header to the MHV Account Creation API so that it caches the responses for a short period of time. This should prevent race conditions when calling the service
- For now this should only apply in non-prod environments

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/515

## Testing done

- Testing will have to be done in staging, this should have no impact that we can measure on localhost