### PR TITLE
FES Validations part 3

### DIFF
--- a/modules/claims_api/spec/controllers/concerns/claims_api/v2/revised_disability_compensation_validation_spec.rb
+++ b/modules/claims_api/spec/controllers/concerns/claims_api/v2/revised_disability_compensation_validation_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe ClaimsApi::V2::RevisedDisabilityCompensationValidation do
   let(:test_class) do
     Class.new do
       include ClaimsApi::V2::RevisedDisabilityCompensationValidation
+      include ClaimsApi::V2::DisabilityCompensationSharedServiceModule
 
       attr_accessor :form_attributes
 
@@ -197,6 +198,349 @@ RSpec.describe ClaimsApi::V2::RevisedDisabilityCompensationValidation do
           error_details = errors.map { |e| e[:detail] }
           expect(error_details).to include(match(/claim date was in the future/))
           expect(error_details).to include('activeDutyEndDate (0) needs to be after activeDutyBeginDate.')
+        end
+      end
+    end
+
+    # FES Val Section 7: disabilities validations
+    context 'disabilities validations' do
+      context 'when disabilities array is empty' do
+        let(:form_attributes) do
+          base_form_attributes.merge('disabilities' => [])
+        end
+
+        it 'returns validation error' do
+          errors = subject.validate_form_526_fes_values
+          expect(errors).to be_an(Array)
+          expect(errors.first[:source]).to eq('/disabilities')
+          expect(errors.first[:detail]).to eq('List of disabilities must be provided')
+        end
+      end
+
+      context 'when disabilities exceed 150' do
+        let(:form_attributes) do
+          disabilities = Array.new(151) { |i| { 'name' => "Disability #{i}" } }
+          base_form_attributes.merge('disabilities' => disabilities)
+        end
+
+        it 'returns validation error' do
+          errors = subject.validate_form_526_fes_values
+          expect(errors).to be_an(Array)
+          error = errors.find { |e| e[:detail].include?('must be between 1 and 150') }
+          expect(error).not_to be_nil
+        end
+      end
+
+      context 'NONE with secondary disabilities' do
+        context 'when NONE has secondary but no diagnosticCode' do
+          let(:form_attributes) do
+            base_form_attributes.merge(
+              'disabilities' => [{
+                'name' => 'PTSD',
+                'disabilityActionType' => 'NONE',
+                'secondaryDisabilities' => [{ 'name' => 'Anxiety' }]
+              }]
+            )
+          end
+
+          it 'returns validation error' do
+            errors = subject.validate_form_526_fes_values
+            expect(errors).to be_an(Array)
+            error = errors.find { |e| e[:detail].include?('NONE" is not currently supported') }
+            expect(error).not_to be_nil
+          end
+        end
+      end
+
+      context 'REOPEN validation' do
+        context 'when disabilityActionType is REOPEN' do
+          let(:form_attributes) do
+            base_form_attributes.merge(
+              'disabilities' => [{
+                'name' => 'PTSD',
+                'disabilityActionType' => 'REOPEN'
+              }]
+            )
+          end
+
+          it 'returns validation error' do
+            errors = subject.validate_form_526_fes_values
+            expect(errors).to be_an(Array)
+            error = errors.find { |e| e[:detail].include?('REOPEN" is not currently supported') }
+            expect(error).not_to be_nil
+          end
+        end
+      end
+
+      context 'disability name validations' do
+        context 'when name is missing' do
+          let(:form_attributes) do
+            base_form_attributes.merge(
+              'disabilities' => [{
+                'disabilityActionType' => 'NEW'
+              }]
+            )
+          end
+
+          it 'returns validation error' do
+            errors = subject.validate_form_526_fes_values
+            expect(errors).to be_an(Array)
+            expect(errors.first[:source]).to eq('/disabilities/0/name')
+            expect(errors.first[:detail]).to include('disability name (0) is required')
+          end
+        end
+
+        context 'when name exceeds 255 characters' do
+          let(:form_attributes) do
+            base_form_attributes.merge(
+              'disabilities' => [{
+                'name' => 'A' * 256,
+                'disabilityActionType' => 'NEW'
+              }]
+            )
+          end
+
+          it 'returns validation error' do
+            errors = subject.validate_form_526_fes_values
+            expect(errors).to be_an(Array)
+            error = errors.find { |e| e[:detail].include?('less than 256 characters') }
+            expect(error).not_to be_nil
+          end
+        end
+
+        context 'when NEW disability name has invalid format' do
+          let(:form_attributes) do
+            base_form_attributes.merge(
+              'disabilities' => [{
+                'name' => 'PTSD!!!',
+                'disabilityActionType' => 'NEW'
+              }]
+            )
+          end
+
+          it 'returns validation error' do
+            errors = subject.validate_form_526_fes_values
+            expect(errors).to be_an(Array)
+            error = errors.find { |e| e[:detail].include?('does not match the expected format') }
+            expect(error).not_to be_nil
+          end
+        end
+      end
+
+      context 'approximateBeginDate validations' do
+        context 'when date is in future' do
+          let(:form_attributes) do
+            base_form_attributes.merge(
+              'disabilities' => [{
+                'name' => 'PTSD',
+                'disabilityActionType' => 'NEW',
+                'approximateBeginDate' => (Date.current + 30).to_s
+              }]
+            )
+          end
+
+          it 'returns validation error' do
+            errors = subject.validate_form_526_fes_values
+            expect(errors).to be_an(Array)
+            error = errors.find { |e| e[:detail].include?('must be in the past') }
+            expect(error).not_to be_nil
+          end
+        end
+
+        context 'when month is invalid' do
+          let(:form_attributes) do
+            base_form_attributes.merge(
+              'disabilities' => [{
+                'name' => 'PTSD',
+                'disabilityActionType' => 'NEW',
+                'approximateBeginDate' => '2020-13-01'
+              }]
+            )
+          end
+
+          it 'returns month validation error' do
+            errors = subject.validate_form_526_fes_values
+            expect(errors).to be_an(Array)
+            error = errors.find { |e| e[:detail] == 'The month is not a valid value' }
+            expect(error).not_to be_nil
+          end
+        end
+
+        context 'when day is invalid' do
+          let(:form_attributes) do
+            base_form_attributes.merge(
+              'disabilities' => [{
+                'name' => 'PTSD',
+                'disabilityActionType' => 'NEW',
+                'approximateBeginDate' => '2020-02-30'
+              }]
+            )
+          end
+
+          it 'returns day validation error' do
+            errors = subject.validate_form_526_fes_values
+            expect(errors).to be_an(Array)
+            error = errors.find { |e| e[:detail] == 'The day is not a valid value' }
+            expect(error).not_to be_nil
+          end
+        end
+
+        context 'when date is invalid' do
+          let(:form_attributes) do
+            base_form_attributes.merge(
+              'disabilities' => [{
+                'name' => 'PTSD',
+                'disabilityActionType' => 'NEW',
+                'approximateBeginDate' => 'invalid-date'
+              }]
+            )
+          end
+
+          it 'returns validation error' do
+            errors = subject.validate_form_526_fes_values
+            expect(errors).to be_an(Array)
+            # This will fail the parse_date_safely check
+            expect(errors).not_to be_nil
+          end
+        end
+      end
+
+      context 'special issues validations' do
+        context 'when INCREASE has invalid special issue' do
+          let(:form_attributes) do
+            base_form_attributes.merge(
+              'disabilities' => [{
+                'name' => 'PTSD',
+                'disabilityActionType' => 'INCREASE',
+                'diagnosticCode' => '9411',
+                'ratedDisabilityId' => '123',
+                'specialIssues' => ['ALS']
+              }]
+            )
+          end
+
+          it 'returns validation error' do
+            errors = subject.validate_form_526_fes_values
+            expect(errors).to be_an(Array)
+            error = errors.find { |e| e[:detail].include?('cannot be added to a primary disability after') }
+            expect(error).not_to be_nil
+          end
+        end
+
+        context 'when HEPC without Hepatitis' do
+          let(:form_attributes) do
+            base_form_attributes.merge(
+              'disabilities' => [{
+                'name' => 'Back Pain',
+                'disabilityActionType' => 'NEW',
+                'specialIssues' => ['HEPC']
+              }]
+            )
+          end
+
+          it 'returns validation error' do
+            errors = subject.validate_form_526_fes_values
+            expect(errors).to be_an(Array)
+            error = errors.find { |e| e[:detail].include?('HEPC can only exist for the disability Hepatitis') }
+            expect(error).not_to be_nil
+          end
+        end
+
+        context 'when POW without confinements' do
+          let(:form_attributes) do
+            base_form_attributes.merge(
+              'disabilities' => [{
+                'name' => 'PTSD',
+                'disabilityActionType' => 'NEW',
+                'specialIssues' => ['POW']
+              }],
+              'serviceInformation' => {
+                'servicePeriods' => [{
+                  'activeDutyBeginDate' => '2000-01-01',
+                  'activeDutyEndDate' => '2005-01-01'
+                }]
+              }
+            )
+          end
+
+          it 'returns validation error' do
+            errors = subject.validate_form_526_fes_values
+            expect(errors).to be_an(Array)
+            error = errors.find do |e|
+              e[:detail].include?('prisoner of war must have at least one period of confinement')
+            end
+            expect(error).not_to be_nil
+          end
+        end
+      end
+
+      context 'duplicate disability names' do
+        context 'when disabilities have duplicate names' do
+          let(:form_attributes) do
+            base_form_attributes.merge(
+              'disabilities' => [
+                { 'name' => 'PTSD', 'disabilityActionType' => 'NEW' },
+                { 'name' => 'Back Pain', 'disabilityActionType' => 'NEW' },
+                { 'name' => 'PTSD', 'disabilityActionType' => 'NEW' }
+              ]
+            )
+          end
+
+          it 'returns validation error for duplicate name' do
+            errors = subject.validate_form_526_fes_values
+            expect(errors).to be_an(Array)
+            error = errors.find { |e| e[:detail].include?('Duplicate disability name found: PTSD') }
+            expect(error).not_to be_nil
+            expect(error[:source]).to eq('/disabilities')
+          end
+        end
+
+        context 'when all disability names are unique' do
+          let(:form_attributes) do
+            base_form_attributes.merge(
+              'disabilities' => [
+                { 'name' => 'PTSD', 'disabilityActionType' => 'NEW' },
+                { 'name' => 'Back Pain', 'disabilityActionType' => 'NEW' },
+                { 'name' => 'Knee Pain', 'disabilityActionType' => 'NEW' }
+              ]
+            )
+          end
+
+          it 'returns no duplicate name errors' do
+            errors = subject.validate_form_526_fes_values
+            # Should have no errors for unique names
+            expect(errors).to be_nil
+          end
+        end
+      end
+    end
+
+    # FES Val Section 10: Special Circumstances
+    context 'special circumstances validation' do
+      context 'when special circumstances exceed 100' do
+        let(:form_attributes) do
+          circumstances = Array.new(101) { |i| "Circumstance #{i}" }
+          base_form_attributes.merge('specialCircumstances' => circumstances)
+        end
+
+        it 'returns validation error' do
+          errors = subject.validate_form_526_fes_values
+          expect(errors).to be_an(Array)
+          error = errors.find { |e| e[:detail] == 'A maximum of 100 special circumstances are allowed' }
+          expect(error).not_to be_nil
+          expect(error[:source]).to eq('/specialCircumstances')
+        end
+      end
+
+      context 'when special circumstances are within limit' do
+        let(:form_attributes) do
+          circumstances = Array.new(100) { |i| "Circumstance #{i}" }
+          base_form_attributes.merge('specialCircumstances' => circumstances)
+        end
+
+        it 'returns no error' do
+          errors = subject.validate_form_526_fes_values
+          expect(errors).to be_nil
         end
       end
     end


### PR DESCRIPTION
## Summary
- Revised validations for v2 disability compensation for transition from EVSS to FES.
- This PR covers the remaining section 7 validations, section 10 and additional warnings.
- Requirements doc attached for reference:
[EVSS->FES-validations-update.pdf](https://github.com/user-attachments/files/21722827/EVSS-.FES-validations-update.pdf)
## Related issue(s)
Reference ticket: https://jira.devops.va.gov/browse/API-47330

<img width="855" height="1196" alt="Screenshot 2025-08-21 at 11 58 01 AM" src="https://github.com/user-attachments/assets/5f67b403-4d49-4e74-92d4-a8ef24226785" />

<img width="775" height="290" alt="Screenshot 2025-08-21 at 11 59 56 AM" src="https://github.com/user-attachments/assets/51e16275-e8fa-420c-9652-918b72cb0c0b" />

