### PR TITLE
[10-10CG] Remove caregiver_use_rails_logging_over_sentry toggle and usage

### DIFF
--- a/app/sidekiq/form1010cg/submission_job.rb
+++ b/app/sidekiq/form1010cg/submission_job.rb
@@ -121,11 +121,7 @@ module Form1010cg
     private
 
     def log_error(exception, message, claim_id)
-      if Flipper.enabled?(:caregiver_use_rails_logging_over_sentry)
-        Rails.logger.error(message, { exception:, claim_id: })
-      else
-        log_exception_to_sentry(exception, { claim_id: })
-      end
+      Rails.logger.error(message, { exception:, claim_id: })
     end
   end
 end

--- a/config/features.yml
+++ b/config/features.yml
@@ -149,9 +149,6 @@ features:
   caregiver_request_duration_monitoring:
     actor_type: user
     description: Enables logging of 10-10CG request durations to StatsD
-  caregiver_use_rails_logging_over_sentry:
-    actor_type: user
-    description: Use Rails for logging instead of Sentry
   cerner_non_eligible_sis_enabled:
     actor_type: user
     description: Enables Sign in Service for cerner authentication

--- a/spec/services/form1010cg/service_spec.rb
+++ b/spec/services/form1010cg/service_spec.rb
@@ -424,28 +424,14 @@ RSpec.describe Form1010cg::Service do
   end
 
   describe '#assert_veteran_status' do
-    context 'with :caregiver_use_rails_logging_over_sentry enabled' do
-      it "raises error if veteran's icn can not be found" do
-        allow(Flipper).to receive(:enabled?).with(:caregiver_use_rails_logging_over_sentry).and_return(true)
-        expect(subject).to receive(:icn_for).with('veteran').and_return('NOT_FOUND')
-        # expect(subject).to receive(:log_exception_to_sentry).with(instance_of(described_class::InvalidVeteranStatus))
-        expect(Rails.logger).to receive(:error).with(
-          '[10-10CG] - Error fetching Veteran ICN',
-          { error: instance_of(described_class::InvalidVeteranStatus) }
-        )
+    it "raises error if veteran's icn can not be found" do
+      expect(subject).to receive(:icn_for).with('veteran').and_return('NOT_FOUND')
+      expect(Rails.logger).to receive(:error).with(
+        '[10-10CG] - Error fetching Veteran ICN',
+        { error: instance_of(described_class::InvalidVeteranStatus) }
+      )
 
-        expect { subject.assert_veteran_status }.to raise_error(described_class::InvalidVeteranStatus)
-      end
-    end
-
-    context 'with :caregiver_use_rails_logging_over_sentry disabled' do
-      it "raises error if veteran's icn can not be found" do
-        allow(Flipper).to receive(:enabled?).with(:caregiver_use_rails_logging_over_sentry).and_return(false)
-        expect(subject).to receive(:icn_for).with('veteran').and_return('NOT_FOUND')
-        expect(subject).to receive(:log_exception_to_sentry).with(instance_of(described_class::InvalidVeteranStatus))
-
-        expect { subject.assert_veteran_status }.to raise_error(described_class::InvalidVeteranStatus)
-      end
+      expect { subject.assert_veteran_status }.to raise_error(described_class::InvalidVeteranStatus)
     end
 
     it "does not raise error if veteran's icn is found" do
@@ -626,47 +612,22 @@ RSpec.describe Form1010cg::Service do
         allow(mule_soft_client).to receive(:create_submission_v2).and_raise(exception)
       end
 
-      context 'with :caregiver_use_rails_logging_over_sentry enabled' do
-        it 'logs claim_guid for any exceptions and raises error' do
-          allow(Flipper).to receive(:enabled?).with(:caregiver_use_rails_logging_over_sentry).and_return(true)
-          expect(Rails.logger).to receive(:error).with(
-            '[10-10CG] - Error processing Caregiver submission',
-            { form: '10-10CG', exception:, claim_guid: claim_with_mpi_veteran.guid }
-          )
+      it 'logs claim_guid for any exceptions and raises error' do
+        expect(Rails.logger).to receive(:error).with(
+          '[10-10CG] - Error processing Caregiver submission',
+          { form: '10-10CG', exception:, claim_guid: claim_with_mpi_veteran.guid }
+        )
 
