### PR TITLE
Don't match on URL if service name exists in breakers_matcher

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1335,6 +1335,7 @@ spec/lib/claim_status_tool @department-of-veterans-affairs/benefits-management-t
 spec/lib/common/client/concerns/mhv_fhir_session_client_spec.rb @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/backend-review-group
 spec/lib/common/client/concerns/mhv_jwt_session_client_spec.rb @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/backend-review-group
 spec/lib/common/client/concerns/mhv_locked_session_client_spec.rb @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/backend-review-group
+spec/lib/common/client/configuration @department-of-veterans-affairs/backend-review-group
 spec/lib/common/client/middleware @department-of-veterans-affairs/backend-review-group
 spec/lib/common/client/session_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/lib/common/convert_to_pdf_spec.rb @department-of-veterans-affairs/backend-review-group

--- a/lib/common/client/configuration/base.rb
+++ b/lib/common/client/configuration/base.rb
@@ -103,11 +103,13 @@ module Common
           base_uri = URI.parse(base_path)
           proc do |breakers_service, request_env, request_service_name|
             # Match by service_name if available.
-            request_service_name == breakers_service.name if request_service_name
-
-            # Fall back to matching by request URL.
-            request_env.url.host == base_uri.host && request_env.url.port == base_uri.port &&
-              request_env.url.path =~ /^#{base_uri.path}/
+            if request_service_name
+              request_service_name == breakers_service.name
+            else
+              # Fall back to matching by request URL.
+              request_env.url.host == base_uri.host && request_env.url.port == base_uri.port &&
+                request_env.url.path =~ /^#{base_uri.path}/
+            end
           end
         end
 

--- a/spec/lib/common/client/configuration/base_spec.rb
+++ b/spec/lib/common/client/configuration/base_spec.rb
@@ -25,4 +25,53 @@ describe Common::Client::Configuration::Base do
       expect(SomeRandomModule).to be_const_defined('ServiceException')
     end
   end
+
+  describe '#breakers_matcher' do
+    let(:matcher) { subject.breakers_matcher }
+    let(:breakers_service) { double('breakers_service', name: 'derived_class') }
+    let(:request_env) do
+      double('request_env',
+             url: double('url',
+                         host: 'fakehost.gov',
+                         port: 443,
+                         path: '/base_path/some/endpoint'))
+    end
+
+    context 'when request_service_name is provided' do
+      it 'returns true when service names match' do
+        result = matcher.call(breakers_service, request_env, 'derived_class')
+        expect(result).to be true
+      end
+
+      it 'returns false when service names do not match' do
+        result = matcher.call(breakers_service, request_env, 'HCA')
+        expect(result).to be false
+      end
+    end
+
+    context 'when request_service_name is not provided' do
+      it 'returns true when URL matches host, port, and path prefix' do
+        result = matcher.call(breakers_service, request_env, nil)
+        expect(result).to be_truthy
+      end
+
+      it 'returns false when host does not match' do
+        allow(request_env.url).to receive(:host).and_return('nope.gov')
+        result = matcher.call(breakers_service, request_env, nil)
+        expect(result).to be_falsey
+      end
+
+      it 'returns false when port does not match' do
+        allow(request_env.url).to receive(:port).and_return(8080)
+        result = matcher.call(breakers_service, request_env, nil)
+        expect(result).to be_falsey
+      end
+
+      it 'returns false when path does not match prefix' do
+        allow(request_env.url).to receive(:path).and_return('/different_path/endpoint')
+        result = matcher.call(breakers_service, request_env, nil)
+        expect(result).to be_falsey
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper):* NO

The [proc in breakers_matcher](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/common/client/configuration/base.rb#L104-L110) gets called for every Breakers service until one returns true (i.e. matches). It's been returning true prematurely for at least one service (`Rx`) because it will match by request URL on `SM` because there are many URI similarities between the two services. This PR makes it so the matcher sees that the `request_service_name` is "SM" and checks to see if it matches the `breakers_service.name` ("Rx"). They don't match, so the `breakers_matcher` returns false. yay. And when `request_service_name` does meet its match, it will return true. 

## Related issue(s)
- Support request: https://dsva.slack.com/archives/CBU0KDSB1/p1753385484382109

## Testing done

- [x] *New code is covered by unit tests*

I tested in the console and also have new unit tests.

## What areas of the site does it impact?
The breakers_matcher in `lib/common/client/configuration/base.rb`

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
