### PR TITLE
Log external service errors for `GET /v0/user` contact information

### DIFF
--- a/app/services/users/profile.rb
+++ b/app/services/users/profile.rb
@@ -135,7 +135,9 @@ module Users
         fax_number: person.fax_number
       }
     rescue => e
-      scaffold.errors << Users::ExceptionHandler.new(e, 'VAProfile').serialize_error
+      error_hash = Users::ExceptionHandler.new(e, 'VAProfile').serialize_error
+      scaffold.errors << error_hash
+      log_external_service_error(error_hash)
       nil
     end
 
@@ -157,7 +159,9 @@ module Users
           active_mhv_ids: user.active_mhv_ids
         }
       else
-        scaffold.errors << Users::ExceptionHandler.new(user.mpi_error, 'MVI').serialize_error
+        error_hash = Users::ExceptionHandler.new(user.mpi_error, 'MVI').serialize_error
+        scaffold.errors << error_hash
+        log_external_service_error(error_hash)
         nil
       end
     end
@@ -169,7 +173,9 @@ module Users
         served_in_military: user.served_in_military?
       }
     rescue => e
-      scaffold.errors << Users::ExceptionHandler.new(e, 'VAProfile').serialize_error
+      error_hash = Users::ExceptionHandler.new(e, 'VAProfile').serialize_error
+      scaffold.errors << error_hash
+      log_external_service_error(error_hash)
       nil
     end
 
@@ -221,6 +227,16 @@ module Users
       {
         show: user.show_onboarding_flow_on_login
       }
+    end
+
+    def log_external_service_error(error_hash)
+      Rails.logger.warn(
+        {
+          error: error_hash,
+          user_uuid: user.uuid,
+          loa: user.loa
+        }.to_json
+      )
     end
   end
 end

--- a/spec/services/users/profile_spec.rb
+++ b/spec/services/users/profile_spec.rb
@@ -523,5 +523,65 @@ RSpec.describe Users::Profile do
           .to eq({ auth_broker: SAML::URLService::BROKER_CODE, ssoe: true, transactionid: 'a' })
       end
     end
+
+    describe '#log_external_service_error' do
+      let(:logging_user) { build(:user, :loa3, vet360_id: '1', uuid: 'test-uuid') }
+      let(:logging_profile) { described_class.new(logging_user) }
+
+      context 'when VA Profile service returns an error' do
+        let(:vet360_error) do
+          Common::Client::Errors::ClientError.new('Vet360 error', 502, {})
+        end
+        let(:vet_status_error) do
+          Common::Client::Errors::ClientError.new('VAProfile error', 502, {})
+        end
+        let(:expected_va_profile_log_hash) do
+          {
+            'user_uuid' => 'test-uuid',
+            'loa' => { 'current' => 3, 'highest' => 3 },
+            'error' => hash_including('external_service' => 'VAProfile')
+          }
+        end
+
+        it 'logs errors for vet360_contact_information' do
+          allow(logging_user).to receive(:vet360_contact_info).and_raise(vet360_error)
+          expect(Rails.logger).to receive(:warn) do |log_arg|
+            log_hash = JSON.parse(log_arg)
+            expect(log_hash).to include(expected_va_profile_log_hash)
+          end
+          logging_profile.send(:vet360_contact_information)
+        end
+
+        it 'logs errors for veteran_status' do
+          allow(logging_user).to receive(:veteran?).and_raise(vet_status_error)
+          expect(Rails.logger).to receive(:warn) do |log_arg|
+            log_hash = JSON.parse(log_arg)
+            expect(log_hash).to include(expected_va_profile_log_hash)
+          end
+          logging_profile.send(:veteran_status)
+        end
+      end
+
+      context 'when MPI service returns an error' do
+        let(:mpi_error) { Common::Client::Errors::ClientError.new('MPI error', 502, {}) }
+        let(:expected_mpi_log_hash) do
+          {
+            'user_uuid' => 'test-uuid',
+            'loa' => { 'current' => 3, 'highest' => 3 },
+            'error' => hash_including('external_service' => 'MVI')
+          }
+        end
+
+        it 'logs errors for mpi_profile' do
+          allow(logging_user).to receive(:mpi_status).and_return(:error)
+          allow(logging_user).to receive(:mpi_error).and_return(mpi_error)
+          expect(Rails.logger).to receive(:warn) do |log_arg|
+            log_hash = JSON.parse(log_arg)
+            expect(log_hash).to include(expected_mpi_log_hash)
+          end
+          logging_profile.send(:mpi_profile)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper):* NO

This PR adds logging for external service errors encountered when fetching a user’s contact information via `GET /v0/user`.

In vets-api, we assign a `296` status code to indicate that a request was partially successful - due to an upstream failure from VA Profile or MPI. The rate of these `296` responses has exceeded our target threshold of <1%.

By logging which external service(s) failed and how often, we aim to gather the necessary insights to re-engage with the VA Profile and/or MPI teams. This will allow us to investigate root causes and work toward reducing the frequency of partial successes in our user profile requests.

- Team: Authenticated Experience

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/115675

## Testing done

- [x] *New code is covered by unit tests*
- We will be able to confirm these changes by observing DataDog and seeing the new logs with the expected information/details about the external service errors


## What areas of the site does it impact?
N/A - only adding logging

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature