### PR TITLE
Api 48224 v2 poa pdf cleanup

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/v2/poa_form_builder_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/v2/poa_form_builder_job.rb
@@ -82,8 +82,8 @@ module ClaimsApi
       def data(power_of_attorney, form_number, rep)
         res = power_of_attorney.form_data
         res.deep_merge!(veteran_attributes(power_of_attorney))
-        if power_of_attorney.auth_headers['depenedent'].present?
-          res.deep_merge!(power_of_attorney.auth_headers['depenedent'])
+        if power_of_attorney.auth_headers['dependent'].present?
+          res.deep_merge!(dependent_attributes(power_of_attorney.auth_headers))
         end
         res.deep_merge!(appointment_date(power_of_attorney))
 
@@ -107,6 +107,15 @@ module ClaimsApi
       def appointment_date(power_of_attorney)
         {
           'appointmentDate' => power_of_attorney.created_at
+        }
+      end
+
+      def dependent_attributes(auth_headers)
+        {
+          'dependent' => {
+            'first_name' => auth_headers['dependent']['first_name'],
+            'last_name' => auth_headers['dependent']['last_name']
+          }
         }
       end
 

--- a/modules/claims_api/lib/claims_api/v2/poa_pdf_constructor/base.rb
+++ b/modules/claims_api/lib/claims_api/v2/poa_pdf_constructor/base.rb
@@ -87,12 +87,13 @@ module ClaimsApi
           country_code = phone['countryCode']
           area_code = phone['areaCode']
           phone_number = phone['phoneNumber']
+          number = []
 
-          if country_code.blank?
-            "#{area_code} #{phone_number}"
-          else
-            "+#{country_code} #{area_code} #{phone_number}"
-          end
+          number << "+#{country_code}" if country_code.present?
+          number << area_code.to_s if area_code.present?
+          number << phone_number.to_s if phone_number.present?
+
+          number.join(' ')
         end
 
         private

--- a/modules/claims_api/lib/claims_api/v2/poa_pdf_constructor/individual.rb
+++ b/modules/claims_api/lib/claims_api/v2/poa_pdf_constructor/individual.rb
@@ -102,9 +102,8 @@ module ClaimsApi
 
             # Section II
             # Item 10
-            "#{base_form}.Claimants_First_Name[0]": data.dig('claimant', 'firstName'),
-            "#{base_form}.Claimants_Middle_Initial1[0]": data.dig('claimant', 'middleInitial'),
-            "#{base_form}.Claimants_Last_Name[0]": data.dig('claimant', 'lastName'),
+            "#{base_form}.Claimants_First_Name[0]": data.dig('dependent', 'first_name'),
+            "#{base_form}.Claimants_Last_Name[0]": data.dig('dependent', 'last_name'),
             # Item 11
             "#{base_form}.MailingAddress_NumberAndStreet[0]": data.dig('claimant', 'address', 'addressLine1'),
             "#{base_form}.MailingAddress_ApartmentOrUnitNumber[0]": data.dig('claimant', 'address', 'addressLine2'),

--- a/modules/claims_api/spec/lib/claims_api/v2/poa_pdf_constructor/individual_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/poa_pdf_constructor/individual_spec.rb
@@ -5,122 +5,68 @@ require 'claims_api/v2/poa_pdf_constructor/individual'
 require_relative '../../../../support/pdf_matcher'
 
 describe ClaimsApi::V2::PoaPdfConstructor::Individual do
