### PR TITLE
Update certificate checker job

### DIFF
--- a/app/models/sign_in/certificate.rb
+++ b/app/models/sign_in/certificate.rb
@@ -4,6 +4,8 @@ module SignIn
   class Certificate < ApplicationRecord
     self.table_name = 'sign_in_certificates'
 
+    EXPIRING_WINDOW = 60.days
+
     has_many :config_certificates, dependent: :destroy
     has_many :client_configs, through: :config_certificates, source: :config, source_type: 'ClientConfig'
     has_many :service_account_configs, through: :config_certificates, source: :config,
@@ -11,8 +13,8 @@ module SignIn
 
     delegate :not_before, :not_after, :subject, :issuer, :serial, to: :certificate
 
-    scope :active, -> { select(&:active?) }
-    scope :expired, -> { select(&:expired?) }
+    scope :active,   -> { select(&:active?) }
+    scope :expired,  -> { select(&:expired?) }
     scope :expiring, -> { select(&:expiring?) }
 
     validates :pem, presence: true
@@ -24,26 +26,34 @@ module SignIn
       nil
     end
 
+    def certificate?
+      certificate.present?
+    end
+
     def public_key
       certificate&.public_key
     end
 
-    def active?
-      return if certificate.blank?
-
-      !expired?
-    end
-
     def expired?
-      return if certificate.blank?
-
-      not_after < Time.current
+      certificate? && not_after < Time.current
     end
 
     def expiring?
-      return if certificate.blank?
+      certificate? && !expired? && not_after < EXPIRING_WINDOW.from_now
+    end
 
-      not_after < 60.days.from_now
+    def active?
+      certificate? && not_after >= EXPIRING_WINDOW.from_now
+    end
+
+    def status
+      if expired?
+        'expired'
+      elsif expiring?
+        'expiring'
+      elsif active?
+        'active'
+      end
     end
 
     private

--- a/app/sidekiq/sign_in/certificate_checker_job.rb
+++ b/app/sidekiq/sign_in/certificate_checker_job.rb
@@ -18,8 +18,13 @@ class SignIn::CertificateCheckerJob
   private
 
   def check_certificates(config)
-    log_expired_certs(config) if config.certs.active.blank?
-    log_expiring_certs(config)
+    return if config.certs.active.any?
+
+    if config.certs.expiring.any?
+      log_expiring_certs(config)
+    elsif config.certs.expired.any?
+      log_expired_certs(config)
+    end
   end
 
   def log_expired_certs(config)

--- a/spec/models/sign_in/certificate_spec.rb
+++ b/spec/models/sign_in/certificate_spec.rb
@@ -120,6 +120,48 @@ RSpec.describe SignIn::Certificate, type: :model do
     end
   end
 
+  describe '#certificate?' do
+    context 'when certificate is valid' do
+      it 'returns true' do
+        expect(certificate.certificate?).to be true
+      end
+    end
+
+    context 'when certificate is invalid' do
+      subject(:certificate) { build(:sign_in_certificate, pem: 'not a valid pem') }
+
+      it 'returns false' do
+        expect(certificate.certificate?).to be false
+      end
+    end
+  end
+
+  describe '#status' do
+    context 'when certificate is active' do
+      subject(:certificate) { build(:sign_in_certificate) }
+
+      it 'returns "active"' do
+        expect(certificate.status).to eq('active')
+      end
+    end
+
+    context 'when certificate is expired' do
+      subject(:certificate) { build(:sign_in_certificate, :expired) }
+
+      it 'returns "expired"' do
+        expect(certificate.status).to eq('expired')
+      end
+    end
+
+    context 'when certificate is expiring' do
+      subject(:certificate) { build(:sign_in_certificate, :expiring) }
+
+      it 'returns "expiring"' do
+        expect(certificate.status).to eq('expiring')
+      end
+    end
+  end
+
   describe '#public_key' do
     context 'when certificate is valid' do
       it 'returns the public key of the certificate' do

--- a/spec/sidekiq/sign_in/certificate_checker_job_spec.rb
+++ b/spec/sidekiq/sign_in/certificate_checker_job_spec.rb
@@ -10,16 +10,30 @@ RSpec.describe SignIn::CertificateCheckerJob, type: :job do
   end
 
   describe '#perform' do
-    context 'when all configurations have valid certificates' do
-      it 'does not log any alerts' do
-        job.perform
-        expect(Rails.logger).not_to have_received(:warn)
-      end
-    end
-
     %i[service_account_config client_config].each do |factory_name|
