### PR TITLE
Update resubmission metadata properties - form 10-7959a

### DIFF
--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
@@ -120,7 +120,7 @@ module IvcChampva
       {
         'pdi_number' => pdi_or_claim == 'PDI number' ? identifying_number : '',
         'claim_number' => pdi_or_claim == 'Claim control number' ? identifying_number : ''
-      }.reject { |_k, v| v == '' }
+      }.compact_blank
     end
   end
 end

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
@@ -36,10 +36,17 @@ module IvcChampva
       }.merge(add_resubmission_properties)
     end
 
+    ##
+    # Extracts resubmission-related properties from the submission data
+    # and formats claim/PDI number fields according to the submission type.
+    # @return [Hash] A hash containing all resubmission properties
     def add_resubmission_properties
-      # TODO: When the frontend adds the actual PDI number field, add to this list
-      @data.slice('claim_status', 'pdi_or_claim_number', 'claim_type', 'provider_name', 'beginning_date_of_service',
-                  'end_date_of_service', 'medication_name', 'prescription_fill_date')
+      # Extract relevant fields for resubmission
+      @data.slice('claim_status', 'pdi_or_claim_number', 'claim_type',
+                  'provider_name', 'beginning_date_of_service',
+                  'end_date_of_service', 'medication_name',
+                  'prescription_fill_date')
+           .merge(claim_number_fields)
     end
 
     ##
@@ -97,6 +104,23 @@ module IvcChampva
 
     def respond_to_missing?(_method_name, _include_private = false)
       true
+    end
+
+    private
+
+    ##
+    # Associates the resubmitted submission's identifying_number with the appropriate
+    # metadata key to be processed by Pega.
+    # @return [Hash] hash with the appropriate metadata key populated (empty hash
+    # if no appropriate number present)
+    def claim_number_fields
+      pdi_or_claim = @data['pdi_or_claim_number']
+      identifying_number = @data['identifying_number']
+
+      {
+        'pdi_number' => pdi_or_claim == 'PDI number' ? identifying_number : '',
+        'claim_number' => pdi_or_claim == 'Claim control number' ? identifying_number : ''
+      }.reject { |_k, v| v == '' }
     end
   end
 end

--- a/modules/ivc_champva/spec/models/vha_10_7959a_spec.rb
+++ b/modules/ivc_champva/spec/models/vha_10_7959a_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe IvcChampva::VHA107959a do
           {
             'claim_status' => 'resubmission',
             'pdi_or_claim_number' => 'PDI number',
+            'identifying_number' => 'va12345678',
             'claim_type' => 'medical',
             'provider_name' => 'BCBS',
             'beginning_date_of_service' => '01-01-1999',
@@ -78,11 +79,18 @@ RSpec.describe IvcChampva::VHA107959a do
         expect(res.keys.include?('provider_name')).to be(true)
         expect(res.keys.include?('beginning_date_of_service')).to be(true)
         expect(res.keys.include?('end_date_of_service')).to be(true)
+        expect(res.keys.include?('pdi_number')).to be(true)
       end
 
       it 'contains resubmission data' do
         res = vha107959a_medical_resubmission.add_resubmission_properties
         expect(res['claim_status']).to eq('resubmission')
+      end
+
+      it 'includes relevant pdi field and excludes claim number field when pdi number was specified' do
+        res = vha107959a_medical_resubmission.add_resubmission_properties
+        expect(res.keys.include?('pdi_number')).to be(true)
+        expect(res.keys.include?('claim_number')).to be(false)
       end
     end
 


### PR DESCRIPTION
## Summary

This PR updates the metadata sent alongside form 10-7959a when we're dealing with a resubmission.

1. If it's a resubmission and there is a PDI number, there will be a metadata field `pdi_number` that contains the pdi number.
2. if it's a resubmission and there is a claim control number, there will be a metadata field `claim_number` that contains the claim control number.
3. If it's a new submission (not a resub), neither of these fields will be present.
4. These two properties are treated as mutually exclusive, so there will only ever be one of these metadata fields present depending on the circumstances

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/112032

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
