### PR TITLE
Add rescue logs for central service submission

### DIFF
--- a/app/services/bgs/dependent_service.rb
+++ b/app/services/bgs/dependent_service.rb
@@ -163,6 +163,10 @@ module BGS
         KmsEncrypted::Box.new.encrypt(vet_info.to_json),
         KmsEncrypted::Box.new.encrypt(user.to_h.to_json)
       )
+    rescue => e
+      Rails.logger.error("BGS::DependentService failed to submit to central service: #{e.message}")
+      # raising the error here causes the user to get a 500 error response
+      raise e
     end
 
     def external_key

--- a/app/services/bgs/dependent_v2_service.rb
+++ b/app/services/bgs/dependent_v2_service.rb
@@ -183,6 +183,10 @@ module BGS
         KmsEncrypted::Box.new.encrypt(vet_info.to_json),
         KmsEncrypted::Box.new.encrypt(user.to_h.to_json)
       )
+    rescue => e
+      Rails.logger.error("BGS::DependentV2Service failed to submit to central service: #{e.message}")
+      # raising the error here causes the user to get a 500 error response
+      raise e
     end
 
     def external_key


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This pull request adds improved error logging to the `submit_to_central_service` method in both the `BGS::DependentService` and `BGS::DependentV2Service` classes. Now, if an error occurs during submission, a descriptive error message will be logged before the error is re-raised, making it easier to diagnose issues in production.
- The goal is to determine if the errors described in https://github.com/issues/assigned?issue=department-of-veterans-affairs%7Cva.gov-team%7C116479 are caused by the new error handling in `submit_pdf_job` or are happening in `submit_to_central_service`.

## Related issue(s)

- https://github.com/issues/assigned?issue=department-of-veterans-affairs%7Cva.gov-team%7C116479

## Testing done

- [ ] *New code is covered by unit tests*

## What areas of the site does it impact?
Dependents

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
