### PR TITLE
[CST] Removes references to friendly-language feature flipper

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -467,10 +467,6 @@ features:
     actor_type: user
     description: When enabled, CST overrides RV1 - Reserve Records Request tracked items to be NEEDED_FROM_OTHERS on mobile app
     enable_in_development: true
-  cst_friendly_evidence_requests:
-    actor_type: user
-    description: When enabled, CST overrides tracked items' display names and descriptions to be more human-readable
-    enable_in_development: true
   cst_filter_ep_codes:
     actor_type: user
     description: When enabled, benefits_claims/get_claims service filters certain ep codes based on issue 90936 research from the response

--- a/lib/lighthouse/benefits_claims/service.rb
+++ b/lib/lighthouse/benefits_claims/service.rb
@@ -46,7 +46,7 @@ module BenefitsClaims
       # See https://github.com/department-of-veterans-affairs/va-mobile-app/issues/9671
       # This should be removed when the items are re-categorized by BGS
       override_tracked_items(claim['data']) if Flipper.enabled?(:cst_override_pmr_pending_tracked_items)
-      apply_friendlier_language(claim['data']) if Flipper.enabled?(:cst_friendly_evidence_requests)
+      apply_friendlier_language(claim['data'])
       claim
     rescue Faraday::TimeoutError
       raise BenefitsClaims::ServiceException.new({ status: 504 }), 'Lighthouse Error'

--- a/spec/controllers/v0/benefits_claims_controller_spec.rb
+++ b/spec/controllers/v0/benefits_claims_controller_spec.rb
@@ -174,9 +174,71 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
 
   describe '#show' do
     context 'when successful' do
+      before do
+        allow(Flipper).to receive(:enabled?).and_call_original
+      end
+
+      it 'modifies the claim data to include additional, human-readable fields' do
+        VCR.use_cassette('lighthouse/benefits_claims/show/200_response') do
+          get(:show, params: { id: '600383363' })
+        end
+        tracked_items = JSON.parse(response.body)['data']['attributes']['trackedItems']
+        can_upload_values = tracked_items.map { |i| i['canUploadFile'] }
+        expect(can_upload_values).to eq([true, true, true, true, true, true, false, true, true, true, false, false,
+                                         true])
+        friendly_name_values = tracked_items.map { |i| i['friendlyName'] }
+        expect(friendly_name_values).to include('Authorization to disclose information')
+        expect(friendly_name_values).to include('Proof of service')
+        expect(friendly_name_values).to include('Employment information')
+        expect(friendly_name_values).to include('Direct deposit information')
+        expect(friendly_name_values).to include('Details about cause of PTSD')
+        expect(friendly_name_values).to include('Reserve records')
+        expect(friendly_name_values).to include('Non-VA medical records')
+        expect(friendly_name_values).to include('Disability exam for hearing')
+        expect(friendly_name_values).to include('Mental health exam')
+        activity_description_values = tracked_items.map { |i| i['activityDescription'] }
+        expect(activity_description_values).to include('We need your permission to request your personal' \
+                                                       ' information from a non-VA source, like a private' \
+                                                       ' doctor or hospital.')
+        expect(activity_description_values).to include('We need employment information from your most' \
+                                                       ' recent employer.')
+        expect(activity_description_values).to include('We need your direct deposit information in' \
+                                                       ' order to pay benefits, if awarded.')
+        expect(activity_description_values).to include('We need information about the cause of' \
+                                                       ' your posttraumatic stress disorder (PTSD).')
+        expect(activity_description_values).to include('We’ve requested your reserve records on' \
+                                                       ' your behalf. No action is needed.')
+        expect(activity_description_values).to include('We’ve requested your proof of service on' \
+                                                       ' your behalf. No action is needed.')
+        expect(activity_description_values).to include('We’ve requested your non-VA medical records on' \
+                                                       ' your behalf. No action is needed.')
+        expect(activity_description_values).to include('We’ve requested a disability exam for your hearing.' \
+                                                       ' The examiner’s office will contact you to schedule' \
+                                                       ' this appointment.')
+        expect(activity_description_values).to include('We’ve requested a mental health exam for you.' \
+                                                       ' The examiner’s office will contact you to schedule' \
+                                                       ' this appointment.')
+        short_description_values = tracked_items.map { |i| i['shortDescription'] }
+        expect(short_description_values).to include('We’ve requested your service' \
+                                                    ' records or treatment records from your reserve unit.')
+        expect(short_description_values).to include('We’ve requested all your' \
+                                                    ' DD Form 214’s or other separation papers for all' \
+                                                    ' your periods of military service.')
+        support_alias_values = tracked_items.map { |i| i['supportAliases'] }
+        expect(support_alias_values).to include(['21-4142/21-4142a'])
+        expect(support_alias_values).to include(['VA Form 21-4192'])
+        expect(support_alias_values).to include(['EFT - Treasure Mandate Notification'])
+        expect(support_alias_values).to include(['VA Form 21-0781', 'PTSD - Need stressor details'])
+        expect(support_alias_values).to include(['RV1 - Reserve Records Request'])
+        expect(support_alias_values).to include(['Proof of Service (DD214, etc.)'])
+        expect(support_alias_values).to include(['PMR Request', 'General Records Request (Medical)'])
+        expect(support_alias_values).to include(['General Records Request (Medical)', 'PMR Request'])
+        expect(support_alias_values).to include(['DBQ AUDIO Hearing Loss and Tinnitus'])
+        expect(support_alias_values).to include(['DBQ PSYCH Mental Disorders'])
+      end
+
       context 'when cst_override_reserve_records_website flipper is enabled' do
         before do
