### PR TITLE
Updated Burials::BenefitsIntake::SubmitClaimJob to fix flakey failures

### DIFF
--- a/modules/burials/spec/lib/benefits_intake/submit_claim_job_spec.rb
+++ b/modules/burials/spec/lib/benefits_intake/submit_claim_job_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Burials::BenefitsIntake::SubmitClaimJob, :uploader_helpers do
 
       expect { job.perform(claim.id, :user_account_uuid) }.to raise_error(
         ActiveRecord::RecordNotFound,
-        "Couldn't find UserAccount with 'id'=user_account_uuid"
+        /Couldn't find UserAccount/
       )
     end
 

--- a/modules/dependents_verification/spec/lib/dependents_verification/benefits_intake/submit_claim_job_spec.rb
+++ b/modules/dependents_verification/spec/lib/dependents_verification/benefits_intake/submit_claim_job_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe DependentsVerification::BenefitsIntake::SubmitClaimJob, :uploader
 
       expect { job.perform(claim.id, :user_account_uuid) }.to raise_error(
         ActiveRecord::RecordNotFound,
-        "Couldn't find UserAccount with 'id'=user_account_uuid"
+        /Couldn't find UserAccount/
       )
     end
 

--- a/modules/income_and_assets/spec/lib/income_and_assets/benefits_intake/submit_claim_job_spec.rb
+++ b/modules/income_and_assets/spec/lib/income_and_assets/benefits_intake/submit_claim_job_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe IncomeAndAssets::BenefitsIntake::SubmitClaimJob, :uploader_helper
 
       expect { job.perform(claim.id, :user_account_uuid) }.to raise_error(
         ActiveRecord::RecordNotFound,
-        "Couldn't find UserAccount with 'id'=user_account_uuid"
+        /Couldn't find UserAccount/
       )
     end
 

--- a/modules/pensions/spec/lib/benefits_intake/submit_claim_job_spec.rb
+++ b/modules/pensions/spec/lib/benefits_intake/submit_claim_job_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Pensions::BenefitsIntake::SubmitClaimJob, :uploader_helpers do
 
       expect { job.perform(claim.id, :user_account_uuid) }.to raise_error(
         ActiveRecord::RecordNotFound,
-        "Couldn't find UserAccount with 'id'=user_account_uuid"
+        /Couldn't find UserAccount/
       )
     end
 


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

Fix flaky spec in SubmitClaimJob by updating the error matcher to use a regex. When jobs run in parallel, user_account_uuid may be passed as a symbol (:user_account_uuid) instead of a string, causing intermittent failures. This change ensures the spec reliably matches the ActiveRecord::RecordNotFound error regardless of symbol vs string formatting.

Other related specs were also updated because future RuboCop versions will not allow literal matches like "Couldn't find UserAccount with 'id'=user_account_uuid". This change ensures all specs reliably match the ActiveRecord::RecordNotFound error regardless of symbol vs string formatting.

Error:
```
  1) Burials::BenefitsIntake::SubmitClaimJob#perform is unable to find user_account
     Failure/Error: 
       expect { job.perform(claim.id, :user_account_uuid) }.to raise_error(
         ActiveRecord::RecordNotFound,
         "Couldn't find UserAccount with 'id'=user_account_uuid"
       )
       Expected raised exception #<ActiveRecord::RecordNotFound "Couldn't find UserAccount with 'id'=:user_account_uuid">
                        to match a kind of ActiveRecord::RecordNotFound with message "Couldn't find UserAccount with 'id'=user_account_uuid"
     # ./modules/burials/spec/lib/benefits_intake/submit_claim_job_spec.rb:96:in `block (3 levels) in <top (required)>'
     # /usr/local/bundle/cache/ruby/3.3.0/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/cache/ruby/3.3.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # /usr/local/bundle/cache/ruby/3.3.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # /usr/local/bundle/cache/ruby/3.3.0/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # /usr/local/bundle/cache/ruby/3.3.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'

```
The flakey lines were updated to match the error message more loosely.
```
expect { job.perform(claim.id, :user_account_uuid) }.to raise_error(
  ActiveRecord::RecordNotFound,
  /Couldn't find UserAccount/
)
```

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
