### PR TITLE
API-48782-fix-index-response-with-claimant

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -34,11 +34,12 @@ module ClaimsApi
           )
 
           poa_list = service.get_poa_list
+          poa_list_with_dependent_data = add_dependent_data_to_poa_response(poa_list)
 
           raise Common::Exceptions::Lighthouse::BadGateway unless poa_list
 
           render json: ClaimsApi::V2::Blueprints::PowerOfAttorneyRequestBlueprint.render(
-            poa_list, view: :shared_response, root: :data
+            poa_list_with_dependent_data, view: :shared_response, root: :data
           ), status: :ok
         end
 
@@ -164,6 +165,24 @@ module ClaimsApi
         end
 
         private
+
+        def add_dependent_data_to_poa_response(poa_list)
+          poa_list.each do |item|
+            next unless item['claimant_icn']
+
+            first_name, last_name = get_dependent_name(item['claimant_icn'])
+            item['claimantFirstName'] = first_name
+            item['claimantLastName'] = last_name
+          end
+
+          poa_list
+        end
+
+        def get_dependent_name(icn)
+          dependent = build_veteran_or_dependent_data(icn)
+
+          [dependent.first_name, dependent.last_name]
+        end
 
         def validate_decide_representative_params!(poa_code, representative_id)
           representative = ::Veteran::Service::Representative.find_by('? = ANY(poa_codes) AND ? = representative_id',

--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -34,9 +34,9 @@ module ClaimsApi
           )
 
           poa_list = service.get_poa_list
-          poa_list_with_dependent_data = add_dependent_data_to_poa_response(poa_list)
-
           raise Common::Exceptions::Lighthouse::BadGateway unless poa_list
