### PR TITLE
API-48516-mocking-sandbox-id-return-from-create-for-decide

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -145,6 +145,10 @@ module ClaimsApi
                                                                     metadata: res['meta'])
             form_attributes['id'] = poa_request.id
           end
+          # The only way to get an ID value returned in Sandbox since we do not save the requests
+          if Flipper.enabled?(:lighthouse_claims_v2_poa_requests_skip_bgs)
+            form_attributes['id'] = 'c5ab49ca-0bd3-4529-8c48-5e277083f9eb'
+          end
 
           response_data = ClaimsApi::V2::Blueprints::PowerOfAttorneyRequestBlueprint.render(form_attributes,
                                                                                             view: :create,

--- a/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
+++ b/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
@@ -704,6 +704,23 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
       end
     end
 
+    context 'returning a Lighthouse ID' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:lighthouse_claims_v2_poa_requests_skip_bgs).and_return(true)
+      end
+
+      let(:sandbox_lh_id) { 'c5ab49ca-0bd3-4529-8c48-5e277083f9eb' }
+
+      it 'returns a specific ID when the flipper is enabled' do
+        mock_ccg(scopes) do |auth_header|
+          create_request_with(veteran_id:, form_attributes:, auth_header:)
+
+          expect(response).to have_http_status(:created)
+          expect(JSON.parse(response.body)['data']['id']).to eq(sandbox_lh_id)
+        end
+      end
+    end
+
     context 'handling countryCodes' do
       it 'returns a 422 when the veteran countryCode has no match in the BRD countries list' do
         mock_ccg(scopes) do |auth_header|


### PR DESCRIPTION
## Summary
* Because we mock BGS calls in sandbox our `create` endpoint never returns an ID, which we need for the decide endpoint's URL. The only solution at the moment is to return a hard coded ID in sandbox used for mocking the return from `create` so we can use it in the `decide` endpoint.

## Related issue(s)
[API-48516](https://jira.devops.va.gov/browse/API-48516)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
	modified:   modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
