### PR TITLE
API-48176-pdf-constructor-claimant-name-v2-fix

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/v2/poa_form_builder_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/v2/poa_form_builder_job.rb
@@ -82,6 +82,9 @@ module ClaimsApi
       def data(power_of_attorney, form_number, rep)
         res = power_of_attorney.form_data
         res.deep_merge!(veteran_attributes(power_of_attorney))
+        if power_of_attorney.auth_headers['depenedent'].present?
+          res.deep_merge!(power_of_attorney.auth_headers['depenedent'])
+        end
         res.deep_merge!(appointment_date(power_of_attorney))
 
         signatures = if form_number == '2122A'
@@ -158,8 +161,8 @@ module ClaimsApi
       def veteran_or_claimant_signature(power_of_attorney)
         claimant = power_of_attorney.form_data['claimant'].present?
         if claimant
-          first_name = power_of_attorney.form_data['claimant']['firstName']
-          last_name = power_of_attorney.form_data['claimant']['lastName']
+          first_name = power_of_attorney.auth_headers['dependent']['first_name']
+          last_name = power_of_attorney.auth_headers['dependent']['last_name']
         else
           first_name = power_of_attorney.auth_headers['va_eauth_firstName']
           last_name = power_of_attorney.auth_headers['va_eauth_lastName']

--- a/modules/claims_api/lib/claims_api/v2/poa_pdf_constructor/organization.rb
+++ b/modules/claims_api/lib/claims_api/v2/poa_pdf_constructor/organization.rb
@@ -93,9 +93,8 @@ module ClaimsApi
 
             # Section II
             # Item 10
-            "#{base_form}.Claimants_FirstName[0]": data.dig('claimant', 'firstName'),
-            "#{base_form}.Claimants_MiddleInitial1[0]": data.dig('claimant', 'middleInitial'),
-            "#{base_form}.Claimants_LastName[0]": data.dig('claimant', 'lastName'),
+            "#{base_form}.Claimants_FirstName[0]": data.dig('dependent', 'first_name'),
+            "#{base_form}.Claimants_LastName[0]": data.dig('dependent', 'last_name'),
             # Item 11
             "#{base_form}.Claimants_MailingAddress_NumberAndStreet[0]": data.dig('claimant', 'address', 'addressLine1'),
             "#{base_form}.Claimants_MailingAddress_ApartmentOrUnitNumber[0]": data.dig('claimant', 'address', 'addressLine2'),

--- a/modules/claims_api/spec/lib/claims_api/v2/poa_pdf_constructor/organization_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/poa_pdf_constructor/organization_spec.rb
@@ -5,203 +5,126 @@ require 'claims_api/v2/poa_pdf_constructor/organization'
 require_relative '../../../../support/pdf_matcher'
 
 describe ClaimsApi::V2::PoaPdfConstructor::Organization do
+  subject { ClaimsApi::V2::PoaPdfConstructor::Organization.new }
+
   let(:temp) { create(:power_of_attorney, :with_full_headers) }
+  # we do not do anything for item 3 & 6
+  let(:item_one) { %w[GRAY JESSE] } # veteran name
+  let(:item_two) { %w[796 37 8881] } # vet ssn
+  let(:item_four) { %w[12 05 1953] } # vet birthdate
+  let(:item_five) { nil } # insurance number
+  let(:item_seven) { [nil, nil, nil, nil, nil, nil, nil] } # vet address
+  let(:item_eight) { nil } # telephone
+  let(:item_nine) { nil } # email
+  let(:item_ten) { [nil, nil] } # claimant's name
+  let(:item_eleven) { [nil, nil, nil, nil, nil, nil, nil] } # claimant's address
+  let(:item_twelve) { nil } # claimant's telephone
+  let(:item_thirteen) { nil } # claimant's email
+  let(:item_fourteen) { nil } # claimant's relationship to vet
+  let(:item_fifteen) { 'I Help Vets LLC' } # name of service org
+  let(:item_sixteen_a) { 'Bob Representative' } # rep name
+  let(:item_sixteen_b) { nil } # job title (for item 15)
+  let(:item_seventeen) { nil } # org email
+  let(:item_eighteen) { '01/01/2020' } # appointment date
+  let(:expected_page1_values) do
+    [
+      *item_one, *item_two, *item_four, item_five, *item_seven,
+      item_eight, item_nine, *item_ten, *item_eleven, item_twelve,
+      item_thirteen, item_fourteen, item_fifteen, item_sixteen_a,
+      item_sixteen_b, item_seventeen, item_eighteen
+    ]
+  end
+  let(:expected_page2_values) do
+    [
+      *item_two, # build for vet ssn
+      0, # record consent
+      0, 0, 0, 0, 0, # consent limits
+      '01/01/2020', # date signed
+      '01/01/2020' # date signed
+    ]
+  end
+  let(:data) do
+    power_of_attorney.form_data.deep_merge(
+      {
+        'veteran' => veteran_attributes,
+        'appointmentDate' => power_of_attorney.created_at,
+        'text_signatures' => signatures,
+        'serviceOrganization' => service_org
+      }
+    )
+  end
   let(:invalid_temp) { create(:power_of_attorney, :with_full_headers) }
   let(:phone_country_codes_temp) { create(:power_of_attorney, :with_full_headers) }
