### PR TITLE
[ID-582] Update cerner eligibility

### DIFF
--- a/app/controllers/concerns/authentication_and_sso_concerns.rb
+++ b/app/controllers/concerns/authentication_and_sso_concerns.rb
@@ -107,7 +107,7 @@ module AuthenticationAndSSOConcerns # rubocop:disable Metrics/ModuleLength
 
   def set_cerner_eligibility_cookie
     cookie_name = V1::SessionsController::CERNER_ELIGIBLE_COOKIE_NAME
-    existing = cookies.signed[cookie_name].present?
+    previous_value = cookies.signed[cookie_name]
 
     eligible = @current_user.cerner_eligible?
 
@@ -116,10 +116,8 @@ module AuthenticationAndSSOConcerns # rubocop:disable Metrics/ModuleLength
       domain: IdentitySettings.sign_in.info_cookie_domain
     }
 
-    unless existing
-      Rails.logger.info('[SessionsController] Cerner Eligibility', eligible:, cookie_action: :set,
-                                                                   icn: @current_user.icn)
-    end
+    Rails.logger.info('[SessionsController] Cerner Eligibility', eligible:, previous_value:, cookie_action: :set,
+                                                                 icn: @current_user.icn)
   end
 
   def set_session_expiration_header

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -473,7 +473,7 @@ class User < Common::RedisStore
   end
 
   def cerner_eligible?
-    loa3? && cerner_id.present?
+    loa3? && (cerner_id.present? || cerner_facility_ids.present?)
   end
 
   def can_create_mhv_account?

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -828,11 +828,13 @@ RSpec.describe V1::SessionsController, type: :controller do
       end
 
       context 'when cerner eligibility is checked' do
-        let(:user) { build(:user, :loa3, cerner_id:) }
+        let(:user) { build(:user, :loa3, cerner_id:, cerner_facility_ids:) }
         let(:cerner_id) { 'some-cerner-id' }
+        let(:cerner_facility_ids) { ['some-facility-id'] }
         let(:cerner_eligible_cookie) { 'CERNER_ELIGIBLE' }
         let(:expected_log_message) { '[SessionsController] Cerner Eligibility' }
-        let(:expected_log_payload) { { eligible:, cookie_action: :set, icn: user.icn } }
+        let(:previous_value) { nil }
+        let(:expected_log_payload) { { eligible:, previous_value:, cookie_action: :set, icn: user.icn } }
 
         before do
           SAMLRequestTracker.create(uuid: login_uuid, payload: { type: 'idme', application: 'some-applicaton' })
@@ -858,6 +860,7 @@ RSpec.describe V1::SessionsController, type: :controller do
 
           context 'when the user is not cerner eligible' do
             let(:cerner_id) { nil }
+            let(:cerner_facility_ids) { [] }
             let(:eligible) { false }
 
             it 'sets the cookie and logs the cerner eligibility' do
@@ -870,14 +873,17 @@ RSpec.describe V1::SessionsController, type: :controller do
         end
 
         context 'when the cerner eligible cookie is present' do
+          let(:eligible) { true }
+          let(:previous_value) { true }
+
           before do
-            cookies.signed[cerner_eligible_cookie] = 'true'
+            cookies.signed[cerner_eligible_cookie] = true
           end
 
-          it 'does not log a message' do
+          it 'logs the cerner eligibility with the previous value' do
             call_endpoint
 
-            expect(Rails.logger).not_to have_received(:info).with(expected_log_message, anything)
+            expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
           end
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1580,8 +1580,9 @@ RSpec.describe User, type: :model do
   end
 
   describe '#provision_cerner_async' do
-    let(:user) { build(:user, :loa3, cerner_id:) }
+    let(:user) { build(:user, :loa3, cerner_id:, cerner_facility_ids:) }
     let(:cerner_id) { 'some-cerner-id' }
+    let(:cerner_facility_ids) { ['some-cerner-facility-id'] }
 
     before do
       allow(Identity::CernerProvisionerJob).to receive(:perform_async)
@@ -1596,8 +1597,9 @@ RSpec.describe User, type: :model do
         end
       end
 
-      context 'when the user does not have a cerner_id' do
+      context 'when the user does not have a cerner_id nor cerner_facility_ids' do
         let(:cerner_id) { nil }
+        let(:cerner_facility_ids) { [] }
 
         it 'does not enqueue a job to provision the Cerner account' do
           user.provision_cerner_async
@@ -1619,18 +1621,30 @@ RSpec.describe User, type: :model do
   end
 
   describe '#cerner_eligible?' do
-    let(:user) { build(:user, :loa3, cerner_id:) }
-    let(:cerner_id) { 'some-cerner-id' }
+    let(:user) { build(:user, :loa3, cerner_id:, cerner_facility_ids:) }
 
     context 'when the user is loa3' do
       context 'when the user has a cerner_id' do
+        let(:cerner_id) { 'some-cerner-id' }
+        let(:cerner_facility_ids) { [] }
+
         it 'returns true' do
           expect(user.cerner_eligible?).to be true
         end
       end
 
-      context 'when the user does not have a cerner_id' do
+      context 'when the user has cerner_facility_ids' do
         let(:cerner_id) { nil }
+        let(:cerner_facility_ids) { ['some-cerner-facility-id'] }
+
+        it 'returns true' do
+          expect(user.cerner_eligible?).to be true
+        end
+      end
+
+      context 'when the user does not have a cerner_id nor cerner_facility_ids' do
+        let(:cerner_id) { nil }
+        let(:cerner_facility_ids) { [] }
 
         it 'returns false' do
           expect(user.cerner_eligible?).to be false


### PR DESCRIPTION
## Summary

- Update Cerner eligibility check to include facility ids

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/582

## Testing 
- Sign in with SSOe
- You should see a `CERNER_ELIGIBLE` cookie in your browser
   ```ruby
     [SessionsController] Cerner Eligibility -- { :eligible => true, :previous_value => nil, :cookie_action => :set, icn: <icn> }
   ```

## What areas of the site does it impact?
cerner eligibility cookie

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

