### PR TITLE
API-47460 Backfill header_hash (Part 2)

### DIFF
--- a/lib/periodic_jobs.rb
+++ b/lib/periodic_jobs.rb
@@ -157,6 +157,12 @@ PERIODIC_JOBS = lambda { |mgr| # rubocop:disable Metrics/BlockLength
   # Daily find POAs caching
   mgr.register('0 2 * * *', 'ClaimsApi::FindPoasJob')
 
+  # Off-peak hours job to fill in header_hash for ClaimsApi::PowerOfAttorney and AutoEstablishedClaim
+  # Two jobs are registered to run hourly at "late evening" and "early morning"
+  # The batch will spawn multiple jobs throughout the hour using perform_in, so ending at 3am will fill out runs to 4am
+  mgr.register('10 21-23 * * *', 'ClaimsApi::OneOff::HeaderHashFillerBatchJob') # 9:10pm-11:10pm
+  mgr.register('10 0-3 * * *', 'ClaimsApi::OneOff::HeaderHashFillerBatchJob')   # 12:10am-3:10am
+
   # TODO: Document this job
   mgr.register('30 2 * * *', 'Identity::UserAcceptableVerifiedCredentialTotalsJob')
 

--- a/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_batch_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_batch_job.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'claims_api/claim_logger'
+
+module ClaimsApi::OneOff
+  class HeaderHashFillerBatchJob < ClaimsApi::ServiceBase
+    sidekiq_options retry: false
+    LOG_TAG = 'header_hash_filler_batch_job'
+    SINGLE_RUN_SIZE = 750 # The number of records to process per batch. See HeaderHashFillerJob for why.
+
+    def perform
+      unless Flipper.enabled? :lighthouse_claims_api_run_header_hash_filler_job
+        log level: :warn, details: 'Feature flag is disabled for header hash filling'
+        return
+      end
+
+      counts = { poas: ClaimsApi::PowerOfAttorney.where(header_hash: nil).count,
+                 aecs: ClaimsApi::AutoEstablishedClaim.where(header_hash: nil).count }
+
+      if counts[:poas].zero? && counts[:aecs].zero?
+        notify_batches_finished
+        return
+      end
+
+      log details: "Remaining blank header_hash records - POAs: #{counts[:poas]}, AECs: #{counts[:aecs]}"
+
+      enqueue_jobs 'ClaimsApi::PowerOfAttorney', counts[:poas] if counts[:poas].positive?
+      enqueue_jobs 'ClaimsApi::AutoEstablishedClaim', counts[:aecs], 2 if counts[:aecs].positive?
+    rescue => e
+      log level: :error,
+          detail: 'Failed to enqueue jobs for header hash filling',
+          error_class: e.class.name,
+          error_message: e.message
+    end
+
+    # Sets up jobs to run every 5 mins for the next hour. Is public so it can be called from the Rails console
+    # Ignores the feature flag, so it can be used to backfill header hashes manually if needed
+    # @param model_str [String] The model class name as a string, e.g. 'ClaimsApi::PowerOfAttorney'
+    # @param count [Integer] The number of records to process in total
+    # @param delay [Integer] Delay in mins before queue starts. Used to stagger job starts between models
+    def enqueue_jobs(model_str, count, delay = 0)
+      total_batches = (count / SINGLE_RUN_SIZE.to_f).ceil
+      total_batches = 10 if total_batches > 10 # Limit to 10 batches to load up runs for ~50 mins
+
+      total_batches.times do |i|
+        ClaimsApi::OneOff::HeaderHashFillerJob.perform_in(delay.minutes + (i * 5.minutes), model_str)
+      end
+    end
+
+    private
+
+    def log(**)
+      ClaimsApi::Logger.log(LOG_TAG, **)
+    end
+
+    def notify_batches_finished
+      msg = 'No records left to process for header hash filling.'
+      log details: msg
+      slack_alert_on_failure(LOG_TAG, msg) # Not really a failure, but we want to notify
+    end
+  end
+end

--- a/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_batch_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_batch_job.rb
@@ -28,7 +28,7 @@ module ClaimsApi::OneOff
       enqueue_jobs 'ClaimsApi::AutoEstablishedClaim', counts[:aecs], 2 if counts[:aecs].positive?
     rescue => e
       log level: :error,
-          detail: 'Failed to enqueue jobs for header hash filling',
+          details: 'Failed to enqueue jobs for header hash filling',
           error_class: e.class.name,
           error_message: e.message
     end

--- a/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_job.rb
@@ -9,7 +9,8 @@ module ClaimsApi::OneOff
     LOG_TAG = 'header_hash_filler_job'
 
     # rubocop:disable Metrics/MethodLength
-    def perform(model = 'ClaimsApi::PowerOfAttorney', ids = [], max_to_process = 1_000)
+    # Testing max_to_process at 5k was 5m long, so 750 should stay under the 1m timeout limit for Sidekiq jobs
+    def perform(model = 'ClaimsApi::PowerOfAttorney', ids = [], max_to_process = 750)
       return unless Flipper.enabled? :lighthouse_claims_api_run_header_hash_filler_job
       return unless args_are_valid?(model, ids)
 

--- a/modules/claims_api/spec/sidekiq/one_off/header_hash_filler_batch_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/one_off/header_hash_filler_batch_job_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'pdf_fill/filler'
+
+RSpec.describe ClaimsApi::OneOff::HeaderHashFillerBatchJob, type: :job do
+  subject { described_class.new }
+
+  before do
+    Timecop.freeze(1.year.ago) do
+      create_list(:power_of_attorney, 10)
+      ClaimsApi::PowerOfAttorney.update_all(header_hash: nil) # rubocop:disable Rails/SkipsModelValidations
+      create_list(:auto_established_claim, 10)
+      ClaimsApi::AutoEstablishedClaim.update_all(header_hash: nil) # rubocop:disable Rails/SkipsModelValidations
+    end
+    allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_run_header_hash_filler_job).and_return true
+  end
+
+  describe '#perform' do
+    it 'enqueues jobs for filling header_hash in batches' do
+      expect_any_instance_of(described_class).to receive(:enqueue_jobs).twice
+      subject.perform
+    end
+
+    context 'when no records need processing' do
+      it 'skips processing and alerts' do
+        ClaimsApi::PowerOfAttorney.update_all(header_hash: 'some_value') # rubocop:disable Rails/SkipsModelValidations
+        ClaimsApi::AutoEstablishedClaim.update_all(header_hash: 'some_value') # rubocop:disable Rails/SkipsModelValidations
+
+        expect_any_instance_of(described_class).not_to receive(:enqueue_jobs)
+        expect_any_instance_of(SlackNotify::Client).to receive(:notify)
+        subject.perform
+      end
+    end
+  end
+
+  describe '#enqueue_jobs' do
+    it 'enqueues jobs for filling header_hash in batches' do
+      expect(ClaimsApi::OneOff::HeaderHashFillerJob).to receive(:perform_in).exactly(3).times
+      subject.enqueue_jobs('ClaimsApi::PowerOfAttorney', 1_501)
+    end
+
+    it 'limits the number of batches to 10' do
+      expect(ClaimsApi::OneOff::HeaderHashFillerJob).to receive(:perform_in).exactly(10).times
+      subject.enqueue_jobs('ClaimsApi::PowerOfAttorney', 100_000)
+    end
+  end
+end

--- a/modules/claims_api/spec/sidekiq/one_off/header_hash_filler_batch_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/one_off/header_hash_filler_batch_job_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe ClaimsApi::OneOff::HeaderHashFillerBatchJob, type: :job do
       subject.perform
     end
 
+    it 'skips processing if the feature flag is disabled' do
+      allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_api_run_header_hash_filler_job).and_return false
+      expect_any_instance_of(described_class).not_to receive(:enqueue_jobs)
+      expect_any_instance_of(described_class).to receive(:log)
+      subject.perform
+    end
+
     context 'when no records need processing' do
       it 'skips processing and alerts' do
         ClaimsApi::PowerOfAttorney.update_all(header_hash: 'some_value') # rubocop:disable Rails/SkipsModelValidations


### PR DESCRIPTION
## Summary
Adds & schedules (gated behind the `lighthouse_claims_api_run_header_hash_filler_job` flag) an hourly batch job that enqueues an hours worth of HeaderHashFiller jobs for both the models that need it.

The schedule is set to only run the jobs from 9:10pm to ~4:00am Eastern time.

## Related issue(s)

#23158 
https://jira.devops.va.gov/browse/API-47460

## Testing done

- [x] *New code is covered by unit tests*

**Test plan:**
Keep `lighthouse_claims_api_run_header_hash_filler_job` disabled and manually run `#enqueue_jobs` to verify behavior & load on production. If clear, enable `lighthouse_claims_api_run_header_hash_filler_job` and let the schedule take over.
 
## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)