-  let(:temp) { create(:power_of_attorney, :with_full_headers) }
-  let(:other_service_branch_temp) { create(:power_of_attorney, :with_full_headers) }
-  let(:phone_country_codes_temp) { create(:power_of_attorney, :with_full_headers) }
+  subject { ClaimsApi::V2::PoaPdfConstructor::Individual.new }
+
+  let(:power_of_attorney) { create(:power_of_attorney, :with_full_headers) }
+  let(:signatures) do
+    { 'page2' => [
+      { 'signature' => 'Lillian Disney - signed via api.va.gov', 'x' => 35, 'y' => 306 },
+      { 'signature' => 'Bob Law - signed via api.va.gov', 'x' => 35, 'y' => 200 }
+    ] }
+  end
+  let(:rep_attributes) do
+    {
+      'firstName' => 'Bob',
+      'lastName' => 'Law'
+    }
+  end
+  let(:dependent_attributes) do
+    {
+      'first_name' => 'Lillian',
+      'last_name' => 'Disney'
+    }
+  end
+  let(:date_signed) { '01/01/2020' }
+  # we do not do anything for item 3
+  let(:item_one) { %w[GRAY JESSE] } # veteran name
+  let(:item_two) { %w[796 37 8881] } # vet ssn
+  let(:item_four) { %w[12 05 1953] } # vet birthdate
+  let(:item_five) { '987654321' } # insurance number
+  let(:item_six) { [1, 0, 0, 0, 0, 0, 0, nil] } # service branch:
+  let(:item_seven) { ['2719 Hyperion Ave', nil, 'Los Angeles', 'CA', 'US', '92264', nil] } # vet address
+  let(:item_eight) { '+1 555 5551337' } # telephone
+  let(:item_nine) { 'test@example.com' } # email
+  let(:item_ten) { %w[Lillian Disney] } # claimant's name
+  let(:item_eleven) { ['2688 S Camino Real', nil, 'Palm Springs', 'CA', 'US', '92264', nil] } # claimant's address
+  let(:item_twelve) { '+44 555 5551337' } # claimant's telephone
+  let(:item_thirteen) { 'lillian@disney.com' } # claimant's email
+  let(:item_fourteen) { 'Spouse' } # claimant's relationship to vet
+  let(:item_fifteen_a) { 'Bob Law' } # representative name
+  let(:item_fifteen_b) { [1, 0] } # representative type: ATTORNEY or AGENT
+  let(:item_eighteen) { '2719 Hyperion Ave, Los Angeles CA 92264' } # address of rep
+  let(:item_nineteen) { 1 } # record consent
+  let(:item_twenty) { %(DRUG ABUSE, SICKLE CELL) } # consent limits
+  let(:item_twenty_one) { 1 } # consentAddressChange
+  # 22b and 24b are date signed
+  let(:item_twenty_three) { %(Condition 1, Condition 2) } # conditionsOfAppointment
+  let(:expected_page1_values) do
+    [
+      *item_one, *item_two, *item_four, item_five, *item_six, *item_seven,
+      item_eight, item_nine, *item_ten, *item_eleven, item_twelve,
+      item_thirteen, item_fourteen, item_fifteen_a, *item_fifteen_b,
+      item_eighteen
+    ]
+  end
+  let(:expected_page2_values) do
+    [
+      *item_two, item_nineteen, *item_twenty, item_twenty_one, date_signed,
+      *item_twenty_three, date_signed
+    ]
+  end
 
   before do
     Timecop.freeze(Time.zone.parse('2020-01-01T08:00:00Z'))
