### PR TITLE
Added new key prefix to better differentiate v1 data

### DIFF
--- a/lib/lighthouse/benefits_claims/intent_to_file/monitor.rb
+++ b/lib/lighthouse/benefits_claims/intent_to_file/monitor.rb
@@ -124,35 +124,35 @@ module BenefitsClaims
       # ITF controller metrics and logging
 
       def track_show_itf(form_id, itf_type, user_uuid)
-        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "version:v1"]
+        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", 'version:v1']
         StatsD.increment("#{STATSD_V1_KEY_PREFIX}.#{itf_type}.show", tags:)
         context = { itf_type:, form_id:, user_uuid: }
         Rails.logger.info('IntentToFilesController ITF show', context)
       end
 
       def track_submit_itf(form_id, itf_type, user_uuid)
-        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "version:v1"]
+        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", 'version:v1']
         StatsD.increment("#{STATSD_V1_KEY_PREFIX}.#{itf_type}.submit", tags:)
         context = { itf_type:, form_id:, user_uuid: }
         Rails.logger.info('IntentToFilesController ITF submit', context)
       end
 
       def track_missing_user_icn_itf_controller(method, form_id, itf_type, user_uuid, error)
-        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "method:#{method}", "version:v1"]
+        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "method:#{method}", 'version:v1']
         StatsD.increment('v1.user.icn.blank', tags:)
         context = { error:, method:, form_id:, itf_type:, user_uuid: }
         Rails.logger.info('IntentToFilesController ITF user.icn is blank', context)
       end
 
       def track_missing_user_pid_itf_controller(method, form_id, itf_type, user_uuid, error)
-        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "method:#{method}", "version:v1"]
+        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "method:#{method}", 'version:v1']
         StatsD.increment('v1.user.participant_id.blank', tags:)
         context = { error:, method:, form_id:, itf_type:, user_uuid: }
         Rails.logger.info('IntentToFilesController ITF user.participant_id is blank', context)
       end
 
       def track_invalid_itf_type_itf_controller(method, form_id, itf_type, user_uuid, error)
-        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "method:#{method}", "version:v1"]
+        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "method:#{method}", 'version:v1']
         StatsD.increment('v1.itf.type.invalid', tags:)
         context = { error:, method:, form_id:, itf_type:, user_uuid: }
         Rails.logger.info('IntentToFilesController ITF invalid ITF type', context)

--- a/lib/lighthouse/benefits_claims/intent_to_file/monitor.rb
+++ b/lib/lighthouse/benefits_claims/intent_to_file/monitor.rb
@@ -14,7 +14,8 @@ module BenefitsClaims
 
       # This metric does not include retries from failed attempts
       def track_create_itf_initiated(itf_type, form_start_date, user_account_uuid, form_id)
