### PR TITLE
API-47460 Optimize header_hash filler job

### DIFF
--- a/modules/claims_api/spec/sidekiq/one_off/header_hash_filler_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/one_off/header_hash_filler_job_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe ClaimsApi::OneOff::HeaderHashFillerJob, type: :job do
     it 'logs count of records processed' do
       expect(ClaimsApi::Logger).to receive(:log).with(
         'header_hash_filler_job',
-        details: 'ClaimsApi::PowerOfAttorney completed with 10 record(s)'
+        details: 'Processed 10 records for ClaimsApi::PowerOfAttorney. 0 records remain.'
       )
 
       subject.perform 'ClaimsApi::PowerOfAttorney'


### PR DESCRIPTION
## Summary
Optimizations for #23158. Doing a test run of the original on sandbox took 7 minutes to update 5000 records 😞 . This job refactors to add some common memory & processing-reduction steps to see if that improves performance, along with changing some arguments & logging so a naive call w/o args won't stall for 7 minutes 😛

## Related issue(s)
#23158

## Testing done

- [x] *New code is covered by unit tests*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs