### PR TITLE
114674 mhv secure messaging migrate to api gateway redo

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -915,8 +915,7 @@ mhv:
     x_api_key: fake-x-api-key
   sm:
     app_token: fake-app-token
-    base_path: mhv-sm-api/patient/v1/
-    gw_base_path: v1/sm/patient/
+    base_path: v1/sm/patient/
     host: https://mhv-api.example.com
     mock: true
     x_api_key: fake-x-api-key

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -914,8 +914,7 @@ mhv:
     x_api_key: fake-x-api-key
   sm:
     app_token: fake-app-token
-    base_path: mhv-sm-api/patient/v1/
-    gw_base_path: v1/sm/patient/
+    base_path: v1/sm/patient/
     host: http://mhv-api.example.com
     mock: true
     x_api_key: fake-x-api-key

--- a/lib/sm/client.rb
+++ b/lib/sm/client.rb
@@ -591,26 +591,18 @@ module SM
     private
 
     def auth_headers
-      headers = config.base_request_headers.merge(
+      config.base_request_headers.merge(
         'appToken' => config.app_token,
-        'mhvCorrelationId' => session.user_id.to_s
+        'mhvCorrelationId' => session.user_id.to_s,
+        'x-api-key' => config.x_api_key
       )
-      if Flipper.enabled?(:mhv_secure_messaging_migrate_to_api_gateway)
-        headers.merge('x-api-key' => config.x_api_key)
-      else
-        headers
-      end
     end
 
     def token_headers
-      headers = config.base_request_headers.merge(
-        'Token' => session.token
+      config.base_request_headers.merge(
+        'Token' => session.token,
+        'x-api-key' => config.x_api_key
       )
-      if Flipper.enabled?(:mhv_secure_messaging_migrate_to_api_gateway)
-        headers.merge('x-api-key' => config.x_api_key)
-      else
-        headers
-      end
     end
 
     def reply_draft?(id)

--- a/lib/sm/configuration.rb
+++ b/lib/sm/configuration.rb
@@ -33,14 +33,7 @@ module SM
     # @return [String] Base path for dependent URLs
     #
     def base_path
-      if FlipperUtils.safe_enabled?(:mhv_secure_messaging_migrate_to_api_gateway)
-        "#{Settings.mhv.api_gateway.hosts.sm_patient}/#{Settings.mhv.sm.gw_base_path}"
-      else
-        "#{Settings.mhv.sm.host}/#{Settings.mhv.sm.base_path}"
-      end
-    rescue NoMethodError => e
-      Rails.logger.error("SM:Configuration Flipper error: #{e.message}")
-      "#{Settings.mhv.sm.host}/#{Settings.mhv.sm.base_path}" # Default path
+      "#{Settings.mhv.api_gateway.hosts.sm_patient}/#{Settings.mhv.sm.base_path}"
     end
 
     ##

--- a/spec/lib/sm/client_spec.rb
+++ b/spec/lib/sm/client_spec.rb
@@ -17,35 +17,19 @@ describe SM::Client do
 
   let(:client) { @client }
 
-  describe 'Test new API gateway methods' do
+  describe 'Test API gateway methods' do
     let(:config) { SM::Configuration.instance }
 
-    context 'when mhv_secure_messaging_migrate_to_api_gateway flipper flag is true' do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:mhv_secure_messaging_migrate_to_api_gateway).and_return(true)
-        allow(Settings.mhv.sm).to receive(:x_api_key).and_return('test-api-key')
-      end
-
-      it 'returns the x-api-key header' do
-        result = client.send(:auth_headers)
-        headers = { 'base-header' => 'value', 'appToken' => 'test-app-token', 'mhvCorrelationId' => '10616687' }
-        allow(client).to receive(:auth_headers).and_return(headers)
-        expect(result).to include('x-api-key' => 'test-api-key')
-        expect(config.x_api_key).to eq('test-api-key')
-      end
+    before do
+      allow(Settings.mhv.sm).to receive(:x_api_key).and_return('test-api-key')
     end
 
-    context 'when mhv_secure_messaging_migrate_to_api_gateway flipper flag is false' do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:mhv_secure_messaging_migrate_to_api_gateway).and_return(false)
-      end
-
-      it 'returns nil for x-api-key' do
-        result = client.send(:auth_headers)
-        headers = { 'base-header' => 'value', 'appToken' => 'test-app-token', 'mhvCorrelationId' => '10616687' }
-        allow(client).to receive(:auth_headers).and_return(headers)
-        expect(result).not_to include('x-api-key')
-      end
+    it 'returns the x-api-key header' do
+      result = client.send(:auth_headers)
+      headers = { 'base-header' => 'value', 'appToken' => 'test-app-token', 'mhvCorrelationId' => '10616687' }
+      allow(client).to receive(:auth_headers).and_return(headers)
+      expect(result).to include('x-api-key' => 'test-api-key')
+      expect(config.x_api_key).to eq('test-api-key')
     end
   end
 end

