### PR TITLE
bmt1/115627: only return date (no time stamp)

### DIFF
--- a/lib/claim_letters/providers/claim_letters/lighthouse_claim_letters_provider.rb
+++ b/lib/claim_letters/providers/claim_letters/lighthouse_claim_letters_provider.rb
@@ -114,7 +114,7 @@ class LighthouseClaimLettersProvider
       ClaimLetters::Utils::LetterTransformer.decorate_description(doc_type) || letter['documentTypeLabel']
 
     received_at = parse_date(letter['receivedAt'], 'received_at')
-    upload_date = parse_date(letter['uploadedDateTime'], 'upload_at')
+    upload_date = parse_date(letter['uploadedDateTime'], 'upload_date')
 
     ClaimLetters::Responses::ClaimLetterResponse.new(
       # Please note:
@@ -154,6 +154,7 @@ class LighthouseClaimLettersProvider
   end
 
   def parse_date(date, attribute_name)
+    return nil if date.nil? || date.to_s.strip.empty?
     Date.parse(date)
   rescue => e
     Rails.logger.warn(

--- a/lib/claim_letters/providers/claim_letters/lighthouse_claim_letters_provider.rb
+++ b/lib/claim_letters/providers/claim_letters/lighthouse_claim_letters_provider.rb
@@ -113,8 +113,8 @@ class LighthouseClaimLettersProvider
     type_description =
       ClaimLetters::Utils::LetterTransformer.decorate_description(doc_type) || letter['documentTypeLabel']
 
-    received_at = Time.zone.parse(letter['receivedAt']) if letter['receivedAt']
-    upload_date = Time.zone.parse(letter['uploadedDateTime']) if letter['uploadedDateTime']
+    received_at = Date.parse(letter['receivedAt']) if letter['receivedAt']
+    upload_date = Date.parse(letter['uploadedDateTime']) if letter['uploadedDateTime']
 
     ClaimLetters::Responses::ClaimLetterResponse.new(
       # Please note:

--- a/lib/claim_letters/providers/claim_letters/lighthouse_claim_letters_provider.rb
+++ b/lib/claim_letters/providers/claim_letters/lighthouse_claim_letters_provider.rb
@@ -155,6 +155,7 @@ class LighthouseClaimLettersProvider
 
   def parse_date(date, attribute_name)
     return nil if date.nil? || date.to_s.strip.empty?
+
     Date.parse(date)
   rescue => e
     Rails.logger.warn(

--- a/lib/claim_letters/providers/claim_letters/lighthouse_claim_letters_provider.rb
+++ b/lib/claim_letters/providers/claim_letters/lighthouse_claim_letters_provider.rb
@@ -113,8 +113,8 @@ class LighthouseClaimLettersProvider
     type_description =
       ClaimLetters::Utils::LetterTransformer.decorate_description(doc_type) || letter['documentTypeLabel']
 
-    received_at = Date.parse(letter['receivedAt']) rescue nil if letter['receivedAt']
-    upload_date = Date.parse(letter['uploadedDateTime']) rescue nil if letter['uploadedDateTime']
+    received_at = parse_date(letter['receivedAt'], 'received_at')
+    upload_date = parse_date(letter['uploadedDateTime'], 'upload_at')
 
     ClaimLetters::Responses::ClaimLetterResponse.new(
       # Please note:
@@ -151,5 +151,21 @@ class LighthouseClaimLettersProvider
     end
 
     documents
+  end
+
+  def parse_date(date, attribute_name)
+    Date.parse(date)
+  rescue => e
+    Rails.logger.warn(
+      'Bad claim letter date',
+      {
+        user_uuid: @user.uuid,
+        attribute_name:,
+        date:,
+        error_type: e.class.to_s,
+        error_backtrace: e.backtrace&.first(3)
+      }
+    )
+    nil
   end
 end

--- a/lib/claim_letters/providers/claim_letters/lighthouse_claim_letters_provider.rb
+++ b/lib/claim_letters/providers/claim_letters/lighthouse_claim_letters_provider.rb
@@ -113,8 +113,8 @@ class LighthouseClaimLettersProvider
     type_description =
       ClaimLetters::Utils::LetterTransformer.decorate_description(doc_type) || letter['documentTypeLabel']
 
-    received_at = Date.parse(letter['receivedAt']) if letter['receivedAt']
-    upload_date = Date.parse(letter['uploadedDateTime']) if letter['uploadedDateTime']
+    received_at = Date.parse(letter['receivedAt']) rescue nil if letter['receivedAt']
+    upload_date = Date.parse(letter['uploadedDateTime']) rescue nil if letter['uploadedDateTime']
 
     ClaimLetters::Responses::ClaimLetterResponse.new(
       # Please note:

--- a/spec/lib/claim_letters/providers/lighthouse_claim_letters_provider_spec.rb
+++ b/spec/lib/claim_letters/providers/lighthouse_claim_letters_provider_spec.rb
@@ -781,7 +781,7 @@ RSpec.describe LighthouseClaimLettersProvider do
               {
                 'docTypeId' => 184,
                 'documentUuid' => 'valid-date',
-                'receivedAt' => '2023-06-15',
+                'receivedAt' => '2023-06-15T10:30:00Z',
                 'uploadedDateTime' => '2023-06-15T10:30:00Z'
               }
             ]
@@ -795,9 +795,6 @@ RSpec.describe LighthouseClaimLettersProvider do
 
       before do
         allow(mock_service).to receive(:claim_letters_search).and_return(lighthouse_response)
-        allow(Time.zone).to receive(:parse).and_call_original
-        allow(Time.zone).to receive(:parse).with('').and_return(nil)
-        allow(Time.zone).to receive(:parse).with('not-a-date').and_return(nil)
       end
 
       it 'handles various date parsing scenarios' do
@@ -815,8 +812,7 @@ RSpec.describe LighthouseClaimLettersProvider do
 
         # Valid date should parse correctly
         valid_date_letter = letters.find { |l| l[:document_id] == 'valid-date' }
-        expect(valid_date_letter[:received_at]).not_to be_nil
-        expect(valid_date_letter[:received_at]).to be_a(Date)
+        expect(valid_date_letter[:received_at]).to eq('2023-06-15')
       end
     end
 

--- a/spec/lib/claim_letters/providers/lighthouse_claim_letters_provider_spec.rb
+++ b/spec/lib/claim_letters/providers/lighthouse_claim_letters_provider_spec.rb
@@ -816,7 +816,7 @@ RSpec.describe LighthouseClaimLettersProvider do
         # Valid date should parse correctly
         valid_date_letter = letters.find { |l| l[:document_id] == 'valid-date' }
         expect(valid_date_letter[:received_at]).not_to be_nil
-        expect(valid_date_letter[:received_at]).to be_a(Time)
+        expect(valid_date_letter[:received_at]).to be_a(Date)
       end
     end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- instead of returning a full date stamp, only return year, month, day

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/115627

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
