### PR TITLE
Fix: Configure TOE service to use correct configuration

### DIFF
--- a/config/initializers/breakers.rb
+++ b/config/initializers/breakers.rb
@@ -12,6 +12,7 @@ require 'dgi/eligibility/configuration'
 require 'dgi/status/configuration'
 require 'dgi/submission/configuration'
 require 'dgi/letters/configuration'
+require 'dgi/toe/configuration'
 require 'evss/claims_service'
 require 'evss/common_service'
 require 'evss/disability_compensation_form/configuration'
@@ -96,6 +97,7 @@ Rails.application.reloader.to_prepare do
     ClaimsApi::LocalBGS.breakers_service,
     MebApi::DGI::Configuration.instance.breakers_service,
     MebApi::DGI::Letters::Configuration.instance.breakers_service,
+    MebApi::DGI::Toe::Configuration.instance.breakers_service,
     UnifiedHealthData::Configuration.instance.breakers_service,
     MDOT::Configuration.instance.breakers_service,
     Eps::Configuration.instance.breakers_service,

--- a/modules/meb_api/lib/dgi/toe/service.rb
+++ b/modules/meb_api/lib/dgi/toe/service.rb
@@ -10,7 +10,7 @@ module MebApi
   module DGI
     module Toe
       class Service < MebApi::DGI::Service
-        configuration MebApi::DGI::Letters::Configuration
+        configuration MebApi::DGI::Toe::Configuration
         STATSD_KEY_PREFIX = 'api.dgi.status'
 
         def get_toe_letter(claimant_id)


### PR DESCRIPTION
Root cause: TOE service was incorrectly using Letters configuration, causing Breakers middleware conflicts when both services shared the same config and service name.

Changes:
- Updated TOE service to use MebApi::DGI::Toe::Configuration
- Added TOE configuration to Breakers client registration
- Resolves 'DGI/Letters' service name error in production logs

This ensures each service has its own distinct Breakers configuration with unique service names: Letters='DGI/Letters', TOE='DGI/ToeLetters'

Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): NO*
We've been seeing production errors about missing service_name arguments for the Breakers middleware, specifically mentioning "DGI/Letters".
Turns out the TOE service was accidentally configured to use the Letters configuration instead of its own. This meant both services were trying to use the same Breakers setup with the same service name, causing conflicts.
Fixed it by updating the TOE service to use MebApi::DGI::toe::Configuration and registering it properly in the Breakers initializer. Now the Letters service uses 'DGI/Letters' and TOE uses 'DGI/ToeLetters'.
**Changed:**
•  modules/meb_api/lib/dgi/toe/service.rb - switched to correct configuration
•  config/initializers/breakers.rb - added TOE service registration

## Related issue(s)
[DataDog Logs for issue](https://vagov.ddog-gov.com/logs?query=env%3Aeks-prod%20%22Please%20pass%20a%20service_name%20argument%20to%20the%20Breakers%20middleware%20for%20service%3A%20DGI%2FLetters%22%20status%3Aerror&agg_m=count&agg_m_source=base&agg_q=%40message_content&agg_q_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1754252237485&to_ts=1755615606000&live=false)
<img width="2558" height="1290" alt="Screenshot 2025-08-20 at 1 13 58 PM" src="https://github.com/user-attachments/assets/c65636d3-9bc9-4003-83f5-5e633939cbe4" />


## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?


## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