--- a/spec/lib/sm/configuration_spec.rb
+++ b/spec/lib/sm/configuration_spec.rb
@@ -14,55 +14,12 @@ RSpec.describe SM::Configuration do
   end
 
   describe '#base_path' do
-    context 'when mhv_secure_messaging_migrate_to_api_gateway flipper flag is true' do
-      it 'returns the new API base path' do
-        allow(Flipper).to receive(:respond_to?).with(:enabled).and_return(true)
-        allow(Flipper).to receive(:enabled?).with(:mhv_secure_messaging_migrate_to_api_gateway).and_return(true)
-        allow(Settings.mhv.sm).to receive_messages(
-          base_path: 'mhv-sm-api/patient/v1/',
-          gw_base_path: 'v1/sm/patient/'
-        )
-        allow(Settings.mhv.api_gateway.hosts).to receive(:sm_patient).and_return('https://new-api.example.com')
-        expect(configuration.base_path).to eq('https://new-api.example.com/v1/sm/patient/')
-      end
-    end
-
-    context 'when flipper is not enabled (bootup)' do
-      it 'returns the old API base path' do
-        allow(Flipper).to receive(:respond_to?).with(:enabled).and_return(false)
-        allow(Settings.mhv.sm).to receive_messages(
-          host: 'https://old-api.example.com',
-          base_path: 'mhv-sm-api-patient/v1/',
-          gw_base_path: 'v1/sm/patient/'
-        )
-        expect(configuration.base_path).to eq('https://old-api.example.com/mhv-sm-api-patient/v1/')
-      end
-    end
-
-    context 'when mhv_secure_messaging_migrate_to_api_gateway flipper flag is false' do
-      it 'returns the old API base path' do
-        allow(Flipper).to receive(:respond_to?).with(:enabled).and_return(true)
-        allow(Flipper).to receive(:enabled?).with(:mhv_secure_messaging_migrate_to_api_gateway).and_return(false)
-        allow(Settings.mhv.sm).to receive_messages(
-          host: 'https://old-api.example.com',
-          base_path: 'mhv-sm-api-patient/v1/',
-          gw_base_path: 'v1/sm/patient/'
-        )
-        expect(configuration.base_path).to eq('https://old-api.example.com/mhv-sm-api-patient/v1/')
-      end
-    end
-
-    context 'when a NoMethodError occurs' do
-      it 'logs the error and returns the default base path' do
-        allow(Flipper).to receive(:respond_to?).with(:enabled).and_return(true)
-        allow(Flipper).to receive(:enabled?).and_raise(NoMethodError, 'undefined method')
-        allow(Settings.mhv.sm).to receive_messages(
-          host: 'https://error-api.example.com',
-          base_path: 'mhv-api-patient/v1/'
-        )
-        expect(Rails.logger).to receive(:error).with(/SM:Configuration Flipper error: undefined method/)
-        expect(configuration.base_path).to eq('https://error-api.example.com/mhv-api-patient/v1/')
-      end
+    it 'returns the new API base path' do
+      allow(Settings.mhv.sm).to receive_messages(
+        base_path: 'v1/sm/patient/'
+      )
+      allow(Settings.mhv.api_gateway.hosts).to receive(:sm_patient).and_return('https://new-api.example.com')
+      expect(configuration.base_path).to eq('https://new-api.example.com/v1/sm/patient/')
     end
   end
 

--- a/spec/support/sm_spec_helper.rb
+++ b/spec/support/sm_spec_helper.rb
@@ -6,7 +6,6 @@ RSpec.configure do |config|
   config.before do
     allow(Flipper).to receive(:enabled?).and_call_original
     allow(Flipper).to receive(:enabled?).with(:mhv_secure_messaging_cerner_pilot, instance_of(User)).and_return(false)
-    allow(Flipper).to receive(:enabled?).with(:mhv_secure_messaging_migrate_to_api_gateway).and_return(false)
     allow(Flipper).to receive(:enabled?).with(:mhv_secure_messaging_large_attachments).and_return(false)
   end
 end

