### PR TITLE
API 47335 - 526 Validation Rules 7t, 7u, 7v, 7w: `disabilities`

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
@@ -207,10 +207,11 @@ module ClaimsApi
     def validate_form_526_disabilities!
       validate_form_526_fewer_than_150_disabilities!
       validate_form_526_disability_classification_code!
-      # TODO: pull these validations over from original 526 validations
-      # validate_form_526_disability_approximate_begin_date!
-      # validate_form_526_special_issues!
-      # validate_form_526_disability_secondary_disabilities!
+      validate_form_526_disability_approximate_begin_date!
+      validate_form_526_special_issues!
+      # TODO: These will be added in a followup
+      # validate_form_526_disability_unique_names!
+      # validate_form_526_disability_names!
     end
 
     def validate_form_526_fewer_than_150_disabilities!
@@ -259,6 +260,68 @@ module ClaimsApi
                                                             classification_code)
         end
       end
+    end
+
+    def validate_form_526_disability_approximate_begin_date!
+      disabilities = form_attributes['disabilities']
+      return if disabilities.blank?
+
+      disabilities.each do |disability|
+        approx_begin_date = disability['approximateBeginDate']
+        next if approx_begin_date.blank?
+
+        next if Date.parse(approx_begin_date) < Time.zone.today
+
+        raise ::Common::Exceptions::InvalidFieldValue.new('disability.approximateBeginDate', approx_begin_date)
+      end
+    end
+
+    def validate_form_526_special_issues!
+      disabilities = form_attributes['disabilities']
+      return if disabilities.blank?
+
+      disabilities.each do |disability|
+        special_issues = disability['specialIssues']
+        next if special_issues.blank?
+
+        if invalid_hepatitis_c_special_issue?(special_issues:, disability:)
+          message = "'disability.specialIssues' :: Claim must include a disability with the name 'hepatitis'"
+          raise ::Common::Exceptions::InvalidFieldValue.new(message, special_issues)
+        end
+
+        if invalid_pow_special_issue?(special_issues:)
+          message = "'disability.specialIssues' :: Claim must include valid 'serviceInformation.confinements' value"
+          raise ::Common::Exceptions::InvalidFieldValue.new(message, special_issues)
+        end
+
+        if invalid_type_increase_special_issue?(special_issues:)
+          message = "'disability.specialIssues' :: A Special Issue cannot be added to a primary disability after " \
+                    'the disability has been rated'
+          raise ::Common::Exceptions::InvalidFieldValue.new(message, special_issues)
+        end
+      end
+    end
+
+    def invalid_hepatitis_c_special_issue?(special_issues:, disability:)
+      # if 'specialIssues' includes 'HEPC', then EVSS requires the disability 'name' to equal 'hepatitis'
+      special_issues.include?('HEPC') && !disability['name'].casecmp?('hepatitis')
+    end
+
+    def invalid_pow_special_issue?(special_issues:)
+      return false unless special_issues.include?('POW')
+
+      # if 'specialIssues' includes 'POW', then EVSS requires there also be a 'serviceInformation.confinements'
+      confinements = form_attributes['serviceInformation']['confinements']
+      confinements.blank?
+    end
+
+    def invalid_type_increase_special_issue?(special_issues:)
+      return false unless form_attributes['disabilityActionType'] == 'INCREASE'
+      return false if special_issues.blank?
+
+      # if 'specialIssues' includes 'EMP' or 'RRD', then EVSS allows the disability to be submitted with a type of
+      # INCREASE otherwise, the disability must not have any special issues
+      true unless special_issues.include?('EMP') || special_issues.include?('RRD')
     end
   end
 end


### PR DESCRIPTION
## Summary

_This is a continuation of the work started [here](https://github.com/department-of-veterans-affairs/vets-api/pull/23421)._

This PR adds validation rules for a disabilities, as well as accompanying specs. Note that while pictured, 7a is not covered in this PR (it is already enforced by the 526 schema).

|| Business rules addressed|
|-|-|
|Strikethrough: obsolete rule; Red text: new messaging/behavior|<img width="1250" height="323" alt="Screenshot 2025-08-20 at 12 22 06" src="https://github.com/user-attachments/assets/977a99f0-0b1b-45b3-8706-b006c36bb25c" />|

## Related issue(s)

|[Jira ticket](https://jira.devops.va.gov/browse/API-47335)|
|-|
|<img width="967" height="801" alt="Screenshot 2025-08-06 at 08 58 46" src="https://github.com/user-attachments/assets/1e4504fb-25d0-40f1-81e1-83ca4124595c" />|

## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

```
modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
```

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
