### PR TITLE
Update config certificate api creation

### DIFF
--- a/app/models/sign_in/client_config.rb
+++ b/app/models/sign_in/client_config.rb
@@ -6,7 +6,10 @@ module SignIn
     attribute :refresh_token_duration, :interval
 
     has_many :config_certificates, as: :config, dependent: :destroy, inverse_of: :config
-    has_many :certs, through: :config_certificates, class_name: 'SignIn::Certificate', inverse_of: :client_configs
+    has_many :certs, through: :config_certificates,
+                     class_name: 'SignIn::Certificate',
+                     inverse_of: :client_configs,
+                     index_errors: true
 
     accepts_nested_attributes_for :certs,
                                   allow_destroy: true,
@@ -80,7 +83,7 @@ module SignIn
           cert = certs.find(id)
           certs.destroy(cert)
         else
-          cert = SignIn::Certificate.find_or_create_by(pem:)
+          cert = SignIn::Certificate.find_or_initialize_by(pem:)
           certs << cert unless certs.include?(cert)
         end
       end

--- a/app/models/sign_in/service_account_config.rb
+++ b/app/models/sign_in/service_account_config.rb
@@ -7,7 +7,8 @@ module SignIn
     has_many :config_certificates, as: :config, dependent: :destroy, inverse_of: :config
     has_many :certs, through: :config_certificates,
                      class_name: 'SignIn::Certificate',
-                     inverse_of: :service_account_configs
+                     inverse_of: :service_account_configs,
+                     index_errors: true
 
     accepts_nested_attributes_for :certs,
                                   allow_destroy: true,
@@ -31,7 +32,7 @@ module SignIn
           cert = certs.find(id)
           certs.destroy(cert)
         else
-          cert = SignIn::Certificate.find_or_create_by(pem:)
+          cert = SignIn::Certificate.find_or_initialize_by(pem:)
           certs << cert unless certs.include?(cert)
         end
       end

--- a/db/seeds/development/identity/client_configs.rb
+++ b/db/seeds/development/identity/client_configs.rb
@@ -111,5 +111,3 @@ sample_client_api.update!(authentication: SignIn::Constants::Auth::API,
                           access_token_audience: 'sample_client',
                           logout_redirect_uri: 'http://localhost:4567',
                           refresh_token_duration: SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES)
-
-SignIn::ClientConfig.where(certificates: nil).update(certificates: [])

--- a/spec/controllers/sign_in/client_configs_controller_spec.rb
+++ b/spec/controllers/sign_in/client_configs_controller_spec.rb
@@ -73,14 +73,48 @@ RSpec.describe SignIn::ClientConfigsController, type: :controller do
     end
 
     context 'with certs_attributes' do
-      let(:cert) { create(:sign_in_certificate) }
+      context 'when a cert with the pem already exists' do
+        let!(:cert) { create(:sign_in_certificate) }
 
-      it 'creates a new certificate for the client config' do
-        post :create, params: { client_config: valid_attributes.merge(certs_attributes: [cert.attributes]) }, as: :json
+        it 'associates the existing cert with the client config' do
+          post :create, params: { client_config: valid_attributes.merge(certs_attributes: [cert.attributes]) },
+                        as: :json
 
-        expect(response).to have_http_status(:created)
-        expect(response_body['certs']).to include(a_hash_including('id' => cert.id))
-        expect(SignIn::ClientConfig.last.certs).to include(cert)
+          expect(response).to have_http_status(:created)
+          expect(response_body['certs']).to include(a_hash_including('id' => cert.id))
+          expect(SignIn::ClientConfig.last.certs).to include(cert)
+        end
+
+        it 'does not create a new cert' do
+          expect do
+            post :create, params: { client_config: valid_attributes.merge(certs_attributes: [cert.attributes]) },
+                          as: :json
+          end.not_to change(SignIn::Certificate, :count)
+        end
+      end
+
+      context 'when a cert with the pem does not exist' do
+        let(:cert) { build(:sign_in_certificate) }
+
+        it 'creates a new certificate and associates it with the client config' do
+          post :create, params: { client_config: valid_attributes.merge(certs_attributes: [cert.attributes]) },
+                        as: :json
+
+          expect(response).to have_http_status(:created)
+          expect(response_body['certs']).to include(a_hash_including('pem' => cert.pem))
+          expect(SignIn::Certificate.count).to eq(1)
+        end
+      end
+
+      context 'when a cert has a validation error' do
+        let(:cert) { build(:sign_in_certificate, pem: 'bad_pem') }
+
+        it 'does not create the cert and returns an error' do
+          post :create, params: { client_config: valid_attributes.merge(certs_attributes: [cert.attributes]) },
+                        as: :json
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response_body.dig('errors', 'certs[0].pem')).to include('not a valid X.509 certificate')
+        end
       end
     end
   end

--- a/spec/models/sign_in/client_config_spec.rb
+++ b/spec/models/sign_in/client_config_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe SignIn::ClientConfig, type: :model do
            access_token_duration:,
            access_token_audience:,
            refresh_token_duration:,
-           certificates:,
            access_token_attributes:,
            enforced_terms:,
            terms_of_use_url:,
@@ -24,7 +23,6 @@ RSpec.describe SignIn::ClientConfig, type: :model do
   end
   let(:client_id) { 'some-client-id' }
   let(:authentication) { SignIn::Constants::Auth::API }
-  let(:certificates) { [] }
   let(:anti_csrf) { false }
   let(:shared_sessions) { false }
   let(:json_api_compatibility) { false }

--- a/spec/models/sign_in/service_account_config_spec.rb
+++ b/spec/models/sign_in/service_account_config_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe SignIn::ServiceAccountConfig, type: :model do
-  let(:certificates) { [] }
   let(:service_account_id) { SecureRandom.hex }
   let(:access_token_duration) { SignIn::Constants::ServiceAccountAccessToken::VALIDITY_LENGTH_SHORT_MINUTES }
   let(:description) { 'some-description' }
@@ -15,8 +14,7 @@ RSpec.describe SignIn::ServiceAccountConfig, type: :model do
            access_token_duration:,
            description:,
            access_token_audience:,
-           access_token_user_attributes:,
-           certificates:)
+           access_token_user_attributes:)
   end
 
   describe 'associations' do


### PR DESCRIPTION
## Summary

- Update config certificate creation to initialize instead of create so if errors occur on config.save the errors are properly nested for multiple certs
   ```ruby
   <ActiveModel::Error attribute=certs[0].pem, type=certificate is expired, options={}> 
   ```

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/581

# Testing
## Setup
migrate and seed the database
- `rails db:migrate`
- `rails db:seed`

Start the server
- `rails s`
- start a rails console - `rails c`

Update the service account config used to request an access token
- `rails c`
```ruby
SignIn::ServiceAccountConfig.find_by(service_account_id: 'sample_sts_service_account').update!(scopes: ['http://localhost:3000/sign_in/service_account_configs', 'http://localhost:3000/sign_in/client_configs'])
```

## Service Account Configs:

Run these requests in the rails console - `rails c`
**Note:** if your token expires just request a new one

### Request access token
```ruby
assertion_payload = {
  iss: 'http://localhost:3000',
  sub: 'vets.gov.user+0@gmail.com',
  aud: 'http://localhost:3000/v0/sign_in/token',
  iat: Time.zone.now.to_i,
  exp: Time.zone.now.to_i + 1000,
  scopes: ['http://localhost:3000/sign_in/service_account_configs'],
  service_account_id: 'sample_sts_service_account'
}

private_key = OpenSSL::PKey::RSA.new(File.read('spec/fixtures/sign_in/sts_client.pem'))
assertion = JWT.encode(assertion_payload, private_key, 'RS256')

# Generate Token
token_query_params = {
  grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
  assertion: assertion
}

token_uri = URI.parse('http://localhost:3000/v0/sign_in/token')
token_uri.query = token_query_params.to_query

http = Net::HTTP.new(token_uri.host, token_uri.port)
token_request = Net::HTTP::Post.new(token_uri.request_uri)
token = JSON.parse(http.request(token_request).body)['data']['access_token']
```
### Test `certs` Errors
```ruby
uri = URI.parse('http://localhost:3000/sign_in/service_account_configs')
request = Net::HTTP::Post.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  service_account_config: {
    service_account_id: 'sample_sts_service_account_new2',
    description: 'Sample STS service account',
    access_token_audience: 'http://localhost:3000',
    access_token_duration: 300,
    scopes: [],
    certs_attributes: [
      {
         pem: 'bad_pem'
      }
    ]
  }
}.to_json

response = http.request(request)
JSON.parse(response.body) # you should get the correct nested error for certs
```

