### PR TITLE
Change slack webhook_url to known working value

### DIFF
--- a/modules/representation_management/app/models/representation_management/accreditation_api_entity_count.rb
+++ b/modules/representation_management/app/models/representation_management/accreditation_api_entity_count.rb
@@ -187,7 +187,7 @@ module RepresentationManagement
     def log_to_slack_threshold_channel(message)
       return unless Settings.vsp_environment == 'production'
 
-      slack_client = SlackNotify::Client.new(webhook_url: Settings.claims_api.slack.webhook_url,
+      slack_client = SlackNotify::Client.new(webhook_url: Settings.edu.slack.webhook_url,
                                              channel: '#benefits-representation-management-notifications',
                                              username: 'RepresentationManagement::AccreditationApiEntityCount')
       slack_client.notify(message)

--- a/modules/representation_management/app/services/representation_management/gclaws/client.rb
+++ b/modules/representation_management/app/services/representation_management/gclaws/client.rb
@@ -113,7 +113,7 @@ module RepresentationManagement
         return unless Settings.vsp_environment == 'production'
 
         slack_client = SlackNotify::Client.new(
-          webhook_url: Settings.claims_api.slack.webhook_url,
+          webhook_url: Settings.edu.slack.webhook_url,
           channel: '#benefits-representation-management-notifications',
           username: 'RepresentationManagement::GCLAWS::ClientBot'
         )

--- a/modules/representation_management/app/sidekiq/representation_management/accredited_entities_queue_updates.rb
+++ b/modules/representation_management/app/sidekiq/representation_management/accredited_entities_queue_updates.rb
@@ -574,7 +574,7 @@ module RepresentationManagement
     def log_to_slack_channel(message)
       return unless Settings.vsp_environment == 'production'
 
-      slack_client = SlackNotify::Client.new(webhook_url: Settings.claims_api.slack.webhook_url,
+      slack_client = SlackNotify::Client.new(webhook_url: Settings.edu.slack.webhook_url,
                                              channel: '#benefits-representation-management-notifications',
                                              username: 'RepresentationManagement::AccreditationApiEntityCountBot')
       slack_client.notify(message)

--- a/modules/veteran/app/sidekiq/veteran/vso_reloader.rb
+++ b/modules/veteran/app/sidekiq/veteran/vso_reloader.rb
@@ -169,15 +169,6 @@ module Veteran
       client.notify(message)
     end
 
-    def log_to_slack_threshold_channel(message)
-      return unless Settings.vsp_environment == 'production'
-
-      client = SlackNotify::Client.new(webhook_url: Settings.edu.slack.webhook_url,
-                                       channel: '#benefits-representation-management-notifications',
-                                       username: 'VSOReloader')
-      client.notify(message)
-    end
-
     def fetch_initial_counts
       {
         attorneys: Veteran::Service::Representative.where("'#{USER_TYPE_ATTORNEY}' = ANY(user_types)").count,
@@ -233,7 +224,7 @@ module Veteran
                 "Threshold: #{(threshold * 100).round(2)}%\n" \
                 'Action: Update skipped, manual review required'
 
-      log_to_slack_threshold_channel(message)
+      log_to_slack(message)
       log_message_to_sentry("VSO Reloader threshold exceeded for #{rep_type}", :warn,
                             previous_count:,
                             new_count:,

--- a/modules/veteran/app/sidekiq/veteran/vso_reloader.rb
+++ b/modules/veteran/app/sidekiq/veteran/vso_reloader.rb
@@ -163,7 +163,7 @@ module Veteran
     def log_to_slack(message)
       return unless Settings.vsp_environment == 'production'
 
-      client = SlackNotify::Client.new(webhook_url: Settings.claims_api.slack.webhook_url,
+      client = SlackNotify::Client.new(webhook_url: Settings.edu.slack.webhook_url,
                                        channel: '#benefits-representation-management-notifications',
                                        username: 'VSOReloader')
       client.notify(message)
@@ -172,7 +172,7 @@ module Veteran
     def log_to_slack_threshold_channel(message)
       return unless Settings.vsp_environment == 'production'
 
-      client = SlackNotify::Client.new(webhook_url: Settings.claims_api.slack.webhook_url,
+      client = SlackNotify::Client.new(webhook_url: Settings.edu.slack.webhook_url,
                                        channel: '#benefits-representation-management-notifications',
                                        username: 'VSOReloader')
       client.notify(message)

--- a/modules/veteran/spec/sidekiq/veteran/vso_reloader_spec.rb
+++ b/modules/veteran/spec/sidekiq/veteran/vso_reloader_spec.rb
@@ -269,9 +269,9 @@ RSpec.describe Veteran::VSOReloader, type: :job do
       before { reloader.send(:ensure_initial_counts) }
 
       it 'sends a notification to Slack' do
-        allow(reloader).to receive(:log_to_slack_threshold_channel)
+        allow(reloader).to receive(:log_to_slack)
 
-        expect(reloader).to receive(:log_to_slack_threshold_channel).with(
+        expect(reloader).to receive(:log_to_slack).with(
           include('Attorneys count decreased beyond threshold!')
         )
 


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): YES*
- *(Summarize the changes that have been made to the platform)*: All `webhook_url`s for `SlackNotify::Client` have been changed to a known good value.  I'm not sure how we got to a state where we were using two different values but this PR updates all to one value we know is working.  We know the good value is working because it is being used to ping our notifications channel as I write this.
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*: Some of our jobs were failing with `SlackNotify::Client` errors where the only difference was a different `webhook_url` value.
- *(Which team do you work for, does your team own the maintenance of this component?)*: FAR/ARM, we own the maintenance.
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*: Sidekiq jobs that used the known good value are actively adding to our notifications channel as intended.  Jobs that used the other value are stuck in the Sidekiq retry queue with `SlackNotify::Client` errors.
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*: Once deployed, we should start to see the daily report for the Accreditation API job in the notifications channel.
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*: This impacts the data intake processes for the Find a Rep and Appoint a Rep products.  The legacy intake is in the `Veteran` module and the new intake is in the `RepresentationManagement` module.

## Acceptance criteria

- [x]  I updated unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
