### PR TITLE
API 47335 - 526 Validation Rules 7x: `disabilities`

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
@@ -353,7 +353,7 @@ module ClaimsApi
     end
 
     def valid_disability_name_format?(name)
-      %r{\A([a-zA-Z0-9\-'.,/()]([a-zA-Z0-9\-',. ])?)+\z}.match?(name)
+      %r{([a-zA-Z0-9\-'.,/()]([a-zA-Z0-9\-',. ])?)+$}.match?(name)
     end
 
     def valid_disability_name_length?(name)

--- a/modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
@@ -26,6 +26,12 @@ module ClaimsApi
       validate_form_526_change_of_address!
       # ensure no more than 150 disabilities are provided
       # ensure any provided 'disability.classificationCode' is a known value in BGS
+      # ensure any provided 'disability.approximateBeginDate' is in the past
+      # ensure a 'disability.specialIssue' of 'HEPC' has a `disability.name` of 'hepatitis'
+      # ensure a 'disability.specialIssue' of 'POW' has a valid 'serviceInformation.confinement'
+      # ensure any provided 'disability.name' is <= 255 characters in length
+      # ensure any provided 'disability.name' meets appropriate regex format
+      # ensure any provided 'disability.name' is unique across all disabilities
       validate_form_526_disabilities!
     end
 

--- a/modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
@@ -326,7 +326,6 @@ module ClaimsApi
       # if 'specialIssues' includes 'EMP' or 'RRD', then EVSS allows the disability to be submitted with a type of
       # INCREASE otherwise, the disability must not have any special issues
       !(special_issues.include?('EMP') || special_issues.include?('RRD'))
-      # true unless special_issues.include?('EMP') || special_issues.include?('RRD')
     end
 
     def validate_form_526_disability_names!

--- a/modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
@@ -29,8 +29,6 @@ module ClaimsApi
       # ensure any provided 'disability.approximateBeginDate' is in the past
       # ensure a 'disability.specialIssue' of 'HEPC' has a `disability.name` of 'hepatitis'
       # ensure a 'disability.specialIssue' of 'POW' has a valid 'serviceInformation.confinement'
-      # ensure any provided 'disability.name' is <= 255 characters in length
-      # ensure any provided 'disability.name' meets appropriate regex format
       # ensure any provided 'disability.name' is unique across all disabilities
       validate_form_526_disabilities!
     end
@@ -216,7 +214,6 @@ module ClaimsApi
       validate_form_526_disability_approximate_begin_date!
       validate_form_526_special_issues!
       validate_form_526_disability_unique_names!
-      validate_form_526_disability_names!
     end
 
     def validate_form_526_fewer_than_150_disabilities!
@@ -328,49 +325,27 @@ module ClaimsApi
       !(special_issues.include?('EMP') || special_issues.include?('RRD'))
     end
 
-    def validate_form_526_disability_names!
-      return if form_attributes['disabilities'].blank?
-      return unless form_attributes['disabilityActionType'] == 'NEW'
-
-      form_attributes['disabilities'].each do |disability|
-        name = disability['name']
-        unless valid_disability_name_format?(name)
-          raise ::Common::Exceptions::InvalidFieldValue.new(
-            'disabilities.name',
-            "The request failed disability validation: The disability name #{name} does not match " \
-            "the expected format for a disabilityActionType of 'NEW'"
-          )
-        end
-
-        unless valid_disability_name_length?(name)
-          raise ::Common::Exceptions::InvalidFieldValue.new(
-            'disabilities.name',
-            'The disability name must be less than 256 characters'
-          )
-        end
-      end
-    end
-
-    def valid_disability_name_format?(name)
-      %r{([a-zA-Z0-9\-'.,/()]([a-zA-Z0-9\-',. ])?)+$}.match?(name)
-    end
-
-    def valid_disability_name_length?(name)
-      name.length < 256
-    end
-
     def validate_form_526_disability_unique_names!
       disabilities = form_attributes['disabilities']
       return if disabilities.blank?
 
       names = disabilities.map { |d| d['name'].downcase }
       duplicates = names.select { |name| names.count(name) > 1 }.uniq
+      masked_duplicates = duplicates.map { |name| mask_all_but_first_character(name) }
 
       unless duplicates.empty?
         raise ::Common::Exceptions::InvalidFieldValue.new('disabilities.name',
                                                           'Duplicate disability name found: ' \
-                                                          "#{duplicates.join(', ')}")
+                                                          "#{masked_duplicates.join(', ')}")
       end