### POST - Create config with certs
```ruby
uri = URI.parse('http://localhost:3000/sign_in/service_account_configs')
request = Net::HTTP::Post.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  service_account_config: {
    service_account_id: 'sample_sts_service_account_new2',
    description: 'Sample STS service account',
    access_token_audience: 'http://localhost:3000',
    access_token_duration: 300,
    scopes: [],
    certs_attributes: [
      {
         pem: File.read('spec/fixtures/sign_in/identity_dashboard_service_account.crt')
      }
    ]
  }
}.to_json

response = http.request(request)
JSON.parse(response.body) # you should see certs array in the response
```

### PUT - update config - Delete a cert. Should destroy the join table relation not the certificate itself
```ruby
service_account_id = 'sample_sts_service_account_new2'
uri = URI.parse("http://localhost:3000/sign_in/service_account_configs/#{service_account_id}")
request = Net::HTTP::Put.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  service_account_config: {
    certs_attributes: [
      {
        id: "0f54112f-e8ac-4aa2-a5aa-5af981e11626", # replace this with the cert ID in POST response
        _destroy: "true"
      }
    ]
  }
}.to_json

response = http.request(request)
JSON.parse(response.body) 
```

## Client Configs:

Run these requests in the rails console
**Note:** if your token expires just request a new one

### Request access token
```ruby
assertion_payload = {
  iss: 'http://localhost:3000',
  sub: 'vets.gov.user+0@gmail.com',
  aud: 'http://localhost:3000/v0/sign_in/token',
  iat: Time.zone.now.to_i,
  exp: Time.zone.now.to_i + 1000,
  scopes: ['http://localhost:3000/sign_in/client_configs'],
  service_account_id: 'sample_sts_service_account'
}

private_key = OpenSSL::PKey::RSA.new(File.read('spec/fixtures/sign_in/sts_client.pem'))
assertion = JWT.encode(assertion_payload, private_key, 'RS256')

# Generate Token
token_query_params = {
  grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
  assertion: assertion
}

token_uri = URI.parse('http://localhost:3000/v0/sign_in/token')
token_uri.query = token_query_params.to_query

http = Net::HTTP.new(token_uri.host, token_uri.port)
token_request = Net::HTTP::Post.new(token_uri.request_uri)
token = JSON.parse(http.request(token_request).body)['data']['access_token']
```
### Test `certs` errors
```ruby
uri = URI.parse('http://localhost:3000/sign_in/client_configs')
request = Net::HTTP::Post.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  client_config: {
    client_id: 'sample_client_config_new2',
    description: 'Sample Client Config',
    authentication: 'cookie',
    anti_csrf: true,
    redirect_uri: 'http://localhost:3000/sessions/callback',
    access_token_duration: 300,
    refresh_token_duration: 1800,
    logout_redirect_uri: 'http://localhost:3000/sessions/logout_callback',
    pkce: true,
    certs_attributes: [
      {
         pem: 'bad_pem'
      }
    ]
  }
}.to_json

response = http.request(request)
JSON.parse(response.body) # you should get the correct nested error for certs
```

### POST - Create config with certs
```ruby
uri = URI.parse('http://localhost:3000/sign_in/client_configs')
request = Net::HTTP::Post.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  client_config: {
    client_id: 'sample_client_config_new2',
    description: 'Sample Client Config',
    authentication: 'cookie',
    anti_csrf: true,
    redirect_uri: 'http://localhost:3000/sessions/callback',
    access_token_duration: 300,
    refresh_token_duration: 1800,
    logout_redirect_uri: 'http://localhost:3000/sessions/logout_callback',
    pkce: true,
    certs_attributes: [
      {
         pem: File.read('spec/fixtures/sign_in/identity_dashboard_service_account.crt')
      }
    ]
  }
}.to_json

response = http.request(request)
JSON.parse(response.body)
```

### PUT - update config - Delete a cert. Should destroy the join table relation not the certificate itself
```ruby
client_id = 'sample_client_config_new2'
uri = URI.parse("http://localhost:3000/sign_in/client_configs/#{client_id}")
request = Net::HTTP::Put.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  client_config: {
    certs_attributes: [
      {
        id: "0f54112f-e8ac-4aa2-a5aa-5af981e11626", # replace this with the cert ID in POST response
        _destroy: "true"
      }
    ]
  }
}.to_json

response = http.request(request)
JSON.parse(response.body)
```

## What areas of the site does it impact?
Sign-in service

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
