### PR TITLE
[ID-583] - Send mhvapi-idempotency-key in prod

### DIFF
--- a/lib/mhv/account_creation/service.rb
+++ b/lib/mhv/account_creation/service.rb
@@ -67,8 +67,8 @@ module MHV
         {
           'Authorization' => "Bearer #{config.sts_token(user_identifier: icn)}",
           'x-api-key' => config.access_key,
-          'mhvapi-idempotency-key' => Settings.vsp_environment == 'production' ? nil : icn
-        }.compact
+          'mhvapi-idempotency-key' => icn
+        }
       end
 
       def normalize_response_body(response_body)

--- a/spec/lib/mhv/account_creation/service_spec.rb
+++ b/spec/lib/mhv/account_creation/service_spec.rb
@@ -30,17 +30,31 @@ describe MHV::AccountCreation::Service do
       { user_profile_id:, premium:, champ_va:, patient:, sm_account_created:, message: }
     end
 
+    let(:access_key) { 'some-access-key' }
+    let(:sts_token) { 'some-token' }
+    let(:config) { instance_double(MHV::AccountCreation::Configuration) }
+
     before do
       allow(Rails.logger).to receive(:info)
       allow(Rails.logger).to receive(:error)
       allow_any_instance_of(SignInService::Sts).to receive(:base_url).and_return('https://staging-api.va.gov')
       allow(Time).to receive(:current).and_return(start_time, end_time)
+      allow(IdentitySettings.mhv.account_creation).to receive(:access_key).and_return(access_key)
+      allow(MHV::AccountCreation::Configuration).to receive(:new).and_return(config)
+      allow(config).to receive(:sts_token).with(user_identifier: icn).and_return(sts_token)
     end
 
     context 'when making a request' do
       let(:expected_tou_datetime) { tou_occurred_at.iso8601 }
       let(:expected_log_message) { "#{log_prefix} create_account request" }
       let(:expected_log_payload) { { icn: } }
+      let(:expected_request_headers) do
+        {
+          'Authorization' => "Bearer #{config.sts_token(user_identifier: icn)}",
+          'x-api-key' => access_key,
+          'mhvapi-idempotency-key' => icn
+        }
+      end
 
       it 'sends vaTermsOfUseDateTime in the correct format' do
         VCR.use_cassette('mhv/account_creation/account_creation_service_200_created') do
@@ -54,6 +68,14 @@ describe MHV::AccountCreation::Service do
         VCR.use_cassette('mhv/account_creation/account_creation_service_200_created') do
           subject
           expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
+        end
+      end
+
+      it 'sends the expected headers' do
+        VCR.use_cassette('mhv/account_creation/account_creation_service_200_created') do
+          subject
+          expect(a_request(:post, "#{account_creation_base_url}/#{account_creation_path}")
+                 .with(headers: expected_request_headers)).to have_been_made
         end
       end
     end

--- a/spec/support/vcr_cassettes/mhv/account_creation/account_creation_service_200_created.yml
+++ b/spec/support/vcr_cassettes/mhv/account_creation/account_creation_service_200_created.yml
@@ -50,7 +50,7 @@ http_interactions:
       - '844'
     body:
       encoding: UTF-8
-      string: '{"data":{"access_token":"eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJ2YS5nb3Ygc2lnbiBpbiIsImF1ZCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzAwMCIsImp0aSI6ImNkYzNmN2JlLTQ5MTMtNGQxZC04ZTI4LTRhNmJkZmJiYjYxOCIsInN1YiI6IjEwMTAxVjk2NDE0NCIsImV4cCI6MTcyNDg5ODk2MiwiaWF0IjoxNzI0ODk4NjYyLCJ2ZXJzaW9uIjoiVjAiLCJzY29wZXMiOlsiaHR0cHM6Ly9taHYtaW50Yi1hcGkubXloZWFsdGgudmEuZ292L21odmFwaS92MS91c2VybWdtdC9hY2NvdW50LXNlcnZpY2UvYWNjb3VudCJdLCJzZXJ2aWNlX2FjY291bnRfaWQiOiJjMzRiODZmMjEzMGZmM2NkNGIxZDMwOWJjMDlkODc0MCIsInVzZXJfYXR0cmlidXRlcyI6e319.Ld_KvqHnm2HDuZE0sO5LAbILSA9ccPahuZXBDbvnDI2Vl9n1TPUovCo7V1iQr50T_kttgZtE4fz5FIs8wpbsTfC2G2CtT2TEaT6wKODBAXb2Fdyskv7lkN29K_PlhW8_HJIFiaSpxIcg2AQxvByTnfAvOZ4qWjBu16OXqnJjC4koLpyL-tcj0yO9tMzd_Cup8irdmLcDruqIjfkG1sIyuFHTAKThBX0_3oDs5eNSEM20Iwd3pxylfP8RmN67WrMo38oH53skJNg2BorfsLwebcr3JjLmJQJcRR7fypovBqXSMjDiXLMOkg6NTr23XfOmxmnEbJLx936U1uOuWpg4hA"}}'
+      string: '{"data":{"access_token":"some-token"}}'
   recorded_at: Thu, 29 Aug 2024 02:31:02 GMT
 - request:
     method: post