-    temp.form_data = {
-      veteran: {
-        serviceNumber: '987654321',
-        serviceBranch: 'ARMY',
-        address: {
-          addressLine1: '2719 Hyperion Ave',
-          city: 'Los Angeles',
-          stateCode: 'CA',
-          country: 'US',
-          zipCode: '92264'
-        },
-        phone: {
-          areaCode: '555',
-          phoneNumber: '5551337'
-        },
-        email: 'test@example.com'
-      },
-      claimant: {
-        firstName: 'Lillian',
-        middleInitial: 'A',
-        lastName: 'Disney',
-        email: 'lillian@disney.com',
-        relationship: 'Spouse',
-        address: {
-          addressLine1: '2688 S Camino Real',
-          city: 'Palm Springs',
-          stateCode: 'CA',
-          country: 'US',
-          zipCode: '92264'
-        },
-        phone: {
-          areaCode: '555',
-          phoneNumber: '5551337'
-        }
-      },
-      representative: {
-        poaCode: 'A1Q',
-        registrationNumber: '1234',
-        type: 'ATTORNEY',
-        address: {
-          addressLine1: '2719 Hyperion Ave',
-          city: 'Los Angeles',
-          stateCode: 'CA',
-          country: 'US',
-          zipCode: '92264'
-        }
-      },
-      recordConsent: true,
-      consentAddressChange: true,
-      consentLimits: %w[DRUG_ABUSE SICKLE_CELL],
-      conditionsOfAppointment: ['Condition 1', 'Condition 2']
-    }
-    temp.save
-
-    other_service_branch_temp.form_data = {
-      veteran: {
-        serviceNumber: '987654321',
-        serviceBranch: 'OTHER',
-        serviceBranchOther: 'Air National Guard',
-        address: {
-          addressLine1: '2719 Hyperion Ave',
-          city: 'Los Angeles',
-          stateCode: 'CA',
-          country: 'US',
-          zipCode: '92264'
-        },
-        phone: {
-          areaCode: '555',
-          phoneNumber: '5551337'
-        },
-        email: 'test@example.com'
-      },
-      claimant: {
-        firstName: 'Lillian',
-        middleInitial: 'A',
-        lastName: 'Disney',
-        email: 'LILLian@disney.com',
-        relationship: 'Spouse',
-        address: {
-          addressLine1: '2688 S Camino Real',
-          city: 'Palm Springs',
-          stateCode: 'CA',
-          country: 'US',
-          zipCode: '92264'
-        },
-        phone: {
-          areaCode: '555',
-          phoneNumber: '5551337'
-        }
-      },
-      representative: {
-        poaCode: 'A1Q',
-        type: 'ATTORNEY',
-        registrationNumber: '1234',
-        address: {
-          addressLine1: '2719 Hyperion Ave',
-          city: 'Los Angeles',
-          stateCode: 'CA',
-          country: 'US',
-          zipCode: '92264'
-        }
-      },
-      recordConsent: true,
-      consentAddressChange: true,
-      consentLimits: %w[DRUG_ABUSE SICKLE_CELL],
-      conditionsOfAppointment: ['Condition 1', 'Condition 2']
-    }
-    other_service_branch_temp.save
-
-    phone_country_codes_temp.form_data = {
+    power_of_attorney.form_data = {
       veteran: {
         serviceNumber: '987654321',
         serviceBranch: 'ARMY',
@@ -139,9 +85,7 @@ describe ClaimsApi::V2::PoaPdfConstructor::Individual do
         email: 'test@example.com'
       },
       claimant: {
-        firstName: 'Lillian',
-        middleInitial: 'A',
-        lastName: 'Disney',
+        claimantId: '00000000V0000',
         email: 'lillian@disney.com',
         relationship: 'Spouse',
         address: {
@@ -153,6 +97,7 @@ describe ClaimsApi::V2::PoaPdfConstructor::Individual do
         },
         phone: {
           countryCode: '44',
+          areaCode: '555',
           phoneNumber: '5551337'
         }
       },
@@ -173,127 +118,55 @@ describe ClaimsApi::V2::PoaPdfConstructor::Individual do
       consentLimits: %w[DRUG_ABUSE SICKLE_CELL],
       conditionsOfAppointment: ['Condition 1', 'Condition 2']
     }
-    phone_country_codes_temp.save
+    power_of_attorney.form_data.deep_merge!(
+      {
+        'veteran' => veteran_attributes(power_of_attorney.auth_headers),
+        'representative' => rep_attributes,
+        'dependent' => dependent_attributes,
+        'appointmentDate' => power_of_attorney.created_at,
+        'text_signatures' => signatures
+      }
+    )
+    power_of_attorney.save!
   end
 
   after do
     Timecop.return
   end
 
-  it 'construct pdf' do
-    power_of_attorney = ClaimsApi::PowerOfAttorney.find(temp.id)
-    data = power_of_attorney.form_data.deep_merge(
-      {
-        'veteran' => {
-          'firstName' => power_of_attorney.auth_headers['va_eauth_firstName'],
-          'lastName' => power_of_attorney.auth_headers['va_eauth_lastName'],
-          'ssn' => power_of_attorney.auth_headers['va_eauth_pnid'],
-          'birthdate' => power_of_attorney.auth_headers['va_eauth_birthdate']
-        },
-        'appointmentDate' => power_of_attorney.created_at,
-        'text_signatures' => {
-          'page2' => [
-            {
-              'signature' => 'Lillian Disney - signed via api.va.gov',
-              'x' => 35,
-              'y' => 306
-            },
-            {
-              'signature' => 'Bob Law - signed via api.va.gov',
-              'x' => 35,
-              'y' => 200
-            }
-          ]
-        },
-        'representative' => {
-          'firstName' => 'Bob',
-          'lastName' => 'Law'
-        }
-      }
-    )
+  context 'page1_options' do
+    it 'returns the expected values' do
+      res = subject.send(:page1_options, power_of_attorney.form_data)
 
-    constructor = ClaimsApi::V2::PoaPdfConstructor::Individual.new
-    expected_pdf = Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', '21-22A', 'v2',
-                                   'signed_filled_final.pdf')
-    generated_pdf = constructor.construct(data, id: power_of_attorney.id)
-    expect(generated_pdf).to match_pdf_content_of(expected_pdf)
+      expect(res.values).to match(expected_page1_values)
+    end
   end
 
