### PR TITLE
Match attribute name with pdf engine section attribute name

### DIFF
--- a/modules/dependents_verification/app/controllers/dependents_verification/v0/claims_controller.rb
+++ b/modules/dependents_verification/app/controllers/dependents_verification/v0/claims_controller.rb
@@ -64,7 +64,7 @@ module DependentsVerification
       # @return [Hash] the form data with SSN and veteran file number
       def form_data_with_ssn_filenumber
         form_data_as_sym = JSON.parse(filtered_params[:form]).deep_symbolize_keys
-        form_data_as_sym[:veteranInformation].merge!(ssn: current_user.ssn, veteranFileNumber: veteran_file_number)
+        form_data_as_sym[:veteranInformation].merge!(ssn: current_user.ssn, vaFileNumber: veteran_file_number)
         form_data_as_sym
       end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Match attribute name when merging in veteran file number to pdf engine section [here](https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/dependents_verification/lib/dependents_verification/pdf_fill/sections/section1.rb#L152)
- If you run the current code locally, you can see that the pdf does not fill the va file number correctly
- Solution is to fix the attribute name to match the pdf filler
- *(Which team do you work for, does your team own the maintenance of this component?)*
- Lifestage Benefits/Dependents Management

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/115684

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
  - VA file number was not filling in correctly in the PDF
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
  - I tested submission before and after change to verify 


## Screenshots
**Before Fix (Current)**
<img width="1095" height="684" alt="Screenshot 2025-08-04 at 11 31 38 AM" src="https://github.com/user-attachments/assets/4aebc1d4-1a38-4537-bf1d-710a3351e59b" />


**After Fix**
<img width="1066" height="800" alt="Screenshot 2025-08-04 at 11 24 26 AM" src="https://github.com/user-attachments/assets/6a310120-b2dd-443a-a2c9-7ba46901d200" />


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
Just Dependents Management Verification - 21_0538

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

Unfortunately our test setup missed this because we can't really test the full flow of things without mocking some things. This can be verified through manual testing though as provided with the screenshots.
