### PR TITLE
[Form 526] Improve logging detail on Veteran claim submission

### DIFF
--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -163,7 +163,8 @@ module V0
         in_progress_form = InProgressForm.form_for_user(FormProfiles::VA526ez::FORM_ID, @current_user) if @current_user
 
         monitor.track_saved_claim_save_error(
-          claim&.errors,
+          # Array of ActiveModel::Error instances from the claim that failed to save
+          claim&.errors&.errors,
           in_progress_form&.id,
           @current_user.uuid
         )

--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -160,7 +160,7 @@ module V0
     def log_failure(claim)
       if Flipper.enabled?(:disability_526_track_saved_claim_error) && claim&.errors
         monitor = DisabilityCompensation::Loggers::Monitor.new
-        in_progress_form = @current_user ? InProgressForm.form_for_user(claim.form_id, @current_user) : nil
+        in_progress_form = InProgressForm.form_for_user(FormProfiles::VA526ez::FORM_ID, @current_user) if @current_user
 
         monitor.track_saved_claim_save_error(
           claim&.errors,

--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -6,6 +6,7 @@ require 'evss/disability_compensation_form/form4142'
 require 'evss/disability_compensation_form/service'
 require 'lighthouse/benefits_reference_data/response_strategy'
 require 'disability_compensation/factories/api_provider_factory'
+require 'disability_compensation/loggers/monitor'
 
 module V0
   class DisabilityCompensationFormsController < ApplicationController
@@ -157,6 +158,17 @@ module V0
     end
 
     def log_failure(claim)
+      if Flipper.enabled?(:disability_526_track_saved_claim_error) && claim&.errors
+        monitor = DisabilityCompensation::Loggers::Monitor.new
+        in_progress_form = @current_user ? InProgressForm.form_for_user(claim.form_id, @current_user) : nil
+
+        monitor.track_saved_claim_save_error(
+          claim&.errors,
+          in_progress_form&.id,
+          @current_user.uuid
+        )
+      end
+
       StatsD.increment("#{stats_key}.failure")
       raise Common::Exceptions::ValidationErrors, claim
     end

--- a/config/features.yml
+++ b/config/features.yml
@@ -753,6 +753,9 @@ features:
     actor_type: user
     description: enables the 2024 version of form 4142 in the disability 526 submission frontend workflow
     enable_in_development: true
+  disability_526_track_saved_claim_error:
+    actor_type: user
+    description: enables improved logging of SavedClaim::DisabilityCompensation::Form526AllClaim save failures
   education_reports_cleanup:
     actor_type: user
     description: Updates to the daily education reports to remove old data that isn't needed in the new fiscal year

--- a/lib/disability_compensation/loggers/monitor.rb
+++ b/lib/disability_compensation/loggers/monitor.rb
@@ -25,30 +25,31 @@ module DisabilityCompensation
 
       # Logs SavedClaim ActiveRecord save errors
       #
-      # We use these logs to debug unforseen validation issues with
-      # SavedClaim::DisabilityCompensation::Form526AllClaim saves to the database. Saves in_progress_form_id, since we
+      # We use these logs to debug unforseen validation issues when
+      # SavedClaim::DisabilityCompensation::Form526AllClaim saves to the database. Includes in_progress_form_id, since we
       # can use this to inspect Veteran's form selections in the production console, even if claim itself failed to save
       #
-      # @param saved_claim_errors [ActiveModel::Errors] errors object from a SavedClaim that failed to save
+      # @param saved_claim_errors [Array<ActiveModel::Error>] array of error objects from a SavedClaim that failed to save
       # @param in_progress_form_id [Integer] ID of the InProgressForm for this claim
       # @param user_uuid [uuid] uuid of the user attempting to save the claim
-      def track_saved_claim_save_error(saved_claim_errors, in_progress_form_id, user_uuid)
-        error_details = {
-          error_details: saved_claim_errors&.details.to_s,
-          error_messages: saved_claim_errors&.full_messages.to_s
-        }
-
+      def track_saved_claim_save_error(errors, in_progress_form_id, user_uuid)
         submit_event(
           :error,
           "#{self.class.name} Form526 SavedClaim save error",
           self.class::CLAIM_STATS_KEY,
           in_progress_form_id:,
-          user_uuid:,
-          **error_details
+          user_account_uuid: user_uuid,
+          form_id: '21-526EZ-ALLCLAIMS',
+          errors: format_active_model_errors(errors)
         )
       end
 
       private
+
+      # Loops through array of ActiveModel::Error instances and formats a readable log
+      def format_active_model_errors(errors)
+        errors.map { |error| { "#{error.attribute}": error.type.to_s } }.to_s
+      end
 
       ##
       # Module application name used for logging

--- a/spec/lib/disability_compensation/loggers/monitor_spec.rb
+++ b/spec/lib/disability_compensation/loggers/monitor_spec.rb
@@ -35,4 +35,38 @@ RSpec.describe DisabilityCompensation::Loggers::Monitor do
       )
     end
   end
+
+  describe('#track_saved_claim_save_error') do
+    let(:user) { build(:disabilities_compensation_user, icn: '123498767V234859') }
+    let(:in_progress_form) { create(:in_progress_form) }
+
+    let(:error_details) { { base: [{ error: :invalid }] } }
+    let(:error_messages) { ['Base is invalid', 'Other Error Message'] }
+
+    let(:mock_errors) do
+      instance_double(
+        ActiveModel::Errors,
+        details: error_details,
+        full_messages: error_messages
+      )
+    end
+
+    it 'logs the error metadata' do
+      expect(monitor).to receive(:submit_event).with(
+        :error,
+        "#{described_class} Form526 SavedClaim save error",
+        described_class::CLAIM_STATS_KEY,
+        in_progress_form_id: in_progress_form.id,
+        user_uuid: user.uuid,
+        error_details: error_details.to_s,
+        error_messages: error_messages.to_s
+      )
+
+      monitor.track_saved_claim_save_error(
+        mock_errors,
+        in_progress_form.id,
+        user.uuid
+      )
+    end
+  end
 end

--- a/spec/lib/disability_compensation/loggers/monitor_spec.rb
+++ b/spec/lib/disability_compensation/loggers/monitor_spec.rb
@@ -68,12 +68,13 @@ RSpec.describe DisabilityCompensation::Loggers::Monitor do
     end
 
     # NOTE: in_progress_form_id, user_account_uuid, and errors keys are whitelisted payload keys
-    # for monitors inheriting from Logging::BaseMonitor; ensures this informaiton will not be filtered out when it is
+    # for monitors inheriting from Logging::BaseMonitor; ensures this information will not be filtered out when it is
     # written to the Rails logger; see config/initializers/filter_parameter_logging.rb
     it 'does not filter out error details when writing to the Rails logger' do
       expect(Rails.logger).to receive(:error) do |_, payload|
         expect(payload[:context][:user_account_uuid]).to eq(user.uuid)
         expect(payload[:context][:errors]).to eq([{ form: mock_form_error }].to_s)
+        expect(payload[:context][:in_progress_form_id]).to eq(in_progress_form.id)
       end
 
       monitor.track_saved_claim_save_error(

--- a/spec/lib/disability_compensation/loggers/monitor_spec.rb
+++ b/spec/lib/disability_compensation/loggers/monitor_spec.rb
@@ -39,16 +39,14 @@ RSpec.describe DisabilityCompensation::Loggers::Monitor do
   describe('#track_saved_claim_save_error') do
     let(:user) { build(:disabilities_compensation_user, icn: '123498767V234859') }
     let(:in_progress_form) { create(:in_progress_form) }
+    let(:mock_form_error) { 'Mock form validation error' }
 
-    let(:error_details) { { base: [{ error: :invalid }] } }
-    let(:error_messages) { ['Base is invalid', 'Other Error Message'] }
-
-    let(:mock_errors) do
-      instance_double(
-        ActiveModel::Errors,
-        details: error_details,
-        full_messages: error_messages
-      )
+    let(:claim_with_save_error) do
+      claim = SavedClaim::DisabilityCompensation::Form526AllClaim.new
+      errors = ActiveModel::Errors.new(claim)
+      errors.add(:form, mock_form_error)
+      allow(claim).to receive_messages(errors:)
+      claim
     end
 
     it 'logs the error metadata' do
@@ -56,14 +54,30 @@ RSpec.describe DisabilityCompensation::Loggers::Monitor do
         :error,
         "#{described_class} Form526 SavedClaim save error",
         described_class::CLAIM_STATS_KEY,
+        form_id: '21-526EZ-ALLCLAIMS',
         in_progress_form_id: in_progress_form.id,
-        user_uuid: user.uuid,
-        error_details: error_details.to_s,
-        error_messages: error_messages.to_s
+        errors: [{ form: mock_form_error }].to_s,
+        user_account_uuid: user.uuid
       )
 
       monitor.track_saved_claim_save_error(
-        mock_errors,
+        claim_with_save_error.errors.errors,
+        in_progress_form.id,
+        user.uuid
+      )
+    end
+
+    # NOTE: in_progress_form_id, user_account_uuid, and errors keys are whitelisted payload keys
+    # for monitors inheriting from Logging::BaseMonitor; ensures this informaiton will not be filtered out when it is
+    # written to the Rails logger; see config/initializers/filter_parameter_logging.rb
+    it 'does not filter out error details when writing to the Rails logger' do
+      expect(Rails.logger).to receive(:error) do |_, payload|
+        expect(payload[:context][:user_account_uuid]).to eq(user.uuid)
+        expect(payload[:context][:errors]).to eq([{ form: mock_form_error }].to_s)
+      end
+
+      monitor.track_saved_claim_save_error(
+        claim_with_save_error.errors,
         in_progress_form.id,
         user.uuid
       )

--- a/spec/requests/v0/disability_compensation_form_spec.rb
+++ b/spec/requests/v0/disability_compensation_form_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 require 'lighthouse/auth/client_credentials/service'
 require 'lighthouse/service_exception'
 require 'disability_compensation/factories/api_provider_factory'
