### PR TITLE
[10-10CG] Refactor MuleSoft client

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -147,6 +147,9 @@ features:
   caregiver_use_rails_logging_over_sentry:
     actor_type: user
     description: Use Rails for logging instead of Sentry
+  caregiver_mulesoft_config_v2:
+    actor_type: user
+    description: Use refactored mulesoft configuration
   cerner_non_eligible_sis_enabled:
     actor_type: user
     description: Enables Sign in Service for cerner authentication

--- a/lib/carma/client/mule_soft_auth_token_client.rb
+++ b/lib/carma/client/mule_soft_auth_token_client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'carma/client/mule_soft_auth_token_configuration'
+require 'carma/client/mule_soft_auth_token_configuration_v2'
 
 module CARMA
   module Client
@@ -11,7 +12,11 @@ module CARMA
       GRANT_TYPE = 'client_credentials'
       SCOPE = 'DTCWriteResource'
 
-      configuration MuleSoftAuthTokenConfiguration
+      if Flipper.enabled?(:caregiver_mulesoft_config_v2)
+        configuration MuleSoftAuthTokenConfigurationV2
+      else
+        configuration MuleSoftAuthTokenConfiguration
+      end
 
       class GetAuthTokenError < StandardError; end
 
@@ -21,7 +26,7 @@ module CARMA
                              auth_token_path,
                              params,
                              token_headers,
-                             { timeout: config.timeout })
+                             *(Flipper.enabled?(:caregiver_mulesoft_config_v2) ? [] : [{ timeout: config.timeout }]))
 
           return JSON.parse(response.body)['access_token'] if response.status == 200
 

--- a/lib/carma/client/mule_soft_auth_token_client.rb
+++ b/lib/carma/client/mule_soft_auth_token_client.rb
@@ -12,12 +12,6 @@ module CARMA
       GRANT_TYPE = 'client_credentials'
       SCOPE = 'DTCWriteResource'
 
-      if Flipper.enabled?(:caregiver_mulesoft_config_v2)
-        configuration MuleSoftAuthTokenConfigurationV2
-      else
-        configuration MuleSoftAuthTokenConfiguration
-      end
-
       class GetAuthTokenError < StandardError; end
 
       def new_bearer_token
@@ -35,6 +29,14 @@ module CARMA
       end
 
       private
