### PR TITLE
Api 48575 schema validation for decide endpoint

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -73,7 +73,6 @@ module ClaimsApi
           request = find_poa_request!(lighthouse_id)
           proc_id = request.proc_id
 
-          validate_decide_params!(proc_id:, decision:)
           validate_decide_representative_params!(request.poa_code, representative_id)
 
           vet_icn = request.veteran_icn
@@ -168,7 +167,7 @@ module ClaimsApi
 
         def validate_decide_representative_params!(poa_code, representative_id)
           representative = ::Veteran::Service::Representative.find_by('? = ANY(poa_codes) AND ? = representative_id',
-                                                                      poa_code, representative_id.to_s)
+                                                                      poa_code, representative_id)
           unless representative
             raise ::ClaimsApi::Common::Exceptions::Lighthouse::ResourceNotFound.new(
               detail: "The accredited representative with registration number #{representative_id} does not match " \
@@ -297,20 +296,6 @@ module ClaimsApi
           if claimant_cc.present? && ClaimsApi::BRD::COUNTRY_CODES[claimant_cc.to_s.upcase].blank?
             raise ::Common::Exceptions::UnprocessableEntity.new(
               detail: 'The country provided is not valid.'
-            )
-          end
-        end
-
-        def validate_decide_params!(proc_id:, decision:)
-          if proc_id.blank?
-            raise ::Common::Exceptions::ParameterMissing.new('procId',
-                                                             detail: 'procId is required')
-          end
-
-          unless decision.present? && %w[accepted declined].include?(decision)
-            raise ::Common::Exceptions::ParameterMissing.new(
-              'decision',
-              detail: 'decision is required and must be either "ACCEPTED" or "DECLINED"'
             )
           end
         end

--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -66,6 +66,7 @@ module ClaimsApi
 
         # rubocop:disable Metrics/MethodLength
         def decide
+          validate_json_schema('DECIDE')
           lighthouse_id = params[:id]
           decision = normalize(form_attributes['decision'])
           representative_id = form_attributes['representativeId']

--- a/modules/claims_api/config/schemas/v2/decide.json
+++ b/modules/claims_api/config/schemas/v2/decide.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Power Of Attorney Request Decide",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "decision",
+    "representativeId"
+  ],
+  "properties": {
+    "decision": {
+      "type": "string",
+      "description": "The decision of the request.",
+      "enum": [
+        "ACCEPTED",
+        "DECLINED"
+      ]
+    },
+    "declinedReason": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The reason for declining the request.",
+      "nullable": true
+    },
+    "representativeId": {
+      "type": "string",
+      "example": "142645388769",
+      "description": "The unique identifier of the requestʼs representative."
+    }
+  }
+}

--- a/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
+++ b/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
@@ -289,11 +289,23 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
         power_of_attorney_id: nil
       )
     end
+    let(:accepted_form_attributes) do
+      {
+        decision: 'ACCEPTED',
+        declinedReason: nil,
+        representativeId: '987654321654'
+      }
+    end
+    let(:declined_form_attributes) do
+      {
+        decision: 'DECLINED',
+        declinedReason: 'Reason for declining',
+        representativeId: '123456789456'
+      }
+    end
 
     context 'when the decide endpoint is called' do
       context 'when decision is not present' do
-        let(:decision) { '' }
-
         before do
           allow(ClaimsApi::PowerOfAttorneyRequest).to receive(:find_by).and_return(request_response)
         end
@@ -301,37 +313,42 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
         it 'raises an error if decision is not present' do
           mock_ccg(scopes) do |auth_header|
             VCR.use_cassette('claims_api/bgs/manage_representative_service/update_poa_request_accepted') do
-              decide_request_with(id:, decision:, auth_header:)
-              expect(response).to have_http_status(:bad_request)
+              accepted_form_attributes[:decision] = ''
+              decide_request_with(id:, form_attributes: accepted_form_attributes, auth_header:)
+
               response_body = JSON.parse(response.body)
