### PR TITLE
API 48126 - Remove debug logging from `exactly_one_rep_match?`

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
@@ -94,14 +94,8 @@ module ClaimsApi
 
       private
 
-      def exactly_one_rep_match?(reps, poa_code, rep_method: nil)
-        count = reps.count
-        # Optional debug logging to help diagnose what's happening in valid_poa_code_for_current_user?
-        if rep_method
-          ClaimsApi::Logger.log('poa_verification', rep_method:,
-                                                    details: "Found #{count} reps for POA code #{poa_code}")
-        end
-        reps.first.poa_codes.include?(poa_code) if count == 1
+      def exactly_one_rep_match?(reps, poa_code)
+        reps.first.poa_codes.include?(poa_code) if reps.count == 1
       end
 
       def find_by_suffix(poa_code)
@@ -130,16 +124,14 @@ module ClaimsApi
                                                                            last_name: @current_user.last_name,
                                                                            poa_code:)
 
-        # Log out count and poa code when we reach this point (since this is the final
-        # check before we fall into handle_not_found)
-        exactly_one_rep_match?(reps_by_poa_code, poa_code, rep_method: 'find_by_poa_code')
+        exactly_one_rep_match?(reps_by_poa_code, poa_code)
       end
 
       def handle_not_found(reps, poa_code)
         ClaimsApi::Logger.log 'poa_verification',
-                              detail: "Found #{reps.size} reps for POA code #{poa_code}",
-                              level: :warn, poa_code:, rep_size: reps.size, rep_count: reps.count,
-                              current_users_uuid: @current_user.uuid
+                              detail: "Found 0 reps for POA code #{poa_code}" \
+                                      " out of #{reps.size} possible matches (found by name).",
+                              level: :warn, poa_code:, rep_count: reps.size, current_users_uuid: @current_user.uuid
         raise ::Common::Exceptions::UnprocessableEntity, detail: 'Ambiguous VSO Representative Results' if reps.size > 1
 
         # Intentionally does not raise in other cases. Doing so would break some shared behavior.

--- a/modules/claims_api/spec/concerns/claims_api/poa_verification_spec.rb
+++ b/modules/claims_api/spec/concerns/claims_api/poa_verification_spec.rb
@@ -114,48 +114,5 @@ describe FakeController do
         expect(res).to be(true)
       end
     end
-
-    context 'logging in exactly_one_rep_match?' do
-      context 'when called via find_by_poa_code' do
-        before do
-          # Set up expectations for first/last name lookup to fail, so we reach find_by_poa_code
-          allow(Veteran::Service::Representative).to receive(:all_for_user).with(
-            first_name:,
-            last_name:
-          ).and_return([])
-
-          # Mock the suffix and middle_name/middle_initial search to return empty
-          allow(subject.instance_variable_get(:@current_user)).to receive_messages(suffix: nil,
-                                                                                   middle_name: 'Alexander')
-          allow(Veteran::Service::Representative).to receive(:all_for_user).with(
-            first_name:,
-            last_name:,
-            middle_initial: 'A'
-          ).and_return([])
-        end
-
-        it 'logs when exactly one rep is found' do
-          # Create a rep with the matching POA code
-          rep = create(:representative, representative_id: '12345', first_name:,
-                                        last_name:, poa_codes: [poa_code])
-
-          allow(Veteran::Service::Representative).to receive(:all_for_user).with(
-            first_name:,
-            last_name:,
-            poa_code:
-          ).and_return([rep])
-
-          expect(ClaimsApi::Logger).to receive(:log).with(
-            'poa_verification',
-            rep_method: 'find_by_poa_code',
-            details: "Found 1 reps for POA code #{poa_code}"
-          )
-
-          # Call the method
-          result = subject.valid_poa_code_for_current_user?(poa_code)
-          expect(result).to be(true)
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
## Summary

This PR rolls back the changes added in https://github.com/department-of-veterans-affairs/vets-api/pull/23414 now that we're reasonably confident the issue was due to misleading logging in the first place.

This PR also adjusts the logging output in `handle_not_found` so that it explicitly calls out when representative results are present via a name search, but not a match for the provided POA code.

## Related issue(s)

| [Jira ticket](https://jira.devops.va.gov/browse/API-48126)|
|-|
|<img width="966" height="742" alt="Screenshot 2025-08-05 at 14 46 37" src="https://github.com/user-attachments/assets/5ab34fd6-a629-4102-9017-e9cffdf59c8f" />|

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

```
modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
modules/claims_api/spec/concerns/claims_api/poa_verification_spec.rb
```

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA