### PR TITLE
arp/received_and_confirmation_emails_for_form_upload

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1383,6 +1383,10 @@ vanotify:
       email:
         error:
           template_id: <%= ENV['vanotify__services__accredited_representative_portal__email__error__template_id'] %>
+        received:
+          template_id: <%= ENV['vanotify__services__accredited_representative_portal__email__received__template_id'] %>
+        confirmation:
+          template_id: <%= ENV['vanotify__services__accredited_representative_portal__email__confirmation__template_id'] %>
     benefits_decision_review:
       api_key: <%= ENV['vanotify__services__benefits_decision_review__api_key'] %>
       template_id:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1402,6 +1402,10 @@ vanotify:
       email:
         error:
           template_id: accredited_representative_portal_error_email_template_id
+        received:
+          template_id: accredited_representative_portal_received_email_template_id
+        confirmation:
+          template_id: accredited_representative_portal_confirmation_email_template_id
     benefits_decision_review:
       api_key: fake_secret
       template_id:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1401,6 +1401,10 @@ vanotify:
       email:
         error:
           template_id: arp_error_email_template_id
+        received:
+          template_id: arp_received_email_template_id
+        confirmation:
+          template_id: arp_confirmation_email_template_id
     benefits_decision_review:
       api_key: fake_secret
       template_id:

--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_form_upload_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_form_upload_controller.rb
@@ -24,6 +24,7 @@ module AccreditedRepresentativePortal
 
         saved_claim = service.perform(
           type: form_class,
+          user_account_id: current_user.icn,
           metadata:, attachment_guids:,
           claimant_representative:
         )

--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/saved_claim_service/create.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/saved_claim_service/create.rb
@@ -19,7 +19,7 @@ module AccreditedRepresentativePortal
 
       class << self
         def perform(
-          type:, metadata:, attachment_guids:,
+          type:, metadata:, user_account_id:, attachment_guids:,
           claimant_representative:
         )
           type.new.tap do |saved_claim|
@@ -28,6 +28,7 @@ module AccreditedRepresentativePortal
             form_id = saved_claim.class::PROPER_FORM_ID
             organize_attachments!(form_id, attachment_guids).tap do |attachments|
               saved_claim.form_attachment = attachments[:form]
+              saved_claim.user_account_id = user_account_id
 
               attachments[:documentations].each do |attachment|
                 saved_claim.persistent_attachments << attachment

--- a/modules/accredited_representative_portal/app/sidekiq/accredited_representative_portal/submit_benefits_intake_claim_job.rb
+++ b/modules/accredited_representative_portal/app/sidekiq/accredited_representative_portal/submit_benefits_intake_claim_job.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'accredited_representative_portal/monitor'
+require 'accredited_representative_portal/notification_email'
+require 'lighthouse/benefits_intake/service'
+
 module AccreditedRepresentativePortal
   class SubmitBenefitsIntakeClaimJob < Lighthouse::SubmitBenefitsIntakeClaim
     ##
@@ -37,6 +41,15 @@ module AccreditedRepresentativePortal
           service.instance_variable_set(:@uuid, upload[:uuid])
           service.instance_variable_set(:@location, upload[:location])
         end
+      @intake_service = ::BenefitsIntake::Service.new
+      @user_account_uuid = @claim.user_account_id
+      @monitor = AccreditedRepresentativePortal::Monitor.new
+    end
+
+    def send_confirmation_email
+      AccreditedRepresentativePortal::NotificationEmail.new(@claim.id).deliver(:confirmation)
+    rescue => e
+      @monitor.track_send_email_failure(@claim, @intake_service, @user_account_uuid, 'confirmation', e)
     end
 
     ##

--- a/modules/accredited_representative_portal/lib/accredited_representative_portal/notification_email.rb
+++ b/modules/accredited_representative_portal/lib/accredited_representative_portal/notification_email.rb
@@ -15,10 +15,8 @@ module AccreditedRepresentativePortal
       ::SavedClaim
     end
 
-    def claimant_first_name
-      parsed = claim.parsed_form
-      name = parsed['dependent']&.dig('name', 'first') || parsed['veteran']&.dig('name', 'first')
-      name&.upcase
+    def form_id
+      claim.class::PROPER_FORM_ID
     end
 
     def saved_claim_claimant_representative
