### PR TITLE
Create get traits msg class

### DIFF
--- a/app/services/ssoe/messages/get_ssoe_traits_by_cspid_message.rb
+++ b/app/services/ssoe/messages/get_ssoe_traits_by_cspid_message.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module SSOe
+  module Messages
+    class GetSSOeTraitsByCspidMessage
+      attr_reader :credential_method,
+                  :credential_id,
+                  :first_name,
+                  :last_name,
+                  :birth_date,
+                  :ssn,
+                  :email,
+                  :phone,
+                  :street1,
+                  :city,
+                  :state,
+                  :zipcode
+
+      def initialize(**params)
+        @credential_method = params[:credential_method]
+        @credential_id     = params[:credential_id]
+        @first_name        = params[:first_name]
+        @last_name         = params[:last_name]
+        @birth_date        = params[:birth_date]
+        @ssn               = params[:ssn]
+        @email             = params[:email]
+        @phone             = params[:phone]
+        @street1           = params[:street1]
+        @city              = params[:city]
+        @state             = params[:state]
+        @zipcode           = params[:zipcode]
+      end
+
+      def perform
+        <<~XML
+          <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ws="http://ws.ssoe.acs">
+            <soapenv:Header/>
+            <soapenv:Body>
+              <ws:getSSOeTraitsByCSPID>
+                <ws:cspid>#{full_credential_id}</ws:cspid>
+                <ws:firstname>#{first_name}</ws:firstname>
+                <ws:lastname>#{last_name}</ws:lastname>
+                <ws:email>#{email}</ws:email>
+                <ws:uid>#{credential_id}</ws:uid>
+                <ws:cspbirthDate>#{birth_date}</ws:cspbirthDate>
+                <ws:versioncode>#{version_code}</ws:versioncode>
+                <ws:pnid>#{ssn}</ws:pnid>
+                <ws:authenticationMethod>#{authentication_method}</ws:authenticationMethod>
+                <ws:credAssuranceLevel>#{credential_assurance_level}</ws:credAssuranceLevel>
+                <ws:ial>#{ial}</ws:ial>
+                <ws:issueInstant>#{issue_instant}</ws:issueInstant>
+                <ws:street1>#{street1}</ws:street1>
+                <ws:city>#{city}</ws:city>
+                <ws:state>#{state}</ws:state>
+                <ws:zipcode>#{zipcode}</ws:zipcode>
+                <ws:phone>#{phone}</ws:phone>
+                <ws:cspIdentifier>#{credential_identifier}</ws:cspIdentifier>
+                <ws:cspMethod>#{credential_method}</ws:cspMethod>
+                <ws:proofingAuthority>#{proofing_authority}</ws:proofingAuthority>
+              </ws:getSSOeTraitsByCSPID>
+            </soapenv:Body>
+          </soapenv:Envelope>
+        XML
+      end
+
+      private
+
+      def full_credential_id
+        "#{credential_identifier}_#{credential_id}"
+      end
+
+      def issue_instant
+        Time.zone.now
+      end
+
+      def credential_identifier
+        case credential_method
+        when 'idme'
+          '200VIDM'
+        when 'logingov'
+          '200VLGN'
+        end
+      end
+
+      def authentication_method
+        'http://idmanagement.gov/ns/assurance/aal/2'
+      end
+
+      def ial
+        2
+      end
+
+      def credential_assurance_level
+        3
+      end
+
+      def version_code
+        '1.0.0'
+      end
+
+      def proofing_authority
+        'FICAM'
+      end
+    end
+  end
+end

