### PR TITLE
API-48161-va-notify-accepted-get-v2-claimant-name

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/va_notify_accepted_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/va_notify_accepted_job.rb
@@ -174,7 +174,11 @@ module ClaimsApi
     end
 
     def claimant_first_name(poa)
-      poa.form_data.dig('claimant', 'firstName').presence || poa.auth_headers['va_eauth_firstName']
+      claimant = poa.form_data&.dig('claimant')
+      claimant_name = claimant&.dig('firstName')
+      fallback = poa.auth_headers&.dig('dependent', 'first_name') || poa.auth_headers&.[]('va_eauth_firstName')
+
+      claimant_name.presence || fallback
     end
 
     def organization_filing?(form_data)

--- a/modules/claims_api/spec/sidekiq/va_notify_accepted_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/va_notify_accepted_job_spec.rb
@@ -303,6 +303,31 @@ describe ClaimsApi::VANotifyAcceptedJob, type: :job do
     end
   end
 
+  describe '#claimant_first_name' do
+    let(:expected) { 'Ralph' }
+
+    it 'returns expected name for v1 forms' do
+      poa = {
+        'form_data' => { 'claimant' => { 'firstName' => 'Ralph' } }
+      }
+
+      res = subject.send(:claimant_first_name, OpenStruct.new(poa))
+
+      expect(res).to eq(expected)
+    end
+
+    it 'returns expected name for v2 forms' do
+      poa = {
+        'form_data' => { 'claimant' => { 'claimantId' => '1012667169V030190' } },
+        'auth_headers' => { 'dependent' => { 'first_name' => 'Ralph' } }
+      }
+
+      res = subject.send(:claimant_first_name, OpenStruct.new(poa))
+
+      expect(res).to eq(expected)
+    end
+  end
+
   describe '#build_address' do
     it 'formats the values correctly with line1 & line2 & line3' do
       expected = "123 First St.\n Apt. 2\n Suite 5"


### PR DESCRIPTION
## Summary
* In the event of a v2 POA the accepted job will not find the claimants name correctly, resultng in it defaulting to the filing vet's name from the headers
* Updates the logic to get the name from v1 like before, but then also fallback to getting the name for v2, and then still fial default is the filing vet's name from the headers.

## Related issue(s)


## Testing done

- [x] *New code is covered by unit tests*

While testing out the full workflow for 

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/sidekiq/claims_api/va_notify_accepted_job.rb
	modified:   modules/claims_api/spec/sidekiq/va_notify_accepted_job_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
