### PR TITLE
Set appointment modality and derived date fields for cancelled appointments

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -199,10 +199,13 @@ module VAOS
           else
             appointment = update_appointment_vaos(appt_id, status).body
             convert_appointment_time(appointment)
+            find_and_merge_provider_name(appointment) if cc?(appointment)
             extract_appointment_fields(appointment)
             merge_clinic(appointment)
             merge_facility(appointment)
             set_type(appointment)
+            set_modality(appointment)
+            set_derived_appointment_date_fields(appointment)
             appointment[:show_schedule_link] = schedulable?(appointment)
             OpenStruct.new(appointment)
           end

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -1337,6 +1337,10 @@ describe VAOS::V2::AppointmentsService do
                   response = subject.update_appointment('70060', 'cancelled')
                   expect(response.status).to eq('cancelled')
                   expect(response[:show_schedule_link]).to be(true)
+                  expect(response[:modality]).to be('vaInPerson')
+                  expect(response[:past]).to be(true)
+                  expect(response[:pending]).to be(true)
+                  expect(response[:future]).to be(false)
                 end
               end
             end
@@ -1370,6 +1374,10 @@ describe VAOS::V2::AppointmentsService do
                   response = subject.update_appointment('70060', 'cancelled')
                   expect(response.status).to eq('cancelled')
                   expect(response[:show_schedule_link]).to be(true)
+                  expect(response[:modality]).to be('vaInPerson')
+                  expect(response[:past]).to be(true)
+                  expect(response[:pending]).to be(true)
+                  expect(response[:future]).to be(false)
                 end
               end
             end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- We found out that we're not setting the appointment modality and derived date fields on the cancel appointments endpoint. As a result, the appointments were displayed as "Not defined" on the frontend
- This PR updates the post-processing steps of the cancel appointments endpoint to match the behavior of gets and create and set these missing fields.
- United Appointments Experience 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/115538

## Testing done

- [x] *New code is covered by unit tests*
- Updated existing tests to include the assertion of the missing fields

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