--- a/spec/support/vcr_cassettes/mobile/messages/get_threads_in_folder_400.yml
+++ b/spec/support/vcr_cassettes/mobile/messages/get_threads_in_folder_400.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_HOST>/mhv-sm-api/patient/v1/folder/threadlistview/100?pageNumber=1&pageSize=5&sortField=SENDER_NAME&sortOrder=ASC"
+      uri: "<MHV_HOST>/v1/sm/patient/folder/threadlistview/100?pageNumber=1&pageSize=5&sortField=SENDER_NAME&sortOrder=ASC"
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/support/vcr_cassettes/mobile/messages/gets_a_message_with_id_and_attachment.yml
+++ b/spec/support/vcr_cassettes/mobile/messages/gets_a_message_with_id_and_attachment.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/573059/read"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/573059/read"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/mobile/messages/session_error.yml
+++ b/spec/support/vcr_cassettes/mobile/messages/session_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_HOST>/mhv-sm-api/patient/v1/session"
+    uri: "<MHV_HOST>/v1/sm/patient/session"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/mobile/messages/v0_gets_a_message_thread.yml
+++ b/spec/support/vcr_cassettes/mobile/messages/v0_gets_a_message_thread.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/573059/history"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/573059/history"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/mobile/messages/v1_get_thread.yml
+++ b/spec/support/vcr_cassettes/mobile/messages/v1_get_thread.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/573059/messagesforthread"
+      uri: "<MHV_SM_HOST>/v1/sm/patient/message/573059/messagesforthread"
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/support/vcr_cassettes/sm_client/folders/creates_a_folder_and_deletes_a_folder.yml
+++ b/spec/support/vcr_cassettes/sm_client/folders/creates_a_folder_and_deletes_a_folder.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/folder"
     body:
       encoding: UTF-8
       string: '{"name":"test folder 66745"}'
@@ -38,7 +38,7 @@ http_interactions:
   recorded_at: Tue, 31 Jan 2017 22:56:03 GMT
 - request:
     method: delete
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder/674886"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/folder/674886"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/folders/deletes_a_folder.yml
+++ b/spec/support/vcr_cassettes/sm_client/folders/deletes_a_folder.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder/674886"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/folder/674886"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/folders/deletes_a_folder_id_error.yml
+++ b/spec/support/vcr_cassettes/sm_client/folders/deletes_a_folder_id_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder/1000"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/folder/1000"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/folders/gets_a_collection_of_folders.yml
+++ b/spec/support/vcr_cassettes/sm_client/folders/gets_a_collection_of_folders.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/folder"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/folders/gets_a_collection_of_folders_with_oh_messages.yml
+++ b/spec/support/vcr_cassettes/sm_client/folders/gets_a_collection_of_folders_with_oh_messages.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder?requiresOHMessages=1"
+      uri: "<MHV_SM_HOST>/v1/sm/patient/folder?requiresOHMessages=1"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/sm_client/folders/gets_a_single_folder.yml
+++ b/spec/support/vcr_cassettes/sm_client/folders/gets_a_single_folder.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder/0"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/folder/0"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/folders/gets_a_single_folder_id_error.yml
+++ b/spec/support/vcr_cassettes/sm_client/folders/gets_a_single_folder_id_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder/1000"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/folder/1000"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/folders/gets_a_single_folder_oh_messages.yml
+++ b/spec/support/vcr_cassettes/sm_client/folders/gets_a_single_folder_oh_messages.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder/0?requiresOHMessages=1"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/folder/0?requiresOHMessages=1"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/folders/nested_resources/gets_a_collection_of_messages.yml
+++ b/spec/support/vcr_cassettes/sm_client/folders/nested_resources/gets_a_collection_of_messages.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder/0/message/page/1/pageSize/250"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/folder/0/message/page/1/pageSize/250"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/folders/nested_resources/gets_a_collection_of_messages_id_error.yml
+++ b/spec/support/vcr_cassettes/sm_client/folders/nested_resources/gets_a_collection_of_messages_id_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder/1000/message/page/1/pageSize/250"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/folder/1000/message/page/1/pageSize/250"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/folders/nested_resources/gets_a_collection_of_messages_mhv_max_.yml
+++ b/spec/support/vcr_cassettes/sm_client/folders/nested_resources/gets_a_collection_of_messages_mhv_max_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder/0/message/page/1/pageSize/2"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/folder/0/message/page/1/pageSize/2"
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
   recorded_at: Tue, 31 Jan 2017 21:29:12 GMT
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder/0/message/page/2/pageSize/2"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/folder/0/message/page/2/pageSize/2"
     body:
       encoding: US-ASCII
       string: ''
@@ -86,7 +86,7 @@ http_interactions:
   recorded_at: Tue, 31 Jan 2017 21:29:13 GMT
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder/0/message/page/3/pageSize/2"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/folder/0/message/page/3/pageSize/2"
     body:
       encoding: US-ASCII
       string: ''
