### PR TITLE
API-47722: Remove Unused Settings for `vba_documents` Module

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1624,7 +1624,6 @@ vba_documents:
   slack:
     api_key: <%= ENV['vba_documents__slack__api_key'] %>
     channel_id: <%= ENV['vba_documents__slack__channel_id'] %>
-    daily_notification_hour: 7
     default_alert_email: <%= ENV['vba_documents__slack__default_alert_email'] %>
     enabled: <%= ENV['vba_documents__slack__enabled'] %>
     in_flight_notification_hung_time_in_days: 14
@@ -1639,8 +1638,6 @@ vba_documents:
   webhooks:
     registration_max_retries: 3
     registration_next_run_in_minutes: 15
-    registration_next_run_minutes: 15
-    registration_rescue_in_minutes: 60
 vbms:
   ca_cert: <%= ENV['vbms__ca_cert'] %>
   cert: <%= ENV['vbms__cert'] %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1643,7 +1643,6 @@ vba_documents:
   slack:
     api_key: ''
     channel_id: ''
-    daily_notification_hour: 7
     default_alert_email: ''
     enabled: false
     in_flight_notification_hung_time_in_days: 14
@@ -1660,8 +1659,6 @@ vba_documents:
   webhooks:
     registration_max_retries: 3
     registration_next_run_in_minutes: 15
-    registration_next_run_minutes: 15
-    registration_rescue_in_minutes: 60
 vbms:
   ca_cert: VBMS-Client-Signing-CA.crt
   cert: vetsapi.client.vbms.aide.oit.va.gov.crt

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1642,7 +1642,6 @@ vba_documents:
   slack:
     api_key: ''
     channel_id: ''
-    daily_notification_hour: 7
     default_alert_email: ''
     enabled: false
     in_flight_notification_hung_time_in_days: 14
@@ -1659,8 +1658,6 @@ vba_documents:
   webhooks:
     registration_max_retries: 3
     registration_next_run_in_minutes: 15
-    registration_next_run_minutes: 15
-    registration_rescue_in_minutes: 60
 vbms:
   ca_cert: VBMS-Client-Signing-CA.crt
   cert: vetsapi.client.vbms.aide.oit.va.gov.crt


### PR DESCRIPTION
## Summary
This work is behind a feature toggle (flipper): *NO*

After a recent secrets and settings audit of the `vba_documents` module, we discovered three settings that were not in use anywhere in `vets-api` and could therefore be safely removed. This PR removes those settings from the repo.

My team (Lighthouse Banana Peels) owns the `vba_documents` module.

## Related issue(s)
- [API-47722](https://jira.devops.va.gov/browse/API-47722)

<img width="704" height="337" alt="Jira Ticket Screenshot" src="https://github.com/user-attachments/assets/c549e58f-2e0a-4950-9a69-b2f24bbc7be4" />

## Testing done
- [ ] *New code is covered by unit tests* – N/A, as there is no new code
- Confirmed that the settings were not in use anywhere in the application. Existing unit tests are all passing.

## Screenshots
None

## What areas of the site does it impact?
This PR impacts the `vba_documents` module only.

## Acceptance criteria
- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable). – N/A
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) – N/A
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable) – N/A
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature – N/A

## Requested Feedback
No specific feedback requested for this PR.
