### PR TITLE
[ID-642] Update assertion validator 

### DIFF
--- a/app/models/sign_in/client_config.rb
+++ b/app/models/sign_in/client_config.rb
@@ -78,7 +78,13 @@ module SignIn
           config_cert_id = find_config_certificate_for_destruction(cert_attrs)
           { id: config_cert_id, _destroy: true }.compact
         else
-          { cert_attributes: { id: cert_attrs[:id].presence, pem: cert_attrs[:pem].to_s }.compact }
+          cert = SignIn::Certificate.where(id: cert_attrs[:id].presence)
+                                    .or(SignIn::Certificate.where(pem: cert_attrs[:pem].presence))
+                                    .first
+
+          next if certs.include?(cert)
+
+          { cert_attributes: { id: cert&.id, pem: cert_attrs[:pem].to_s }.compact }
         end
       end
     end

--- a/app/models/sign_in/service_account_config.rb
+++ b/app/models/sign_in/service_account_config.rb
@@ -27,7 +27,13 @@ module SignIn
           config_cert_id = find_config_certificate_for_destruction(cert_attrs)
           { id: config_cert_id, _destroy: true }.compact
         else
-          { cert_attributes: { id: cert_attrs[:id].presence, pem: cert_attrs[:pem].to_s }.compact }
+          cert = SignIn::Certificate.where(id: cert_attrs[:id].presence)
+                                    .or(SignIn::Certificate.where(pem: cert_attrs[:pem].presence))
+                                    .first
+
+          next if certs.include?(cert)
+
+          { cert_attributes: { id: cert&.id, pem: cert_attrs[:pem].to_s }.compact }
         end
       end
     end

--- a/app/services/sign_in/assertion_validator.rb
+++ b/app/services/sign_in/assertion_validator.rb
@@ -1,175 +1,100 @@
 # frozen_string_literal: true
 
 module SignIn
-  class AssertionValidator
-    attr_reader :assertion
+  class AssertionValidator < BaseAssertionValidator
+    attr_reader :assertion, :decoded_assertion, :service_account_config
 
     def initialize(assertion:)
+      super()
       @assertion = assertion
     end
 
     def perform
-      validate_service_account_config
+      @decoded_assertion = decode_assertion!(assertion)
       validate_issuer
-      validate_audience
       validate_scopes
       validate_user_attributes
-      validate_subject
-      validate_issued_at_time
-      validate_expiration
+
       create_new_access_token
     end
 
     private
 
-    def validate_service_account_config
-      if service_account_config.blank?
-        raise Errors::ServiceAccountConfigNotFound.new message: 'Service account config not found'
-      end
+    delegate :service_account_id, to: :service_account_config
+
+    def create_new_access_token
+      ServiceAccountAccessToken.new(
+        service_account_id:,
+        audience: config_audience,
+        scopes: assertion_scopes,
+        user_attributes: assertion_user_attributes,
+        user_identifier: assertion_user_identifier
+      )
     end
 
     def validate_issuer
-      if issuer != service_account_id && issuer != audience
-        raise Errors::ServiceAccountAssertionAttributesError.new message: 'Assertion issuer is not valid'
-      end
-    end
-
-    def validate_audience
-      unless assertion_audience.include?(token_route)
-        raise Errors::ServiceAccountAssertionAttributesError.new message: 'Assertion audience is not valid'
+      if assertion_iss != service_account_id && assertion_iss != config_audience
+        raise Errors::ServiceAccountAssertionAttributesError.new message: 'Invalid issuer'
       end
     end
 
     def validate_scopes
-      unless decoded_assertion_scopes_are_defined_in_config?
-        raise Errors::ServiceAccountAssertionAttributesError.new message: 'Assertion scopes are not valid'
-      end
+      return if assertion_scopes_in_config?
+
+      raise Errors::ServiceAccountAssertionAttributesError.new message: 'Invalid scopes'
     end
 
     def validate_user_attributes
-      if (user_attributes.keys.map(&:to_s) - service_account_config.access_token_user_attributes).any?
-        raise Errors::ServiceAccountAssertionAttributesError.new message: 'Assertion user attributes are not valid'
+      if (assertion_user_attributes.keys.map(&:to_s) - service_account_config.access_token_user_attributes).any?
+        raise Errors::ServiceAccountAssertionAttributesError.new message: 'Invalid user attributes'
       end
     end
 
-    def validate_subject
-      if user_identifier.blank?
-        raise Errors::ServiceAccountAssertionAttributesError.new message: 'Assertion subject is not valid'
+    def jwt_decode_options
+      {
+        aud: [token_route],
+        verify_aud: true,
+        verify_iat: true,
+        verify_expiration: true,
+        required_claims: %w[iat sub exp iss],
+        algorithms: [algorithm]
+      }
+    end
+
+    def jwt_keyfinder(header, payload)
+      @service_account_config = find_service_account_config(payload)
+      super(header, payload)
+    end
+
+    def active_certs
+      @active_certs ||= service_account_config.certs.active
+    end
+
+    def find_service_account_config(payload)
+      service_account_id = payload['service_account_id'] || payload['iss']
+      if service_account_id.blank?
+        raise Errors::ServiceAccountAssertionAttributesError.new message: 'Invalid client identifier'
       end
+
+      ServiceAccountConfig.find_by!(service_account_id:)
+    rescue ActiveRecord::RecordNotFound
+      raise Errors::ServiceAccountConfigNotFound.new message: 'Service account config not found'
     end
 
-    def validate_issued_at_time
-      if issued_at_time.blank? || issued_at_time > Time.now.to_i
-        raise Errors::ServiceAccountAssertionAttributesError.new message: 'Assertion issuance timestamp is not valid'
-      end
+    def assertion_scopes_in_config?
+      return service_account_config.scopes.blank? if assertion_scopes.blank?
+
+      (assertion_scopes - service_account_config.scopes).empty?
     end
 