@@ -128,7 +128,7 @@ http_interactions:
   recorded_at: Tue, 31 Jan 2017 21:29:13 GMT
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder/0/message/page/4/pageSize/2"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/folder/0/message/page/4/pageSize/2"
     body:
       encoding: US-ASCII
       string: ''
@@ -170,7 +170,7 @@ http_interactions:
   recorded_at: Tue, 31 Jan 2017 21:29:14 GMT
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder/0/message/page/5/pageSize/2"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/folder/0/message/page/5/pageSize/2"
     body:
       encoding: US-ASCII
       string: ''
@@ -212,7 +212,7 @@ http_interactions:
   recorded_at: Tue, 31 Jan 2017 21:29:14 GMT
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder/0/message/page/6/pageSize/2"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/folder/0/message/page/6/pageSize/2"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/folders/renames_a_folder.yml
+++ b/spec/support/vcr_cassettes/sm_client/folders/renames_a_folder.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_HOST>/mhv-sm-api/patient/v1/folder/7207029/rename"
+    uri: "<MHV_HOST>/v1/sm/patient/folder/7207029/rename"
     body:
       encoding: UTF-8
       string: '{"folderName":"Test222"}'

--- a/spec/support/vcr_cassettes/sm_client/folders/searches_a_folder.yml
+++ b/spec/support/vcr_cassettes/sm_client/folders/searches_a_folder.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_HOST>/mhv-sm-api/patient/v1/folder/0/searchMessage/page/1/pageSize/250"
+    uri: "<MHV_HOST>/v1/sm/patient/folder/0/searchMessage/page/1/pageSize/250"
     body:
       encoding: UTF-8
       string: '{"exactMatch":null,"sender":null,"subject":"test","category":null,"recipient":null,"fromDate":null,"toDate":null,"messageId":null}'

--- a/spec/support/vcr_cassettes/sm_client/folders/searches_a_folder_oh_messages.yml
+++ b/spec/support/vcr_cassettes/sm_client/folders/searches_a_folder_oh_messages.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: post
-      uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder/0/searchMessage/page/1/pageSize/250?requiresOHMessages=1"
+      uri: "<MHV_SM_HOST>/v1/sm/patient/folder/0/searchMessage/page/1/pageSize/250?requiresOHMessages=1"
       body:
         encoding: UTF-8
         string: '{"exactMatch":null,"sender":null,"subject":"THREAD","category":null,"recipient":null,"fromDate":null,"toDate":null,"messageId":null}'

--- a/spec/support/vcr_cassettes/sm_client/message_drafts/creates_a_draft.yml
+++ b/spec/support/vcr_cassettes/sm_client/message_drafts/creates_a_draft.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/draft"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/draft"
     body:
       encoding: UTF-8
       string: '{"category":"OTHER","subject":"Subject 1","body":"Body 1","recipientId":613586}'

--- a/spec/support/vcr_cassettes/sm_client/message_drafts/creates_a_draft_reply.yml
+++ b/spec/support/vcr_cassettes/sm_client/message_drafts/creates_a_draft_reply.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/674874/replydraft"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/674874/replydraft"
     body:
       encoding: UTF-8
       string: '{"category":"OTHER","subject":"Subject 1","body":"Body 1","recipientId":613586}'

--- a/spec/support/vcr_cassettes/sm_client/message_drafts/creates_a_draft_reply_signature_only.yml
+++ b/spec/support/vcr_cassettes/sm_client/message_drafts/creates_a_draft_reply_signature_only.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/674874/replydraft"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/674874/replydraft"
     body:
       encoding: UTF-8
       string: '{"category":"OTHER","subject":"Subject 1","body":"Body 1","recipientId":613586}'

--- a/spec/support/vcr_cassettes/sm_client/message_drafts/creates_a_draft_signature_only.yml
+++ b/spec/support/vcr_cassettes/sm_client/message_drafts/creates_a_draft_signature_only.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/draft"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/draft"
     body:
       encoding: UTF-8
       string: '{"category":"OTHER","subject":"Subject 1","body":"Body 1","recipientId":613586}'

--- a/spec/support/vcr_cassettes/sm_client/message_drafts/updates_a_draft.yml
+++ b/spec/support/vcr_cassettes/sm_client/message_drafts/updates_a_draft.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/674942/history"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/674942/history"
     body:
       encoding: US-ASCII
       string: ''
@@ -38,7 +38,7 @@ http_interactions:
   recorded_at: Thu, 02 Feb 2017 17:36:35 GMT
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/draft"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/draft"
     body:
       encoding: UTF-8
       string: '{"category":"OTHER","subject":"Updated Subject","body":"Body 1","recipientId":613586,"id":674942}'

