### PR TITLE
114906: Update logic to use track_request

### DIFF
--- a/app/models/lighthouse/submission_attempt.rb
+++ b/app/models/lighthouse/submission_attempt.rb
@@ -17,38 +17,44 @@ class Lighthouse::SubmissionAttempt < SubmissionAttempt
     manually: 'manually'
   }
 
+  STATS_KEY = 'api.lighthouse.submission_attempt'
+
   def fail!
     failure!
     log_hash = status_change_hash
     log_hash[:message] = 'Lighthouse Submission Attempt failed'
-    Rails.logger.public_send(:error, log_hash)
+    monitor.track_request(:error, log_hash[:message], STATS_KEY, **log_hash)
   end
 
   def manual!
     manually!
     log_hash = status_change_hash
     log_hash[:message] = 'Lighthouse Submission Attempt is being manually remediated'
-    Rails.logger.public_send(:warn, log_hash)
+    monitor.track_request(:warn, log_hash[:message], STATS_KEY, **log_hash)
   end
 
   def vbms!
     update(status: :vbms)
     log_hash = status_change_hash
     log_hash[:message] = 'Lighthouse Submission Attempt went to vbms'
-    Rails.logger.public_send(:info, log_hash)
+    monitor.track_request(:info, log_hash[:message], STATS_KEY, **log_hash)
   end
 
   def pending!
     update(status: :pending)
     log_hash = status_change_hash
     log_hash[:message] = 'Lighthouse Submission Attempt is pending'
-    Rails.logger.public_send(:info, log_hash)
+    monitor.track_request(:info, log_hash[:message], STATS_KEY, **log_hash)
   end
 
   def success!
     submitted!
     log_hash = status_change_hash
     log_hash[:message] = 'Lighthouse Submission Attempt is submitted'
-    Rails.logger.public_send(:info, log_hash)
+    monitor.track_request(:info, log_hash[:message], STATS_KEY, **log_hash)
+  end
+
+  def monitor
+    @monitor ||= Logging::Monitor.new('lighthouse_submission_attempt')
   end
 end


### PR DESCRIPTION
IN the screenshot below you'll see we are just doing a regular logger without and sculpting of the data. We want everything to be within a context within a payload and be uniform.

## Summary

- Replace Rails.logger with monitor
- Update spec

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114906

## Testing done

- [X] *New code is covered by unit tests*

## Screenshots

<img width="663" height="844" alt="Screenshot 2025-07-22 at 12 58 26 PM" src="https://github.com/user-attachments/assets/ebd76a39-2d48-4262-a736-3e54607d1422" />