### PR TITLE
Allow 'error' param in logs

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -40,6 +40,7 @@ ALLOWLIST = %w[
   user_account_uuid
   confirmation_number
   message
+  error
   errors
   claim_id
   form_id

--- a/spec/lib/logging/monitor_spec.rb
+++ b/spec/lib/logging/monitor_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe Logging::Monitor do
 
         monitor.track_request(error_level, 'TEST', metric, call_location:, **additional_context)
       end
+
+      it 'allows an "error" parameter' do
+        tags = ["service:#{service}", "function:#{call_location.base_label}", 'form_id:FORM_ID']
+        context = { error: 'Test error message', tags: }
+
+        expect(StatsD).to receive(:increment).with(metric, tags:)
+        expect(Rails.logger).to receive(:error) do |_, payload|
+          expect(payload[:context][:error]).to eq('Test error message')
+        end
+
+        monitor.track_request('error', '404 Not Found!', metric, call_location:, **context)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- In many locations we log errors under 'error', but the value is getting filtered out. Adds 'error' to the allow list. 

## Testing done

- [ ] *New code is covered by unit tests*

## Screenshots
Example of issue in DataDog:
<img width="1033" height="219" alt="Screenshot 2025-07-17 at 4 51 37 PM" src="https://github.com/user-attachments/assets/6e0669e5-7102-4e96-9a50-7ee8013c7d58" />

## What areas of the site does it impact?
Logs

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature