### PR TITLE
API 47335 - 526 Validation Rules 4b(iv): servicePeriods

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
@@ -14,6 +14,10 @@ module ClaimsApi
       validate_form_526_submission_claim_date!
       # ensure any provided 'separationLocationCode' values are valid EVSS ReferenceData values
       validate_form_526_location_codes!
+
+      # ensure no more than 100 service periods are provided, and begin/end dates are in order
+      validate_service_periods_quantity!
+      validate_service_periods_chronology!
     end
 
     def retrieve_separation_locations

--- a/modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
@@ -18,6 +18,8 @@ module ClaimsApi
       # ensure no more than 100 service periods are provided, and begin/end dates are in order
       validate_service_periods_quantity!
       validate_service_periods_chronology!
+
+      validate_form_526_no_active_duty_end_date_more_than_180_days_in_future!
     end
 
     def retrieve_separation_locations
@@ -80,6 +82,25 @@ module ClaimsApi
             "begin=#{begin_date} end=#{end_date}"
           )
         end
+      end
+    end
+
+    def validate_form_526_no_active_duty_end_date_more_than_180_days_in_future!
+      service_periods = form_attributes.dig('serviceInformation', 'servicePeriods')
+
+      end_date_180_days_in_future = service_periods.find do |sp|
+        active_duty_end_date = sp['activeDutyEndDate']
+        next if active_duty_end_date.blank?
+
+        Date.parse(active_duty_end_date) > 180.days.from_now.end_of_day
+      end
+
+      unless end_date_180_days_in_future.nil?
+        raise ::Common::Exceptions::InvalidFieldValue.new(
+          'serviceInformation/servicePeriods/activeDutyEndDate',
+          "Provided service period duty end date is more than 180 days in the future: \
+          #{end_date_180_days_in_future['activeDutyEndDate']}"
+        )
       end
     end
   end

--- a/modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
+++ b/modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
@@ -273,4 +273,107 @@ RSpec.describe ClaimsApi::RevisedDisabilityCompensationValidations do
       end
     end
   end
+
+  describe '#validate_form_526_no_active_duty_end_date_more_than_180_days_in_future!' do
+    context 'when service period end date is less than 180 days in the future' do
+      let(:form_attributes) do
+        {
+          'serviceInformation' => {
+            'servicePeriods' => [
+              {
+                'activeDutyBeginDate' => '2020-01-01',
+                'activeDutyEndDate' => 90.days.from_now.to_date.iso8601
+              }
+            ]
+          }
+        }
+      end
+
+      it 'does not raise an error' do
+        expect { subject.validate_form_526_no_active_duty_end_date_more_than_180_days_in_future! }.not_to raise_error
+      end
+    end
+
+    context 'when service period end date is exactly 180 days in the future' do
+      let(:form_attributes) do
+        {
+          'serviceInformation' => {
+            'servicePeriods' => [
+              {
+                'activeDutyBeginDate' => '2020-01-01',
+                'activeDutyEndDate' => 180.days.from_now.to_date.iso8601
+              }
+            ]
+          }
+        }
+      end
+
+      it 'does not raise an error' do
+        expect { subject.validate_form_526_no_active_duty_end_date_more_than_180_days_in_future! }.not_to raise_error
+      end
+    end
+
+    context 'when service period end date is more than 180 days in the future' do
+      let(:form_attributes) do
+        {
+          'serviceInformation' => {
+            'servicePeriods' => [
+              {
+                'activeDutyBeginDate' => '2020-01-01',
+                'activeDutyEndDate' => 181.days.from_now.to_date.iso8601
+              }
+            ]
+          }
+        }
+      end
+
+      it 'raises an InvalidFieldValue error' do
+        expect { subject.validate_form_526_no_active_duty_end_date_more_than_180_days_in_future! }
+          .to raise_error(Common::Exceptions::InvalidFieldValue)
+      end
+    end
+
+    context 'when service period end date is missing' do
+      let(:form_attributes) do
+        {
+          'serviceInformation' => {
+            'servicePeriods' => [
+              {
+                'activeDutyBeginDate' => '2020-01-01',
+                'activeDutyEndDate' => nil
+              }
+            ]
+          }
+        }
+      end
+
+      it 'does not raise an error' do
+        expect { subject.validate_form_526_no_active_duty_end_date_more_than_180_days_in_future! }.not_to raise_error
+      end
+    end
+
+    context 'with multiple service periods with mixed validity' do
+      let(:form_attributes) do
+        {
+          'serviceInformation' => {
+            'servicePeriods' => [
+              {
+                'activeDutyBeginDate' => '2020-01-01',
+                'activeDutyEndDate' => 90.days.from_now.to_date.iso8601
+              },
+              {
+                'activeDutyBeginDate' => '2021-01-01',
+                'activeDutyEndDate' => 200.days.from_now.to_date.iso8601
+              }
+            ]
+          }
+        }
+      end
+
+      it 'raises an InvalidFieldValue error for the invalid period' do
+        expect { subject.validate_form_526_no_active_duty_end_date_more_than_180_days_in_future! }
+          .to raise_error(Common::Exceptions::InvalidFieldValue)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

_This is a continuation of the work started [here](https://github.com/department-of-veterans-affairs/vets-api/pull/23421)._

This PR adds some service period validation functionality to the revised form 526 validation logic + introduces unit tests for that validator.

These validations aren't called in the validator class yet because they will be part of a larger `validate_service_periods!` method that will run all the service period validations in the proper order.

|| Business rules addressed|
|-|-|
|Strikethrough: obsolete rule; Red text: new messaging/behavior|<img width="788" height="105" alt="Screenshot 2025-08-11 at 08 26 51" src="https://github.com/user-attachments/assets/acec51eb-198a-48f9-81e3-f141aab843a9" />|

## Related issue(s)

|[Jira ticket](https://jira.devops.va.gov/browse/API-47335)|
|-|
|<img width="967" height="801" alt="Screenshot 2025-08-06 at 08 58 46" src="https://github.com/user-attachments/assets/1e4504fb-25d0-40f1-81e1-83ca4124595c" />|

## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

```
modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
```

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