-        StatsD.increment("#{STATSD_KEY_PREFIX}.#{itf_type}.initiated")
+        tags = ["itf_type:#{itf_type}", 'version:v0']
+        StatsD.increment("#{STATSD_KEY_PREFIX}.#{itf_type}.initiated", tags:)
         context = {
           itf_type:,
           form_start_date:,
@@ -25,7 +26,8 @@ module BenefitsClaims
       end
 
       def track_create_itf_active_found(itf_type, form_start_date, user_account_uuid, itf_found)
-        StatsD.increment("#{STATSD_KEY_PREFIX}.#{itf_type}.active_found")
+        tags = ["itf_type:#{itf_type}", 'version:v0']
+        StatsD.increment("#{STATSD_KEY_PREFIX}.#{itf_type}.active_found", tags:)
         context = {
           itf_type:,
           itf_created: itf_found&.dig('data', 'attributes', 'creationDate'),
@@ -38,7 +40,8 @@ module BenefitsClaims
 
       # This metric includes retries from failed attempts
       def track_create_itf_begun(itf_type, form_start_date, user_account_uuid)
-        StatsD.increment("#{STATSD_KEY_PREFIX}.#{itf_type}.begun")
+        tags = ["itf_type:#{itf_type}", 'version:v0']
+        StatsD.increment("#{STATSD_KEY_PREFIX}.#{itf_type}.begun", tags:)
         context = {
           itf_type:,
           form_start_date:,
@@ -48,7 +51,8 @@ module BenefitsClaims
       end
 
       def track_create_itf_success(itf_type, form_start_date, user_account_uuid)
-        StatsD.increment("#{STATSD_KEY_PREFIX}.#{itf_type}.success")
+        tags = ["itf_type:#{itf_type}", 'version:v0']
+        StatsD.increment("#{STATSD_KEY_PREFIX}.#{itf_type}.success", tags:)
         context = {
           itf_type:,
           form_start_date:,
@@ -58,7 +62,8 @@ module BenefitsClaims
       end
 
       def track_create_itf_failure(itf_type, form_start_date, user_account_uuid, e)
-        StatsD.increment("#{STATSD_KEY_PREFIX}.#{itf_type}.failure")
+        tags = ["itf_type:#{itf_type}", 'version:v0']
+        StatsD.increment("#{STATSD_KEY_PREFIX}.#{itf_type}.failure", tags:)
         context = {
           itf_type:,
           form_start_date:,
@@ -69,6 +74,7 @@ module BenefitsClaims
       end
 
       def track_create_itf_exhaustion(itf_type, form, error)
+        tags = ["form_id:#{form&.form_id}", "itf_type:#{itf_type}", 'version:v0']
         context = {
           error:,
           itf_type:,
@@ -77,12 +83,13 @@ module BenefitsClaims
         }
         log_silent_failure(context, form&.user_account_id, call_location: caller_locations.first)
 
-        StatsD.increment("#{STATSD_KEY_PREFIX}.exhausted")
+        StatsD.increment("#{STATSD_KEY_PREFIX}.exhausted", tags:)
         Rails.logger.error("Lighthouse::CreateIntentToFileJob create #{itf_type} ITF exhausted", context)
       end
 
       def track_missing_user_icn(form, error)
-        StatsD.increment('user.icn.blank')
+        tags = ["form_id:#{form&.form_id}", 'version:v0']
+        StatsD.increment('user.icn.blank', tags:)
         context = {
           error: error.message,
           in_progress_form_id: form&.id,
@@ -92,7 +99,8 @@ module BenefitsClaims
       end
 
       def track_missing_user_pid(form, error)
-        StatsD.increment('user.participant_id.blank')
+        tags = ["form_id:#{form&.form_id}", 'version:v0']
+        StatsD.increment('user.participant_id.blank', tags:)
         context = {
           error: error.message,
           in_progress_form_id: form&.id,
@@ -102,7 +110,8 @@ module BenefitsClaims
       end
 
       def track_missing_form(form, error)
-        StatsD.increment('form.missing')
+        tags = ["form_id:#{form&.form_id}", 'version:v0']
+        StatsD.increment('form.missing', tags:)
         context = {
           error: error.message,
           in_progress_form_id: form&.id,
@@ -112,7 +121,8 @@ module BenefitsClaims
       end
 
       def track_invalid_itf_type(form, error)
-        StatsD.increment('itf.type.invalid')
+        tags = ["form_id:#{form&.form_id}", 'version:v0']
+        StatsD.increment('itf.type.invalid', tags:)
         context = {
           error: error.message,
           in_progress_form_id: form&.id,

--- a/lib/lighthouse/benefits_claims/intent_to_file/monitor.rb
+++ b/lib/lighthouse/benefits_claims/intent_to_file/monitor.rb
@@ -6,6 +6,7 @@ module BenefitsClaims
   module IntentToFile
     class Monitor < ::ZeroSilentFailures::Monitor
       STATSD_KEY_PREFIX = 'worker.lighthouse.create_itf_async'
+      STATSD_V1_KEY_PREFIX = 'worker.lighthouse.create_itf.v1'
 
       def initialize
         super('pension-itf')
@@ -123,38 +124,38 @@ module BenefitsClaims
       # ITF controller metrics and logging
 
       def track_show_itf(form_id, itf_type, user_uuid)
-        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}"]
-        StatsD.increment("#{STATSD_KEY_PREFIX}.#{itf_type}.show", tags:)
+        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "version:v1"]
+        StatsD.increment("#{STATSD_V1_KEY_PREFIX}.#{itf_type}.show", tags:)
         context = { itf_type:, form_id:, user_uuid: }
-        Rails.logger.info('V0 IntentToFilesController ITF show', context)
+        Rails.logger.info('IntentToFilesController ITF show', context)
       end
 
       def track_submit_itf(form_id, itf_type, user_uuid)
-        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}"]
-        StatsD.increment("#{STATSD_KEY_PREFIX}.#{itf_type}.submit", tags:)
+        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "version:v1"]
+        StatsD.increment("#{STATSD_V1_KEY_PREFIX}.#{itf_type}.submit", tags:)
         context = { itf_type:, form_id:, user_uuid: }
-        Rails.logger.info('V0 IntentToFilesController ITF submit', context)
+        Rails.logger.info('IntentToFilesController ITF submit', context)
       end
 
       def track_missing_user_icn_itf_controller(method, form_id, itf_type, user_uuid, error)
-        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "method:#{method}"]
-        StatsD.increment('user.icn.blank', tags:)
+        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "method:#{method}", "version:v1"]
+        StatsD.increment('v1.user.icn.blank', tags:)
         context = { error:, method:, form_id:, itf_type:, user_uuid: }
-        Rails.logger.info('V0 IntentToFilesController ITF user.icn is blank', context)
+        Rails.logger.info('IntentToFilesController ITF user.icn is blank', context)
       end
 
       def track_missing_user_pid_itf_controller(method, form_id, itf_type, user_uuid, error)
-        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "method:#{method}"]
-        StatsD.increment('user.participant_id.blank', tags:)
+        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "method:#{method}", "version:v1"]
+        StatsD.increment('v1.user.participant_id.blank', tags:)
         context = { error:, method:, form_id:, itf_type:, user_uuid: }
-        Rails.logger.info('V0 IntentToFilesController ITF user.participant_id is blank', context)
+        Rails.logger.info('IntentToFilesController ITF user.participant_id is blank', context)
       end
 
       def track_invalid_itf_type_itf_controller(method, form_id, itf_type, user_uuid, error)
-        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "method:#{method}"]
-        StatsD.increment('itf.type.invalid', tags:)
+        tags = ["form_id:#{form_id}", "itf_type:#{itf_type}", "method:#{method}", "version:v1"]
+        StatsD.increment('v1.itf.type.invalid', tags:)
         context = { error:, method:, form_id:, itf_type:, user_uuid: }
