### PR TITLE
Prevent error raising if backup triggered

### DIFF
--- a/app/services/bgs/dependent_v2_service.rb
+++ b/app/services/bgs/dependent_v2_service.rb
@@ -111,8 +111,6 @@ module BGS
                            'BGS::DependentV2Service#submit_pdf_job failed, submitting to Lighthouse Benefits Intake',
                            "#{STATS_KEY}.submit_pdf.failure", { error: e })
       submit_to_central_service(claim:)
-
-      raise e
     end
 
     def submit_claim_via_claims_evidence(claim)

--- a/spec/services/bgs/dependent_v2_service_spec.rb
+++ b/spec/services/bgs/dependent_v2_service_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe BGS::DependentV2Service do
   let(:encrypted_vet_info) { KmsEncrypted::Box.new.encrypt(vet_info.to_json) }
 
   before do
-    allow(claim).to receive(:id).and_return('1234')
+    allow(claim).to receive_messages(id: '1234', use_v2: true, user_account_id: user.user_account_uuid,
+                                     submittable_686?: false, submittable_674?: true, add_veteran_info: true,
+                                     valid?: true, persistent_attachments: [], upload_pdf: true)
     allow_any_instance_of(KmsEncrypted::Box).to receive(:encrypt).and_return(encrypted_vet_info)
 
     allow(Flipper).to receive(:enabled?).with(anything).and_call_original
@@ -361,6 +363,32 @@ RSpec.describe BGS::DependentV2Service do
       expect(monitor).to receive(:track_event).with('debug', 'BGS::DependentV2Service#submit_pdf_job completed',
                                                     "#{stats_key}.submit_pdf.completed")
 
+      service.send(:submit_pdf_job, claim:, encrypted_vet_info:)
+    end
+  end
+
+  describe '#submit_pdf_job' do
+    before do
+      allow(SavedClaim::DependencyClaim).to receive(:find).and_return(claim)
+    end
+
+    it 'calls the VBMS::SubmitDependentsPdfJob with the correct arguments' do
+      service = BGS::DependentV2Service.new(user)
+      expect(VBMS::SubmitDependentsPdfV2Job).to receive(:perform_sync).with(
+        claim.id, encrypted_vet_info, false,
+        true
+      )
+      # use 'send' to call the private method
+      service.send(:submit_pdf_job, claim:, encrypted_vet_info:)
+    end
+
+    it 'in case of error it logs the exception and submits to central service' do
+      service = BGS::DependentV2Service.new(user)
+      allow(VBMS::SubmitDependentsPdfV2Job).to receive(:perform_sync).and_raise(StandardError, 'Test error')
+      expect(Rails.logger).to receive(:warn)
+      expect(service).to receive(:submit_to_central_service).with(claim:)
+
+      # use 'send' to call the private method
       service.send(:submit_pdf_job, claim:, encrypted_vet_info:)
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This pull request refactors the `submit_pdf_job` method in the `BGS::DependentService` class to prevent errors being raised to the user if we have successfully sent the job to the backup path, and adds test coverage for the method. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/115771

## Testing done

- [x] *New code is covered by unit tests*
- [x] Submit a claim that will trigger an error (or add a 'raise error' in the body of `submit_pdf_job`) and ensure:
           * an error is not shown in the UI
           * the claim enters the backup path

## What areas of the site does it impact?
Dependents

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

