### PR TITLE
API 47335 - 526 Validation Rules 5c(i, ii, iii, iv): `changeOfAddress`

### DIFF
--- a/modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
+++ b/modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
@@ -490,7 +490,9 @@ RSpec.describe ClaimsApi::RevisedDisabilityCompensationValidations do
   end
 
   describe '#validate_form_526_current_mailing_address_country!' do
-    let(:valid_countries) { ['Bolivia', 'China', 'Serbia/Montenegro'] }
+    # These country values are the example ones displayed in the API documentation
+    # at https://developer.va.gov/explore/api/benefits-reference-data/docs?version=current
+    let(:valid_countries) { %w[Bolivia China Serbia/Montenegro] }
 
     before do
       # Stubbing this because it's a method on the subject that fetches data from BRD
@@ -543,6 +545,116 @@ RSpec.describe ClaimsApi::RevisedDisabilityCompensationValidations do
 
       it 'raises an InvalidFieldValue error' do
         expect { subject.validate_form_526_current_mailing_address_country! }
+          .to raise_error(Common::Exceptions::InvalidFieldValue)
+      end
+    end
+  end
+
+  describe '#validate_form_526_change_of_address!' do
+    let(:valid_countries) { %w[USA Canada] }
+
+    before do
+      # Stubbing this because it's a method on the subject that fetches data from BRD
+      # rubocop:disable RSpec/SubjectStub
+      allow(subject).to receive(:valid_countries).and_return(valid_countries)
+      # rubocop:enable RSpec/SubjectStub
+    end
+
+    context 'when changeOfAddress is blank' do
+      let(:form_attributes) { { 'veteran' => { 'changeOfAddress' => nil } } }
+
+      it 'does not raise an error' do
+        expect { subject.validate_form_526_change_of_address! }.not_to raise_error
+      end
+    end
+
+    context 'when addressChangeType is TEMPORARY' do
+      let(:form_attributes) do
+        {
+          'veteran' => {
+            'changeOfAddress' => {
+              'addressChangeType' => 'TEMPORARY',
+              'beginningDate' => 1.day.from_now.to_date.iso8601,
+              'endingDate' => 2.days.from_now.to_date.iso8601,
+              'country' => 'USA'
+            }
+          }
+        }
+      end
+
+      it 'does not raise an error for valid dates and country' do
+        expect { subject.validate_form_526_change_of_address! }.not_to raise_error
+      end
+
+      it 'raises error if beginningDate is not in the future' do
+        form_attributes['veteran']['changeOfAddress']['beginningDate'] = 1.day.ago.to_date.iso8601
+        expect { subject.validate_form_526_change_of_address! }
+          .to raise_error(Common::Exceptions::InvalidFieldValue)
+      end
+
+      it 'raises error if endingDate is missing' do
+        form_attributes['veteran']['changeOfAddress'].delete('endingDate')
+        expect { subject.validate_form_526_change_of_address! }
+          .to raise_error(Common::Exceptions::InvalidFieldValue)
+      end
+
+      it 'raises error if beginningDate is after or equal to endingDate' do
+        form_attributes['veteran']['changeOfAddress']['endingDate'] = form_attributes['veteran']['changeOfAddress']['beginningDate']
+        expect { subject.validate_form_526_change_of_address! }
+          .to raise_error(Common::Exceptions::InvalidFieldValue)
+      end
+
+      it 'raises error if country is invalid' do
+        form_attributes['veteran']['changeOfAddress']['country'] = 'Invalid'
+        expect { subject.validate_form_526_change_of_address! }
+          .to raise_error(Common::Exceptions::InvalidFieldValue)
+      end
+    end
+
+    context 'when addressChangeType is PERMANENT' do
+      let(:form_attributes) do
+        {
+          'veteran' => {
+            'changeOfAddress' => {
+              'addressChangeType' => 'PERMANENT',
+              'endingDate' => nil,
+              'country' => 'USA'
+            }
+          }
+        }
+      end
+
+      it 'does not raise an error if endingDate is not present' do
+        expect { subject.validate_form_526_change_of_address! }.not_to raise_error
+      end
+
+      it 'raises error if endingDate is present' do
+        form_attributes['veteran']['changeOfAddress']['endingDate'] = 1.day.from_now.to_date.iso8601
+        expect { subject.validate_form_526_change_of_address! }
+          .to raise_error(Common::Exceptions::InvalidFieldValue)
+      end
+
+      it 'raises error if country is invalid' do
+        form_attributes['veteran']['changeOfAddress']['country'] = 'Invalid'
+        expect { subject.validate_form_526_change_of_address! }
+          .to raise_error(Common::Exceptions::InvalidFieldValue)
+      end
+    end
+
+    context 'when country is missing' do
+      let(:form_attributes) do
+        {
+          'veteran' => {
+            'changeOfAddress' => {
+              'addressChangeType' => 'PERMANENT'
+              # country missing
+            }
+          }
+        }
+      end
+
+      it 'raises an InvalidFieldValue error' do
+        expect { subject.validate_form_526_change_of_address! }
           .to raise_error(Common::Exceptions::InvalidFieldValue)
       end
     end


### PR DESCRIPTION
## Summary

_This is a continuation of the work started [here](https://github.com/department-of-veterans-affairs/vets-api/pull/23421)._

This PR adds validation rules for a change of address, as well as accompanying specs.

|| Business rules addressed|
|-|-|
|Strikethrough: obsolete rule; Red text: new messaging/behavior|<img width="1019" height="107" alt="Screenshot 2025-08-12 at 14 27 47" src="https://github.com/user-attachments/assets/6e37381e-f665-4ec6-8b8e-751d2b80c45b" />|

## Related issue(s)

|[Jira ticket](https://jira.devops.va.gov/browse/API-47335)|
|-|
|<img width="967" height="801" alt="Screenshot 2025-08-06 at 08 58 46" src="https://github.com/user-attachments/assets/1e4504fb-25d0-40f1-81e1-83ca4124595c" />|

## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

```
modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
```

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
