### PR TITLE
fix: defer base_path evaluation to avoid Flipper initialization errors

### DIFF
--- a/lib/common/client/configuration/base.rb
+++ b/lib/common/client/configuration/base.rb
@@ -100,13 +100,13 @@ module Common
         end
 
         def breakers_matcher
-          base_uri = URI.parse(base_path)
           proc do |breakers_service, request_env, request_service_name|
             # Match by service_name if available.
             if request_service_name
               request_service_name == breakers_service.name
             else
               # Fall back to matching by request URL.
+              base_uri = URI.parse(base_path)
               request_env.url.host == base_uri.host && request_env.url.port == base_uri.port &&
                 request_env.url.path =~ /^#{base_uri.path}/
             end

--- a/lib/sm/configuration.rb
+++ b/lib/sm/configuration.rb
@@ -35,9 +35,6 @@ module SM
       else
         "#{Settings.mhv.sm.host}/#{Settings.mhv.sm.base_path}"
       end
-    rescue => e
-      Rails.logger.error("SM:Configuration Flipper error: #{e.message}")
-      "#{Settings.mhv.sm.host}/#{Settings.mhv.sm.base_path}" # Default path
     end
 
     ##

--- a/spec/lib/sm/configuration_spec.rb
+++ b/spec/lib/sm/configuration_spec.rb
@@ -51,19 +51,6 @@ RSpec.describe SM::Configuration do
         expect(configuration.base_path).to eq('https://old-api.example.com/mhv-sm-api-patient/v1/')
       end
     end
-
-    context 'when a NoMethodError occurs' do
-      it 'logs the error and returns the default base path' do
-        allow(Flipper).to receive(:respond_to?).with(:enabled).and_return(true)
-        allow(Flipper).to receive(:enabled?).and_raise(NoMethodError, 'undefined method')
-        allow(Settings.mhv.sm).to receive_messages(
-          host: 'https://error-api.example.com',
-          base_path: 'mhv-api-patient/v1/'
-        )
-        expect(Rails.logger).to receive(:error).with(/SM:Configuration Flipper error: undefined method/)
-        expect(configuration.base_path).to eq('https://error-api.example.com/mhv-api-patient/v1/')
-      end
-    end
   end
 
   describe '#service_name' do


### PR DESCRIPTION
## Summary
Alternative approach to #23334 that eliminates the need for rescue blocks by deferring base_path evaluation.

## Problem
When Rails initializes, `breakers.rb` calls `breakers_service` on all configuration instances, which in turn calls `breakers_matcher`. The matcher was immediately calling `base_path`, which for some configurations (like `SM::Configuration`) checks Flipper feature flags. During `rake db:setup` or when the database doesn't exist, this causes `ActiveRecord::NoDatabaseError`.

## Solution
Move the `URI.parse(base_path)` call inside the proc returned by `breakers_matcher`. This defers the `base_path` evaluation (and thus any Flipper checks) until the matcher is actually used during request processing, when the database is guaranteed to be available.

## Changes
- Modified `breakers_matcher` in `Common::Client::Configuration::Base` to defer `base_path` evaluation
- Removed the rescue block from `SM::Configuration#base_path` that was added in #23334

## Benefits
- Cleaner code without rescue blocks
- No risk of silently swallowing unexpected errors  
- More maintainable solution that addresses the root cause
- Prevents similar issues in other configuration classes that might check Flipper in their `base_path` methods

## Related
- Fixes the same issue as #23334 but with a cleaner approach
- Related to the incident documented in flipper-revert-fail.md

## Testing
The same CI tests that validate #23334 will ensure this solution works correctly. The key test is that `rake db:setup` and similar commands work without database errors.