### PR TITLE
Update preferred dates to use full weekday

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
@@ -24,9 +24,9 @@ module VAOS
       INPUT_FORMAT = '%m/%d/%Y %p'
 
       # Output format for preferred dates
-      # Example: "Thu, July 18, 2024 in the ..."
-      OUTPUT_FORMAT_AM = '%a, %B %-d, %Y in the morning'
-      OUTPUT_FORMAT_PM = '%a, %B %-d, %Y in the afternoon'
+      # Example: "Thursday, July 8, 2024 in the ..."
+      OUTPUT_FORMAT_AM = '%A, %B %-d, %Y in the morning'
+      OUTPUT_FORMAT_PM = '%A, %B %-d, %Y in the afternoon'
 
       # Modifies the appointment, extracting individual fields from the reason code text whenever possible.
       #

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -42,9 +42,9 @@ module VAOS
       ].freeze
 
       # Output format for preferred dates
-      # Example: "Thu, July 18, 2024 in the ..."
-      OUTPUT_FORMAT_AM = '%a, %B %-d, %Y in the morning'
-      OUTPUT_FORMAT_PM = '%a, %B %-d, %Y in the afternoon'
+      # Example: "Thursday, July 8, 2024 in the ..."
+      OUTPUT_FORMAT_AM = '%A, %B %-d, %Y in the morning'
+      OUTPUT_FORMAT_PM = '%A, %B %-d, %Y in the afternoon'
 
       # rubocop:disable Metrics/MethodLength
       def get_appointments(start_date, # rubocop:disable Metrics/ParameterLists

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -2259,15 +2259,15 @@ describe VAOS::V2::AppointmentsService do
       # demonstrates that the preferred dates from reason code text are not overwritten.
       appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, user:).attributes
       subject.send(:extract_appointment_fields, appt)
-      expect(appt[:preferred_dates]).to eq(['Wed, June 26, 2024 in the morning',
-                                            'Wed, June 26, 2024 in the afternoon'])
+      expect(appt[:preferred_dates]).to eq(['Wednesday, June 26, 2024 in the morning',
+                                            'Wednesday, June 26, 2024 in the afternoon'])
     end
 
     it 'extracts preferred dates if possible' do
       appt = build(:appointment_form_v2, :community_cares_multiple_request_dates, user:).attributes
       subject.send(:extract_appointment_fields, appt)
-      expect(appt[:preferred_dates]).to eq(['Wed, August 28, 2024 in the morning',
-                                            'Wed, August 28, 2024 in the afternoon'])
+      expect(appt[:preferred_dates]).to eq(['Wednesday, August 28, 2024 in the morning',
+                                            'Wednesday, August 28, 2024 in the afternoon'])
     end
 
     it 'do not extract preferred dates if no requested periods' do

--- a/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
@@ -71,8 +71,8 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       expect(appt[:contact][:telecom][1]).to eq({ type: 'email', value: 'myemail72585885@unattended.com' })
       expect(appt[:patient_comments]).to eq('colon:in:comment')
       expect(appt[:reason_for_appointment]).to eq('Routine/Follow-up')
-      expect(appt[:preferred_dates]).to eq(['Wed, June 26, 2024 in the morning',
-                                            'Wed, June 26, 2024 in the afternoon'])
+      expect(appt[:preferred_dates]).to eq(['Wednesday, June 26, 2024 in the morning',
+                                            'Wednesday, June 26, 2024 in the afternoon'])
       expect(appt[:preferred_modality]).to eq('In person')
     end
 
@@ -84,8 +84,8 @@ describe VAOS::V2::AppointmentsReasonCodeService do
         expect(appt[:contact][:telecom][1]).to eq({ type: 'email', value: 'myemail72585885@unattended.com' })
         expect(appt[:patient_comments]).to be_nil
         expect(appt[:reason_for_appointment]).to be_nil
-        expect(appt[:preferred_dates]).to eq(['Wed, June 26, 2024 in the morning',
-                                              'Wed, June 26, 2024 in the afternoon'])
+        expect(appt[:preferred_dates]).to eq(['Wednesday, June 26, 2024 in the morning',
+                                              'Wednesday, June 26, 2024 in the afternoon'])
         expect(appt[:preferred_modality]).to eq('In person')
       end
     end
@@ -148,10 +148,11 @@ describe VAOS::V2::AppointmentsReasonCodeService do
   describe '#extract_preferred_dates' do
     [
       ['', nil],
-      ['06/26/2024 AM', ['Wed, June 26, 2024 in the morning']],
-      ['06/26/2024 PM', ['Wed, June 26, 2024 in the afternoon']],
-      ['06/26/2024 AM,06/26/2024 PM', ['Wed, June 26, 2024 in the morning', 'Wed, June 26, 2024 in the afternoon']],
-      ['09/06/2024 PM', ['Fri, September 6, 2024 in the afternoon']]
+      ['06/26/2024 AM', ['Wednesday, June 26, 2024 in the morning']],
+      ['06/26/2024 PM', ['Wednesday, June 26, 2024 in the afternoon']],
+      ['06/26/2024 AM,06/26/2024 PM',
+       ['Wednesday, June 26, 2024 in the morning', 'Wednesday, June 26, 2024 in the afternoon']],
+      ['09/06/2024 PM', ['Friday, September 6, 2024 in the afternoon']]
     ].each do |input, output|
       it "#{input} returns #{output}" do
         input_hash = {}


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- From Accessibility feedback we decided to use full weekday names (e.g. Friday) instead of abbreviations (e.g. Fri).
- United Appointments Experience

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111877

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