-    def validate_expiration
-      if expiration.blank?
-        raise Errors::ServiceAccountAssertionAttributesError.new message: 'Assertion expiration timestamp is not valid'
-      end
-    end
-
-    def create_new_access_token
-      ServiceAccountAccessToken.new(service_account_id:,
-                                    audience:,
-                                    scopes:,
-                                    user_attributes:,
-                                    user_identifier:)
-    end
-
-    def decoded_assertion_scopes_are_defined_in_config?
-      return service_account_config.scopes.blank? if scopes.blank?
-
-      (scopes - service_account_config.scopes).empty?
-    end
-
-    def token_route
-      "#{hostname}#{Constants::Auth::TOKEN_ROUTE_PATH}"
-    end
-
-    def hostname
-      return localhost_hostname if Settings.vsp_environment == 'localhost'
-      return staging_hostname if Settings.review_instance_slug.present?
-
-      "https://#{Settings.hostname}"
-    end
-
-    def decoded_assertion
-      @decoded_assertion ||= jwt_decode
-    end
-
-    def decoded_assertion_without_validation
-      @decoded_assertion_without_validation ||= jwt_decode(with_validation: false)
-    end
-
-    def service_account_id
-      @service_account_id ||= decoded_assertion_without_validation.service_account_id ||
-                              decoded_assertion_without_validation.iss
-    end
-
-    def scopes
-      @scopes ||= Array(decoded_assertion.scopes)
-    end
-
-    def user_attributes
-      @user_attributes = decoded_assertion.user_attributes || {}
-    end
-
-    def user_identifier
-      @user_identifier ||= decoded_assertion.sub
-    end
-
-    def issuer
-      @issuer ||= decoded_assertion.iss
-    end
-
-    def assertion_audience
-      @assertion_audience ||= Array(decoded_assertion.aud)
-    end
-
-    def audience
-      @audience ||= service_account_config.access_token_audience
-    end
-
-    def issued_at_time
-      @issued_at_time ||= decoded_assertion.iat
-    end
-
-    def expiration
-      @expiration ||= decoded_assertion.exp
-    end
-
-    def service_account_config
-      @service_account_config ||= ServiceAccountConfig.find_by(service_account_id:)
-    end
-
-    def jwt_decode(with_validation: true)
-      assertion_public_keys = with_validation ? service_account_config.certs.map(&:public_key) : nil
-
-      decoded_jwt = JWT.decode(
-        assertion,
-        assertion_public_keys,
-        with_validation,
-        { verify_expiration: with_validation, algorithm: Constants::Auth::ASSERTION_ENCODE_ALGORITHM }
-      )&.first
-      OpenStruct.new(decoded_jwt)
-    rescue JWT::VerificationError
-      raise Errors::AssertionSignatureMismatchError.new message: 'Assertion body does not match signature'
-    rescue JWT::ExpiredSignature
-      raise Errors::AssertionExpiredError.new message: 'Assertion has expired'
-    rescue JWT::DecodeError
-      raise Errors::AssertionMalformedJWTError.new message: 'Assertion is malformed'
-    end
-
-    def localhost_hostname
-      port = URI.parse("http://#{Settings.hostname}").port
-
-      "http://localhost:#{port}"
-    end
-
-    def staging_hostname
-      'https://staging-api.va.gov'
-    end
+    def config_audience                 = service_account_config.access_token_audience
+    def assertion_scopes                = Array(decoded_assertion[:scopes])
+    def assertion_user_attributes       = decoded_assertion[:user_attributes] || {}
+    def assertion_user_identifier       = decoded_assertion[:sub]
+    def assertion_iss                   = decoded_assertion[:iss]
+    def attributes_error_class          = Errors::ServiceAccountAssertionAttributesError
+    def signature_mismatch_error_class  = Errors::AssertionSignatureMismatchError
+    def expired_error_class             = Errors::AssertionExpiredError
+    def malformed_error_class           = Errors::AssertionMalformedJWTError
   end
 end

--- a/app/services/sign_in/base_assertion_validator.rb
+++ b/app/services/sign_in/base_assertion_validator.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module SignIn
+  class BaseAssertionValidator
+    private
+
+    def decode_assertion!(assertion)
+      payload, _header = JWT.decode(assertion, nil, true, jwt_decode_options, &method(:jwt_keyfinder))
+      payload.deep_symbolize_keys
+    rescue JWT::InvalidAudError, JWT::InvalidIatError, JWT::InvalidIssuerError,
+           JWT::InvalidSubError, JWT::MissingRequiredClaim => e
+      raise attributes_error_class.new(message: e.message)
+    rescue JWT::VerificationError
+      raise signature_mismatch_error_class.new(message: signature_mismatch_message)
+    rescue JWT::ExpiredSignature
+      raise expired_error_class.new(message: expired_message)
+    rescue JWT::DecodeError
+      raise malformed_error_class.new(message: malformed_message)
+    end
+
+    def jwt_keyfinder(_header, _payload)
+      certs = active_certs
+      raise Errors::AssertionCertificateExpiredError.new message: 'Certificates are expired' if certs.blank?
+
+      certs.map(&:public_key)
+    end
+
+    def hostname
+      return localhost_hostname if Settings.vsp_environment == 'localhost'
+      return staging_hostname if Settings.review_instance_slug.present?
+
+      "https://#{Settings.hostname}"
+    end
+
+    def algorithm                      = Constants::Auth::ASSERTION_ENCODE_ALGORITHM
+    def token_route                    = "#{hostname}#{Constants::Auth::TOKEN_ROUTE_PATH}"
+    def staging_hostname               = 'https://staging-api.va.gov'
+    def localhost_hostname             = "http://localhost:#{URI("http://#{Settings.hostname}").port}"
+    def signature_mismatch_message     = 'Assertion body does not match signature'
+    def expired_message                = 'Assertion has expired'
+    def malformed_message              = 'Assertion is malformed'
+    def attributes_error_class         = raise NotImplementedError
+    def signature_mismatch_error_class = raise NotImplementedError
+    def expired_error_class            = raise NotImplementedError
+    def malformed_error_class          = raise NotImplementedError
+    def active_certs                   = raise NotImplementedError
+  end
+end

--- a/app/services/sign_in/errors.rb
+++ b/app/services/sign_in/errors.rb
@@ -20,6 +20,7 @@ module SignIn
     class AssertionExpiredError < StandardError; end
     class AssertionMalformedJWTError < StandardError; end
     class AssertionSignatureMismatchError < StandardError; end
+    class AssertionCertificateExpiredError < StandardError; end
     class AttributeMismatchError < StandardError; end
     class ClientAssertionAttributesError < StandardError; end
     class ClientAssertionExpiredError < StandardError; end

--- a/spec/controllers/v0/sign_in_controller_token_authorization_code_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_token_authorization_code_spec.rb
@@ -239,7 +239,8 @@ RSpec.describe V0::SignInController, type: :controller do
                     aud:,
                     sub:,
                     jti:,
-                    exp:
+                    exp:,
+                    iat:
                   }
                 end
                 let(:iss) { client_id }
@@ -247,6 +248,7 @@ RSpec.describe V0::SignInController, type: :controller do
                 let(:sub) { client_id }
                 let(:jti) { 'some-jti' }
                 let(:exp) { 1.month.since.to_i }
+                let(:iat) { Time.current.to_i }
                 let(:client_assertion_encode_algorithm) { SignIn::Constants::Auth::ASSERTION_ENCODE_ALGORITHM }
                 let(:client_assertion_value) do
                   JWT.encode(client_assertion_payload, private_key, client_assertion_encode_algorithm)

--- a/spec/factories/sign_in/certificates.rb
+++ b/spec/factories/sign_in/certificates.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
                   end
     signer_key = self_signed ? key : ca_key
 
-    OpenSSL::X509::Certificate.new.tap do |c|
+    cert = OpenSSL::X509::Certificate.new.tap do |c|
       c.version    = 2
       c.serial     = rand(1_000_000)
       c.subject    = OpenSSL::X509::Name.parse("/CN=#{subject_cn}")
@@ -37,6 +37,7 @@ FactoryBot.define do
       c.not_after  = not_after
       c.sign(signer_key, OpenSSL::Digest.new('SHA256'))
     end
+    [cert, key]
   end
 
   factory :sign_in_certificate, class: 'SignIn::Certificate' do
@@ -46,12 +47,19 @@ FactoryBot.define do
       self_signed { false }
     end
 
-    pem do
-      if self_signed
-        build_leaf.call(nil, nil, not_before, not_after, true).to_pem
-      else
-        ca_cert, ca_key = build_ca.call(not_before - 1.day, not_after + 1.day)
-        build_leaf.call(ca_cert, ca_key, not_before, not_after, false).to_pem
+    after(:build) do |certificate, t|
+      if certificate.pem.blank?
+        ca_cert, ca_key = if t.self_signed
+                            [nil, nil]
+                          else
+                            build_ca.call(t.not_before - 1.day, t.not_after + 1.day)
+                          end
+
+        leaf_cert, leaf_key = build_leaf.call(ca_cert, ca_key, t.not_before, t.not_after, t.self_signed)
+
+        certificate.pem = leaf_cert.to_pem
+
+        certificate.define_singleton_method(:private_key) { leaf_key }
       end
     end
 

--- a/spec/models/sign_in/certificate_spec.rb
+++ b/spec/models/sign_in/certificate_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe SignIn::Certificate, type: :model do
 
       it 'is not valid and adds expired error' do
         expect(certificate).not_to be_valid
-        expect(certificate.errors[:pem]).to include('certificate is expired')
+        expect(certificate.errors[:pem]).to include('X.509 certificate is expired')
       end
 
       it '#expired? returns true' do
@@ -82,7 +82,7 @@ RSpec.describe SignIn::Certificate, type: :model do
 
       it 'is not valid and adds “not yet valid” error' do
         expect(certificate).not_to be_valid
-        expect(certificate.errors[:pem]).to include('certificate is not yet valid')
+        expect(certificate.errors[:pem]).to include('X.509 certificate is not yet valid')
       end
     end
 
@@ -91,23 +91,23 @@ RSpec.describe SignIn::Certificate, type: :model do
 
       it 'is not valid and adds self‑signed error' do
         expect(certificate).not_to be_valid
-        expect(certificate.errors[:pem]).to include('certificate is self-signed')
+        expect(certificate.errors[:pem]).to include('X.509 certificate is self-signed')
       end
     end
   end
 
   describe 'delegations' do
-    it { is_expected.to delegate_method(:not_before).to(:certificate) }
-    it { is_expected.to delegate_method(:not_after).to(:certificate) }
-    it { is_expected.to delegate_method(:subject).to(:certificate) }
-    it { is_expected.to delegate_method(:issuer).to(:certificate) }
-    it { is_expected.to delegate_method(:serial).to(:certificate) }
+    it { is_expected.to delegate_method(:not_before).to(:x509) }
+    it { is_expected.to delegate_method(:not_after).to(:x509) }
+    it { is_expected.to delegate_method(:subject).to(:x509) }
+    it { is_expected.to delegate_method(:issuer).to(:x509) }
+    it { is_expected.to delegate_method(:serial).to(:x509) }
   end
 
   describe '#certificate' do
     context 'when PEM is valid' do
       it 'returns an OpenSSL::X509::Certificate object' do
-        expect(certificate.certificate).to be_a(OpenSSL::X509::Certificate)
+        expect(certificate.x509).to be_a(OpenSSL::X509::Certificate)
       end
     end
 
@@ -115,7 +115,7 @@ RSpec.describe SignIn::Certificate, type: :model do
       subject(:certificate) { build(:sign_in_certificate, pem: 'not a valid pem') }
 
       it 'returns nil' do
-        expect(certificate.certificate).to be_nil
+        expect(certificate.x509).to be_nil
       end
     end
   end
@@ -123,7 +123,7 @@ RSpec.describe SignIn::Certificate, type: :model do
   describe '#certificate?' do
     context 'when certificate is valid' do
       it 'returns true' do
-        expect(certificate.certificate?).to be true
+        expect(certificate.x509?).to be true
       end
     end
 
@@ -131,7 +131,7 @@ RSpec.describe SignIn::Certificate, type: :model do
       subject(:certificate) { build(:sign_in_certificate, pem: 'not a valid pem') }
 
       it 'returns false' do
-        expect(certificate.certificate?).to be false
+        expect(certificate.x509?).to be false
       end
     end
   end

--- a/spec/services/sign_in/assertion_validator_spec.rb
+++ b/spec/services/sign_in/assertion_validator_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe SignIn::AssertionValidator do
   describe '#perform' do
     subject { SignIn::AssertionValidator.new(assertion:).perform }
 
-    let(:private_key) { OpenSSL::PKey::RSA.new(File.read(private_key_path)) }
-    let(:private_key_path) { 'spec/fixtures/sign_in/sts_client.pem' }
+    let(:private_key) { assertion_certificate.private_key }
+    let!(:assertion_certificate) { create(:sign_in_certificate) }
     let(:assertion_payload) do
       {
         iss:,
@@ -21,270 +21,288 @@ RSpec.describe SignIn::AssertionValidator do
       }
     end
     let(:iss) { 'some-iss' }
-    let(:aud) { 'some-aud' }
+    let(:aud) { token_route }
     let(:sub) { 'some-sub' }
     let(:jti) { 'some-jti' }
     let(:iat) { 1.month.ago.to_i }
     let(:exp) { 1.month.since.to_i }
     let(:scopes) { service_account_config.scopes }
     let(:service_account_id) { service_account_config.service_account_id }
-    let(:service_account_config) { create(:service_account_config, certs: [assertion_certificate]) }
+    let(:service_account_config) { create(:service_account_config) }
     let(:service_account_audience) { service_account_config.access_token_audience }
     let(:assertion_encode_algorithm) { SignIn::Constants::Auth::ASSERTION_ENCODE_ALGORITHM }
-    let(:assertion) { JWT.encode(assertion_payload, private_key, assertion_encode_algorithm) }
-    let(:certificate_path) { 'spec/fixtures/sign_in/sts_client.crt' }
-    let(:assertion_certificate) do
-      create(:sign_in_certificate, pem: File.read(certificate_path))
-    end
+    let(:assertion) { JWT.encode(assertion_payload, private_key, 'RS256') }
     let(:token_route) { "https://#{Settings.hostname}#{SignIn::Constants::Auth::TOKEN_ROUTE_PATH}" }
 
-    context 'when jwt was not encoded with expected signature' do
-      let(:private_key) { OpenSSL::PKey::RSA.new(2048) }
-      let(:expected_error) { SignIn::Errors::AssertionSignatureMismatchError }
-      let(:expected_error_message) { 'Assertion body does not match signature' }
-
-      it 'raises assertion signature mismatch error' do
-        expect { subject }.to raise_error(expected_error, expected_error_message)
+    context 'when the clients certificates are active' do
+      before do
+        service_account_config.certs << assertion_certificate
       end
-    end
 
-    context 'when jwt is expired' do
-      let(:exp) { 1.month.ago.to_i }
-      let(:expected_error) { SignIn::Errors::AssertionExpiredError }
-      let(:expected_error_message) { 'Assertion has expired' }
+      context 'when jwt was not encoded with expected signature' do
+        let(:private_key) { OpenSSL::PKey::RSA.new(2048) }
+        let(:expected_error) { SignIn::Errors::AssertionSignatureMismatchError }
+        let(:expected_error_message) { 'Assertion body does not match signature' }
 
-      it 'raises assertion malformed error' do
-        expect { subject }.to raise_error(expected_error, expected_error_message)
-      end
-    end
-
-    context 'when jwt was not properly encoded' do
-      let(:assertion) { JWT.encode(assertion_payload, nil) }
-      let(:expected_error) { SignIn::Errors::AssertionMalformedJWTError }
-      let(:expected_error_message) { 'Assertion is malformed' }
-
-      it 'raises assertion malformed error' do
-        expect { subject }.to raise_error(expected_error, expected_error_message)
-      end
-    end
-
-    context 'when jwt is valid' do
-      let(:assertion) { JWT.encode(assertion_payload, private_key, assertion_encode_algorithm) }
-      let(:expected_error) { SignIn::Errors::ServiceAccountAssertionAttributesError }
-
-      context 'and service account config in assertion does not match an existing service account config' do
-        let(:service_account_id) { 'some-service-account-id' }
-        let(:expected_error) { SignIn::Errors::ServiceAccountConfigNotFound }
-        let(:expected_error_message) { 'Service account config not found' }
-
-        it 'raises service account config not found error' do
+        it 'raises assertion signature mismatch error' do
           expect { subject }.to raise_error(expected_error, expected_error_message)
         end
       end
 
