### PR TITLE
Skip send_emails_by_date_range_spec

### DIFF
--- a/modules/simple_forms_api/spec/tasks/send_emails_by_date_range_spec.rb
+++ b/modules/simple_forms_api/spec/tasks/send_emails_by_date_range_spec.rb
@@ -4,8 +4,7 @@ require 'rails_helper'
 require 'rake'
 require SimpleFormsApi::Engine.root.join('spec', 'spec_helper.rb')
 
-RSpec.describe 'simple_forms_api:send_emails_by_date_range', type: :task do
-  skip 'Skipping due to flakey "Rake task not found" error'
+RSpec.describe 'simple_forms_api:send_emails_by_date_range', skip: 'flakey', type: :task do
   load File.expand_path('../../lib/tasks/send_emails_by_date_range.rake', __dir__)
 
   let(:task) { Rake::Task['simple_forms_api:send_emails_by_date_range'] }


### PR DESCRIPTION
## Summary
This was originally skipped in https://github.com/department-of-veterans-affairs/vets-api/pull/23123, but I saw all four tests failing again today in [this test run](https://github.com/department-of-veterans-affairs/vets-api/runs/47703525716) with the error:
```
simple_forms_api:send_emails_by_date_range when valid dates are provided FormSubmissionAttempts are not a Simple Form does not send a Notification::Email (modules.simple_forms_api.spec.tasks.send_emails_by_date_range_spec) failed 
RSpec::Core::MultipleExceptionError
\e[1mFailure/Error: \e[0mUnable to find matching line from backtrace

  Don't know how to build task 'simple_forms_api:send_emails_by_date_range' (See the list of available tasks with `rake --tasks`)
  Did you mean?  simple_forms_api:remediate_0781_and_0781v2_forms

  Don't know how to build task 'simple_forms_api:send_emails_by_date_range' (See the list of available tasks with `rake --tasks`)
  Did you mean?  simple_forms_api:remediate_0781_and_0781v2_forms
```
I ran the file locally and it appears the `skip` wasn't working properly. 
## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-api/pull/23123
## Testing done
**Before**:
```
rebeccatolmach ~/git/vets-api be rspec modules/simple_forms_api/spec/tasks/send_emails_by_date_range_spec.rb
Run options:
  include {:focus=>true}
  exclude {:skip=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 11111
[rspec-sidekiq] WARNING! Sidekiq will *NOT* process jobs in this environment. See https://github.com/wspurgin/rspec-sidekiq/wiki/FAQ-&-Troubleshooting
....

Finished in 0.44304 seconds (files took 9.22 seconds to load)
4 examples, 0 failures
```
**After**:
```
rebeccatolmach ~/git/vets-api be rspec modules/simple_forms_api/spec/tasks/send_emails_by_date_range_spec.rb
Run options:
  include {:focus=>true}
  exclude {:skip=>true}

All examples were filtered out; ignoring {:focus=>true}

All examples were filtered out

Randomized with seed 4268
[rspec-sidekiq] WARNING! Sidekiq will *NOT* process jobs in this environment. See https://github.com/wspurgin/rspec-sidekiq/wiki/FAQ-&-Troubleshooting


Finished in 0.21273 seconds (files took 8.59 seconds to load)
0 examples, 0 failures
```

## What areas of the site does it impact?
send_emails_by_date_range_spec.rb

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