-        Rails.logger.info('V0 IntentToFilesController ITF invalid ITF type', context)
+        Rails.logger.info('IntentToFilesController ITF invalid ITF type', context)
       end
     end
   end

--- a/spec/lib/lighthouse/benefits_claims/intent_to_file/monitor_spec.rb
+++ b/spec/lib/lighthouse/benefits_claims/intent_to_file/monitor_spec.rb
@@ -6,6 +6,7 @@ require 'lighthouse/benefits_claims/intent_to_file/monitor'
 RSpec.describe BenefitsClaims::IntentToFile::Monitor do
   let(:monitor) { described_class.new }
   let(:itf_stats_key) { described_class::STATSD_KEY_PREFIX }
+  let(:itf_v1_stats_key) { described_class::STATSD_V1_KEY_PREFIX }
   let(:claim) { create(:pensions_saved_claim) }
   let(:ipf) { create(:in_progress_form, user_account: current_user.user_account) }
 
@@ -187,15 +188,15 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
 
     describe '#track_show_itf' do
       it 'logs a show ITF' do
-        tags = ['form_id:21P-527EZ', 'itf_type:pension']
-        log = 'V0 IntentToFilesController ITF show'
+        tags = ['form_id:21P-527EZ', 'itf_type:pension', 'version:v1']
+        log = 'IntentToFilesController ITF show'
         payload = {
           itf_type: 'pension',
           form_id: '21P-527EZ',
           user_uuid: current_user.uuid
         }
 
