### PR TITLE
[ID-581] - Update client configs api to accept certs attributes

### DIFF
--- a/app/controllers/sign_in/client_configs_controller.rb
+++ b/app/controllers/sign_in/client_configs_controller.rb
@@ -48,10 +48,11 @@ module SignIn
       params.require(:client_config).permit(:client_id, :authentication, :redirect_uri, :refresh_token_duration,
                                             :access_token_duration, :access_token_audience, :logout_redirect_uri,
                                             :pkce, :terms_of_use_url, :enforced_terms, :shared_sessions, :anti_csrf,
-                                            :description, :json_api_compatibility, certificates: [],
-                                                                                   access_token_attributes: [],
-                                                                                   service_levels: [],
-                                                                                   credential_service_providers: [])
+                                            :description, :json_api_compatibility,
+                                            access_token_attributes: [],
+                                            service_levels: [],
+                                            credential_service_providers: [],
+                                            certs_attributes: %i[id pem _destroy])
     end
 
     def set_client_config

--- a/app/controllers/sign_in/service_account_configs_controller.rb
+++ b/app/controllers/sign_in/service_account_configs_controller.rb
@@ -50,8 +50,8 @@ module SignIn
                                                      :access_token_audience,
                                                      :access_token_duration,
                                                      scopes: [],
-                                                     certificates: [],
-                                                     access_token_user_attributes: [])
+                                                     access_token_user_attributes: [],
+                                                     certs_attributes: %i[id pem _destroy])
     end
 
     def set_service_account_config

--- a/app/models/sign_in/service_account_config.rb
+++ b/app/models/sign_in/service_account_config.rb
@@ -4,8 +4,14 @@ module SignIn
   class ServiceAccountConfig < ApplicationRecord
     attribute :access_token_duration, :interval
 
-    has_many :config_certificates, as: :config, dependent: :destroy
-    has_many :certs, through: :config_certificates, class_name: 'SignIn::Certificate'
+    has_many :config_certificates, as: :config, dependent: :destroy, inverse_of: :config
+    has_many :certs, through: :config_certificates,
+                     class_name: 'SignIn::Certificate',
+                     inverse_of: :service_account_configs
+
+    accepts_nested_attributes_for :certs,
+                                  allow_destroy: true,
+                                  reject_if: ->(attrs) { attrs['pem'].blank? && attrs['id'].blank? }
 
     validates :service_account_id, presence: true, uniqueness: true
     validates :description, presence: true
@@ -14,5 +20,27 @@ module SignIn
               presence: true,
               inclusion: { in: Constants::ServiceAccountAccessToken::VALIDITY_LENGTHS, allow_nil: false }
     validates :access_token_user_attributes, inclusion: { in: Constants::ServiceAccountAccessToken::USER_ATTRIBUTES }
+
+    def certs_attributes=(certs_attributes)
+      certs_attributes.each do |cert_attributes|
+        id = cert_attributes[:id].to_s
+        pem = cert_attributes[:pem].to_s
+        destroy = ActiveModel::Type::Boolean.new.cast(cert_attributes[:_destroy])
+
+        if destroy && id.present?
+          cert = certs.find(id)
+          certs.destroy(cert)
+        else
+          cert = SignIn::Certificate.find_or_create_by(pem:)
+          certs << cert unless certs.include?(cert)
+        end
+      end
+    end
+
+    def as_json(options = {})
+      super(options).tap do |hash|
+        hash['certs'] = certs.map(&:as_json)
+      end
+    end
   end
 end

