### PR TITLE
Removes mhv_medications_display_refill_content feature toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1353,10 +1353,6 @@ features:
     actor_type: user
     description: Enables/disables Medications on VA.gov (initial transition from MHV to VA.gov)
     enable_in_development: true
-  mhv_medications_display_refill_content:
-    actor_type: user
-    description: Enables/disables refill-related content for Medications on VA.gov
-    enable_in_development: true
   mhv_medications_display_documentation_content:
     actor_type: user
     description: Enables/disables documentation-related content for Medications on VA.gov


### PR DESCRIPTION
## Summary

- Removes `mhv_medications_display_refill_content` feature toggle

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#114376

