### PR TITLE
API-40053-va-notify-followup-params-fix

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/va_notify_follow_up_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/va_notify_follow_up_job.rb
@@ -24,19 +24,21 @@ module ClaimsApi
       slack_client.notify(msg)
     end
 
-    def perform(notification_id, poa_id) # rubocop:disable Metrics/MethodLength
+    def perform(notification_id, poa_id = nil) # rubocop:disable Metrics/MethodLength
       status = notification_response_status(notification_id)
       detail = "Status for notification #{notification_id} was '#{status}'"
 
-      # Call logic to map VANotify status to our internal step status
-      step_status = map_notify_status(status)
-      # Update the POA process step with latest status
-      poa = ClaimsApi::PowerOfAttorney.find(poa_id)
-      process = ClaimsApi::Process.find_or_create_by(processable: poa, step_type: 'CLAIMANT_NOTIFICATION')
-      if step_status == 'IN_PROGRESS'
-        process.update!(step_status:, error_messages: [])
-      else
-        process.update!(step_status:, error_messages: [], completed_at: Time.zone.now)
+      if poa_id
+        # Call logic to map VANotify status to our internal step status
+        step_status = map_notify_status(status)
+        # Update the POA process step with latest status
+        poa = ClaimsApi::PowerOfAttorney.find(poa_id)
+        process = ClaimsApi::Process.find_or_create_by(processable: poa, step_type: 'CLAIMANT_NOTIFICATION')
+        if step_status == 'IN_PROGRESS'
+          process.update!(step_status:, error_messages: [])
+        else
+          process.update!(step_status:, error_messages: [], completed_at: Time.zone.now)
+        end
       end
 
       handle_failure(detail) if status == 'permanent-failure'

--- a/modules/claims_api/spec/sidekiq/va_notify_declined_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/va_notify_declined_job_spec.rb
@@ -7,13 +7,13 @@ describe ClaimsApi::VANotifyDeclinedJob, type: :job do
 
   let(:va_notify_key) { ClaimsApi::V2::Veterans::PowerOfAttorney::BaseController::VA_NOTIFY_KEY.to_s }
   let(:lockbox) { Lockbox.new(key: Settings.lockbox.master_key) }
+  let(:vanotify_service) { instance_double(VaNotify::Service) }
+  let(:ptcpnt_id) { '123456789' }
+  let(:first_name) { 'Jane' }
+  let(:encrypted_ptcpnt_id) { Base64.strict_encode64(lockbox.encrypt(ptcpnt_id)) }
+  let(:encrypted_first_name) { Base64.strict_encode64(lockbox.encrypt(first_name)) }
 
   context 'when the representative is a service organization' do
-    let(:vanotify_service) { instance_double(VaNotify::Service) }
-    let(:ptcpnt_id) { '123456789' }
-    let(:first_name) { 'Jane' }
-    let(:encrypted_ptcpnt_id) { Base64.strict_encode64(lockbox.encrypt(ptcpnt_id)) }
-    let(:encrypted_first_name) { Base64.strict_encode64(lockbox.encrypt(first_name)) }
     let(:representative_id) { '123' }
 
     before do
@@ -40,11 +40,6 @@ describe ClaimsApi::VANotifyDeclinedJob, type: :job do
   end
 
   context 'when the representative is an individual' do
-    let(:vanotify_service) { instance_double(VaNotify::Service) }
-    let(:ptcpnt_id) { '123456789' }
-    let(:first_name) { 'Jane' }
-    let(:encrypted_ptcpnt_id) { Base64.strict_encode64(lockbox.encrypt(ptcpnt_id)) }
-    let(:encrypted_first_name) { Base64.strict_encode64(lockbox.encrypt(first_name)) }
     let(:representative_id) { '456' }
 
     before do

--- a/modules/claims_api/spec/sidekiq/va_notify_follow_up_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/va_notify_follow_up_job_spec.rb
@@ -13,6 +13,30 @@ describe ClaimsApi::VANotifyFollowUpJob, type: :job do
     let(:notification_id) { '111111-1111-1111-11111111' }
     let(:temp) { create(:power_of_attorney, :with_full_headers) }
 
+    context 'queue up the job' do
+      before do
+        allow_any_instance_of(described_class).to receive(:notification_response_status).and_return('delivered')
+      end
+
+      it 'queues up with just the notification_id' do
+        expect do
+          subject.perform(notification_id)
+        end.not_to raise_error
+      end
+
+      it 'queues up with notification_id and poa_id' do
+        expect do
+          subject.perform(notification_id, temp.id)
+        end.not_to raise_error
+      end
+
+      it 'throws an argument error when other params are added' do
+        expect do
+          subject.perform(notification_id, 'status_id', temp.id)
+        end.to raise_error(ArgumentError)
+      end
+    end
+
     context 'no retry statues' do
       shared_examples 'does not requeue the job' do |status|
         it "when the status is #{status}" do


### PR DESCRIPTION
## Summary
* Makes `poa_id` param optional since we do not send this from the declined workflow
* Adjusts the follow up job code to handle the optional param
* Includes a refactor to just clean up a little bit of duplication in a related test file

## Related issue(s)
[API-48226](https://jira.devops.va.gov/browse/API-48226)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/sidekiq/claims_api/va_notify_follow_up_job.rb
	modified:   modules/claims_api/spec/sidekiq/va_notify_declined_job_spec.rb

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
