### PR TITLE
Enable 0969 PDF overflow redesign and remove feature toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1449,10 +1449,6 @@ features:
     actor_type: user
     description: >
       When enabled, 21P-527EZ will display additional explanations for the income and assets requirement.
-  pension_income_and_assets_overflow_pdf_redesign:
-    actor_type: user
-    description: >
-      When enabled, 21P-0969 will use the new extras redesign when generating the overflow pdf.
   pension_medical_evidence_clarification:
     actor_type: user
     description: >

--- a/modules/income_and_assets/lib/income_and_assets/benefits_intake/submit_claim_job.rb
+++ b/modules/income_and_assets/lib/income_and_assets/benefits_intake/submit_claim_job.rb
@@ -43,8 +43,7 @@ module IncomeAndAssets
         init(saved_claim_id, user_account_uuid)
 
         # generate and validate claim pdf documents
-        @form_path = process_document(@claim.to_pdf(@claim.id, { extras_redesign: extras_redesign_enabled?,
-                                                                 omit_esign_stamp: true }))
+        @form_path = process_document(@claim.to_pdf(@claim.id, { extras_redesign: true, omit_esign_stamp: true }))
         @attachment_paths = @claim.persistent_attachments.map { |pa| process_document(pa.to_pdf) }
         @metadata = generate_metadata
 
@@ -173,14 +172,6 @@ module IncomeAndAssets
         @attachment_paths&.each { |p| Common::FileHelpers.delete_file_if_exists(p) }
       rescue => e
         monitor.track_file_cleanup_error(@claim, @intake_service, @user_account_uuid, e)
-      end
-
-      # Check if the extras redesign feature flag is enabled for the current user
-      #
-      # @return [Boolean]
-      def extras_redesign_enabled?
-        user = OpenStruct.new({ flipper_id: @user_account_uuid })
-        Flipper.enabled?(:pension_income_and_assets_overflow_pdf_redesign, user)
       end
     end
   end

--- a/modules/income_and_assets/spec/lib/income_and_assets/benefits_intake/submit_claim_job_spec.rb
+++ b/modules/income_and_assets/spec/lib/income_and_assets/benefits_intake/submit_claim_job_spec.rb
@@ -15,79 +15,74 @@ RSpec.describe IncomeAndAssets::BenefitsIntake::SubmitClaimJob, :uploader_helper
   let(:user_account_uuid) { 123 }
 
   describe '#perform' do
-    [true, false].each do |extras_redesign|
-      context "when the extras_redesign flipper is #{extras_redesign}" do
-        let(:response) { double('response') }
-        let(:pdf_path) { 'random/path/to/pdf' }
-        let(:location) { 'test_location' }
-        let(:omit_esign_stamp) { true }
+    let(:response) { double('response') }
+    let(:pdf_path) { 'random/path/to/pdf' }
+    let(:location) { 'test_location' }
+    let(:extras_redesign) { true }
+    let(:omit_esign_stamp) { true }
 
-        before do
-          allow(Flipper).to receive(:enabled?).with(:pension_income_and_assets_overflow_pdf_redesign,
-                                                    anything).and_return(extras_redesign)
-          job.instance_variable_set(:@claim, claim)
-          allow(IncomeAndAssets::SavedClaim).to receive(:find).and_return(claim)
-          allow(claim).to receive(:to_pdf).with(claim.id, { extras_redesign:, omit_esign_stamp: }).and_return(pdf_path)
-          allow(claim).to receive(:persistent_attachments).and_return([])
+    before do
+      job.instance_variable_set(:@claim, claim)
+      allow(IncomeAndAssets::SavedClaim).to receive(:find).and_return(claim)
+      allow(claim).to receive(:to_pdf).with(claim.id, { extras_redesign:, omit_esign_stamp: }).and_return(pdf_path)
+      allow(claim).to receive(:persistent_attachments).and_return([])
 
-          job.instance_variable_set(:@intake_service, service)
-          allow(BenefitsIntake::Service).to receive(:new).and_return(service)
-          allow(service).to receive(:uuid)
-          allow(service).to receive(:request_upload)
-          allow(service).to receive_messages(location:, perform_upload: response)
-          allow(response).to receive(:success?).and_return true
+      job.instance_variable_set(:@intake_service, service)
+      allow(BenefitsIntake::Service).to receive(:new).and_return(service)
+      allow(service).to receive(:uuid)
+      allow(service).to receive(:request_upload)
+      allow(service).to receive_messages(location:, perform_upload: response)
+      allow(response).to receive(:success?).and_return true
 
-          job.instance_variable_set(:@monitor, monitor)
-        end
+      job.instance_variable_set(:@monitor, monitor)
+    end
 