+
+          poa_list_with_dependent_data = add_dependent_data_to_poa_response(poa_list)
 
           render json: ClaimsApi::V2::Blueprints::PowerOfAttorneyRequestBlueprint.render(
             poa_list_with_dependent_data, view: :shared_response, root: :data

--- a/modules/claims_api/spec/services/power_of_attorney_request_service/index_spec.rb
+++ b/modules/claims_api/spec/services/power_of_attorney_request_service/index_spec.rb
@@ -7,11 +7,22 @@ describe ClaimsApi::PowerOfAttorneyRequestService::Index do
   subject { described_class.new(poa_codes: ['002'], page_size: 10, page_index: 1, filter: {}) }
 
   describe '#get_poa_list' do
+    let(:proc_ids) { %w[10906 10907] }
+
+    let(:metadata_with_claimant) do
+      { 'veteran' => { 'vnp_mail_id' => '158364', 'vnp_email_id' => '158365', 'vnp_phone_id' => '112568' },
+        'claimant' => { 'vnp_mail_id' => '158366', 'vnp_email_id' => '158367', 'vnp_phone_id' => '112569' } }
+    end
+
+    let(:metadata_without_claimant) do
+      { 'veteran' => { 'vnp_mail_id' => '158364', 'vnp_email_id' => '158365', 'vnp_phone_id' => '112568' } }
+    end
+
     let(:obj_response_data) do
       {
         'poaRequestRespondReturnVOList' => {
           'poaCode' => '002',
-          'procID' => '10906'
+          'procID' => proc_ids[0]
         }
       }
     end
@@ -20,20 +31,24 @@ describe ClaimsApi::PowerOfAttorneyRequestService::Index do
       {
         'poaRequestRespondReturnVOList' => [{
           'poaCode' => '002',
-          'procID' => '10906'
+          'procID' => proc_ids[0]
         }, {
           'poaCode' => '002',
-          'procID' => '10907'
+          'procID' => proc_ids[1]
         }]
       }
     end
 
+    let(:service_double) { instance_double(ClaimsApi::ManageRepresentativeService) }
+
+    before do
+      allow(ClaimsApi::ManageRepresentativeService).to receive(:new).with(any_args)
+                                                                    .and_return(service_double)
+    end
+
     context 'when page size is set to 1' do
       before do
-        @page_size = 1
-        service_double = instance_double(ClaimsApi::ManageRepresentativeService)
-        allow(ClaimsApi::ManageRepresentativeService).to receive(:new).with(any_args)
-                                                                      .and_return(service_double)
+        subject.instance_variable_set(:@page_size, 1)
         allow(service_double).to receive(:read_poa_request).with(any_args).and_return(obj_response_data)
       end
 
@@ -46,10 +61,7 @@ describe ClaimsApi::PowerOfAttorneyRequestService::Index do
 
     context 'when page size is over 1 and less then the max allowed' do
       before do
-        @page_size = 5
-        service_double = instance_double(ClaimsApi::ManageRepresentativeService)
-        allow(ClaimsApi::ManageRepresentativeService).to receive(:new).with(any_args)
-                                                                      .and_return(service_double)
+        subject.instance_variable_set(:@page_size, 5)
         allow(service_double).to receive(:read_poa_request).with(any_args).and_return(arr_response_data)
       end
 
@@ -57,6 +69,32 @@ describe ClaimsApi::PowerOfAttorneyRequestService::Index do
         expect do
           subject.get_poa_list
         end.not_to raise_error
+      end
+    end
+
+    context 'when claimant information is present on the request' do
+      before do
+        create(:claims_api_power_of_attorney_request,
+               proc_id: proc_ids[0], veteran_icn: '1012667169V030190', claimant_icn: '1013093331V548481',
+               poa_code: '002', metadata: metadata_with_claimant, power_of_attorney_id: nil)
+        create(:claims_api_power_of_attorney_request,
+               proc_id: proc_ids[1], veteran_icn: '1012667169V030190', claimant_icn: nil,
+               poa_code: '003', metadata: metadata_without_claimant, power_of_attorney_id: nil)
+      end
+
+      let(:poa_requests_by_proc_id) do
+        { proc_ids[0] => { id: '8602049e-06c1-4c47-b419-4d64fbaed28d', claimant_icn: '1013093331V548481' } }
+      end
+
+      describe '#map_list_data' do
+        it 'adds claimant ICN to the returned object when it is present on the request' do
+          allow(service_double).to receive(:read_poa_request).with(anything).and_return(arr_response_data)
+
+          res = subject.send(:map_list_data, poa_requests_by_proc_id)
+          record_with_claimant = res.detect { |record| record['procID'] == proc_ids[0] }
+
+          expect(record_with_claimant['claimant_icn']).to eq('1013093331V548481')
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
* Adds dependent `first_name` and `last_name` to the response, when it is included on the request, for returns in the index.  The names will appear inside the `claimant` key in the response (see screenshot below for example)
* In the Index class add the `claimant_icn` to the list if it is present.  It's presence means a dependent was included on the filing.
* We need to return to the request_controller to utilize the target_veteran build.
	* Once back in the controller we get the target_veteran build from the dependent's ICN to get the first and last name and add them to the record
	* This allows it to then show up in the Index method's response
* There were some small refactors done in the Index class to the altered functionality in an effort keep everything clean.  Just two bits of functionality that were moved into their own methods when being updated.

## Related issue(s)
[API-48782](https://jira.devops.va.gov/browse/API-48782)

## Testing done

- [x] *New code is covered by unit tests*

#### Testing Notes
* To see a response wit dependent information attached to it you can hit the index endpoint using poa code '067'

* Creating your own to view will be a little mroe involved.  You will need in your DB:
* A representative (::Veteran::Service::Representative) or Organizaiton (::Veteran::Service::Organization)
* You will then need to create a POA request using a correct veteran/dependent pair (see some examples [here](https://github.com/department-of-veterans-affairs/lighthouse-dash/blob/main/docs/developer/mock_data/dependent_user_relationships.md)) (Janet Moore does not work for this, but Ralph Lee and Margie Curtis do)
* Once that is `create` you can then hit the index endpoint with the POA code you used and should be able to see it (note you may need to increase the page size if there are a lot for thatpoa code, the default is 10 in a return)

## Screenshots
<img width="555" height="624" alt="Screenshot 2025-08-13 at 2 18 14 PM" src="https://github.com/user-attachments/assets/2cec3e64-f198-4bc8-b945-87617a496c3e" />


## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
	modified:   modules/claims_api/app/services/claims_api/power_of_attorney_request_service/index.rb
	modified:   modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
	modified:   modules/claims_api/spec/services/power_of_attorney_request_service/index_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
