### PR TITLE
API 473351 - 526 Validation Rules 4a: `separationLocationCode`

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
@@ -12,6 +12,15 @@ module ClaimsApi
     def validate_form_526_submission_values!
       # ensure 'claimDate', if provided, is a valid date not in the future
       validate_form_526_submission_claim_date!
+      # ensure any provided 'separationLocationCode' values are valid EVSS ReferenceData values
+      validate_form_526_location_codes!
+    end
+
+    def retrieve_separation_locations
+      ClaimsApi::BRD.new.intake_sites
+    rescue
+      exception_msg = 'Failed To Obtain Intake Sites (Request Failed)'
+      raise ::Common::Exceptions::ServiceUnavailable.new({ source: 'intake_sites', detail: exception_msg })
     end
 
     def validate_form_526_submission_claim_date!
@@ -20,6 +29,25 @@ module ClaimsApi
 
       exception_msg = 'The request failed validation, because the claim date was in the future.'
       raise ::Common::Exceptions::InvalidFieldValue.new('claimDate', exception_msg)
+    end
+
+    def validate_form_526_location_codes!
+      # only retrieve separation locations if we'll need them
+      need_locations = form_attributes['serviceInformation']['servicePeriods'].detect do |service_period|
+        Date.parse(service_period['activeDutyEndDate']) > Time.zone.today
+      end
+      separation_locations = retrieve_separation_locations if need_locations
+
+      form_attributes['serviceInformation']['servicePeriods'].each do |service_period|
+        next if Date.parse(service_period['activeDutyEndDate']) <= Time.zone.today
+        next if separation_locations.any? do |location|
+                  location[:id]&.to_s == service_period['separationLocationCode']
+                end
+
+        exception_msg = "Provided separation location code is not valid: #{service_period['separationLocationCode']}"
+        raise ::Common::Exceptions::InvalidFieldValue.new('Invalid separation location code',
+                                                          exception_msg)
+      end
     end
   end
 end

--- a/modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
+++ b/modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe ClaimsApi::RevisedDisabilityCompensationValidations do
   let(:test_class) do
     Class.new do
       include ClaimsApi::RevisedDisabilityCompensationValidations
-
-      # Mock any methods the module might expect to be present
       attr_accessor :form_attributes
 
       def initialize(attributes = {})
@@ -45,6 +43,108 @@ RSpec.describe ClaimsApi::RevisedDisabilityCompensationValidations do
       it 'raises an InvalidFieldValue error' do
         expect { subject.validate_form_526_submission_claim_date! }
           .to raise_error(Common::Exceptions::InvalidFieldValue)
+      end
+    end
+  end
+
+  describe '#validate_form_526_location_codes!' do
+    context 'when service periods are in the past' do
+      let(:form_attributes) do
+        {
+          'serviceInformation' => {
+            'servicePeriods' => [
+              { 'activeDutyEndDate' => 1.year.ago.to_date.iso8601, 'separationLocationCode' => '123' }
+            ]
+          }
+        }
+      end
+
+      it 'does not raise an error' do
+        expect { subject.validate_form_526_location_codes! }.not_to raise_error
+      end
+    end
+
+    context 'when service periods are in the future' do
+      let(:brd_client) { instance_double(ClaimsApi::BRD) }
+      let(:separation_locations) { [{ id: '123' }, { id: '456' }] }
+      let(:form_attributes) do
+        {
+          'serviceInformation' => {
+            'servicePeriods' => [
+              { 'activeDutyEndDate' => 1.year.from_now.to_date.iso8601, 'separationLocationCode' => '123' }
+            ]
+          }
+        }
+      end
+
+      before do
+        allow(ClaimsApi::BRD).to receive(:new).and_return(brd_client)
+        allow(brd_client).to receive(:intake_sites).and_return(separation_locations)
+      end
+
+      context 'with a valid separation location code' do
+        it 'does not raise an error' do
+          expect { subject.validate_form_526_location_codes! }.not_to raise_error
+        end
+      end
+
+      context 'with an invalid separation location code' do
+        let(:form_attributes) do
+          {
+            'serviceInformation' => {
+              'servicePeriods' => [
+                { 'activeDutyEndDate' => 1.year.from_now.to_date.iso8601, 'separationLocationCode' => '999' }
+              ]
+            }
+          }
+        end
+
+        it 'raises an InvalidFieldValue error' do
+          expect { subject.validate_form_526_location_codes! }
+            .to raise_error(Common::Exceptions::InvalidFieldValue)
+        end
+      end
+
+      context 'with multiple service periods' do
+        let(:form_attributes) do
+          {
+            'serviceInformation' => {
+              'servicePeriods' => [
+                { 'activeDutyEndDate' => 1.year.ago.to_date.iso8601, 'separationLocationCode' => '999' },
+                { 'activeDutyEndDate' => 1.year.from_now.to_date.iso8601, 'separationLocationCode' => '123' }
+              ]
+            }
+          }
+        end
+
+        it 'only validates future service periods' do
+          expect { subject.validate_form_526_location_codes! }.not_to raise_error
+        end
+      end
+    end
+
+    context 'when BRD client raises an error' do
+      let(:brd_client) { instance_double(ClaimsApi::BRD) }
+      let(:form_attributes) do
+        {
+          'serviceInformation' => {
+            'servicePeriods' => [
+              { 'activeDutyEndDate' => 1.year.from_now.to_date.iso8601, 'separationLocationCode' => '123' }
+            ]
+          }
+        }
+      end
+
+      before do
+        allow(ClaimsApi::BRD).to receive(:new).and_return(brd_client)
+        allow(brd_client).to receive(:intake_sites).and_raise(
+          StandardError.new('Failed to retrieve intake sites')
+        )
+      end
+
+      it 'propagates a ServiceUnavailable error' do
+        expect { subject.validate_form_526_location_codes! }
+          .to raise_error(Common::Exceptions::ServiceUnavailable)
       end
     end
   end


### PR DESCRIPTION
## Summary

_This is a continuation of the work started [here](https://github.com/department-of-veterans-affairs/vets-api/pull/23421)._

This PR adds the separation location code validation functionality to the revised form 526 validation logic + introduces unit tests for that validator.

|| Business rules addressed|
|-|-|
|Strikethrough: obsolete rule; Red text: new messaging/behavior|<img width="865" height="234" alt="Screenshot 2025-08-06 at 17 09 59" src="https://github.com/user-attachments/assets/ac76dc9b-dee4-402c-b310-93d2b12fde04" />|

## Related issue(s)

|[Jira ticket](https://jira.devops.va.gov/browse/API-47335)|
|-|
|<img width="967" height="801" alt="Screenshot 2025-08-06 at 08 58 46" src="https://github.com/user-attachments/assets/1e4504fb-25d0-40f1-81e1-83ca4124595c" />|

## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

```
modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
```

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
