### PR TITLE
Allow redesigned 0969 to omit e-sign stamp to avoid footer clash

### DIFF
--- a/lib/pdf_fill/filler.rb
+++ b/lib/pdf_fill/filler.rb
@@ -177,9 +177,7 @@ module PdfFill
         template_path, file_path, new_hash, flatten: Rails.env.production?
       )
 
-      if should_stamp_form?(form_id, fill_options, submit_date)
-        file_path = stamp_form(file_path, submit_date)
-      end
+      file_path = stamp_form(file_path, submit_date) if should_stamp_form?(form_id, fill_options, submit_date)
       output = combine_extras(file_path, hash_converter.extras_generator)
       Rails.logger.info('PdfFill done', fill_options.merge(form_id:, file_name_extension:, extras: output != file_path))
       output

--- a/lib/pdf_fill/filler.rb
+++ b/lib/pdf_fill/filler.rb
@@ -158,9 +158,6 @@ module PdfFill
         return process_form_with_continuation_sheets(form_id, form_data, form_class, file_name_extension, fill_options)
       end
 
-      # special exception for dependents that isnt in extras_redesign
-      dependents = %w[686C-674 686C-674-V2 21-674 21-674-V2].include?(form_id)
-
       folder = 'tmp/pdfs'
       FileUtils.mkdir_p(folder)
       file_path = "#{folder}/#{form_id}_#{file_name_extension}.pdf"
@@ -180,13 +177,7 @@ module PdfFill
         template_path, file_path, new_hash, flatten: Rails.env.production?
       )
 
-      # If the form is being generated with the overflow redesign, stamp the top and bottom of the document before the
-      # form is combined with the extras overflow pages. This allows the stamps to be placed correctly for the redesign
-      # implemented in lib/pdf_fill/extras_generator_v2.rb.
-      # special exception made for dependents which is not currently involved and not getting watermark.
-      if (fill_options.fetch(:extras_redesign, false) || dependents) && submit_date.present?
-        file_path = stamp_form(file_path, submit_date)
-      end
+      file_path = optionally_stamp_form(form_id, file_path, fill_options, submit_date)
       output = combine_extras(file_path, hash_converter.extras_generator)
       Rails.logger.info('PdfFill done', fill_options.merge(form_id:, file_name_extension:, extras: output != file_path))
       output
@@ -231,7 +222,16 @@ module PdfFill
       HashConverter.new(form_class.date_strftime, extras_generator)
     end
 
-    def stamp_form(file_path, submit_date)
+    def optionally_stamp_form(form_id, file_path, fill_options, submit_date)
+      # special exception for dependents that isn't in extras_redesign
+      dependents = %w[686C-674 686C-674-V2 21-674 21-674-V2].include?(form_id)
+
+      # If the form is being generated with the overflow redesign, stamp the top and bottom of the document before the
+      # form is combined with the extras overflow pages. This allows the stamps to be placed correctly for the redesign
+      # implemented in lib/pdf_fill/extras_generator_v2.rb.
+      return file_path if fill_options[:omit_esign_stamp]
+      return file_path unless (fill_options[:extras_redesign] || dependents) && submit_date.present?
+
       original_path = file_path
       sig = "Signed electronically and submitted via VA.gov at #{format_timestamp(submit_date)}. " \
             'Signee signed with an identity-verified account.'

--- a/modules/income_and_assets/lib/income_and_assets/benefits_intake/submit_claim_job.rb
+++ b/modules/income_and_assets/lib/income_and_assets/benefits_intake/submit_claim_job.rb
@@ -43,7 +43,8 @@ module IncomeAndAssets
         init(saved_claim_id, user_account_uuid)
 
         # generate and validate claim pdf documents
-        @form_path = process_document(@claim.to_pdf(@claim.id, { extras_redesign: extras_redesign_enabled? }))
+        @form_path = process_document(@claim.to_pdf(@claim.id, { extras_redesign: extras_redesign_enabled?,
+                                                                 omit_esign_stamp: true }))
         @attachment_paths = @claim.persistent_attachments.map { |pa| process_document(pa.to_pdf) }
         @metadata = generate_metadata
 

--- a/modules/income_and_assets/spec/lib/income_and_assets/benefits_intake/submit_claim_job_spec.rb
+++ b/modules/income_and_assets/spec/lib/income_and_assets/benefits_intake/submit_claim_job_spec.rb
@@ -20,13 +20,14 @@ RSpec.describe IncomeAndAssets::BenefitsIntake::SubmitClaimJob, :uploader_helper
         let(:response) { double('response') }
         let(:pdf_path) { 'random/path/to/pdf' }
         let(:location) { 'test_location' }
+        let(:omit_esign_stamp) { true }
 
         before do
           allow(Flipper).to receive(:enabled?).with(:pension_income_and_assets_overflow_pdf_redesign,
                                                     anything).and_return(extras_redesign)
           job.instance_variable_set(:@claim, claim)
           allow(IncomeAndAssets::SavedClaim).to receive(:find).and_return(claim)