-      context 'and service account id in assertion is missing' do
-        let(:expected_error) { SignIn::Errors::ServiceAccountConfigNotFound }
-        let(:expected_error_message) { 'Service account config not found' }
+      context 'when jwt is expired' do
+        let(:exp) { 1.month.ago.to_i }
+        let(:expected_error) { SignIn::Errors::AssertionExpiredError }
+        let(:expected_error_message) { 'Assertion has expired' }
 
-        before { assertion_payload.delete(:service_account_id) }
-
-        context 'and issuer in assertion matches an existing service account config' do
-          let(:iss) { service_account_config.service_account_id }
-
-          it 'uses issuer as service account id to query the service account config' do
-            expect { subject }.not_to raise_error(expected_error, expected_error_message)
-          end
+        it 'raises assertion malformed error' do
+          expect { subject }.to raise_error(expected_error, expected_error_message)
         end
+      end
 
-        context 'and issuer in assertion does not match an existing service account config' do
-          let(:iss) { 'some-iss' }
+      context 'when jwt was not properly encoded' do
+        let(:assertion) { JWT.encode(assertion_payload, nil) }
+        let(:expected_error) { SignIn::Errors::AssertionMalformedJWTError }
+        let(:expected_error_message) { 'Assertion is malformed' }
+
+        it 'raises assertion malformed error' do
+          expect { subject }.to raise_error(expected_error, expected_error_message)
+        end
+      end
+
+      context 'when jwt is valid' do
+        let(:assertion) { JWT.encode(assertion_payload, private_key, assertion_encode_algorithm) }
+        let(:expected_error) { SignIn::Errors::ServiceAccountAssertionAttributesError }
+
+        context 'and service account config in assertion does not match an existing service account config' do
+          let(:service_account_id) { 'some-service-account-id' }
+          let(:expected_error) { SignIn::Errors::ServiceAccountConfigNotFound }
+          let(:expected_error_message) { 'Service account config not found' }
 
           it 'raises service account config not found error' do
             expect { subject }.to raise_error(expected_error, expected_error_message)
           end
         end
-      end
 
-      context 'and service account config in assertion does match an existing service account config' do
-        let(:service_account_id) { service_account_config.service_account_id }
+        context 'and service account id in assertion is missing' do
+          let(:expected_error) { SignIn::Errors::ServiceAccountConfigNotFound }
+          let(:expected_error_message) { 'Service account config not found' }
 
-        context 'and iss does not equal service account config audience' do
-          let(:expected_error_message) { 'Assertion issuer is not valid' }
+          before { assertion_payload.delete(:service_account_id) }
 
-          context 'and iss equals service account id' do
-            let(:iss) { service_account_id }
+          context 'and issuer in assertion matches an existing service account config' do
+            let(:iss) { service_account_config.service_account_id }
 
-            it 'does not raise an error' do
-              expect { subject }.not_to raise_error(expected_error, expected_error_message)
+            it 'returns a service account access token' do
+              expect(subject).to be_a(SignIn::ServiceAccountAccessToken)
             end
           end
 
-          context 'and iss does not equal service account id' do
+          context 'and issuer in assertion does not match an existing service account config' do
             let(:iss) { 'some-iss' }
 
-            it 'raises service account assertion attributes error' do
+            it 'raises service account config not found error' do
               expect { subject }.to raise_error(expected_error, expected_error_message)
             end
           end
         end
 
-        context 'and iss equals service account config audience' do
-          let(:iss) { service_account_audience }
+        context 'and service account config in assertion does match an existing service account config' do
+          let(:service_account_id) { service_account_config.service_account_id }
 
-          context 'and audience is not present' do
-            let(:expected_error_message) { 'Assertion audience is not valid' }
+          context 'and iss does not equal service account config audience' do
+            let(:expected_error_message) { 'Invalid issuer' }
 
-            before { assertion_payload.delete(:aud) }
+            context 'and iss equals service account id' do
+              let(:iss) { service_account_id }
 
-            it 'raises service account assertion attributes error' do
-              expect { subject }.to raise_error(expected_error, expected_error_message)
-            end
-          end
-
-          context 'and audience does not match token route' do
-            let(:aud) { 'some-aud' }
-            let(:expected_error_message) { 'Assertion audience is not valid' }
-
-            it 'raises service account assertion attributes error' do
-              expect { subject }.to raise_error(expected_error, expected_error_message)
-            end
-          end
-
-          context 'and audience matches token route' do
-            let(:aud) { token_route }
-
-            context 'and scopes are not present' do
-              before { assertion_payload.delete(:scopes) }
-
-              context 'and service account config scopes are not present' do
-                let(:service_account_config) do
-                  create(:service_account_config, certs: [assertion_certificate], scopes: [])
-                end
-
-                it 'does not raise an error' do
-                  expect { subject }.not_to raise_error
-                end
-              end
-
-              context 'and service account config scopes are present' do
-                let(:expected_error_message) { 'Assertion scopes are not valid' }
-
-                it 'raises service account assertion attributes error' do
-                  expect { subject }.to raise_error(expected_error, expected_error_message)
-                end
+              it 'decodes the assertion and returns a token' do
+                expect(subject).to be_a(SignIn::ServiceAccountAccessToken)
               end
             end
 