@@ -60,7 +60,11 @@ http_interactions:
       string: '{"icn":"1012830712V627751","email":"some-email@email.com","vaTermsOfUseStatus":"accepted","vaTermsOfUseDateTime":"2017-07-26T19:56:07Z","vaTermsOfUseRevision":"3","vaTermsOfUseLegalVersion":"1.0","vaTermsOfUseDocTitle":"VA Enterprise Terms of Use"}'
     headers:
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJ2YS5nb3Ygc2lnbiBpbiIsImF1ZCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzAwMCIsImp0aSI6ImNkYzNmN2JlLTQ5MTMtNGQxZC04ZTI4LTRhNmJkZmJiYjYxOCIsInN1YiI6IjEwMTAxVjk2NDE0NCIsImV4cCI6MTcyNDg5ODk2MiwiaWF0IjoxNzI0ODk4NjYyLCJ2ZXJzaW9uIjoiVjAiLCJzY29wZXMiOlsiaHR0cHM6Ly9taHYtaW50Yi1hcGkubXloZWFsdGgudmEuZ292L21odmFwaS92MS91c2VybWdtdC9hY2NvdW50LXNlcnZpY2UvYWNjb3VudCJdLCJzZXJ2aWNlX2FjY291bnRfaWQiOiJjMzRiODZmMjEzMGZmM2NkNGIxZDMwOWJjMDlkODc0MCIsInVzZXJfYXR0cmlidXRlcyI6e319.Ld_KvqHnm2HDuZE0sO5LAbILSA9ccPahuZXBDbvnDI2Vl9n1TPUovCo7V1iQr50T_kttgZtE4fz5FIs8wpbsTfC2G2CtT2TEaT6wKODBAXb2Fdyskv7lkN29K_PlhW8_HJIFiaSpxIcg2AQxvByTnfAvOZ4qWjBu16OXqnJjC4koLpyL-tcj0yO9tMzd_Cup8irdmLcDruqIjfkG1sIyuFHTAKThBX0_3oDs5eNSEM20Iwd3pxylfP8RmN67WrMo38oH53skJNg2BorfsLwebcr3JjLmJQJcRR7fypovBqXSMjDiXLMOkg6NTr23XfOmxmnEbJLx936U1uOuWpg4hA
+      - Bearer some-token
+      X-Api-Key:
+      - some-access-key
+      Mhvapi-Idempotency-Key:
+      - 10101V964144
       Accept:
       - application/json
       Content-Type:


### PR DESCRIPTION
⚠️ Do not merge until MHV confirms they are ready for this ⚠️ 

## Summary

This PR allows the MHV Account Creation API cache header in production. This should prevent race conditions when calling the service


## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/583

## Testing done

- Testing has been done on staging for a few weeks.

- add logging to Faraday connection [here](https://github.com/department-of-veterans-affairs/vets-api/blob/7c23742543493f502e775a445b9ca0ebbbfa42eb/lib/mhv/account_creation/configuration.rb#L50-L58)
   ```ruby
   conn.request(:curl, ::Logger.new($stdout), :info)
   ```
- in rails console make a request
   ```ruby
   require 'mhv/account_creation/service'

   user_verification = UserVerification.joins(user_account: :terms_of_use_agreements).where(terms_of_use_agreements: { response: 'accepted' }).last
   icn = user_verification.user_account.icn
   tou_occurred_at = user_verification.user_account.terms_of_use_agreements.current.last.created_at
   email = user_verification.user_credential_email.credential_email  
  
   MHV::AccountCreation::Service.new.create_account(icn:, email:, tou_occurred_at:)
   ```
- you should see a curl request log with the expected headers:
   ```bash
   curl -v -X POST \
    "https://apigw-intb.aws.myhealth.va.gov/v1/usermgmt/account-service/account" \
    -H 'Accept: application/json' \
    -H 'Content-Type: application/json' \
    -H 'User-Agent: Vets.gov Agent' \
    -H 'Authorization: Bearer eyJ0eXAiOiJKV1QiLCJraWQiOiI1ODM0...<snipped>...Bu4EoMUDuOg' \
    -H 'x-api-key: ' \
    -H 'mhvapi-idempotency-key: 1008596379V859838' \
    -d '{
      "icn":                 "1008596379V859838",
      "email":               "vets.gov.user+1@gmail.com",
      "vaTermsOfUseDateTime":"2025-03-10T15:16:40Z",
      "vaTermsOfUseStatus":  "accepted",
      "vaTermsOfUseRevision":"3",
      "vaTermsOfUseLegalVersion":"1.0",
      "vaTermsOfUseDocTitle":"VA Enterprise Terms of Use"
    }'
   ```

## What areas of the site does it impact?
MHV Account Creation API

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

