### PR TITLE
Revert "fix: move SentryLogging deprecation warning from boot to method usage"

### DIFF
--- a/lib/sentry_logging.rb
+++ b/lib/sentry_logging.rb
@@ -5,14 +5,11 @@ require 'sentry_logging'
 module SentryLogging
   # WARNING: This module is deprecated, and will be removed in October 2025. Please use Vets::SharedLogging instead.
   # If your team currently uses this module, please see documentation for migrating to Vets::SharedLogging: TODO
+  ActiveSupport::Deprecation
+    .new.warn('SentryLogging is deprecated and will be removed in October 2025. Use Vets::SharedLogging instead.')
   extend self
 
-  DEPRECATION_MESSAGE = 'SentryLogging is deprecated and will be removed in October 2025. ' \
-                        'Use Vets::SharedLogging instead.'
-  DEPRECATION_INSTANCE = ActiveSupport::Deprecation.new
-
   def log_message_to_sentry(message, level, extra_context = {}, tags_context = {})
-    DEPRECATION_INSTANCE.warn(DEPRECATION_MESSAGE)
     level = normalize_level(level, nil)
     formatted_message = extra_context.empty? ? message : "#{message} : #{extra_context}"
     rails_logger(level, formatted_message)
@@ -24,7 +21,6 @@ module SentryLogging
   end
 
   def log_exception_to_sentry(exception, extra_context = {}, tags_context = {}, level = 'error')
-    DEPRECATION_INSTANCE.warn(DEPRECATION_MESSAGE)
     level = normalize_level(level, exception)
 
     if Settings.sentry.dsn.present?


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#23060

Trying this while we debug CI tests. The output makes it hard to identify any failures. This will be temporary.