@@ -37,6 +35,7 @@ module AccreditedRepresentativePortal
       default = super
 
       {
+        'form_id' => form_id,
         'confirmation_number' => claim.confirmation_number,
         'first_name' => representative&.first_name || 'Representative',
         'submission_date' => claim.created_at.strftime('%B %-d, %Y')

--- a/modules/accredited_representative_portal/lib/accredited_representative_portal/submission_handler.rb
+++ b/modules/accredited_representative_portal/lib/accredited_representative_portal/submission_handler.rb
@@ -29,5 +29,10 @@ module AccreditedRepresentativePortal
       @avoided = notification_email.deliver(:error)
       super
     end
+
+    def on_success
+      notification_email.deliver(:received)
+      super
+    end
   end
 end

--- a/modules/accredited_representative_portal/spec/lib/notification_email_spec.rb
+++ b/modules/accredited_representative_portal/spec/lib/notification_email_spec.rb
@@ -9,18 +9,25 @@ RSpec.describe AccreditedRepresentativePortal::NotificationEmail do
   describe '#deliver' do
     it 'successfully sends an error email' do
       saved_claim_claimant_representative = create(:saved_claim_claimant_representative,
-                                                   saved_claim_id: saved_claim.id)
+        saved_claim_id: saved_claim.id)
       create(:representative,
-             representative_id: saved_claim_claimant_representative.accredited_individual_registration_number)
+        representative_id: saved_claim_claimant_representative.accredited_individual_registration_number)
 
       expect(SavedClaim).to receive(:find).with(saved_claim.id).and_return(saved_claim)
 
       allow_any_instance_of(described_class).to receive(:email).and_return('example@email.com')
 
+      expected_personalization = hash_including(
+        'form_id' => saved_claim.class::PROPER_FORM_ID,
+        'confirmation_number' => saved_claim.confirmation_number,
+        'first_name' => anything,
+        'submission_date' => anything
+      )
+
       args = [
         'example@email.com',
         Settings.vanotify.services.accredited_representative_portal.email.error.template_id,
-        anything,
+        expected_personalization,
         Settings.vanotify.services.accredited_representative_portal.api_key,
         {
           callback_klass: AccreditedRepresentativePortal::NotificationCallback.to_s,

--- a/modules/accredited_representative_portal/spec/lib/submission_handler_spec.rb
+++ b/modules/accredited_representative_portal/spec/lib/submission_handler_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 require 'rails_helper'
 require 'accredited_representative_portal/submission_handler'
 require 'accredited_representative_portal/monitor'
@@ -14,7 +13,6 @@ RSpec.describe AccreditedRepresentativePortal::SubmissionHandler do
     let(:form_submission) do
       create(:form_submission, saved_claim: claim, form_type: '21-686C_BENEFITS-INTAKE')
     end
-
     let!(:submission_attempt) do
       create(:form_submission_attempt, form_submission:, aasm_state: 'pending')
     end
@@ -48,6 +46,7 @@ RSpec.describe AccreditedRepresentativePortal::SubmissionHandler do
         hash_including(claim_id: claim.id),
         call_location: nil
       )
+
       instance.handle(:failure)
     end
 
@@ -58,7 +57,31 @@ RSpec.describe AccreditedRepresentativePortal::SubmissionHandler do
         hash_including(message:),
         call_location: nil
       )
+
       expect { instance.handle(:failure) }.to raise_error message
+    end
+  end
+
+  describe '#on_success' do
+    let(:notification) { instance_double(AccreditedRepresentativePortal::NotificationEmail) }
+
+    before do
+      allow(AccreditedRepresentativePortal::NotificationEmail).to receive(:new).with(claim.id).and_return(notification)
+      allow(SavedClaim).to receive(:find).and_return(claim)
+    end
+
+    it 'sends success notification email' do
+      expect(notification).to receive(:deliver).with(:received)
+
+      instance.handle(:success)
+    end
+
+    it 'calls super after sending notification' do
+      allow(notification).to receive(:deliver).with(:received)
+
+      expect_any_instance_of(::BenefitsIntake::SubmissionHandler::SavedClaim).to receive(:on_success)
+
+      instance.handle(:success)
     end
   end
 end

--- a/modules/accredited_representative_portal/spec/sidekiq/accredited_representative_portal/submit_benefits_intake_claim_job_spec.rb
+++ b/modules/accredited_representative_portal/spec/sidekiq/accredited_representative_portal/submit_benefits_intake_claim_job_spec.rb
@@ -1,100 +1,128 @@
 # frozen_string_literal: true
-
 require 'rails_helper'
 require AccreditedRepresentativePortal::Engine.root / 'spec/spec_helper'
 
