### PR TITLE
send submission notification email for dv 0538

### DIFF
--- a/modules/dependents_verification/lib/dependents_verification/benefits_intake/submit_claim_job.rb
+++ b/modules/dependents_verification/lib/dependents_verification/benefits_intake/submit_claim_job.rb
@@ -49,6 +49,8 @@ module DependentsVerification
         @metadata = generate_metadata
 
         upload_document
+
+        send_submitted_email
         monitor.track_submission_success(@claim, @intake_service, @user_account_uuid)
 
         @intake_service.uuid
@@ -186,13 +188,6 @@ module DependentsVerification
         end
 
         Datadog::Tracing.active_trace&.set_tag('benefits_intake_uuid', @intake_service.uuid)
-      end
-
-      # VANotify job to send email to veteran
-      def send_confirmation_email
-        DependentsVerification::NotificationEmail.new(@claim.id).deliver(:confirmation)
-      rescue => e
-        monitor.track_send_email_failure(@claim, @intake_service, @user_account_uuid, 'confirmation', e)
       end
 
       # VANotify job to send Submission in Progress email to veteran

--- a/modules/dependents_verification/spec/factories/dependents_verification/dependents_verification_claim.rb
+++ b/modules/dependents_verification/spec/factories/dependents_verification/dependents_verification_claim.rb
@@ -2,9 +2,13 @@
 
 FactoryBot.define do
   factory :dependents_verification_claim, class: 'DependentsVerification::SavedClaim' do
+    transient do
+      veteran_ssn { '123456789' }
+    end
+
     form_id { '21-0538' }
     form do
-      {
+      form_data = {
         veteranInformation: {
           fullName: {
             first: 'Jane',
@@ -50,7 +54,12 @@ FactoryBot.define do
         electronicCorrespondence: 'true',
         statementOfTruthSignature: 'Jane Elizabeth Maximal',
         statementOfTruthCertified: true
-      }.to_json
+      }
+
+      # Add SSN if provided
+      form_data[:veteranInformation][:ssn] = veteran_ssn
+
+      form_data.to_json
     end
 
     trait :pending do


### PR DESCRIPTION
=
## Summary

- *This work is behind a feature toggle (flipper): YES*
- *kick of the submitted notification email and remove confirmation email (since not needed)*

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114058

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*


## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
