### PR TITLE
Removes enabled mhv_medications_display_documentation_content feature toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1371,10 +1371,6 @@ features:
     actor_type: user
     description: Enables/disables the use of pre-transformed vital objects
     enable_in_development: true
-  mhv_medications_display_documentation_content:
-    actor_type: user
-    description: Enables/disables documentation-related content for Medications on VA.gov
-    enable_in_development: true
   mhv_medications_display_allergies:
     actor_type: user
     description: Enables/disables allergies and reactions data

--- a/modules/my_health/app/controllers/my_health/v1/prescription_documentation_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/prescription_documentation_controller.rb
@@ -4,22 +4,16 @@ module MyHealth
   module V1
     class PrescriptionDocumentationController < RxController
       def index
-        if Flipper.enabled?(:mhv_medications_display_documentation_content, @current_user)
-          begin
-            id = params[:id]
-            rx = client.get_rx_details(id)
-            raise StandardError, 'Rx not found' if rx.nil?
-            raise StandardError, 'Missing NDC number' if rx.cmop_ndc_value.nil?
+        id = params[:id]
+        rx = client.get_rx_details(id)
+        raise StandardError, 'Rx not found' if rx.nil?
+        raise StandardError, 'Missing NDC number' if rx.cmop_ndc_value.nil?
 
-            documentation = client.get_rx_documentation(rx.cmop_ndc_value)
-            prescription_documentation = PrescriptionDocumentation.new({ html: documentation[:data] })
-            render json: PrescriptionDocumentationSerializer.new(prescription_documentation)
-          rescue => e
-            render json: { error: "Unable to fetch documentation: #{e}" }, status: :service_unavailable
-          end
-        else
-          render json: { error: 'Documentation is not available' }, status: :not_found
-        end
+        documentation = client.get_rx_documentation(rx.cmop_ndc_value)
+        prescription_documentation = PrescriptionDocumentation.new({ html: documentation[:data] })
+        render json: PrescriptionDocumentationSerializer.new(prescription_documentation)
+      rescue => e
+        render json: { error: "Unable to fetch documentation: #{e}" }, status: :service_unavailable
       end
     end
   end

--- a/modules/my_health/spec/requests/my_health/v1/prescriptions_spec.rb
+++ b/modules/my_health/spec/requests/my_health/v1/prescriptions_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe 'MyHealth::V1::Prescriptions', type: :request do
 
   before do
     allow(Rx::Client).to receive(:new).and_return(authenticated_client)
-    Flipper.enable(:mhv_medications_display_documentation_content)
     sign_in_as(current_user)
   end
 
@@ -515,15 +514,6 @@ RSpec.describe 'MyHealth::V1::Prescriptions', type: :request do
           expect(response).to have_http_status(:service_unavailable)
           error = JSON.parse(response.body)['error']
           expect(error).to include('Unable to fetch documentation')
-        end
-
-        it 'responds with not_found when the feature is disabled' do
-          Flipper.disable(:mhv_medications_display_documentation_content)
-          VCR.use_cassette('rx_client/prescriptions/gets_rx_documentation') do
-            get '/my_health/v1/prescriptions/21296515/documentation'
-          end
-          expect(response).to have_http_status(:not_found)
-          expect(JSON.parse(response.body)).to eq({ 'error' => 'Documentation is not available' })
         end
       end
 


### PR DESCRIPTION
## Summary

- Removes enabled `mhv_medications_display_documentation_content` feature toggle

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#114376
- Merge after https://github.com/department-of-veterans-affairs/vets-website/pull/38076 has been deployed.
