### PR TITLE
Update Mobile Logic for Telehealth Appointments Using vvsVistaVideoAppt Fallback

### DIFF
--- a/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointment.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointment.rb
@@ -309,7 +309,8 @@ module Mobile
           elsif VIDEO_CONNECT_AT_VA.include?(vvs_kind)
             APPOINTMENT_TYPES[:va_video_connect_onsite]
           else
-            APPOINTMENT_TYPES[:va]
+            vvs_video_appt = appointment.dig(:extension, :vvs_vista_video_appt)
+            vvs_video_appt.to_s.downcase == 'true' ? APPOINTMENT_TYPES[:va_video_connect_home] : APPOINTMENT_TYPES[:va]
           end
         end
 

--- a/modules/mobile/spec/support/fixtures/VAOS_v2_appointments.json
+++ b/modules/mobile/spec/support/fixtures/VAOS_v2_appointments.json
@@ -1091,5 +1091,65 @@
     "extension": {
       "patient_has_mobile_gfe": true
     }
+  },
+  {
+    "id": "50101",
+    "identifier": [
+      {
+        "system": "http://med.va.gov/fhir/urn/vaos/arsid",
+        "value": "8a487fd67ba6a62d017bc0cc86d80002"
+      }
+    ],
+    "kind": "telehealth",
+    "type": "VA",
+    "location": {
+      "id": "442",
+      "name": "Cheyenne VA Medical Center",
+      "time_zone": {
+        "time_zone_id": "America/Denver"
+      },
+      "physical_address": {
+        "type": "physical",
+        "line": [
+          "2360 East Pershing Boulevard"
+        ],
+        "city": "Cheyenne",
+        "state": "WY",
+        "postal_code": "82001-5356"
+      },
+      "lat": 41.148026,
+      "long": -104.786255,
+      "phone": {
+        "main": "307-778-7550"
+      },
+      "url": null,
+      "code": null
+    },
+    "status": "proposed",
+    "service_type": "PrimaryCare",
+    "patient_icn": "1012845331V153043",
+    "location_id": "983",
+    "reason": "Test_SM test (tele)",
+    "requested_periods": [
+      {
+        "start": "2021-09-08T12:00:00Z",
+        "end": "2021-09-08T23:59:59.999Z"
+      }
+    ],
+    "contact": {
+      "telecom": [
+        {
+          "type": "phone",
+          "value": "9999999992"
+        }
+      ]
+    },
+    "cancellation_reason": {
+      "code": "other"
+    },
+    "cancellable": true,
+    "telehealth": {
+      "url": "http://www.meeting.com"
+    }
   }
 ]


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- This PR updates mobile endpoint logic to use the extensions.vvs_vista_video_appt field to determine appointment type when telehealth.vvs_kind is missing from the API response. This would bring the mobile logic up to parity with the web logic.
- Appointments FE Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114809

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
