### PR TITLE
arp/fix_user_with_toggler

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/application_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/application_controller.rb
@@ -37,7 +37,7 @@ module AccreditedRepresentativePortal
     def deny_access_unless_form_enabled(form_id)
       form_class = SavedClaim::BenefitsIntake.form_class_from_proper_form_id(form_id)
       routing_error unless form_class&.const_defined?(:FEATURE_FLAG) &&
-                           Flipper.enabled?(form_class::FEATURE_FLAG)
+                           Flipper.enabled?(form_class::FEATURE_FLAG, @current_user)
     end
 
     def routing_error


### PR DESCRIPTION
## Summary

- We had a user of our app not be able to upload a form. there was an error with how our toggler was being used in the call stack 
  
We were able to recreate the bug with our toggler locally and added @current_user into the method. It worked

## Related issue(s)

- https://github.com/orgs/department-of-veterans-affairs/projects/1471/views/6?sliceBy%5Bvalue%5D=In+Progress&pane=issue&itemId=124789146&issue=department-of-veterans-affairs%7Cva.gov-team%7C117132

## Testing done

- walked through locally



## What areas of the site does it impact?
representative/representative-form-upload

## Acceptance criteria

- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
