### PR TITLE
0969 | Removing feature toggle for overflow redesign

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1449,10 +1449,6 @@ features:
     actor_type: user
     description: >
       When enabled, 21P-527EZ will display additional explanations for the income and assets requirement.
-  pension_income_and_assets_overflow_pdf_redesign:
-    actor_type: user
-    description: >
-      When enabled, 21P-0969 will use the new extras redesign when generating the overflow pdf.
   pension_medical_evidence_clarification:
     actor_type: user
     description: >

--- a/modules/income_and_assets/lib/income_and_assets/benefits_intake/submit_claim_job.rb
+++ b/modules/income_and_assets/lib/income_and_assets/benefits_intake/submit_claim_job.rb
@@ -38,12 +38,12 @@ module IncomeAndAssets
       # @return [UUID] benefits intake upload uuid
       #
       def perform(saved_claim_id, user_account_uuid = nil)
-        return unless Flipper.enabled?(:pension_income_and_assets_clarification)
+        return unless Flipper.enabled?(:income_and_assets_form_enabled)
 
         init(saved_claim_id, user_account_uuid)
 
         # generate and validate claim pdf documents
-        @form_path = process_document(@claim.to_pdf(@claim.id, { extras_redesign: extras_redesign_enabled?,
+        @form_path = process_document(@claim.to_pdf(@claim.id, { extras_redesign: true,
                                                                  omit_esign_stamp: true }))
         @attachment_paths = @claim.persistent_attachments.map { |pa| process_document(pa.to_pdf) }
         @metadata = generate_metadata
@@ -173,14 +173,6 @@ module IncomeAndAssets
         @attachment_paths&.each { |p| Common::FileHelpers.delete_file_if_exists(p) }
       rescue => e
         monitor.track_file_cleanup_error(@claim, @intake_service, @user_account_uuid, e)
-      end
-
-      # Check if the extras redesign feature flag is enabled for the current user
-      #
-      # @return [Boolean]
-      def extras_redesign_enabled?
-        user = OpenStruct.new({ flipper_id: @user_account_uuid })
-        Flipper.enabled?(:pension_income_and_assets_overflow_pdf_redesign, user)
       end
     end
   end

--- a/modules/income_and_assets/spec/lib/income_and_assets/benefits_intake/submit_claim_job_spec.rb
+++ b/modules/income_and_assets/spec/lib/income_and_assets/benefits_intake/submit_claim_job_spec.rb
@@ -23,8 +23,6 @@ RSpec.describe IncomeAndAssets::BenefitsIntake::SubmitClaimJob, :uploader_helper
         let(:omit_esign_stamp) { true }
 
         before do
-          allow(Flipper).to receive(:enabled?).with(:pension_income_and_assets_overflow_pdf_redesign,
-                                                    anything).and_return(extras_redesign)
           job.instance_variable_set(:@claim, claim)
           allow(IncomeAndAssets::SavedClaim).to receive(:find).and_return(claim)
           allow(claim).to receive(:to_pdf).with(claim.id, { extras_redesign:, omit_esign_stamp: }).and_return(pdf_path)


### PR DESCRIPTION
## Summary
We've decided to enable the overflow redesign by default for the 0969, so we are removing the feature toggle

- *This work is behind a feature toggle (flipper): YES*

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/116356

## Testing done
Tests should continue to pass

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