-            context 'and scopes are not a subset of service account config scopes' do
-              let(:scopes) { ['some-scopes'] }
-              let(:expected_error_message) { 'Assertion scopes are not valid' }
+            context 'and iss does not equal service account id' do
+              let(:iss) { 'some-iss' }
+
+              it 'raises service account assertion attributes error' do
+                expect { subject }.to raise_error(expected_error, expected_error_message)
+              end
+            end
+          end
+
+          context 'and iss equals service account config audience' do
+            let(:iss) { service_account_audience }
+
+            context 'and audience is not present' do
+              let(:expected_error_message) { "Invalid audience. Expected [\"#{token_route}\"], received <none>" }
+
+              before { assertion_payload.delete(:aud) }
 
               it 'raises service account assertion attributes error' do
                 expect { subject }.to raise_error(expected_error, expected_error_message)
               end
             end
 
-            context 'and scopes are a subset of service account config scopes' do
-              let(:scopes) { [service_account_config.scopes.first] }
+            context 'and audience does not match token route' do
+              let(:aud) { 'some-aud' }
+              let(:expected_error_message) { "Invalid audience. Expected [\"#{token_route}\"], received #{aud}" }
 
-              context 'and subject is not present' do
-                let(:expected_error_message) { 'Assertion subject is not valid' }
+              it 'raises service account assertion attributes error' do
+                expect { subject }.to raise_error(expected_error, expected_error_message)
+              end
+            end
 
-                before { assertion_payload.delete(:sub) }
+            context 'and audience matches token route' do
+              let(:aud) { token_route }
+
+              context 'and scopes are not present' do
+                before { assertion_payload.delete(:scopes) }
+
+                context 'and service account config scopes are not present' do
+                  let(:service_account_config) do
+                    create(:service_account_config, certs: [assertion_certificate], scopes: [])
+                  end
+
+                  it 'does not raise an error' do
+                    expect { subject }.not_to raise_error
+                  end
+                end
+
+                context 'and service account config scopes are present' do
+                  let(:expected_error_message) { 'Invalid scopes' }
+
+                  it 'raises service account assertion attributes error' do
+                    expect { subject }.to raise_error(expected_error, expected_error_message)
+                  end
+                end
+              end
+
+              context 'and scopes are not a subset of service account config scopes' do
+                let(:scopes) { ['some-scopes'] }
+                let(:expected_error_message) { 'Invalid scopes' }
 
                 it 'raises service account assertion attributes error' do
                   expect { subject }.to raise_error(expected_error, expected_error_message)
                 end
               end
 
-              context 'and subject is present' do
-                context 'and iat is missing' do
-                  let(:expected_error_message) { 'Assertion issuance timestamp is not valid' }
+              context 'and scopes are a subset of service account config scopes' do
+                let(:scopes) { [service_account_config.scopes.first] }
 
-                  before { assertion_payload.delete(:iat) }
+                context 'and subject is not present' do
+                  let(:expected_error_message) { 'Missing required claim sub' }
 
-                  it 'raises service account assertion attributes error' do
-                    expect { subject }.to raise_error(expected_error, expected_error_message)
-                  end
-                end
-
-                context 'and iat is in the future' do
-                  let(:iat) { 1.month.from_now.to_i }
-                  let(:expected_error_message) { 'Assertion issuance timestamp is not valid' }
+                  before { assertion_payload.delete(:sub) }
 
                   it 'raises service account assertion attributes error' do
                     expect { subject }.to raise_error(expected_error, expected_error_message)
                   end
                 end
 
-                context 'and exp is missing' do
-                  let(:expected_error_message) { 'Assertion expiration timestamp is not valid' }
+                context 'and subject is present' do
+                  context 'and iat is missing' do
+                    let(:expected_error_message) { 'Missing required claim iat' }
 
-                  before { assertion_payload.delete(:exp) }
+                    before { assertion_payload.delete(:iat) }
 
-                  it 'raises service account assertion attributes error' do
-                    expect { subject }.to raise_error(expected_error, expected_error_message)
-                  end
-                end
-
-                context 'and iat & exp are present and valid' do
-                  it 'returns service account access token with expected service account id' do
-                    expect(subject.service_account_id).to eq(service_account_id)
+                    it 'raises service account assertion attributes error' do
+                      expect { subject }.to raise_error(expected_error, expected_error_message)
+                    end
                   end
 
-                  it 'returns service account access token with expected audience' do
-                    expect(subject.audience).to eq(service_account_audience)
+                  context 'and iat is in the future' do
+                    let(:iat) { 1.month.from_now.to_i }
+                    let(:expected_error_message) { 'Invalid iat' }
+
+                    it 'raises service account assertion attributes error' do
+                      expect { subject }.to raise_error(expected_error, expected_error_message)
+                    end
                   end
 
-                  it 'returns service account access token with expected scopes' do
-                    expect(subject.scopes).to eq(scopes)
+                  context 'and exp is missing' do
+                    let(:expected_error_message) { 'Missing required claim exp' }
+
+                    before { assertion_payload.delete(:exp) }
+
+                    it 'raises service account assertion attributes error' do
+                      expect { subject }.to raise_error(expected_error, expected_error_message)
+                    end
                   end
 
-                  it 'returns service account access token with expected user identifier' do
-                    expect(subject.user_identifier).to eq(sub)
+                  context 'and iat & exp are present and valid' do
+                    it 'returns service account access token with expected service account id' do
+                      expect(subject.service_account_id).to eq(service_account_id)
+                    end
+
+                    it 'returns service account access token with expected audience' do
+                      expect(subject.audience).to eq(service_account_audience)
+                    end
+
+                    it 'returns service account access token with expected scopes' do
+                      expect(subject.scopes).to eq(scopes)
+                    end
+
+                    it 'returns service account access token with expected user identifier' do
+                      expect(subject.user_identifier).to eq(sub)
+                    end
                   end
                 end
               end
             end
           end
         end
+
+        context 'and user_attributes claim is provided' do
+          let(:service_account_config) do
+            create(:service_account_config, certs: [assertion_certificate], access_token_user_attributes: ['icn'])
+          end
+          let(:assertion_payload) do
+            {
+              iss: service_account_audience,
+              aud: token_route,
+              sub:,
+              jti:,
+              iat:,
+              exp: 1.month.from_now.to_i,
+              service_account_id: service_account_config.service_account_id,
+              scopes: [service_account_config.scopes.first],
+              user_attributes:
+            }
+          end
+
+          context 'and contains attributes that are not allowed for the service account' do
+            let(:user_attributes) { { some_attribute: 'some-value' } }
+            let(:expected_error) { SignIn::Errors::ServiceAccountAssertionAttributesError }
+            let(:expected_error_message) { 'Invalid user attributes' }
+
+            it 'raises service account assertion attributes error' do
+              expect { subject }.to raise_error(expected_error, expected_error_message)
+            end
+          end
+
+          context 'and does not contain attributes that are not allowed for the service account' do
+            let(:user_attributes) { { icn: 'some-value' } }
+
+            it 'returns the service account access token with the user attributes' do
+              expect(subject.user_attributes).to eq(user_attributes)
+            end
+          end
+        end
+      end
+    end
+
+    context 'when the certificate is expired' do
+      let!(:assertion_certificate) { build(:sign_in_certificate, :expired) }
+      let(:expected_error) { SignIn::Errors::AssertionCertificateExpiredError }
+      let(:expected_error_message) { 'Certificates are expired' }
+
+      before do
+        assertion_certificate.save(validate: false)
+        config_certificate = service_account_config.config_certificates.new(cert: assertion_certificate)
+        config_certificate.save(validate: false)
       end
 
-      context 'and user_attributes claim is provided' do
-        let(:service_account_config) do
-          create(:service_account_config, certs: [assertion_certificate], access_token_user_attributes: ['icn'])
-        end
-        let(:assertion_payload) do
-          {
-            iss: service_account_audience,
-            aud: token_route,
-            sub:,
-            jti:,
-            iat:,
-            exp: 1.month.from_now.to_i,
-            service_account_id: service_account_config.service_account_id,
-            scopes: [service_account_config.scopes.first],
-            user_attributes:
-          }
-        end
-
-        context 'and contains attributes that are not allowed for the service account' do
-          let(:user_attributes) { { 'some-attribute' => 'some-value' } }
-          let(:expected_error) { SignIn::Errors::ServiceAccountAssertionAttributesError }
-          let(:expected_error_message) { 'Assertion user attributes are not valid' }
-
-          it 'raises service account assertion attributes error' do
-            expect { subject }.to raise_error(expected_error, expected_error_message)
-          end
-        end
-
-        context 'and does not contain attributes that are not allowed for the service account' do
-          let(:user_attributes) { { 'icn' => 'some-value' } }
-
-          it 'returns the service account access token with the user attributes' do
-            expect(subject.user_attributes).to eq(user_attributes)
-          end
-        end
+      it 'raises the expected error' do
+        expect { subject }.to raise_error(expected_error, expected_error_message)
       end
     end
   end

--- a/spec/services/sign_in/base_assertion_validator_spec.rb
+++ b/spec/services/sign_in/base_assertion_validator_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SignIn::BaseAssertionValidator do
+  subject(:base_validator) { described_class.new }
+
+  describe 'abstract method enforcement' do
+    it 'raises NotImplementedError for abstract methods' do
+      %i[
+        attributes_error_class
+        signature_mismatch_error_class
+        expired_error_class
+        malformed_error_class
+        active_certs
+      ].each do |method_name|
+        expect { base_validator.send(method_name) }
+          .to raise_error(NotImplementedError), "expected #{method_name} to be abstract"
+      end
+    end
+  end
+end

--- a/spec/services/sign_in/code_validator_spec.rb
+++ b/spec/services/sign_in/code_validator_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe SignIn::CodeValidator do
     let(:code_verifier) { 'some-code-verifier' }
     let(:client_assertion) { 'some-client-assertion' }
     let(:client_assertion_type) { 'some-client-assertion-type' }
+    let(:token_path) { "https://#{Settings.hostname}#{SignIn::Constants::Auth::TOKEN_ROUTE_PATH}" }
+    let(:aud) { token_path }
 
     context 'when code container that matches code does not exist' do
       let(:code) { 'some-arbitrary-code' }
@@ -64,7 +66,7 @@ RSpec.describe SignIn::CodeValidator do
           context 'and user verification uuid in code container does not match with a user verification' do
             let(:user_verification_id) { 'some-arbitrary-user-verification-uuid' }
             let(:expected_error) { ActiveRecord::RecordNotFound }
-            let(:expected_error_message) { /Couldn't find UserVerification with 'id'/ }
+            let(:expected_error_message) { "Couldn't find UserVerification with 'id'=\"#{user_verification_id}\"" }
 
             it 'raises a user verification not found error' do
               expect { subject }.to raise_exception(expected_error, expected_error_message)
@@ -111,14 +113,16 @@ RSpec.describe SignIn::CodeValidator do
             aud:,
             sub:,
             jti:,
-            exp:
+            exp:,
+            iat:
           }
         end
         let(:iss) { 'some-iss' }
-        let(:aud) { 'some-aud' }
+        let(:aud) { token_path }
         let(:sub) { 'some-sub' }
         let(:jti) { 'some-jti' }
         let(:exp) { 1.month.since.to_i }
+        let(:iat) { Time.current.to_i }
         let(:client_assertion_encode_algorithm) { SignIn::Constants::Auth::ASSERTION_ENCODE_ALGORITHM }
         let(:client_assertion) do
           JWT.encode(client_assertion_payload, private_key, client_assertion_encode_algorithm)
