### PR TITLE
API-47460 Backfill header_hash (Part 1)

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -382,6 +382,10 @@ features:
     actor_type: user
     description: Use new Form526 Establishment Service (FES) for v2 disability compensation claims
     enable_in_development: true
+  lighthouse_claims_api_run_header_hash_filler_job:
+    actor_type: user
+    description: When enabled, will allow for the header hash to be filled in by the HeaderHashFillerJob
+    enable_in_development: true
   confirmation_page_new:
     actor_type: user
     description: Enables the 2024 version of the confirmation page view in simple forms

--- a/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_job.rb
@@ -20,7 +20,6 @@ module ClaimsApi::OneOff
         next if record.header_hash.present?
 
         begin
-          # Since
           record.save! touch: false
           count += 1
         rescue => e

--- a/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_job.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'claims_api/claim_logger'
+
+module ClaimsApi::OneOff
+  class HeaderHashFillerJob < ClaimsApi::ServiceBase
+    sidekiq_options retry: false
+
+    LOG_TAG = 'header_hash_filler_job'
+
+    def perform(model = 'ClaimsApi::PowerOfAttorney', ids = [], batch_size: 5_000)
+      return unless args_are_valid?(model, ids)
+
+      relation = model.constantize.where(header_hash: nil)
+      relation = relation.where(id: ids) unless ids.empty?
+
+      count = 0
+      relation.limit(batch_size).find_each do |record|
+        next if record.header_hash.present?
+
+        begin
+          # Since
+          record.save! touch: false
+          count += 1
+        rescue => e
+          ClaimsApi::Logger.log LOG_TAG, level: :error,
+                                         detail: "Failed to fill header hash for #{model} with ID: #{record.id}",
+                                         error_class: e.class.name,
+                                         error_message: e.message
+        end
+      end
+      ClaimsApi::Logger.log LOG_TAG, details: "#{model} completed with #{count} record(s)"
+    end
+
+    private
+
+    def args_are_valid?(model, ids)
+      return false unless model.is_a?(String) && ids.is_a?(Array)
+      return false unless model.constantize.method_defined?(:set_header_hash)
+
+      true
+    rescue => e # model.constantize throws if the model is invalid, but may as well catch everything
+      ClaimsApi::Logger.log LOG_TAG, level: :error,
+                                     detail: 'Invalid arguments provided',
+                                     error_class: e.class.name,
+                                     error_message: e.message
+      false
+    end
+  end
+end

--- a/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_job.rb
@@ -9,6 +9,7 @@ module ClaimsApi::OneOff
     LOG_TAG = 'header_hash_filler_job'
 
     def perform(model = 'ClaimsApi::PowerOfAttorney', ids = [], batch_size: 5_000)
+      return unless Flipper.enabled? :lighthouse_claims_api_run_header_hash_filler_job
       return unless args_are_valid?(model, ids)
 
       relation = model.constantize.where(header_hash: nil)

--- a/modules/claims_api/spec/sidekiq/one_off/header_hash_filler_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/one_off/header_hash_filler_job_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'pdf_fill/filler'
+
+RSpec.describe ClaimsApi::OneOff::HeaderHashFillerJob, type: :job do
+  subject { described_class.new }
+
+  before do
+    Timecop.freeze(1.year.ago) do
+      create_list(:power_of_attorney, 10)
+      ClaimsApi::PowerOfAttorney.update_all(header_hash: nil) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+
+  describe '#perform' do
+    it 'fills header_hash for POA records where it is missing' do
+      ClaimsApi::PowerOfAttorney.first.save # Fills in header hash, so we can test filling for others
+      expect do
+        subject.perform 'ClaimsApi::PowerOfAttorney'
+      end.to change { ClaimsApi::PowerOfAttorney.where(header_hash: nil).count }.from(9).to(0)
+    end
+
+    it 'fills in header_hash for specific records' do
+      ids =  ClaimsApi::PowerOfAttorney.all.pluck(:id).sample(3)
+      subject.perform 'ClaimsApi::PowerOfAttorney', ids
+      ids.each do |id|
+        expect(ClaimsApi::PowerOfAttorney.find_by(id:).header_hash).not_to be_blank
+      end
+      # Ensure other records are not affected
+      expect(ClaimsApi::PowerOfAttorney.where.not(id: ids).first.header_hash).to be_blank
+    end
+
+    it 'does not change timestamps when filling header_hash' do
+      poa = ClaimsApi::PowerOfAttorney.first
+      original_updated_at = poa.updated_at
+      subject.perform 'ClaimsApi::PowerOfAttorney', [poa.id]
+      expect(poa.reload.updated_at).to eq(original_updated_at)
+    end
+
+    it 'logs count of records processed' do
+      expect(ClaimsApi::Logger).to receive(:log).with(
+        'header_hash_filler_job',
+        details: 'ClaimsApi::PowerOfAttorney completed with 10 record(s)'
+      )
+
+      subject.perform 'ClaimsApi::PowerOfAttorney'
+    end
+
+    it 'logs an error and returns cleanly if filling header_hash fails' do
+      allow_any_instance_of(ClaimsApi::PowerOfAttorney)
+        .to receive(:set_header_hash).and_raise(StandardError.new('Test error'))
+      poa = ClaimsApi::PowerOfAttorney.first
+
+      expect(ClaimsApi::Logger).to receive(:log).twice # Once for the error, once for the completion log
+
+      expect do
+        subject.perform('ClaimsApi::PowerOfAttorney', [poa.id])
+      end.not_to raise_error
+    end
+
+    it 'works on AutoEstablishedClaims too' do
+      create_list(:auto_established_claim, 10)
+      ClaimsApi::AutoEstablishedClaim.update_all(header_hash: nil) # rubocop:disable Rails/SkipsModelValidations
+      ClaimsApi::AutoEstablishedClaim.first.save # Fills in header hash, so we can test filling for others
+      expect do
+        subject.perform 'ClaimsApi::AutoEstablishedClaim'
+      end.to change { ClaimsApi::AutoEstablishedClaim.where(header_hash: nil).count }.from(9).to(0)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

With the move away from md5 hashing of the headers of some models due to concerns with security & collisions, we still have many (> 500k) records without the new SHA256 `header_hash` in place. New records automatically have both fields generated, but old records from before the `header_hash` field have this remain empty.

This job will fill those in so that we may eventually remove the MD5 field.

Part 1 because we should test the behavior before turning this into scheduled job(s).

## Related issue(s)

https://jira.devops.va.gov/browse/API-47460

## Testing done

- [x] *New code is covered by unit tests*
- [x] * Flipper `lighthouse_claims_api_run_header_hash_filler_job` added & included in unit tests

## What areas of the site does it impact?

This will affect old records that we have previously stored an md5 hash on and still need their modern header _hash filled.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs