### PR TITLE
[CST] Removes references to benefits_documents_filter_duplicates flipper

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -123,10 +123,6 @@ features:
     actor_type: user
     description: Use lighthouse instead of EVSS to view/download benefit letters.
     enable_in_development: true
-  benefits_documents_filter_duplicates:
-    actor_type: user
-    description: When enabled, attempt to catch duplicate documents before sending them to LH
-    enable_in_development: false
   benefits_documents_use_lighthouse:
     actor_type: user
     description: Use lighthouse instead of EVSS to upload benefits documents.

--- a/lib/lighthouse/benefits_documents/service.rb
+++ b/lib/lighthouse/benefits_documents/service.rb
@@ -87,7 +87,7 @@ module BenefitsDocuments
       Rails.logger.info('file content type', file&.content_type)
       Rails.logger.info('participant_id present?', @user.participant_id.present?)
 
-      if Flipper.enabled?(:benefits_documents_filter_duplicates) && presumed_duplicate?(claim_id, file)
+      if presumed_duplicate?(claim_id, file)
         raise Common::Exceptions::UnprocessableEntity.new(
           detail: 'DOC_UPLOAD_DUPLICATE',
           source: self.class.name

--- a/spec/controllers/v0/benefits_documents_controller_spec.rb
+++ b/spec/controllers/v0/benefits_documents_controller_spec.rb
@@ -16,110 +16,101 @@ RSpec.describe V0::BenefitsDocumentsController, type: :controller do
   end
 
   describe '#create' do
-    [true, false].each do |filter_duplicates|
-      context "when benefits_documents_filter_duplicates is #{filter_duplicates}" do
+    [true, false].each do |validate_claimant|
+      context "when benefits_documents_validate_claimant is #{validate_claimant}" do
         before do
-          allow(Flipper).to receive(:enabled?).with(:benefits_documents_filter_duplicates).and_return(filter_duplicates)
+          allow(Flipper).to receive(:enabled?).with(:benefits_documents_validate_claimant)
+                                              .and_return(validate_claimant)
+          allow_any_instance_of(BenefitsDocuments::Service).to receive(:validate_claimant_can_upload)
+            .and_return(true)
         end
 
-        [true, false].each do |validate_claimant|
-          context "when benefits_documents_validate_claimant is #{validate_claimant}" do
+        context 'when successful' do
+          before do
+            allow_any_instance_of(BenefitsDocuments::Service)
+              .to receive(:queue_document_upload)
+              .and_return({ jid: 12 })
+          end
+
+          it 'returns a status of 202 and the job ID' do
+            file = Rack::Test::UploadedFile.new(Tempfile.new('banana.pdf'))
+
+            post(:create, params: { file:, benefits_claim_id: 1, document_type: 'L015' })
+
+            expect(response).to have_http_status(:accepted)
+          end
+        end
+
+        context 'when NOT successful' do
+          context 'but the upload is not a duplicate' do
+            it 'returns a 400 when the file parameter is missing' do
+              post(:create, params: { benefits_claim_id: 1, document_type: 'L015' })
+
+              expect(response).to have_http_status(:bad_request)
+            end
+
+            it 'returns a 404 when unable to find the associated claim' do
+              allow_any_instance_of(BenefitsDocuments::Service)
+                .to receive(:queue_document_upload)
+                .and_raise(Common::Exceptions::ResourceNotFound)
+
+              file = Rack::Test::UploadedFile.new(Tempfile.new('banana.pdf'))
+
+              post(:create, params: { file:, benefits_claim_id: 1, document_type: 'L015' })
+
+              expect(response).to have_http_status(:not_found)
+            end
+
+            it 'returns a 422 when the document metadata is not valid' do
+              file = Rack::Test::UploadedFile.new(Tempfile.new('banana.pdf'))
+
+              post(:create, params: { file:, benefits_claim_id: 1, document_type: 'BANANA' })
+
+              expect(response).to have_http_status(:unprocessable_entity)
+            end
+          end
+
+          context 'and the upload is a duplicate' do
+            before do
+              allow_any_instance_of(BenefitsDocuments::Service).to receive(:presumed_duplicate?).and_return(true)
+            end
+
+            it 'returns a 422' do
+              file = Rack::Test::UploadedFile.new(Tempfile.new('banana.pdf'))
+
+              post(:create, params: { file:, benefits_claim_id: 1, document_type: 'L015' })
+
+              expect(response).to have_http_status(:unprocessable_entity)
+              json_response = JSON.parse(response.body)['errors'].first
+              expect(json_response['title']).to eq('Unprocessable Entity')
+              expect(json_response['code']).to eq('422')
+              expect(json_response['status']).to eq('422')
+              expect(json_response['source']).to eq('BenefitsDocuments::Service')
+              expect(json_response['detail']).to eq('DOC_UPLOAD_DUPLICATE')
+            end
+          end
+
+          context 'and the claimant cannot be validated to upload' do
             before do
               allow(Flipper).to receive(:enabled?).with(:benefits_documents_validate_claimant)
-                                                  .and_return(validate_claimant)
+                                                  .and_return(true)
               allow_any_instance_of(BenefitsDocuments::Service).to receive(:validate_claimant_can_upload)
-                .and_return(true)
+                .and_return(false)
             end
 
-            context 'when successful' do
-              before do
-                allow_any_instance_of(BenefitsDocuments::Service)
-                  .to receive(:queue_document_upload)
-                  .and_return({ jid: 12 })
-              end
+            it 'returns a 422' do
+              file = Rack::Test::UploadedFile.new(Tempfile.new('banana.pdf'))
 
-              it 'returns a status of 202 and the job ID' do
-                file = Rack::Test::UploadedFile.new(Tempfile.new('banana.pdf'))
+              post(:create, params: { file:, benefits_claim_id: 1, document_type: 'L015' })
 
-                post(:create, params: { file:, benefits_claim_id: 1, document_type: 'L015' })
-
-                expect(response).to have_http_status(:accepted)
-              end
-            end
-
-            context 'when NOT successful' do
-              context 'but the upload is not a duplicate' do
-                it 'returns a 400 when the file parameter is missing' do
-                  post(:create, params: { benefits_claim_id: 1, document_type: 'L015' })
-
-                  expect(response).to have_http_status(:bad_request)
-                end
-
-                it 'returns a 404 when unable to find the associated claim' do
-                  allow_any_instance_of(BenefitsDocuments::Service)
-                    .to receive(:queue_document_upload)
-                    .and_raise(Common::Exceptions::ResourceNotFound)
-
-                  file = Rack::Test::UploadedFile.new(Tempfile.new('banana.pdf'))
-
-                  post(:create, params: { file:, benefits_claim_id: 1, document_type: 'L015' })
-
-                  expect(response).to have_http_status(:not_found)
-                end
-
-                it 'returns a 422 when the document metadata is not valid' do
-                  file = Rack::Test::UploadedFile.new(Tempfile.new('banana.pdf'))
-
-                  post(:create, params: { file:, benefits_claim_id: 1, document_type: 'BANANA' })
-
-                  expect(response).to have_http_status(:unprocessable_entity)
-                end
-              end
-
-              context 'and the upload is a duplicate' do
-                before do
-                  allow(Flipper).to receive(:enabled?).with(:benefits_documents_filter_duplicates).and_return(true)
-                  allow_any_instance_of(BenefitsDocuments::Service).to receive(:presumed_duplicate?).and_return(true)
-                end
-
-                it 'returns a 422' do
-                  file = Rack::Test::UploadedFile.new(Tempfile.new('banana.pdf'))
-
-                  post(:create, params: { file:, benefits_claim_id: 1, document_type: 'L015' })
-
-                  expect(response).to have_http_status(:unprocessable_entity)
-                  json_response = JSON.parse(response.body)['errors'].first
-                  expect(json_response['title']).to eq('Unprocessable Entity')
-                  expect(json_response['code']).to eq('422')
-                  expect(json_response['status']).to eq('422')
-                  expect(json_response['source']).to eq('BenefitsDocuments::Service')
-                  expect(json_response['detail']).to eq('DOC_UPLOAD_DUPLICATE')
-                end
-              end
-
-              context 'and the claimant cannot be validated to upload' do
-                before do
-                  allow(Flipper).to receive(:enabled?).with(:benefits_documents_validate_claimant)
-                                                      .and_return(true)
-                  allow_any_instance_of(BenefitsDocuments::Service).to receive(:validate_claimant_can_upload)
-                    .and_return(false)
-                end
-
-                it 'returns a 422' do
-                  file = Rack::Test::UploadedFile.new(Tempfile.new('banana.pdf'))
-
-                  post(:create, params: { file:, benefits_claim_id: 1, document_type: 'L015' })
-
-                  expect(response).to have_http_status(:unprocessable_entity)
-                  json_response = JSON.parse(response.body)['errors'].first
-                  expect(json_response['title']).to eq('Unprocessable Entity')
-                  expect(json_response['code']).to eq('422')
-                  expect(json_response['status']).to eq('422')
-                  expect(json_response['source']).to eq('BenefitsDocuments::Service')
-                  expect(json_response['detail'])
-                    .to eq('DOC_UPLOAD_INVALID_CLAIMANT')
-                end
-              end
+              expect(response).to have_http_status(:unprocessable_entity)
+              json_response = JSON.parse(response.body)['errors'].first
+              expect(json_response['title']).to eq('Unprocessable Entity')
+              expect(json_response['code']).to eq('422')
+              expect(json_response['status']).to eq('422')
+              expect(json_response['source']).to eq('BenefitsDocuments::Service')
+              expect(json_response['detail'])
+                .to eq('DOC_UPLOAD_INVALID_CLAIMANT')
             end
           end
         end

--- a/spec/lib/lighthouse/benefits_documents/service_spec.rb
+++ b/spec/lib/lighthouse/benefits_documents/service_spec.rb
@@ -50,91 +50,82 @@ RSpec.describe BenefitsDocuments::Service do
         BenefitsDocuments::Utilities::Helpers.format_date_for_mailers(issue_instant)
       end
 
-      [true, false].each do |filter_duplicates|
-        context "when benefits_documents_filter_duplicates is #{filter_duplicates}" do
+      [true, false].each do |validate_claimant|
+        context "when benefits_documents_validate_claimant is #{validate_claimant}" do
           before do
-            allow(Flipper).to receive(:enabled?).with(:benefits_documents_filter_duplicates)
-                                                .and_return(filter_duplicates)
+            allow(Flipper).to receive(:enabled?).with(:benefits_documents_validate_claimant)
+                                                .and_return(validate_claimant)
+            allow_any_instance_of(BenefitsDocuments::Service).to receive(:validate_claimant_can_upload)
+              .and_return(true)
           end
 
-          [true, false].each do |validate_claimant|
-            context "when benefits_documents_validate_claimant is #{validate_claimant}" do
+          context 'when the document being uploaded is not a duplicate' do
+            context 'when cst_synchronous_evidence_uploads is false and cst_send_evidence_submission_failure_emails is true' do # rubocop:disable Layout/LineLength
               before do
-                allow(Flipper).to receive(:enabled?).with(:benefits_documents_validate_claimant)
-                                                    .and_return(validate_claimant)
-                allow_any_instance_of(BenefitsDocuments::Service).to receive(:validate_claimant_can_upload)
-                  .and_return(true)
+                allow(Flipper).to receive(:enabled?).with(:cst_send_evidence_submission_failure_emails)
+                                                    .and_return(true)
+                allow(Flipper).to receive(:enabled?).with(:cst_synchronous_evidence_uploads,
+                                                          instance_of(User)).and_return(false)
+                allow_any_instance_of(BenefitsDocuments::Service).to receive(:presumed_duplicate?)
+                  .and_return(false)
+                allow(StatsD).to receive(:increment)
+                allow(Rails.logger).to receive(:info)
               end
 
-              context 'when the document being uploaded is not a duplicate' do
-                context 'when cst_synchronous_evidence_uploads is false and cst_send_evidence_submission_failure_emails is true' do # rubocop:disable Layout/LineLength
-                  before do
-                    allow(Flipper).to receive(:enabled?).with(:cst_send_evidence_submission_failure_emails)
-                                                        .and_return(true)
-                    allow(Flipper).to receive(:enabled?).with(:cst_synchronous_evidence_uploads,
-                                                              instance_of(User)).and_return(false)
-                    allow_any_instance_of(BenefitsDocuments::Service).to receive(:presumed_duplicate?)
-                      .and_return(false)
-                    allow(StatsD).to receive(:increment)
-                    allow(Rails.logger).to receive(:info)
-                  end
+              it 'enqueues a job' do
+                expect do
+                  service.queue_document_upload(params)
+                end.to change(Lighthouse::EvidenceSubmissions::DocumentUpload.jobs, :size).by(1)
+              end
 
-                  it 'enqueues a job' do
-                    expect do
-                      service.queue_document_upload(params)
-                    end.to change(Lighthouse::EvidenceSubmissions::DocumentUpload.jobs, :size).by(1)
-                  end
+              it 'records evidence submission with CREATED status' do
+                subject.queue_document_upload(params)
+                expect(EvidenceSubmission.count).to eq(1)
+                evidence_submission = EvidenceSubmission.first
+                current_personalisation = JSON.parse(evidence_submission.template_metadata)['personalisation']
+                expect(evidence_submission.upload_status)
+                  .to eql(BenefitsDocuments::Constants::UPLOAD_STATUS[:CREATED])
+                expect(current_personalisation['date_submitted']).to eql(submitted_date)
+                expect(evidence_submission.tracked_item_id).to be(1)
+                expect(evidence_submission.file_size).to eq(File.size(params[:file]))
+                expect(StatsD)
+                  .to have_received(:increment)
+                  .with('cst.lighthouse.document_uploads.evidence_submission_record_created')
+                expect(Rails.logger)
+                  .to have_received(:info)
+                  .with('LH - Created Evidence Submission Record', any_args)
+              end
+            end
 
-                  it 'records evidence submission with CREATED status' do
-                    subject.queue_document_upload(params)
-                    expect(EvidenceSubmission.count).to eq(1)
-                    evidence_submission = EvidenceSubmission.first
-                    current_personalisation = JSON.parse(evidence_submission.template_metadata)['personalisation']
-                    expect(evidence_submission.upload_status)
-                      .to eql(BenefitsDocuments::Constants::UPLOAD_STATUS[:CREATED])
-                    expect(current_personalisation['date_submitted']).to eql(submitted_date)
-                    expect(evidence_submission.tracked_item_id).to be(1)
-                    expect(evidence_submission.file_size).to eq(File.size(params[:file]))
-                    expect(StatsD)
-                      .to have_received(:increment)
-                      .with('cst.lighthouse.document_uploads.evidence_submission_record_created')
-                    expect(Rails.logger)
-                      .to have_received(:info)
-                      .with('LH - Created Evidence Submission Record', any_args)
-                  end
-                end
+            context 'when cst_synchronous_evidence_uploads and cst_send_evidence_submission_failure_emails is disabled' do # rubocop:disable Layout/LineLength
+              before do
+                allow(Flipper).to receive(:enabled?).with(:cst_send_evidence_submission_failure_emails)
+                                                    .and_return(false)
+                allow(Flipper).to receive(:enabled?).with(:cst_synchronous_evidence_uploads,
+                                                          instance_of(User)).and_return(false)
+              end
 
-                context 'when cst_synchronous_evidence_uploads and cst_send_evidence_submission_failure_emails is disabled' do # rubocop:disable Layout/LineLength
-                  before do
-                    allow(Flipper).to receive(:enabled?).with(:cst_send_evidence_submission_failure_emails)
-                                                        .and_return(false)
-                    allow(Flipper).to receive(:enabled?).with(:cst_synchronous_evidence_uploads,
-                                                              instance_of(User)).and_return(false)
-                  end
+              it 'does not record an evidence submission' do
+                expect do
+                  service.queue_document_upload(params)
+                end.not_to change(EvidenceSubmission, :count)
+              end
+            end
 
-                  it 'does not record an evidence submission' do
-                    expect do
-                      service.queue_document_upload(params)
-                    end.not_to change(EvidenceSubmission, :count)
-                  end
-                end
+            context 'when cst_synchronous_evidence_uploads is true and cst_send_evidence_submission_failure_emails is false' do # rubocop:disable Layout/LineLength
+              before do
+                allow(Flipper).to receive(:enabled?).with(:cst_send_evidence_submission_failure_emails)
+                                                    .and_return(false)
+                allow(Flipper).to receive(:enabled?).with(:cst_synchronous_evidence_uploads,
+                                                          instance_of(User)).and_return(true)
+              end
 
-                context 'when cst_synchronous_evidence_uploads is true and cst_send_evidence_submission_failure_emails is false' do # rubocop:disable Layout/LineLength
-                  before do
-                    allow(Flipper).to receive(:enabled?).with(:cst_send_evidence_submission_failure_emails)
-                                                        .and_return(false)
-                    allow(Flipper).to receive(:enabled?).with(:cst_synchronous_evidence_uploads,
-                                                              instance_of(User)).and_return(true)
-                  end
-
-                  it 'does not enqueue a job' do
-                    VCR.use_cassette('lighthouse/benefits_claims/documents/lighthouse_document_upload_200_pdf') do
-                      expect do
-                        service.queue_document_upload(params)
-                      end.not_to change(Lighthouse::EvidenceSubmissions::DocumentUpload.jobs, :size)
-                      expect(EvidenceSubmission.count).to eq(0)
-                    end
-                  end
+              it 'does not enqueue a job' do
+                VCR.use_cassette('lighthouse/benefits_claims/documents/lighthouse_document_upload_200_pdf') do
+                  expect do
+                    service.queue_document_upload(params)
+                  end.not_to change(Lighthouse::EvidenceSubmissions::DocumentUpload.jobs, :size)
+                  expect(EvidenceSubmission.count).to eq(0)
                 end
               end
             end
@@ -143,10 +134,6 @@ RSpec.describe BenefitsDocuments::Service do
       end
 
       context 'when the document being uploaded is a duplicate' do
-        before do
-          allow(Flipper).to receive(:enabled?).with(:benefits_documents_filter_duplicates).and_return(true)
-        end
-
         let(:evidence_submission) do
           create(:bd_evidence_submission_pending, claim_id:, user_account:)
         end


### PR DESCRIPTION
After this is deployed, the actual Flipper should be removed via Flipper.remove in the console.

va.gov-team issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/115657

This feature is considered complete and so its feature flag can be removed.