+  let(:power_of_attorney) { ClaimsApi::PowerOfAttorney.find(temp.id) }
+  let(:signatures) do
+    {
+      'page2' => [
+        {
+          'signature' => 'Lillian Disney - signed via api.va.gov',
+          'x' => 35,
+          'y' => 240
+        },
+        {
+          'signature' => 'Bob Representative - signed via api.va.gov',
+          'x' => 35,
+          'y' => 200
+        }
+      ]
+    }
+  end
+  let(:veteran_attributes) do
+    {
+      'firstName' => power_of_attorney.auth_headers['va_eauth_firstName'],
+      'lastName' => power_of_attorney.auth_headers['va_eauth_lastName'],
+      'ssn' => power_of_attorney.auth_headers['va_eauth_pnid'],
+      'birthdate' => power_of_attorney.auth_headers['va_eauth_birthdate']
+    }
+  end
+  let(:dependent_attributes) do
+    {
+      'dependent' => {
+        'first_name' => 'Lillian',
+        'last_name' => 'Disney'
+      }
+    }
+  end
+  let(:service_org) do
+    {
+      'firstName' => 'Bob',
+      'lastName' => 'Representative',
+      'organizationName' => 'I Help Vets LLC'
+    }
+  end
 
   before do
     Timecop.freeze(Time.zone.parse('2020-01-01T08:00:00Z'))
-    temp.form_data = {
-      veteran: {
-        address: {
-          addressLine1: '2719 Hyperion Ave',
-          city: 'Los Angeles',
-          stateCode: 'CA',
-          country: 'US',
-          zipCode: '92264'
-        },
-        phone: {
-          areaCode: '555',
-          phoneNumber: '5551337'
-        },
-        email: 'test@example.com',
-        insuranceNumber: 'Ar67346578674'
-      },
-      claimant: {
-        firstName: 'Lillian',
-        middleInitial: 'A',
-        lastName: 'Disney',
-        email: 'LILLIAN@disney.com',
-        relationship: 'Spouse',
-        address: {
-          addressLine1: '2688 S Camino Real',
-          city: 'Palm Springs',
-          stateCode: 'CA',
-          country: 'US',
-          zipCode: '92264'
-        },
-        phone: {
-          areaCode: '555',
-          phoneNumber: '5551337'
-        }
-      },
-      serviceOrganization: {
-        poaCode: '456',
-        registrationNumber: '1234',
-        address: {
-          addressLine1: '2719 Hyperion Ave',
-          city: 'Los Angeles',
-          stateCode: 'CA',
-          country: 'US',
-          zipCode: '92264'
-        },
-        jobTitle: 'Veteran Service Officer',
-        email: 'example@test.com'
-      },
-      recordConsent: true,
-      consentAddressChange: true,
-      consentLimits: %w[DRUG_ABUSE SICKLE_CELL]
-    }
-    temp.save
-
-    phone_country_codes_temp.form_data = {
-      veteran: {
-        address: {
-          addressLine1: '2719 Hyperion Ave',
-          city: 'Los Angeles',
-          stateCode: 'CA',
-          country: 'US',
-          zipCode: '92264'
-        },
-        phone: {
-          countryCode: '1',
-          areaCode: '555',
-          phoneNumber: '5551337'
-        },
-        email: 'test@example.com',
-        insuranceNumber: 'Ar67346578674'
-      },
-      claimant: {
-        firstName: 'Lillian',
-        middleInitial: 'A',
-        lastName: 'Disney',
-        email: 'LILLIAN@disney.com',
-        relationship: 'Spouse',
-        address: {
-          addressLine1: '2688 S Camino Real',
-          city: 'Palm Springs',
-          stateCode: 'CA',
-          country: 'US',
-          zipCode: '92264'
-        },
-        phone: {
-          countryCode: '44',
-          phoneNumber: '5551337'
-        }
-      },
-      serviceOrganization: {
-        poaCode: '456',
-        registrationNumber: '1234',
-        address: {
-          addressLine1: '2719 Hyperion Ave',
-          city: 'Los Angeles',
-          stateCode: 'CA',
-          country: 'US',
-          zipCode: '92264'
-        },
-        jobTitle: 'Veteran Service Officer',
-        email: 'example@test.com'
-      },
-      recordConsent: true,
-      consentAddressChange: true,
-      consentLimits: %w[DRUG_ABUSE SICKLE_CELL]
-    }
-    phone_country_codes_temp.save
   end
 
   after do
     Timecop.return
   end
 