-              expect(response_body['errors'][0]['title']).to eq('Missing parameter')
-              expect(response_body['errors'][0]['status']).to eq('400')
+
+              expect(response).to have_http_status(:unprocessable_entity)
+              expect(response_body['errors'][0]['detail']).to include(
+                'The property /decision did not match the following requirements:'
+              )
             end
           end
         end
       end
 
       context 'when decision is not ACCEPTED or DECLINED' do
-        let(:decision) { 'indecision' }
-
         before do
           allow(ClaimsApi::PowerOfAttorneyRequest).to receive(:find_by).and_return(request_response)
         end
 
         it 'raises an error if decision is not valid' do
           mock_ccg(scopes) do |auth_header|
-            decide_request_with(id:, decision:, auth_header:)
-            expect(response).to have_http_status(:bad_request)
+            declined_form_attributes[:decision] = 'indecision'
+            decide_request_with(id:, form_attributes: declined_form_attributes, auth_header:)
+
             response_body = JSON.parse(response.body)
-            expect(response_body['errors'][0]['title']).to eq('Missing parameter')
-            expect(response_body['errors'][0]['status']).to eq('400')
+
+            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response_body['errors'][0]['detail']).to include(
+              'The property /decision did not match the following requirements:'
+            )
           end
         end
       end
     end
 
     context 'when procId is present and valid and decision is accepted' do
-      let(:decision) { 'ACCEPTED' }
       let(:service) { instance_double(ClaimsApi::PowerOfAttorneyRequestService::Show) }
 
       before do
@@ -351,9 +368,11 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
       it 'updates the secondaryStatus and returns a hash containing the ACC code' do
         mock_ccg(scopes) do |auth_header|
           VCR.use_cassette('claims_api/bgs/manage_representative_service/update_poa_request_accepted') do
-            decide_request_with(id:, decision:, auth_header:)
-            expect(response).to have_http_status(:ok)
+            decide_request_with(id:, form_attributes: accepted_form_attributes, auth_header:)
+
             response_body = JSON.parse(response.body)
+
+            expect(response).to have_http_status(:ok)
             expect(response_body['data']['id']).to eq(id)
           end
         end
@@ -362,7 +381,7 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
       it 'includes location in the response header' do
         mock_ccg(scopes) do |auth_header|
           VCR.use_cassette('claims_api/bgs/manage_representative_service/update_poa_request_accepted') do
-            decide_request_with(id:, decision:, auth_header:)
+            decide_request_with(id:, form_attributes: accepted_form_attributes, auth_header:)
 
             expect(response.headers).to have_key('Location')
           end
@@ -399,13 +418,10 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
         allow_any_instance_of(
           ClaimsApi::PowerOfAttorneyRequestService::DecisionHandler
         ).to receive(:call).and_return(return_data)
-
         allow_any_instance_of(
           ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController
         ).to receive(:build_auth_headers).and_return({})
-
         allow(ClaimsApi::PowerOfAttorney).to receive(:create!).with(anything).and_return(dummy_record)
-
         allow_any_instance_of(
           ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController
         ).to receive(:claims_v2_logging)
@@ -415,13 +431,11 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
         expect_any_instance_of(
           ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController
         ).to receive(:validate_mapped_data!).with(ptcpnt_id, form_type_code, poa_code)
-
         expect_any_instance_of(
           ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController
         ).to receive(:decide_request_attributes).with(
           poa_code:, decide_form_attributes: form_attributes
         ).and_return(return_data[0]['data']['attributes'])
