### PR TITLE
API-48824-fix-show-response-with-dependent

### DIFF
--- a/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
+++ b/modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
@@ -65,8 +65,7 @@ module ClaimsApi
           end
 
           render json: ClaimsApi::V2::Blueprints::PowerOfAttorneyRequestBlueprint.render(res, view: :shared_response,
-                                                                                              root: :data),
-                 status: :ok
+                                                                                              root: :data), status: :ok
         end
 
         # rubocop:disable Metrics/MethodLength

--- a/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
+++ b/modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb
@@ -305,6 +305,7 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
     end
 
     context 'when the request is filed by a dependent' do
+      let(:service) { instance_double(ClaimsApi::PowerOfAttorneyRequestService::Show) }
       let(:dependent_icn) { '1013093331V548481' }
       let(:poa_res_only_dependent_info) do
         {
@@ -314,19 +315,22 @@ Rspec.describe ClaimsApi::V2::Veterans::PowerOfAttorney::RequestController, type
           'claimantZip' => '92264', 'dateRequestActioned' => '2025-08-13T15:21:51-05:00',
           'dateRequestReceived' => '2025-08-13T15:21:51-05:00', 'declinedReason' => nil, 'healthInfoAuth' => 'Y',
           'poaCode' => '067', 'procID' => '3865154', 'secondaryStatus' => 'New', 'vetFirstName' => 'Margie',
-          'vetLastName' => 'Curtis', 'vetMiddleName' => nil, 'vetPtcpntID' => '600052700',
-          'id' => '2a23a3b5-7b4b-4a0b-bcba-f2d0fa8e51e3', 'claimant_icn' => dependent_icn
+          'vetLastName' => 'Curtis', 'vetMiddleName' => nil, 'vetPtcpntID' => '600052700'
         }
       end
+      let(:poa_request_with_dependent) { create(:claims_api_power_of_attorney_request, claimant_icn: dependent_icn) }
 
-      describe '#add_dependent_data_to_poa_response' do
-        it 'handles an object while adding the first_name and last_name of the claimant to the record' do
-          allow(subject).to receive(:build_veteran_or_dependent_data).with(anything).and_return(dependent)
+      before do
+        allow(ClaimsApi::PowerOfAttorneyRequestService::Show).to receive(:new).and_return(service)
+        allow(service).to receive(:get_poa_request).and_return(poa_res_only_dependent_info)
+      end
 
-          poa_res_with_dependent = subject.send(:add_dependent_data_to_poa_response, poa_res_only_dependent_info)
+      it 'has the claimant firstName andlastName in the response' do
+        mock_ccg(scopes) do |auth_header|
+          show_request_with(id: poa_request_with_dependent.id, auth_header:)
 
-          expect(poa_res_with_dependent.first['claimantFirstName']).to eq(dependent.first_name)
-          expect(poa_res_with_dependent.first['claimantLastName']).to eq(dependent.last_name)
+          expect(JSON.parse(response.body)['data']['attributes']['claimant']['firstName']).not_to be_nil
+          expect(JSON.parse(response.body)['data']['attributes']['claimant']['lastName']).not_to be_nil
         end
       end
     end


### PR DESCRIPTION
## Summary
* Set ups show response to use same method for handling dependent as the Index response
* Adds the dependent first name and last name to the object going to the blueprinter and displays it in the response when present

## Related issue(s)


## Testing done

- [x] *New code is covered by unit tests*

#### Testing Notes
* For this one you will have to create a request.  Make sure the poa code used matches a rep or org in your local DB.  Here is a sample request you can use to create a request:
````
{
  "data": {
    "attributes": {
      "veteran": {
        "serviceNumber": "123678453",
        "serviceBranch": "ARMY",
        "address": {
          "addressLine1":  "2719 Mars Ave",
          "addressLine2": "Apt 2",
          "city": "Los Angeles",
          "countryCode":  "VN",
          "stateCode": "CA",
          "zipCode": "92264",
          "zipCodeSuffix": "0200"
        },
        "phone": {
          "areaCode": "555",
          "phoneNumber": "5551234"
        },
        "email": "test@test.com",
        "insuranceNumber": "1234567890"
      },
      "claimant": {
        "claimantId": "1013030865V203693",
        "address": {
          "addressLine1":  "123 Main St",
          "addressLine2": "Apt 3",
          "city": "Boston",
          "countryCode":  "US",
          "stateCode": "MA",
          "zipCode": "02110",
          "zipCodeSuffix": "1000"
        },
        "phone": {
          "areaCode": "555",
          "phoneNumber": "5559876"
        },
        "email": "example@example.com",
        "relationship": "Spouse"
      },
      "representative": {
        "poaCode": "067" // INDVIDUAL: 067, ORG: 083
      },
      "recordConsent": true,
      "consentAddressChange": true,
      "consentLimits": ["DRUG_ABUSE", "SICKLE_CELL", "HIV", "ALCOHOLISM"]
    }
  }
}
````
* It would be worth the work to test a create without a dependent and make sure it still displays correctly (in which case the claimant first and last name will be nil in the `show` response)
* One you get the ID from the create you can use that to hit the `show` endpoint and make sure it displays correctly

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/claims_api/v2/veterans/power_of_attorney/request_controller.rb
	modified:   modules/claims_api/spec/controllers/v2/veterans/power_of_attorney/request_controller_spec.rb

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