-  it 'construct pdf' do
-    power_of_attorney = ClaimsApi::PowerOfAttorney.find(temp.id)
-    data = power_of_attorney.form_data.deep_merge(
-      {
-        'veteran' => {
-          'firstName' => power_of_attorney.auth_headers['va_eauth_firstName'],
-          'lastName' => power_of_attorney.auth_headers['va_eauth_lastName'],
-          'ssn' => power_of_attorney.auth_headers['va_eauth_pnid'],
-          'birthdate' => power_of_attorney.auth_headers['va_eauth_birthdate']
-        },
-        'appointmentDate' => power_of_attorney.created_at,
-        'text_signatures' => {
-          'page2' => [
-            {
-              'signature' => 'Lillian Disney - signed via api.va.gov',
-              'x' => 35,
-              'y' => 240
-            },
-            {
-              'signature' => 'Bob Representative - signed via api.va.gov',
-              'x' => 35,
-              'y' => 200
-            }
-          ]
-        },
-        'serviceOrganization' =>
-          {
-            'firstName' => 'Bob',
-            'lastName' => 'Representative',
-            'organizationName' => 'I Help Vets LLC'
-          }
-      }
-    )
+  context 'page1_options' do
+    it 'returns the expected values' do
+      res = subject.send(:page1_options, data)
 
-    constructor = ClaimsApi::V2::PoaPdfConstructor::Organization.new
-    expected_pdf = Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', '21-22', 'v2',
-                                   'signed_filled_final.pdf')
-    generated_pdf = constructor.construct(data, id: power_of_attorney.id)
-    expect(generated_pdf).to match_pdf_content_of(expected_pdf)
+      expect(res.values).to match(expected_page1_values)
+    end
+
+    it 'returns the expected values with a dependent' do
+      data_w_claimant = data.deep_merge!(dependent_attributes)
+
+      res = subject.send(:page1_options, data_w_claimant)
+
+      expect(res.values).to include('Lillian', 'Disney')
+    end
   end
 
-  it 'constructs the pdf when phone country codes are present on form' do
-    power_of_attorney = ClaimsApi::PowerOfAttorney.find(phone_country_codes_temp.id)
-    data = power_of_attorney.form_data.deep_merge(
-      {
-        'veteran' => {
-          'firstName' => power_of_attorney.auth_headers['va_eauth_firstName'],
-          'lastName' => power_of_attorney.auth_headers['va_eauth_lastName'],
-          'ssn' => power_of_attorney.auth_headers['va_eauth_pnid'],
-          'birthdate' => power_of_attorney.auth_headers['va_eauth_birthdate']
-        },
-        'appointmentDate' => power_of_attorney.created_at,
-        'text_signatures' => {
-          'page2' => [
-            {
-              'signature' => 'Lillian Disney - signed via api.va.gov',
-              'x' => 35,
-              'y' => 240
-            },
-            {
-              'signature' => 'Bob Representative - signed via api.va.gov',
-              'x' => 35,
-              'y' => 200
-            }
-          ]
-        },
-        'serviceOrganization' =>
-          {
-            'firstName' => 'Bob',
-            'lastName' => 'Representative',
-            'organizationName' => 'I Help Vets LLC'
-          }
-      }
-    )
+  describe '#page2_options pdf' do
+    it 'returns the expected values' do
+      res = subject.send(:page2_options, data)
 