-          start_time = Time.current
-          allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start_time }
-          allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond)
-          allow(Process).to receive(:clock_gettime).with(Process::CLOCK_THREAD_CPUTIME_ID, :float_millisecond)
-          expected_arguments = { context: :process, event: :failure, start_time: }
-          expect(described_class::AUDITOR).to receive(:log_caregiver_request_duration).with(
-            **expected_arguments
-          )
+        start_time = Time.current
+        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start_time }
+        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond)
+        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_THREAD_CPUTIME_ID, :float_millisecond)
+        expected_arguments = { context: :process, event: :failure, start_time: }
+        expect(described_class::AUDITOR).to receive(:log_caregiver_request_duration).with(
+          **expected_arguments
+        )
 
-          expect { subject }.to raise_error(exception)
-        end
-      end
-
-      context 'with :caregiver_use_rails_logging_over_sentry disabled' do
-        it 'logs claim_guid for any exceptions and raises error' do
-          allow(Flipper).to receive(:enabled?).with(:caregiver_use_rails_logging_over_sentry).and_return(false)
-          expect(service).to receive(:log_exception_to_sentry)
-            .with(exception, {
-                    form: '10-10CG',
-                    claim_guid: claim_with_mpi_veteran.guid
-                  })
-
-          start_time = Time.current
-          allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start_time }
-          allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond)
-          allow(Process).to receive(:clock_gettime).with(Process::CLOCK_THREAD_CPUTIME_ID, :float_millisecond)
-          expected_arguments = { context: :process, event: :failure, start_time: }
-          expect(described_class::AUDITOR).to receive(:log_caregiver_request_duration).with(
-            **expected_arguments
-          )
-
-          expect { subject }.to raise_error(exception)
-        end
+        expect { subject }.to raise_error(exception)
       end
     end
   end

--- a/spec/sidekiq/form1010cg/submission_job_spec.rb
+++ b/spec/sidekiq/form1010cg/submission_job_spec.rb
@@ -145,72 +145,20 @@ RSpec.describe Form1010cg::SubmissionJob do
 
     context 'when there is a standarderror' do
       it 'increments statsd except applications_retried' do
-        allow(Flipper).to receive(:enabled?).with(:caregiver_use_rails_logging_over_sentry).and_return(false)
-        start_time = Time.current
-        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { start_time }
-        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC, :float_millisecond)
-        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_THREAD_CPUTIME_ID, :float_millisecond)
-        expected_arguments = { context: :process_job, event: :failure, start_time: }
-        auditor_double = instance_double(Form1010cg::Auditor)
-        allow(Form1010cg::Auditor).to receive(:new) { auditor_double }
-        expect(auditor_double).to receive(:log_caregiver_request_duration).with(**expected_arguments).twice
-
         allow_any_instance_of(Form1010cg::Service).to receive(
           :process_claim_v2!
         ).and_raise(StandardError)
 
-        expect(StatsD).to receive(:increment).twice.with('api.form1010cg.async.retries')
-        expect(StatsD).not_to receive(:increment).with('api.form1010cg.async.applications_retried')
-        expect_any_instance_of(SentryLogging).to receive(:log_exception_to_sentry).twice
-
-        # If we're stubbing StatsD, we also have to expect this because of SavedClaim's after_create metrics logging
-        expect(StatsD).to receive(:increment).with('saved_claim.create', { tags: ['form_id:10-10CG'] })
+        expect(Rails.logger).to receive(:error).with(
+          '[10-10CG] - Error processing Caregiver claim submission in job',
+          { exception: StandardError, claim_id: claim.id }
+        ).twice
+        expect(job).not_to receive(:log_exception_to_sentry)
 
         2.times do
           expect do
             job.perform(claim.id)
           end.to raise_error(StandardError)