-          allow(claim).to receive(:to_pdf).with(claim.id, { extras_redesign: }).and_return(pdf_path)
+          allow(claim).to receive(:to_pdf).with(claim.id, { extras_redesign:, omit_esign_stamp: }).and_return(pdf_path)
           allow(claim).to receive(:persistent_attachments).and_return([])
 
           job.instance_variable_set(:@intake_service, service)
@@ -42,7 +43,7 @@ RSpec.describe IncomeAndAssets::BenefitsIntake::SubmitClaimJob, :uploader_helper
         it 'submits the saved claim successfully' do
           allow(job).to receive(:process_document).and_return(pdf_path)
 
-          expect(claim).to receive(:to_pdf).with(claim.id, { extras_redesign: }).and_return(pdf_path)
+          expect(claim).to receive(:to_pdf).with(claim.id, { extras_redesign:, omit_esign_stamp: }).and_return(pdf_path)
           expect(Lighthouse::Submission).to receive(:create)
           expect(Lighthouse::SubmissionAttempt).to receive(:create)
           expect(Datadog::Tracing).to receive(:active_trace)

--- a/spec/lib/pdf_fill/filler_spec.rb
+++ b/spec/lib/pdf_fill/filler_spec.rb
@@ -84,7 +84,7 @@ describe PdfFill::Filler, type: :model do
               # this is only for 21-674-V2 but it passes in the extras hash. passing nil for all other scenarios
               student = form_id == '21-674-V2' ? form_data['dependents_application']['student_information'][0] : nil
 
-              expect(described_class).to receive(:optionally_stamp_form).once.and_call_original if extras_redesign
+              expect(described_class).to receive(:stamp_form).once.and_call_original if extras_redesign
 
               file_path = described_class.fill_ancillary_form(form_data, 1, form_id, { extras_redesign:, student: })
 

--- a/spec/lib/pdf_fill/filler_spec.rb
+++ b/spec/lib/pdf_fill/filler_spec.rb
@@ -162,25 +162,19 @@ describe PdfFill::Filler, type: :model do
     context 'when not given the extras_redesign fill option' do
       let(:fill_options) { {} }
 
-      it 'returns false' do
-        expect(subject).to eq(false)
-      end
+      it { is_expected.to be(false) }
 
       context 'when filling out a non-redesigned dependent form' do
         let(:form_id) { '686C-674' }
 
-        it 'returns true' do
-          expect(subject).to eq(true)
-        end
+        it { is_expected.to be(true) }
       end
     end
 
     context 'when given the omit_esign_stamp fill option' do
       let(:fill_options) { { omit_esign_stamp: true, extras_redesign: true } }
 
-      it 'returns false' do
-        expect(subject).to eq(false)
-      end
+      it { is_expected.to be(false) }
     end
   end
 

--- a/spec/lib/pdf_fill/filler_spec.rb
+++ b/spec/lib/pdf_fill/filler_spec.rb
@@ -84,7 +84,7 @@ describe PdfFill::Filler, type: :model do
               # this is only for 21-674-V2 but it passes in the extras hash. passing nil for all other scenarios
               student = form_id == '21-674-V2' ? form_data['dependents_application']['student_information'][0] : nil
 
-              expect(described_class).to receive(:stamp_form).once.and_call_original if extras_redesign
+              expect(described_class).to receive(:optionally_stamp_form).once.and_call_original if extras_redesign
 
               file_path = described_class.fill_ancillary_form(form_data, 1, form_id, { extras_redesign:, student: })
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
This PR adds a new `omit_esign_stamp` option to the redesigned PDF generator, to allow omitting the built-in e-signature footer stamp in case it clashes with another footer stamp -- which is the case with the upcoming form 0969.

I work for the Employee Experience team, which owns maintenance of the redesigned PDF generator.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/114575
https://github.com/department-of-veterans-affairs/va.gov-team/issues/115787

## Testing done
- [x] *New code is covered by unit tests*
- New behavior:
  - Passing `omit_esign_stamp: true` to PdfFill will omit the e-signature stamp
  - Updated test for `extras_redesign: true`
  - New test for `extras_redesign: true, omit_esign_stamp: false`
  - New test for `extras_redesign: false`
- *If this work is behind a flipper:*
  - The redesigned PDF generator is gated by the new form 0969, due to launch in August. In other words, this logic is not relevant to the flipper off scenario.

## Screenshots
Before:
<img width="666" height="861" alt="Screenshot 2025-08-01 at 12 39 35" src="https://github.com/user-attachments/assets/635c75a6-41d5-4228-b6ff-881b457a859d" />

After:
<img width="665" height="860" alt="Screenshot 2025-08-01 at 12 39 54" src="https://github.com/user-attachments/assets/e680d158-e7fe-4605-baa7-05be73370d14" />

Note that in the before screenshot, there is also a clashing header stamp in the upper-right, which is resolved in the after screenshot as well.

## What areas of the site does it impact?
PDF generator for form 0969. No user-facing impact.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
