### PR TITLE
Rewrite environment manipulation spec to prevent downstream failures

### DIFF
--- a/spec/lib/kafka/avro_producer_spec.rb
+++ b/spec/lib/kafka/avro_producer_spec.rb
@@ -63,9 +63,6 @@ describe Kafka::AvroProducer do
           
           Singleton.__init__(Kafka::ProducerManager)
         end
-        
-        # Reset singleton after test
-        Singleton.__init__(Kafka::ProducerManager)
       end
 
       it 'uses the Rdkafka client' do


### PR DESCRIPTION
## Summary

- This fixes some intermittent spec failures our team has been [made aware of](https://dsva.slack.com/archives/C05UUQBSVLL/p1752869875355449)
- Used the same seed `54558` that caused the specs in [avro_producer_payload_spec.rb](https://github.com/department-of-veterans-affairs/vets-api/blob/master/spec/lib/kafka/avro_producer_payload_spec.rb) to fail to confirm that the fix is working.
- **Explanation**: The `WaterDrop::Producer` is configured to use a [different Kafka client in the test environment](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/kafka/producer_manager.rb#L32-L36). To test this behavior, we originally mocked the `Rails.env` call to return a different environment in some of the tests. Additionally, we're using a Singleton instance of the producer to avoid the overhead of reconnecting on every usage. Taken together, manipulating the environment and using a singleton producer caused some downstream specs to use the _real_ (i.e. production) Kafka client instance which shouldn't be used in the test environment. This PR isolates the environment manipulation code and resets the Singleton after use to prevent this type of leakage. 

## Related issue(s)
- n/a