--- a/spec/support/vcr_cassettes/sm_client/message_drafts/updates_a_draft_reply.yml
+++ b/spec/support/vcr_cassettes/sm_client/message_drafts/updates_a_draft_reply.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/674944/history"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/674944/history"
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Thu, 02 Feb 2017 17:36:37 GMT
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/674874/replydraft"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/674874/replydraft"
     body:
       encoding: UTF-8
       string: '{"category":"OTHER","subject":"Subject 1","body":"Updated Body","recipientId":613586,"id":674944}'

--- a/spec/support/vcr_cassettes/sm_client/messages/creates/a_new_message_with_4_attachments.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/creates/a_new_message_with_4_attachments.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/attach"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/attach"
     body:
       encoding: ASCII-8BIT
       string: !binary |-

--- a/spec/support/vcr_cassettes/sm_client/messages/creates/a_new_message_without_attachments.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/creates/a_new_message_without_attachments.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message"
     body:
       encoding: UTF-8
       string: '{"subject":"CI Run","category":"OTHER","recipientId":613586,"body":"Continuous

--- a/spec/support/vcr_cassettes/sm_client/messages/creates/a_new_message_without_attachments_recipient_id_error.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/creates/a_new_message_without_attachments_recipient_id_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message"
     body:
       encoding: UTF-8
       string: '{"subject":"CI Run","category":"OTHER","recipientId":1,"body":"Continuous

--- a/spec/support/vcr_cassettes/sm_client/messages/creates/a_reply_with_4_attachments.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/creates/a_reply_with_4_attachments.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/674838/reply/attach"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/674838/reply/attach"
     body:
       encoding: ASCII-8BIT
       string: !binary |-

--- a/spec/support/vcr_cassettes/sm_client/messages/creates/a_reply_without_attachments.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/creates/a_reply_without_attachments.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/674838/reply"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/674838/reply"
     body:
       encoding: UTF-8
       string: '{"subject":"CI Run","category":"OTHER","recipientId":613586,"body":"Continuous

--- a/spec/support/vcr_cassettes/sm_client/messages/creates/a_reply_without_attachments_id_error.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/creates/a_reply_without_attachments_id_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/999999/reply"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/999999/reply"
     body:
       encoding: UTF-8
       string: '{"subject":"CI Run","category":"OTHER","recipientId":613586,"body":"Continuous

--- a/spec/support/vcr_cassettes/sm_client/messages/creates/cannot_send_draft_as_reply.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/creates/cannot_send_draft_as_reply.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/655626/history"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/655626/history"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/messages/creates/cannot_send_reply_draft_as_message.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/creates/cannot_send_reply_draft_as_message.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/655623/history"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/655623/history"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/messages/deletes_the_message_with_id.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/deletes_the_message_with_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/573052"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/573052"
     body:
       encoding: UTF-8
       string: "{}"

--- a/spec/support/vcr_cassettes/sm_client/messages/deletes_the_message_with_id_error.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/deletes_the_message_with_id_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/999999"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/999999"
     body:
       encoding: UTF-8
       string: "{}"

--- a/spec/support/vcr_cassettes/sm_client/messages/gets_a_message_thread.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/gets_a_message_thread.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/573059/history"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/573059/history"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/messages/gets_a_message_thread_full.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/gets_a_message_thread_full.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/3188782/messagesforthread"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/3188782/messagesforthread"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/messages/gets_a_message_thread_full_body.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/gets_a_message_thread_full_body.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/3188782/allmessagesforthread/1"
+      uri: "<MHV_SM_HOST>/v1/sm/patient/message/3188782/allmessagesforthread/1"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/sm_client/messages/gets_a_message_thread_id_error.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/gets_a_message_thread_id_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/999999/history"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/999999/history"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/messages/gets_a_message_thread_oh_messages.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/gets_a_message_thread_oh_messages.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/3188782/messagesforthread?requiresOHMessages=1"
+      uri: "<MHV_SM_HOST>/v1/sm/patient/message/3188782/messagesforthread?requiresOHMessages=1"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/sm_client/messages/gets_a_message_with_id.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/gets_a_message_with_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/573059/read"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/573059/read"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/messages/gets_a_message_with_id_error.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/gets_a_message_with_id_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/999999/read"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/999999/read"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/messages/gets_empty_message_signature.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/gets_empty_message_signature.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/preferences/signature"
+      uri: "<MHV_SM_HOST>/v1/sm/patient/preferences/signature"
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/support/vcr_cassettes/sm_client/messages/gets_message_categories.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/gets_message_categories.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/category"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/category"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/messages/gets_message_signature.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/gets_message_signature.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/preferences/signature"
+      uri: "<MHV_SM_HOST>/v1/sm/patient/preferences/signature"
       body:
         encoding: US-ASCII
         string: ''

