### PR TITLE
Accreditation api add registration number to reps, remove location requirement for orgs

### DIFF
--- a/app/models/accredited_individual.rb
+++ b/app/models/accredited_individual.rb
@@ -37,15 +37,7 @@ class AccreditedIndividual < ApplicationRecord
 
   # Set the full_name attribute for the representative
   def set_full_name
-    self.full_name = if first_name.blank? && last_name.blank?
-                       ''
-                     elsif first_name.blank?
-                       last_name.strip
-                     elsif last_name.blank?
-                       first_name.strip
-                     else
-                       "#{first_name.strip} #{last_name.strip}"
-                     end
+    self.full_name = [first_name, last_name].map(&:to_s).map(&:strip).reject(&:blank?).join(' ')
   end
 
   DEFAULT_FUZZY_THRESHOLD = AccreditedRepresentation::Constants::FUZZY_SEARCH_THRESHOLD

--- a/app/models/accredited_individual.rb
+++ b/app/models/accredited_individual.rb
@@ -33,6 +33,21 @@ class AccreditedIndividual < ApplicationRecord
     'representative' => 'representative'
   }
 
+  before_save :set_full_name
+
+  # Set the full_name attribute for the representative
+  def set_full_name
+    self.full_name = if first_name.blank? && last_name.blank?
+                       ''
+                     elsif first_name.blank?
+                       last_name.strip
+                     elsif last_name.blank?
+                       first_name.strip
+                     else
+                       "#{first_name.strip} #{last_name.strip}"
+                     end
+  end
+
   DEFAULT_FUZZY_THRESHOLD = AccreditedRepresentation::Constants::FUZZY_SEARCH_THRESHOLD
 
   # Find all [AccreditedIndividuals] that are located within a distance of a specific location

--- a/app/models/accredited_individual.rb
+++ b/app/models/accredited_individual.rb
@@ -37,7 +37,7 @@ class AccreditedIndividual < ApplicationRecord
 
   # Set the full_name attribute for the representative
   def set_full_name
-    self.full_name = [first_name, last_name].map(&:to_s).map(&:strip).reject(&:blank?).join(' ')
+    self.full_name = [first_name, last_name].map(&:to_s).map(&:strip).compact_blank.join(' ')
   end
 
   DEFAULT_FUZZY_THRESHOLD = AccreditedRepresentation::Constants::FUZZY_SEARCH_THRESHOLD

--- a/modules/representation_management/app/services/representation_management/accredited_entity_query.rb
+++ b/modules/representation_management/app/services/representation_management/accredited_entity_query.rb
@@ -67,7 +67,6 @@ module RepresentationManagement
             accredited_organizations
           WHERE
             word_similarity(:query_string, name) >= :threshold
-            AND location IS NOT NULL
         )
         SELECT
           id,

--- a/modules/representation_management/app/sidekiq/representation_management/accredited_entities_queue_updates.rb
+++ b/modules/representation_management/app/sidekiq/representation_management/accredited_entities_queue_updates.rb
@@ -292,7 +292,8 @@ module RepresentationManagement
                                   address_line2: rep['workAddress2'],
                                   address_line3: rep['workAddress3'],
                                   zip_code: rep['workZip'],
-                                  raw_address: raw_address_for_representative(rep)
+                                  raw_address: raw_address_for_representative(rep),
+                                  registration_number: rep['representative']['id']
                                 })
     end
 

--- a/modules/representation_management/app/sidekiq/representation_management/accredited_entities_queue_updates.rb
+++ b/modules/representation_management/app/sidekiq/representation_management/accredited_entities_queue_updates.rb
@@ -293,7 +293,7 @@ module RepresentationManagement
                                   address_line3: rep['workAddress3'],
                                   zip_code: rep['workZip'],
                                   raw_address: raw_address_for_representative(rep),
-                                  registration_number: rep['representative']['id']
+                                  registration_number: rep.dig('representative', 'id')
                                 })
     end
 

--- a/modules/representation_management/spec/requests/representation_management/v0/accredited_entities_for_appoint_spec.rb
+++ b/modules/representation_management/spec/requests/representation_management/v0/accredited_entities_for_appoint_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 RSpec.describe 'RepresentationManagement::V0::AccreditedEntitiesForAppoint', type: :request do
   let(:path) { '/representation_management/v0/accredited_entities_for_appoint' }
