### PR TITLE
Update telephone Swagger docs for international phones

### DIFF
--- a/app/swagger/swagger/schemas/vet360/telephone.rb
+++ b/app/swagger/swagger/schemas/vet360/telephone.rb
@@ -17,13 +17,15 @@ module Swagger
                    maxLength: 3,
                    pattern: ::VAProfile::Models::Telephone::VALID_AREA_CODE_REGEX.inspect,
                    description: 'The three-digit code that begins a North American (the U.S., Canada and Mexico) phone
-                   number.'
+                   number. Omit or set to null for non-North American phone numbers.'
           property :country_code,
                    type: :string,
-                   enum: ['1'],
-                   example: '1',
-                   description: 'First two to four digits of a non- North American phone number that routes the call to
-                   country of that phone number.'
+                   minLength: 1,
+                   maxLength: 3,
+                   example: '44',
+                   default: '1',
+                   pattern: ::VAProfile::Models::Telephone::VALID_COUNTRY_CODE_REGEX.inspect,
+                   description: 'One- to three-digit code prefix that routes the call to the country of that phone number.'
           property :extension,
                    type: :string,
                    example: '101',
@@ -32,7 +34,9 @@ module Swagger
                    an establishment, in order to reach a specific party.'
           property :is_international,
                    type: :boolean,
-                   example: false
+                   example: true,
+                   default: false,
+                   description: 'Indicates phone number has a non-North American country code.'
           property :is_textable,
                    type: :boolean,
                    example: true,
@@ -82,13 +86,15 @@ module Swagger
                    maxLength: 3,
                    pattern: ::VAProfile::Models::Telephone::VALID_AREA_CODE_REGEX.inspect,
                    description: 'The three-digit code that begins a North American (the U.S., Canada and Mexico) phone
-                   number.'
+                   number. Omit or set to null for non-North American phone numbers.'
           property :country_code,
                    type: :string,
-                   enum: ['1'],
-                   example: '1',
-                   description: 'First two to four digits of a non- North American phone number that routes the call to
-                   country of that phone number.'
+                   minLength: 1,
+                   maxLength: 3,
+                   example: '44',
+                   default: '1',
+                   pattern: ::VAProfile::Models::Telephone::VALID_COUNTRY_CODE_REGEX.inspect,
+                   description: 'One- to three-digit code prefix that routes the call to the country of that phone number.'
           property :extension,
                    type: :string,
                    example: '101',
@@ -97,7 +103,9 @@ module Swagger
                    an establishment, in order to reach a specific party.'
           property :is_international,
                    type: :boolean,
-                   example: false
+                   example: true,
+                   default: false,
+                   description: 'Indicates phone number has a non-North American country code.'
           property :is_textable,
                    type: :boolean,
                    example: true,

--- a/app/swagger/swagger/schemas/vet360/telephone.rb
+++ b/app/swagger/swagger/schemas/vet360/telephone.rb
@@ -25,7 +25,7 @@ module Swagger
                    example: '44',
                    default: '1',
                    pattern: ::VAProfile::Models::Telephone::VALID_COUNTRY_CODE_REGEX.inspect,
-                   description: 'One- to three-digit code prefix that routes the call to the country of that phone number.'
+                   description: 'One- to three-digit code that routes the call to the country of that phone number.'
           property :extension,
                    type: :string,
                    example: '101',
@@ -94,7 +94,7 @@ module Swagger
                    example: '44',
                    default: '1',
                    pattern: ::VAProfile::Models::Telephone::VALID_COUNTRY_CODE_REGEX.inspect,
-                   description: 'One- to three-digit code prefix that routes the call to the country of that phone number.'
+                   description: 'One- to three-digit code that routes the call to the country of that phone number.'
           property :extension,
                    type: :string,
                    example: '101',

--- a/app/swagger/swagger/schemas/vet360/telephone.rb
+++ b/app/swagger/swagger/schemas/vet360/telephone.rb
@@ -9,20 +9,21 @@ module Swagger
         include Swagger::Blocks
 
         swagger_schema :PostVet360Telephone do
-          key :required, %i[phone_number area_code phone_type is_international country_code]
+          key :required, %i[phone_number phone_type is_international country_code]
           property :area_code,
                    type: :string,
+                   nullable: true,
                    example: '303',
                    minLength: 3,
                    maxLength: 3,
                    pattern: ::VAProfile::Models::Telephone::VALID_AREA_CODE_REGEX.inspect,
                    description: 'The three-digit code that begins a North American (the U.S., Canada and Mexico) phone
-                   number. Omit or set to null for non-North American phone numbers.'
+                   number. Required when is_international is false. Omit or set null for non-North American numbers.'
           property :country_code,
                    type: :string,
                    minLength: 1,
                    maxLength: 3,
-                   example: '44',
+                   example: '1',
                    default: '1',
                    pattern: ::VAProfile::Models::Telephone::VALID_COUNTRY_CODE_REGEX.inspect,
                    description: 'One- to three-digit code that routes the call to the country of that phone number.'
@@ -34,7 +35,7 @@ module Swagger
                    an establishment, in order to reach a specific party.'
           property :is_international,
                    type: :boolean,
-                   example: true,
+                   example: false,
                    default: false,
                    description: 'Indicates phone number has a non-North American country code.'
           property :is_textable,
@@ -75,23 +76,24 @@ module Swagger
         end
 
         swagger_schema :PutVet360Telephone do
-          key :required, %i[id phone_number area_code phone_type is_international country_code]
+          key :required, %i[id phone_number phone_type is_international country_code]
           property :id,
                    type: :integer,
                    example: 1
           property :area_code,
                    type: :string,
+                   nullable: true,
                    example: '303',
                    minLength: 3,
                    maxLength: 3,
                    pattern: ::VAProfile::Models::Telephone::VALID_AREA_CODE_REGEX.inspect,
                    description: 'The three-digit code that begins a North American (the U.S., Canada and Mexico) phone
-                   number. Omit or set to null for non-North American phone numbers.'
+                   number. Required when is_international is false. Omit or set null for non-North American numbers.'
           property :country_code,
                    type: :string,
                    minLength: 1,
                    maxLength: 3,
-                   example: '44',
+                   example: '1',
                    default: '1',
                    pattern: ::VAProfile::Models::Telephone::VALID_COUNTRY_CODE_REGEX.inspect,
                    description: 'One- to three-digit code that routes the call to the country of that phone number.'
@@ -103,7 +105,7 @@ module Swagger
                    an establishment, in order to reach a specific party.'
           property :is_international,
                    type: :boolean,
-                   example: true,
+                   example: false,
                    default: false,
                    description: 'Indicates phone number has a non-North American country code.'
           property :is_textable,

--- a/lib/va_profile/models/telephone.rb
+++ b/lib/va_profile/models/telephone.rb
@@ -73,6 +73,7 @@ module VAProfile
 
       validates(
         :is_international,
+        presence: true,
         inclusion: { in: [true, false] }
       )
 


### PR DESCRIPTION
## Summary
VA.gov Profile is implementing support for international numbers. This PR updates the telephone swagger API docs to reflect this change.

Team: Authenticated Experience

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/107884

## Testing done

N/A - documentation updates only

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
