### PR TITLE
116526 improved fwd proxy tunnel workflow

### DIFF
--- a/rakelib/secure_messaging.rake
+++ b/rakelib/secure_messaging.rake
@@ -1,0 +1,75 @@
+namespace :sm do 
+    desc 'set up test users'
+    task :setup_test_user => :environment do
+        user_number = ENV.fetch('user_number', nil)
+        mhv_correlation_id = ENV.fetch('mhv_id', nil)
+        unless user_number && mhv_correlation_id
+            raise 'Run this task like this: bundle exec rake sm:setup_test_user user_number=210 mhv_id=22336066'
+        end
+        
+        puts("\nCorrelating mock user: vets.gov.user+#{user_number}@gmail.com to MHV ID: #{mhv_correlation_id}")
+
+        idme_uuid = get_idme_uuid(user_number) #'f37e9bef73df46a8a0c3f744e8f05185'
+        icn = MPI::Service.new.find_profile_by_identifier(identifier: idme_uuid, identifier_type: MPI::Constants::IDME_UUID)&.profile&.icn
+
+        puts("\nID.me UUID: #{idme_uuid}")
+        puts("ICN: #{icn}")
+        user_verification = Login::UserVerifier.new(
+            login_type: SAML::User::IDME_CSID,
+            auth_broker: nil,
+            mhv_uuid: nil,
+            idme_uuid: idme_uuid,
+            dslogon_uuid: nil,
+            logingov_uuid: nil,
+            icn: icn
+        ).perform
+
+        user_account = user_verification.user_account
+        
+        print("\nUser verification: ")
+        pp user_verification
+
+        print("\nUser Account: ")
+        pp user_account
+
+        if user_account.needs_accepted_terms_of_use?
+            puts "\nAccepting Terms of Use..."
+            user_account.terms_of_use_agreements.new(agreement_version: IdentitySettings.terms_of_use.current_version).accepted!
+        end
+        
+        print("\nAccepted TOU:")
+        pp user_account.terms_of_use_agreements.current.last
+
+        puts("\nCaching MHV account... (this is the important part)")
+        cache_mhv_account(icn, mhv_correlation_id)
+
+        print("Cached MHV account:")
+        pp Rails.cache.read("mhv_account_creation_#{icn}")
+    end
+
+    def get_idme_uuid(number)
+        path = File.join(Settings.betamocks.cache_dir, 'credentials', 'idme', "vetsgovuser#{number}.json")
+        json = JSON.parse(File.read(path))
+        json['uuid']
+    rescue => e
+        puts("Encountered an error while trying to source ID.me UUID. Is the user number you provided legitimate?")
+        raise e
+    end
+
+    def cache_mhv_account(icn, mhv_correlation_id)
+        Rails.cache.write(
+            "mhv_account_creation_#{icn}",
+            {
+                user_profile_id: mhv_correlation_id,
+                premium: true,
+                champ_va: true,
+                patient: true,
+                sm_account_created: true,
+                message: 'This cache entry was created by rakelib/secure_messaging.rake',
+            }
+        )
+    rescue => e
+        puts "Something went wrong while trying to cache the user's mhv_account."
+        raise e
+    end
+end

--- a/rakelib/secure_messaging.rake
+++ b/rakelib/secure_messaging.rake
@@ -66,10 +66,11 @@ namespace :sm do
                 patient: true,
                 sm_account_created: true,
                 message: 'This cache entry was created by rakelib/secure_messaging.rake',
-            }
+            },
+            expires_in: 1.year
         )
     rescue => e
-        puts "Something went wrong while trying to cache the user's mhv_account."
+        puts "Something went wrong while trying to cache mhv_account for user with ICN: #{icn}."
         raise e
     end
 end


### PR DESCRIPTION
## Summary

_This work is not behind a feature toggle_
Add a rake task to easily configure mock users for development of Secure Messaging application

## Related issue(s)
[116526](https://github.com/department-of-veterans-affairs/va.gov-team/issues/116526)
[This documentation](https://github.com/department-of-veterans-affairs/mhv-developer-docs/blob/main/how-to/setting_up_SM_with_mhv_api_tunnel.md)

## What areas of the site does it impact?
Records on the developer's local db and redis cache

## Acceptance criteria

- [ ]  When socat tunnel is running, mock users should be able to send and receive messages locally via the SM application
