### PR TITLE
API-48515-upfront-rep-validation-for-decide

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -69,19 +69,16 @@ module ClaimsApi
           lighthouse_id = params[:id]
           decision = normalize(form_attributes['decision'])
           representative_id = form_attributes['representativeId']
-
           request = find_poa_request!(lighthouse_id)
-
           proc_id = request.proc_id
 
           validate_decide_params!(proc_id:, decision:)
+          validate_decide_representative_params!(request.poa_code, representative_id)
 
           vet_icn = request.veteran_icn
           claimant_icn = request.claimant_icn
-
           veteran_data = build_veteran_or_dependent_data(vet_icn)
           claimant_data = build_veteran_or_dependent_data(claimant_icn) if claimant_icn.present?
-
           # Will either get null when a decision is declined or
           # a poa.id for record saved in our DB when decision is accepted
           decision_response = process_poa_decision(decision:, proc_id:, representative_id:, poa_code: request.poa_code,
@@ -157,6 +154,17 @@ module ClaimsApi
         end
 
         private
+
+        def validate_decide_representative_params!(poa_code, representative_id)
+          validate_accredited_representative(poa_code)
+
+          unless @representative.representative_id == representative_id
+            raise ::ClaimsApi::Common::Exceptions::Lighthouse::ResourceNotFound.new(
+              detail: "The accredited representative with registration number #{representative_id} does not match " \
+                      "poa code: #{poa_code}."
+            )
+          end
+        end
 
         # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
         def process_poa_decision(decision:, proc_id:, representative_id:, poa_code:, metadata:, veteran:, claimant:)

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
@@ -688,6 +688,9 @@ describe 'PowerOfAttorney',
             allow(poa_request_service).to receive(:get_poa_request).and_return(get_poa_request_response)
             allow_any_instance_of(ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController)
               .to receive(:process_poa_decision).and_return(OpenStruct.new(id: '1234'))
+            allow_any_instance_of(
+              ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController
+            ).to receive(:validate_decide_representative_params!).with(anything, anything).and_return(nil)
 
             mock_ccg(scopes) do
               VCR.use_cassette('claims_api/bgs/manage_representative_service/update_poa_request_accepted') do


### PR DESCRIPTION
## Summary
* Adds up front validation to ensure the rep ID passed in the submission matches that on the request.
	* adds a test and updates related tests

## Related issue(s)
[API-48515](https://jira.devops.va.gov/browse/API-48515)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
	modified:   modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
	modified:   modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
