### PR TITLE
API 47335 - 526 Validation Rules 4b(iv): `servicePeriods` (fix for Reserves case)

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
@@ -23,6 +23,9 @@ module ClaimsApi
 
       # ensure 'title10ActivationDate' if provided, is after the earliest servicePeriod.activeDutyBeginDate and on or before the current date # rubocop:disable Layout/LineLength
       validate_form_526_title10_activation_date!
+
+      # ensure 'currentMailingAddress' attributes are valid
+      validate_form_526_current_mailing_address!
     end
 
     def retrieve_separation_locations
@@ -122,6 +125,22 @@ module ClaimsApi
                 Date.parse(title10_activation_date) <= Time.zone.now
 
       raise ::Common::Exceptions::InvalidFieldValue.new('title10ActivationDate', title10_activation_date)
+    end
+
+    def valid_countries
+      @valid_countries ||= ClaimsApi::BRD.new.countries
+    end
+
+    def validate_form_526_current_mailing_address!
+      validate_form_526_current_mailing_address_country!
+    end
+
+    def validate_form_526_current_mailing_address_country!
+      current_mailing_address = form_attributes.dig('veteran', 'currentMailingAddress')
+
+      return if valid_countries.include?(current_mailing_address['country'])
+
+      raise ::Common::Exceptions::InvalidFieldValue.new('country', current_mailing_address['country'])
     end
   end
 end

--- a/modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
+++ b/modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
@@ -422,4 +422,64 @@ RSpec.describe ClaimsApi::RevisedDisabilityCompensationValidations do
       end
     end
   end
+
+  describe '#validate_form_526_current_mailing_address_country!' do
+    let(:valid_countries) { ['Bolivia', 'China', 'Serbia/Montenegro'] }
+
+    before do
+      # Stubbing this because it's a method on the subject that fetches data from BRD
+      # rubocop:disable RSpec/SubjectStub
+      allow(subject).to receive(:valid_countries).and_return(valid_countries)
+      # rubocop:enable RSpec/SubjectStub
+    end
+
+    context 'when country is valid' do
+      let(:form_attributes) do
+        {
+          'veteran' => {
+            'currentMailingAddress' => {
+              'country' => 'Bolivia'
+            }
+          }
+        }
+      end
+
+      it 'does not raise an error' do
+        expect { subject.validate_form_526_current_mailing_address_country! }.not_to raise_error
+      end
+    end
+
+    context 'when country is invalid' do
+      let(:form_attributes) do
+        {
+          'veteran' => {
+            'currentMailingAddress' => {
+              'country' => '123'
+            }
+          }
+        }
+      end
+
+      it 'raises an InvalidFieldValue error' do
+        expect { subject.validate_form_526_current_mailing_address_country! }
+          .to raise_error(Common::Exceptions::InvalidFieldValue)
+      end
+    end
+
+    context 'when country is missing' do
+      let(:form_attributes) do
+        {
+          'veteran' => {
+            'currentMailingAddress' => {}
+          }
+        }
+      end
+
+      it 'raises an InvalidFieldValue error' do
+        expect { subject.validate_form_526_current_mailing_address_country! }
+          .to raise_error(Common::Exceptions::InvalidFieldValue)
+      end
+    end
+
+  end
 end

--- a/modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
+++ b/modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
@@ -376,4 +376,50 @@ RSpec.describe ClaimsApi::RevisedDisabilityCompensationValidations do
       end
     end
   end
+
+  describe '#validate_form_526_title10_activation_date!' do
+    let(:service_periods) do
+      [
+        { 'activeDutyBeginDate' => '2000-01-01', 'activeDutyEndDate' => '2005-01-01' },
+        { 'activeDutyBeginDate' => '2010-01-01', 'activeDutyEndDate' => '2015-01-01' }
+      ]
+    end
+
+    let(:form_attributes) do
+      {
+        'serviceInformation' => {
+          'servicePeriods' => service_periods,
+          'reservesNationalGuardService' => {
+            'title10Activation' => { 'title10ActivationDate' => title10_activation_date }
+          }
+        }
+      }
+    end
+
+    context 'when title10ActivationDate is after the earliest begin date and not in the future' do
+      let(:title10_activation_date) { '2001-01-01' }
+
+      it 'does not raise an error' do
+        expect { subject.validate_form_526_title10_activation_date! }.not_to raise_error
+      end
+    end
+
+    context 'when title10ActivationDate is before the earliest begin date' do
+      let(:title10_activation_date) { '1999-12-31' }
+
+      it 'raises an InvalidFieldValue error' do
+        expect { subject.validate_form_526_title10_activation_date! }
+          .to raise_error(Common::Exceptions::InvalidFieldValue)
+      end
+    end
+
+    context 'when title10ActivationDate is in the future' do
+      let(:title10_activation_date) { 1.day.from_now.to_date.iso8601 }
+
+      it 'raises an InvalidFieldValue error' do
+        expect { subject.validate_form_526_title10_activation_date! }
+          .to raise_error(Common::Exceptions::InvalidFieldValue)
+      end
+    end
+  end
 end

--- a/modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
+++ b/modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
@@ -480,6 +480,5 @@ RSpec.describe ClaimsApi::RevisedDisabilityCompensationValidations do
           .to raise_error(Common::Exceptions::InvalidFieldValue)
       end
     end
-
   end
 end


### PR DESCRIPTION
## Summary

_This is a continuation of the work started [here](https://github.com/department-of-veterans-affairs/vets-api/pull/23421)._

This PR calls some previously added service period validation functions and adds a new 180-day validation rule.

|| Business rules addressed|
|-|-|
|Strikethrough: obsolete rule; Red text: new messaging/behavior|<img width="1019" height="107" alt="Screenshot 2025-08-12 at 14 27 47" src="https://github.com/user-attachments/assets/6e37381e-f665-4ec6-8b8e-751d2b80c45b" />|

## Related issue(s)

|[Jira ticket](https://jira.devops.va.gov/browse/API-47335)|
|-|
|<img width="967" height="801" alt="Screenshot 2025-08-06 at 08 58 46" src="https://github.com/user-attachments/assets/1e4504fb-25d0-40f1-81e1-83ca4124595c" />|

## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

```
modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
```

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
