### PR TITLE
Resolved GHSL-2025-105 security concern

### DIFF
--- a/.github/workflows/ready_for_review.yml
+++ b/.github/workflows/ready_for_review.yml
@@ -51,11 +51,11 @@ jobs:
               echo "pr_requested_teams=$(echo '${{ toJSON(github.event.pull_request.requested_teams.*.slug) }}' | jq -c '.')" >> "$GITHUB_OUTPUT"
             fi
 
-          elif ${{ github.event_name == 'workflow_run' }}; then
-            if ${{ github.event.workflow_run.event == 'push' }}; then
+          elif [ "${{ github.event_name }}" = "workflow_run" ]; then
+            if [ "${{ github.event.workflow_run.event }}" = "push" ]; then
               echo "Workflow was triggered by push to $SAFE_WORKFLOW_HEAD_BRANCH. Labeling not required."
               exit 0
-            elif ${{ toJSON(github.event.workflow_run.pull_requests) != '[]' }}; then
+            elif [ "${{ toJSON(github.event.workflow_run.pull_requests) }}" != "[]" ]; then
               PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
 
               echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary


- *This work is behind a feature toggle (flipper): NO
- This pull request resolves the Code injection in [Github Actions ready_for_review.yml (`GHSL-2025-105`)](https://github.com/department-of-veterans-affairs/vets-api/security/advisories/GHSA-3fh4-x69x-px75) security concern.

- *(What is the solution, why is this the solution?)*:

This is flagged as GHSL-2025-105, a code injection vulnerability in GitHub Actions, because untrusted inputs from github.head_ref and github.event.workflow_run.head_branch are being evaluated directly in the shell during workflow execution. Intermediate environment variables should be used instead of evaluating expressions directly in run steps. For example:

When a pull request workflow dispatch executes ready_for_review workflow, the $SAFE_HEAD_REF will be assigned as the pr branch.
`SAFE_HEAD_REF: ${{ github.head_ref }}`

When another workflow executes ready_for_review workflow, the $SAFE_WORKFLOW_HEAD_BRANCH will be assigned as the pr branch.
`SAFE_WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
`


--------------------------------------------------------------------------------
Another fix:
I noticed there was a syntax error when other workflow runs dispatched ready_for_review workflow. Failed workflow example [here](https://github.com/department-of-veterans-affairs/vets-api/actions/runs/16939428023/job/48004199901). I updated other places in the code to resolve this syntax issue. 

Brackets were added around if statements to resolve syntax errors.
<img width="673" height="198" alt="Screenshot 2025-08-13 at 9 05 08 AM" src="https://github.com/user-attachments/assets/201429ec-b6fc-44b6-b1e7-ed6c19d2b7ef" />



## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/116791
- department-of-veterans-affairs/vets-api/security/advisories/GHSA-3fh4-x69x-px75

## Testing done
- Workflow tested in PR runs.

## Screenshots
<img width="324" height="143" alt="Screenshot 2025-08-13 at 8 33 48 AM" src="https://github.com/user-attachments/assets/f48d78c2-df62-45d6-a465-12bfeefae1e9" />

## What areas of the site does it impact?
Github Actions

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
