### PR TITLE
Add recipient_type to ar_power_of_attorney_request_notifications for distinguishing notification targets

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_17_152023) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_31_004219) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -346,6 +346,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_17_152023) do
     t.string "type", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "recipient_type"
     t.index ["notification_id"], name: "idx_on_notification_id_2402e9daad"
     t.index ["power_of_attorney_request_id"], name: "idx_on_power_of_attorney_request_id_b7c74f46e5"
   end

--- a/modules/accredited_representative_portal/db/migrate/20250731004219_add_recipient_type_to_ar_power_of_attorney_request_notifications.rb
+++ b/modules/accredited_representative_portal/db/migrate/20250731004219_add_recipient_type_to_ar_power_of_attorney_request_notifications.rb
@@ -1,0 +1,5 @@
+class AddRecipientTypeToArPowerOfAttorneyRequestNotifications < ActiveRecord::Migration[7.2]
+  def change
+    add_column :ar_power_of_attorney_request_notifications, :recipient_type, :string
+  end
+end


### PR DESCRIPTION
This PR adds a new recipient_type field to ar_power_of_attorney_request_notifications for distinguishing notification targets

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/98668

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