-        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.pension.show", tags:)
+        expect(StatsD).to receive(:increment).with("#{itf_v1_stats_key}.pension.show", tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_show_itf('21P-527EZ', 'pension', current_user.uuid)
@@ -204,15 +205,15 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
 
     describe '#track_submit_itf' do
       it 'logs a submit ITF' do
-        tags = ['form_id:21P-527EZ', 'itf_type:pension']
-        log = 'V0 IntentToFilesController ITF submit'
+        tags = ['form_id:21P-527EZ', 'itf_type:pension', 'version:v1']
+        log = 'IntentToFilesController ITF submit'
         payload = {
           itf_type: 'pension',
           form_id: '21P-527EZ',
           user_uuid: current_user.uuid
         }
 
-        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.pension.submit", tags:)
+        expect(StatsD).to receive(:increment).with("#{itf_v1_stats_key}.pension.submit", tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_submit_itf('21P-527EZ', 'pension', current_user.uuid)
@@ -221,8 +222,8 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
 
     describe '#track_missing_user_icn_itf_controller' do
       it 'logs a missing user ICN' do
-        tags = ['form_id:21P-527EZ', 'itf_type:pension', 'method:post']
-        log = 'V0 IntentToFilesController ITF user.icn is blank'
+        tags = ['form_id:21P-527EZ', 'itf_type:pension', 'method:post', 'version:v1']
+        log = 'IntentToFilesController ITF user.icn is blank'
         payload = {
           error: 'error',
           method: 'post',
@@ -231,7 +232,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
           user_uuid: current_user.uuid
         }
 
-        expect(StatsD).to receive(:increment).with('user.icn.blank', tags:)
+        expect(StatsD).to receive(:increment).with('v1.user.icn.blank', tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_missing_user_icn_itf_controller('post', '21P-527EZ', 'pension', current_user.uuid, 'error')
@@ -240,8 +241,8 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
 
     describe '#track_missing_user_pid_itf_controller' do
       it 'logs a missing user PID' do
-        tags = ['form_id:21P-527EZ', 'itf_type:pension', 'method:post']
-        log = 'V0 IntentToFilesController ITF user.participant_id is blank'
+        tags = ['form_id:21P-527EZ', 'itf_type:pension', 'method:post', 'version:v1']
+        log = 'IntentToFilesController ITF user.participant_id is blank'
         payload = {
           error: 'error',
           method: 'post',
@@ -250,7 +251,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
           user_uuid: current_user.uuid
         }
 
-        expect(StatsD).to receive(:increment).with('user.participant_id.blank', tags:)
+        expect(StatsD).to receive(:increment).with('v1.user.participant_id.blank', tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_missing_user_pid_itf_controller('post', '21P-527EZ', 'pension', current_user.uuid, 'error')
@@ -259,8 +260,8 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
 
     describe '#track_invalid_itf_type_itf_controller' do
       it 'logs an invalid ITF type' do
-        tags = ['form_id:21P-527EZ', 'itf_type:pension', 'method:post']
-        log = 'V0 IntentToFilesController ITF invalid ITF type'
+        tags = ['form_id:21P-527EZ', 'itf_type:pension', 'method:post', 'version:v1']
+        log = 'IntentToFilesController ITF invalid ITF type'
         payload = {
           error: 'error',
           method: 'post',
@@ -269,7 +270,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
           user_uuid: current_user.uuid
         }
 
-        expect(StatsD).to receive(:increment).with('itf.type.invalid', tags:)
+        expect(StatsD).to receive(:increment).with('v1.itf.type.invalid', tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_invalid_itf_type_itf_controller('post', '21P-527EZ', 'pension', current_user.uuid, 'error')

--- a/spec/lib/lighthouse/benefits_claims/intent_to_file/monitor_spec.rb
+++ b/spec/lib/lighthouse/benefits_claims/intent_to_file/monitor_spec.rb
@@ -16,13 +16,14 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
 
     describe '#track_create_itf_initiated' do
       it 'logs a create ITF initiated' do
+        tags = ['itf_type:pension', 'version:v0']
         log = "Lighthouse::CreateIntentToFileJob create pension ITF initiated for form ##{ipf.id}"
         payload = {
           itf_type: 'pension',
           form_start_date: ipf.created_at,
           user_account_uuid: current_user.user_account_uuid
         }
-        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.pension.initiated")
+        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.pension.initiated", tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_create_itf_initiated('pension', ipf.created_at, current_user.user_account_uuid, ipf.id)
@@ -40,6 +41,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
               'type' => 'pension',
               'status' => 'active' } } }
 
+        tags = ['itf_type:pension', 'version:v0']
         log = 'Lighthouse::CreateIntentToFileJob create pension ITF active record found'
         payload = {
           itf_type: 'pension',
@@ -48,7 +50,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
           form_start_date: ipf.created_at,
           user_account_uuid: current_user.user_account_uuid
         }
-        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.pension.active_found")
+        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.pension.active_found", tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_create_itf_active_found('pension', ipf.created_at, current_user.user_account_uuid, itf_found)
@@ -57,6 +59,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
 
     describe '#track_create_itf_begun' do
       it 'logs a create ITF begun' do
+        tags = ['itf_type:pension', 'version:v0']
         log = 'Lighthouse::CreateIntentToFileJob create pension ITF begun'
         payload = {
           itf_type: 'pension',
@@ -64,7 +67,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
           user_account_uuid: current_user.user_account_uuid
         }
 
-        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.pension.begun")
+        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.pension.begun", tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_create_itf_begun('pension', ipf.created_at, current_user.user_account_uuid)
@@ -73,6 +76,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
 
     describe '#track_create_itf_success' do
       it 'logs a create ITF success' do
+        tags = ['itf_type:pension', 'version:v0']
         log = 'Lighthouse::CreateIntentToFileJob create pension ITF succeeded'
         payload = {
           itf_type: 'pension',
@@ -80,7 +84,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
           user_account_uuid: current_user.user_account_uuid
         }
 
-        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.pension.success")
+        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.pension.success", tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_create_itf_success('pension', ipf.created_at, current_user.user_account_uuid)
@@ -89,6 +93,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
 
     describe '#track_create_itf_failure' do
       it 'logs a create ITF failure' do
+        tags = ['itf_type:pension', 'version:v0']
         log = 'Lighthouse::CreateIntentToFileJob create pension ITF failed'
         payload = {
           itf_type: 'pension',
@@ -97,7 +102,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
           errors: monitor_error.message
         }
 
-        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.pension.failure")
+        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.pension.failure", tags:)
         expect(Rails.logger).to receive(:warn).with(log, payload)
 
         monitor.track_create_itf_failure('pension', ipf.created_at, current_user.user_account_uuid, monitor_error)
@@ -106,6 +111,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
 
     describe '#track_create_itf_exhaustion' do
       it 'logs a create ITF exhaustion' do
+        tags = ["form_id:#{ipf.form_id}", 'itf_type:pension', 'version:v0']
         log = 'Lighthouse::CreateIntentToFileJob create pension ITF exhausted'
         payload = {
           error: monitor_error.message,
@@ -115,7 +121,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
         }
 
         expect(monitor).to receive(:log_silent_failure).with(payload, current_user.user_account_uuid, anything)
-        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.exhausted")
+        expect(StatsD).to receive(:increment).with("#{itf_stats_key}.exhausted", tags:)
         expect(Rails.logger).to receive(:error).with(log, payload)
 
         monitor.track_create_itf_exhaustion('pension', ipf, monitor_error.message)
@@ -124,6 +130,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
 
     describe '#track_missing_user_icn' do
       it 'logs a missing user ICN' do
+        tags = ["form_id:#{ipf.form_id}", 'version:v0']
         log = 'V0 InProgressFormsController async ITF user.icn is blank'
         payload = {
           error: monitor_error.message,
@@ -131,7 +138,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
           user_account_uuid: current_user.user_account_uuid
         }
 
-        expect(StatsD).to receive(:increment).with('user.icn.blank')
+        expect(StatsD).to receive(:increment).with('user.icn.blank', tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_missing_user_icn(ipf, monitor_error)
@@ -140,6 +147,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
 
     describe '#track_missing_user_pid' do
       it 'logs a missing user PID' do
+        tags = ["form_id:#{ipf.form_id}", 'version:v0']
         log = 'V0 InProgressFormsController async ITF user.participant_id is blank'
         payload = {
           error: monitor_error.message,
@@ -147,7 +155,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
           user_account_uuid: current_user.user_account_uuid
         }
 
-        expect(StatsD).to receive(:increment).with('user.participant_id.blank')
+        expect(StatsD).to receive(:increment).with('user.participant_id.blank', tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_missing_user_pid(ipf, monitor_error)
@@ -156,6 +164,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
 
     describe '#track_missing_form' do
       it 'logs a missing form' do
+        tags = ["form_id:#{ipf.form_id}", 'version:v0']
         log = 'V0 InProgressFormsController async ITF form is missing'
         payload = {
           error: monitor_error.message,
@@ -163,7 +172,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
           user_account_uuid: current_user.user_account_uuid
         }
 
-        expect(StatsD).to receive(:increment).with('form.missing')
+        expect(StatsD).to receive(:increment).with('form.missing', tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_missing_form(ipf, monitor_error)
@@ -172,6 +181,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
 
     describe '#track_invalid_itf_type' do
       it 'logs an invalid ITF type' do
+        tags = ["form_id:#{ipf.form_id}", 'version:v0']
         log = 'V0 InProgressFormsController async ITF invalid ITF type'
         payload = {
           error: monitor_error.message,
@@ -179,7 +189,7 @@ RSpec.describe BenefitsClaims::IntentToFile::Monitor do
           user_account_uuid: current_user.user_account_uuid
         }
 
-        expect(StatsD).to receive(:increment).with('itf.type.invalid')
+        expect(StatsD).to receive(:increment).with('itf.type.invalid', tags:)
         expect(Rails.logger).to receive(:info).with(log, payload)
 
         monitor.track_invalid_itf_type(ipf, monitor_error)


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): NO*
- Updated pension ITF datadog monitor key prefixes to better differentiate v1 data from v0.
- Pension and Burials team to own this change.

## Related issue(s)

- [*Link to ticket created in va.gov-team repo*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/108930)

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
