### PR TITLE
Send test event in Sidekiq initializer

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -52,8 +52,10 @@ Rails.application.reloader.to_prepare do
     end
 
     config.on(:startup) do
-      # Initialize and start the long-lived Kafka producer
-      Kafka.submit_test_event({"startup" => "true"})
+      if Flipper.enabled?(:kafka_producer)
+        # Initialize and start the long-lived Kafka producer
+        Kafka.submit_test_event({ 'startup' => 'true' })
+      end
     end
 
     config.on(:shutdown) do

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -51,6 +51,11 @@ Rails.application.reloader.to_prepare do
       Rails.logger.error "#{job['class']} #{job['jid']} died with error #{ex.message}."
     end
 
+    config.on(:startup) do
+      # Initialize and start the long-lived Kafka producer
+      Kafka.submit_test_event({"startup" => "true"})
+    end
+
     config.on(:shutdown) do
       Kafka::ProducerManager.instance.producer&.close
     end


### PR DESCRIPTION
## Summary

- Added a startup block to the Sidekiq initializer file to start the Kafka producer when the system starts. It sends a test event which establishes the connection to the Event Bus. 
- This is important for receiving metrics continuously in DataDog. Because of the low volume of events, the producer might not start for long after the system has been restarted. In that case, we would not see metrics come through in DataDog.

## Related issue(s)

- [VES #5129](https://github.com/department-of-veterans-affairs/VES/issues/5129)

## Testing done

- n/a; I have tested this locally
