### PR TITLE
API-48780-small-request-blueprinter-refactor

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/blueprints/power_of_attorney_request_blueprint.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/blueprints/power_of_attorney_request_blueprint.rb
@@ -4,7 +4,7 @@ module ClaimsApi
   module V2
     module Blueprints
       class PowerOfAttorneyRequestBlueprint < Blueprinter::Base
-        view :index_or_show do
+        view :shared_response do
           field :id do |request|
             request['id']
           end

--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -38,7 +38,7 @@ module ClaimsApi
           raise Common::Exceptions::Lighthouse::BadGateway unless poa_list
 
           render json: ClaimsApi::V2::Blueprints::PowerOfAttorneyRequestBlueprint.render(
-            poa_list, view: :index_or_show, root: :data
+            poa_list, view: :shared_response, root: :data
           ), status: :ok
         end
 
@@ -59,7 +59,7 @@ module ClaimsApi
           res = service.get_poa_request
           res['id'] = poa_request.id
 
-          render json: ClaimsApi::V2::Blueprints::PowerOfAttorneyRequestBlueprint.render(res, view: :index_or_show,
+          render json: ClaimsApi::V2::Blueprints::PowerOfAttorneyRequestBlueprint.render(res, view: :shared_response,
                                                                                               root: :data),
                  status: :ok
         end
@@ -99,11 +99,11 @@ module ClaimsApi
           # Two different responses needed, if declined no location URL is required
           if decision_response.nil?
             render json: ClaimsApi::V2::Blueprints::PowerOfAttorneyRequestBlueprint.render(get_poa_response,
-                                                                                           view: :index_or_show,
+                                                                                           view: :shared_response,
                                                                                            root: :data), status: :ok
           else
             render json: ClaimsApi::V2::Blueprints::PowerOfAttorneyRequestBlueprint.render(
-              get_poa_response, view: :index_or_show, root: :data
+              get_poa_response, view: :shared_response, root: :data
             ), status: :ok, location: url_for(
               controller: 'power_of_attorney/base', action: 'status', id: decision_response.id, veteranId: vet_icn
             )


### PR DESCRIPTION
## Summary
* Small refactor to rename the blue printer method being called for the request `index`, `show` and `decide` endpoints

## Related issue(s)
[API-48780](https://jira.devops.va.gov/browse/API-48780)

## Testing done
Submissions to the endpoint responded as expected.  All tests still green after change, but no new functionality was added, just a very small no-regret refactor.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/claims_api/v2/blueprints/power_of_attorney_request_blueprint.rb
	modified:   modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
