### PR TITLE
Fixes return from decision handler

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -82,21 +82,29 @@ module ClaimsApi
           veteran_data = build_veteran_or_dependent_data(vet_icn)
           claimant_data = build_veteran_or_dependent_data(claimant_icn) if claimant_icn.present?
 
-          # poa here means the poa record saved in our DB, not the poa request record saved in our DB
-          poa = process_poa_decision(decision:, proc_id:, representative_id:, poa_code: request.poa_code,
-                                     metadata: request.metadata, veteran: veteran_data, claimant: claimant_data)
-
+          # Will either get null when a decision is declined or
+          # a poa.id for record saved in our DB when decision is accepted
+          decision_response = process_poa_decision(decision:, proc_id:, representative_id:, poa_code: request.poa_code,
+                                                   metadata: request.metadata, veteran: veteran_data,
+                                                   claimant: claimant_data)
+          # updates the request with the decision in BGS (BEP)
           manage_representative_update_poa_request(proc_id:, secondary_status: decision,
                                                    declined_reason: form_attributes['declinedReason'],
                                                    service: manage_representative_service)
 
           get_poa_response = handle_get_poa_request(ptcpnt_id: veteran_data.participant_id, lighthouse_id:)
-
-          render json: ClaimsApi::V2::Blueprints::PowerOfAttorneyRequestBlueprint.render(
-            get_poa_response, view: :index_or_show, root: :data
-          ), status: :ok, location: url_for(
-            controller: 'power_of_attorney/base', action: 'show', id: poa.id, veteranId: vet_icn
-          )
+          # Two different responses needed, if declined no location URL is required
+          if decision_response.nil?
+            render json: ClaimsApi::V2::Blueprints::PowerOfAttorneyRequestBlueprint.render(get_poa_response,
+                                                                                           view: :index_or_show,
+                                                                                           root: :data), status: :ok
+          else
+            render json: ClaimsApi::V2::Blueprints::PowerOfAttorneyRequestBlueprint.render(
+              get_poa_response, view: :index_or_show, root: :data
+            ), status: :ok, location: url_for(
+              controller: 'power_of_attorney/base', action: 'show', id: decision_response.id, veteranId: vet_icn
+            )
+          end
         end
         # rubocop:enable Metrics/MethodLength
 
@@ -150,18 +158,20 @@ module ClaimsApi
 
         private
 
-        # rubocop:disable Metrics/ParameterLists
+        # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
         def process_poa_decision(decision:, proc_id:, representative_id:, poa_code:, metadata:, veteran:, claimant:)
-          @json_body, type = ClaimsApi::PowerOfAttorneyRequestService::DecisionHandler.new(
+          result = ClaimsApi::PowerOfAttorneyRequestService::DecisionHandler.new(
             decision:, proc_id:, registration_number: representative_id, poa_code:, metadata:, veteran:, claimant:
           ).call
-          validate_mapped_data!(veteran.participant_id, type, poa_code)
+          return nil if result.nil?
 
+          @json_body, type = result
+          validate_mapped_data!(veteran.participant_id, result, poa_code)
+          # build headers
           @claimant_icn = claimant.icn.presence || claimant.mpi.icn if claimant
-
           build_auth_headers(veteran)
           attrs = decide_request_attributes(poa_code:, decide_form_attributes: form_attributes)
-
+          # save record
           power_of_attorney = ClaimsApi::PowerOfAttorney.create!(attrs)
           if power_of_attorney.present?
             claims_v2_logging('process_poa_decision',
@@ -173,10 +183,9 @@ module ClaimsApi
         rescue => e
           claims_v2_logging('process_poa_decision',
                             message: "Failed to save power of attorney record. Error: #{e}")
-
           raise e
         end
-        # rubocop:enable Metrics/ParameterLists
+        # rubocop:enable Metrics/ParameterLists, Metrics/MethodLength
 
         def validate_mapped_data!(veteran_participant_id, type, poa_code)
           claims_v2_logging('process_poa_decision',

--- a/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/accepted_decision_handler.rb
+++ b/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/accepted_decision_handler.rb
@@ -22,6 +22,7 @@ module ClaimsApi
         )
 
         gathered_data = poa_auto_establishment_gatherer
+        # This returns an array to the controller [mapped_data, type]
         poa_auto_establishment_mapper(gathered_data)
       end
 

--- a/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/declined_decision_handler.rb
+++ b/modules/claims_api/app/services/claims_api/power_of_attorney_request_service/declined_decision_handler.rb
@@ -14,6 +14,8 @@ module ClaimsApi
         first_name = extract_first_name(poa_request)
 
         send_declined_notification(ptcpnt_id: @ptcpnt_id, first_name:, representative_id: @representative_id)
+
+        nil
       end
 
       private

--- a/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
+++ b/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
@@ -320,13 +320,11 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
 
         it 'raises an error if decision is not valid' do
           mock_ccg(scopes) do |auth_header|
-            VCR.use_cassette('claims_api/bgs/manage_representative_service/update_poa_request_accepted') do
-              decide_request_with(id:, decision:, auth_header:)
-              expect(response).to have_http_status(:bad_request)
-              response_body = JSON.parse(response.body)
-              expect(response_body['errors'][0]['title']).to eq('Missing parameter')
-              expect(response_body['errors'][0]['status']).to eq('400')
-            end
+            decide_request_with(id:, decision:, auth_header:)
+            expect(response).to have_http_status(:bad_request)
+            response_body = JSON.parse(response.body)
+            expect(response_body['errors'][0]['title']).to eq('Missing parameter')
+            expect(response_body['errors'][0]['status']).to eq('400')
           end
         end
       end
@@ -402,6 +400,14 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
 
           decide_request_with(id:, decision:, auth_header:,
                               representative_id:)
+        end
+      end
+
+      it 'does not include location in the response header' do
+        mock_ccg(scopes) do |auth_header|
+          decide_request_with(id:, decision:, auth_header:)
+
+          expect(response.headers).not_to have_key('Location')
         end
       end
     end


### PR DESCRIPTION
## Summary
* Fixes a bug with the decision handler's return between the accepted and declined decisions.
    * I missed taking into account the handling of the return when the decision is declined.
    * This PR addresses this by adding a return (nil) and handling that to get back into the workflow of the decide method
    * We also have two different returns based on `accepted` and `declined` and I had also missed that factor in this feature.
        * The difference is one has a location URL in the response headers (accepted) and one does not (declined) 

## Related issue(s)
[API-43734](https://jira.devops.va.gov/browse/API-43734)

## Testing done
* Added test for the different responses on the method
* Manual testing of the requets to verify behavior

## Screenshots
_Note: Optional_

## What areas of the site does it impact?


## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
