### PR TITLE
[CST] Removes references to Event Bus Gateway send-email flipper

### DIFF
--- a/app/controllers/v0/event_bus_gateway_controller.rb
+++ b/app/controllers/v0/event_bus_gateway_controller.rb
@@ -5,12 +5,10 @@ module V0
     service_tag 'event_bus_gateway'
 
     def send_email
-      if Flipper.enabled?(:event_bus_gateway_emails_enabled)
-        EventBusGateway::LetterReadyEmailJob.perform_async(
-          participant_id,
-          send_email_params[:template_id]
-        )
-      end
+      EventBusGateway::LetterReadyEmailJob.perform_async(
+        participant_id,
+        send_email_params[:template_id]
+      )
       head :ok
     end
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -764,10 +764,6 @@ features:
     actor_type: user
     description: Enables duplicate prevention for digital dispute submissions
     enable_in_development: false
-  event_bus_gateway_emails_enabled:
-    actor_type: user
-    description: When enabled, vets-api opens an endpoint to Event Bus Gateway for sending notification emails
-    enable_in_development: true
   facilities_autosuggest_vamc_services_enabled:
     actor_type: user
     description: Allow use of the VA health facilities auto-suggest feature (versus static dropdown)

--- a/spec/requests/v0/event_bus_gateway_spec.rb
+++ b/spec/requests/v0/event_bus_gateway_spec.rb
@@ -11,47 +11,18 @@ RSpec.describe 'V0::EventBusGateway', type: :request do
       }
     end
 
-    context 'when :event_bus_gateway_emails_enabled is enabled' do
-      before do
-        allow(Flipper).to receive(:enabled?).and_call_original
-        allow(Flipper).to receive(:enabled?).with(:event_bus_gateway_emails_enabled).and_return(true)
-      end
-
-      context 'with the authentication header included' do
-        it 'invokes the email-sending job' do
-          expect(EventBusGateway::LetterReadyEmailJob).to receive(:perform_async).with('1234', '5678')
-          post '/v0/event_bus_gateway/send_email', params:, headers: service_account_auth_header
-          expect(response).to have_http_status(:ok)
-        end
-      end
-
-      context 'without the authentication header' do
-        it 'returns an unauthorized response' do
-          post '/v0/event_bus_gateway/send_email', params:, headers: nil
-          expect(response).to have_http_status(:unauthorized)
-        end
+    context 'with the authentication header included' do
+      it 'invokes the email-sending job' do
+        expect(EventBusGateway::LetterReadyEmailJob).to receive(:perform_async).with('1234', '5678')
+        post '/v0/event_bus_gateway/send_email', params:, headers: service_account_auth_header
+        expect(response).to have_http_status(:ok)
       end
     end
 
-    context 'when :event_bus_gateway_emails_enabled is disabled' do
-      before do
-        allow(Flipper).to receive(:enabled?).and_call_original
-        allow(Flipper).to receive(:enabled?).with(:event_bus_gateway_emails_enabled).and_return(false)
-      end
-
-      context 'without the authentication header' do
-        it 'returns an unauthorized response' do
-          post '/v0/event_bus_gateway/send_email', params:, headers: nil
-          expect(response).to have_http_status(:unauthorized)
-        end
-      end
-
-      context 'with the authentication header included' do
-        it 'does not invoke the email-sending job' do
-          expect(EventBusGateway::LetterReadyEmailJob).not_to receive(:perform_async)
-          post '/v0/event_bus_gateway/send_email', params:, headers: service_account_auth_header
-          expect(response).to have_http_status(:ok)
-        end
+    context 'without the authentication header' do
+      it 'returns an unauthorized response' do
+        post '/v0/event_bus_gateway/send_email', params:, headers: nil
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end


### PR DESCRIPTION
After this is deployed, the actual Flipper should be removed via Flipper.remove in the console.

va.gov-team issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/102324

This feature is considered complete and so its feature flag can be removed.