-  it "constructs the pdf when 'other service branch' is entered in" do
-    power_of_attorney = ClaimsApi::PowerOfAttorney.find(other_service_branch_temp.id)
-    data = power_of_attorney.form_data.deep_merge(
-      {
-        'veteran' => {
-          'firstName' => power_of_attorney.auth_headers['va_eauth_firstName'],
-          'lastName' => power_of_attorney.auth_headers['va_eauth_lastName'],
-          'ssn' => power_of_attorney.auth_headers['va_eauth_pnid'],
-          'birthdate' => power_of_attorney.auth_headers['va_eauth_birthdate']
-        },
-        'appointmentDate' => power_of_attorney.created_at,
-        'text_signatures' => {
-          'page2' => [
-            {
-              'signature' => 'Lillian Disney - signed via api.va.gov',
-              'x' => 35,
-              'y' => 306
-            },
-            {
-              'signature' => 'Bob Law - signed via api.va.gov',
-              'x' => 35,
-              'y' => 200
-            }
-          ]
-        },
-        'representative' => {
-          'firstName' => 'Bob',
-          'lastName' => 'Law'
-        }
-      }
-    )
+  context 'page2_options' do
+    it 'returns the expected values' do
+      res = subject.send(:page2_options, power_of_attorney.form_data)
 
-    constructor = ClaimsApi::V2::PoaPdfConstructor::Individual.new
-    expected_pdf = Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', '21-22A', 'v2',
-                                   'signed_filled_final_other_service_branch.pdf')
-    generated_pdf = constructor.construct(data, id: power_of_attorney.id)
-    expect(generated_pdf).to match_pdf_content_of(expected_pdf)
+      expect(res.values).to match(expected_page2_values)
+    end
   end
 
-  it 'constructs the pdf when phone country codes are present on form' do
-    power_of_attorney = ClaimsApi::PowerOfAttorney.find(phone_country_codes_temp.id)
-    data = power_of_attorney.form_data.deep_merge(
-      {
-        'veteran' => {
-          'firstName' => power_of_attorney.auth_headers['va_eauth_firstName'],
-          'lastName' => power_of_attorney.auth_headers['va_eauth_lastName'],
-          'ssn' => power_of_attorney.auth_headers['va_eauth_pnid'],
-          'birthdate' => power_of_attorney.auth_headers['va_eauth_birthdate']
-        },
-        'appointmentDate' => power_of_attorney.created_at,
-        'text_signatures' => {
-          'page2' => [
-            {
-              'signature' => 'Lillian Disney - signed via api.va.gov',
-              'x' => 35,
-              'y' => 306
-            },
-            {
-              'signature' => 'Bob Law - signed via api.va.gov',
-              'x' => 35,
-              'y' => 200
-            }
-          ]
-        },
-        'representative' => {
-          'firstName' => 'Bob',
-          'lastName' => 'Law'
-        }
-      }
-    )
+  private
 
