### PR TITLE
API-47460 Fix when missing form_data field; Add job forcing

### DIFF
--- a/modules/claims_api/app/models/claims_api/auto_established_claim.rb
+++ b/modules/claims_api/app/models/claims_api/auto_established_claim.rb
@@ -126,7 +126,7 @@ module ClaimsApi
                                     'va_eauth_service_transaction_id',
                                     'va_eauth_issueinstant',
                                     'Authorization')
-      self.header_hash = Digest::SHA256.hexdigest form_data.merge(headers).to_json
+      self.header_hash = Digest::SHA256.hexdigest (form_data || {}).merge(headers).to_json
     end
 
     def status_from_phase(*)

--- a/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_job.rb
@@ -10,8 +10,8 @@ module ClaimsApi::OneOff
 
     # rubocop:disable Metrics/MethodLength
     # Testing max_to_process at 5k was 5m long, so 750 should stay under the 1m timeout limit for Sidekiq jobs
-    def perform(model = 'ClaimsApi::PowerOfAttorney', ids = [], max_to_process = 750)
-      return unless Flipper.enabled? :lighthouse_claims_api_run_header_hash_filler_job
+    def perform(model = 'ClaimsApi::PowerOfAttorney', ids = [], max_to_process = 750, force: false)
+      return if (force == false) && !Flipper.enabled?(:lighthouse_claims_api_run_header_hash_filler_job)
       return unless args_are_valid?(model, ids)
 
       # Only grab columns that are needed for processing

--- a/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_job.rb
@@ -11,7 +11,7 @@ module ClaimsApi::OneOff
     # rubocop:disable Metrics/MethodLength
     # Testing max_to_process at 5k was 5m long, so 750 should stay under the 1m timeout limit for Sidekiq jobs
     def perform(model = 'ClaimsApi::PowerOfAttorney', ids = [], max_to_process = 750, force: false)
-      return if (force == false) && !Flipper.enabled?(:lighthouse_claims_api_run_header_hash_filler_job)
+      return if !force && !Flipper.enabled?(:lighthouse_claims_api_run_header_hash_filler_job)
       return unless args_are_valid?(model, ids)
 
       # Only grab columns that are needed for processing


### PR DESCRIPTION
## Summary

* Fixes error when saving `header_hash` on record with an empty `form_data` field
* Adds ability to force a run even if the feature flag is disabled

## Related issue(s)

#23158 Part 1
#23355 Part 2

https://jira.devops.va.gov/browse/API-47460

## Testing done

- [x] *New code is covered by unit tests*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.