### PR TITLE
Api 48515 fix validation check

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -158,7 +158,7 @@ module ClaimsApi
         def validate_decide_representative_params!(poa_code, representative_id)
           validate_accredited_representative(poa_code)
 
-          unless @representative.representative_id == representative_id
+          unless @representative.representative_id == representative_id.to_s
             raise ::ClaimsApi::Common::Exceptions::Lighthouse::ResourceNotFound.new(
               detail: "The accredited representative with registration number #{representative_id} does not match " \
                       "poa code: #{poa_code}."

--- a/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
+++ b/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
@@ -504,7 +504,7 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
 
     context 'validating the params' do
       let(:decision) { 'ACCEPTED' }
-      let(:representative_id) { '456' }
+      let(:representative_id) { 456 } # this comes in on the form as a integer, not a string
       let(:poa_code) { '123' }
       let(:representative) do
         OpenStruct.new(


### PR DESCRIPTION
## Summary
* The `registration_id` comes in from the form as an integer so the check fails since `@representative.registration_id` is a string.
	* This bug was just because the test I wrote I trusted but had the data wrong, fixing the test to send in an integer fixes this (and casting the `representative_id` to a string when checking obviously)
	
## Related issue(s)
[API-40053](https://jira.devops.va.gov/browse/API-40053)

## Testing done

- [x] *New code is covered by unit tests*


## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
	modified:   modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
