### PR TITLE
feat: add trace tags for file and form_id validation in attachment uploads

### DIFF
--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/representative_form_uploads_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/representative_form_uploads_spec.rb
@@ -245,6 +245,111 @@ RSpec.describe AccreditedRepresentativePortal::V0::RepresentativeFormUploadContr
                                       }]
                                     })
     end
+
+    context 'when form_id is missing' do
+      it 'returns 400 and does not create a record' do
+        clamscan = double(safe?: true)
+        allow(Common::VirusScan).to receive(:scan).and_return(clamscan)
+        file = fixture_file_upload('doctors-note.gif')
+
+        params = { file: } # <- missing form_id
+
+        expect do
+          post '/accredited_representative_portal/v0/representative_form_upload', params:
+        end.not_to change(PersistentAttachments::VAForm, :count)
+
+        expect(response).to have_http_status(:bad_request)
+        expect(parsed_response).to eq({
+                                        'errors' => [{
+                                          'title' => 'Missing parameter',
+                                          'detail' => 'The required parameter "representative_form_upload", is missing',
+                                          'code' => '108',
+                                          'status' => '400'
+                                        }]
+                                      })
+      end
+    end
+
+    context 'when file is missing' do
+      it 'returns 400 and does not create a record' do
+        params = { form_id: form_number } # <- missing file
+
+        expect do
+          post '/accredited_representative_portal/v0/representative_form_upload', params:
+        end.not_to change(PersistentAttachments::VAForm, :count)
+
+        expect(response).to have_http_status(:bad_request)
+        expect(parsed_response).to eq({
+                                        'errors' => [{
+                                          'title' => 'Missing parameter',
+                                          'detail' => 'The required parameter "file", is missing',
+                                          'code' => '108',
+                                          'status' => '400'
+                                        }]
+                                      })
+      end
+    end
+
+    context 'when form_id is unknown/unmapped' do
+      it 'returns 422, does not call Attach, and does not create a record' do
+        clamscan = double(safe?: true)
+        allow(Common::VirusScan).to receive(:scan).and_return(clamscan)
+        file = fixture_file_upload('doctors-note.gif')
+
+        params = { form_id: '99-9999', file: }
+
+        expect(AccreditedRepresentativePortal::SavedClaimService::Attach).not_to receive(:perform)
+
+        expect do
+          post '/accredited_representative_portal/v0/representative_form_upload', params:
+        end.not_to change(PersistentAttachments::VAForm, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response).to eq({
+                                        'errors' => [{
+                                          'title' => 'Unprocessable Entity',
+                                          'detail' => 'Unknown form_id "99-9999"',
+                                          'code' => '422',
+                                          'status' => '422'
+                                        }]
+                                      })
+      end
+    end
+
+    context 'normalization: "-UPLOAD" suffix' do
+      it 'accepts form_id with -UPLOAD suffix' do
+        clamscan = double(safe?: true)
+        allow(Common::VirusScan).to receive(:scan).and_return(clamscan)
+        allow_any_instance_of(BenefitsIntakeService::Service).to receive(:valid_document?).and_return(pdf_path)
+
+        file = fixture_file_upload('doctors-note.gif')
+        params = { form_id: "#{form_number}-UPLOAD", file: }
+
+        expect do
+          post '/accredited_representative_portal/v0/representative_form_upload', params:
+        end.to change(PersistentAttachments::VAForm, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'normalization: uppercase form id (adjust if mapping is case-sensitive)' do
+      it 'accepts uppercase form id variant' do
+        clamscan = double(safe?: true)
+        allow(Common::VirusScan).to receive(:scan).and_return(clamscan)
+        allow_any_instance_of(BenefitsIntakeService::Service).to receive(:valid_document?).and_return(pdf_path)
+
+        file = fixture_file_upload('doctors-note.gif')
+        params = { form_id: '21-686C', file: }
+
+        # If your mapping is case-sensitive, change this example to expect 422 instead.
+        expect do
+          post '/accredited_representative_portal/v0/representative_form_upload', params:
+        end.to change(PersistentAttachments::VAForm, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 
   describe '#upload_supporting_documents' do
@@ -300,6 +405,111 @@ RSpec.describe AccreditedRepresentativePortal::V0::RepresentativeFormUploadContr
                                         'status' => '422'
                                       }]
                                     })