--- a/spec/support/vcr_cassettes/sm_client/messages/moves_a_message_with_id.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/moves_a_message_with_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/573052/move/tofolder/0"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/573052/move/tofolder/0"
     body:
       encoding: UTF-8
       string: "{}"

--- a/spec/support/vcr_cassettes/sm_client/messages/moves_a_message_with_id_error.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/moves_a_message_with_id_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/999999/move/tofolder/0"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/999999/move/tofolder/0"
     body:
       encoding: UTF-8
       string: "{}"

--- a/spec/support/vcr_cassettes/sm_client/messages/nested_resources/gets_a_file_attachment.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/nested_resources/gets_a_file_attachment.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/629999/attachment/629993"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/629999/attachment/629993"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/messages/nested_resources/gets_a_file_attachment_attachment_id_error.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/nested_resources/gets_a_file_attachment_attachment_id_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/629999/attachment/999999"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/629999/attachment/999999"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/messages/nested_resources/gets_a_file_attachment_message_id_error.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/nested_resources/gets_a_file_attachment_message_id_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/999999/attachment/629993"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/999999/attachment/629993"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/messages/nested_resources/gets_a_single_attachment_by_id.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/nested_resources/gets_a_single_attachment_by_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/629999/attachment/629993"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/629999/attachment/629993"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/messages/nested_resources/gets_a_single_attachment_with_quotes_in_filename.yml
+++ b/spec/support/vcr_cassettes/sm_client/messages/nested_resources/gets_a_single_attachment_with_quotes_in_filename.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/629999/attachment/629993"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/629999/attachment/629993"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/preferences/fetches_email_settings_for_notifications.yml
+++ b/spec/support/vcr_cassettes/sm_client/preferences/fetches_email_settings_for_notifications.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_HOST>/mhv-sm-api/patient/v1/preferences/notification"
+    uri: "<MHV_HOST>/v1/sm/patient/preferences/notification"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/preferences/fetches_list_of_email_frequency_constants.yml
+++ b/spec/support/vcr_cassettes/sm_client/preferences/fetches_list_of_email_frequency_constants.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_HOST>/mhv-sm-api/patient/v1/preferences/notification/list"
+    uri: "<MHV_HOST>/v1/sm/patient/preferences/notification/list"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/preferences/fetches_the_signature_preferences.yml
+++ b/spec/support/vcr_cassettes/sm_client/preferences/fetches_the_signature_preferences.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/preferences/signature"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/preferences/signature"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/preferences/fetches_the_signature_preferences_include_signature_false.yml
+++ b/spec/support/vcr_cassettes/sm_client/preferences/fetches_the_signature_preferences_include_signature_false.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/preferences/signature"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/preferences/signature"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/preferences/missing_params_updating_the_signature_preferences.yml
+++ b/spec/support/vcr_cassettes/sm_client/preferences/missing_params_updating_the_signature_preferences.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/preferences/signature"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/preferences/signature"
     body:
       encoding: UTF-8
       string: '{"signatureName":null,"signatureTitle":null,"includeSignature":true}'

--- a/spec/support/vcr_cassettes/sm_client/preferences/raises_a_backend_service_exception_when_email_includes_spaces.yml
+++ b/spec/support/vcr_cassettes/sm_client/preferences/raises_a_backend_service_exception_when_email_includes_spaces.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_HOST>/mhv-sm-api/patient/v1/preferences/notification"
+    uri: "<MHV_HOST>/v1/sm/patient/preferences/notification"
     body:
       encoding: UTF-8
       string: '{"emailAddress":"kamyar karshenas@va.gov","notifyMe":0}'

--- a/spec/support/vcr_cassettes/sm_client/preferences/sets_the_email_notification_settings.yml
+++ b/spec/support/vcr_cassettes/sm_client/preferences/sets_the_email_notification_settings.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_HOST>/mhv-sm-api/patient/v1/preferences/notification"
+    uri: "<MHV_HOST>/v1/sm/patient/preferences/notification"
     body:
       encoding: UTF-8
       string: '{"emailAddress":"kamyar.karshenas@va.gov","notifyMe":0}'
@@ -36,7 +36,7 @@ http_interactions:
   recorded_at: Tue, 02 May 2017 07:10:24 GMT
 - request:
     method: get
-    uri: "<MHV_HOST>/mhv-sm-api/patient/v1/preferences/notification"
+    uri: "<MHV_HOST>/v1/sm/patient/preferences/notification"
     body:
       encoding: US-ASCII
       string: ''
