### PR TITLE
change not_self_sufficient from payload into does_child_have_permanen…

### DIFF
--- a/app/models/bgs_dependents_v2/child.rb
+++ b/app/models/bgs_dependents_v2/child.rb
@@ -94,7 +94,7 @@ module BGSDependentsV2
       @reason_marriage_ended = reason_marriage_ended
       @ever_married_ind = marriage_indicator
       @child_income = formatted_boolean(@child_info['income_in_last_year'])
-      @not_self_sufficient = formatted_boolean(@child_info['not_self_sufficient'])
+      @not_self_sufficient = formatted_boolean(@child_info['does_child_have_permanent_disability'])
       @first = @child_info['full_name']['first']
       @middle = @child_info['full_name']['middle']
       @last = @child_info['full_name']['last']

--- a/spec/models/bgs_dependents_v2/child_spec.rb
+++ b/spec/models/bgs_dependents_v2/child_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe BGSDependentsV2::Child do
       'marriage_end_description' => 'description of annulment',
       'full_name' => { 'first' => 'first', 'middle' => 'middle', 'last' => 'last' },
       'ssn' => '987654321',
-      'birth_date' => '2005-01-01'
+      'birth_date' => '2005-01-01',
+      'does_child_have_permanent_disability' => false
     }
   end
   let(:all_flows_payload_v2) { build(:form686c_674_v2) }
@@ -54,7 +55,7 @@ RSpec.describe BGSDependentsV2::Child do
           'last' => 'last',
           'suffix' => nil,
           'child_income' => 'N',
-          'not_self_sufficient' => nil
+          'not_self_sufficient' => 'N'
         }
       end
 


### PR DESCRIPTION
…t_disability

Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): NO*
- Change the handling of the payload to look for does_child_have_permanent_disability instead of not_self_sufficient when building the bgs model.
-VA Lifestage Dependents


## Related issue(s)

[- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/117020)
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