@@ -177,7 +181,7 @@ RSpec.describe SignIn::CodeValidator do
             context 'and iss does not equal client id' do
               let(:iss) { 'some-iss' }
               let(:expected_error) { SignIn::Errors::ClientAssertionAttributesError }
-              let(:expected_error_message) { 'Client assertion issuer is not valid' }
+              let(:expected_error_message) { "Invalid issuer. Expected [\"#{client_id}\"], received #{iss}" }
 
               it 'raises client assertion attributes error' do
                 expect { subject }.to raise_error(expected_error, expected_error_message)
@@ -190,7 +194,7 @@ RSpec.describe SignIn::CodeValidator do
               context 'and sub does not equal client id' do
                 let(:sub) { 'some-sub' }
                 let(:expected_error) { SignIn::Errors::ClientAssertionAttributesError }
-                let(:expected_error_message) { 'Client assertion subject is not valid' }
+                let(:expected_error_message) { "Invalid subject. Expected #{client_id}, received #{sub}" }
 
                 it 'raises client assertion attributes error' do
                   expect { subject }.to raise_error(expected_error, expected_error_message)
@@ -203,7 +207,7 @@ RSpec.describe SignIn::CodeValidator do
                 context 'and aud does not equal token route' do
                   let(:aud) { 'some-aud' }
                   let(:expected_error) { SignIn::Errors::ClientAssertionAttributesError }
-                  let(:expected_error_message) { 'Client assertion audience is not valid' }
+                  let(:expected_error_message) { "Invalid audience. Expected [\"#{token_path}\"], received #{aud}" }
 
                   it 'raises client assertion attributes error' do
                     expect { subject }.to raise_error(expected_error, expected_error_message)


### PR DESCRIPTION
⚠️ Do not merge until Chatbot updates their private key ⚠️ 

## Summary

- Check expiration of clients certs
- Only decode the JWT once by providing keyfinder proc to verify a signature
- Use built in JWT validity checks for some validations.
-  Other cleanup

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/642

## Testing
### STS Assertion - you should get a token back
```ruby
SignIn::ServiceAccountConfig.find_by(service_account_id: 'sample_sts_service_account').update!(scopes: ['http://localhost:3000/sign_in/service_account_configs', 'http://localhost:3000/sign_in/client_configs'])

assertion_payload = {
  iss: 'http://localhost:3000',
  sub: 'vets.gov.user+0@gmail.com',
  aud: 'http://localhost:3000/v0/sign_in/token',
  iat: Time.zone.now.to_i,
  exp: Time.zone.now.to_i + 1000,
  scopes: ['http://localhost:3000/sign_in/service_account_configs'],
  service_account_id: 'sample_sts_service_account'
}

private_key = OpenSSL::PKey::RSA.new(File.read('spec/fixtures/sign_in/sts_client.pem'))
assertion = JWT.encode(assertion_payload, private_key, 'RS256')

# Generate Token
token_query_params = {
  grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
  assertion: assertion
}

token_uri = URI.parse('http://localhost:3000/v0/sign_in/token')
token_uri.query = token_query_params.to_query

http = Net::HTTP.new(token_uri.host, token_uri.port)
token_request = Net::HTTP::Post.new(token_uri.request_uri)
token = JSON.parse(http.request(token_request).body)['data']['access_token']
```

### Client Assertion - you should get a token back
#### Create client
```ruby
sample_client = SignIn::ClientConfig.find_or_initialize_by(client_id: 'sample_client_cert')
sample_client.update!(authentication: SignIn::Constants::Auth::API,
                      anti_csrf: true,
                      pkce: false,
                      redirect_uri: 'http://localhost:4567/auth/result',
                      access_token_duration: SignIn::Constants::AccessToken::VALIDITY_LENGTH_SHORT_MINUTES,
                      access_token_audience: 'sample_client_cert',
                      logout_redirect_uri: 'http://localhost:4567',
                      shared_sessions: true,
                      refresh_token_duration: SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES)

client_cert = SignIn::Certificate.find_or_create_by!(pem: File.read('spec/fixtures/sign_in/sts_client.crt'))

sample_client.certs << client_cert
```
#### In your browser go to this url and sign in:
http://localhost:3000/v0/sign_in/authorize?type=idme&acr=min&client_id=sample_client_cert

#### Grab the code from the url after you login
http://localhost:4567/auth/result?code=c49c1d6a-e69a-4a67-b7e0-ac30e6cb42ee&type=idme
**c49c1d6a-e69a-4a67-b7e0-ac30e6cb42ee**

#### Request token  with assertion
```ruby
jwt_payload = {
  iss: 'sample_client_cert',
  aud: 'http://localhost:3000/v0/sign_in/token',
  sub: 'sample_client_cert',
  exp: Time.now.to_i + 3600,
  jti: SecureRandom.uuid,
  iat: Time.now.to_i
}

private_key = OpenSSL::PKey::RSA.new(File.read('spec/fixtures/sign_in/sts_client.pem'))

jwt = JWT.encode(jwt_payload, private_key, 'RS256')

token_uri = URI.parse('http://localhost:3000/v0/sign_in/token')

token_params = {
  grant_type: 'authorization_code',
  code: 'c50a1b85-dcd4-408b-ad32-3b2fb818684a',
  client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
  client_assertion: jwt
}

http = Net::HTTP.new(token_uri.host, token_uri.port)

token_request = Net::HTTP::Post.new(token_uri.request_uri)
token_request.body = token_params.to_json
token_request.content_type = 'application/json'
response = JSON.parse(http.request(token_request).body)
token = response['data']['access_token']
```
## What areas of the site does it impact?
STS Assertion, Client assertion

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