-    constructor = ClaimsApi::V2::PoaPdfConstructor::Individual.new
-    expected_pdf = Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', '21-22A', 'v2',
-                                   'signed_filled_phone_country_codes.pdf')
-    generated_pdf = constructor.construct(data, id: power_of_attorney.id)
-    expect(generated_pdf).to match_pdf_content_of(expected_pdf)
+  def veteran_attributes(auth_headers)
+    {
+      'firstName' => auth_headers['va_eauth_firstName'],
+      'lastName' => auth_headers['va_eauth_lastName'],
+      'ssn' => auth_headers['va_eauth_pnid'],
+      'birthdate' => auth_headers['va_eauth_birthdate']
+    }
+  end
+
+  def data_for_poa(poa)
+    {
+      'veteran' => veteran(poa.auth_headers),
+      'appointmentDate' => poa.created_at,
+      'text_signatures' => signatures,
+      'representative' => representative
+    }
   end
 end

--- a/modules/claims_api/spec/lib/claims_api/v2/poa_pdf_constructor/organization_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/poa_pdf_constructor/organization_spec.rb
@@ -7,7 +7,7 @@ require_relative '../../../../support/pdf_matcher'
 describe ClaimsApi::V2::PoaPdfConstructor::Organization do
   subject { ClaimsApi::V2::PoaPdfConstructor::Organization.new }
 
-  let(:temp) { create(:power_of_attorney, :with_full_headers) }
+  let(:power_of_attorney) { create(:power_of_attorney, :with_full_headers) }
   # we do not do anything for item 3 & 6
   let(:item_one) { %w[GRAY JESSE] } # veteran name
   let(:item_two) { %w[796 37 8881] } # vet ssn
@@ -53,9 +53,6 @@ describe ClaimsApi::V2::PoaPdfConstructor::Organization do
       }
     )
   end
-  let(:invalid_temp) { create(:power_of_attorney, :with_full_headers) }
-  let(:phone_country_codes_temp) { create(:power_of_attorney, :with_full_headers) }
-  let(:power_of_attorney) { ClaimsApi::PowerOfAttorney.find(temp.id) }
   let(:signatures) do
     {
       'page2' => [

--- a/modules/claims_api/spec/sidekiq/v2/poa_form_builder_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/v2/poa_form_builder_job_spec.rb
@@ -197,36 +197,33 @@ RSpec.describe ClaimsApi::V2::PoaFormBuilderJob, type: :job, vcr: 'bgs/person_we
                        'lastName' => power_of_attorney.auth_headers['va_eauth_lastName'],
                        'ssn' => power_of_attorney.auth_headers['va_eauth_pnid'],
                        'birthdate' => power_of_attorney.auth_headers['va_eauth_birthdate']
-                     }
-                   }
-                 )
-                 .deep_merge(
-                   {
+                     },
+                     'text_signatures' => {
+                       'page2' => [
+                         {
+                           'signature' => 'Mitchell Jenkins - signed via api.va.gov',
+                           'x' => 35,
+                           'y' => 306
+                         },
+                         {
+                           'signature' => 'Bob Representative - signed via api.va.gov',
+                           'x' => 35,
+                           'y' => 200
+                         }
+                       ]
+                     },
+                     'representative' => {
+                       'firstName' => 'Bob',
+                       'lastName' => 'Representative'
+                     },
+                     'dependent' => {
+                       'first_name' => 'Mitchell',
+                       'last_name' => 'Jenkins'
+                     },
                      'appointmentDate' => power_of_attorney.created_at
                    }
                  )