+require 'disability_compensation/loggers/monitor'
 
 RSpec.describe 'V0::DisabilityCompensationForm', type: :request do
   include SchemaMatchers
@@ -325,6 +326,67 @@ RSpec.describe 'V0::DisabilityCompensationForm', type: :request do
         json_object['form526'].delete('newSecondaryDisabilities')
         updated_form = JSON.generate(json_object)
         post('/v0/disability_compensation_form/submit_all_claim', params: updated_form, headers:)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'SavedClaim::DisabilityCompensation::Form526AllClaim save error logging' do
+    let(:form_params) { File.read 'spec/support/disability_compensation_form/all_claims_fe_submission.json' }
+    let(:claim_with_save_error) do
+      claim = SavedClaim::DisabilityCompensation::Form526AllClaim.new
+      errors = ActiveModel::Errors.new(claim)
+      errors.add(:base, 'mock validation error')
+      allow(claim).to receive_messages(errors:, save: false)
+      claim
+    end
+
+    context 'when the disability_526_track_saved_claim_error Flipper is enabled' do
+      before do
+        Flipper.enable(:disability_526_track_saved_claim_error)
+      end
+
+      after { Flipper.disable(:disability_526_track_saved_claim_error) }
+
+      context 'when the claim fails to save' do
+        before do
+          allow(SavedClaim::DisabilityCompensation::Form526AllClaim).to receive(:from_hash)
+            .and_return(claim_with_save_error)
+        end
+
+        it 'logs save errors for the claim and still returns a 422' do
+          expect_any_instance_of(DisabilityCompensation::Loggers::Monitor).to receive(:track_saved_claim_save_error)
+
+          post('/v0/disability_compensation_form/submit_all_claim', params: form_params, headers:)
+
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+
+      context 'when the claim saves successfully' do
+        it 'does not track an error and returns a 200 response' do
+          expect_any_instance_of(DisabilityCompensation::Loggers::Monitor)
+            .not_to receive(:track_saved_claim_save_error)
+
+          post('/v0/disability_compensation_form/submit_all_claim', params: form_params, headers:)
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+
+    context 'when the disability_526_track_saved_claim_error Flipper is disabled' do
+      before do
+        Flipper.disable(:disability_526_track_saved_claim_error)
+        allow(SavedClaim::DisabilityCompensation::Form526AllClaim).to receive(:from_hash)
+          .and_return(claim_with_save_error)
+      end
+
+      it 'does not log save errors and still returns a 422' do
+        expect_any_instance_of(DisabilityCompensation::Loggers::Monitor)
+          .not_to receive(:track_saved_claim_save_error)
+
+        post('/v0/disability_compensation_form/submit_all_claim', params: form_params, headers:)
+
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end

--- a/spec/requests/v0/disability_compensation_form_spec.rb
+++ b/spec/requests/v0/disability_compensation_form_spec.rb
@@ -358,7 +358,7 @@ RSpec.describe 'V0::DisabilityCompensationForm', type: :request do
         it 'logs save errors for the claim and still returns a 422' do
           expect_any_instance_of(DisabilityCompensation::Loggers::Monitor).to receive(:track_saved_claim_save_error)
             .with(
-              claim_with_save_error.errors,
+              claim_with_save_error.errors.errors,
               in_progress_form.id,
               user.uuid
             )


### PR DESCRIPTION

## Summary

- *This work is behind a feature toggle (flipper): **YES**
- *(Summarize the changes that have been made to the platform)*

Adds more detailed logging to SavedClaim save errors on the Form 526 submit_all_claim endpoint.

This is the primary endpoint for Form 526, where a Veteran submits their claim, but some Veterans have been triggering error responses (primarily 422s) and the existing logging just doesn't save enough information for us to pinpoint the cause of those errors.

Leverages the shared monitoring framework built by the Pensions and Burials team that I extended to Disability Benefits in https://github.com/department-of-veterans-affairs/vets-api/pull/23142. This provides a standardized method of tracking and logging events.


**Note one of the requirements of the ticket is that this logging protects against logging PII; this behavior was already implemented as part of the monitoring framework [here](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/logging/monitor.rb#L26)**

- *(Which team do you work for, does your team own the maintenance of this component?)*

Specialized Pathways (Disability Benefits Experience); we do.

- *(If introducing a flipper, what is the success criteria being targeted?)*

The Flipper is a simple killswitch to turn on to begin logging these errors. It will likely stay on if the logging seems to be working correctly over a week or so; it will probably be removed after that. There doesn't seem to be any risk in turning it on it's just a safety featrue.

**Note I intentionally introduced this code in a branch of logic in the controller that handles SavedClaim errors, so if there are any issues it won't interrupt valid claims**

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/115462


## Testing done

- [X] *New code is covered by unit tests*

- *What is the testing plan for rolling out the feature?*

See notes on Flipper above


## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation) N/A
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable) N/A
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected N/A
- [ ]  I added a screenshot of the developed feature N/A