+    end
+
+    context 'when form_id is missing' do
+      it 'returns 400 and does not create a record' do
+        clamscan = double(safe?: true)
+        allow(Common::VirusScan).to receive(:scan).and_return(clamscan)
+        file = fixture_file_upload('doctors-note.gif')
+
+        params = { file: } # <- missing form_id
+
+        expect do
+          post '/accredited_representative_portal/v0/upload_supporting_documents', params:
+        end.not_to change(PersistentAttachments::VAFormDocumentation, :count)
+
+        expect(response).to have_http_status(:bad_request)
+        expect(parsed_response).to eq({
+                                        'errors' => [{
+                                          'title' => 'Missing parameter',
+                                          'detail' => 'The required parameter "representative_form_upload", is missing',
+                                          'code' => '108',
+                                          'status' => '400'
+                                        }]
+                                      })
+      end
+    end
+
+    context 'when file is missing' do
+      it 'returns 400 and does not create a record' do
+        params = { form_id: form_number } # <- missing file
+
+        expect do
+          post '/accredited_representative_portal/v0/upload_supporting_documents', params:
+        end.not_to change(PersistentAttachments::VAFormDocumentation, :count)
+
+        expect(response).to have_http_status(:bad_request)
+        expect(parsed_response).to eq({
+                                        'errors' => [{
+                                          'title' => 'Missing parameter',
+                                          'detail' => 'The required parameter "file", is missing',
+                                          'code' => '108',
+                                          'status' => '400'
+                                        }]
+                                      })
+      end
+    end
+
+    context 'when form_id is unknown/unmapped' do
+      it 'returns 422, does not call Attach, and does not create a record' do
+        clamscan = double(safe?: true)
+        allow(Common::VirusScan).to receive(:scan).and_return(clamscan)
+        file = fixture_file_upload('doctors-note.gif')
+
+        params = { form_id: '99-9999', file: }
+
+        expect(AccreditedRepresentativePortal::SavedClaimService::Attach).not_to receive(:perform)
+
+        expect do
+          post '/accredited_representative_portal/v0/upload_supporting_documents', params:
+        end.not_to change(PersistentAttachments::VAFormDocumentation, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response).to eq({
+                                        'errors' => [{
+                                          'title' => 'Unprocessable Entity',
+                                          'detail' => 'Unknown form_id "99-9999"',
+                                          'code' => '422',
+                                          'status' => '422'
+                                        }]
+                                      })
+      end
+    end
+
+    context 'normalization: "-UPLOAD" suffix' do
+      it 'accepts form_id with -UPLOAD suffix' do
+        clamscan = double(safe?: true)
+        allow(Common::VirusScan).to receive(:scan).and_return(clamscan)
+        allow_any_instance_of(BenefitsIntakeService::Service).to receive(:valid_document?).and_return(pdf_path)
+
+        file = fixture_file_upload('doctors-note.gif')
+        params = { form_id: "#{form_number}-UPLOAD", file: }
+
+        expect do
+          post '/accredited_representative_portal/v0/upload_supporting_documents', params:
+        end.to change(PersistentAttachments::VAFormDocumentation, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'normalization: uppercase form id (adjust if mapping is case-sensitive)' do
+      it 'accepts uppercase form id variant' do
+        clamscan = double(safe?: true)
+        allow(Common::VirusScan).to receive(:scan).and_return(clamscan)
+        allow_any_instance_of(BenefitsIntakeService::Service).to receive(:valid_document?).and_return(pdf_path)
+
+        file = fixture_file_upload('doctors-note.gif')
+        params = { form_id: '21-686C', file: }
+
+        # If your mapping is case-sensitive, change this example to expect 422 instead.
+        expect do
+          post '/accredited_representative_portal/v0/upload_supporting_documents', params:
+        end.to change(PersistentAttachments::VAFormDocumentation, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+      end
     end
   end
 end


### PR DESCRIPTION


- Added `validation.file_present` and `validation.form_class_present` tags to `handle_attachment_upload` span
- Tags are set before validation raises to ensure failed requests are traceable in observability tools
- Helps filter and diagnose attachment upload failures caused by missing files or invalid form_id values

Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.


## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