-          final_data = data.deep_merge(
-            {
-              'text_signatures' => {
-                'page2' => [
-                  {
-                    'signature' => 'Mitchell Jenkins - signed via api.va.gov',
-                    'x' => 35,
-                    'y' => 306
-                  },
-                  {
-                    'signature' => 'Bob Representative - signed via api.va.gov',
-                    'x' => 35,
-                    'y' => 200
-                  }
-                ]
-              },
-              'representative' => {
-                'firstName' => 'Bob',
-                'lastName' => 'Representative'
-              }
-            }
-          )
+
           power_of_attorney.auth_headers.deep_merge!(
             {
               'dependent' => {
@@ -240,7 +237,7 @@ RSpec.describe ClaimsApi::V2::PoaFormBuilderJob, type: :job, vcr: 'bgs/person_we
           allow_any_instance_of(BGS::PersonWebService).to receive(:find_by_ssn).and_return({ file_nbr: '123456789' })
           expect_any_instance_of(ClaimsApi::V2::PoaPdfConstructor::Individual)
             .to receive(:construct)
-            .with(final_data, id: power_of_attorney.id)
+            .with(data, id: power_of_attorney.id)
             .and_call_original
 
           subject.new.perform(power_of_attorney.id, '2122A', 'post',
@@ -295,43 +292,35 @@ RSpec.describe ClaimsApi::V2::PoaFormBuilderJob, type: :job, vcr: 'bgs/person_we
                      'lastName' => power_of_attorney.auth_headers['va_eauth_lastName'],
                      'ssn' => power_of_attorney.auth_headers['va_eauth_pnid'],
                      'birthdate' => power_of_attorney.auth_headers['va_eauth_birthdate']
+                   },
+                   'appointmentDate' => power_of_attorney.created_at,
+                   'text_signatures' => {
+                     'page2' => [
+                       {
+                         'signature' => 'JESSE GRAY - signed via api.va.gov',
+                         'x' => 35,
+                         'y' => 240
+                       },
+                       {
+                         'signature' => 'Bob Representative - signed via api.va.gov',
+                         'x' => 35,
+                         'y' => 200
+                       }
+                     ]
+                   },
+                   'serviceOrganization' => {
+                     'firstName' => 'Bob',
+                     'lastName' => 'Representative',
+                     'organizationName' => 'I Help Vets LLC'
                    }
                  }
                )
-               .deep_merge(
-                 {
-                   'appointmentDate' => power_of_attorney.created_at
-                 }
-               )
-        final_data = data.deep_merge(
-          {
-            'text_signatures' => {
-              'page2' => [
-                {
-                  'signature' => 'JESSE GRAY - signed via api.va.gov',
-                  'x' => 35,
-                  'y' => 240
-                },
-                {
-                  'signature' => 'Bob Representative - signed via api.va.gov',
-                  'x' => 35,
-                  'y' => 200
-                }
-              ]
-            },
-            'serviceOrganization' => {
-              'firstName' => 'Bob',
-              'lastName' => 'Representative',
-              'organizationName' => 'I Help Vets LLC'
-            }
-          }
-        )
 
         allow_any_instance_of(BGS::PersonWebService).to receive(:find_by_ssn).and_return({ file_nbr: '123456789' })
         VCR.use_cassette('claims_api/mpi/find_candidate/valid_icn_full') do
           expect_any_instance_of(ClaimsApi::V2::PoaPdfConstructor::Organization)
             .to receive(:construct)
-            .with(final_data, id: power_of_attorney.id)
+            .with(data, id: power_of_attorney.id)
             .and_call_original
 
           subject.new.perform(power_of_attorney.id, '2122', 'post',
@@ -420,37 +409,33 @@ RSpec.describe ClaimsApi::V2::PoaFormBuilderJob, type: :job, vcr: 'bgs/person_we
                      'lastName' => power_of_attorney.auth_headers['va_eauth_lastName'],
                      'ssn' => power_of_attorney.auth_headers['va_eauth_pnid'],
                      'birthdate' => power_of_attorney.auth_headers['va_eauth_birthdate']
-                   }
-                 }
-               )
-               .deep_merge(
-                 {
+                   },
+                   'text_signatures' => {
+                     'page2' => [
+                       {
+                         'signature' => 'Mitchell Jenkins - signed via api.va.gov',
+                         'x' => 35,
+                         'y' => 240
+                       },
+                       {
+                         'signature' => 'Bob Representative - signed via api.va.gov',
+                         'x' => 35,
+                         'y' => 200
+                       }
+                     ]
+                   },
+                   'serviceOrganization' => {
+                     'firstName' => 'Bob',
+                     'lastName' => 'Representative',
+                     'organizationName' => 'I Help Vets LLC'
+                   },
+                   'dependent' => {
+                     'first_name' => 'Mitchell',
+                     'last_name' => 'Jenkins'
+                   },
                    'appointmentDate' => power_of_attorney.created_at
                  }
                )