+
+      def config
+        if Flipper.enabled?(:caregiver_mulesoft_config_v2)
+          MuleSoftAuthTokenConfigurationV2.instance
+        else
+          MuleSoftAuthTokenConfiguration.instance
+        end
+      end
 
       def params
         URI.encode_www_form({

--- a/lib/carma/client/mule_soft_auth_token_configuration_v2.rb
+++ b/lib/carma/client/mule_soft_auth_token_configuration_v2.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module CARMA
+  module Client
+    class MuleSoftAuthTokenConfigurationV2 < Common::Client::Configuration::REST
+      def connection
+        Faraday.new(base_path) do |conn|
+          conn.use(:breakers, service_name:)
+          conn.request :instrumentation, name: service_name
+          conn.options.timeout = timeout
+          conn.adapter Faraday.default_adapter
+        end
+      end
+
+      def service_name
+        self.class.name
+      end
+
+      def timeout
+        settings.key?(:timeout) ? settings.timeout : 30
+      end
+
+      def settings
+        Settings.form_10_10cg.carma.mulesoft.auth
+      end
+
+      private
+
+      def base_path
+        "#{settings.token_url}/"
+      end
+    end
+  end
+end

--- a/lib/carma/client/mule_soft_client.rb
+++ b/lib/carma/client/mule_soft_client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'carma/client/mule_soft_configuration'
+require 'carma/client/mule_soft_configuration_v2'
 require 'carma/client/mule_soft_auth_token_client'
 
 module CARMA
@@ -8,7 +9,11 @@ module CARMA
     class MuleSoftClient < Common::Client::Base
       include Common::Client::Concerns::Monitoring
 
-      configuration MuleSoftConfiguration
+      if Flipper.enabled?(:caregiver_mulesoft_config_v2)
+        configuration MuleSoftConfigurationV2
+      else
+        configuration MuleSoftConfiguration
+      end
 
       STATSD_KEY_PREFIX = 'api.carma.mulesoft'
 
@@ -38,8 +43,8 @@ module CARMA
             :post,
             resource,
             get_body(payload),
-            headers,
-            { timeout: config.settings.async_timeout }
+            *(Flipper.enabled?(:caregiver_mulesoft_config_v2) ? [] : [headers]),
+            *(Flipper.enabled?(:caregiver_mulesoft_config_v2) ? [] : [{ timeout: config.settings.async_timeout }])
           )
 
           handle_response(resource, response)

--- a/lib/carma/client/mule_soft_client.rb
+++ b/lib/carma/client/mule_soft_client.rb
@@ -9,12 +9,6 @@ module CARMA
     class MuleSoftClient < Common::Client::Base
       include Common::Client::Concerns::Monitoring
 
-      if Flipper.enabled?(:caregiver_mulesoft_config_v2)
-        configuration MuleSoftConfigurationV2
-      else
-        configuration MuleSoftConfiguration
-      end
-
       STATSD_KEY_PREFIX = 'api.carma.mulesoft'
 
       class RecordParseError < StandardError; end
@@ -33,6 +27,14 @@ module CARMA
       end
 
       private
+
+      def config
+        if Flipper.enabled?(:caregiver_mulesoft_config_v2)
+          MuleSoftConfigurationV2.instance
+        else
+          MuleSoftConfiguration.instance
+        end
+      end
 
       def perform_post(payload)
         resource = 'v2/application/1010CG/submit'

--- a/lib/carma/client/mule_soft_configuration_v2.rb
+++ b/lib/carma/client/mule_soft_configuration_v2.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module CARMA
+  module Client
+    class MuleSoftConfigurationV2 < Common::Client::Configuration::REST
+      def connection
+        Faraday.new(base_path, headers: base_request_headers) do |conn|
+          conn.use(:breakers, service_name:)
+          conn.request :instrumentation, name: service_name
+          conn.options.timeout = timeout
+          conn.adapter Faraday.default_adapter
+        end
+      end
+
+      def service_name
+        self.class.name
+      end
+
+      # @return [Integer] Value given by configuration key `form_10_10cg.carma.mulesoft.timeout`
+      # setting. Defaults to 600 if unset.
+      def timeout
+        settings.key?(:timeout) ? settings.timeout : 600
+      end
+
+      # @return [Config::Options]
+      def settings
+        Settings.form_10_10cg.carma.mulesoft
+      end
+
+      def base_request_headers
+        super.merge(
+          'Authorization' => "Bearer #{bearer_token}"
+        )
+      end
+
+      private
+
+      # @return [String]
+      def base_path
+        "#{settings.host}/va-carma-caregiver-papi/api/"
+      end
+
+      def bearer_token
+        @bearer_token ||= CARMA::Client::MuleSoftAuthTokenClient.new.new_bearer_token
+      end
+    end
+  end
+end

--- a/spec/lib/carma/client/mule_soft_auth_token_client_spec.rb
+++ b/spec/lib/carma/client/mule_soft_auth_token_client_spec.rb
@@ -58,6 +58,11 @@ describe CARMA::Client::MuleSoftAuthTokenClient do
         allow(Flipper).to receive(:enabled?).with(:caregiver_mulesoft_config_v2).and_return(false)
       end
 
+      it 'uses MuleSoftAuthTokenConfiguration config' do
+        allow(client).to receive(:config).and_call_original
+        expect(client.send(:config)).to be_a(CARMA::Client::MuleSoftAuthTokenConfiguration)
+      end
+
       context 'successfully gets token' do
         it 'calls perform with expected params' do
           expect(client).to receive(:perform)
@@ -91,6 +96,11 @@ describe CARMA::Client::MuleSoftAuthTokenClient do
     context ':caregiver_mulesoft_config_v2 toggle enabled' do
       before do
         allow(Flipper).to receive(:enabled?).with(:caregiver_mulesoft_config_v2).and_return(true)
+      end
+
+      it 'uses MuleSoftAuthTokenConfigurationV2 config' do
+        allow(client).to receive(:config).and_call_original
+        expect(client.send(:config)).to be_a(CARMA::Client::MuleSoftAuthTokenConfigurationV2)
       end
 
       context 'successfully gets token' do

--- a/spec/lib/carma/client/mule_soft_auth_token_configuration_v2_spec.rb
+++ b/spec/lib/carma/client/mule_soft_auth_token_configuration_v2_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'carma/client/mule_soft_auth_token_configuration_v2'
+
+describe CARMA::Client::MuleSoftAuthTokenConfigurationV2 do
+  subject { described_class.instance }
+
+  let(:token_url) { 'https://www.somesite.gov' }
+
+  before do
+    allow(Settings.form_10_10cg.carma.mulesoft.auth).to receive(:token_url).and_return(token_url)
+  end
+
+  describe 'connection' do
+    let(:faraday) { double('Faraday::Connection', options: double('Faraday::Options')) }
+
+    it 'creates a new Faraday connection with the correct base path' do
+      expect(Faraday).to receive(:new).with("#{token_url}/")
+      subject.connection
+    end
+
+    it 'creates the connection' do
+      allow(Faraday).to receive(:new).and_yield(faraday)
+      allow(faraday.options).to receive(:timeout=)
+
+      expect(faraday).to receive(:use).once.with(:breakers, { service_name: subject.service_name })
+      expect(faraday).to receive(:request).once.with(:instrumentation,
+                                                     { name: 'CARMA::Client::MuleSoftAuthTokenConfigurationV2' })
+      expect(faraday).to receive(:adapter).once.with(Faraday.default_adapter)
+      expect(faraday.options).to receive(:timeout=).once.with(subject.timeout)
+
+      subject.connection
+    end
+  end
+
+  it 'service_name returns class name' do
+    expect(subject.service_name).to eq('CARMA::Client::MuleSoftAuthTokenConfigurationV2')
+  end
+
+  describe 'timeout' do
+    context 'has a configured value' do
+      before do
+        allow(Settings.form_10_10cg.carma.mulesoft.auth).to receive(:timeout).and_return(23)
+      end
+
+      it 'returns the configured value' do
+        expect(subject.timeout).to eq(23)
+      end
+    end
+
+    context 'does not have a configured value' do
+      before do
+        allow(Settings.form_10_10cg.carma.mulesoft.auth).to receive(:key?).and_return(nil)
+      end
+
+      it 'returns the default value' do
+        expect(subject.timeout).to eq(30)
+      end
+    end
+  end
+
+  describe 'settings' do
+    let(:expected_settings) { 'my_fake_settings_value' }
+
+    before do
+      allow(Settings.form_10_10cg.carma.mulesoft).to receive(:auth).and_return(expected_settings)
+    end
+
+    it 'returns expected settings path' do
+      expect(subject.settings).to eq(expected_settings)
+    end
+  end
+end

--- a/spec/lib/carma/client/mule_soft_client_spec.rb
+++ b/spec/lib/carma/client/mule_soft_client_spec.rb
@@ -12,21 +12,20 @@ describe CARMA::Client::MuleSoftClient do
 
   describe 'submitting 10-10CG' do
     context ':caregiver_mulesoft_config_v2 toggle disabled' do
-      let(:config) { double('config') }
-      let(:exp_headers) { { client_id: '1234', client_secret: 'abcd' } }
-      let(:timeout) { 60 }
-
       before do
         allow(Flipper).to receive(:enabled?).with(:caregiver_mulesoft_config_v2).and_return(false)
-        allow(client).to receive(:config).and_return(config)
-        allow(config).to receive_messages(base_request_headers: exp_headers, timeout: 10,
-                                          settings: OpenStruct.new(
-                                            async_timeout: timeout
-                                          ))
+      end
+
+      it 'uses MuleSoftConfiguration config' do
+        expect(client.send(:config)).to be_a(CARMA::Client::MuleSoftConfiguration)
       end
 
       describe '#create_submission_v2' do
         subject { client.create_submission_v2(payload) }
+
+        let(:config) { double('config') }
+        let(:exp_headers) { { client_id: '1234', client_secret: 'abcd' } }
+        let(:timeout) { 60 }
 
         let(:resource) { 'v2/application/1010CG/submit' }
         let(:payload) { {} }
@@ -34,6 +33,11 @@ describe CARMA::Client::MuleSoftClient do
         let(:mulesoft_auth_token_client) { instance_double(CARMA::Client::MuleSoftAuthTokenClient) }
 
         before do
+          allow(client).to receive(:config).and_return(config)
+          allow(config).to receive_messages(base_request_headers: exp_headers, timeout: 10,
+                                            settings: OpenStruct.new(
+                                              async_timeout: timeout
+                                            ))
           allow(CARMA::Client::MuleSoftAuthTokenClient).to receive(:new).and_return(mulesoft_auth_token_client)
         end
 
@@ -190,28 +194,31 @@ describe CARMA::Client::MuleSoftClient do
     end
 
     context ':caregiver_mulesoft_config_v2 toggle enabled' do
-      let(:config) { double('config') }
-      let(:exp_headers) { { client_id: '1234', client_secret: 'abcd' } }
-      let(:timeout) { 60 }
-
       before do
         allow(Flipper).to receive(:enabled?).with(:caregiver_mulesoft_config_v2).and_return(true)
-        allow(client).to receive(:config).and_return(config)
-        allow(config).to receive_messages(base_request_headers: exp_headers, timeout: 10,
-                                          settings: OpenStruct.new(
-                                            async_timeout: timeout
-                                          ))
       end
 
       it 'uses MuleSoftConfigurationV2 config' do
-        expect(described_class.configuration).to be_a(CARMA::Client::MuleSoftConfigurationV2)
+        expect(client.send(:config)).to be_a(CARMA::Client::MuleSoftConfigurationV2)
       end
 
       describe '#create_submission_v2' do
         subject { client.create_submission_v2(payload) }
 
+        let(:config) { double('config') }
+        let(:exp_headers) { { client_id: '1234', client_secret: 'abcd' } }
+        let(:timeout) { 60 }
+
         let(:resource) { 'v2/application/1010CG/submit' }
         let(:payload) { {} }
+
+        before do
+          allow(client).to receive(:config).and_return(config)
+          allow(config).to receive_messages(base_request_headers: exp_headers, timeout: 10,
+                                            settings: OpenStruct.new(
+                                              async_timeout: timeout
+                                            ))
+        end
 
         context 'successfully gets token' do
           let(:bearer_token) { 'my-bearer-token' }

--- a/spec/lib/carma/client/mule_soft_client_spec.rb
+++ b/spec/lib/carma/client/mule_soft_client_spec.rb
@@ -11,177 +11,344 @@ describe CARMA::Client::MuleSoftClient do
   end
 
   describe 'submitting 10-10CG' do
-    let(:config) { double('config') }
-    let(:exp_headers) { { client_id: '1234', client_secret: 'abcd' } }
-    let(:timeout) { 60 }
-
-    before do
-      allow(client).to receive(:config).and_return(config)
-      allow(config).to receive_messages(base_request_headers: exp_headers, timeout: 10,
-                                        settings: OpenStruct.new(
-                                          async_timeout: timeout
-                                        ))
-    end
-
-    describe '#create_submission_v2' do
-      subject { client.create_submission_v2(payload) }
-
-      let(:resource) { 'v2/application/1010CG/submit' }
-      let(:payload) { {} }
-
-      let(:mulesoft_auth_token_client) { instance_double(CARMA::Client::MuleSoftAuthTokenClient) }
+    context ':caregiver_mulesoft_config_v2 toggle disabled' do
+      let(:config) { double('config') }
+      let(:exp_headers) { { client_id: '1234', client_secret: 'abcd' } }
+      let(:timeout) { 60 }
 
       before do
-        allow(CARMA::Client::MuleSoftAuthTokenClient).to receive(:new).and_return(mulesoft_auth_token_client)
+        allow(Flipper).to receive(:enabled?).with(:caregiver_mulesoft_config_v2).and_return(false)
+        allow(client).to receive(:config).and_return(config)
+        allow(config).to receive_messages(base_request_headers: exp_headers, timeout: 10,
+                                          settings: OpenStruct.new(
+                                            async_timeout: timeout
+                                          ))
       end
 
-      context 'successfully gets token' do
-        let(:bearer_token) { 'my-bearer-token' }
-        let(:headers) do
-          {
-            'Authorization' => "Bearer #{bearer_token}",
-            'Content-Type' => 'application/json'
-          }
-        end
+      describe '#create_submission_v2' do
+        subject { client.create_submission_v2(payload) }
 
-        let(:has_errors) { false }
-        let(:results) { {} }
+        let(:resource) { 'v2/application/1010CG/submit' }
+        let(:payload) { {} }
 
-        let(:response_body) do
-          {
-            data: {
-              carmacase: {
-                createdAt: '2022-08-04 16:44:37',
-                id: 'aB93S0000000FTqSAM'
-              }
-            },
-            record: {
-              hasErrors: has_errors,
-              results:
-            }
-          }.to_json
-        end
-
-        let(:status) { 201 }
-        let(:mock_response) { double('FaradayResponse', status:, body: response_body) }
+        let(:mulesoft_auth_token_client) { instance_double(CARMA::Client::MuleSoftAuthTokenClient) }
 
         before do
-          allow(mulesoft_auth_token_client).to receive(:new_bearer_token).and_return(bearer_token)
-          allow(client).to receive(:perform)
-            .with(:post, resource, payload.to_json, headers, { timeout: })
-            .and_return(mock_response)
+          allow(CARMA::Client::MuleSoftAuthTokenClient).to receive(:new).and_return(mulesoft_auth_token_client)
         end
 
-        context 'successful response' do
-          [200, 201, 202].each do |status_code|
-            context "with a #{status_code} status code" do
-              let(:status) { status_code }
+        context 'successfully gets token' do
+          let(:bearer_token) { 'my-bearer-token' }
+          let(:headers) do
+            {
+              'Authorization' => "Bearer #{bearer_token}",
+              'Content-Type' => 'application/json'
+            }
+          end
 
-              it 'logs submission and response code' do
-                expect(Rails.logger).to receive(:info).with(
-                  "[Form 10-10CG] Submitting to '#{resource}' using bearer token"
-                )
-                expect(Rails.logger).to receive(:info)
-                  .with("[Form 10-10CG] Submission to '#{resource}' resource resulted in response code #{status}")
-                expect(Sentry).to receive(:set_extras).with(response_body: mock_response.body)
+          let(:has_errors) { false }
+          let(:results) { {} }
 
-                subject
+          let(:response_body) do
+            {
+              data: {
+                carmacase: {
+                  createdAt: '2022-08-04 16:44:37',
+                  id: 'aB93S0000000FTqSAM'
+                }
+              },
+              record: {
+                hasErrors: has_errors,
+                results:
+              }
+            }.to_json
+          end
+
+          let(:status) { 201 }
+          let(:mock_response) { double('FaradayResponse', status:, body: response_body) }
+
+          before do
+            allow(mulesoft_auth_token_client).to receive(:new_bearer_token).and_return(bearer_token)
+            allow(client).to receive(:perform)
+              .with(:post, resource, payload.to_json, headers, { timeout: })
+              .and_return(mock_response)
+          end
+
+          context 'successful response' do
+            [200, 201, 202].each do |status_code|
+              context "with a #{status_code} status code" do
+                let(:status) { status_code }
+
+                it 'logs submission and response code' do
+                  expect(Rails.logger).to receive(:info).with(
+                    "[Form 10-10CG] Submitting to '#{resource}' using bearer token"
+                  )
+                  expect(Rails.logger).to receive(:info)
+                    .with("[Form 10-10CG] Submission to '#{resource}' resource resulted in response code #{status}")
+                  expect(Sentry).to receive(:set_extras).with(response_body: mock_response.body)
+
+                  subject
+                end
+              end
+            end
+          end
+
+          context 'non 200 response' do
+            let(:status) { 500 }
+
+            it 'raises SchemaValidationError' do
+              expect(Rails.logger).to receive(:info)
+                .with("[Form 10-10CG] Submitting to '#{resource}' using bearer token")
+              expect(Rails.logger).to receive(:info)
+                .with("[Form 10-10CG] Submission to '#{resource}' resource resulted in response code 500")
+              expect(Rails.logger).to receive(:error).with(
+                '[Form 10-10CG] Submission expected 200 status but received 500'
+              )
+
+              expect { subject }.to raise_error(Common::Exceptions::SchemaValidationErrors)
+            end
+          end
+
+          context 'hasErrors is true' do
+            let(:has_errors) { true }
+
+            context 'hasErrors in response is true' do
+              context 'results is empty' do
+                it 'logs carma response' do
+                  expect(Rails.logger).to receive(:error)
+                    .with('[Form 10-10CG] response contained attachment errors',
+                          {
+                            created_at: '2022-08-04 16:44:37',
+                            id: 'aB93S0000000FTqSAM',
+                            attachments: []
+                          })
+                  expect { subject }.to raise_error(CARMA::Client::MuleSoftClient::RecordParseError)
+                end
+              end
+
+              context 'results has attachment data' do
+                let(:errors) do
+                  [
+                    {
+                      duplicateResult: nil,
+                      message: 'Document Type: bad value for restricted picklist field: invalid',
+                      fields: [
+                        'CARMA_Document_Type__c'
+                      ],
+                      statusCode: 'INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST'
+                    }
+                  ]
+                end
+                let(:results) do
+                  [
+                    {
+                      referenceId: '1010CG',
+                      title: '10-10CG_Jane Doe_Doe_06-25-2025',
+                      id: nil,
+                      errors:
+                    }
+                  ]
+                end
+
+                it 'logs carma response' do
+                  expect(Rails.logger).to receive(:error)
+                    .with('[Form 10-10CG] response contained attachment errors',
+                          {
+                            created_at: '2022-08-04 16:44:37',
+                            id: 'aB93S0000000FTqSAM',
+                            attachments: [{
+                              reference_id: '1010CG',
+                              id: '',
+                              errors: [
+                                {
+                                  'duplicateResult' => nil,
+                                  'message' => 'Document Type: bad value for restricted picklist field: invalid',
+                                  'fields' => ['CARMA_Document_Type__c'],
+                                  'statusCode' => 'INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST'
+                                }
+                              ]
+                            }]
+                          })
+                  expect { subject }.to raise_error(CARMA::Client::MuleSoftClient::RecordParseError)
+                end
               end
             end
           end
         end
 
-        context 'non 200 response' do
-          let(:status) { 500 }
+        context 'error getting token' do
+          it 'logs error' do
+            expect(mulesoft_auth_token_client).to receive(:new_bearer_token)
+              .and_raise(CARMA::Client::MuleSoftAuthTokenClient::GetAuthTokenError)
 
-          it 'raises SchemaValidationError' do
-            expect(Rails.logger).to receive(:info)
-              .with("[Form 10-10CG] Submitting to '#{resource}' using bearer token")
-            expect(Rails.logger).to receive(:info)
-              .with("[Form 10-10CG] Submission to '#{resource}' resource resulted in response code 500")
-            expect(Rails.logger).to receive(:error).with(
-              '[Form 10-10CG] Submission expected 200 status but received 500'
-            )
-
-            expect { subject }.to raise_error(Common::Exceptions::SchemaValidationErrors)
-          end
-        end
-
-        context 'hasErrors is true' do
-          let(:has_errors) { true }
-
-          context 'hasErrors in response is true' do
-            context 'results is empty' do
-              it 'logs carma response' do
-                expect(Rails.logger).to receive(:error)
-                  .with('[Form 10-10CG] response contained attachment errors',
-                        {
-                          created_at: '2022-08-04 16:44:37',
-                          id: 'aB93S0000000FTqSAM',
-                          attachments: []
-                        })
-                expect { subject }.to raise_error(CARMA::Client::MuleSoftClient::RecordParseError)
-              end
-            end
-
-            context 'results has attachment data' do
-              let(:errors) do
-                [
-                  {
-                    duplicateResult: nil,
-                    message: 'Document Type: bad value for restricted picklist field: invalid',
-                    fields: [
-                      'CARMA_Document_Type__c'
-                    ],
-                    statusCode: 'INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST'
-                  }
-                ]
-              end
-              let(:results) do
-                [
-                  {
-                    referenceId: '1010CG',
-                    title: '10-10CG_Jane Doe_Doe_06-25-2025',
-                    id: nil,
-                    errors:
-                  }
-                ]
-              end
-
-              it 'logs carma response' do
-                expect(Rails.logger).to receive(:error)
-                  .with('[Form 10-10CG] response contained attachment errors',
-                        {
-                          created_at: '2022-08-04 16:44:37',
-                          id: 'aB93S0000000FTqSAM',
-                          attachments: [{
-                            reference_id: '1010CG',
-                            id: '',
-                            errors: [
-                              {
-                                'duplicateResult' => nil,
-                                'message' => 'Document Type: bad value for restricted picklist field: invalid',
-                                'fields' => ['CARMA_Document_Type__c'],
-                                'statusCode' => 'INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST'
-                              }
-                            ]
-                          }]
-                        })
-                expect { subject }.to raise_error(CARMA::Client::MuleSoftClient::RecordParseError)
-              end
-            end
+            expect do
+              subject
+            end.to raise_error(CARMA::Client::MuleSoftAuthTokenClient::GetAuthTokenError)
           end
         end
       end
+    end
 
-      context 'error getting token' do
-        it 'logs error' do
-          expect(mulesoft_auth_token_client).to receive(:new_bearer_token)
-            .and_raise(CARMA::Client::MuleSoftAuthTokenClient::GetAuthTokenError)
+    context ':caregiver_mulesoft_config_v2 toggle enabled' do
+      let(:config) { double('config') }
+      let(:exp_headers) { { client_id: '1234', client_secret: 'abcd' } }
+      let(:timeout) { 60 }
 
-          expect do
-            subject
-          end.to raise_error(CARMA::Client::MuleSoftAuthTokenClient::GetAuthTokenError)
+      before do
+        allow(Flipper).to receive(:enabled?).with(:caregiver_mulesoft_config_v2).and_return(true)
+        allow(client).to receive(:config).and_return(config)
+        allow(config).to receive_messages(base_request_headers: exp_headers, timeout: 10,
+                                          settings: OpenStruct.new(
+                                            async_timeout: timeout
+                                          ))
+      end
+
+      it 'uses MuleSoftConfigurationV2 config' do
+        expect(described_class.configuration).to be_a(CARMA::Client::MuleSoftConfigurationV2)
+      end
+
+      describe '#create_submission_v2' do
+        subject { client.create_submission_v2(payload) }
+
+        let(:resource) { 'v2/application/1010CG/submit' }
+        let(:payload) { {} }
+
+        context 'successfully gets token' do
+          let(:bearer_token) { 'my-bearer-token' }
+          let(:headers) do
+            {
+              'Authorization' => "Bearer #{bearer_token}",
+              'Content-Type' => 'application/json'
+            }
+          end
+
+          let(:has_errors) { false }
+          let(:results) { {} }
+
+          let(:response_body) do
+            {
+              data: {
+                carmacase: {
+                  createdAt: '2022-08-04 16:44:37',
+                  id: 'aB93S0000000FTqSAM'
+                }
+              },
+              record: {
+                hasErrors: has_errors,
+                results:
+              }
+            }.to_json
+          end
+
+          let(:status) { 201 }
+          let(:mock_response) { double('FaradayResponse', status:, body: response_body) }
+
+          before do
+            allow(client).to receive(:perform)
+              .with(:post, resource, payload.to_json)
+              .and_return(mock_response)
+          end
+
+          context 'successful response' do
+            [200, 201, 202].each do |status_code|
+              context "with a #{status_code} status code" do
+                let(:status) { status_code }
+
+                it 'logs submission and response code' do
+                  expect(Rails.logger).to receive(:info).with(
+                    "[Form 10-10CG] Submitting to '#{resource}' using bearer token"
+                  )
+                  expect(Rails.logger).to receive(:info)
+                    .with("[Form 10-10CG] Submission to '#{resource}' resource resulted in response code #{status}")
+                  expect(Sentry).to receive(:set_extras).with(response_body: mock_response.body)
+
+                  subject
+                end
+              end
+            end
+          end
+
+          context 'non 200 response' do
+            let(:status) { 500 }
+
+            it 'raises SchemaValidationError' do
+              expect(Rails.logger).to receive(:info)
+                .with("[Form 10-10CG] Submitting to '#{resource}' using bearer token")
+              expect(Rails.logger).to receive(:info)
+                .with("[Form 10-10CG] Submission to '#{resource}' resource resulted in response code 500")
+              expect(Rails.logger).to receive(:error).with(
+                '[Form 10-10CG] Submission expected 200 status but received 500'
+              )
+
+              expect { subject }.to raise_error(Common::Exceptions::SchemaValidationErrors)
+            end
+          end
+
+          context 'hasErrors is true' do
+            let(:has_errors) { true }
+
+            context 'hasErrors in response is true' do
+              context 'results is empty' do
+                it 'logs carma response' do
+                  expect(Rails.logger).to receive(:error)
+                    .with('[Form 10-10CG] response contained attachment errors',
+                          {
+                            created_at: '2022-08-04 16:44:37',
+                            id: 'aB93S0000000FTqSAM',
+                            attachments: []
+                          })
+                  expect { subject }.to raise_error(CARMA::Client::MuleSoftClient::RecordParseError)
+                end
+              end
+
+              context 'results has attachment data' do
+                let(:errors) do
+                  [
+                    {
+                      duplicateResult: nil,
+                      message: 'Document Type: bad value for restricted picklist field: invalid',
+                      fields: [
+                        'CARMA_Document_Type__c'
+                      ],
+                      statusCode: 'INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST'
+                    }
+                  ]
+                end
+                let(:results) do
+                  [
+                    {
+                      referenceId: '1010CG',
+                      title: '10-10CG_Jane Doe_Doe_06-25-2025',
+                      id: nil,
+                      errors:
+                    }
+                  ]
+                end
+
+                it 'logs carma response' do
+                  expect(Rails.logger).to receive(:error)
+                    .with('[Form 10-10CG] response contained attachment errors',
+                          {
+                            created_at: '2022-08-04 16:44:37',
+                            id: 'aB93S0000000FTqSAM',
+                            attachments: [{
+                              reference_id: '1010CG',
+                              id: '',
+                              errors: [
+                                {
+                                  'duplicateResult' => nil,
+                                  'message' => 'Document Type: bad value for restricted picklist field: invalid',
+                                  'fields' => ['CARMA_Document_Type__c'],
+                                  'statusCode' => 'INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST'
+                                }
+                              ]
+                            }]
+                          })
+                  expect { subject }.to raise_error(CARMA::Client::MuleSoftClient::RecordParseError)
+                end
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- Refactored the `CARMA::Client::MuleSoftClient` and `CARMA::Client::MuleSoftAuthTokenClient` classes and their corresponding configurations to be more readable.
-  No longer using the `form_10_10cg/carma/mulesoft/client_id` and `form_10_10cg/carma/mulesoft/client_secret` params since we use the token client to fetch a token for authentication. 
- Added a V2 that I will eventually rename back to the configuration after we fully test it in staging. I do not plan for both configurations to exist for long. 
- This PR is longer because I have specs for each side of the toggle, and the specs are largely very similar. 
- 1010 Health Apps
- `caregiver_mulesoft_config_v2` flipper toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101075

## Testing done

- [x] *New code is covered by unit tests*
- [ ] Manual QA in a RI as a sanity check 

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
