### PR TITLE
Try http if https dod cert doesn't resolve

### DIFF
--- a/import-va-certs.sh
+++ b/import-va-certs.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
     # DoD ECA
     (
-        curl -LO https://dl.dod.cyber.mil/wp-content/uploads/pki-pke/zip/unclass-certificates_pkcs7_ECA.zip
+        curl --connect-timeout 10 -LO https://dl.dod.cyber.mil/wp-content/uploads/pki-pke/zip/unclass-certificates_pkcs7_ECA.zip || curl --connect-timeout 10 -LO http://dl.dod.cyber.mil/wp-content/uploads/pki-pke/zip/unclass-certificates_pkcs7_ECA.zip
         unzip ./unclass-certificates_pkcs7_ECA.zip -d ECA_CA
         cd ECA_CA/certificates_pkcs7_v5_12_eca/
         openssl pkcs7 -inform DER -in ./certificates_pkcs7_v5_12_eca_ECA_Root_CA_5_der.p7b -print_certs | awk '/BEGIN/{i++} {print > ("eca_cert" i ".pem")}'


### PR DESCRIPTION
## Summary
The Build, Push & Deploy action is failing with the error:
```
  > [stage-2  8/17] RUN ./import-va-certs.sh:

100  1777  100  1777    0     0   2048      0 --:--:-- --:--:-- --:--:--  2047

  0     0    0     0    0     0      0      0 --:--:--  0:05:00 --:--:--     0
301.9 curl: (28) Failed to connect to dl.dod.cyber.mil port 443 after 300859 ms: Timeout was reached
------
Dockerfile:42
--------------------
  40 |     # Download VA Certs
  41 |     COPY ./import-va-certs.sh .
  42 | >>> RUN ./import-va-certs.sh
  43 |     
  44 |     COPY config/clamd.conf /etc/clamav/clamd.conf
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c ./import-va-certs.sh" did not complete successfully: exit code: 28
```
@rbeckwith-oddball noticed the https URL is not working for https://dl.dod.cyber.mil/wp-content/uploads/pki-pke/zip/unclass-certificates_pkcs7_ECA.zip and recommended changing it to http, which is currently working. 

Build, Push, & Deploy action:https://github.com/department-of-veterans-affairs/vets-api/actions/runs/16762662822/job/47505056339#step:7:2256

## Related issue(s)

- [Slack thread](https://dsva.slack.com/archives/C039HRTHXDH/p1754424903094699?thread_ts=1754417479.160839&cid=C039HRTHXDH)

## Testing done

- I was able to resolve the http url (it downloaded a zip)

## What areas of the site does it impact?
Build, Push, & Deploy github action. When this action passes, it deploys a commit to the manifest repo, which then gets picked up by Argo and deploys to dev/staging (and then highers at deploy time)

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature