### PR TITLE
Adding okta_stg to user_info client ids list

### DIFF
--- a/config/identity_settings/settings.yml
+++ b/config/identity_settings/settings.yml
@@ -84,6 +84,7 @@ sign_in:
     key_path: spec/fixtures/sign_in/sts_client.pem
   user_info_clients:
     - okta_test
+    - okta_stg
   usip_uri: http://localhost:3001/sign-in
   vaweb_client_id: vaweb
   vamobile_client_id: vamobile


### PR DESCRIPTION
This PR adds an additional okta test client_id to the `sign_in/user_info` route