### PR TITLE
MBMS-79601 Updated pre need integration error message for unprocessab…

### DIFF
--- a/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
+++ b/modules/simple_forms_api/app/controllers/simple_forms_api/v1/uploads_controller.rb
@@ -62,7 +62,16 @@ module SimpleFormsApi
               service = BenefitsIntakeService::Service.new
               service.valid_document?(document: file_path)
             rescue BenefitsIntakeService::Service::InvalidDocumentError => e
-              render json: { error: "Document validation failed: #{e.message}" }, status: :unprocessable_entity
+              # Custom error message for form 40-10007
+              if params[:form_id] == '40-10007'
+                render json: { 
+                  errors: [{
+                    detail: "We weren't able to upload your file. Make sure the file is an accepted format and size before continuing."
+                  }]
+                }, status: :unprocessable_entity
+              else
+                render json: { error: "Document validation failed: #{e.message}" }, status: :unprocessable_entity
+              end
               return
             end
           end


### PR DESCRIPTION
## Summary
- Improved error messaging for pre need integration supporting docs
- This vets-api change takes unprocessable content responses from the lighthouse api and gives the front end a custom error message to display

## Related issue(s)
- https://jira.devops.va.gov/browse/MBMS-78601
- Vets-website PR: https://github.com/department-of-veterans-affairs/vets-website/pull/38099

## Testing done

- Backend Tests Passing
- Internal Review
- External Review
- QA

## Screenshots
https://github.com/user-attachments/assets/84b4ccbe-c3a3-4918-9b2d-15011774bf71

## Acceptance criteria
<img width="720" height="429" alt="image" src="https://github.com/user-attachments/assets/f2641462-6bd1-48d2-8844-400c0249497c" />