### PR TITLE
[ID-629] - Log if user is missing sec_id

### DIFF
--- a/app/services/sign_in/attribute_validator.rb
+++ b/app/services/sign_in/attribute_validator.rb
@@ -44,6 +44,7 @@ module SignIn
         validate_existing_mpi_attributes
       elsif mpi_record_exists?
         validate_existing_mpi_attributes
+        validate_sec_id
         update_mpi_correlation_record
       else
         add_mpi_user
@@ -62,6 +63,12 @@ module SignIn
       check_id_mismatch(mpi_response_profile.participant_ids, 'CORP_ID', Constants::ErrorCode::MULTIPLE_CORP_ID)
       check_id_mismatch(mpi_response_profile.mhv_iens, 'MHV_ID', Constants::ErrorCode::MULTIPLE_MHV_IEN,
                         raise_error: false)
+    end
+
+    def validate_sec_id
+      return if sec_id.present?
+
+      sign_in_logger.info('mpi record missing sec_id', icn: verified_icn)
     end
 
     def add_mpi_user
@@ -189,6 +196,10 @@ module SignIn
 
     def verified_icn
       @verified_icn ||= mpi_response_profile.icn
+    end
+
+    def sec_id
+      @sec_id ||= mpi_response_profile.sec_id
     end
 
     def credential_uuid


### PR DESCRIPTION
## Summary

- Add a log during auth if a person is missing an `sec_id`
- Will add calling add_user once we confirm with iam that this is ok to call on existing users

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/629
## Testing done

- Login with SiS with a user that does not have a `sec_id`
  - you can remove the line that looks like this from your users mockdata 
     ```xml
      <id extension="{00000XXXXX}^PN^200PROV^USDVA^A" root="2.16.840.1.113883.4.349"/>
     ```
- You should see a log with - `mpi record missing sec_id`

## What areas of the site does it impact?
Sign-in service

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

