### PR TITLE
pass encrypted_vet_info instead of rebuilding vet_info

### DIFF
--- a/app/services/bgs/dependent_v2_service.rb
+++ b/app/services/bgs/dependent_v2_service.rb
@@ -59,7 +59,7 @@ module BGS
 
       { submit_form_job_id: }
     rescue PDFSubmissionError
-      submit_to_central_service(claim:)
+      submit_to_central_service(claim:, encrypted_vet_info:)
     rescue => e
       @monitor.track_event('warn', 'BGS::DependentService#submit_686c_form method failed!',
                            "#{STATS_KEY}.failure", { error: e.message })
@@ -173,14 +173,13 @@ module BGS
       end
     end
 
-    def submit_to_central_service(claim:)
+    def submit_to_central_service(claim:, encrypted_vet_info:)
       vet_info = JSON.parse(claim.form)['dependents_application']
-      vet_info.merge!(get_form_hash_686c) unless vet_info['veteran_information']
-
+    
       user = BGS::SubmitForm686cV2Job.generate_user_struct(vet_info)
       Lighthouse::BenefitsIntake::SubmitCentralForm686cV2Job.perform_async(
         claim.id,
-        KmsEncrypted::Box.new.encrypt(vet_info.to_json),
+        encrypted_vet_info,
         KmsEncrypted::Box.new.encrypt(user.to_h.to_json)
       )
     end

--- a/app/services/bgs/dependent_v2_service.rb
+++ b/app/services/bgs/dependent_v2_service.rb
@@ -175,7 +175,7 @@ module BGS
 
     def submit_to_central_service(claim:, encrypted_vet_info:)
       vet_info = JSON.parse(claim.form)['dependents_application']
-    
+
       user = BGS::SubmitForm686cV2Job.generate_user_struct(vet_info)
       Lighthouse::BenefitsIntake::SubmitCentralForm686cV2Job.perform_async(
         claim.id,


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): NO*
- Instead of rebuilding the vet_info hash, pass encrypted_vet_info which had already been created to the backup path. This will help avoid the missing ssn issue.
- VA Lifestage Dependents

## Related issue(s)

[- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/116666)
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