+    end
+
+    def mask_all_but_first_character(value)
+      return value if value.blank?
+      return value unless value.is_a? String
+
+      # Mask all but the first character of the string
+      value[0] + ('*' * (value.length - 1))
     end
   end
 end

--- a/modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
+++ b/modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
@@ -957,61 +957,26 @@ RSpec.describe ClaimsApi::RevisedDisabilityCompensationValidations do
           .to raise_error(Common::Exceptions::InvalidFieldValue)
       end
     end
-
-    context 'when disabilities is blank' do
-      let(:form_attributes) { { 'disabilities' => [] } }
-
-      it 'does not raise an error' do
-        expect { subject.validate_form_526_disability_unique_names! }.not_to raise_error
-      end
-    end
   end
 
-  describe '#validate_form_526_disability_names!' do
-    context 'when disabilities is blank' do
-      let(:form_attributes) { { 'disabilities' => [] } }
-
-      it 'does not raise an error' do
-        expect { subject.validate_form_526_disability_names! }.not_to raise_error
-      end
+  describe '#mask_all_but_first_character' do
+    it 'returns nil if value is blank' do
+      expect(subject.mask_all_but_first_character(nil)).to be_nil
+      expect(subject.mask_all_but_first_character('')).to eq('')
     end
 
-    context "when disabilityActionType is not 'NEW'" do
-      let(:form_attributes) do
-        {
-          'disabilityActionType' => 'INCREASE',
-          'disabilities' => [{ 'name' => 'PTSD' }]
-        }
-      end
-
-      it 'does not raise an error' do
-        expect { subject.validate_form_526_disability_names! }.not_to raise_error
-      end
+    it 'returns the value if it is not a String' do
+      expect(subject.mask_all_but_first_character(123)).to eq(123)
+      expect(subject.mask_all_but_first_character([])).to eq([])
     end
 
-    context "when disabilityActionType is 'NEW'" do
-      let(:form_attributes) do
-        {
-          'disabilityActionType' => 'NEW',
-          'disabilities' => [{ 'name' => 'PTSD' }]
-        }
-      end
+    it 'returns the value if it is a single character' do
+      expect(subject.mask_all_but_first_character('A')).to eq('A')
+    end
 
-      it 'does not raise an error for valid name' do
-        expect { subject.validate_form_526_disability_names! }.not_to raise_error
-      end
-
-      it 'raises error for invalid format' do
-        form_attributes['disabilities'][0]['name'] = 'PTSD!'
-        expect { subject.validate_form_526_disability_names! }
-          .to raise_error(Common::Exceptions::InvalidFieldValue)
-      end
-
-      it 'raises error for name longer than 255 chars' do
-        form_attributes['disabilities'][0]['name'] = 'A' * 256
-        expect { subject.validate_form_526_disability_names! }
-          .to raise_error(Common::Exceptions::InvalidFieldValue)
-      end
+    it 'masks all but the first character for longer strings' do
+      expect(subject.mask_all_but_first_character('PTSD')).to eq('P***')
+      expect(subject.mask_all_but_first_character('hepatitis')).to eq('h********')
     end
   end
 end


### PR DESCRIPTION
## Summary

_This is a continuation of the work started [here](https://github.com/department-of-veterans-affairs/vets-api/pull/23421)._

This PR adds more validation rules for disabilities.

|| Business rules addressed|
|-|-|
|Strikethrough: obsolete rule; Red text: new messaging/behavior|<img width="526" height="66" alt="Screenshot 2025-08-22 at 08 52 39" src="https://github.com/user-attachments/assets/69a24c87-8f7f-48d4-9de3-235bd2af591e" />|

## Related issue(s)

|[Jira ticket](https://jira.devops.va.gov/browse/API-47335)|
|-|
|<img width="967" height="801" alt="Screenshot 2025-08-06 at 08 58 46" src="https://github.com/user-attachments/assets/1e4504fb-25d0-40f1-81e1-83ca4124595c" />|

## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

```
modules/claims_api/app/controllers/concerns/claims_api/revised_disability_compensation_validations.rb
modules/claims_api/spec/requests/v1/forms/526_revised_validations_spec.rb
```

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

Looking for feedback on the masking mechanism. Should this be included here or is there a better location for such functionality?