-      context "when there are #{factory_name.to_s.pluralize}" do
+      context "for #{factory_name.to_s.humanize} configs" do
         let(:config) { create(factory_name) }
+
+        context 'with no certificates' do
+          it 'does not log any alerts' do
+            job.perform
+            expect(Rails.logger).not_to have_received(:warn)
+          end
+        end
+
+        context 'with only an active certificate' do
+          let(:active_certificate) { create(:sign_in_certificate) }
+
+          before do
+            config.certs << active_certificate
+            config.save(validate: false)
+          end
+
+          it 'does not log any alerts' do
+            job.perform
+            expect(Rails.logger).not_to have_received(:warn)
+          end
+        end
 
         context 'with an expired certificate' do
           let(:expired_certificate) { build(:sign_in_certificate, :expired) }
@@ -32,21 +46,22 @@ RSpec.describe SignIn::CertificateCheckerJob, type: :job do
 
           it 'logs an alert for the expired certificate' do
             job.perform
-
             expect(Rails.logger).to have_received(:warn).with(
               '[SignIn] [CertificateChecker] expired_certificate',
-              config_type: config.class.name,
-              config_id: config.id,
-              config_description: config.description,
-              certificate_subject: expired_certificate.subject.to_s,
-              certificate_issuer: expired_certificate.issuer.to_s,
-              certificate_serial: expired_certificate.serial.to_s,
-              certificate_not_before: expired_certificate.not_before.to_s,
-              certificate_not_after: expired_certificate.not_after.to_s
+              hash_including(
+                config_type: config.class.name,
+                config_id: config.id,
+                config_description: config.description,
+                certificate_subject: expired_certificate.subject.to_s,
+                certificate_issuer: expired_certificate.issuer.to_s,
+                certificate_serial: expired_certificate.serial.to_s,
+                certificate_not_before: expired_certificate.not_before.to_s,
+                certificate_not_after: expired_certificate.not_after.to_s
+              )
             )
           end
 
-          context 'and it also has an active certificate' do
+          context 'and an active certificate exists' do
             let(:active_certificate) { create(:sign_in_certificate) }
 
             before do
@@ -54,9 +69,25 @@ RSpec.describe SignIn::CertificateCheckerJob, type: :job do
               config.save(validate: false)
             end
 
-            it 'does not log an alert for the expired certificate when an active one exists' do
+            it 'does not log an alert for the expired certificate' do
               job.perform
+              expect(Rails.logger).not_to have_received(:warn).with(
+                '[SignIn] [CertificateChecker] expired_certificate',
+                anything
+              )
+            end
+          end
 
