### PR TITLE
Add DataDog metrics for broker health

### DIFF
--- a/lib/kafka/enhanced_listener.rb
+++ b/lib/kafka/enhanced_listener.rb
@@ -1,28 +1,27 @@
+# frozen_string_literal: true
+
 require 'waterdrop/instrumentation/vendors/datadog/metrics_listener'
 require 'datadog/statsd'
 
 module Kafka
   class EnhancedListener < WaterDrop::Instrumentation::Vendors::Datadog::MetricsListener
-
-
     def service_check(key, *args)
       metric_value, tags = args
       status = case metric_value
-      when 'UP'
-        Datadog::Statsd::OK
-      when 'INIT', 'TRY_CONNECT'
-        Datadog::Statsd::WARNING
-      when 'DOWN'
-        Datadog::Statsd::CRITICAL
-      else
-        Datadog::Statsd::UNKNOWN
-      end
+               when 'UP'
+                 Datadog::Statsd::OK
+               when 'INIT', 'TRY_CONNECT'
+                 Datadog::Statsd::WARNING
+               when 'DOWN'
+                 Datadog::Statsd::CRITICAL
+               else
+                 Datadog::Statsd::UNKNOWN
+               end
       client.service_check(
         namespaced_metric(key),
         status,
         tags
       )
     end
-
   end
 end

--- a/lib/kafka/enhanced_listener.rb
+++ b/lib/kafka/enhanced_listener.rb
@@ -1,0 +1,28 @@
+require 'waterdrop/instrumentation/vendors/datadog/metrics_listener'
+require 'datadog/statsd'
+
+module Kafka
+  class EnhancedListener < WaterDrop::Instrumentation::Vendors::Datadog::MetricsListener
+
+
+    def service_check(key, *args)
+      metric_value, tags = args
+      status = case metric_value
+      when 'UP'
+        Datadog::Statsd::OK
+      when 'INIT', 'TRY_CONNECT'
+        Datadog::Statsd::WARNING
+      when 'DOWN'
+        Datadog::Statsd::CRITICAL
+      else
+        Datadog::Statsd::UNKNOWN
+      end
+      client.service_check(
+        namespaced_metric(key),
+        status,
+        tags
+      )
+    end
+
+  end
+end

--- a/lib/kafka/producer_manager.rb
+++ b/lib/kafka/producer_manager.rb
@@ -76,7 +76,7 @@ module Kafka
           list_class_ref::RdKafkaMetric.new(:count, :brokers, 'connects', 'connects'),
           list_class_ref::RdKafkaMetric.new(:count, :brokers, 'disconnects', 'disconnects'),
           list_class_ref::RdKafkaMetric.new(:gauge, :brokers, 'rxidle', 'rxidle'),
-          list_class_ref::RdKafkaMetric.new(:service_check, :brokers, 'state', 'state')
+          list_class_ref::RdKafkaMetric.new(:broker_service_check, :brokers, 'state', 'state')
         ]
       end
 

--- a/lib/kafka/producer_manager.rb
+++ b/lib/kafka/producer_manager.rb
@@ -3,8 +3,8 @@
 require 'singleton'
 require 'waterdrop'
 require 'kafka/oauth_token_refresher'
+require 'kafka/enhanced_listener'
 require 'datadog/statsd'
-require 'waterdrop/instrumentation/vendors/datadog/metrics_listener'
 
 module Kafka
   class ProducerManager
@@ -66,11 +66,18 @@ module Kafka
     end
 
     def setup_datadog_instrumentation
-      listener = ::WaterDrop::Instrumentation::Vendors::Datadog::MetricsListener.new do |config|
+      list_class_ref = Kafka::EnhancedListener
+      listener = list_class_ref.new do |config|
         statsd_addr = ENV['STATSD_ADDR'] || '127.0.0.1:8125'
         host, port = statsd_addr.split(':')
         config.client = Datadog::Statsd.new(host, port)
         config.default_tags = ["host:#{host}"]
+        config.rd_kafka_metrics = config.rd_kafka_metrics + [
+          list_class_ref::RdKafkaMetric.new(:count, :brokers, 'connects', 'connects'),
+          list_class_ref::RdKafkaMetric.new(:count, :brokers, 'disconnects', 'disconnects'),
+          list_class_ref::RdKafkaMetric.new(:gauge, :brokers, 'rxidle', 'rxidle'),
+          list_class_ref::RdKafkaMetric.new(:service_check, :brokers, 'state', 'state')
+        ]
       end
 
       producer.monitor.subscribe(listener)

--- a/spec/lib/kafka/enhanced_listener_spec.rb
+++ b/spec/lib/kafka/enhanced_listener_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Kafka::EnhancedListener do
       config.client = mock_statsd_client
       config.default_tags = ['environment:test']
       config.rd_kafka_metrics = [
-        described_class::RdKafkaMetric.new(:service_check, :brokers, 'brokers.state', 'state'),
+        described_class::RdKafkaMetric.new(:broker_service_check, :brokers, 'brokers.state', 'state'),
         described_class::RdKafkaMetric.new(:count, :brokers, 'brokers.connects', 'connects'),
         described_class::RdKafkaMetric.new(:count, :brokers, 'brokers.disconnects', 'disconnects'),
         described_class::RdKafkaMetric.new(:gauge, :brokers, 'brokers.rxidle', 'rxidle')

--- a/spec/lib/kafka/enhanced_listener_spec.rb
+++ b/spec/lib/kafka/enhanced_listener_spec.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'kafka/enhanced_listener'
+
+RSpec.describe Kafka::EnhancedListener do
+  let(:mock_statsd_client) { instance_double(Datadog::Statsd) }
+  let(:listener) do
+    described_class.new do |config|
+      config.client = mock_statsd_client
+      config.default_tags = ['environment:test']
+      config.rd_kafka_metrics = [
+        described_class::RdKafkaMetric.new(:service_check, :brokers, 'brokers.state', 'state'),
+        described_class::RdKafkaMetric.new(:count, :brokers, 'brokers.connects', 'connects'),
+        described_class::RdKafkaMetric.new(:count, :brokers, 'brokers.disconnects', 'disconnects'),
+        described_class::RdKafkaMetric.new(:gauge, :brokers, 'brokers.rxidle', 'rxidle')
+      ]
+    end
+  end
+
+  let(:event) do
+    {
+      statistics: {
+        'brokers' => {
+          'localhost:9092/1001' => {
+            'nodename' => 'localhost:9092',
+            'state' => 'UP',
+            'connects' => 5,
+            'disconnects' => 2,
+            'rxidle' => 1029387488
+          }
+        }
+      }
+    }
+  end
+
+  before do
+    allow(mock_statsd_client).to receive(:service_check)
+    allow(mock_statsd_client).to receive(:count)
+    allow(mock_statsd_client).to receive(:gauge)
+  end
+
+  describe 'service check functionality' do
+    context 'when broker state is UP' do
+
+      it 'sends OK status to Datadog' do
+        listener.on_statistics_emitted(event)
+
+        expect(mock_statsd_client).to have_received(:service_check).with(
+          'waterdrop.brokers.state',
+          Datadog::Statsd::OK,
+          { tags: ["environment:test", "broker:localhost:9092"] }
+        )
+      end
+    end
+
+    context 'when broker state is INIT or TRY_CONNECT' do
+      %w[INIT TRY_CONNECT].each do |state|
+        context "with state #{state}" do
+          before do
+            event[:statistics]['brokers']['localhost:9092/1001']['state'] = state
+          end
+
+          it 'sends WARNING status to Datadog' do
+            listener.on_statistics_emitted(event)
+
+            expect(mock_statsd_client).to have_received(:service_check).with(
+              'waterdrop.brokers.state',
+              Datadog::Statsd::WARNING,
+              { tags: ["environment:test", "broker:localhost:9092"] }
+            )
+          end
+        end
+      end
+    end
+
+    context 'when broker state is DOWN' do
+      before do
+        event[:statistics]['brokers']['localhost:9092/1001']['state'] = 'DOWN'
+      end
+
+      it 'sends CRITICAL status to Datadog' do
+        listener.on_statistics_emitted(event)
+
+        expect(mock_statsd_client).to have_received(:service_check).with(
+          'waterdrop.brokers.state',
+          Datadog::Statsd::CRITICAL,
+          { tags: ["environment:test", "broker:localhost:9092"] }
+        )
+      end
+    end
+
+    context 'when broker state is unknown' do
+      before do
+        event[:statistics]['brokers']['localhost:9092/1001']['state'] = 'APIVERSION_QUERY'
+      end
+
+      it 'sends UNKNOWN status to Datadog' do
+        listener.on_statistics_emitted(event)
+
+        expect(mock_statsd_client).to have_received(:service_check).with(
+          'waterdrop.brokers.state',
+          Datadog::Statsd::UNKNOWN,
+          { tags: ["environment:test", "broker:localhost:9092"] }
+        )
+      end
+    end
+  end
+
+  describe 'count metrics' do
+
+    before do
+      event[:statistics]['brokers']['localhost:9092/1001']['connects'] = 10
+      event[:statistics]['brokers']['localhost:9092/1001']['disconnects'] = 3
+    end
+
+    it 'sends count metrics for connects and disconnects' do
+      listener.on_statistics_emitted(event)
+
+      expect(mock_statsd_client).to have_received(:count).with(
+        'waterdrop.brokers.connects',
+        10,
+        { tags: ["environment:test", "broker:localhost:9092"] }
+      )
+
+      expect(mock_statsd_client).to have_received(:count).with(
+        'waterdrop.brokers.disconnects',
+        3,
+        { tags: ["environment:test", "broker:localhost:9092"] }
+      )
+    end
+  end
+
+  describe 'gauge metrics' do
+    before do
+      event[:statistics]['brokers']['localhost:9092/1001']['rxidle'] = 1234567890
+    end
+
+    it 'sends gauge metrics for rxidle' do
+      listener.on_statistics_emitted(event)
+
+      expect(mock_statsd_client).to have_received(:gauge).with(
+        'waterdrop.brokers.rxidle',
+        1234567890,
+        { tags: ["environment:test", "broker:localhost:9092"] }
+      )
+    end
+  end
+
+  describe 'multiple broker handling' do
+    let(:event_with_multiple_brokers) do
+      {
+        statistics: {
+          'brokers' => {
+            'localhost:9092/1001' => {
+              'nodename' => 'localhost:9092',
+              'state' => 'UP',          
+              'connects' => 5
+            },
+            'localhost:9093/1002' => {
+              'nodename' => 'localhost:9093',     
+              'state' => 'DOWN',
+              'disconnects' => 1
+            }
+          }
+        }
+      }
+    end
+
+    it 'sends service checks and counts for all brokers' do
+      listener.on_statistics_emitted(event_with_multiple_brokers)   
+      expect(mock_statsd_client).to have_received(:service_check).with(
+        'waterdrop.brokers.state',
+        Datadog::Statsd::OK,
+        { tags: ["environment:test", "broker:localhost:9092"] }
+      )     
+      expect(mock_statsd_client).to have_received(:service_check).with(
+        'waterdrop.brokers.state',
+        Datadog::Statsd::CRITICAL,
+        { tags: ["environment:test", "broker:localhost:9093"] }
+      )   
+      expect(mock_statsd_client).to have_received(:count).with(
+        'waterdrop.brokers.connects',
+        5,
+        { tags: ["environment:test", "broker:localhost:9092"] }
+      )
+      expect(mock_statsd_client).to have_received(:count).with(
+        'waterdrop.brokers.disconnects',      
+        1,
+        { tags: ["environment:test", "broker:localhost:9093"] }
+      )
+    end
+  end
+
+  describe 'integration with ProducerManager' do
+    let(:producer) { instance_double(WaterDrop::Producer) }
+    let(:monitor) { instance_double(WaterDrop::Instrumentation::Monitor) }
+
+    before do
+      allow(WaterDrop::Producer).to receive(:new).and_return(producer)
+      allow(producer).to receive(:monitor).and_return(monitor)
+      allow(monitor).to receive(:subscribe)
+      Singleton.__init__(Kafka::ProducerManager)
+    end
+
+    after do
+      # Force singleton reset to ensure clean state
+      Singleton.__init__(Kafka::ProducerManager)
+    end
+
+    it 'subscribes the listener to the producer monitor' do
+      Kafka::ProducerManager.instance
+
+      expect(monitor).to have_received(:subscribe).with(instance_of(described_class))
+    end
+  end
+end

--- a/spec/lib/kafka/enhanced_listener_spec.rb
+++ b/spec/lib/kafka/enhanced_listener_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Kafka::EnhancedListener do
             'state' => 'UP',
             'connects' => 5,
             'disconnects' => 2,
-            'rxidle' => 1029387488
+            'rxidle' => 1_029_387_488
           }
         }
       }
@@ -42,14 +42,13 @@ RSpec.describe Kafka::EnhancedListener do
 
   describe 'service check functionality' do
     context 'when broker state is UP' do
-
       it 'sends OK status to Datadog' do
         listener.on_statistics_emitted(event)
 
         expect(mock_statsd_client).to have_received(:service_check).with(
           'waterdrop.brokers.state',
           Datadog::Statsd::OK,
-          { tags: ["environment:test", "broker:localhost:9092"] }
+          { tags: ['environment:test', 'broker:localhost:9092'] }
         )
       end
     end
@@ -67,7 +66,7 @@ RSpec.describe Kafka::EnhancedListener do
             expect(mock_statsd_client).to have_received(:service_check).with(
               'waterdrop.brokers.state',
               Datadog::Statsd::WARNING,
-              { tags: ["environment:test", "broker:localhost:9092"] }
+              { tags: ['environment:test', 'broker:localhost:9092'] }
             )
           end
         end
@@ -85,7 +84,7 @@ RSpec.describe Kafka::EnhancedListener do
         expect(mock_statsd_client).to have_received(:service_check).with(
           'waterdrop.brokers.state',
           Datadog::Statsd::CRITICAL,
-          { tags: ["environment:test", "broker:localhost:9092"] }
+          { tags: ['environment:test', 'broker:localhost:9092'] }
         )
       end
     end