-RSpec.describe AccreditedRepresentativePortal::SubmitBenefitsIntakeClaimJob do
-  fixture_path =
-    'form_data/saved_claim/benefits_intake/dependent_claimant.json'
+RSpec.describe AccreditedRepresentativePortal::SubmitBenefitsIntakeClaimJob, :uploader_helpers do
+  stub_virus_scan
 
-  dependent_claimant_form =
-    load_fixture(fixture_path) do |fixture|
-      JSON.parse(fixture)
+  let(:job) { described_class.new }
+  let(:claim) { create(:saved_claim_benefits_intake) }
+  let(:lighthouse_service) { double('lighthouse_service') }
+  let(:intake_service) { double('intake_service') }
+  let(:monitor) { double('monitor') }
+
+  describe '#perform' do
+    let(:response) { double('response', success?: true, body: 'success') }
+    let(:pdf_path) { 'random/path/to/pdf' }
+    let(:location) { 'test_location' }
+    let(:uuid) { 'test-uuid' }
+
+    before do
+      job.instance_variable_set(:@claim, claim)
+      job.instance_variable_set(:@lighthouse_service, lighthouse_service)
+      job.instance_variable_set(:@intake_service, intake_service)
+      job.instance_variable_set(:@user_account_uuid, '123-456-789')
+      job.instance_variable_set(:@monitor, monitor)
+
+      allow(lighthouse_service).to receive_messages(uuid: uuid, location: location, upload_doc: response)
+      allow(intake_service).to receive(:valid_document?).and_return(pdf_path)
+      allow(monitor).to receive(:track_submission_success)
+      allow(job).to receive(:init).and_return(nil)
+      allow(job).to receive(:process_record).and_return(pdf_path)
+      allow(job).to receive(:create_form_submission_attempt).and_return(nil)
+      allow(job).to receive(:send_confirmation_email).and_return(nil)
+      allow(job).to receive(:cleanup_file_paths).and_return(nil)
     end
 
