### PR TITLE
115203 cc appts log missing req params for draft endpoint

### DIFF
--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -75,24 +75,21 @@ module VAOS
       def create_draft
         referral_id = draft_params[:referral_number]
         referral_consult_id = draft_params[:referral_consult_id]
-
-        begin
-          response_data = process_draft_appointment(referral_id, referral_consult_id)
-          if response_data[:success]
-            StatsD.increment(APPT_DRAFT_CREATION_SUCCESS_METRIC, tags: ['service:community_care_appointments'])
-            ccra_referral_service.clear_referral_cache(referral_id, current_user.icn)
-            render json: Eps::DraftAppointmentSerializer.new(response_data[:data]), status: :created
-          else
-            StatsD.increment(APPT_DRAFT_CREATION_FAILURE_METRIC, tags: ['service:community_care_appointments'])
-            render json: response_data[:json], status: response_data[:status]
-          end
-        rescue Redis::BaseError => e
+        response_data = process_draft_appointment(referral_id, referral_consult_id)
+        if response_data[:success]
+          StatsD.increment(APPT_DRAFT_CREATION_SUCCESS_METRIC, tags: ['service:community_care_appointments'])
+          ccra_referral_service.clear_referral_cache(referral_id, current_user.icn)
+          render json: Eps::DraftAppointmentSerializer.new(response_data[:data]), status: :created
+        else
           StatsD.increment(APPT_DRAFT_CREATION_FAILURE_METRIC, tags: ['service:community_care_appointments'])
-          handle_redis_error(e)
-        rescue => e
-          StatsD.increment(APPT_DRAFT_CREATION_FAILURE_METRIC, tags: ['service:community_care_appointments'])
-          handle_appointment_creation_error(e)
+          render json: response_data[:json], status: response_data[:status]
         end
+      rescue Redis::BaseError => e
+        StatsD.increment(APPT_DRAFT_CREATION_FAILURE_METRIC, tags: ['service:community_care_appointments'])
+        handle_redis_error(e)
+      rescue => e
+        StatsD.increment(APPT_DRAFT_CREATION_FAILURE_METRIC, tags: ['service:community_care_appointments'])
+        handle_appointment_creation_error(e)
       end
 
       def update
@@ -791,10 +788,15 @@ module VAOS
       # @return [void] Renders JSON error response with appropriate HTTP status
       #
       def handle_appointment_creation_error(e)
-        Rails.logger.error("#{CC_APPOINTMENTS}: Appointment creation error: #{e.class}")
-        original_status = e.respond_to?(:original_status) ? e.original_status : nil
-        status_code = appointment_error_status(original_status)
-        render(json: appt_creation_failed_error(error: e, status: original_status), status: status_code)
+        if e.is_a?(ActionController::ParameterMissing)
+          Rails.logger.error("#{CC_APPOINTMENTS}: Appointment creation error: #{e.class} - #{e.message}\n#{e.backtrace&.join("\n")}")
+          status_code = :bad_request
+        else
+          Rails.logger.error("#{CC_APPOINTMENTS}: Appointment creation error: #{e.class}")
+          original_status = e.respond_to?(:original_status) ? e.original_status : nil
+          status_code = appointment_error_status(original_status)
+        end
+        render(json: appt_creation_failed_error(error: e, status: status_code), status: status_code)
       end
 
       ##

--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -789,7 +789,9 @@ module VAOS
       #
       def handle_appointment_creation_error(e)
         if e.is_a?(ActionController::ParameterMissing)
-          Rails.logger.error("#{CC_APPOINTMENTS}: Appointment creation error: #{e.class} - #{e.message}\n#{e.backtrace&.join("\n")}")
+          error_message = "#{CC_APPOINTMENTS}: Appointment creation error: #{e.class} - #{e.message}\n"
+          error_message += e.backtrace&.join("\n") if e.backtrace
+          Rails.logger.error(error_message)
           status_code = :bad_request
         else
           Rails.logger.error("#{CC_APPOINTMENTS}: Appointment creation error: #{e.class}")

--- a/modules/vaos/spec/requests/vaos/v2/appointments_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/appointments_spec.rb
@@ -1795,6 +1795,14 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
           expect(error['detail']).to eq('Redis connection error')
         end
       end
+
+      context 'when request params are missing' do
+        it 'returns a bad_request status and appropriate error message' do
+          post '/vaos/v2/appointments/draft', params: { referral_consult_id: '12345' }, headers: inflection_header
+          expect(response).to have_http_status(:bad_request)
+          expect(response.body).to include('param is missing or the value is empty: referral_number')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): No

Adds logging for missing request params for the `create_draft` action.

## Related issue(s)

https://github.com/orgs/department-of-veterans-affairs/projects/1323/views/35?pane=issue&itemId=121408549&issue=department-of-veterans-affairs%7Cva.gov-team%7C115203

## Testing done

- [ ] *New code is covered by unit tests*
- [ ] *tested locally with betamocks*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
