### PR TITLE
Remove logging from lib/pdf_fill/filler.rb

### DIFF
--- a/lib/pdf_fill/filler.rb
+++ b/lib/pdf_fill/filler.rb
@@ -179,7 +179,6 @@ module PdfFill
 
       file_path = stamp_form(file_path, submit_date) if should_stamp_form?(form_id, fill_options, submit_date)
       output = combine_extras(file_path, hash_converter.extras_generator)
-      Rails.logger.info('PdfFill done', fill_options.merge(form_id:, file_name_extension:, extras: output != file_path))
       output
     end
     # rubocop:enable Metrics/MethodLength

--- a/lib/pdf_fill/filler.rb
+++ b/lib/pdf_fill/filler.rb
@@ -178,8 +178,7 @@ module PdfFill
       )
 
       file_path = stamp_form(file_path, submit_date) if should_stamp_form?(form_id, fill_options, submit_date)
-      output = combine_extras(file_path, hash_converter.extras_generator)
-      output
+      combine_extras(file_path, hash_converter.extras_generator)
     end
     # rubocop:enable Metrics/MethodLength
 


### PR DESCRIPTION
## Summary
Form 21-686c-674 was logging too much info.


## Related issue(s)
https://dsva.slack.com/archives/CBU0KDSB1/p1755289823971839

## Testing done

- [ ] After deploy, logs should be gone. 

## Screenshots
All of the logs contain this message:
<img width="234" height="27" alt="image" src="https://github.com/user-attachments/assets/381af767-6e39-4a06-89e4-51c7d90bdef1" />
So I'm removing the log completely. 

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
