### PR TITLE
[#104862] Travel Pay, Decision reason ID fix

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/claims_service.rb
+++ b/modules/travel_pay/app/services/travel_pay/claims_service.rb
@@ -72,7 +72,7 @@ module TravelPay
         if Flipper.enabled?(:travel_pay_claims_management_decision_reason_api, @user)
           decision_document = find_decision_letter_document(claim)
           if (claim['claimStatus'].eql?('Denied') || claim['claimStatus'].eql?('Paid')) && !decision_document.nil?
-            claim['decision_letter_reason'] = get_decision_reason(claim_id, decision_document['id'])
+            claim['decision_letter_reason'] = get_decision_reason(claim_id, decision_document['documentId'])
           end
         end
 
@@ -174,7 +174,7 @@ module TravelPay
 
       claim['documents'].find do |document|
         filename = document['filename'] || ''
-        filename.match?(/Decision Letter|Rejection Letter/i)
+        filename.match?(/Decision Letter|Rejection Letter/i) && document['documentId'].present?
       end
     end
 

--- a/modules/travel_pay/app/services/travel_pay/documents_service.rb
+++ b/modules/travel_pay/app/services/travel_pay/documents_service.rb
@@ -15,7 +15,7 @@ module TravelPay
     def download_document(claim_id, doc_id)
       unless claim_id.present? && doc_id.present?
         raise ArgumentError,
-              message: "Missing claim ID or document ID, given: #{params}"
+              message: "Missing claim ID or document ID, given: claim_id=#{claim_id}, doc_id=#{doc_id}"
       end
 
       params = { claim_id:, doc_id: }

--- a/modules/travel_pay/spec/services/claims_service_spec.rb
+++ b/modules/travel_pay/spec/services/claims_service_spec.rb
@@ -706,13 +706,13 @@ describe TravelPay::ClaimsService do
         claim = {
           'documents' => [
             { 'filename' => 'receipt.pdf' },
-            { 'filename' => 'Decision Letter.docx', 'id' => 'decision_doc_id' },
+            { 'filename' => 'Decision Letter.docx', 'documentId' => 'decision_doc_id' },
             { 'filename' => 'other.pdf' }
           ]
         }
 
         result = service.send(:find_decision_letter_document, claim)
-        expect(result['id']).to eq('decision_doc_id')
+        expect(result['documentId']).to eq('decision_doc_id')
         expect(result['filename']).to eq('Decision Letter.docx')
       end
 
@@ -720,13 +720,13 @@ describe TravelPay::ClaimsService do
         claim = {
           'documents' => [
             { 'filename' => 'receipt.pdf' },
-            { 'filename' => 'Rejection Letter.docx', 'id' => 'rejection_doc_id' },
+            { 'filename' => 'Rejection Letter.docx', 'documentId' => 'rejection_doc_id' },
             { 'filename' => 'other.pdf' }
           ]
         }
 
         result = service.send(:find_decision_letter_document, claim)
-        expect(result['id']).to eq('rejection_doc_id')
+        expect(result['documentId']).to eq('rejection_doc_id')
         expect(result['filename']).to eq('Rejection Letter.docx')
       end
 
@@ -759,12 +759,45 @@ describe TravelPay::ClaimsService do
       it 'handles case insensitive matching' do
         claim = {
           'documents' => [
-            { 'filename' => 'decision letter.pdf', 'id' => 'decision_doc_id' }
+            { 'filename' => 'decision letter.pdf', 'documentId' => 'decision_doc_id' }
           ]
         }
 
         result = service.send(:find_decision_letter_document, claim)
-        expect(result['id']).to eq('decision_doc_id')
+        expect(result['documentId']).to eq('decision_doc_id')
+      end
+
+      it 'returns nil when decision letter document has no documentId' do
+        claim = {
+          'documents' => [
+            { 'filename' => 'Decision Letter.docx' }
+          ]
+        }
+
+        result = service.send(:find_decision_letter_document, claim)
+        expect(result).to be_nil
+      end
+
+      it 'returns nil when decision letter document has empty documentId' do
+        claim = {
+          'documents' => [
+            { 'filename' => 'Decision Letter.docx', 'documentId' => '' }
+          ]
+        }
+
+        result = service.send(:find_decision_letter_document, claim)
+        expect(result).to be_nil
+      end
+
+      it 'returns nil when decision letter document has nil documentId' do
+        claim = {
+          'documents' => [
+            { 'filename' => 'Decision Letter.docx', 'documentId' => nil }
+          ]
+        }
+
+        result = service.send(:find_decision_letter_document, claim)
+        expect(result).to be_nil
       end
     end
 


### PR DESCRIPTION
## Summary

After observing this behavior in staging, it became clear that a fix was needed for the attempt to access `params` as well as the property name used for the document id.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/104862

## Testing done

- [x] *New code is covered by unit tests*

Prior to the change, we were seeing error logs indicating `params` was `undefined` within `download_document`.


## What areas of the site does it impact?
Travel Pay

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected