### PR TITLE
refactor(monitoring): use official span.set_error for proper Datadog error tracing

### DIFF
--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/monitoring.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/monitoring.rb
@@ -25,9 +25,7 @@ module AccreditedRepresentativePortal
         begin
           yield(span)
         rescue => e
-          span.set_tag('error', true)
-          span.set_tag('error.type', e.class.name)
-          span.set_tag('error.message', e.message)
+          span.set_error(e)
           raise
         end
       end

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/monitoring_spec.rb
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/monitoring_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe AccreditedRepresentativePortal::Monitoring do
 
     before do
       allow(Datadog::Tracing).to receive(:trace).and_yield(mock_span)
-      allow(mock_span).to receive(:set_tag)
+      allow(mock_span).to receive(:set_error)
     end
 
     it 'calls Datadog::Tracing.trace with the correct span name and service' do
@@ -81,14 +81,12 @@ RSpec.describe AccreditedRepresentativePortal::Monitoring do
       let(:error_message) { 'Something went wrong!' }
       let(:test_error) { StandardError.new(error_message) }
 
-      it 'sets error tags on the span' do
-        expect(mock_span).to receive(:set_tag).with('error', true)
-        expect(mock_span).to receive(:set_tag).with('error.type', test_error.class.name)
-        expect(mock_span).to receive(:set_tag).with('error.message', error_message)
+      it 'calls set_error on the span' do
+        expect(mock_span).to receive(:set_error).with(test_error)
 
         expect do
           subject.trace(span_name) { raise test_error }
-        end.to raise_error(test_error) # Ensure the original error is re-raised
+        end.to raise_error(test_error)
       end
 
       it 're-raises the original exception' do


### PR DESCRIPTION
This is a tiny but important improvement.

Replaces manual error tagging (set_tag('error', ...)) with span.set_error(e) to ensure Datadog correctly captures and classifies span errors. Updates corresponding specs to assert set_error behavior instead of legacy tag checks.

This fix allows Datadog to classify the span as an official error instead of just having error metadata.

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