-  let!(:bob_law) { create(:accredited_individual, :with_location, full_name: 'Bob Law') }
-  let!(:bob_smith) { create(:accredited_individual, :with_location, full_name: 'Bob Smith') }
+  let!(:bob_law) { create(:accredited_individual, :with_location, first_name: 'Bob', last_name: 'Law') }
+  let!(:bob_smith) { create(:accredited_individual, :with_location, first_name: 'Bob', last_name: 'Smith') }
   let!(:bob_law_firm) { create(:accredited_organization, :with_location, name: 'Bob Law Firm') }
   let!(:bob_smith_firm) { create(:accredited_organization, :with_location, name: 'Bob Smith Firm') }
 

--- a/modules/representation_management/spec/services/representation_management/accredited_entity_query_spec.rb
+++ b/modules/representation_management/spec/services/representation_management/accredited_entity_query_spec.rb
@@ -3,13 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe RepresentationManagement::AccreditedEntityQuery, type: :model do
-  let!(:individual1) { create(:accredited_individual, :with_location, full_name: 'Bob Law') }
-  let!(:individual2) { create(:accredited_individual, :with_location, full_name: 'Bob Smith') }
-  let!(:individual3) { create(:accredited_individual, :with_location, :attorney, full_name: 'aaaabc') }
-  let!(:individual4) { create(:accredited_individual, :with_location, :claims_agent, full_name: 'aaaab') }
-  let!(:individual5) { create(:accredited_individual, :with_location, full_name: 'aaaabcde') }
-  let!(:individual6) { create(:accredited_individual, :with_location, full_name: 'aaaa') }
-  let!(:individual7) { create(:accredited_individual, :with_location, full_name: 'aaaabcd') }
+  let!(:individual1) { create(:accredited_individual, :with_location, first_name: 'Bob', last_name: 'Law') }
+  let!(:individual2) { create(:accredited_individual, :with_location, first_name: 'Bob', last_name: 'Smith') }
+  let!(:individual3) { create(:accredited_individual, :with_location, :attorney, first_name: 'aaaabc', last_name: '') }
+  let!(:individual4) do
+    create(:accredited_individual, :with_location, :claims_agent, first_name: 'aaaab', last_name: '')
+  end
+  let!(:individual5) { create(:accredited_individual, :with_location, first_name: 'aaaabcde', last_name: '') }
+  let!(:individual6) { create(:accredited_individual, :with_location, first_name: 'aaaa', last_name: '') }
+  let!(:individual7) { create(:accredited_individual, :with_location, first_name: 'aaaabcd', last_name: '') }
 
   let!(:organization1) { create(:accredited_organization, name: 'Bob Law Firm') }
   let!(:organization2) { create(:accredited_organization, name: 'Bob Smith Firm') }
@@ -76,7 +78,7 @@ RSpec.describe RepresentationManagement::AccreditedEntityQuery, type: :model do
     end
 
     it 'returns at most 10 results' do
-      create_list(:accredited_individual, 20, :with_location, full_name: 'Bob')
+      create_list(:accredited_individual, 20, :with_location, first_name: 'Bob', last_name: '')
 
       results = described_class.new('Bob').results
 

--- a/modules/representation_management/spec/services/representation_management/accredited_entity_query_spec.rb
+++ b/modules/representation_management/spec/services/representation_management/accredited_entity_query_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe RepresentationManagement::AccreditedEntityQuery, type: :model do
   let!(:individual6) { create(:accredited_individual, :with_location, full_name: 'aaaa') }
   let!(:individual7) { create(:accredited_individual, :with_location, full_name: 'aaaabcd') }
 
-  let!(:organization1) { create(:accredited_organization, :with_location, name: 'Bob Law Firm') }
-  let!(:organization2) { create(:accredited_organization, :with_location, name: 'Bob Smith Firm') }
-  let!(:organization3) { create(:accredited_organization, :with_location, name: 'aaaabcdefgh') }
-  let!(:organization4) { create(:accredited_organization, :with_location, name: 'aaaabcdefg') }
-  let!(:organization5) { create(:accredited_organization, :with_location, name: 'aaaabcdefghij') }
-  let!(:organization6) { create(:accredited_organization, :with_location, name: 'aaaabcdef') }
-  let!(:organization7) { create(:accredited_organization, :with_location, name: 'aaaabcdefghi') }
+  let!(:organization1) { create(:accredited_organization, name: 'Bob Law Firm') }
+  let!(:organization2) { create(:accredited_organization, name: 'Bob Smith Firm') }
+  let!(:organization3) { create(:accredited_organization, name: 'aaaabcdefgh') }
+  let!(:organization4) { create(:accredited_organization, name: 'aaaabcdefg') }
+  let!(:organization5) { create(:accredited_organization, name: 'aaaabcdefghij') }
+  let!(:organization6) { create(:accredited_organization, name: 'aaaabcdef') }
+  let!(:organization7) { create(:accredited_organization, name: 'aaaabcdefghi') }
 
   describe '#results' do
     it 'returns nothing for a blank query string' do

