### PR TITLE
[10-10CG] Revert generating Oauth token in config to instead generate in perform in client class

### DIFF
--- a/lib/carma/client/mule_soft_client.rb
+++ b/lib/carma/client/mule_soft_client.rb
@@ -45,7 +45,7 @@ module CARMA
             :post,
             resource,
             get_body(payload),
-            *(Flipper.enabled?(:caregiver_mulesoft_config_v2) ? [] : [headers]),
+            headers,
             *(Flipper.enabled?(:caregiver_mulesoft_config_v2) ? [] : [{ timeout: config.settings.async_timeout }])
           )
 

--- a/lib/carma/client/mule_soft_configuration_v2.rb
+++ b/lib/carma/client/mule_soft_configuration_v2.rb
@@ -4,7 +4,7 @@ module CARMA
   module Client
     class MuleSoftConfigurationV2 < Common::Client::Configuration::REST
       def connection
-        Faraday.new(base_path, headers: base_request_headers) do |conn|
+        Faraday.new(base_path) do |conn|
           conn.use(:breakers, service_name:)
           conn.request :instrumentation, name: service_name
           conn.options.timeout = timeout
@@ -27,21 +27,11 @@ module CARMA
         Settings.form_10_10cg.carma.mulesoft
       end
 
-      def base_request_headers
-        super.merge(
-          'Authorization' => "Bearer #{bearer_token}"
-        )
-      end
-
       private
 
       # @return [String]
       def base_path
         "#{settings.host}/va-carma-caregiver-papi/api/"
-      end
-
-      def bearer_token
-        @bearer_token ||= CARMA::Client::MuleSoftAuthTokenClient.new.new_bearer_token
       end
     end
   end

--- a/spec/lib/carma/client/mule_soft_configuration_v2_spec.rb
+++ b/spec/lib/carma/client/mule_soft_configuration_v2_spec.rb
@@ -7,24 +7,13 @@ describe CARMA::Client::MuleSoftConfigurationV2 do
   subject { described_class.instance }
 
   let(:host) { 'https://www.somesite.gov' }
-  let(:bearer_token) { 'test_bearer_token' }
 
   describe 'connection' do
     let(:faraday) { double('Faraday::Connection', options: double('Faraday::Options')) }
 
-    before do
-      allow_any_instance_of(CARMA::Client::MuleSoftAuthTokenClient).to receive(:new_bearer_token)
-        .and_return(bearer_token)
-    end
-
     it 'creates a new Faraday connection with the correct base path' do
       allow(Settings.form_10_10cg.carma.mulesoft).to receive(:host).and_return(host)
-      expect(Faraday).to receive(:new).with("#{host}/va-carma-caregiver-papi/api/", {
-                                              headers: { 'Accept' => 'application/json',
-                                                         'Authorization' => "Bearer #{bearer_token}",
-                                                         'Content-Type' => 'application/json',
-                                                         'User-Agent' => 'Vets.gov Agent' }
-                                            })
+      expect(Faraday).to receive(:new).with("#{host}/va-carma-caregiver-papi/api/")
       subject.connection
     end
 
@@ -39,40 +28,6 @@ describe CARMA::Client::MuleSoftConfigurationV2 do
       expect(faraday.options).to receive(:timeout=).once.with(subject.timeout)
 
       subject.connection
-    end
-  end
-
-  describe 'base_request_headers' do
-    let(:base_request_headers) { subject.base_request_headers }
-
-    before do
-      subject.instance_variable_set(:@bearer_token, nil)
-    end
-
-    context 'successfully fetches bearer token' do
-      before do
-        allow_any_instance_of(CARMA::Client::MuleSoftAuthTokenClient).to receive(:new_bearer_token)
-          .and_return(bearer_token)
-      end
-
-      it 'includes the Authorization header with the bearer token' do
-        expect(base_request_headers).to eq({ 'Accept' => 'application/json',
-                                             'Content-Type' => 'application/json',
-                                             'User-Agent' => 'Vets.gov Agent',
-                                             'Authorization' => "Bearer #{bearer_token}" })
-      end
-    end
-
-    context 'error getting bearer token' do
-      before do
-        allow_any_instance_of(CARMA::Client::MuleSoftAuthTokenClient).to receive(:new_bearer_token).and_raise(
-          StandardError, 'Token fetch error'
-        )
-      end
-
-      it 'raises an error when fetching the bearer token fails' do
-        expect { base_request_headers }.to raise_error(StandardError, 'Token fetch error')
-      end
     end
   end
 


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- Reverted change from https://github.com/department-of-veterans-affairs/vets-api/pull/23162 to generate the oauth bearer token in the client instead of the client configuration. 
- We had some 401 errors in prod after turning this on, and I suspect this is the culprit since the token has a higher likelihood of expiring when generating it in the config vs right when we call the perform method to make the request.
-  No longer using the `form_10_10cg/carma/mulesoft/client_id` and `form_10_10cg/carma/mulesoft/client_secret` params since we use the token client to fetch a token for authentication. 
- 1010 Health Apps
- `caregiver_mulesoft_config_v2` flipper toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101075

## Testing done

- [x] *New code is covered by unit tests*
- [ ] Manual QA in a RI as a sanity check 

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
