### PR TITLE
Update to avoid nil context

### DIFF
--- a/app/helpers/parameter_filter_helper.rb
+++ b/app/helpers/parameter_filter_helper.rb
@@ -1,8 +1,19 @@
 # frozen_string_literal: true
 
+#
+# ParameterFilterHelper
+#
+# This helper provides a method to filter parameters using the lambda
+# defined in Rails.application.config.filter_parameters. Note:
+#
+# When running in Rails Console, Rails.application.config.filter_parameters
+# will be [] because the initializer (config/initializers/filter_parameter_logging.rb)
+# which sets up the filtering lambda gets reset in console_filter_toggles.rb.
+# In such cases, filter_params will return nil since there is no lambda to call.
+#
 module ParameterFilterHelper
   def filter_params(params)
-    Rails.application.config.filter_parameters.first.call(nil, params.deep_dup)
+    Rails.application.config.filter_parameters.first&.call(nil, params.deep_dup)
   end
   module_function :filter_params
 end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -61,11 +61,11 @@ Rails.application.config.filter_parameters = [
         result[key] = if ALLOWLIST.include?(nested_key.to_s)
                         nested_value
                       else
-                        Rails.application.config.filter_parameters.first.call(nested_key, nested_value)
+                        Rails.application.config.filter_parameters.first&.call(nested_key, nested_value)
                       end
       end
     when Array # Recursively map all elements in arrays
-      v.map { |element| Rails.application.config.filter_parameters.first.call(k, element) }
+      v.map { |element| Rails.application.config.filter_parameters.first&.call(k, element) }
     when ActionDispatch::Http::UploadedFile # Base case
       v.instance_variables.each do |var| # could put specific instance vars here, but made more generic
         var_name = var.to_s.delete_prefix('@')

--- a/lib/logging/monitor.rb
+++ b/lib/logging/monitor.rb
@@ -23,7 +23,7 @@ module Logging
       tags = (["service:#{service}", "function:#{function}"] + (context[:tags] || [])).uniq
       StatsD.increment(metric, tags:)
 
-      filtered_context = context.present? ? ParameterFilterHelper.filter_params(context) : {}
+      filtered_context = ParameterFilterHelper.filter_params(context || {})
 
       if %w[debug info warn error fatal unknown].include?(error_level.to_s)
         payload = {

--- a/lib/logging/monitor.rb
+++ b/lib/logging/monitor.rb
@@ -23,7 +23,7 @@ module Logging
       tags = (["service:#{service}", "function:#{function}"] + (context[:tags] || [])).uniq
       StatsD.increment(metric, tags:)
 
-      filtered_context = ParameterFilterHelper.filter_params(context)
+      filtered_context = context.present? ? ParameterFilterHelper.filter_params(context) : {}
 
       if %w[debug info warn error fatal unknown].include?(error_level.to_s)
         payload = {

--- a/lib/logging/monitor.rb
+++ b/lib/logging/monitor.rb
@@ -23,7 +23,7 @@ module Logging
       tags = (["service:#{service}", "function:#{function}"] + (context[:tags] || [])).uniq
       StatsD.increment(metric, tags:)
 
-      filtered_context = ParameterFilterHelper.filter_params(context || {})
+      filtered_context = ParameterFilterHelper.filter_params(context)
 
       if %w[debug info warn error fatal unknown].include?(error_level.to_s)
         payload = {


### PR DESCRIPTION
Update logic to use `&` as the logic's lambda gets set to [] in the console which could cause confusion. We noticed in the `ConsoleFilterToggles` class that this `Rails.application.config.filter_parameters` gets overridden to `[]` when loading up the rails console `if defined?(Rails::Console)`. So if you were to test-run a Sidekiq job or something it would throw an error:

<img width="2684" height="490" alt="image" src="https://github.com/user-attachments/assets/18977610-d0de-4ec2-88fd-87ecba659196" />

This fix is just to ensure it doesn't throw an error when running anything in the terminal


## Related issue(s)

- Not ticket, noticed it while testing something else