-          allow(Flipper).to receive(:enabled?).and_call_original
           allow(Flipper).to receive(:enabled?).with(:cst_override_reserve_records_website).and_return(true)
         end
 
@@ -194,7 +256,6 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
 
       context 'when cst_override_reserve_records_website flipper is disabled' do
         before do
-          allow(Flipper).to receive(:enabled?).and_call_original
           allow(Flipper).to receive(:enabled?).with(:cst_override_reserve_records_website).and_return(false)
         end
 
@@ -212,7 +273,6 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
 
       context 'when :cst_suppress_evidence_requests_website is enabled' do
         before do
-          allow(Flipper).to receive(:enabled?).and_call_original
           allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests_website).and_return(true)
         end
 
@@ -231,7 +291,6 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
 
       context 'when :cst_suppress_evidence_requests_website is disabled' do
         before do
-          allow(Flipper).to receive(:enabled?).and_call_original
           allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests_website).and_return(false)
         end
 
@@ -249,99 +308,8 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
         end
       end
 
-      context 'when :cst_friendly_evidence_requests is disabled' do
-        before do
-          allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:cst_friendly_evidence_requests).and_return(false)
-        end
-
-        it 'does not modify the claim data and leaves the less-readable data as-is' do
-          VCR.use_cassette('lighthouse/benefits_claims/show/200_response') do
-            get(:show, params: { id: '600383363' })
-          end
-          tracked_items = JSON.parse(response.body)['data']['attributes']['trackedItems']
-          can_upload_values = tracked_items.map { |i| i['canUploadFile'] }
-          expect(can_upload_values).to eq([nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
-          friendly_name_values = tracked_items.map { |i| i['friendlyName'] }
-          expect(friendly_name_values).to eq([nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
-          activity_description_values = tracked_items.map { |i| i['activityDescription'] }
-          expect(activity_description_values).to eq([nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
-          short_description_values = tracked_items.map { |i| i['shortDescription'] }
-          expect(short_description_values).to eq([nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
-          support_alias_values = tracked_items.map { |i| i['supportAliases'] }
-          expect(support_alias_values).to eq([nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
-        end
-      end
-
-      context 'when :cst_friendly_evidence_requests is enabled' do
-        before do
-          allow(Flipper).to receive(:enabled?).and_call_original
-          allow(Flipper).to receive(:enabled?).with(:cst_friendly_evidence_requests).and_return(true)
-        end
-
-        it 'modifies the claim data to include additional, human-readable fields' do
-          VCR.use_cassette('lighthouse/benefits_claims/show/200_response') do
-            get(:show, params: { id: '600383363' })
-          end
-          tracked_items = JSON.parse(response.body)['data']['attributes']['trackedItems']
-          can_upload_values = tracked_items.map { |i| i['canUploadFile'] }
-          expect(can_upload_values).to eq([true, true, true, true, true, true, false, true, true, true, false, false,
-                                           true])
-          friendly_name_values = tracked_items.map { |i| i['friendlyName'] }
-          expect(friendly_name_values).to include('Authorization to disclose information')
-          expect(friendly_name_values).to include('Proof of service')
-          expect(friendly_name_values).to include('Employment information')
-          expect(friendly_name_values).to include('Direct deposit information')
-          expect(friendly_name_values).to include('Details about cause of PTSD')
-          expect(friendly_name_values).to include('Reserve records')
-          expect(friendly_name_values).to include('Non-VA medical records')
-          expect(friendly_name_values).to include('Disability exam for hearing')
-          expect(friendly_name_values).to include('Mental health exam')
-          activity_description_values = tracked_items.map { |i| i['activityDescription'] }
-          expect(activity_description_values).to include('We need your permission to request your personal' \
-                                                         ' information from a non-VA source, like a private' \
-                                                         ' doctor or hospital.')
-          expect(activity_description_values).to include('We need employment information from your most' \
-                                                         ' recent employer.')
-          expect(activity_description_values).to include('We need your direct deposit information in' \
-                                                         ' order to pay benefits, if awarded.')
-          expect(activity_description_values).to include('We need information about the cause of' \
-                                                         ' your posttraumatic stress disorder (PTSD).')
-          expect(activity_description_values).to include('We’ve requested your reserve records on' \
-                                                         ' your behalf. No action is needed.')
-          expect(activity_description_values).to include('We’ve requested your proof of service on' \
-                                                         ' your behalf. No action is needed.')
-          expect(activity_description_values).to include('We’ve requested your non-VA medical records on' \
-                                                         ' your behalf. No action is needed.')
-          expect(activity_description_values).to include('We’ve requested a disability exam for your hearing.' \
-                                                         ' The examiner’s office will contact you to schedule' \
-                                                         ' this appointment.')
-          expect(activity_description_values).to include('We’ve requested a mental health exam for you.' \
-                                                         ' The examiner’s office will contact you to schedule' \
-                                                         ' this appointment.')
-          short_description_values = tracked_items.map { |i| i['shortDescription'] }
-          expect(short_description_values).to include('We’ve requested your service' \
-                                                      ' records or treatment records from your reserve unit.')
-          expect(short_description_values).to include('We’ve requested all your' \
-                                                      ' DD Form 214’s or other separation papers for all' \
-                                                      ' your periods of military service.')
-          support_alias_values = tracked_items.map { |i| i['supportAliases'] }
-          expect(support_alias_values).to include(['21-4142/21-4142a'])
-          expect(support_alias_values).to include(['VA Form 21-4192'])
-          expect(support_alias_values).to include(['EFT - Treasure Mandate Notification'])
-          expect(support_alias_values).to include(['VA Form 21-0781', 'PTSD - Need stressor details'])
-          expect(support_alias_values).to include(['RV1 - Reserve Records Request'])
-          expect(support_alias_values).to include(['Proof of Service (DD214, etc.)'])
-          expect(support_alias_values).to include(['PMR Request', 'General Records Request (Medical)'])
-          expect(support_alias_values).to include(['General Records Request (Medical)', 'PMR Request'])
-          expect(support_alias_values).to include(['DBQ AUDIO Hearing Loss and Tinnitus'])
-          expect(support_alias_values).to include(['DBQ PSYCH Mental Disorders'])
-        end
-      end
-
       context 'when :cst_show_document_upload_status is disabled' do
         before do
-          allow(Flipper).to receive(:enabled?).and_call_original
           allow(Flipper).to receive(:enabled?).with(:cst_show_document_upload_status).and_return(false)
         end
 
@@ -357,7 +325,6 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
       context 'when :cst_show_document_upload_status is enabled' do
         context 'when record does not have a tracked item' do
           before do
-            allow(Flipper).to receive(:enabled?).and_call_original
             allow(Flipper).to receive(:enabled?).with(:cst_show_document_upload_status).and_return(true)
             create(:bd_lh_evidence_submission_success, claim_id:)
           end
@@ -375,7 +342,6 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
           let(:tracked_item_id) { 394_443 }
 
           before do
-            allow(Flipper).to receive(:enabled?).and_call_original
             allow(Flipper).to receive(:enabled?).with(:cst_show_document_upload_status).and_return(true)
             create(:bd_lh_evidence_submission_success, claim_id:, tracked_item_id:)
           end


### PR DESCRIPTION
After this is deployed, the actual Flipper should be removed via Flipper.remove in the console.

va.gov-team issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/106930

This feature is considered complete and so its feature flag can be removed.