### PR TITLE
Remove old flipper code

### DIFF
--- a/app/controllers/v0/dependents_applications_controller.rb
+++ b/app/controllers/v0/dependents_applications_controller.rb
@@ -42,7 +42,7 @@ module V0
       dependent_service.submit_686c_form(claim)
 
       Rails.logger.info "ClaimID=#{claim.confirmation_number} Form=#{claim.class::FORM}"
-      claim.send_submitted_email(current_user) if Flipper.enabled?(:dependents_submitted_email)
+      claim.send_submitted_email(current_user)
 
       # clear_saved_form(claim.form_id) # We do not want to destroy the InProgressForm for this submission
 

--- a/app/models/saved_claim/dependency_claim.rb
+++ b/app/models/saved_claim/dependency_claim.rb
@@ -206,7 +206,7 @@ class SavedClaim::DependencyClaim < CentralMailClaim
     self.form_id = original_form_id
   end
 
-  def send_failure_email(email) # rubocop:disable Metrics/MethodLength
+  def send_failure_email(email)
     # if the claim is both a 686c and a 674, send a combination email.
     # otherwise, check to see which individual type it is and send the corresponding email.
     personalisation = {
@@ -225,15 +225,7 @@ class SavedClaim::DependencyClaim < CentralMailClaim
                     nil
                   end
     if email.present? && template_id.present?
-      if Flipper.enabled?(:dependents_failure_callback_email)
-        Dependents::Form686c674FailureEmailJob.perform_async(id, email, template_id, personalisation)
-      else
-        VANotify::EmailJob.perform_async(
-          email,
-          template_id,
-          personalisation
-        )
-      end
+      Dependents::Form686c674FailureEmailJob.perform_async(id, email, template_id, personalisation)
     end
   end
 

--- a/app/sidekiq/bgs/submit_form674_job.rb
+++ b/app/sidekiq/bgs/submit_form674_job.rb
@@ -118,18 +118,7 @@ module BGS
     end
 
     def send_confirmation_email
-      return claim.send_received_email(user) if Flipper.enabled?(:dependents_separate_confirmation_email)
-
-      template_id = Settings.vanotify.services.va_gov.template_id.form686c_confirmation_email
-
-      return if user.va_profile_email.blank?
-
-      VANotify::ConfirmationEmail.send(
-        email_address: user.va_profile_email,
-        template_id:,
-        first_name: user&.first_name&.upcase,
-        user_uuid_and_form_id: "#{user.uuid}_#{FORM_ID}"
-      )
+      claim.send_received_email(user)
     end
 
     def init_monitor(saved_claim_id)

--- a/app/sidekiq/bgs/submit_form674_v2_job.rb
+++ b/app/sidekiq/bgs/submit_form674_v2_job.rb
@@ -118,18 +118,7 @@ module BGS
     end
 
     def send_confirmation_email
-      return claim.send_received_email(user) if Flipper.enabled?(:dependents_separate_confirmation_email)
-
-      template_id = Settings.vanotify.services.va_gov.template_id.form686c_confirmation_email
-
-      return if user.va_profile_email.blank?
-
-      VANotify::ConfirmationEmail.send(
-        email_address: user.va_profile_email,
-        template_id:,
-        first_name: user&.first_name&.upcase,
-        user_uuid_and_form_id: "#{user.uuid}_#{FORM_ID}"
-      )
+      claim.send_received_email(user)
     end
 
     def init_monitor(saved_claim_id)

--- a/app/sidekiq/bgs/submit_form686c_job.rb
+++ b/app/sidekiq/bgs/submit_form686c_job.rb
@@ -31,29 +31,20 @@ module BGS
     end
 
     # method length lint disabled because this will be cut in half when flipper is removed
-    def perform(user_uuid, icn, saved_claim_id, encrypted_vet_info) # rubocop:disable Metrics/MethodLength
+    def perform(user_uuid, icn, saved_claim_id, encrypted_vet_info)
       @monitor = init_monitor(saved_claim_id)
       @monitor.track_event('info', 'BGS::SubmitForm686cJob running!', "#{STATS_KEY}.begin")
       instance_params(encrypted_vet_info, icn, user_uuid, saved_claim_id)
 
-      if Flipper.enabled?(:dependents_separate_confirmation_email)
-        submit_686c
-        @monitor.track_event('info', 'BGS::SubmitForm686cJob succeeded!', "#{STATS_KEY}.success")
+      submit_686c
+      @monitor.track_event('info', 'BGS::SubmitForm686cJob succeeded!', "#{STATS_KEY}.success")
 
-        if claim.submittable_674?
-          enqueue_674_job(encrypted_vet_info)
-        else
-          # if no 674, form submission is complete
-          send_686c_confirmation_email
-          InProgressForm.destroy_by(form_id: FORM_ID, user_uuid:)
-        end
+      if claim.submittable_674?
+        enqueue_674_job(encrypted_vet_info)
       else
-        submit_forms(encrypted_vet_info)
-
-        send_confirmation_email
-
-        @monitor.track_event('info', 'BGS::SubmitForm686cJob succeeded!', "#{STATS_KEY}.success")
-        InProgressForm.destroy_by(form_id: FORM_ID, user_uuid:) unless claim.submittable_674?
+        # if no 674, form submission is complete
+        send_686c_confirmation_email
+        InProgressForm.destroy_by(form_id: FORM_ID, user_uuid:)
       end
     rescue => e
       handle_filtered_errors!(e:, encrypted_vet_info:)

--- a/app/sidekiq/bgs/submit_form686c_v2_job.rb
+++ b/app/sidekiq/bgs/submit_form686c_v2_job.rb
@@ -30,30 +30,21 @@ module BGS
     end
 
     # method length lint disabled because this will be cut in half when flipper is removed
-    def perform(user_uuid, icn, saved_claim_id, encrypted_vet_info) # rubocop:disable Metrics/MethodLength
+    def perform(user_uuid, icn, saved_claim_id, encrypted_vet_info)
       @monitor = init_monitor(saved_claim_id)
       @monitor.track_event('info', 'BGS::SubmitForm686cJob running!', "#{STATS_KEY}.begin")
 
       instance_params(encrypted_vet_info, icn, user_uuid, saved_claim_id)
 
-      if Flipper.enabled?(:dependents_separate_confirmation_email)
-        submit_686c
-        @monitor.track_event('info', 'BGS::SubmitForm686cJob succeeded!', "#{STATS_KEY}.success")
+      submit_686c
+      @monitor.track_event('info', 'BGS::SubmitForm686cJob succeeded!', "#{STATS_KEY}.success")
 
-        if claim.submittable_674?
-          enqueue_674_job(encrypted_vet_info)
-        else
-          # if no 674, form submission is complete
-          send_686c_confirmation_email
-          InProgressForm.destroy_by(form_id: FORM_ID, user_uuid:)
-        end
+      if claim.submittable_674?
+        enqueue_674_job(encrypted_vet_info)
       else
-        submit_forms(encrypted_vet_info)
-
-        send_confirmation_email
-
-        @monitor.track_event('info', 'BGS::SubmitForm686cJob succeeded!', "#{STATS_KEY}.success")
-        InProgressForm.destroy_by(form_id: FORM_ID, user_uuid:) unless claim.submittable_674?
+        # if no 674, form submission is complete
+        send_686c_confirmation_email
+        InProgressForm.destroy_by(form_id: FORM_ID, user_uuid:)
       end
     rescue => e
       handle_filtered_errors!(e:, encrypted_vet_info:)

--- a/app/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job.rb
+++ b/app/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job.rb
@@ -35,9 +35,7 @@ module Lighthouse
       sidekiq_options retry: RETRY
 
       sidekiq_retries_exhausted do |msg, _ex|
-        if Flipper.enabled?(:dependents_trigger_action_needed_email)
-          Lighthouse::BenefitsIntake::SubmitCentralForm686cJob.trigger_failure_events(msg)
-        end
+        Lighthouse::BenefitsIntake::SubmitCentralForm686cJob.trigger_failure_events(msg)
       end
 
       def perform(saved_claim_id, encrypted_vet_info, encrypted_user_struct)
@@ -242,17 +240,7 @@ module Lighthouse
       end
 
       def send_confirmation_email(user)
-        return claim.send_received_email(user) if Flipper.enabled?(:dependents_separate_confirmation_email)
-
-        return if user.va_profile_email.blank?
-
-        form_id = FORM_ID
-        VANotify::ConfirmationEmail.send(
-          email_address: user.va_profile_email,
-          template_id: Settings.vanotify.services.va_gov.template_id.form686c_confirmation_email,
-          first_name: user&.first_name&.upcase,
-          user_uuid_and_form_id: "#{user.uuid}_#{form_id}"
-        )
+        claim.send_received_email(user)
       end
 
       def self.trigger_failure_events(msg)

--- a/app/sidekiq/lighthouse/benefits_intake/submit_central_form686c_v2_job.rb
+++ b/app/sidekiq/lighthouse/benefits_intake/submit_central_form686c_v2_job.rb
@@ -33,9 +33,7 @@ module Lighthouse
       sidekiq_options retry: RETRY
 
       sidekiq_retries_exhausted do |msg, _ex|
-        if Flipper.enabled?(:dependents_trigger_action_needed_email)
-          Lighthouse::BenefitsIntake::SubmitCentralForm686cV2Job.trigger_failure_events(msg)
-        end
+        Lighthouse::BenefitsIntake::SubmitCentralForm686cV2Job.trigger_failure_events(msg)
       end
 
       def perform(saved_claim_id, encrypted_vet_info, encrypted_user_struct)
@@ -241,17 +239,7 @@ module Lighthouse
       end
 
       def send_confirmation_email(user)
-        return claim.send_received_email(user) if Flipper.enabled?(:dependents_separate_confirmation_email)
-
-        return if user.va_profile_email.blank?
-
-        form_id = FORM_ID_V2
-        VANotify::ConfirmationEmail.send(
-          email_address: user.va_profile_email,
-          template_id: Settings.vanotify.services.va_gov.template_id.form686c_confirmation_email,
-          first_name: user&.first_name&.upcase,
-          user_uuid_and_form_id: "#{user.uuid}_#{form_id}"
-        )
+        claim.send_received_email(user)
       end
 
       def self.trigger_failure_events(msg)

--- a/config/features.yml
+++ b/config/features.yml
@@ -639,18 +639,6 @@ features:
   dependents_claims_evidence_api_upload:
     actor_type: user
     description: Enable using the ClaimsEvidenceAPI module to upload 686/674 documents to VBMS
-  dependents_trigger_action_needed_email:
-    actor_type: user
-    description: Set whether to enable VANotify email to Veteran for Dependents Backup Path failure exhaustion
-  dependents_failure_callback_email:
-    actor_type: user
-    description: Enables the dependents action needed email callback to be used when an action needed email is triggered
-  dependents_submitted_email:
-    actor_type: cookie_id
-    description: Enables the dependents submitted email
-  dependents_separate_confirmation_email:
-    actor_type: cookie_id
-    description: Enables the dependents confirmation/received email to be differentiated by form
   disability_526_form4142_polling_records:
     actor_type: user
     description: enables creation of, and tracking of, sent form 4142 documents, from the 526 flow, to the Lighthouse Benefits Intake API

--- a/spec/controllers/v0/dependents_applications_controller_spec.rb
+++ b/spec/controllers/v0/dependents_applications_controller_spec.rb
@@ -49,8 +49,6 @@ RSpec.describe V0::DependentsApplicationsController do
   describe 'POST create' do
     context 'with valid params v1' do
       before do
-        allow(Flipper).to receive(:enabled?).with(:dependents_separate_confirmation_email).and_return(true)
-        allow(Flipper).to receive(:enabled?).with(:dependents_submitted_email).and_return(true)
         allow(Flipper).to receive(:enabled?).with(:va_dependents_v2).and_return(false)
         allow(Flipper).to receive(:enabled?).with(:remove_pciu, instance_of(User)).and_return(false)
         allow(VBMS::SubmitDependentsPdfJob).to receive(:perform_sync)

--- a/spec/sidekiq/bgs/submit_form674_job_spec.rb
+++ b/spec/sidekiq/bgs/submit_form674_job_spec.rb
@@ -69,48 +69,26 @@ RSpec.describe BGS::SubmitForm674Job, type: :job do
       end.not_to raise_error
     end
 
-    context 'with separate emails by form' do
-      it 'sends confirmation email for combined forms' do
-        allow(Flipper).to receive(:enabled?).with(:dependents_separate_confirmation_email).and_return(true)
-        expect(OpenStruct).to receive(:new)
-          .with(hash_including('icn' => vet_info['veteran_information']['icn']))
-          .and_return(user_struct)
-        expect(VANotify::EmailJob).to receive(:perform_async).with(
-          user.va_profile_email,
-          'fake_received686c674',
-          { 'confirmation_number' => dependency_claim.confirmation_number,
-            'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-            'first_name' => 'WESLEY' },
-          'fake_secret',
-          { callback_klass: 'Dependents::NotificationCallback',
-            callback_metadata: { email_template_id: 'fake_received686c674',
-                                 email_type: :received686c674,
-                                 form_id: '686C-674',
-                                 saved_claim_id: dependency_claim.id,
-                                 service_name: 'dependents' } }
-        )
+    it 'sends confirmation email for combined forms' do
+      expect(OpenStruct).to receive(:new)
+        .with(hash_including('icn' => vet_info['veteran_information']['icn']))
+        .and_return(user_struct)
+      expect(VANotify::EmailJob).to receive(:perform_async).with(
+        user.va_profile_email,
+        'fake_received686c674',
+        { 'confirmation_number' => dependency_claim.confirmation_number,
+          'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+          'first_name' => 'WESLEY' },
+        'fake_secret',
+        { callback_klass: 'Dependents::NotificationCallback',
+          callback_metadata: { email_template_id: 'fake_received686c674',
+                               email_type: :received686c674,
+                               form_id: '686C-674',
+                               saved_claim_id: dependency_claim.id,
+                               service_name: 'dependents' } }
+      )
 
-        subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
-      end
-    end
-
-    context 'without separate emails by form' do
-      it 'sends confirmation email' do
-        allow(Flipper).to receive(:enabled?).with(:dependents_separate_confirmation_email).and_return(false)
-        expect(OpenStruct).to receive(:new)
-          .with(hash_including('icn' => vet_info['veteran_information']['icn']))
-          .and_return(user_struct)
-        expect(VANotify::EmailJob).to receive(:perform_async).with(
-          user.va_profile_email,
-          'fake_template_id',
-          {
-            'date' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
-            'first_name' => 'WESLEY'
-          }
-        )
-
-        subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
-      end
+      subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
     end
   end
 
@@ -147,52 +125,28 @@ RSpec.describe BGS::SubmitForm674Job, type: :job do
   end
 
   context '674 only' do
-    context 'with separate emails by form' do
-      it 'sends confirmation email for 674 only' do
-        expect(BGS::Form674).to receive(:new).and_return(client_stub)
-        expect(client_stub).to receive(:submit).once
-        allow(Flipper).to receive(:enabled?).with(:dependents_separate_confirmation_email).and_return(true)
-        expect(OpenStruct).to receive(:new)
-          .with(hash_including('icn' => vet_info['veteran_information']['icn']))
-          .and_return(user_struct)
-        expect(VANotify::EmailJob).to receive(:perform_async).with(
-          user.va_profile_email,
-          'fake_received674',
-          { 'confirmation_number' => dependency_claim_674_only.confirmation_number,
-            'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-            'first_name' => 'WESLEY' },
-          'fake_secret',
-          { callback_klass: 'Dependents::NotificationCallback',
-            callback_metadata: { email_template_id: 'fake_received674',
-                                 email_type: :received674,
-                                 form_id: '686C-674',
-                                 saved_claim_id: dependency_claim_674_only.id,
-                                 service_name: 'dependents' } }
-        )
+    it 'sends confirmation email for 674 only' do
+      expect(BGS::Form674).to receive(:new).and_return(client_stub)
+      expect(client_stub).to receive(:submit).once
+      expect(OpenStruct).to receive(:new)
+        .with(hash_including('icn' => vet_info['veteran_information']['icn']))
+        .and_return(user_struct)
+      expect(VANotify::EmailJob).to receive(:perform_async).with(
+        user.va_profile_email,
+        'fake_received674',
+        { 'confirmation_number' => dependency_claim_674_only.confirmation_number,
+          'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+          'first_name' => 'WESLEY' },
+        'fake_secret',
+        { callback_klass: 'Dependents::NotificationCallback',
+          callback_metadata: { email_template_id: 'fake_received674',
+                               email_type: :received674,
+                               form_id: '686C-674',
+                               saved_claim_id: dependency_claim_674_only.id,
+                               service_name: 'dependents' } }
+      )
 
-        subject.perform(user.uuid, user.icn, dependency_claim_674_only.id, encrypted_vet_info, encrypted_user_struct)
-      end
-    end
-
-    context 'without separate emails by form' do
-      it 'sends confirmation email' do
-        expect(BGS::Form674).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-        expect(client_stub).to receive(:submit).once
-        allow(Flipper).to receive(:enabled?).with(:dependents_separate_confirmation_email).and_return(false)
-        expect(OpenStruct).to receive(:new)
-          .with(hash_including('icn' => vet_info['veteran_information']['icn']))
-          .and_return(user_struct)
-        expect(VANotify::EmailJob).to receive(:perform_async).with(
-          user.va_profile_email,
-          'fake_template_id',
-          {
-            'date' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
-            'first_name' => 'WESLEY'
-          }
-        )
-
-        subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
-      end
+      subject.perform(user.uuid, user.icn, dependency_claim_674_only.id, encrypted_vet_info, encrypted_user_struct)
     end
   end
 end

--- a/spec/sidekiq/bgs/submit_form674_v2_job_spec.rb
+++ b/spec/sidekiq/bgs/submit_form674_v2_job_spec.rb
@@ -69,131 +69,85 @@ RSpec.describe BGS::SubmitForm674V2Job, type: :job do
       end.not_to raise_error
     end
 
-    context 'with separate emails by form' do
-      it 'sends confirmation email for combined forms' do
-        allow(Flipper).to receive(:enabled?).with(:dependents_separate_confirmation_email).and_return(true)
-        expect(OpenStruct).to receive(:new)
-          .with(hash_including('icn' => vet_info['veteran_information']['icn']))
-          .and_return(user_struct)
-        expect(VANotify::EmailJob).to receive(:perform_async).with(
-          user.va_profile_email,
-          'fake_received686c674',
-          { 'confirmation_number' => dependency_claim.confirmation_number,
-            'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-            'first_name' => 'WESLEY' },
-          'fake_secret',
-          { callback_klass: 'Dependents::NotificationCallback',
-            callback_metadata: { email_template_id: 'fake_received686c674',
-                                 email_type: :received686c674,
-                                 form_id: '686C-674',
-                                 saved_claim_id: dependency_claim.id,
-                                 service_name: 'dependents' } }
-        )
-
-        subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
-      end
-    end
-
-    context 'without separate emails by form' do
-      it 'sends confirmation email' do
-        allow(Flipper).to receive(:enabled?).with(:dependents_separate_confirmation_email).and_return(false)
-        expect(OpenStruct).to receive(:new)
-          .with(hash_including('icn' => vet_info['veteran_information']['icn']))
-          .and_return(user_struct)
-        expect(VANotify::EmailJob).to receive(:perform_async).with(
-          user.va_profile_email,
-          'fake_template_id',
-          {
-            'date' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
-            'first_name' => 'WESLEY'
-          }
-        )
-
-        subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
-      end
-    end
-  end
-
-  context 'error with central submission' do
-    before do
-      allow(OpenStruct).to receive(:new).and_call_original
-      InProgressForm.create!(form_id: '686C-674', user_uuid: user.uuid, user_account: user.user_account,
-                             form_data: all_flows_payload)
-    end
-
-    it 'raises error' do
+    it 'sends confirmation email for combined forms' do
       expect(OpenStruct).to receive(:new)
         .with(hash_including('icn' => vet_info['veteran_information']['icn']))
         .and_return(user_struct)
-      expect(BGSV2::Form674).to receive(:new).with(user_struct, dependency_claim) { client_stub }
-      expect(client_stub).to receive(:submit).and_raise(BGS::SubmitForm674V2Job::Invalid674Claim)
+      expect(VANotify::EmailJob).to receive(:perform_async).with(
+        user.va_profile_email,
+        'fake_received686c674',
+        { 'confirmation_number' => dependency_claim.confirmation_number,
+          'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+          'first_name' => 'WESLEY' },
+        'fake_secret',
+        { callback_klass: 'Dependents::NotificationCallback',
+          callback_metadata: { email_template_id: 'fake_received686c674',
+                               email_type: :received686c674,
+                               form_id: '686C-674',
+                               saved_claim_id: dependency_claim.id,
+                               service_name: 'dependents' } }
+      )
 
-      expect do
-        subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
-      end.to raise_error(BGS::SubmitForm674V2Job::Invalid674Claim)
-    end
-
-    it 'filters based on error cause' do
-      expect(OpenStruct).to receive(:new)
-        .with(hash_including('icn' => vet_info['veteran_information']['icn']))
-        .and_return(user_struct)
-      expect(BGSV2::Form674).to receive(:new).with(user_struct, dependency_claim) { client_stub }
-      expect(client_stub).to receive(:submit) { raise_nested_err }
-
-      expect do
-        subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
-      end.to raise_error(Sidekiq::JobRetry::Skip)
+      subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
     end
   end
+end
 
-  context '674 only' do
-    context 'with separate emails by form' do
-      it 'sends confirmation email for 674 only' do
-        expect(BGSV2::Form674).to receive(:new).and_return(client_stub)
-        expect(client_stub).to receive(:submit).once
-        allow(Flipper).to receive(:enabled?).with(:dependents_separate_confirmation_email).and_return(true)
-        expect(OpenStruct).to receive(:new)
-          .with(hash_including('icn' => vet_info['veteran_information']['icn']))
-          .and_return(user_struct)
-        expect(VANotify::EmailJob).to receive(:perform_async).with(
-          user.va_profile_email,
-          'fake_received674',
-          { 'confirmation_number' => dependency_claim_674_only.confirmation_number,
-            'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-            'first_name' => 'WESLEY' },
-          'fake_secret',
-          { callback_klass: 'Dependents::NotificationCallback',
-            callback_metadata: { email_template_id: 'fake_received674',
-                                 email_type: :received674,
-                                 form_id: '686C-674',
-                                 saved_claim_id: dependency_claim_674_only.id,
-                                 service_name: 'dependents' } }
-        )
+context 'error with central submission' do
+  before do
+    allow(OpenStruct).to receive(:new).and_call_original
+    InProgressForm.create!(form_id: '686C-674', user_uuid: user.uuid, user_account: user.user_account,
+                           form_data: all_flows_payload)
+  end
 
-        subject.perform(user.uuid, user.icn, dependency_claim_674_only.id, encrypted_vet_info, encrypted_user_struct)
-      end
-    end
+  it 'raises error' do
+    expect(OpenStruct).to receive(:new)
+      .with(hash_including('icn' => vet_info['veteran_information']['icn']))
+      .and_return(user_struct)
+    expect(BGSV2::Form674).to receive(:new).with(user_struct, dependency_claim) { client_stub }
+    expect(client_stub).to receive(:submit).and_raise(BGS::SubmitForm674V2Job::Invalid674Claim)
 
-    context 'without separate emails by form' do
-      it 'sends confirmation email' do
-        expect(BGSV2::Form674).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-        expect(client_stub).to receive(:submit).once
-        allow(Flipper).to receive(:enabled?).with(:dependents_separate_confirmation_email).and_return(false)
-        expect(OpenStruct).to receive(:new)
-          .with(hash_including('icn' => vet_info['veteran_information']['icn']))
-          .and_return(user_struct)
-        expect(VANotify::EmailJob).to receive(:perform_async).with(
-          user.va_profile_email,
-          'fake_template_id',
-          {
-            'date' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
-            'first_name' => 'WESLEY'
-          }
-        )
+    expect do
+      subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
+    end.to raise_error(BGS::SubmitForm674V2Job::Invalid674Claim)
+  end
 
-        subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
-      end
-    end
+  it 'filters based on error cause' do
+    expect(OpenStruct).to receive(:new)
+      .with(hash_including('icn' => vet_info['veteran_information']['icn']))
+      .and_return(user_struct)
+    expect(BGSV2::Form674).to receive(:new).with(user_struct, dependency_claim) { client_stub }
+    expect(client_stub).to receive(:submit) { raise_nested_err }
+
+    expect do
+      subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
+    end.to raise_error(Sidekiq::JobRetry::Skip)
+  end
+end
+
+context '674 only' do
+  it 'sends confirmation email for 674 only' do
+    expect(BGSV2::Form674).to receive(:new).and_return(client_stub)
+    expect(client_stub).to receive(:submit).once
+    expect(OpenStruct).to receive(:new)
+      .with(hash_including('icn' => vet_info['veteran_information']['icn']))
+      .and_return(user_struct)
+    expect(VANotify::EmailJob).to receive(:perform_async).with(
+      user.va_profile_email,
+      'fake_received674',
+      { 'confirmation_number' => dependency_claim_674_only.confirmation_number,
+        'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+        'first_name' => 'WESLEY' },
+      'fake_secret',
+      { callback_klass: 'Dependents::NotificationCallback',
+        callback_metadata: { email_template_id: 'fake_received674',
+                             email_type: :received674,
+                             form_id: '686C-674',
+                             saved_claim_id: dependency_claim_674_only.id,
+                             service_name: 'dependents' } }
+    )
+
+    subject.perform(user.uuid, user.icn, dependency_claim_674_only.id, encrypted_vet_info, encrypted_user_struct)
   end
 end
 

--- a/spec/sidekiq/bgs/submit_form674_v2_job_spec.rb
+++ b/spec/sidekiq/bgs/submit_form674_v2_job_spec.rb
@@ -91,63 +91,63 @@ RSpec.describe BGS::SubmitForm674V2Job, type: :job do
       subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
     end
   end
-end
 
-context 'error with central submission' do
-  before do
-    allow(OpenStruct).to receive(:new).and_call_original
-    InProgressForm.create!(form_id: '686C-674', user_uuid: user.uuid, user_account: user.user_account,
-                           form_data: all_flows_payload)
+  context 'error with central submission' do
+    before do
+      allow(OpenStruct).to receive(:new).and_call_original
+      InProgressForm.create!(form_id: '686C-674', user_uuid: user.uuid, user_account: user.user_account,
+                             form_data: all_flows_payload)
+    end
+
+    it 'raises error' do
+      expect(OpenStruct).to receive(:new)
+        .with(hash_including('icn' => vet_info['veteran_information']['icn']))
+        .and_return(user_struct)
+      expect(BGSV2::Form674).to receive(:new).with(user_struct, dependency_claim) { client_stub }
+      expect(client_stub).to receive(:submit).and_raise(BGS::SubmitForm674V2Job::Invalid674Claim)
+
+      expect do
+        subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
+      end.to raise_error(BGS::SubmitForm674V2Job::Invalid674Claim)
+    end
+
+    it 'filters based on error cause' do
+      expect(OpenStruct).to receive(:new)
+        .with(hash_including('icn' => vet_info['veteran_information']['icn']))
+        .and_return(user_struct)
+      expect(BGSV2::Form674).to receive(:new).with(user_struct, dependency_claim) { client_stub }
+      expect(client_stub).to receive(:submit) { raise_nested_err }
+
+      expect do
+        subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
+      end.to raise_error(Sidekiq::JobRetry::Skip)
+    end
   end
 
-  it 'raises error' do
-    expect(OpenStruct).to receive(:new)
-      .with(hash_including('icn' => vet_info['veteran_information']['icn']))
-      .and_return(user_struct)
-    expect(BGSV2::Form674).to receive(:new).with(user_struct, dependency_claim) { client_stub }
-    expect(client_stub).to receive(:submit).and_raise(BGS::SubmitForm674V2Job::Invalid674Claim)
+  context '674 only' do
+    it 'sends confirmation email for 674 only' do
+      expect(BGSV2::Form674).to receive(:new).and_return(client_stub)
+      expect(client_stub).to receive(:submit).once
+      expect(OpenStruct).to receive(:new)
+        .with(hash_including('icn' => vet_info['veteran_information']['icn']))
+        .and_return(user_struct)
+      expect(VANotify::EmailJob).to receive(:perform_async).with(
+        user.va_profile_email,
+        'fake_received674',
+        { 'confirmation_number' => dependency_claim_674_only.confirmation_number,
+          'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+          'first_name' => 'WESLEY' },
+        'fake_secret',
+        { callback_klass: 'Dependents::NotificationCallback',
+          callback_metadata: { email_template_id: 'fake_received674',
+                               email_type: :received674,
+                               form_id: '686C-674',
+                               saved_claim_id: dependency_claim_674_only.id,
+                               service_name: 'dependents' } }
+      )
 
-    expect do
-      subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
-    end.to raise_error(BGS::SubmitForm674V2Job::Invalid674Claim)
-  end
-
-  it 'filters based on error cause' do
-    expect(OpenStruct).to receive(:new)
-      .with(hash_including('icn' => vet_info['veteran_information']['icn']))
-      .and_return(user_struct)
-    expect(BGSV2::Form674).to receive(:new).with(user_struct, dependency_claim) { client_stub }
-    expect(client_stub).to receive(:submit) { raise_nested_err }
-
-    expect do
-      subject.perform(user.uuid, user.icn, dependency_claim.id, encrypted_vet_info, encrypted_user_struct)
-    end.to raise_error(Sidekiq::JobRetry::Skip)
-  end
-end
-
-context '674 only' do
-  it 'sends confirmation email for 674 only' do
-    expect(BGSV2::Form674).to receive(:new).and_return(client_stub)
-    expect(client_stub).to receive(:submit).once
-    expect(OpenStruct).to receive(:new)
-      .with(hash_including('icn' => vet_info['veteran_information']['icn']))
-      .and_return(user_struct)
-    expect(VANotify::EmailJob).to receive(:perform_async).with(
-      user.va_profile_email,
-      'fake_received674',
-      { 'confirmation_number' => dependency_claim_674_only.confirmation_number,
-        'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-        'first_name' => 'WESLEY' },
-      'fake_secret',
-      { callback_klass: 'Dependents::NotificationCallback',
-        callback_metadata: { email_template_id: 'fake_received674',
-                             email_type: :received674,
-                             form_id: '686C-674',
-                             saved_claim_id: dependency_claim_674_only.id,
-                             service_name: 'dependents' } }
-    )
-
-    subject.perform(user.uuid, user.icn, dependency_claim_674_only.id, encrypted_vet_info, encrypted_user_struct)
+      subject.perform(user.uuid, user.icn, dependency_claim_674_only.id, encrypted_vet_info, encrypted_user_struct)
+    end
   end
 end
 

--- a/spec/sidekiq/bgs/submit_form686c_job_spec.rb
+++ b/spec/sidekiq/bgs/submit_form686c_job_spec.rb
@@ -60,99 +60,76 @@ RSpec.describe BGS::SubmitForm686cJob, type: :job do
       expect { job }.not_to raise_error
     end
 
-    context 'with separate emails by form' do
-      it 'sends confirmation email for 686c only' do
-        expect(BGS::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-        expect(client_stub).to receive(:submit).once
-        allow(Flipper).to receive(:enabled?).with(:dependents_separate_confirmation_email).and_return(true)
+    it 'sends confirmation email for 686c only' do
+      expect(BGS::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
+      expect(client_stub).to receive(:submit).once
 
-        expect(VANotify::EmailJob).to receive(:perform_async).with(
-          user.va_profile_email,
-          'fake_received686',
-          { 'confirmation_number' => dependency_claim.confirmation_number,
-            'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-            'first_name' => 'WESLEY' },
-          'fake_secret',
-          { callback_klass: 'Dependents::NotificationCallback',
-            callback_metadata: { email_template_id: 'fake_received686',
-                                 email_type: :received686,
-                                 form_id: '686C-674',
-                                 saved_claim_id: dependency_claim.id,
-                                 service_name: 'dependents' } }
-        )
+      expect(VANotify::EmailJob).to receive(:perform_async).with(
+        user.va_profile_email,
+        'fake_received686',
+        { 'confirmation_number' => dependency_claim.confirmation_number,
+          'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+          'first_name' => 'WESLEY' },
+        'fake_secret',
+        { callback_klass: 'Dependents::NotificationCallback',
+          callback_metadata: { email_template_id: 'fake_received686',
+                               email_type: :received686,
+                               form_id: '686C-674',
+                               saved_claim_id: dependency_claim.id,
+                               service_name: 'dependents' } }
+      )
 
-        expect { job }.not_to raise_error
-      end
-
-      it 'does not send confirmation email for 686c_674 combo' do
-        allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(true)
-        expect(BGS::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-        expect(client_stub).to receive(:submit).once
-        allow(Flipper).to receive(:enabled?).with(:dependents_separate_confirmation_email).and_return(true)
-
-        expect(VANotify::EmailJob).not_to receive(:perform_async)
-
-        expect { job }.not_to raise_error
-      end
+      expect { job }.not_to raise_error
     end
 
-    context 'without separate emails by form' do
-      it 'sends confirmation email' do
-        expect(BGS::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-        expect(client_stub).to receive(:submit).once
-        allow(Flipper).to receive(:enabled?).with(:dependents_separate_confirmation_email).and_return(false)
+    it 'does not send confirmation email for 686c_674 combo' do
+      allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(true)
+      expect(BGS::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
+      expect(client_stub).to receive(:submit).once
 
-        expect(VANotify::EmailJob).to receive(:perform_async).with(
-          user.va_profile_email,
-          'fake_template_id',
-          {
-            'date' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
-            'first_name' => 'WESLEY'
-          }
-        )
+      expect(VANotify::EmailJob).not_to receive(:perform_async)
 
-        expect { job }.not_to raise_error
-      end
-    end
-
-    context 'Claim is submittable_674' do
-      it 'enqueues SubmitForm674Job' do
-        allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(true)
-        expect(BGS::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-        expect(client_stub).to receive(:submit).once
-        expect(BGS::SubmitForm674Job).to receive(:perform_async).with(user.uuid, user.icn,
-                                                                      dependency_claim.id, encrypted_vet_info,
-                                                                      an_instance_of(String))
-
-        expect { job }.not_to raise_error
-      end
-    end
-
-    context 'Claim is not submittable_674' do
-      it 'does not enqueue SubmitForm674Job' do
-        expect(BGS::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-        expect(client_stub).to receive(:submit).once
-        expect(BGS::SubmitForm674Job).not_to receive(:perform_async)
-
-        expect { job }.not_to raise_error
-      end
+      expect { job }.not_to raise_error
     end
   end
 
-  context 'when submission raises error' do
-    it 'raises error' do
+  context 'Claim is submittable_674' do
+    it 'enqueues SubmitForm674Job' do
+      allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(true)
       expect(BGS::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-      expect(client_stub).to receive(:submit).and_raise(BGS::SubmitForm686cJob::Invalid686cClaim)
+      expect(client_stub).to receive(:submit).once
+      expect(BGS::SubmitForm674Job).to receive(:perform_async).with(user.uuid, user.icn,
+                                                                    dependency_claim.id, encrypted_vet_info,
+                                                                    an_instance_of(String))
 
-      expect { job }.to raise_error(BGS::SubmitForm686cJob::Invalid686cClaim)
+      expect { job }.not_to raise_error
     end
+  end
 
-    it 'filters based on error cause' do
+  context 'Claim is not submittable_674' do
+    it 'does not enqueue SubmitForm674Job' do
       expect(BGS::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-      expect(client_stub).to receive(:submit) { raise_nested_err }
+      expect(client_stub).to receive(:submit).once
+      expect(BGS::SubmitForm674Job).not_to receive(:perform_async)
 
-      expect { job }.to raise_error(Sidekiq::JobRetry::Skip)
+      expect { job }.not_to raise_error
     end
+  end
+end
+
+context 'when submission raises error' do
+  it 'raises error' do
+    expect(BGS::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
+    expect(client_stub).to receive(:submit).and_raise(BGS::SubmitForm686cJob::Invalid686cClaim)
+
+    expect { job }.to raise_error(BGS::SubmitForm686cJob::Invalid686cClaim)
+  end
+
+  it 'filters based on error cause' do
+    expect(BGS::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
+    expect(client_stub).to receive(:submit) { raise_nested_err }
+
+    expect { job }.to raise_error(Sidekiq::JobRetry::Skip)
   end
 end
 

--- a/spec/sidekiq/bgs/submit_form686c_job_spec.rb
+++ b/spec/sidekiq/bgs/submit_form686c_job_spec.rb
@@ -115,21 +115,21 @@ RSpec.describe BGS::SubmitForm686cJob, type: :job do
       expect { job }.not_to raise_error
     end
   end
-end
 
-context 'when submission raises error' do
-  it 'raises error' do
-    expect(BGS::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-    expect(client_stub).to receive(:submit).and_raise(BGS::SubmitForm686cJob::Invalid686cClaim)
+  context 'when submission raises error' do
+    it 'raises error' do
+      expect(BGS::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
+      expect(client_stub).to receive(:submit).and_raise(BGS::SubmitForm686cJob::Invalid686cClaim)
 
-    expect { job }.to raise_error(BGS::SubmitForm686cJob::Invalid686cClaim)
-  end
+      expect { job }.to raise_error(BGS::SubmitForm686cJob::Invalid686cClaim)
+    end
 
-  it 'filters based on error cause' do
-    expect(BGS::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-    expect(client_stub).to receive(:submit) { raise_nested_err }
+    it 'filters based on error cause' do
+      expect(BGS::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
+      expect(client_stub).to receive(:submit) { raise_nested_err }
 
-    expect { job }.to raise_error(Sidekiq::JobRetry::Skip)
+      expect { job }.to raise_error(Sidekiq::JobRetry::Skip)
+    end
   end
 end
 

--- a/spec/sidekiq/bgs/submit_form686c_v2_job_spec.rb
+++ b/spec/sidekiq/bgs/submit_form686c_v2_job_spec.rb
@@ -115,21 +115,21 @@ RSpec.describe BGS::SubmitForm686cV2Job, type: :job do
       expect { job }.not_to raise_error
     end
   end
-end
 
-context 'when submission raises error' do
-  it 'raises error' do
-    expect(BGSV2::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-    expect(client_stub).to receive(:submit).and_raise(BGS::SubmitForm686cV2Job::Invalid686cClaim)
+  context 'when submission raises error' do
+    it 'raises error' do
+      expect(BGSV2::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
+      expect(client_stub).to receive(:submit).and_raise(BGS::SubmitForm686cV2Job::Invalid686cClaim)
 
-    expect { job }.to raise_error(BGS::SubmitForm686cV2Job::Invalid686cClaim)
-  end
+      expect { job }.to raise_error(BGS::SubmitForm686cV2Job::Invalid686cClaim)
+    end
 
-  it 'filters based on error cause' do
-    expect(BGSV2::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-    expect(client_stub).to receive(:submit) { raise_nested_err }
+    it 'filters based on error cause' do
+      expect(BGSV2::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
+      expect(client_stub).to receive(:submit) { raise_nested_err }
 
-    expect { job }.to raise_error(Sidekiq::JobRetry::Skip)
+      expect { job }.to raise_error(Sidekiq::JobRetry::Skip)
+    end
   end
 end
 

--- a/spec/sidekiq/bgs/submit_form686c_v2_job_spec.rb
+++ b/spec/sidekiq/bgs/submit_form686c_v2_job_spec.rb
@@ -60,99 +60,76 @@ RSpec.describe BGS::SubmitForm686cV2Job, type: :job do
       expect { job }.not_to raise_error
     end
 
-    context 'with separate emails by form' do
-      it 'sends confirmation email for 686c only' do
-        expect(BGSV2::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-        expect(client_stub).to receive(:submit).once
-        allow(Flipper).to receive(:enabled?).with(:dependents_separate_confirmation_email).and_return(true)
+    it 'sends confirmation email for 686c only' do
+      expect(BGSV2::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
+      expect(client_stub).to receive(:submit).once
 
-        expect(VANotify::EmailJob).to receive(:perform_async).with(
-          user.va_profile_email,
-          'fake_received686',
-          { 'confirmation_number' => dependency_claim.confirmation_number,
-            'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-            'first_name' => 'WESLEY' },
-          'fake_secret',
-          { callback_klass: 'Dependents::NotificationCallback',
-            callback_metadata: { email_template_id: 'fake_received686',
-                                 email_type: :received686,
-                                 form_id: '686C-674',
-                                 saved_claim_id: dependency_claim.id,
-                                 service_name: 'dependents' } }
-        )
+      expect(VANotify::EmailJob).to receive(:perform_async).with(
+        user.va_profile_email,
+        'fake_received686',
+        { 'confirmation_number' => dependency_claim.confirmation_number,
+          'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+          'first_name' => 'WESLEY' },
+        'fake_secret',
+        { callback_klass: 'Dependents::NotificationCallback',
+          callback_metadata: { email_template_id: 'fake_received686',
+                               email_type: :received686,
+                               form_id: '686C-674',
+                               saved_claim_id: dependency_claim.id,
+                               service_name: 'dependents' } }
+      )
 
-        expect { job }.not_to raise_error
-      end
-
-      it 'does not send confirmation email for 686c_674 combo' do
-        allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(true)
-        expect(BGSV2::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-        expect(client_stub).to receive(:submit).once
-        allow(Flipper).to receive(:enabled?).with(:dependents_separate_confirmation_email).and_return(true)
-
-        expect(VANotify::EmailJob).not_to receive(:perform_async)
-
-        expect { job }.not_to raise_error
-      end
+      expect { job }.not_to raise_error
     end
 
-    context 'without separate emails by form' do
-      it 'sends confirmation email' do
-        expect(BGSV2::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-        expect(client_stub).to receive(:submit).once
-        allow(Flipper).to receive(:enabled?).with(:dependents_separate_confirmation_email).and_return(false)
+    it 'does not send confirmation email for 686c_674 combo' do
+      allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(true)
+      expect(BGSV2::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
+      expect(client_stub).to receive(:submit).once
 
-        expect(VANotify::EmailJob).to receive(:perform_async).with(
-          user.va_profile_email,
-          'fake_template_id',
-          {
-            'date' => Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%B %d, %Y'),
-            'first_name' => 'WESLEY'
-          }
-        )
+      expect(VANotify::EmailJob).not_to receive(:perform_async)
 
-        expect { job }.not_to raise_error
-      end
-    end
-
-    context 'Claim is submittable_674' do
-      it 'enqueues SubmitForm674Job' do
-        allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(true)
-        expect(BGSV2::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-        expect(client_stub).to receive(:submit).once
-        expect(BGS::SubmitForm674V2Job).to receive(:perform_async).with(user.uuid, user.icn,
-                                                                        dependency_claim.id, encrypted_vet_info,
-                                                                        an_instance_of(String))
-
-        expect { job }.not_to raise_error
-      end
-    end
-
-    context 'Claim is not submittable_674' do
-      it 'does not enqueue SubmitForm674Job' do
-        expect(BGSV2::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-        expect(client_stub).to receive(:submit).once
-        expect(BGS::SubmitForm674V2Job).not_to receive(:perform_async)
-
-        expect { job }.not_to raise_error
-      end
+      expect { job }.not_to raise_error
     end
   end
 
-  context 'when submission raises error' do
-    it 'raises error' do
+  context 'Claim is submittable_674' do
+    it 'enqueues SubmitForm674Job' do
+      allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(true)
       expect(BGSV2::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-      expect(client_stub).to receive(:submit).and_raise(BGS::SubmitForm686cV2Job::Invalid686cClaim)
+      expect(client_stub).to receive(:submit).once
+      expect(BGS::SubmitForm674V2Job).to receive(:perform_async).with(user.uuid, user.icn,
+                                                                      dependency_claim.id, encrypted_vet_info,
+                                                                      an_instance_of(String))
 
-      expect { job }.to raise_error(BGS::SubmitForm686cV2Job::Invalid686cClaim)
+      expect { job }.not_to raise_error
     end
+  end
 
-    it 'filters based on error cause' do
+  context 'Claim is not submittable_674' do
+    it 'does not enqueue SubmitForm674Job' do
       expect(BGSV2::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
-      expect(client_stub).to receive(:submit) { raise_nested_err }
+      expect(client_stub).to receive(:submit).once
+      expect(BGS::SubmitForm674V2Job).not_to receive(:perform_async)
 
-      expect { job }.to raise_error(Sidekiq::JobRetry::Skip)
+      expect { job }.not_to raise_error
     end
+  end
+end
+
+context 'when submission raises error' do
+  it 'raises error' do
+    expect(BGSV2::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
+    expect(client_stub).to receive(:submit).and_raise(BGS::SubmitForm686cV2Job::Invalid686cClaim)
+
+    expect { job }.to raise_error(BGS::SubmitForm686cV2Job::Invalid686cClaim)
+  end
+
+  it 'filters based on error cause' do
+    expect(BGSV2::Form686c).to receive(:new).with(user_struct, dependency_claim).and_return(client_stub)
+    expect(client_stub).to receive(:submit) { raise_nested_err }
+
+    expect { job }.to raise_error(Sidekiq::JobRetry::Skip)
   end
 end
 

--- a/spec/sidekiq/lighthouse/benefits_intake/submit_central_form686c_v2_job_spec.rb
+++ b/spec/sidekiq/lighthouse/benefits_intake/submit_central_form686c_v2_job_spec.rb
@@ -286,168 +286,84 @@ RSpec.describe Lighthouse::BenefitsIntake::SubmitCentralForm686cV2Job, :uploader
     end
   end
 
-  describe 'sidekiq_retries_exhausted block with dependents_trigger_action_needed_email flipper on' do
+  describe 'sidekiq_retries_exhausted block' do
     before do
       allow(SavedClaim::DependencyClaim).to receive(:find).and_return(claim)
       allow(Dependents::Monitor).to receive(:new).and_return(monitor)
       allow(monitor).to receive :track_submission_exhaustion
-      allow(Flipper).to receive(:enabled?).with(:dependents_trigger_action_needed_email).and_return(true)
     end
 
-    context 'when the the dependents_failure_callback_email flipper is off' do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:dependents_failure_callback_email).and_return(false)
-      end
-
-      it 'logs the error to zsf and sends an email with the 686C template' do
-        Lighthouse::BenefitsIntake::SubmitCentralForm686cJob.within_sidekiq_retries_exhausted_block(
-          { 'args' => [claim.id, encrypted_vet_info, encrypted_user_struct] }
-        ) do
-          exhaustion_msg['args'] = [claim.id, encrypted_vet_info, encrypted_user_struct]
-          expect(monitor).to receive(:track_submission_exhaustion).with(exhaustion_msg, user_struct.va_profile_email)
-          expect(SavedClaim::DependencyClaim).to receive(:find).with(claim.id).and_return(claim)
-          claim.parsed_form['view:selectable686_options']['report674'] = false
-          expect(VANotify::EmailJob).to receive(:perform_async).with(
-            'vets.gov.user+228@gmail.com',
-            'form21_686c_action_needed_email_template_id',
-            {
-              'first_name' => 'MARK',
-              'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-              'confirmation_number' => claim.confirmation_number
-            }
-          )
-        end
-      end
-
-      it 'logs the error to zsf and sends an email with the 674 template' do
-        Lighthouse::BenefitsIntake::SubmitCentralForm686cJob.within_sidekiq_retries_exhausted_block(
-          { 'args' => [claim.id, encrypted_vet_info, encrypted_user_struct] }
-        ) do
-          exhaustion_msg['args'] = [claim.id, encrypted_vet_info, encrypted_user_struct]
-          expect(monitor).to receive(:track_submission_exhaustion).with(exhaustion_msg, user_struct.va_profile_email)
-          expect(SavedClaim::DependencyClaim).to receive(:find).with(claim.id).and_return(claim)
-          claim.parsed_form['view:selectable686_options'].delete('add_child')
-          expect(VANotify::EmailJob).to receive(:perform_async).with(
-            'vets.gov.user+228@gmail.com',
-            'form21_674_action_needed_email_template_id',
-            {
-              'first_name' => 'MARK',
-              'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-              'confirmation_number' => claim.confirmation_number
-            }
-          )
-        end
-      end
-
-      it 'logs the error to zsf and a combo email with 686c-674' do
-        Lighthouse::BenefitsIntake::SubmitCentralForm686cJob.within_sidekiq_retries_exhausted_block(
-          { 'args' => [claim.id, encrypted_vet_info, encrypted_user_struct] }
-        ) do
-          exhaustion_msg['args'] = [claim.id, encrypted_vet_info, encrypted_user_struct]
-          expect(monitor).to receive(:track_submission_exhaustion).with(exhaustion_msg, user_struct.va_profile_email)
-          expect(SavedClaim::DependencyClaim).to receive(:find).with(claim.id).and_return(claim)
-          expect(VANotify::EmailJob).to receive(:perform_async).with(
-            'vets.gov.user+228@gmail.com',
-            'form21_686c_674_action_needed_email_template_id',
-            {
-              'first_name' => 'MARK',
-              'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-              'confirmation_number' => claim.confirmation_number
-            }
-          )
-        end
-      end
-
-      it 'logs the error to zsf and does not send an email' do
-        Lighthouse::BenefitsIntake::SubmitCentralForm686cJob.within_sidekiq_retries_exhausted_block(
-          { 'args' => [claim.id, encrypted_vet_info, encrypted_user_struct] }
-        ) do
-          exhaustion_msg['args'] = [claim.id, encrypted_vet_info, encrypted_user_struct]
-          user_struct.va_profile_email = nil
-          claim.parsed_form['dependents_application'].delete('veteran_contact_information')
-          expect(monitor).to receive(:track_submission_exhaustion).with(exhaustion_msg, nil)
-          expect(SavedClaim::DependencyClaim).to receive(:find).with(claim.id).and_return(claim)
-        end
+    it 'logs the error to zsf and sends an email with the 686C template' do
+      Lighthouse::BenefitsIntake::SubmitCentralForm686cJob.within_sidekiq_retries_exhausted_block(
+        { 'args' => [claim.id, encrypted_vet_info, encrypted_user_struct] }
+      ) do
+        exhaustion_msg['args'] = [claim.id, encrypted_vet_info, encrypted_user_struct]
+        expect(monitor).to receive(:track_submission_exhaustion).with(exhaustion_msg, user_struct.va_profile_email)
+        expect(SavedClaim::DependencyClaim).to receive(:find).with(claim.id).and_return(claim)
+        claim.parsed_form['view:selectable686_options']['report674'] = false
+        expect(Dependents::Form686c674FailureEmailJob).to receive(:perform_async).with(
+          claim.id,
+          'vets.gov.user+228@gmail.com',
+          'form21_686c_action_needed_email_template_id',
+          {
+            'first_name' => 'MARK',
+            'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+            'confirmation_number' => claim.confirmation_number
+          }
+        )
       end
     end
 
-    context 'when the the dependents_failure_callback_email flipper is on' do
-      before do
-        allow(Flipper).to receive(:enabled?).with(:dependents_failure_callback_email).and_return(true)
+    it 'logs the error to zsf and sends an email with the 674 template' do
+      Lighthouse::BenefitsIntake::SubmitCentralForm686cJob.within_sidekiq_retries_exhausted_block(
+        { 'args' => [claim.id, encrypted_vet_info, encrypted_user_struct] }
+      ) do
+        exhaustion_msg['args'] = [claim.id, encrypted_vet_info, encrypted_user_struct]
+        expect(monitor).to receive(:track_submission_exhaustion).with(exhaustion_msg, user_struct.va_profile_email)
+        expect(SavedClaim::DependencyClaim).to receive(:find).with(claim.id).and_return(claim)
+        claim.parsed_form['view:selectable686_options'].delete('add_child')
+        expect(Dependents::Form686c674FailureEmailJob).to receive(:perform_async).with(
+          claim.id,
+          'vets.gov.user+228@gmail.com',
+          'form21_674_action_needed_email_template_id',
+          {
+            'first_name' => 'MARK',
+            'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+            'confirmation_number' => claim.confirmation_number
+          }
+        )
       end
+    end
 
-      it 'logs the error to zsf and sends an email with the 686C template' do
-        Lighthouse::BenefitsIntake::SubmitCentralForm686cJob.within_sidekiq_retries_exhausted_block(
-          { 'args' => [claim.id, encrypted_vet_info, encrypted_user_struct] }
-        ) do
-          exhaustion_msg['args'] = [claim.id, encrypted_vet_info, encrypted_user_struct]
-          expect(monitor).to receive(:track_submission_exhaustion).with(exhaustion_msg, user_struct.va_profile_email)
-          expect(SavedClaim::DependencyClaim).to receive(:find).with(claim.id).and_return(claim)
-          claim.parsed_form['view:selectable686_options']['report674'] = false
-          expect(Dependents::Form686c674FailureEmailJob).to receive(:perform_async).with(
-            claim.id,
-            'vets.gov.user+228@gmail.com',
-            'form21_686c_action_needed_email_template_id',
-            {
-              'first_name' => 'MARK',
-              'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-              'confirmation_number' => claim.confirmation_number
-            }
-          )
-        end
+    it 'logs the error to zsf and a combo email with 686c-674' do
+      Lighthouse::BenefitsIntake::SubmitCentralForm686cJob.within_sidekiq_retries_exhausted_block(
+        { 'args' => [claim.id, encrypted_vet_info, encrypted_user_struct] }
+      ) do
+        exhaustion_msg['args'] = [claim.id, encrypted_vet_info, encrypted_user_struct]
+        expect(monitor).to receive(:track_submission_exhaustion).with(exhaustion_msg, user_struct.va_profile_email)
+        expect(SavedClaim::DependencyClaim).to receive(:find).with(claim.id).and_return(claim)
+        expect(Dependents::Form686c674FailureEmailJob).to receive(:perform_async).with(
+          claim.id,
+          'vets.gov.user+228@gmail.com',
+          'form21_686c_674_action_needed_email_template_id',
+          {
+            'first_name' => 'MARK',
+            'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+            'confirmation_number' => claim.confirmation_number
+          }
+        )
       end
+    end
 
-      it 'logs the error to zsf and sends an email with the 674 template' do
-        Lighthouse::BenefitsIntake::SubmitCentralForm686cJob.within_sidekiq_retries_exhausted_block(
-          { 'args' => [claim.id, encrypted_vet_info, encrypted_user_struct] }
-        ) do
-          exhaustion_msg['args'] = [claim.id, encrypted_vet_info, encrypted_user_struct]
-          expect(monitor).to receive(:track_submission_exhaustion).with(exhaustion_msg, user_struct.va_profile_email)
-          expect(SavedClaim::DependencyClaim).to receive(:find).with(claim.id).and_return(claim)
-          claim.parsed_form['view:selectable686_options'].delete('add_child')
-          expect(Dependents::Form686c674FailureEmailJob).to receive(:perform_async).with(
-            claim.id,
-            'vets.gov.user+228@gmail.com',
-            'form21_674_action_needed_email_template_id',
-            {
-              'first_name' => 'MARK',
-              'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-              'confirmation_number' => claim.confirmation_number
-            }
-          )
-        end
-      end
-
-      it 'logs the error to zsf and a combo email with 686c-674' do
-        Lighthouse::BenefitsIntake::SubmitCentralForm686cJob.within_sidekiq_retries_exhausted_block(
-          { 'args' => [claim.id, encrypted_vet_info, encrypted_user_struct] }
-        ) do
-          exhaustion_msg['args'] = [claim.id, encrypted_vet_info, encrypted_user_struct]
-          expect(monitor).to receive(:track_submission_exhaustion).with(exhaustion_msg, user_struct.va_profile_email)
-          expect(SavedClaim::DependencyClaim).to receive(:find).with(claim.id).and_return(claim)
-          expect(Dependents::Form686c674FailureEmailJob).to receive(:perform_async).with(
-            claim.id,
-            'vets.gov.user+228@gmail.com',
-            'form21_686c_674_action_needed_email_template_id',
-            {
-              'first_name' => 'MARK',
-              'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-              'confirmation_number' => claim.confirmation_number
-            }
-          )
-        end
-      end
-
-      it 'logs the error to zsf and does not send an email' do
-        Lighthouse::BenefitsIntake::SubmitCentralForm686cJob.within_sidekiq_retries_exhausted_block(
-          { 'args' => [claim.id, encrypted_vet_info, encrypted_user_struct] }
-        ) do
-          exhaustion_msg['args'] = [claim.id, encrypted_vet_info, encrypted_user_struct]
-          user_struct.va_profile_email = nil
-          claim.parsed_form['dependents_application'].delete('veteran_contact_information')
-          expect(monitor).to receive(:track_submission_exhaustion).with(exhaustion_msg, nil)
-          expect(SavedClaim::DependencyClaim).to receive(:find).with(claim.id).and_return(claim)
-        end
+    it 'logs the error to zsf and does not send an email' do
+      Lighthouse::BenefitsIntake::SubmitCentralForm686cJob.within_sidekiq_retries_exhausted_block(
+        { 'args' => [claim.id, encrypted_vet_info, encrypted_user_struct] }
+      ) do
+        exhaustion_msg['args'] = [claim.id, encrypted_vet_info, encrypted_user_struct]
+        user_struct.va_profile_email = nil
+        claim.parsed_form['dependents_application'].delete('veteran_contact_information')
+        expect(monitor).to receive(:track_submission_exhaustion).with(exhaustion_msg, nil)
+        expect(SavedClaim::DependencyClaim).to receive(:find).with(claim.id).and_return(claim)
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This pull request removes feature flags for dependents email notifications. It cleans up related flag definitions and updates tests accordingly. This simplifies the codebase by eliminating unnecessary Flipper checks and dead code paths, making the notification logic easier to read, test, and maintain.

## Testing done

- [ ] *New code is covered by unit tests*

## What areas of the site does it impact?
Dependents

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