+          context 'and an expiring certificate exists' do
+            let(:expiring_certificate) { create(:sign_in_certificate, :expiring) }
+
+            before do
+              config.certs << expiring_certificate
+              config.save(validate: false)
+            end
+
+            it 'does not log an alert for the expired certificate' do
+              job.perform
               expect(Rails.logger).not_to have_received(:warn).with(
                 '[SignIn] [CertificateChecker] expired_certificate',
                 anything
@@ -75,17 +106,83 @@ RSpec.describe SignIn::CertificateCheckerJob, type: :job do
 
           it 'logs an alert for the expiring certificate' do
             job.perform
-
             expect(Rails.logger).to have_received(:warn).with(
               '[SignIn] [CertificateChecker] expiring_certificate',
-              config_type: config.class.name,
-              config_id: config.id,
-              config_description: config.description,
-              certificate_subject: expiring_certificate.subject.to_s,
-              certificate_issuer: expiring_certificate.issuer.to_s,
-              certificate_serial: expiring_certificate.serial.to_s,
-              certificate_not_before: expiring_certificate.not_before.to_s,
-              certificate_not_after: expiring_certificate.not_after.to_s
+              hash_including(
+                config_type: config.class.name,
+                config_id: config.id,
+                config_description: config.description,
+                certificate_subject: expiring_certificate.subject.to_s,
+                certificate_issuer: expiring_certificate.issuer.to_s,
+                certificate_serial: expiring_certificate.serial.to_s,
+                certificate_not_before: expiring_certificate.not_before.to_s,
+                certificate_not_after: expiring_certificate.not_after.to_s
+              )
+            )
+          end
+
+          context 'and an active certificate exists' do
+            let(:active_certificate) { create(:sign_in_certificate) }
+
+            before do
+              config.certs << active_certificate
+              config.save(validate: false)
+            end
+
+            it 'does not log an alert for the expiring certificate' do
+              job.perform
+              expect(Rails.logger).not_to have_received(:warn).with(
+                '[SignIn] [CertificateChecker] expiring_certificate',
+                anything
+              )
+            end
+          end
+
+          context 'and an expired certificate exists' do
+            let(:expired_certificate) { build(:sign_in_certificate, :expired) }
+
+            before do
+              expired_certificate.save(validate: false)
+              config.certs << expired_certificate
+              config.save(validate: false)
+            end
+
+            it 'logs only for the expiring certificate' do
+              job.perform
+
+              expect(Rails.logger).to have_received(:warn).with(
+                '[SignIn] [CertificateChecker] expiring_certificate',
+                hash_including(certificate_serial: expiring_certificate.serial.to_s)
+              )
+              expect(Rails.logger).not_to have_received(:warn).with(
+                '[SignIn] [CertificateChecker] expired_certificate',
+                anything
+              )
+            end
+          end
+        end
+
+        context 'with multiple expired certificates' do
+          let(:expired_cert1) { build(:sign_in_certificate, :expired) }
+          let(:expired_cert2) { build(:sign_in_certificate, :expired) }
+
+          before do
+            expired_cert1.save(validate: false)
+            expired_cert2.save(validate: false)
+            config.certs << expired_cert1 << expired_cert2
+            config.save(validate: false)
+          end
+
+          it 'logs an alert for each expired certificate when no active or expiring exist' do
+            job.perform
+
+            expect(Rails.logger).to have_received(:warn).with(
+              '[SignIn] [CertificateChecker] expired_certificate',
+              hash_including(certificate_serial: expired_cert1.serial.to_s)
+            )
+            expect(Rails.logger).to have_received(:warn).with(
+              '[SignIn] [CertificateChecker] expired_certificate',
+              hash_including(certificate_serial: expired_cert2.serial.to_s)
             )
           end
         end


### PR DESCRIPTION
## Summary

- Update certificate checker job to not log expiring certs if there is an active cert.
  - If there are any active certs it does not log anything
  - Does not log expired certs if there are expiring certs

## Testing
### In the rails console:
#### Create test certificates
```ruby
def build_test_pem(not_before:, not_after:)
  key  = OpenSSL::PKey::RSA.new(2048)
  name = OpenSSL::X509::Name.parse("/CN=Test #{SecureRandom.hex(4)}")

  cert = OpenSSL::X509::Certificate.new.tap do |c|
    c.version    = 2
    c.serial     = SecureRandom.random_number(2**64)
    c.subject    = name
    c.issuer     = name
    c.public_key = key.public_key
    c.not_before = not_before
    c.not_after  = not_after

    ef = OpenSSL::X509::ExtensionFactory.new
    ef.subject_certificate = c
    ef.issuer_certificate  = c
    c.add_extension ef.create_extension('basicConstraints', 'CA:FALSE', true)
    c.add_extension ef.create_extension('keyUsage', 'digitalSignature', true)

    c.sign(key, OpenSSL::Digest.new('SHA256'))
  end

  cert.to_pem
end

active_pem   = build_test_pem(not_before:  1.day.ago, not_after: 120.days.from_now)
expiring_pem = build_test_pem(not_before:  1.day.ago, not_after: 30.days.from_now)
expired_pem  = build_test_pem(not_before: 120.days.ago, not_after: 1.day.ago)

active   = SignIn::Certificate.new(pem: active_pem)
expiring = SignIn::Certificate.new(pem: expiring_pem)
expired  = SignIn::Certificate.new(pem: expired_pem)

[active, expiring, expired].each { |cert| cert.save!(validate: false) }
```
#### Check statuses
```ruby
puts active.status   # => "active"
puts expiring.status # => "expiring"
puts expired.status  # => "expired"
```

#### Check individual methods
```ruby
puts active.active?     # => true
puts active.expiring?   # => false
puts active.expired?    # => false

puts expiring.active?   # => false
puts expiring.expiring? # => true
puts expiring.expired?  # => false

puts expired.active?    # => false
puts expired.expiring?  # => false
puts expired.expired?   # => true
```

#### Check scopes
```ruby
puts SignIn::Certificate.active.map(&:id)   # => [active.id]
puts SignIn::Certificate.expiring.map(&:id) # => [expiring.id]
puts SignIn::Certificate.expired.map(&:id)  # => [expired.id]
```
- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
SignIn::Certificate checker

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution

