### PR TITLE
re-format 10203 sco confirmation email based on feedback

### DIFF
--- a/app/mailers/transactional_email_mailer.rb
+++ b/app/mailers/transactional_email_mailer.rb
@@ -27,6 +27,12 @@ class TransactionalEmailMailer < ApplicationMailer
     "#{name.first} #{name.last}"
   end
 
+  def stub_name(name)
+    return '' if name.nil?
+
+    "#{name.first[0..3]}#{name.last[0]}".upcase
+  end
+
   def template(name = self.class::TEMPLATE)
     template_file = File.read("app/mailers/views/#{name}.html.erb")
     ERB.new(template_file).result(binding)

--- a/app/mailers/views/school_certifying_officials.html.erb
+++ b/app/mailers/views/school_certifying_officials.html.erb
@@ -13,11 +13,13 @@
     <p>
       <b>Rogers STEM Scholarship Applicant</b>
       <br>
-      Student's name: <%= first_initial_last_name(@applicant.veteranFullName) %>
+      Student's name: <%= stub_name(@applicant.veteranFullName) %>
       <br>
       Student's school email address: <%= @applicant.schoolEmailAddress %>
       <br>
       Student's school ID number: <%= @applicant.schoolStudentId %>
+      <br>
+      Student’s VA student identifier number: 00<%= @applicant.veteranSocialSecurityNumber[-4..-1] %>
     </p>
 
     <p>

--- a/spec/sidekiq/education_form/send_school_certifying_officials_email_spec.rb
+++ b/spec/sidekiq/education_form/send_school_certifying_officials_email_spec.rb
@@ -111,6 +111,10 @@ RSpec.describe EducationForm::SendSchoolCertifyingOfficialsEmail, form: :educati
         expect(sco_email.subject).to eq('Applicant for VA Rogers STEM Scholarship')
         expect(sco_email.from).to include('stage.va-notifications@public.govdelivery.com')
         expect(sco_email.body.encoded).to include('<p>Dear VA School Certifying Official,</p>')
+        expect(sco_email.body.encoded).to include("Student's name: MARKO")
+        expect(sco_email.body.encoded).to include("Student's school email address: user@school.edu")
+        expect(sco_email.body.encoded).to include("Student's school ID number: 01010101")
+        expect(sco_email.body.encoded).to include("Student’s VA student identifier number: 003334")
 
         # Add a line to download the contents of the email to a file
         File.write('tmp/sco_email_body.html', sco_email.body)


### PR DESCRIPTION
## Summary

The school certifying officials (SCOs) who process the 10203 forms need more information to identify the students who are applying. This PR modifies the 10203 SCO email to include that necessary info, based on discussions with the relevant stakeholders. 

- *This work is behind a feature toggle (flipper): YES/NO*: No
- *(Summarize the changes that have been made to the platform)*: email contents modified
- *(If bug, how to reproduce)*: N/A
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)*: VEBT
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

<img width="1583" height="633" alt="image" src="https://github.com/user-attachments/assets/33c9a46f-3c91-4a8a-ad98-6777fdcf50a6" />


## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*: Student name and ID shown differently
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*: Submit a 10203, get a hold of the email sent to an SCO, confirm email contents.
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
10203 email generation

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [X]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X]  Feature/bug has a monitor built into Datadog (if applicable)

## Requested Feedback