-
         expect_any_instance_of(
           ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController
         ).to receive(:claims_v2_logging).with(
@@ -435,6 +449,7 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
     end
 
     context 'when the decision is declined and a ptcpntId is present' do
+      let(:decision) { 'DECLINED' }
       let(:service) { instance_double(ClaimsApi::ManageRepresentativeService) }
       let(:poa_request_response) do
         {
@@ -448,8 +463,6 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
         }
       end
       let(:mock_lockbox) { double('Lockbox', encrypt: 'encrypted value') }
-      let(:decision) { 'DECLINED' }
-      let(:representative_id) { '456' }
 
       before do
         allow(ClaimsApi::ManageRepresentativeService).to receive(:new).with(anything).and_return(service)
@@ -470,14 +483,13 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
         mock_ccg(scopes) do |auth_header|
           expect(ClaimsApi::PowerOfAttorneyRequestService::DecisionHandler).to receive(:new)
 
-          decide_request_with(id:, decision:, auth_header:,
-                              representative_id:)
+          decide_request_with(id:, form_attributes: declined_form_attributes, auth_header:)
         end
       end
 
       it 'does not include location in the response header' do
         mock_ccg(scopes) do |auth_header|
-          decide_request_with(id:, decision:, auth_header:)
+          decide_request_with(id:, form_attributes: declined_form_attributes, auth_header:)
 
           expect(response.headers).not_to have_key('Location')
         end
@@ -506,7 +518,7 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
 
     context 'validating the params' do
       let(:decision) { 'ACCEPTED' }
-      let(:representative_id) { 456 } # this comes in on the form as a integer, not a string
+      let(:representative_id) { '456' }
       let(:poa_code) { '123' }
 
       context 'registration number and POA code combination do not belong to a representative' do
@@ -533,7 +545,7 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
         it 'raises an error' do
           mock_ccg(scopes) do |auth_header|
             VCR.use_cassette('claims_api/bgs/manage_representative_service/update_poa_request_not_found') do
-              decide_request_with(id:, decision:, auth_header:, representative_id:)
+              decide_request_with(id:, form_attributes: accepted_form_attributes, auth_header:)
 
               expect(response).to have_http_status(:not_found)
               expect(JSON.parse(response.body)['errors'][0]['detail']).to eq(
@@ -890,11 +902,9 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
     get "/services/claims/v2/veterans/power-of-attorney-requests/#{id}", headers: auth_header
   end
 
-  def decide_request_with(id:, decision:, auth_header:, representative_id: nil)
+  def decide_request_with(id:, form_attributes:, auth_header:)
     post "/services/claims/v2/veterans/power-of-attorney-requests/#{id}/decide",
-         params: { data: { attributes: { id:,
-                                         decision:,
-                                         representativeId: representative_id } } }.to_json,
+         params: { data: { attributes: form_attributes } }.to_json,
          headers: auth_header.merge('Content-Type' => 'application/json')
   end
 

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
@@ -720,7 +720,11 @@ describe 'PowerOfAttorney',
           let(:data) do
             {
               'data' => {
-                'attributes' => {}
+                'attributes' => {
+                  'decision' => 'DECLINED',
+                  'declinedReason' => 'RSWAG POA test reason',
+                  'representativeId' => '918273645463'
+                }
               }
             }
           end


### PR DESCRIPTION
## Summary
* Introduces schema file
    * Adjusts related tests
* Cleans up validation code in controller
    * Removes `validate_decide_params` method from controller, this is handled by the schema now.
    * Removes casting the rep ID to a string since schema will enforce it as a string

## Related issue(s)
[API-48575](https://jira.devops.va.gov/browse/API-48575)

## Testing done

- [x] *New code is covered by unit tests*

#### Testing Notes
* Send in a POST to the decide endpoint and it should accept a valid submission like:
```
{
    "data": {
        "attributes": {
            "decision": "DECLINED",
            "declinedReason": "Reasons for the decline.",
            "representativeId": "23456789" <------ (must match what you have in your DB and also match what the request was created with
        }
    }
}
```
* Sending in an invalid value for the rep ID or decision should return a 422
<img width="1154" height="252" alt="Screenshot 2025-08-06 at 7 56 11 AM" src="https://github.com/user-attachments/assets/8c0f3570-b912-425a-ba4f-72c2c5cac2c5" />


## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
	new file:   modules/claims_api/config/schemas/v2/decide.json
	modified:   modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
	modified:   modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