@@ -72,7 +72,7 @@ http_interactions:
   recorded_at: Tue, 02 May 2017 07:10:25 GMT
 - request:
     method: post
-    uri: "<MHV_HOST>/mhv-sm-api/patient/v1/preferences/notification"
+    uri: "<MHV_HOST>/v1/sm/patient/preferences/notification"
     body:
       encoding: UTF-8
       string: '{"emailAddress":"muazzam.khan@va.gov","notifyMe":2}'
@@ -106,7 +106,7 @@ http_interactions:
   recorded_at: Tue, 02 May 2017 07:10:25 GMT
 - request:
     method: get
-    uri: "<MHV_HOST>/mhv-sm-api/patient/v1/preferences/notification"
+    uri: "<MHV_HOST>/v1/sm/patient/preferences/notification"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/preferences/sets_the_signature_preferences.yml
+++ b/spec/support/vcr_cassettes/sm_client/preferences/sets_the_signature_preferences.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/preferences/signature"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/preferences/signature"
     body:
       encoding: UTF-8
       string: '{"signatureName":"Test Mark","signatureTitle":"Test Title API","includeSignature":false}'

--- a/spec/support/vcr_cassettes/sm_client/preferences/sets_the_signature_preferences_exclude_name_and_title.yml
+++ b/spec/support/vcr_cassettes/sm_client/preferences/sets_the_signature_preferences_exclude_name_and_title.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/preferences/signature"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/preferences/signature"
     body:
       encoding: UTF-8
       string: '{"includeSignature":false}'

--- a/spec/support/vcr_cassettes/sm_client/preferences/sets_the_signature_preferences_include_signature_false.yml
+++ b/spec/support/vcr_cassettes/sm_client/preferences/sets_the_signature_preferences_include_signature_false.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/preferences/signature"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/preferences/signature"
     body:
       encoding: UTF-8
       string: '{"signatureName":"Test Mark","signatureTitle":"Test Title API","includeSignature":false}'

--- a/spec/support/vcr_cassettes/sm_client/preferences/updates_triage_team_preferences.yml
+++ b/spec/support/vcr_cassettes/sm_client/preferences/updates_triage_team_preferences.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/preferences/patientpreferredtriagegroups"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/preferences/patientpreferredtriagegroups"
     body:
       encoding: UTF-8
       string: '[{"triageTeamId":"1013155","preferredTeam":"true"}]'

--- a/spec/support/vcr_cassettes/sm_client/preferences/updates_triage_team_preferences_at_least_one_true.yml
+++ b/spec/support/vcr_cassettes/sm_client/preferences/updates_triage_team_preferences_at_least_one_true.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/preferences/patientpreferredtriagegroups"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/preferences/patientpreferredtriagegroups"
     body:
       encoding: UTF-8
       string: '[{"triageTeamId":"1013155","preferredTeam":"false"}]'

--- a/spec/support/vcr_cassettes/sm_client/preferences/updates_triage_team_preferences_error_invalid_triage_team.yml
+++ b/spec/support/vcr_cassettes/sm_client/preferences/updates_triage_team_preferences_error_invalid_triage_team.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/preferences/patientpreferredtriagegroups"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/preferences/patientpreferredtriagegroups"
     body:
       encoding: UTF-8
       string: '[{"triageTeamId":"1013155234","preferredTeam":"true"}]'