-        end
-      end
-
-      context 'with :caregiver_use_rails_logging_over_sentry enabled' do
-        it 'increments statsd except applications_retried' do
-          allow(Flipper).to receive(:enabled?).with(:caregiver_use_rails_logging_over_sentry).and_return(true)
-
-          allow_any_instance_of(Form1010cg::Service).to receive(
-            :process_claim_v2!
-          ).and_raise(StandardError)
-
-          expect(Rails.logger).to receive(:error).with(
-            '[10-10CG] - Error processing Caregiver claim submission in job',
-            { exception: StandardError, claim_id: claim.id }
-          ).twice
-          expect(job).not_to receive(:log_exception_to_sentry)
-
-          2.times do
-            expect do
-              job.perform(claim.id)
-            end.to raise_error(StandardError)
-          end
-        end
-      end
-
-      context 'with :caregiver_use_rails_logging_over_sentry disabled' do
-        it 'increments statsd except applications_retried' do
-          allow(Flipper).to receive(:enabled?).with(:caregiver_use_rails_logging_over_sentry).and_return(false)
-
-          allow_any_instance_of(Form1010cg::Service).to receive(
-            :process_claim_v2!
-          ).and_raise(StandardError)
-
-          expect(Rails.logger).not_to receive(:error)
-          expect_any_instance_of(SentryLogging).to receive(:log_exception_to_sentry).twice
-
-          2.times do
-            expect do
-              job.perform(claim.id)
-            end.to raise_error(StandardError)
-          end
         end
       end
     end
@@ -274,34 +222,18 @@ RSpec.describe Form1010cg::SubmissionJob do
     end
 
     context 'when claim can not be destroyed' do
-      context 'with :caregiver_use_rails_logging_over_sentry enabled' do
-        it 'logs the exception using the Rails logger' do
-          allow(Flipper).to receive(:enabled?).with(:caregiver_use_rails_logging_over_sentry).and_return(true)
-          expect_any_instance_of(Form1010cg::Service).to receive(:process_claim_v2!)
-          error = StandardError.new
-          expect_any_instance_of(SavedClaim::CaregiversAssistanceClaim).to receive(:destroy!).and_raise(error)
+      it 'logs the exception using the Rails logger' do
+        expect_any_instance_of(Form1010cg::Service).to receive(:process_claim_v2!)
+        error = StandardError.new
+        expect_any_instance_of(SavedClaim::CaregiversAssistanceClaim).to receive(:destroy!).and_raise(error)
 
-          expect(Rails.logger).to receive(:error).with(
-            '[10-10CG] - Error destroying Caregiver claim after processing submission in job',
-            { exception: error, claim_id: claim.id }
-          )
-          expect(job).not_to receive(:log_exception_to_sentry)
+        expect(Rails.logger).to receive(:error).with(
+          '[10-10CG] - Error destroying Caregiver claim after processing submission in job',
+          { exception: error, claim_id: claim.id }
+        )
+        expect(job).not_to receive(:log_exception_to_sentry)
 
-          job.perform(claim.id)
-        end
-      end
-
-      context 'with :caregiver_use_rails_logging_over_sentry disabled' do
-        it 'logs the exception to sentry' do
-          allow(Flipper).to receive(:enabled?).with(:caregiver_use_rails_logging_over_sentry).and_return(false)
-          expect_any_instance_of(Form1010cg::Service).to receive(:process_claim_v2!)
-          error = StandardError.new
-          expect_any_instance_of(SavedClaim::CaregiversAssistanceClaim).to receive(:destroy!).and_raise(error)
-
-          expect(Rails.logger).not_to receive(:error)
-          expect(job).to receive(:log_exception_to_sentry).with(error, { claim_id: claim.id })
-          job.perform(claim.id)
-        end
+        job.perform(claim.id)
       end
     end
 


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Delete `caregiver_use_rails_logging_over_sentry` toggle and usage. We no longer need to toggle between Sentry and Rails logs. 
- We will delete it from the databases after merging and deploying
- 1010 Health Apps

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108604

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
