### PR TITLE
API 47978 - Update alert language

### DIFF
--- a/modules/claims_api/spec/sidekiq/claim_uploader_spec.rb
+++ b/modules/claims_api/spec/sidekiq/claim_uploader_spec.rb
@@ -129,6 +129,20 @@ RSpec.describe ClaimsApi::ClaimUploader, type: :job do
     expect(subject.jobs).to eq([])
   end
 
+  it 'calls slack_alert_on_failure with appropriate message if claim of type "claim" is errored' do
+    msg = 'Claim Uploader job failed to upload 526EZ PDF to Benefits Documents ' \
+          "API due to claim submission error for claim #{errored_auto_claim.id}"
+    expect_any_instance_of(subject).to receive(:slack_alert_on_failure).with('ClaimsApi::ClaimUploader', msg)
+    subject.new.perform(errored_auto_claim.id, 'claim')
+  end
+
+  it 'calls slack_alert_on_failure with appropriate message if claim of type "document" is errored' do
+    msg = "Claim Uploader job failed to upload attachment #{errored_auto_claim.id} " \
+          "to Benefits Documents API due to claim submission error for claim #{errored_auto_claim.id}"
+    expect_any_instance_of(subject).to receive(:slack_alert_on_failure).with('ClaimsApi::ClaimUploader', msg)
+    subject.new.perform(errored_auto_claim.id, 'document')
+  end
+
   it 'transforms a claim document to the right properties for EVSS' do
     evss_service_stub = instance_double(EVSS::DocumentsService)
     allow(EVSS::DocumentsService).to receive(:new) { evss_service_stub }


### PR DESCRIPTION
## Summary

This PR updates the `ClaimUploader` Slack alert language to better reflect what errors triggered the alert.

## Related issue(s)

| [Jira ticket](https://jira.devops.va.gov/browse/API-47978) |
|-|
|<img width="981" height="764" alt="Screenshot 2025-07-31 at 13 47 31" src="https://github.com/user-attachments/assets/b762fd7b-8890-4761-b7ae-1ea6c7a5aa3a" />|

## Testing done

- [X] *New code is covered by unit tests*
- Prior to this change the Slack alert language was a bit more vague. Now it includes more specifics related to the two cases where it might fire ('claims' or 'document').
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots

NA

## What areas of the site does it impact?

```
modules/claims_api/spec/sidekiq/claim_uploader_spec.rb
```

## Acceptance criteria

- [X]  I added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA