### PR TITLE
MHV-MR/116117 Fix undefined method `resourceType` error 

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1316,6 +1316,10 @@ features:
     actor_type: user
     description: Enables/disables Medical Records new Milestone 2 changes
     enable_in_development: true
+  mhv_medical_records_retry_next_page:
+    actor_type: user
+    description: Enables/disables with_retries when getting the next page
+    enable_in_development: true
   mhv_medical_records_support_backend_pagination_allergy:
     actor_type: user
     description: Enables/disables backend caching/pagination for allergies

--- a/spec/lib/medical_records/client_spec.rb
+++ b/spec/lib/medical_records/client_spec.rb
@@ -673,6 +673,195 @@ describe MedicalRecords::Client do
         .to eq('https://fwdproxy.va.gov/v1/fhir?_getpages=abc&_getpagesoffset=1&_count=2')
     end
 
+    describe '#fhir_search' do
+      let(:client) { MedicalRecords::Client.new(session: { user_id: 'test', icn: 'test' }) }
+      let(:fhir_model) { FHIR::AllergyIntolerance }
+      let(:search_params) do
+        {
+          search: {
+            parameters: {
+              patient: 'patient-123',
+              'clinical-status': 'active'
+            }
+          }
+        }
+      end
+      let(:mock_fhir_client) { double('FHIR::Client') }
+      let(:first_bundle) { FHIR::Bundle.new(entry: [entry1, entry2], next_link: 'https://example.com/fhir?_getpages=abc&_getpagesoffset=1') }
+      let(:second_bundle) { FHIR::Bundle.new(entry: [entry3]) }
+      let(:entry1) { FHIR::Bundle::Entry.new(resource: FHIR::AllergyIntolerance.new(id: '1')) }
+      let(:entry2) { FHIR::Bundle::Entry.new(resource: FHIR::AllergyIntolerance.new(id: '2')) }
+      let(:entry3) { FHIR::Bundle::Entry.new(resource: FHIR::AllergyIntolerance.new(id: '3')) }
+
+      before do
+        allow(client).to receive_messages(
+          fhir_client: mock_fhir_client,
+          default_headers: { 'Cache-Control' => 'no-cache' },
+          rewrite_next_link: nil
+        )
+        allow(client).to receive(:handle_api_errors).and_raise(Common::Exceptions::BackendServiceException.new(400,
+                                                                                                               'Error'))
+        MedicalRecords::Client.send(:public, *MedicalRecords::Client.protected_instance_methods)
+      end
+
+      after do
+        MedicalRecords::Client.send(:protected, *MedicalRecords::Client.protected_instance_methods)
+      end
+
+      context 'when there is only one page of results' do
+        let(:first_reply) { double('FHIR::ClientReply', resource: first_bundle) }
+
+        before do
+          allow(client).to receive(:fhir_search_query).and_return(first_reply)
+          allow(first_bundle).to receive(:next_link).and_return(nil)
+        end
+
+        it 'returns the single bundle without pagination' do
+          result = client.fhir_search(fhir_model, search_params)
+
+          expect(client).to have_received(:fhir_search_query).with(fhir_model, search_params)
+          expect(client).to have_received(:rewrite_next_link).with(first_bundle)
+          expect(result).to eq(first_bundle)
+          expect(result.entry.length).to eq(2)
+        end
+      end
+
+      context 'when there are multiple pages of results' do
+        let(:first_reply) { double('FHIR::ClientReply', resource: first_bundle) }
+        let(:second_reply) { double('FHIR::ClientReply', resource: second_bundle) }
+        let(:next_link) { 'https://example.com/fhir?_getpages=abc&_getpagesoffset=1' }
+
+        before do
+          allow(client).to receive(:fhir_search_query).and_return(first_reply)
+
+          # First call to next_link returns the link, second call returns nil
+          allow(first_bundle).to receive(:next_link).and_return(next_link)
+          allow(second_bundle).to receive(:next_link).and_return(nil)
+
+          allow(mock_fhir_client).to receive(:next_page)
+            .with(first_reply, headers: { 'Cache-Control' => 'no-cache' })
+            .and_return(second_reply)
+
+          allow(client).to receive(:merge_bundles)
+            .with(first_bundle, second_bundle)
+            .and_return(FHIR::Bundle.new(entry: [entry1, entry2, entry3]))
+        end
+
+        context 'when retry feature flag is disabled' do
+          before do
+            allow(Flipper).to receive(:enabled?).with(:mhv_medical_records_retry_next_page).and_return(false)
+          end
+
+          it 'fetches all pages and merges them into a single bundle' do
+            result = client.fhir_search(fhir_model, search_params)
+
+            expect(client).to have_received(:fhir_search_query).with(fhir_model, search_params)
+            expect(client).to have_received(:rewrite_next_link).with(first_bundle)
+            expect(client).to have_received(:rewrite_next_link).with(second_bundle)
+            expect(mock_fhir_client).to have_received(:next_page)
+              .with(first_reply, headers: { 'Cache-Control' => 'no-cache' })
+            expect(client).to have_received(:merge_bundles).with(first_bundle, second_bundle)
+            expect(result.entry.length).to eq(3)
+          end
+
+          it 'handles API errors on next page requests' do
+            error_reply = double('FHIR::ClientReply', resource: nil)
+            allow(mock_fhir_client).to receive(:next_page).and_return(error_reply)
+
+            expect { client.fhir_search(fhir_model, search_params) }.to raise_error(Common::Exceptions::BackendServiceException)
+            expect(client).to have_received(:handle_api_errors).with(error_reply)
+          end
+        end
+
+        context 'when retry feature flag is enabled' do
+          before do
+            allow(Flipper).to receive(:enabled?).with(:mhv_medical_records_retry_next_page).and_return(true)
+            allow(client).to receive(:with_retries).and_yield.and_return(second_reply)
+          end
+
+          it 'uses retries when fetching next pages' do
+            result = client.fhir_search(fhir_model, search_params)
+
+            expect(client).to have_received(:with_retries).with(fhir_model)
+            expect(mock_fhir_client).to have_received(:next_page)
+              .with(first_reply, headers: { 'Cache-Control' => 'no-cache' })
+            expect(result.entry.length).to eq(3)
+          end
+
+          it 'handles API errors with retries on next page requests' do
+            error_reply = double('FHIR::ClientReply', resource: nil)
+            # Override the parent context setup for this specific test
+            allow(mock_fhir_client).to receive(:next_page).and_return(error_reply)
+            allow(client).to receive(:merge_bundles)
+            allow(client).to receive(:with_retries).and_yield.and_return(error_reply)
+
+            expect { client.fhir_search(fhir_model, search_params) }.to raise_error(Common::Exceptions::BackendServiceException)
+            expect(client).to have_received(:handle_api_errors).with(error_reply)
+          end
+        end
+      end
+
+      context 'when there are three pages of results' do
+        let(:first_reply) { double('FHIR::ClientReply', resource: first_bundle) }
+        let(:second_reply) { double('FHIR::ClientReply', resource: second_bundle) }
+        let(:third_bundle) { FHIR::Bundle.new(entry: [FHIR::Bundle::Entry.new(resource: FHIR::AllergyIntolerance.new(id: '4'))]) }
+        let(:third_reply) { double('FHIR::ClientReply', resource: third_bundle) }
+
+        before do
+          allow(Flipper).to receive(:enabled?).with(:mhv_medical_records_retry_next_page).and_return(false)
+          allow(client).to receive(:fhir_search_query).and_return(first_reply)
+
+          # Configure next_link behavior for pagination
+          allow(first_bundle).to receive(:next_link).and_return('page2_link')
+          allow(second_bundle).to receive(:next_link).and_return('page3_link')
+          allow(third_bundle).to receive(:next_link).and_return(nil)
+
+          allow(mock_fhir_client).to receive(:next_page)
+            .with(first_reply, headers: { 'Cache-Control' => 'no-cache' })
+            .and_return(second_reply)
+          allow(mock_fhir_client).to receive(:next_page)
+            .with(second_reply, headers: { 'Cache-Control' => 'no-cache' })
+            .and_return(third_reply)
+
+          # Mock merge_bundles to return progressively larger bundles
+          intermediate_bundle = FHIR::Bundle.new(entry: [entry1, entry2, entry3])
+          end_bundle = FHIR::Bundle.new(entry: [entry1, entry2, entry3,
+                                                FHIR::Bundle::Entry.new(resource: FHIR::AllergyIntolerance.new(id: '4'))])
+
+          allow(client).to receive(:merge_bundles)
+            .with(first_bundle, second_bundle)
+            .and_return(intermediate_bundle)
+          allow(client).to receive(:merge_bundles)
+            .with(intermediate_bundle, third_bundle)
+            .and_return(end_bundle)
+        end
+
+        it 'fetches all three pages and merges them sequentially' do
+          result = client.fhir_search(fhir_model, search_params)
+
+          expect(mock_fhir_client).to have_received(:next_page).twice
+          expect(client).to have_received(:merge_bundles).twice
+          expect(client).to have_received(:rewrite_next_link).exactly(3).times
+          expect(result.entry.length).to eq(4)
+        end
+      end
+
+      context 'when the initial search query fails' do
+        before do
+          # Override the parent context setup and make fhir_search_query raise an exception directly
+          allow(client).to receive(:handle_api_errors).and_call_original
+          allow(client).to receive(:fhir_search_query).and_raise(Common::Exceptions::BackendServiceException.new(400,
+                                                                                                                 'Error'))
+        end
+
+        it 'handles API errors from the initial query' do
+          expect { client.fhir_search(fhir_model, search_params) }.to raise_error(Common::Exceptions::BackendServiceException)
+
+          expect(client).to have_received(:fhir_search_query).with(fhir_model, search_params)
+        end
+      end
+    end
+
     it 'rewrites full URL to relative path for /fhir' do
       next_url = 'https://example.org/fhir?_getpages=xyz&_count=1'
       bundle = FHIR::Bundle.new(


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- This work is behind a feature toggle (flipper): YES
- Feature toggle: `mhv_medical_records_retry_next_page`
- The Medical Records app occasionally throws an unhandled error when fetching paginated data for Labs and Tests, Clinical Notes, and Vitals if the FHIR API fails. 
- This PR adds error handling for those cases and introduces retry logic when next_page requests fail. The request will retry up to three times if the FHIR API fails to return a page, helping prevent crashes and improving resilience. 
- The retry logic is behind a feature toggle, letting us monitor its impact and ensure it doesn’t overload the backend MHV server.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/116117

## Testing done

- [x] *New code is covered by unit tests*
- Refer to this [branch](https://github.com/department-of-veterans-affairs/vets-api/tree/ni-mr-local-server) which adds a local-proxy server to help with testing the solution

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
- MHV Medical Records

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

