### PR TITLE
Rename function - correct tightly-coupled object defect

### DIFF
--- a/app/models/saved_claim/veteran_readiness_employment_claim.rb
+++ b/app/models/saved_claim/veteran_readiness_employment_claim.rb
@@ -212,7 +212,8 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
     process_attachments!
     @sent_to_lighthouse = true
 
-    send_vbms_lighthouse_confirmation_email(user, 'Lighthouse', :confirmation_lighthouse, CONFIRMATION_EMAIL_TEMPLATE_LIGHTHOUSE)
+    send_vbms_lighthouse_confirmation_email(user, 'Lighthouse', :confirmation_lighthouse,
+                                            CONFIRMATION_EMAIL_TEMPLATE_LIGHTHOUSE)
   rescue => e
     Rails.logger.error('Error uploading VRE claim to Benefits Intake API', { user_uuid: user&.uuid, e: })
     raise
@@ -294,8 +295,8 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
     []
   end
 
-  # Lighthouse::SubmitBenefitsClaim will call the function `send_confirmation_email` (if it exists).  
-  # Do not name a function `send_confirmation_email`, unless it accepts 0 arguments. 
+  # Lighthouse::SubmitBenefitsClaim will call the function `send_confirmation_email` (if it exists).
+  # Do not name a function `send_confirmation_email`, unless it accepts 0 arguments.
   def send_vbms_lighthouse_confirmation_email(user, service, _email_type, email_template)
     if user.va_profile_email.blank?
       Rails.logger.warn("#{service} confirmation email was not sent: user missing profile email.",

--- a/app/models/saved_claim/veteran_readiness_employment_claim.rb
+++ b/app/models/saved_claim/veteran_readiness_employment_claim.rb
@@ -178,7 +178,7 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
       end
     end
 
-    send_confirmation_email(user, 'VBMS', :confirmation_vbms, CONFIRMATION_EMAIL_TEMPLATE_VBMS)
+    send_vbms_lighthouse_confirmation_email(user, 'VBMS', :confirmation_vbms, CONFIRMATION_EMAIL_TEMPLATE_VBMS)
   rescue => e
     Rails.logger.error('Error uploading VRE claim to VBMS.', { user_uuid: user&.uuid, messsage: e.message })
     send_to_lighthouse!(user)
@@ -212,7 +212,7 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
     process_attachments!
     @sent_to_lighthouse = true
 
-    send_confirmation_email(user, 'Lighthouse', :confirmation_lighthouse, CONFIRMATION_EMAIL_TEMPLATE_LIGHTHOUSE)
+    send_vbms_lighthouse_confirmation_email(user, 'Lighthouse', :confirmation_lighthouse, CONFIRMATION_EMAIL_TEMPLATE_LIGHTHOUSE)
   rescue => e
     Rails.logger.error('Error uploading VRE claim to Benefits Intake API', { user_uuid: user&.uuid, e: })
     raise
@@ -294,7 +294,9 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
     []
   end
 
-  def send_confirmation_email(user, service, _email_type, email_template)
+  # Lighthouse::SubmitBenefitsClaim will call the function `send_confirmation_email` (if it exists).  
+  # Do not name a function `send_confirmation_email`, unless it accepts 0 arguments. 
+  def send_vbms_lighthouse_confirmation_email(user, service, _email_type, email_template)
     if user.va_profile_email.blank?
       Rails.logger.warn("#{service} confirmation email was not sent: user missing profile email.",
                         { user_uuid: user&.uuid })

--- a/app/models/saved_claim/veteran_readiness_employment_claim.rb
+++ b/app/models/saved_claim/veteran_readiness_employment_claim.rb
@@ -295,7 +295,7 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
     []
   end
 
-  # Lighthouse::SubmitBenefitsClaim will call the function `send_confirmation_email` (if it exists).
+  # Lighthouse::SubmitBenefitsIntakeClaim will call the function `send_confirmation_email` (if it exists).
   # Do not name a function `send_confirmation_email`, unless it accepts 0 arguments.
   def send_vbms_lighthouse_confirmation_email(user, service, _email_type, email_template)
     if user.va_profile_email.blank?
@@ -323,6 +323,9 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
     files.find_each { |f| f.update(saved_claim_id: id) }
 
     Rails.logger.info('VRE claim submitting to Benefits Intake API')
+    # On success, this class will call claim.send_confirmation_email() 
+    # if a function of that name exists.  If you need to implement 
+    # function `send_confirmation_email()`, ensure it accepts 0 arguments
     Lighthouse::SubmitBenefitsIntakeClaim.new.perform(id)
   end
 

--- a/app/models/saved_claim/veteran_readiness_employment_claim.rb
+++ b/app/models/saved_claim/veteran_readiness_employment_claim.rb
@@ -323,8 +323,8 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
     files.find_each { |f| f.update(saved_claim_id: id) }
 
     Rails.logger.info('VRE claim submitting to Benefits Intake API')
-    # On success, this class will call claim.send_confirmation_email() 
-    # if a function of that name exists.  If you need to implement 
+    # On success, this class will call claim.send_confirmation_email()
+    # if a function of that name exists.  If you need to implement
     # function `send_confirmation_email()`, ensure it accepts 0 arguments
     Lighthouse::SubmitBenefitsIntakeClaim.new.perform(id)
   end

--- a/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
+++ b/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
             end
 
             it 'sends confirmation email' do
-              expect(claim).to receive(:send_confirmation_email)
+              expect(claim).to receive(:send_vbms_lighthouse_confirmation_email)
                 .with(user_object, 'VBMS', :confirmation_vbms, 'ch31_vbms_fake_template_id')
 
               claim.send_to_vre(user_object)
@@ -164,7 +164,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
           it 'PDF is sent to Central Mail and not VBMS' do
             expect(claim).to receive(:process_attachments!)
             expect(claim).to receive(:send_to_lighthouse!).with(user_object).once.and_call_original
-            expect(claim).to receive(:send_confirmation_email)
+            expect(claim).to receive(:send_vbms_lighthouse_confirmation_email)
             expect(claim).not_to receive(:upload_to_vbms)
             expect(VeteranReadinessEmploymentMailer).to receive(:build).with(
               user_object.participant_id, 'VRE.VBAPIT@va.gov', true
@@ -185,7 +185,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
       end
     end
 
-    describe '#send_confirmation_email' do
+    describe '#send_vbms_lighthouse_confirmation_email' do
       let(:user) do
         OpenStruct.new(
           edipi: '1007697216',
@@ -214,7 +214,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
             }
           )
 
-          claim.send_confirmation_email(user, 'VBMS', :confirmation_vbms, 'ch31_vbms_fake_template_id')
+          claim.send_vbms_lighthouse_confirmation_email(user, 'VBMS', :confirmation_vbms, 'ch31_vbms_fake_template_id')
         end
       end
     end


### PR DESCRIPTION
## Summary

I'm Adam King, I work on the VA-IIR team, which owns this component.  

When the Chapter 31 form is submitted, an attempt is first made to send the `claim` to the VBMS eFolder.  If that attempt fails, a backup method to submit to a Lighthouse service is called into action.  Both of these services essentially save the state of the form.  VBMS accepts it as a PDF file which is filled out, Lighthouse accepts JSON.  After this step, the submission is sent to RES, which handles the application. 

During the Lighthouse request block, if such a method exists, [Lighthouse::SubmitBenefitsIntakeClaim.new.perform(id)](https://github.com/department-of-veterans-affairs/vets-api/blob/618ef094c0116ac02d3c719b44791b145635cd7f/app/models/saved_claim/veteran_readiness_employment_claim.rb#L323) calls a function to [send_confirmation_email](
https://github.com/department-of-veterans-affairs/vets-api/blob/618ef094c0116ac02d3c719b44791b145635cd7f/app/sidekiq/lighthouse/submit_benefits_intake_claim.rb#L161-L167) with no arguments.  If the method does **not** exist, it does **not** attempt to call a function called `send_confirmation_email`

As a part of the [initial work](https://github.com/department-of-veterans-affairs/vets-api/pull/23432/files) I did to prepare to use the VFS Notification library, I consolidated two functions, `send_vbms_confirmation_email` and `send_lighthouse_confirmation_email` into one function, `send_confirmation_email`, with arguments to determine which email template to use.  This inadvertently created a data contract conflict.  I was not aware that the service would handle the sending of confirmation emails - our code previously handled sending failure and confirmation emails.

I updated the existing tests so that they worked with the new consolidated function, but there had been no tests in place (understandably) to ensure that the `Lighthouse::SubmitBenefitsClaim` class would not attempt to send an email.

In this PR I have updated the unit tests, but they still do not cover the scenario which caused the bug in the first place.  I would like to be able to provide a test which guarantees that `Lighthouse::SubmitBenefitsClaim` does not attempt to call a function, `send_confirmation_email` unless that function obeys this data contract and does not accept any arguments.  This task is made more difficult because the calling function is private.

## Related issue(s)
[VA-IIR Issue 1978](https://github.com/department-of-veterans-affairs/va-iir/issues/1978)
[Offending Pull Request](https://github.com/department-of-veterans-affairs/vets-api/pull/23432)

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change* - a `send_confirmation_email` function did not exist, so the Lighthouse library did not attempt to call it
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