-        it 'submits the saved claim successfully' do
-          allow(job).to receive(:process_document).and_return(pdf_path)
+    it 'submits the saved claim successfully' do
+      allow(job).to receive(:process_document).and_return(pdf_path)
 
-          expect(claim).to receive(:to_pdf).with(claim.id, { extras_redesign:, omit_esign_stamp: }).and_return(pdf_path)
-          expect(Lighthouse::Submission).to receive(:create)
-          expect(Lighthouse::SubmissionAttempt).to receive(:create)
-          expect(Datadog::Tracing).to receive(:active_trace)
-          expect(UserAccount).to receive(:find)
+      expect(claim).to receive(:to_pdf).with(claim.id, { extras_redesign:, omit_esign_stamp: }).and_return(pdf_path)
+      expect(Lighthouse::Submission).to receive(:create)
+      expect(Lighthouse::SubmissionAttempt).to receive(:create)
+      expect(Datadog::Tracing).to receive(:active_trace)
+      expect(UserAccount).to receive(:find)
 
-          expect(service).to receive(:perform_upload).with(
-            upload_url: 'test_location', document: pdf_path, metadata: anything, attachments: []
-          )
-          expect(job).to receive(:cleanup_file_paths)
+      expect(service).to receive(:perform_upload).with(
+        upload_url: 'test_location', document: pdf_path, metadata: anything, attachments: []
+      )
+      expect(job).to receive(:cleanup_file_paths)
 
-          job.perform(claim.id, :user_account_uuid)
-        end
+      job.perform(claim.id, :user_account_uuid)
+    end
 
-        it 'is unable to find user_account' do
-          expect(IncomeAndAssets::SavedClaim).not_to receive(:find)
-          expect(BenefitsIntake::Service).not_to receive(:new)
-          expect(claim).not_to receive(:to_pdf)
+    it 'is unable to find user_account' do
+      expect(IncomeAndAssets::SavedClaim).not_to receive(:find)
+      expect(BenefitsIntake::Service).not_to receive(:new)
+      expect(claim).not_to receive(:to_pdf)
 
-          expect(job).to receive(:cleanup_file_paths)
-          expect(monitor).to receive(:track_submission_retry)
+      expect(job).to receive(:cleanup_file_paths)
+      expect(monitor).to receive(:track_submission_retry)
 
-          expect { job.perform(claim.id, :user_account_uuid) }.to raise_error(
-            ActiveRecord::RecordNotFound,
-            "Couldn't find UserAccount with 'id'=user_account_uuid"
-          )
-        end
+      expect { job.perform(claim.id, :user_account_uuid) }.to raise_error(
+        ActiveRecord::RecordNotFound,
+        "Couldn't find UserAccount with 'id'=user_account_uuid"
+      )
+    end
 
-        it 'is unable to find saved_claim_id' do
-          allow(IncomeAndAssets::SavedClaim).to receive(:find).and_return(nil)
+    it 'is unable to find saved_claim_id' do
+      allow(IncomeAndAssets::SavedClaim).to receive(:find).and_return(nil)
 
-          expect(UserAccount).to receive(:find)
+      expect(UserAccount).to receive(:find)
 
-          expect(BenefitsIntake::Service).not_to receive(:new)
-          expect(claim).not_to receive(:to_pdf)
+      expect(BenefitsIntake::Service).not_to receive(:new)
+      expect(claim).not_to receive(:to_pdf)
 
-          expect(job).to receive(:cleanup_file_paths)
-          expect(monitor).to receive(:track_submission_retry)
+      expect(job).to receive(:cleanup_file_paths)
+      expect(monitor).to receive(:track_submission_retry)
 
-          expect { job.perform(claim.id, :user_account_uuid) }.to raise_error(
-            IncomeAndAssets::BenefitsIntake::SubmitClaimJob::IncomeAndAssetsBenefitIntakeError,
-            "Unable to find IncomeAndAssets::SavedClaim #{claim.id}"
-          )
-        end
-      end
+      expect { job.perform(claim.id, :user_account_uuid) }.to raise_error(
+        IncomeAndAssets::BenefitsIntake::SubmitClaimJob::IncomeAndAssetsBenefitIntakeError,
+        "Unable to find IncomeAndAssets::SavedClaim #{claim.id}"
+      )
     end
     # perform
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
This PR removes the `pension_income_and_assets_overflow_pdf_redesign` feature toggle and enables the feature for all. The toggle was used in development to allow using either the legacy or redesigned PDF overflow generators for form 0969.

I'm on the Employee Experience team, which maintains the redesigned PDF overflow generator and works with Income & Assets on 0969.

**Note:** Ignoring whitespace changes (`?w=1`) this diff is very small.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114543