### PR TITLE
Update BGS 674 manual note

### DIFF
--- a/lib/bgs/form674.rb
+++ b/lib/bgs/form674.rb
@@ -70,17 +70,16 @@ module BGS
 
     def log_claim_status(benefit_claim_record, proc_id)
       if @proc_state == 'MANUAL_VAGOV'
+        reason = 'This application needs manual review.'
         if @saved_claim.submittable_686?
-          monitor.track_event('info', '21-674 Combination 686C-674 claim set to manual by VA.gov: This
-                              application needs manual review because a 674 was submitted alongside a 686c.',
+          reason = 'This application needs manual review because a 674 was submitted alongside a 686c.'
+          monitor.track_event('info', "21-674 Combination 686C-674 claim set to manual by VA.gov: #{reason}",
                               "#{stats_key}.manual.combo", { proc_id: @proc_id, manual: true, combination_claim: true })
         else
-          monitor.track_event('info', '21-674 Claim set to manual by VA.gov: This application needs manual review.',
+          monitor.track_event('info', "21-674 Claim set to manual by VA.gov: #{reason}",
                               "#{stats_key}.manual", { proc_id: @proc_id, manual: true })
         end
-        # keep bgs note the same
-        note_text = 'Claim set to manual by VA.gov: This application needs manual review because a 674 was submitted.'
-        bgs_service.create_note(benefit_claim_record[:benefit_claim_id], note_text)
+        bgs_service.create_note(benefit_claim_record[:benefit_claim_id], "Claim set to manual by VA.gov: #{reason}")
 
         bgs_service.update_proc(proc_id, proc_state: 'MANUAL_VAGOV')
       else

--- a/lib/bgsv2/form674.rb
+++ b/lib/bgsv2/form674.rb
@@ -70,17 +70,16 @@ module BGSV2
 
     def log_claim_status(benefit_claim_record, proc_id)
       if @proc_state == 'MANUAL_VAGOV'
+        reason = 'This application needs manual review.'
         if @saved_claim.submittable_686?
-          monitor.track_event('info', '21-674 Combination 686C-674 claim set to manual by VA.gov: This
-                              application needs manual review because a 674 was submitted alongside a 686c.',
+          reason = 'This application needs manual review because a 674 was submitted alongside a 686c.'
+          monitor.track_event('info', "21-674 Combination 686C-674 claim set to manual by VA.gov: #{reason}",
                               "#{stats_key}.manual.combo", { proc_id: @proc_id, manual: true, combination_claim: true })
         else
-          monitor.track_event('info', '21-674 Claim set to manual by VA.gov: This application needs manual review.',
+          monitor.track_event('info', "21-674 Claim set to manual by VA.gov: #{reason}",
                               "#{stats_key}.manual", { proc_id: @proc_id, manual: true })
         end
-        # keep bgs note the same
-        note_text = 'Claim set to manual by VA.gov: This application needs manual review because a 674 was submitted.'
-        bgs_service.create_note(benefit_claim_record[:benefit_claim_id], note_text)
+        bgs_service.create_note(benefit_claim_record[:benefit_claim_id], "Claim set to manual by VA.gov: #{reason}")
 
         bgs_service.update_proc(proc_id, proc_state: 'MANUAL_VAGOV')
       else


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This pull request improves the clarity of manual claim review logging and note creation in both the `lib/bgs/form674.rb` and `lib/bgsv2/form674.rb` files.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111452

## Testing done

- [ ] *New code is covered by unit tests*

## What areas of the site does it impact?
Dependents

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