--- a/db/seeds/development/identity/client_configs.rb
+++ b/db/seeds/development/identity/client_configs.rb
@@ -39,8 +39,8 @@ vamobile_mock.update!(authentication: SignIn::Constants::Auth::API,
 
 # Create Config for VA Identity Dashboard using cookie auth
 vaid_dash = SignIn::ClientConfig.find_or_initialize_by(client_id: 'identity_dashboard_rails')
-vaid_dash.update!(authentication: SignIn::Constants::Auth::COOKIE,
-                  anti_csrf: true,
+vaid_dash.update!(authentication: SignIn::Constants::Auth::API,
+                  anti_csrf: false,
                   pkce: true,
                   redirect_uri: 'http://localhost:4000/sessions/callback',
                   access_token_duration: SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES,

--- a/spec/controllers/sign_in/service_account_configs_controller_spec.rb
+++ b/spec/controllers/sign_in/service_account_configs_controller_spec.rb
@@ -95,6 +95,20 @@ RSpec.describe SignIn::ServiceAccountConfigsController, type: :controller do
           expect(response_body.dig('errors', 'service_account_id')).to include("can't be blank")
         end
       end
+
+      context 'with certs_attributes' do
+        let(:cert) { create(:sign_in_certificate) }
+
+        it 'creates a new certificate for the service account config' do
+          post :create,
+               params: {
+                 service_account_config: valid_attributes.merge(certs_attributes: [cert.attributes])
+               }, as: :json
+          expect(response).to have_http_status(:created)
+          expect(response_body['certs']).to include(a_hash_including('id' => cert.id))
+          expect(SignIn::ServiceAccountConfig.last.certs).to include(cert)
+        end
+      end
     end
 
     context 'when not authenticated' do
@@ -126,6 +140,47 @@ RSpec.describe SignIn::ServiceAccountConfigsController, type: :controller do
                        as: :json
           expect(response).to have_http_status(:unprocessable_entity)
           expect(response_body.dig('errors', 'service_account_id')).to include("can't be blank")
+        end
+      end
+
+      context 'with certs_attributes' do
+        let(:cert) { create(:sign_in_certificate) }
+
+        it 'updates the service account config with new certificates' do
+          put :update,
+              params: { service_account_id:,
+                        service_account_config: valid_attributes.merge(certs_attributes: [cert.attributes]) },
+              as: :json
+          expect(response).to have_http_status(:ok)
+          expect(response_body['certs']).to include(a_hash_including('id' => cert.id))
+        end
+
+        context 'when certs_attributes are empty' do
+          it 'does not update the certs' do
+            put :update, params: { service_account_id:,
+                                   service_account_config: valid_attributes.merge(certs_attributes: []) }, as: :json
+            expect(response).to have_http_status(:ok)
+            expect(response_body['certs']).to be_empty
+          end
+        end
+
+        context 'when certs_attributes contains _destroy' do
+          let(:cert_to_destroy) { create(:sign_in_certificate) }
+
+          before do
+            service_account_config.certs << cert_to_destroy
+          end
+
+          it 'destroys the specified certificate' do
+            put :update, params: {
+              service_account_id:,
+              service_account_config: {
+                certs_attributes: [{ id: cert_to_destroy.id, _destroy: '1' }]
+              },
+              as: :json
+            }
+            expect(response).to have_http_status(:ok)
+          end
         end
       end
     end
@@ -173,22 +228,6 @@ RSpec.describe SignIn::ServiceAccountConfigsController, type: :controller do
         delete :destroy, params: { service_account_id: }
         expect(response).to have_http_status(:unauthorized)
       end
-    end
-  end
-
-  describe 'permitted params' do
-    let(:service_account_config) { build(:service_account_config) }
-    let(:attributes) { service_account_config.attributes.symbolize_keys }
-
-    let(:expected_permitted_params) do
-      array_params, params = attributes.excluding(:id, :created_at, :updated_at)
-                                       .partition { |_, v| v.is_a?(Array) }
-      params.to_h.keys << array_params.to_h.transform_values { [] }
-    end
-
-    it 'permits the expected params' do
-      expect(subject).to permit(*expected_permitted_params)
-        .for(:create, params: { service_account_config: attributes })
     end
   end
 end


### PR DESCRIPTION
## Summary

- Updates client_configs and service_account_configs controller to work with new certs objects
- create certs and associations
-  destroy associations

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/581

# Testing
## Setup
migrate and seed the database
- `rails db:migrate`
- `rails db:seed`

Start the server
- `rails s`
- start a rails console - `rails c`

Update the service account config used to request an access token
- `rails c`
```ruby
SignIn::ServiceAccountConfig.find_by(service_account_id: 'sample_sts_service_account').update!(scopes: ['http://localhost:3000/sign_in/service_account_configs', 'http://localhost:3000/sign_in/client_configs'])
```

## Service Account Configs:

Run these requests in the rails console - `rails c`
**Note:** if your token expires just request a new one

### Request access token
```ruby
assertion_payload = {
  iss: 'http://localhost:3000',
  sub: 'vets.gov.user+0@gmail.com',
  aud: 'http://localhost:3000/v0/sign_in/token',
  iat: Time.zone.now.to_i,
  exp: Time.zone.now.to_i + 1000,
  scopes: ['http://localhost:3000/sign_in/service_account_configs'],
  service_account_id: 'sample_sts_service_account'
}

private_key = OpenSSL::PKey::RSA.new(File.read('spec/fixtures/sign_in/sts_client.pem'))
assertion = JWT.encode(assertion_payload, private_key, 'RS256')

# Generate Token
token_query_params = {
  grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
  assertion: assertion
}

token_uri = URI.parse('http://localhost:3000/v0/sign_in/token')
token_uri.query = token_query_params.to_query

http = Net::HTTP.new(token_uri.host, token_uri.port)
token_request = Net::HTTP::Post.new(token_uri.request_uri)
token = JSON.parse(http.request(token_request).body)['data']['access_token']
```

### POST - Create config with certs
```ruby
uri = URI.parse('http://localhost:3000/sign_in/service_account_configs')
request = Net::HTTP::Post.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  service_account_config: {
    service_account_id: 'sample_sts_service_account_new2',
    description: 'Sample STS service account',
    access_token_audience: 'http://localhost:3000',
    access_token_duration: 300,
    scopes: [],
    certs_attributes: [
      {
         pem: File.read('spec/fixtures/sign_in/identity_dashboard_service_account.crt')
      }
    ]
  }
}.to_json

response = http.request(request)
JSON.parse(response.body) # you should see certs array in the response
```

### PUT - update config - Delete a cert. Should destroy the join table relation not the certificate itself
```ruby
service_account_id = 'sample_sts_service_account_new2'
uri = URI.parse("http://localhost:3000/sign_in/service_account_configs/#{service_account_id}")
request = Net::HTTP::Put.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  service_account_config: {
    certs_attributes: [
      {
        id: "0f54112f-e8ac-4aa2-a5aa-5af981e11626", # replace this with the cert ID in POST response
        _destroy: "true"
      }
    ]
  }
}.to_json

response = http.request(request)
JSON.parse(response.body) 
```

## Client Configs:

Run these requests in the rails console
**Note:** if your token expires just request a new one

### Request access token
```ruby
assertion_payload = {
  iss: 'http://localhost:3000',
  sub: 'vets.gov.user+0@gmail.com',
  aud: 'http://localhost:3000/v0/sign_in/token',
  iat: Time.zone.now.to_i,
  exp: Time.zone.now.to_i + 1000,
  scopes: ['http://localhost:3000/sign_in/client_configs'],
  service_account_id: 'sample_sts_service_account'
}

private_key = OpenSSL::PKey::RSA.new(File.read('spec/fixtures/sign_in/sts_client.pem'))
assertion = JWT.encode(assertion_payload, private_key, 'RS256')

# Generate Token
token_query_params = {
  grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
  assertion: assertion
}

token_uri = URI.parse('http://localhost:3000/v0/sign_in/token')
token_uri.query = token_query_params.to_query

http = Net::HTTP.new(token_uri.host, token_uri.port)
token_request = Net::HTTP::Post.new(token_uri.request_uri)
token = JSON.parse(http.request(token_request).body)['data']['access_token']
```

### POST - Create config with certs
```ruby
uri = URI.parse('http://localhost:3000/sign_in/client_configs')
request = Net::HTTP::Post.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  client_config: {
    client_id: 'sample_client_config_new2',
    description: 'Sample Client Config',
    authentication: 'cookie',
    anti_csrf: true,
    redirect_uri: 'http://localhost:3000/sessions/callback',
    access_token_duration: 300,
    refresh_token_duration: 1800,
    logout_redirect_uri: 'http://localhost:3000/sessions/logout_callback',
    pkce: true,
    certs_attributes: [
      {
         pem: File.read('spec/fixtures/sign_in/identity_dashboard_service_account.crt')
      }
    ]
  }
}.to_json

response = http.request(request)
JSON.parse(response.body)
```

### PUT - update config - Delete a cert. Should destroy the join table relation not the certificate itself
```ruby
client_id = 'sample_client_config_new2'
uri = URI.parse("http://localhost:3000/sign_in/client_configs/#{client_id}")
request = Net::HTTP::Put.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  client_config: {
    certs_attributes: [
      {
        id: "0f54112f-e8ac-4aa2-a5aa-5af981e11626", # replace this with the cert ID in POST response
        _destroy: "true"
      }
    ]
  }
}.to_json

response = http.request(request)
JSON.parse(response.body)
```

## What areas of the site does it impact?
Sign-in service

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

