### PR TITLE
Update karafka-rdkafka to solve macOS extension issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -656,8 +656,14 @@ GEM
     karafka-core (2.5.2)
       karafka-rdkafka (>= 0.19.2, < 0.21.0)
       logger (>= 1.6.0)
-    karafka-rdkafka (0.19.5)
+    karafka-rdkafka (0.20.1)
       ffi (~> 1.15)
+      logger
+      mini_portile2 (~> 2.6)
+      rake (> 12)
+    karafka-rdkafka (0.20.1-x86_64-linux-gnu)
+      ffi (~> 1.15)
+      logger
       mini_portile2 (~> 2.6)
       rake (> 12)
     kms_encrypted (1.7.0)


### PR DESCRIPTION
## Summary

- Some devs are getting an error when installing this gem:
  ```
   Installing karafka-rdkafka 0.19.5 with native extensions
       Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
  ```
- This update fixes the precompile issues on macOS