--- a/modules/representation_management/spec/sidekiq/representation_management/accredited_entities_queue_updates_spec.rb
+++ b/modules/representation_management/spec/sidekiq/representation_management/accredited_entities_queue_updates_spec.rb
@@ -1712,7 +1712,7 @@ RSpec.describe RepresentationManagement::AccreditedEntitiesQueueUpdates, type: :
       end
     end
   end
-  
+
   describe '#individual_representative_json' do
     let(:record) { instance_double(AccreditedIndividual, id: 42) }
     let(:rep) do

--- a/modules/representation_management/spec/sidekiq/representation_management/accredited_entities_queue_updates_spec.rb
+++ b/modules/representation_management/spec/sidekiq/representation_management/accredited_entities_queue_updates_spec.rb
@@ -1414,4 +1414,302 @@ RSpec.describe RepresentationManagement::AccreditedEntitiesQueueUpdates, type: :
       end
     end
   end
+
+  describe 'registration_number validation' do
+    context 'when processing agents' do
+      let(:agent_with_number) do
+        {
+          'id' => '123',
+          'number' => 'A123',
+          'poa' => 'ABC',
+          'firstName' => 'John',
+          'lastName' => 'Doe',
+          'workAddress1' => '123 Main St',
+          'workZip' => '12345'
+        }
+      end
+
+      let(:agent_without_number) do
+        {
+          'id' => '456',
+          'number' => nil,
+          'poa' => 'DEF',
+          'firstName' => 'Jane',
+          'lastName' => 'Smith',
+          'workAddress1' => '456 Oak St',
+          'workZip' => '67890'
+        }
+      end
+
+      let(:record_with_number) { instance_double(AccreditedIndividual, id: 1, raw_address: nil) }
+      let(:record_without_number) { instance_double(AccreditedIndividual, id: 2, raw_address: nil) }
+
+      before do
+        job.instance_variable_set(:@agent_ids, [])
+        job.instance_variable_set(:@agent_json_for_address_validation, [])
+
+        allow(client).to receive(:get_accredited_entities)
+          .with(type: RepresentationManagement::AGENTS, page: 1)
+          .and_return(instance_double(Faraday::Response,
+                                      body: { 'items' => [agent_with_number, agent_without_number] }))
+        allow(client).to receive(:get_accredited_entities)
+          .with(type: RepresentationManagement::AGENTS, page: 2)
+          .and_return(instance_double(Faraday::Response, body: { 'items' => [] }))
+
+        allow(AccreditedIndividual).to receive(:find_or_create_by) do |args|
+          case args[:ogc_id]
+          when '123' then record_with_number
+          when '456' then record_without_number
+          end
+        end
+
+        allow(record_with_number).to receive(:update)
+        allow(record_without_number).to receive(:update)
+      end
+
+      it 'updates agent records with valid registration_number' do
+        job.send(:update_agents)
+
+        expect(record_with_number).to have_received(:update)
+          .with(hash_including(registration_number: 'A123'))
+      end
+
+      it 'updates agent records with nil registration_number when number is missing' do
+        job.send(:update_agents)
+
+        expect(record_without_number).to have_received(:update)
+          .with(hash_including(registration_number: nil))
+      end
+
+      it 'ensures all agent updates include registration_number key' do
+        job.send(:update_agents)
+
+        expect(record_with_number).to have_received(:update) do |attrs|
+          expect(attrs).to have_key(:registration_number)
+        end
+
+        expect(record_without_number).to have_received(:update) do |attrs|
+          expect(attrs).to have_key(:registration_number)
+        end
+      end
+    end
+
+    context 'when processing attorneys' do
+      let(:attorney_with_number) do
+        {
+          'id' => '789',
+          'number' => 'B789',
+          'poa' => 'GHI',
+          'firstName' => 'Bob',
+          'lastName' => 'Johnson',
+          'workAddress1' => '321 Pine St',
+          'workCity' => 'Anytown',
+          'workState' => 'CA',
+          'workZip' => '98765'
+        }
+      end
+
+      let(:attorney_without_number) do
+        {
+          'id' => '012',
+          'number' => '',
+          'poa' => 'JKL',
+          'firstName' => 'Sarah',
+          'lastName' => 'Williams',
+          'workAddress1' => '654 Elm St',
+          'workCity' => 'Othertown',
+          'workState' => 'NY',
+          'workZip' => '54321'
+        }
+      end
+
+      let(:record_with_number) { instance_double(AccreditedIndividual, id: 3, raw_address: nil) }
+      let(:record_without_number) { instance_double(AccreditedIndividual, id: 4, raw_address: nil) }
+
+      before do
+        job.instance_variable_set(:@attorney_ids, [])
+        job.instance_variable_set(:@attorney_json_for_address_validation, [])
+
+        allow(client).to receive(:get_accredited_entities)
+          .with(type: RepresentationManagement::ATTORNEYS, page: 1)
+          .and_return(instance_double(Faraday::Response,
+                                      body: { 'items' => [attorney_with_number, attorney_without_number] }))
+        allow(client).to receive(:get_accredited_entities)
+          .with(type: RepresentationManagement::ATTORNEYS, page: 2)
+          .and_return(instance_double(Faraday::Response, body: { 'items' => [] }))
+
+        allow(AccreditedIndividual).to receive(:find_or_create_by) do |args|
+          case args[:ogc_id]
+          when '789' then record_with_number
+          when '012' then record_without_number
+          end
+        end
+
+        allow(record_with_number).to receive(:update)
+        allow(record_without_number).to receive(:update)
+      end
+
+      it 'updates attorney records with valid registration_number' do
+        job.send(:update_attorneys)
+
+        expect(record_with_number).to have_received(:update)
+          .with(hash_including(registration_number: 'B789'))
+      end
+
+      it 'updates attorney records with empty string registration_number when number is empty' do
+        job.send(:update_attorneys)
+
+        expect(record_without_number).to have_received(:update)
+          .with(hash_including(registration_number: ''))
+      end
+
+      it 'ensures all attorney updates include registration_number key' do
+        job.send(:update_attorneys)
+
+        expect(record_with_number).to have_received(:update) do |attrs|
+          expect(attrs).to have_key(:registration_number)
+        end
+
+        expect(record_without_number).to have_received(:update) do |attrs|
+          expect(attrs).to have_key(:registration_number)
+        end
+      end
+    end
+
+    context 'when processing representatives' do
+      let(:rep_with_id) do
+        {
+          'id' => 'ea154c64-bf20-47e0-9866-86ae988776a8',
+          'representative' => {
+            'lastName' => 'aalaam',
+            'firstName' => 'judy',
+            'id' => 'dfc36f35-0464-450f-a85b-3fa639705826'
+          },
+          'veteransServiceOrganization' => {
+            'id' => '9c6f8595-4e84-42e5-b90a-270c422c373a'
+          },
+          'workAddress1' => '123 Work St',
+          'workCity' => 'Work City',
+          'workState' => 'CA',
+          'workZip' => '12345'
+        }
+      end
+
+      let(:rep_without_id) do
+        {
+          'id' => 'b50ee54b-ff87-4c78-b41d-7ffe1a8f89e5',
+          'representative' => {
+            'lastName' => 'abad',
+            'firstName' => 'julia',
+            'id' => nil
+          },
+          'veteransServiceOrganization' => {
+            'id' => '8f8d4051-ddcc-4730-973e-9688559a91fc'
+          },
+          'workAddress1' => '456 Office Blvd',
+          'workCity' => 'Office Town',
+          'workState' => 'NY',
+          'workZip' => '54321'
+        }
+      end
+
+      let(:record_with_id) { instance_double(AccreditedIndividual, id: 200, raw_address: nil) }
+      let(:record_without_id) { instance_double(AccreditedIndividual, id: 201, raw_address: nil) }
+
+      before do
+        job.instance_variable_set(:@representative_ids, [])
+        job.instance_variable_set(:@representative_json_for_address_validation, [])
+        job.instance_variable_set(:@rep_to_vso_associations, {})
+
+        allow(client).to receive(:get_accredited_entities)
+          .with(type: RepresentationManagement::REPRESENTATIVES, page: 1)
+          .and_return(instance_double(Faraday::Response, body: { 'items' => [rep_with_id, rep_without_id] }))
+        allow(client).to receive(:get_accredited_entities)
+          .with(type: RepresentationManagement::REPRESENTATIVES, page: 2)
+          .and_return(instance_double(Faraday::Response, body: { 'items' => [] }))
+
+        allow(AccreditedIndividual).to receive(:find_or_create_by) do |args|
+          case args[:ogc_id]
+          when 'dfc36f35-0464-450f-a85b-3fa639705826' then record_with_id
+          when nil then record_without_id
+          end
+        end
+
+        allow(record_with_id).to receive(:update)
+        allow(record_without_id).to receive(:update)
+      end
+
+      it 'updates representative records with valid registration_number from representative ID' do
+        job.send(:update_reps)
+
+        expect(record_with_id).to have_received(:update)
+          .with(hash_including(registration_number: 'dfc36f35-0464-450f-a85b-3fa639705826'))
+      end
+
+      it 'updates representative records with nil registration_number when representative ID is missing' do
+        job.send(:update_reps)
+
+        expect(record_without_id).to have_received(:update)
+          .with(hash_including(registration_number: nil))
+      end
+
+      it 'ensures all representative updates include registration_number key' do
+        job.send(:update_reps)
+
+        expect(record_with_id).to have_received(:update) do |attrs|
+          expect(attrs).to have_key(:registration_number)
+        end
+
+        expect(record_without_id).to have_received(:update) do |attrs|
+          expect(attrs).to have_key(:registration_number)
+        end
+      end
+    end
+
+    context 'when testing data transformation methods directly' do
+      it 'includes registration_number in agent transformation' do
+        agent = { 'number' => 'A123', 'id' => '123', 'firstName' => 'John', 'lastName' => 'Doe' }
+        result = job.send(:data_transform_for_agent, agent)
+
+        expect(result).to have_key(:registration_number)
+        expect(result[:registration_number]).to eq('A123')
+      end
+
+      it 'includes registration_number in attorney transformation' do
+        attorney = { 'number' => 'B456', 'id' => '456', 'firstName' => 'Jane', 'lastName' => 'Smith' }
+        result = job.send(:data_transform_for_attorney, attorney)
+
+        expect(result).to have_key(:registration_number)
+        expect(result[:registration_number]).to eq('B456')
+      end
+
+      it 'includes registration_number in representative transformation' do
+        rep = {
+          'representative' => { 'id' => 'rep-id-789', 'firstName' => 'Bob', 'lastName' => 'Wilson' },
+          'workCity' => 'Test City',
+          'workState' => 'TX'
+        }
+        result = job.send(:data_transform_for_representative, rep)
+
+        expect(result).to have_key(:registration_number)
+        expect(result[:registration_number]).to eq('rep-id-789')
+      end
+
+      it 'handles nil registration_number values gracefully' do
+        agent = { 'number' => nil, 'id' => '999', 'firstName' => 'Test', 'lastName' => 'User' }
+        result = job.send(:data_transform_for_agent, agent)
+
+        expect(result).to have_key(:registration_number)
+        expect(result[:registration_number]).to be_nil
+      end
+
+      it 'handles empty string registration_number values gracefully' do
+        attorney = { 'number' => '', 'id' => '888', 'firstName' => 'Empty', 'lastName' => 'Number' }
+        result = job.send(:data_transform_for_attorney, attorney)
+
+        expect(result).to have_key(:registration_number)
+        expect(result[:registration_number]).to eq('')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): NO*
- *(Summarize the changes that have been made to the platform)*: This PR adds a `registration_number` value to any `AccreditedIndividual` records that have an `individual_type` of `'representative'`.  The `individual_type`s of `'attorney'` and `'claims_agent'` already set that value.  It also includes tests to ensure all three `individual_type`s set the value.  Additionally it removes the requirement for a VSO org to have location data to be searchable in Appoint a Rep.  Orgs don't have address or location data in the Accreditation API so that change makes them still searchable.
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*: `'representative'` types weren't persisting due to a lack of `registration_number`.
- *(Which team do you work for, does your team own the maintenance of this component?)*: FAR/ARM, we own the maintenance.
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114588
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*: Representatives would fail validation so they wouldn't save to the database, and searching for orgs didn't work due to the location requirement.
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*: When deployed records of `AccreditedIndividual` with the `individual_type = 'representative'` will be saved in the table, and org search will work for appoint a rep in staging.
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*: Just the `RepresentationManagement` module.

## Acceptance criteria

- [x]  I updated & added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
