### PR TITLE
Added payload to ALLOWLIST; send custom tags to StatsD monitor

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -51,7 +51,7 @@ ALLOWLIST = %w[
   service
   use_v2
   line
-  payload
+  kafka_payload
 ].freeze
 
 Rails.application.config.filter_parameters = [

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -51,6 +51,7 @@ ALLOWLIST = %w[
   service
   use_v2
   line
+  payload
 ].freeze
 
 Rails.application.config.filter_parameters = [

--- a/lib/kafka/monitor.rb
+++ b/lib/kafka/monitor.rb
@@ -78,7 +78,7 @@ module Kafka
     def add_tags(payload)
       return [] unless payload.is_a?(Hash) && payload.key?('submissionName') && payload.key?('state')
 
-      ["form:#{payload.fetch('submissionName', nil)}", "state:#{payload.fetch('state', nil)}"]
+      ["form:#{payload['submissionName']}", "state:#{payload['state']}"]
     end
   end
 end

--- a/lib/kafka/monitor.rb
+++ b/lib/kafka/monitor.rb
@@ -20,7 +20,7 @@ module Kafka
     # @param topic [String] The Kafka topic to which the message will be sent
     # @param payload [Hash] The message payload to be sent to the Kafka topic
     def track_submission_success(topic, payload)
-      additional_context = { topic:, payload:, tags: add_tags(payload) }
+      additional_context = { topic:, kafka_payload: payload, tags: add_tags(payload) }
       track_request(
         'info',
         "Kafka::EventBusSubmissionJob submission succeeded for topic #{topic}",
@@ -39,7 +39,7 @@ module Kafka
     def track_submission_failure(topic, payload, e)
       additional_context = {
         topic:,
-        payload:,
+        kafka_payload: payload,
         errors: e.try(:errors) || e&.message,
         tags: add_tags(payload)
       }
@@ -63,7 +63,7 @@ module Kafka
     def track_submission_exhaustion(msg, topic, payload)
       additional_context = {
         topic:,
-        payload:,
+        kafka_payload: payload,
         message: msg,
         tags: add_tags(payload)
       }

--- a/spec/lib/kafka/monitor_spec.rb
+++ b/spec/lib/kafka/monitor_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Kafka::Monitor do
         'api.kafka_service.submission.success',
         call_location: instance_of(Thread::Backtrace::Location),
         topic:,
-        payload:,
+        kafka_payload: payload,
         tags: []
       )
       monitor.track_submission_success(topic, payload)
@@ -55,7 +55,7 @@ RSpec.describe Kafka::Monitor do
         'api.kafka_service.submission.failure',
         call_location: instance_of(Thread::Backtrace::Location),
         topic:,
-        payload:,
+        kafka_payload: payload,
         errors: error.message,
         tags: []
       )
@@ -78,7 +78,7 @@ RSpec.describe Kafka::Monitor do
       log = "Kafka::EventBusSubmissionJob for #{topic} exhausted!"
       exhausted_payload = {
         message: msg,
-        payload:,
+        kafka_payload: payload,
         topic:,
         tags: []
       }

--- a/spec/lib/kafka/monitor_spec.rb
+++ b/spec/lib/kafka/monitor_spec.rb
@@ -7,6 +7,21 @@ RSpec.describe Kafka::Monitor do
   let(:monitor) { described_class.new }
   let(:topic) { 'submission_trace_form_status_change_test' }
   let(:payload) { { 'data' => { 'ICN' => '[REDACTED]' } } }
+  let(:form_payload) do
+    {
+      'priorId' => nil,
+      'currentId' => '12345',
+      'nextId' => nil,
+      'icn' => 'ICN123456',
+      'vasiId' => '1234',
+      'systemName' => 'VA_gov',
+      'submissionName' => 'F1010EZ',
+      'state' => 'received',
+      'timestamp' => '2024-03-04T12:00:00Z',
+      'additionalIds' => nil
+    }
+  end
+  let(:statsd_client) { instance_double(StatsD) }
   let(:error) { StandardError.new('Something went wrong') }
 
   describe '#track_submission_success' do
@@ -17,9 +32,18 @@ RSpec.describe Kafka::Monitor do
         'api.kafka_service.submission.success',
         call_location: instance_of(Thread::Backtrace::Location),
         topic:,
-        payload:
+        payload:,
+        tags: []
       )
       monitor.track_submission_success(topic, payload)
+    end
+
+    it 'adds tags to the tracked request' do
+      expect(StatsD).to receive(:increment).with(
+        'api.kafka_service.submission.success',
+        tags: array_including('form:F1010EZ', 'state:received')
+      )
+      monitor.track_submission_success(topic, form_payload)
     end
   end
 
@@ -32,21 +56,31 @@ RSpec.describe Kafka::Monitor do
         call_location: instance_of(Thread::Backtrace::Location),
         topic:,
         payload:,
-        errors: error.message
+        errors: error.message,
+        tags: []
       )
       monitor.track_submission_failure(topic, payload, error)
+    end
+
+    it 'adds tags to the tracked request' do
+      expect(StatsD).to receive(:increment).with(
+        'api.kafka_service.submission.failure',
+        tags: array_including('form:F1010EZ', 'state:received')
+      )
+      monitor.track_submission_failure(topic, form_payload, error)
     end
   end
 
   describe '#track_submission_exhaustion' do
-    it 'logs sidekiq job exhaustion' do
-      msg = { 'args' => [topic, payload] }
+    let(:msg) { { 'args' => [topic, payload] } }
 
+    it 'logs sidekiq job exhaustion' do
       log = "Kafka::EventBusSubmissionJob for #{topic} exhausted!"
       exhausted_payload = {
         message: msg,
         payload:,
-        topic:
+        topic:,
+        tags: []
       }
 
       expect(monitor).to receive(:track_request).with(
@@ -58,6 +92,14 @@ RSpec.describe Kafka::Monitor do
       )
 
       monitor.track_submission_exhaustion(msg, topic, payload)
+    end
+
+    it 'adds tags to the tracked request' do
+      expect(StatsD).to receive(:increment).with(
+        'api.kafka_service.exhausted',
+        tags: array_including('form:F1010EZ', 'state:received')
+      )
+      monitor.track_submission_exhaustion(msg, topic, form_payload)
     end
   end
 end


### PR DESCRIPTION
## Summary

-  This adds `payload` to the `ALLOWLIST` for filter parameter logging. The `Logging::Monitor` class which is used to log failed/successful/exhausted Kafka Sidekiq jobs relies on the payload for some DataDog log filtering. We do scrub the payload of PII separately. 
- Additionally, I also added tags to the `Kafka::Monitor` StatsD call for easier filtering on the details we're interested in. 

## Related issue(s)

- [VES #5241](https://github.com/department-of-veterans-affairs/VES/issues/5242)

## Testing done

- [x] *New code is covered by unit tests*