-        final_data = data.deep_merge(
-          {
-            'text_signatures' => {
-              'page2' => [
-                {
-                  'signature' => 'Mitchell Jenkins - signed via api.va.gov',
-                  'x' => 35,
-                  'y' => 240
-                },
-                {
-                  'signature' => 'Bob Representative - signed via api.va.gov',
-                  'x' => 35,
-                  'y' => 200
-                }
-              ]
-            },
-            'serviceOrganization' => {
-              'firstName' => 'Bob',
-              'lastName' => 'Representative',
-              'organizationName' => 'I Help Vets LLC'
-            }
-          }
-        )
 
         power_of_attorney.auth_headers.deep_merge!(
           {
@@ -466,7 +451,7 @@ RSpec.describe ClaimsApi::V2::PoaFormBuilderJob, type: :job, vcr: 'bgs/person_we
         VCR.use_cassette('claims_api/mpi/find_candidate/valid_icn_full') do
           expect_any_instance_of(ClaimsApi::V2::PoaPdfConstructor::Organization)
             .to receive(:construct)
-            .with(final_data, id: power_of_attorney.id)
+            .with(data, id: power_of_attorney.id)
             .and_call_original
 
           subject.new.perform(power_of_attorney.id, '2122', 'post',


### PR DESCRIPTION
## Summary
* The v2 PDF constructors where looking for the claimant (dependent) information based on the v1 form object.
This PR fixes that
* The tests for the PDf constructors were also using the v1 form.  This refactors those tests to expect the v2 form, and also removes the checks for actual PDf generation, preferring to make sure the data is correct and being handled correctly.

## Related issue(s)
[API-48224](https://jira.devops.va.gov/browse/API-48224)

## Testing done

- [x] *Refactored code and tests, no new functionality introduced here.

## Screenshots
* Vet Claimant
<img width="1048" height="709" alt="Screenshot 2025-07-24 084201" src="https://github.com/user-attachments/assets/f11580d3-fe77-401b-95d2-6a2460b08669" />

* Dependent Claimant
<img width="913" height="646" alt="Screenshot 2025-07-24 084220" src="https://github.com/user-attachments/assets/8b041e9c-703d-4897-94b2-2a4f1465eb46" />

## What areas of the site does it impact?
	modified:   modules/claims_api/app/sidekiq/claims_api/v2/poa_form_builder_job.rb
	modified:   modules/claims_api/lib/claims_api/v2/poa_pdf_constructor/base.rb
	modified:   modules/claims_api/lib/claims_api/v2/poa_pdf_constructor/individual.rb
	modified:   modules/claims_api/spec/factories/claims_api_base_factory.rb
	modified:   modules/claims_api/spec/lib/claims_api/v2/poa_pdf_constructor/individual_spec.rb
	modified:   modules/claims_api/spec/lib/claims_api/v2/poa_pdf_constructor/organization_spec.rb
	modified:   modules/claims_api/spec/sidekiq/v2/poa_form_builder_job_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

The mjority of the line count change is the refactored/ simplified tests