@@ -101,14 +100,13 @@ RSpec.describe Kafka::EnhancedListener do
         expect(mock_statsd_client).to have_received(:service_check).with(
           'waterdrop.brokers.state',
           Datadog::Statsd::UNKNOWN,
-          { tags: ["environment:test", "broker:localhost:9092"] }
+          { tags: ['environment:test', 'broker:localhost:9092'] }
         )
       end
     end
   end
 
   describe 'count metrics' do
-
     before do
       event[:statistics]['brokers']['localhost:9092/1001']['connects'] = 10
       event[:statistics]['brokers']['localhost:9092/1001']['disconnects'] = 3
@@ -120,20 +118,20 @@ RSpec.describe Kafka::EnhancedListener do
       expect(mock_statsd_client).to have_received(:count).with(
         'waterdrop.brokers.connects',
         10,
-        { tags: ["environment:test", "broker:localhost:9092"] }
+        { tags: ['environment:test', 'broker:localhost:9092'] }
       )
 
       expect(mock_statsd_client).to have_received(:count).with(
         'waterdrop.brokers.disconnects',
         3,
-        { tags: ["environment:test", "broker:localhost:9092"] }
+        { tags: ['environment:test', 'broker:localhost:9092'] }
       )
     end
   end
 
   describe 'gauge metrics' do
     before do
-      event[:statistics]['brokers']['localhost:9092/1001']['rxidle'] = 1234567890
+      event[:statistics]['brokers']['localhost:9092/1001']['rxidle'] = 1_234_567_890
     end
 
     it 'sends gauge metrics for rxidle' do
@@ -141,8 +139,8 @@ RSpec.describe Kafka::EnhancedListener do
 
       expect(mock_statsd_client).to have_received(:gauge).with(
         'waterdrop.brokers.rxidle',
-        1234567890,
-        { tags: ["environment:test", "broker:localhost:9092"] }
+        1_234_567_890,
+        { tags: ['environment:test', 'broker:localhost:9092'] }
       )
     end
   end
@@ -154,11 +152,11 @@ RSpec.describe Kafka::EnhancedListener do
           'brokers' => {
             'localhost:9092/1001' => {
               'nodename' => 'localhost:9092',
-              'state' => 'UP',          
+              'state' => 'UP',
               'connects' => 5
             },
             'localhost:9093/1002' => {
-              'nodename' => 'localhost:9093',     
+              'nodename' => 'localhost:9093',
               'state' => 'DOWN',
               'disconnects' => 1
             }
@@ -168,26 +166,26 @@ RSpec.describe Kafka::EnhancedListener do
     end
 
     it 'sends service checks and counts for all brokers' do
-      listener.on_statistics_emitted(event_with_multiple_brokers)   
+      listener.on_statistics_emitted(event_with_multiple_brokers)
       expect(mock_statsd_client).to have_received(:service_check).with(
         'waterdrop.brokers.state',
         Datadog::Statsd::OK,
-        { tags: ["environment:test", "broker:localhost:9092"] }
-      )     
+        { tags: ['environment:test', 'broker:localhost:9092'] }
+      )
       expect(mock_statsd_client).to have_received(:service_check).with(
         'waterdrop.brokers.state',
         Datadog::Statsd::CRITICAL,
-        { tags: ["environment:test", "broker:localhost:9093"] }
-      )   
+        { tags: ['environment:test', 'broker:localhost:9093'] }
+      )
       expect(mock_statsd_client).to have_received(:count).with(
         'waterdrop.brokers.connects',
         5,
-        { tags: ["environment:test", "broker:localhost:9092"] }
+        { tags: ['environment:test', 'broker:localhost:9092'] }
       )
       expect(mock_statsd_client).to have_received(:count).with(
-        'waterdrop.brokers.disconnects',      
+        'waterdrop.brokers.disconnects',
         1,
-        { tags: ["environment:test", "broker:localhost:9093"] }
+        { tags: ['environment:test', 'broker:localhost:9093'] }
       )
     end
   end


### PR DESCRIPTION
## Summary

- Added additional broker statistics to the current `WaterDrop::Instrumentation::Vendors::Datadog::MetricsListener`.
- This required creating a subclass to add `service_check` functionality. This will invoke the corresponding method in the DataDog StatsD client.

## Related issue(s)

- [VES #5129](https://github.com/department-of-veterans-affairs/VES/issues/5129)

## Testing done

- [x] New code is covered by unit tests
- Also ran local [statsd-logger](https://github.com/jimf/statsd-logger) script to verify that DD metrics and service checks were being sent.

