### PR TITLE
Add new vamobile_client_id for development SIS config

### DIFF
--- a/config/identity_settings/environments/staging.yml
+++ b/config/identity_settings/environments/staging.yml
@@ -62,6 +62,7 @@ sign_in:
   vamobile_client_id:
     - vamobile
     - vamobile_test
+    - vamobile_test_dev
 
 ssoe_eauth_cookie:
   domain: .va.gov


### PR DESCRIPTION
## Summary

- Adding a new `vamobile_client_id` setting to work with new SIS config `vamobile_test_dev`. This client is matched with a localhost redirect so that the Mobile Dev Tools rebuild can be tested in development.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-mobile-app/issues/11419