--- a/spec/services/ssoe/messages/get_ssoe_traits_by_cspid_message_spec.rb
+++ b/spec/services/ssoe/messages/get_ssoe_traits_by_cspid_message_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/SpecFilePathFormat
+
+require 'rails_helper'
+
+RSpec.describe SSOe::Messages::GetSSOeTraitsByCspidMessage do
+  let(:message) do
+    described_class.new(
+      credential_method: 'idme',
+      credential_id: 'abc123',
+      first_name: 'John',
+      last_name: 'Doe',
+      birth_date: '19800101',
+      ssn: '123456789',
+      email: 'john.doe@example.com',
+      phone: '555-555-5555',
+      street1: '123 Main St',
+      city: 'Anytown',
+      state: 'VA',
+      zipcode: '12345'
+    )
+  end
+
+  describe '#perform' do
+    it 'generates the correct SOAP request XML' do
+      xml = message.perform
+
+      expect(xml).to include('<ws:cspid>200VIDM_abc123</ws:cspid>')
+      expect(xml).to include('<ws:firstname>John</ws:firstname>')
+      expect(xml).to include('<ws:lastname>Doe</ws:lastname>')
+      expect(xml).to include('<ws:email>john.doe@example.com</ws:email>')
+      expect(xml).to include('<ws:uid>abc123</ws:uid>')
+      expect(xml).to include('<ws:cspbirthDate>19800101</ws:cspbirthDate>')
+      expect(xml).to include('<ws:pnid>123456789</ws:pnid>')
+      expect(xml).to include('<ws:authenticationMethod>http://idmanagement.gov/ns/assurance/aal/2</ws:authenticationMethod>')
+      expect(xml).to include('<ws:credAssuranceLevel>3</ws:credAssuranceLevel>')
+      expect(xml).to include('<ws:ial>2</ws:ial>')
+      expect(xml).to include('<ws:street1>123 Main St</ws:street1>')
+      expect(xml).to include('<ws:state>VA</ws:state>')
+      expect(xml).to include('<ws:proofingAuthority>FICAM</ws:proofingAuthority>')
+    end
+  end
+end
+# rubocop:enable RSpec/SpecFilePathFormat


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): NO*
- *Create a message class for GetSSOeTraitsByCspidJob service to generate request XML. The job will come in a later PR.*
- *(If bug, how to reproduce)*
- [Part 1 of implementation plan](https://docs.google.com/document/d/1E4yb3-Zk2CpjCbQG1SBzb0alcDwqg0ekCAP1GqOZG0k/edit?usp=sharing) for GetSSOeTraitsByCspid
- *(Which team do you work for, does your team own the maintenance of this component?)* Identity

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*
- Placeholder [ticket](https://github.com/orgs/department-of-veterans-affairs/projects/1646/views/2?pane=issue&itemId=119539607&issue=department-of-veterans-affairs%7Cidentity-documentation%7C503) for get traits work
- 

## Testing done

- [ ] *New code is covered by unit tests*
- [ ] Start a rails console and instantiate the message class with some test data
```
message = SSOe::Messages::GetSSOeTraitsByCspidMessage.new(
  credential_method: 'idme',
  credential_id: '12345',
  first_name: 'John',
  last_name: 'Doe',
  birth_date: '1980-01-01',
  ssn: '123-45-6789',
  email: 'john.doe@eaxmple.com',
  phone: '555-1234',
  street1: '123 Main St',
  city: 'Anytown',
  state: 'VA',
  zipcode: '12345'
)
```
- [ ] test the perform method to see the generated SOAP XML by using puts => `puts message.perform`
```
(dev)> puts message.perform
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ws="http://ws.ssoe.acs">
  <soapenv:Header/>
  <soapenv:Body>
    <ws:getSSOeTraitsByCSPID>
      <ws:cspid>200VIDM_12345</ws:cspid>
      <ws:firstname>John</ws:firstname>
      <ws:lastname>Doe</ws:lastname>
      <ws:email>john.doe@eaxmple.com</ws:email>
      <ws:uid>12345</ws:uid>
      <ws:cspbirthDate>1980-01-01</ws:cspbirthDate>
      <ws:versioncode>1.0.0</ws:versioncode>
      <ws:pnid>123-45-6789</ws:pnid>
      <ws:authenticationMethod>http://idmanagement.gov/ns/assurance/aal/2</ws:authenticationMethod>
      <ws:credAssuranceLevel>3</ws:credAssuranceLevel>
      <ws:ial>2</ws:ial>
      <ws:issueInstant>2025-07-18 15:17:39 UTC</ws:issueInstant>
      <ws:street1>123 Main St</ws:street1>
      <ws:city>Anytown</ws:city>
      <ws:state>VA</ws:state>
      <ws:zipcode>12345</ws:zipcode>
      <ws:phone>555-1234</ws:phone>
      <ws:cspIdentifier>200VIDM</ws:cspIdentifier>
      <ws:cspMethod>idme</ws:cspMethod>
      <ws:proofingAuthority>FICAM</ws:proofingAuthority>
    </ws:getSSOeTraitsByCSPID>
  </soapenv:Body>
</soapenv:Envelope>
```
- [ ] optionally we can test specific parts of the message class as well `message.send(:full_credential_id)` should return the `crendeital_identifier_credential_id` (`"200VIDM_12345"`)

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
This does not impact any parts of the site since it is not used in any flows right now. This is a prep msg class for initializing and encapsulating how the XML body should look which will be used in a get_traits service.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
