### PR TITLE
116026 add config vars for travel pay client id and secret

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -145,6 +145,8 @@ check_in:
     client_number: <%= ENV['check_in__travel_reimbursement_api_v2__client_number'] %>
     client_number_oh: <%= ENV['check_in__travel_reimbursement_api_v2__client_number_oh'] %>
     client_secret: <%= ENV['check_in__travel_reimbursement_api_v2__client_secret'] %>
+    travel_pay_client_id: <%= ENV['check_in__travel_reimbursement_api_v2__travel_pay_client_id'] %>
+    travel_pay_client_secret: <%= ENV['check_in__travel_reimbursement_api_v2__travel_pay_client_secret'] %>
     e_subscription_key: <%= ENV['check_in__travel_reimbursement_api_v2__e_subscription_key'] %>
     redis_token_expiry: 3540
     s_subscription_key: <%= ENV['check_in__travel_reimbursement_api_v2__s_subscription_key'] %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -145,6 +145,8 @@ check_in:
     client_number: ~
     client_number_oh: ~
     client_secret: ~
+    travel_pay_client_id: ~
+    travel_pay_client_secret: ~
     e_subscription_key: ~
     redis_token_expiry: 3540
     s_subscription_key: ~

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -145,6 +145,8 @@ check_in:
     client_number_oh: ~
     client_secret: fake_client_secret
     e_subscription_key: ~
+    travel_pay_client_id: fake_travel_pay_client_id
+    travel_pay_client_secret: fake_travel_pay_client_secret
     redis_token_expiry: 3540
     s_subscription_key: ~
     scope: fake_scope/.default


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO

* Adds config vars for new travel pay api

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/116026

## Testing done

- [ ] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
`check_in` module, travel claims

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
