### PR TITLE
Update brakeman gem to unblock CI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,7 +285,7 @@ GEM
     blueprinter (1.1.2)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.0.2)
+    brakeman (7.1.0)
       racc
     breakers (1.0)
       base64 (~> 0.2)


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): NO
Brakeman is failing in CI due to a newer version being available. This is blocking CI. Here's the error message:
```sh
Brakeman 7.0.2 is not the latest version 7.1.0
Error: Process completed with exit code 5.
```
This PR upgrades brakeman to the latest version, unblocking CI.

## Related issue(s)

- N/A

## Testing done

- [N/A] *New code is covered by unit tests*
- Old behavior: Brakeman is failing in CI.
- New behavior: No errors from brakeman regarding its version.

## Screenshots
N/A

## What areas of the site does it impact?
CI

## Acceptance criteria

- [N/A]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [N/A]  Events are being sent to the appropriate logging solution
- [N/A]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [N/A]  Feature/bug has a monitor built into Datadog (if applicable)
- [N/A]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [N/A]  I added a screenshot of the developed feature

## Requested Feedback

Quick code review to get CI unblocked.