-  subject(:perform) do
-    attachments = [
-      create(:persistent_attachment_va_form, form_id: '21-686c'),
-      create(:persistent_attachment_va_form_documentation, form_id: '21-686c')
-    ]
-
-    AccreditedRepresentativePortal::SavedClaimService::Create.perform(
-      type: AccreditedRepresentativePortal::SavedClaim::BenefitsIntake::DependencyClaim,
-      attachment_guids: attachments.map(&:guid),
-      metadata: dependent_claimant_form,
-      claimant_representative:
-        AccreditedRepresentativePortal::ClaimantRepresentative.new(
-          claimant_id: '1234',
-          power_of_attorney_holder_type: 'veteran_service_organization',
-          power_of_attorney_holder_poa_code: '123',
-          accredited_individual_registration_number: '10001'
-        )
-    )
-  end
-
-  let(:vcr_options) do
-    ##
-    # It seems as though request bodies and headers are dynamic given static
-    # inputs, which is why we exclude them from VCR matching.
-    #
-    {
-      match_requests_on: %i[method uri],
-
-      ##
-      # This job is behaving incorrectly if it does not perform all of the
-      # requests to Benefits Intake API that were recorded in the cassette.
-      # Those are:
-      #   - `POST /uploads` (gets an <upload_location>)
-      #   - `POST /uploads/validate_document` (validates 1st document)
-      #   - `POST /uploads/validate_document` (validates 2nd document)
-      #   - `PUT <upload_location>` (submits the document)
-      #
-      allow_unused_http_interactions: false
-    }
-  end
-
-  before do
-    ##
-    # This works around some test configuration weirdness. Without this, the
-    # locations used for reading and writing differ, likely due to a difference
-    # in which Shrine plugins have been plugged in at various points.
-    #
-    allow_any_instance_of(Shrine::UploadedFile).to(
-      receive(:storage).and_return(Shrine.storages[:store])
-    )
-  end
-
-  it 'performs' do
-    use_cassette('performs', vcr_options) do
-      expect_any_instance_of(BenefitsIntakeService::Service).to(
-        receive(:upload_doc).and_call_original
+    it 'performs' do
+      expect(job).to receive(:process_record).with(claim)
+      expect(job).to receive(:create_form_submission_attempt)
+      expect(lighthouse_service).to receive(:upload_doc).with(
+        upload_url: location,
+        file: { file: pdf_path, file_name: 'pdf' },
+        metadata: "{\"veteranFirstName\":\"John\",\"veteranLastName\":\"Doe\",\"fileNumber\":\"123456789\",\"zipCode\":\"12345\",\"source\":\"AccreditedRepresentativePortal::SavedClaim::BenefitsIntake::DependencyClaim va.gov\",\"docType\":\"21-686c\",\"businessLine\":\"CMP\"}",
+        attachments: []
       )
+      expect(job).to receive(:send_confirmation_email)
+      expect(job).to receive(:cleanup_file_paths)
 
-      expect { perform }.to change {
-        FormSubmissionAttempt.where.not(benefits_intake_uuid: nil).count
-      }.by(1)
+      result = job.perform(claim.id)
+      expect(result).to eq(uuid)
     end
-  end
 
-  context 'submission has additional documentation' do
-    around { |example| Timecop.freeze { example.run } }
+    context 'submission has additional documentation' do
+      around { |example| Timecop.freeze { example.run } }
+      
+      let(:stamper) { double }
+      let(:va_form_attachment) { create(:persistent_attachment_va_form_documentation, form_id: '21-686c') }
 
-    let(:stamper) { double }
+      before do
+        # Override the process_record method to actually call stamp_pdf
+        allow(job).to receive(:process_record).and_call_original
+        allow(job).to receive(:stamp_pdf).and_call_original
+        
+        # Set up the claim to have attachments that will trigger stamping
+        allow(claim).to receive(:persistent_attachments).and_return([va_form_attachment])
+        
+        # Mock the valid_document? method on lighthouse_service as well
+        allow(lighthouse_service).to receive(:valid_document?).and_return(pdf_path)
+      end
 
-    it 'stamps the footer of the additional docs' do
-      timestamp = DateTime.now.utc.strftime('%H:%M:%S  %Y-%m-%d %I:%M %p')
-
-      use_cassette('performs', vcr_options) do
+      it 'stamps the footer of the additional docs' do
+        timestamp = DateTime.now.utc.strftime('%H:%M:%S  %Y-%m-%d %I:%M %p')
+        
         # mock stamping of provided VA form
         allow(SimpleFormsApi::PdfStamper).to receive(:new).and_return(stamper)
         allow(stamper).to receive(:stamp_pdf)
-
-        expect_any_instance_of(PDFUtilities::DatestampPdf).to receive(:run).with(
+        
+        # Mock the to_pdf method to return a path
+        allow(va_form_attachment).to receive(:to_pdf).and_return('/tmp/test.pdf')
+        
+        # Mock PDFUtilities::DatestampPdf instead of expecting the real class
+        datestamp_pdf_double = double('datestamp_pdf')
+        allow(PDFUtilities::DatestampPdf).to receive(:new).with('/tmp/test.pdf').and_return(datestamp_pdf_double)
+        expect(datestamp_pdf_double).to receive(:run).with(
           text: "Submitted via VA.gov at #{timestamp} UTC. Signed in and submitted with an identity-verified account.",
-          text_only: true, x: 5, y: 5
-        ).and_call_original
+          text_only: true, 
+          x: 5, 
+          y: 5
+        )
+        
+        job.perform(claim.id)
+      end
+    end
+  end
 
-        perform
+  describe '#send_confirmation_email' do
+    let(:notification) { double('notification') }
+    let(:intake_service) { double('intake_service') }
+    let(:user_account_uuid) { '123-456-789' }
+
+    before do
+      job.instance_variable_set(:@claim, claim)
+      job.instance_variable_set(:@intake_service, intake_service)
+      job.instance_variable_set(:@user_account_uuid, user_account_uuid)
+      job.instance_variable_set(:@monitor, monitor)
+    end
+
+    context 'when email sends successfully' do
+      it 'sends a confirmation email' do
+        allow(AccreditedRepresentativePortal::NotificationEmail).to receive(:new).with(claim.id).and_return(notification)
+        expect(notification).to receive(:deliver).with(:confirmation)
+
+        job.send(:send_confirmation_email)
+      end
+    end
+
+    context 'when email sending fails' do
+      let(:email_error) { StandardError.new('Email delivery failed') }
+
+      it 'logs the error but does not reraise' do
+        allow(AccreditedRepresentativePortal::NotificationEmail).to receive(:new).with(claim.id).and_return(notification)
+        allow(notification).to receive(:deliver).with(:confirmation).and_raise(email_error)
+        expect(monitor).to receive(:track_send_email_failure).with(claim, intake_service, user_account_uuid, 'confirmation', email_error)
+
+        expect { job.send(:send_confirmation_email) }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
## Summary

- We had tests for the error message on form upload. Added received and confirmation

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114174
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114173

## Testing done

- Added new tests


## What areas of the site does it impact?
representative/representative-form-upload

## Acceptance criteria

- [ ]  I updated and added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