-    constructor = ClaimsApi::V2::PoaPdfConstructor::Organization.new
-    expected_pdf = Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', '21-22', 'v2',
-                                   'signed_filled_phone_country_codes.pdf')
-    generated_pdf = constructor.construct(data, id: power_of_attorney.id)
-    expect(generated_pdf).to match_pdf_content_of(expected_pdf)
+      expect(res.values).to eq(expected_page2_values)
+    end
   end
 end

--- a/modules/claims_api/spec/sidekiq/v2/poa_form_builder_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/v2/poa_form_builder_job_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe ClaimsApi::V2::PoaFormBuilderJob, type: :job, vcr: 'bgs/person_we
           },
           claimant: {
             claimantId: '1012830872V584140',
-            email: 'lillian@disney.com',
+            email: 'mitchell@jenkins.com',
             relationship: 'Spouse',
             address: {
               addressLine1: '2688 S Camino Real',
@@ -166,9 +166,7 @@ RSpec.describe ClaimsApi::V2::PoaFormBuilderJob, type: :job, vcr: 'bgs/person_we
             phone: {
               areaCode: '555',
               phoneNumber: '5551337'
-            },
-            firstName: 'Mitchell',
-            lastName: 'Jenkins'
+            }
           },
           representative: {
             poaCode: poa_code.to_s,
@@ -229,6 +227,15 @@ RSpec.describe ClaimsApi::V2::PoaFormBuilderJob, type: :job, vcr: 'bgs/person_we
               }
             }
           )
+          power_of_attorney.auth_headers.deep_merge!(
+            {
+              'dependent' => {
+                'first_name' => 'Mitchell',
+                'last_name' => 'Jenkins'
+              }
+            }
+          )
+          power_of_attorney.save!
 
           allow_any_instance_of(BGS::PersonWebService).to receive(:find_by_ssn).and_return({ file_nbr: '123456789' })
           expect_any_instance_of(ClaimsApi::V2::PoaPdfConstructor::Individual)
@@ -374,7 +381,7 @@ RSpec.describe ClaimsApi::V2::PoaFormBuilderJob, type: :job, vcr: 'bgs/person_we
           },
           claimant: {
             claimantId: '1012830872V584140',
-            email: 'lillian@disney.com',
+            email: 'mitchell@jenkins.com',
             relationship: 'Spouse',
             address: {
               addressLine1: '2688 S Camino Real',
@@ -386,9 +393,7 @@ RSpec.describe ClaimsApi::V2::PoaFormBuilderJob, type: :job, vcr: 'bgs/person_we
             phone: {
               areaCode: '555',
               phoneNumber: '5551337'
-            },
-            firstName: 'Mitchell',
-            lastName: 'Jenkins'
+            }
           },
           serviceOrganization: {
             poaCode: poa_code.to_s,
@@ -446,6 +451,16 @@ RSpec.describe ClaimsApi::V2::PoaFormBuilderJob, type: :job, vcr: 'bgs/person_we
             }
           }
         )
+
+        power_of_attorney.auth_headers.deep_merge!(
+          {
+            'dependent' => {
+              'first_name' => 'Mitchell',
+              'last_name' => 'Jenkins'
+            }
+          }
+        )
+        power_of_attorney.save!
 
         allow_any_instance_of(BGS::PersonWebService).to receive(:find_by_ssn).and_return({ file_nbr: '123456789' })
         VCR.use_cassette('claims_api/mpi/find_candidate/valid_icn_full') do


### PR DESCRIPTION
## Summary
At the moment POA v2 does not support dependent claimants.  One issue this caused is that v2 poa work was built to match the v1 POA schema.  However the claimant's names (first and last) are not present in the form data like they are in v1 so the areas in v2 where we were grabbing those values similar to v1 will not work (are not working).

This was a refactor I was unaware was needed until getting into the current work so could get it done out front.

This PR fixes handling of claimant names in the org PDF constructor and the v2 poa_form_builder_job so that the correct values can be found.

- This does not fix all areas just what is required for the current scope of the work.  There is a follow up ticket for the remainder of the refactoring/fix work here:

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/sidekiq/claims_api/v2/poa_form_builder_job.rb
	modified:   modules/claims_api/lib/claims_api/v2/poa_pdf_constructor/organization.rb
	modified:   modules/claims_api/spec/lib/claims_api/v2/poa_pdf_constructor/organization_spec.rb
	modified:   modules/claims_api/spec/sidekiq/v2/poa_form_builder_job_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
