### PR TITLE
[Decision Reviews] Prevent schema errors related to evidence retrieval requests for duplicate facilities 

### DIFF
--- a/modules/decision_reviews/spec/controllers/supplemental_claims_controller_spec.rb
+++ b/modules/decision_reviews/spec/controllers/supplemental_claims_controller_spec.rb
@@ -1,0 +1,296 @@
+# frozen_string_literal: true
+
+require './modules/decision_reviews/spec/dr_spec_helper'
+require './modules/decision_reviews/spec/support/vcr_helper'
+
+RSpec.describe DecisionReviews::V1::SupplementalClaimsController, type: :controller do
+  routes { DecisionReviews::Engine.routes }
+
+  let(:user) { build(:user, :loa3) }
+
+  before do
+    sign_in_as(user)
+  end
+
+  describe '#normalize_evidence_retrieval_for_lighthouse_schema' do
+    subject(:normalized_data) { controller.send(:normalize_evidence_retrieval_for_lighthouse_schema, req_body_obj) }
+
+    context 'when retrieveFrom is an array with no duplicates' do
+      let(:req_body_obj) do
+        {
+          'data' => {
+            'attributes' => {
+              'evidenceSubmission' => {
+                'evidenceType' => ['retrieval'],
+                'retrieveFrom' => [
+                  {
+                    'attributes' => {
+                      'locationAndName' => 'VA Medical Center - Boston',
+                      'evidenceDates' => [
+                        { 'startDate' => '2005-01', 'endDate' => '2005-01' }
+                      ]
+                    }
+                  },
+                  {
+                    'attributes' => {
+                      'locationAndName' => 'VA Medical Center - Philadelphia',
+                      'evidenceDates' => [
+                        { 'startDate' => '2004-01', 'endDate' => '2004-01' }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      end
+
+      it 'returns the original array unchanged' do
+        expect(normalized_data).to eq(req_body_obj)
+      end
+    end
+
+    context 'when retrieveFrom has duplicate locations' do
+      let(:req_body_obj) do
+        {
+          'data' => {
+            'attributes' => {
+              'evidenceSubmission' => {
+                'evidenceType' => ['retrieval'],
+                'retrieveFrom' => [
+                  {
+                    'attributes' => {
+                      'locationAndName' => 'VA Medical Center - Boston',
+                      'evidenceDates' => [
+                        { 'startDate' => '2005-01', 'endDate' => '2005-01' }
+                      ]
+                    }
+                  },
+                  {
+                    'attributes' => {
+                      'locationAndName' => 'VA Medical Center - Boston',
+                      'evidenceDates' => [
+                        { 'startDate' => '2004-01', 'endDate' => '2004-01' }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      end
+
+      let(:expected_result) do
+        {
+          'data' => {
+            'attributes' => {
+              'evidenceSubmission' => {
+                'evidenceType' => ['retrieval'],
+                'retrieveFrom' => [
+                  {
+                    'attributes' => {
+                      'locationAndName' => 'VA Medical Center - Boston',
+                      'evidenceDates' => [
+                        { 'startDate' => '2004-01', 'endDate' => '2004-01' },
+                        { 'startDate' => '2005-01', 'endDate' => '2005-01' }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      end
+
+      it 'merges entries with the same location' do
+        expect(normalized_data).to eq(expected_result)
+      end
+    end
+  end
+
+  describe '#merge_evidence_entries' do
+    subject(:merged_entry) { controller.send(:merge_evidence_entries, entries) }
+
+    context 'when entries have different evidence dates' do
+      let(:entries) do
+        [
+          {
+            'attributes' => {
+              'locationAndName' => 'VA Medical Center - Boston',
+              'evidenceDates' => [
+                { 'startDate' => '2005-01', 'endDate' => '2005-01' }
+              ]
+            }
+          },
+          {
+            'attributes' => {
+              'locationAndName' => 'VA Medical Center - Boston',
+              'evidenceDates' => [
+                { 'startDate' => '2004-01', 'endDate' => '2004-01' }
+              ]
+            }
+          }
+        ]
+      end
+
+      let(:expected_result) do
+        {
+          'attributes' => {
+            'locationAndName' => 'VA Medical Center - Boston',
+            'evidenceDates' => [
+              { 'startDate' => '2004-01', 'endDate' => '2004-01' },
+              { 'startDate' => '2005-01', 'endDate' => '2005-01' }
+            ]
+          }
+        }
+      end
+
+      it 'combines all evidence dates in chronological order' do
+        expect(merged_entry).to eq(expected_result)
+      end
+    end
+
+    context 'when entries have duplicate evidence dates' do
+      let(:entries) do
+        [
+          {
+            'attributes' => {
+              'locationAndName' => 'VA Medical Center - Boston',
+              'evidenceDates' => [
+                { 'startDate' => '2005-01', 'endDate' => '2005-01' }
+              ]
+            }
+          },
+          {
+            'attributes' => {
+              'locationAndName' => 'VA Medical Center - Boston',
+              'evidenceDates' => [
+                { 'startDate' => '2005-01', 'endDate' => '2005-01' }
+              ]
+            }
+          }
+        ]
+      end
+
+      let(:expected_result) do
+        {
+          'attributes' => {
+            'locationAndName' => 'VA Medical Center - Boston',
+            'evidenceDates' => [
+              { 'startDate' => '2005-01', 'endDate' => '2005-01' }
+            ]
+          }
+        }
+      end
+
+      it 'removes duplicate evidence dates' do
+        expect(merged_entry).to eq(expected_result)
+      end
+    end
+
+    context 'when there are more than 4 evidence dates from multiple entries' do
+      let(:entries) do
+        [
+          {
+            'attributes' => {
+              'locationAndName' => 'VA Medical Center - Boston',
+              'evidenceDates' => [
+                { 'startDate' => '2005-01', 'endDate' => '2005-01' }
+              ]
+            }
+          },
+          {
+            'attributes' => {
+              'locationAndName' => 'VA Medical Center - Boston',
+              'evidenceDates' => [
+                { 'startDate' => '2004-01', 'endDate' => '2004-01' }
+              ]
+            }
+          },
+          {
+            'attributes' => {
+              'locationAndName' => 'VA Medical Center - Boston',
+              'evidenceDates' => [
+                { 'startDate' => '2003-01', 'endDate' => '2003-01' }
+              ]
+            }
+          },
+          {
+            'attributes' => {
+              'locationAndName' => 'VA Medical Center - Boston',
+              'evidenceDates' => [
+                { 'startDate' => '2001-01', 'endDate' => '2001-01' }
+              ]
+            }
+          },
+          {
+            'attributes' => {
+              'locationAndName' => 'VA Medical Center - Boston',
+              'evidenceDates' => [
+                { 'startDate' => '2024-01', 'endDate' => '2024-01' }
+              ]
+            }
+          }
+        ]
+      end
+
+      let(:expected_result) do
+        {
+          'attributes' => {
+            'locationAndName' => 'VA Medical Center - Boston',
+            'evidenceDates' => [
+              { 'startDate' => '2001-01', 'endDate' => '2001-01' },
+              { 'startDate' => '2003-01', 'endDate' => '2003-01' },
+              { 'startDate' => '2004-01', 'endDate' => '2004-01' },
+              { 'startDate' => '2005-01', 'endDate' => '2005-01' }
+            ]
+          }
+        }
+      end
+
+      it 'limits to the first 4 evidence dates' do
+        expect(merged_entry).to eq(expected_result)
+        expect(merged_entry['attributes']['evidenceDates'].length).to eq(4)
+      end
+    end
+
+    context 'when entries have nil evidenceDates' do
+      let(:entries) do
+        [
+          {
+            'attributes' => {
+              'locationAndName' => 'VA Medical Center - Boston',
+              'evidenceDates' => nil
+            }
+          },
+          {
+            'attributes' => {
+              'locationAndName' => 'VA Medical Center - Boston',
+              'evidenceDates' => [
+                { 'startDate' => '2004-01', 'endDate' => '2004-01' }
+              ]
+            }
+          }
+        ]
+      end
+
+      let(:expected_result) do
+        {
+          'attributes' => {
+            'locationAndName' => 'VA Medical Center - Boston',
+            'evidenceDates' => [
+              { 'startDate' => '2004-01', 'endDate' => '2004-01' }
+            ]
+          }
+        }
+      end
+
+      it 'handles nil evidence dates gracefully' do
+        expect(merged_entry).to eq(expected_result)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- *(Which team do you work for, does your team own the maintenance of this component?)* Decision Reviews / yes
This PR fixes one of the most common errors we've been seeing that prevent users from submitting a Supplemental Claim via VA.gov. Lighthouse returns 422 Unprocessable Entity, with code 147 & message: "The (n) items provided did not match the definition", and a pointer to the `/data/attributes/evidenceSubmission/retrieveFrom` part of the schema (example [log from staging](https://vagov.ddog-gov.com/logs?query=env%3Aeks-staging%20service%3Avets-api%20%40payload.action%3A%22Overall%20claim%20submission%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZgyy2w8ph72lAAAABhBWmd5eTNNWEFBRDJIOUdWZUV3LWZnQVQAAAAkMDE5ODMyZGMtZmI5Yy00ZTNlLWFmMzUtMjBiMGU5ZjM0MGI4AAGCjg&graphType=flamegraph&messageDisplay=inline&refresh_mode=paused&sort=time&storage=hot&stream_sort=desc&viz=stream&from_ts=1753156800000&to_ts=1753243199999&live=false) where I reproduced the error).  

It turns out this error is coming from users who are adding the same **exact** (case-sensitive) facility name and treatment date information (when they want us to help retrieve their medical records for them) more than once. Our UI allows this as long as a different issue is checked per facility, but the [Lighthouse schema](https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/appeals_api/config/schemas/decision_reviews/v2/200995.json#L236) expects a unique array. Since we remove the "issues" before submitting, this uniqueness constraint is violated:

> "description": "'upload' indicates that the Veteran has supplied additional evidence as uploaded documents. 'retrieval' indicates that the Veteran has supplied contact information for facilities holding evidence relevant to the claim; the 'retrieveFrom' field will contain the facility's contact information. 'none' indicates that the Veteran has not supplied additional evidence."

## Related issue(s)

- Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/113466 
- This [related UI issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/114573), once fixed, should also make it easier for users to understand that they don't need to provide treatment dates unless they were treated before 2005, making it less likely that they will encounter this error 

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
Steps to reproduce bug (in staging or locally, not using this branch):
1. Start a new Supplemental Claim application. Make sure you select or create at least two contestable issues. 
<img width="539" height="612" alt="Image" src="https://github.com/user-attachments/assets/95149699-7aac-43be-8cf8-b4951417ac0e" />

2. Select the non-VA healthcare provider option on the [facility types screen](http://localhost:3001/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/facility-types)

 <img width="713" height="739" alt="Image" src="https://github.com/user-attachments/assets/8fdeceac-606f-4e2d-a37a-3649a34a7bd6" />

3. On the ["New and relevant evidence" screen](http://localhost:3001/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/supporting-evidence/request-va-medical-records), answer "Yes" to the "Do you want us to get your medical records from a VA or military treatment location?" question
 
4. On the [VA medical records screen ](http://localhost:3001/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/supporting-evidence/va-medical-records), add the same facility twice, but each with a different issue checked, and enter **the same date, e.g. Jan 2020** for both facilities. NOTE: checking the "no treatment date" box for duplicate facilities causes the FE to automatically merge them, so the error won't be triggered. Similarly, providing a different date won't trigger the error, since the FE removes the issues before submitting

<img width="763" height="854" alt="Image" src="https://github.com/user-attachments/assets/2d973b46-5b6e-4589-85ec-14f96b46b722" />

4. In the server logs you should see the 422 Unprocessable Entity error pop up
<img width="694" height="303" alt="Image" src="https://github.com/user-attachments/assets/16f1d163-6c3a-4363-90eb-d45d6294e6a0" />
<img width="1294" height="98" alt="Image" src="https://github.com/user-attachments/assets/035ecd43-746d-4b26-94f1-18f1330d2218" />
<img width="1120" height="458" alt="Screenshot 2025-07-25 at 11 40 35 AM" src="https://github.com/user-attachments/assets/70b7287e-f6c9-4cd0-a2df-d12980d12ae4" />

On this branch, going through the same flow should result in a successful submission and no error.

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)* Decision Reviews - File a Supplemental Claim

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [z]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature