### PR TITLE
API-47460 Remove redundant count query

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_job.rb
@@ -8,7 +8,6 @@ module ClaimsApi::OneOff
 
     LOG_TAG = 'header_hash_filler_job'
 
-    # rubocop:disable Metrics/MethodLength
     # Testing max_to_process at 5k was 5m long, so 750 should stay under the 1m timeout limit for Sidekiq jobs
     def perform(model = 'ClaimsApi::PowerOfAttorney', ids = [], max_to_process = 750, force: false)
       return if !force && !Flipper.enabled?(:lighthouse_claims_api_run_header_hash_filler_job)
@@ -39,7 +38,6 @@ module ClaimsApi::OneOff
       end
       ClaimsApi::Logger.log LOG_TAG, details: "Processed #{processed_count} records for #{model}"
     end
-    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_job.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/one_off/header_hash_filler_job.rb
@@ -37,9 +37,7 @@ module ClaimsApi::OneOff
                                          error_message: e.message
         end
       end
-      remaining = model.constantize.where(header_hash: nil).count
-      ClaimsApi::Logger.log LOG_TAG,
-                            details: "Processed #{processed_count} records for #{model}. #{remaining} records remain."
+      ClaimsApi::Logger.log LOG_TAG, details: "Processed #{processed_count} records for #{model}"
     end
     # rubocop:enable Metrics/MethodLength
 

--- a/modules/claims_api/spec/sidekiq/one_off/header_hash_filler_job_spec.rb
+++ b/modules/claims_api/spec/sidekiq/one_off/header_hash_filler_job_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe ClaimsApi::OneOff::HeaderHashFillerJob, type: :job do
     it 'logs count of records processed' do
       expect(ClaimsApi::Logger).to receive(:log).with(
         'header_hash_filler_job',
-        details: 'Processed 10 records for ClaimsApi::PowerOfAttorney. 0 records remain.'
+        details: 'Processed 10 records for ClaimsApi::PowerOfAttorney'
       )
 
       subject.perform 'ClaimsApi::PowerOfAttorney'


### PR DESCRIPTION
## Summary
The batch job already counts & reports on remaining records. No need to do it for every individual job run, too.

## Related issue(s)
#23158 Part 1
#23355 Part 2
#23371 Blank data fixes; forcing

https://jira.devops.va.gov/browse/API-47460


## Testing done

- [x] *New code is covered by unit tests*
