### PR TITLE
enhance-copilot-instructions-docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,19 @@
 ## Overview
 vets-api is a Ruby on Rails API that powers the website VA.gov. It's a wrapper around VA data services with utilities and tools that support interaction with those services on behalf of a veteran The main user of the APIs is vets-website, the frontend repo that powers VA.gov. Both of them are in this GitHub organization.
 
+## External Documentation References
+When reviewing code or suggesting improvements, reference these comprehensive VA Platform documentation resources:
+- **API Development Guidelines**: https://depo-platform-documentation.scrollhelp.site/developer-docs/api-development
+- **Architecture Patterns**: https://depo-platform-documentation.scrollhelp.site/design/architecture
+- **Security Standards**: https://depo-platform-documentation.scrollhelp.site/developer-docs/security
+- **Testing Guidelines**: https://depo-platform-documentation.scrollhelp.site/developer-docs/testing
+- **Platform Standards**: https://depo-platform-documentation.scrollhelp.site/developer-docs/platform-standards
+- **Error Handling**: https://depo-platform-documentation.scrollhelp.site/developer-docs/error-handling
+- **Database Guidelines**: https://depo-platform-documentation.scrollhelp.site/developer-docs/database
+- **Monitoring & Alerting**: https://depo-platform-documentation.scrollhelp.site/developer-docs/monitoring
+- **Code Review Best Practices**: https://depo-platform-documentation.scrollhelp.site/developer-docs/code-review
+- **API Documentation Standards**: https://depo-platform-documentation.scrollhelp.site/developer-docs/api-documentation
+
 ## Architecture & Patterns
 - Rails API-only app.
 - Follows REST conventions.


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

Enhances Copilot PR reviews and code suggestions by providing links to comprehensive VA Platform documentation including:
- API development guidelines
- Architecture patterns
- Security standards
- Testing guidelines
- Platform standards
- Error handling
- Database guidelines
- Monitoring & alerting
- Code review best practices
- API documentation standards

This allows Copilot to reference official VA Platform standards during code reviews while maintaining all existing instructions and avoiding repository bloat.


## Related issue(s)

- [116423](https://github.com/department-of-veterans-affairs/va.gov-team/issues/116423)