--- a/spec/support/vcr_cassettes/sm_client/session.yml
+++ b/spec/support/vcr_cassettes/sm_client/session.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_HOST>/mhv-sm-api/patient/v1/session"
+    uri: "<MHV_HOST>/v1/sm/patient/session"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/session_error.yml
+++ b/spec/support/vcr_cassettes/sm_client/session_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_HOST>/mhv-sm-api/patient/v1/session"
+      uri: "<MHV_HOST>/v1/sm/patient/session"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/sm_client/session_require_oh.yml
+++ b/spec/support/vcr_cassettes/sm_client/session_require_oh.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_HOST>/mhv-sm-api/patient/v1/session?requiresOHMessages=1"
+    uri: "<MHV_HOST>/v1/sm/patient/session?requiresOHMessages=1"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/threads/gets_threads_in_a_folder.yml
+++ b/spec/support/vcr_cassettes/sm_client/threads/gets_threads_in_a_folder.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_HOST>/mhv-sm-api/patient/v1/folder/threadlistview/0?pageNumber=1&pageSize=5&sortField=SENDER_NAME&sortOrder=ASC"
+    uri: "<MHV_HOST>/v1/sm/patient/folder/threadlistview/0?pageNumber=1&pageSize=5&sortField=SENDER_NAME&sortOrder=ASC"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/threads/gets_threads_in_a_folder_camel.yml
+++ b/spec/support/vcr_cassettes/sm_client/threads/gets_threads_in_a_folder_camel.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_HOST>/mhv-sm-api/patient/v1/folder/threadlistview/0?pageNumber=1&pageSize=5&sortField=SENDER_NAME&sortOrder=ASC"
+    uri: "<MHV_HOST>/v1/sm/patient/folder/threadlistview/0?pageNumber=1&pageSize=5&sortField=SENDER_NAME&sortOrder=ASC"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/threads/gets_threads_in_a_folder_no_messages.yml
+++ b/spec/support/vcr_cassettes/sm_client/threads/gets_threads_in_a_folder_no_messages.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder/threadlistview/0?pageNumber=1&pageSize=5&sortField=SENDER_NAME&sortOrder=ASC"
+      uri: "<MHV_SM_HOST>/v1/sm/patient/folder/threadlistview/0?pageNumber=1&pageSize=5&sortField=SENDER_NAME&sortOrder=ASC"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/sm_client/threads/gets_threads_in_a_folder_oh_messages.yml
+++ b/spec/support/vcr_cassettes/sm_client/threads/gets_threads_in_a_folder_oh_messages.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/folder/threadlistview/0?pageNumber=1&pageSize=5&requiresOHMessages=1&sortField=SENDER_NAME&sortOrder=ASC"
+      uri: "<MHV_SM_HOST>/v1/sm/patient/folder/threadlistview/0?pageNumber=1&pageSize=5&requiresOHMessages=1&sortField=SENDER_NAME&sortOrder=ASC"
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/support/vcr_cassettes/sm_client/threads/moves_a_thread_with_id.yml
+++ b/spec/support/vcr_cassettes/sm_client/threads/moves_a_thread_with_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_HOST>/mhv-sm-api/patient/v1/message/7065799/movethreadmessages/tofolder/0"
+    uri: "<MHV_HOST>/v1/sm/patient/message/7065799/movethreadmessages/tofolder/0"
     body:
       encoding: UTF-8
       string: "{}"

--- a/spec/support/vcr_cassettes/sm_client/threads/moves_a_thread_with_invalid_folder_id.yml
+++ b/spec/support/vcr_cassettes/sm_client/threads/moves_a_thread_with_invalid_folder_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/3470562/movethreadmessages/tofolder/123"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/3470562/movethreadmessages/tofolder/123"
     body:
       encoding: UTF-8
       string: "{}"

--- a/spec/support/vcr_cassettes/sm_client/threads/moves_a_thread_with_invalid_thread_id.yml
+++ b/spec/support/vcr_cassettes/sm_client/threads/moves_a_thread_with_invalid_thread_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/message/123/movethreadmessages/tofolder/0"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/message/123/movethreadmessages/tofolder/0"
     body:
       encoding: UTF-8
       string: "{}"

--- a/spec/support/vcr_cassettes/sm_client/triage_teams/gets_a_collection_of_all_triage_team_recipients.yml
+++ b/spec/support/vcr_cassettes/sm_client/triage_teams/gets_a_collection_of_all_triage_team_recipients.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/alltriageteams"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/alltriageteams"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/triage_teams/gets_a_collection_of_all_triage_team_recipients_require_oh.yml
+++ b/spec/support/vcr_cassettes/sm_client/triage_teams/gets_a_collection_of_all_triage_team_recipients_require_oh.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/alltriageteams?requiresOHTriageGroup=1"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/alltriageteams?requiresOHTriageGroup=1"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_client/triage_teams/gets_a_collection_of_triage_team_recipients.yml
+++ b/spec/support/vcr_cassettes/sm_client/triage_teams/gets_a_collection_of_triage_team_recipients.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/triageteam"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/triageteam"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/vcr_cassettes/sm_session/session_oh_initial_pull.yml
+++ b/spec/support/vcr_cassettes/sm_session/session_oh_initial_pull.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<MHV_SM_HOST>/mhv-sm-api/patient/v1/session?requiresOHMessages=1"
+    uri: "<MHV_SM_HOST>/v1/sm/patient/session?requiresOHMessages=1"
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
## Summary
The `mhv_secure_messaging_migrate_to_api_gateway` feature flag has been at 100% for a while and we're ready to remove the flag from business logic.

## Related issue(s)
[114674](https://github.com/department-of-veterans-affairs/va.gov-team/issues/114674)

## Testing done
specs updated to reflect the new base path

## What areas of the site does it impact?
Secure Messaging

## Acceptance criteria
There are no references to the `mhv_secure_messaging_migrate_to_api_gateway` feature flag in business logic.