### PR TITLE
Replace Virtus with Vets::Model - FacilitiesApi

### DIFF
--- a/lib/vets/type/primitive.rb
+++ b/lib/vets/type/primitive.rb
@@ -9,8 +9,8 @@ require 'vets/type/base'
 class BooleanSafeString < ActiveModel::Type::String
   def cast(value)
     case value
-    when true  then "true"
-    when false then "false"
+    when true  then 'true'
+    when false then 'false'
     else
       super
     end
@@ -18,7 +18,6 @@ class BooleanSafeString < ActiveModel::Type::String
 end
 
 ActiveRecord::Type.register(:boolean_safe_string, BooleanSafeString)
-
 
 module Vets
   module Type

--- a/lib/vets/type/primitive.rb
+++ b/lib/vets/type/primitive.rb
@@ -2,6 +2,24 @@
 
 require 'vets/type/base'
 
+# ActiveModel::Type::String converts booleans to single letter strings.
+# Rather than implement the suggested default approach, I think it would be better
+# to globally change this to a more expected result like .to_s
+# source: https://api.rubyonrails.org/classes/ActiveModel/Type/ImmutableString.html
+class BooleanSafeString < ActiveModel::Type::String
+  def cast(value)
+    case value
+    when true  then "true"
+    when false then "false"
+    else
+      super
+    end
+  end
+end
+
+ActiveRecord::Type.register(:boolean_safe_string, BooleanSafeString)
+
+
 module Vets
   module Type
     class Primitive < Base
@@ -12,7 +30,7 @@ module Vets
 
         begin
           case @klass.name
-          when 'String' then ActiveModel::Type::String.new.cast(value)
+          when 'String' then ActiveRecord::Type.lookup(:boolean_safe_string).cast(value)
           when 'Integer' then ActiveModel::Type::Integer.new.cast(value)
           when 'Float' then ActiveModel::Type::Float.new.cast(value)
           when 'Date' then ActiveModel::Type::Date.new.cast(value)

--- a/modules/facilities_api/app/models/facilities_api/v2/lighthouse/facility.rb
+++ b/modules/facilities_api/app/models/facilities_api/v2/lighthouse/facility.rb
@@ -1,51 +1,45 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
 
 module FacilitiesApi
-  class V2::Lighthouse::Facility < Common::Base
-    include ActiveModel::Serializers::JSON
-    attribute :access, Object
-    attribute :address, Object
+  class V2::Lighthouse::Facility
+    include Vets::Model
+
+    attribute :access, Hash
+    attribute :address, Hash
     attribute :classification, String
     attribute :distance, Float
     attribute :facility_type, String
     attribute :facility_type_prefix, String
-    attribute :feedback, Object
-    attribute :hours, Object
+    attribute :feedback, Hash
+    attribute :hours, Hash
     attribute :id, String
     attribute :lat, Float
     attribute :long, Float
-    attribute :mobile, Boolean
+    attribute :mobile, Bool
     attribute :name, String
-    attribute :operating_status, Object
-    attribute :operational_hours_special_instructions, Object
-    attribute :parent, Object
-    attribute :phone, Object
-    attribute :services, Object
+    attribute :operating_status, Hash
+    attribute :operational_hours_special_instructions, String, array: true
+    attribute :parent, Hash
+    attribute :phone, Hash
+    attribute :services, Hash
     attribute :time_zone, String
     attribute :type, String
     attribute :unique_id, String
     attribute :visn, String
     attribute :website, String
-    attribute :tmp_covid_online_scheduling, Boolean
+    attribute :tmp_covid_online_scheduling, Bool
 
     def initialize(fac)
-      super(fac)
-      set_attributes(fac)
+      @id = fac['id']
+      @facility_type_prefix, self.unique_id = fac['id'].split('_')
+      @feedback = fac['attributes']['satisfaction']
+      @type = fac['type']
 
-      self.id = fac['id']
-      self.facility_type_prefix, self.unique_id = fac['id'].split('_')
-      self.feedback = fac['attributes']['satisfaction']
-      self.type = fac['type']
-    end
+      attributes = fac['attributes'].stringify_keys!.transform_keys!(&:underscore)
 
-    private
-
-    def set_attributes(fac)
-      fac['attributes'].each_key do |key|
-        self[key.underscore] = fac['attributes'][key] if attributes.include?(key.underscore.to_sym)
-      end
+      super(attributes)
     end
   end
 end

--- a/modules/facilities_api/app/models/facilities_api/v2/lighthouse/service.rb
+++ b/modules/facilities_api/app/models/facilities_api/v2/lighthouse/service.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
 
 module FacilitiesApi
-  class V2::Lighthouse::Service < Common::Base
-    include ActiveModel::Serializers::JSON
+  class V2::Lighthouse::Service
+    include Vets::Model
 
     attribute :serviceName, String
     attribute :service, String
@@ -17,15 +17,18 @@ module FacilitiesApi
     # serviceLocations, Array # (not used in frontend)
 
     def initialize(svc)
-      super(svc)
-      self.serviceName = svc['serviceInfo']['name'] if svc['serviceInfo']['name']
-      self.service = svc['serviceInfo']['serviceId'] if svc['serviceInfo']['serviceId']
-      self.serviceType = svc['serviceInfo']['serviceType'] if svc['serviceInfo']['serviceType']
+
+      @serviceName = svc['serviceInfo']['name'] if svc['serviceInfo']['name']
+      @service = svc['serviceInfo']['serviceId'] if svc['serviceInfo']['serviceId']
+      @serviceType = svc['serviceInfo']['serviceType'] if svc['serviceInfo']['serviceType']
+
       if svc['waitTime']
-        self.new = svc['waitTime']['new']
-        self.established = svc['waitTime']['established']
-        self.effectiveDate = svc['waitTime']['effectiveDate']
+        @new = svc['waitTime']['new']
+        @established = svc['waitTime']['established']
+        @effectiveDate = svc['waitTime']['effectiveDate']
       end
+
+      super(svc)
     end
   end
 end

--- a/modules/facilities_api/app/models/facilities_api/v2/lighthouse/service.rb
+++ b/modules/facilities_api/app/models/facilities_api/v2/lighthouse/service.rb
@@ -17,15 +17,16 @@ module FacilitiesApi
     # serviceLocations, Array # (not used in frontend)
 
     def initialize(svc)
-
-      @serviceName = svc['serviceInfo']['name'] if svc['serviceInfo']['name']
-      @service = svc['serviceInfo']['serviceId'] if svc['serviceInfo']['serviceId']
-      @serviceType = svc['serviceInfo']['serviceType'] if svc['serviceInfo']['serviceType']
+      # Can't use instance variables in this case because it will
+      # cause rubocop linting error (Naming/VariableName)
+      self.serviceName = svc['serviceInfo']['name'] if svc['serviceInfo']['name']
+      self.service = svc['serviceInfo']['serviceId'] if svc['serviceInfo']['serviceId']
+      self.serviceType = svc['serviceInfo']['serviceType'] if svc['serviceInfo']['serviceType']
 
       if svc['waitTime']
-        @new = svc['waitTime']['new']
-        @established = svc['waitTime']['established']
-        @effectiveDate = svc['waitTime']['effectiveDate']
+        self.new = svc['waitTime']['new']
+        self.established = svc['waitTime']['established']
+        self.effectiveDate = svc['waitTime']['effectiveDate']
       end
 
       super(svc)

--- a/modules/facilities_api/app/models/facilities_api/v2/ppms/provider.rb
+++ b/modules/facilities_api/app/models/facilities_api/v2/ppms/provider.rb
@@ -27,7 +27,7 @@ module FacilitiesApi
     attribute :provider_identifier, String
     attribute :provider_name, String
     attribute :provider_type, String
-    attribute :trainings, String, array: true, default: []
+    attribute :trainings, String, array: true, default: -> { [] }
 
     def initialize(attr = {})
       new_attr = attr.dup.transform_keys { |k| k.to_s.snakecase.to_sym }

--- a/modules/facilities_api/app/models/facilities_api/v2/ppms/provider.rb
+++ b/modules/facilities_api/app/models/facilities_api/v2/ppms/provider.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
 
 module FacilitiesApi
-  class V2::PPMS::Provider < Common::Base
+  class V2::PPMS::Provider
+    include Vets::Model
+
     attribute :acc_new_patients, String
     attribute :address_city, String
     attribute :address_postal_code, String
@@ -21,14 +23,13 @@ module FacilitiesApi
     attribute :main_phone, String
     attribute :miles, Float
     attribute :name, String
-    attribute :pos_codes, String
+    attribute :pos_codes, String, array: true
     attribute :provider_identifier, String
     attribute :provider_name, String
     attribute :provider_type, String
-    attribute :trainings, Array
+    attribute :trainings, String, array: true, default: []
 
     def initialize(attr = {})
-      super(attr)
       new_attr = attr.dup.transform_keys { |k| k.to_s.snakecase.to_sym }
       new_attr[:acc_new_patients] ||= new_attr.delete(:is_accepting_new_patients)
       new_attr[:acc_new_patients] ||= new_attr.delete(:provider_accepting_new_patients)
@@ -42,7 +43,7 @@ module FacilitiesApi
       new_attr[:id] ||= new_attr[:provider_identifier]
       new_attr[:provider_type] ||= 'GroupPracticeOrAgency'
 
-      self.attributes = new_attr
+      super(new_attr)
     end
 
     def set_hexdigest_as_id!

--- a/modules/facilities_api/app/models/facilities_api/v2/ppms/specialty.rb
+++ b/modules/facilities_api/app/models/facilities_api/v2/ppms/specialty.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module FacilitiesApi
-  class V2::PPMS::Specialty < Common::Base
+  class V2::PPMS::Specialty
+    include Vets::Model
+
     attribute :classification, String
     attribute :grouping, String
     attribute :name, String
@@ -10,11 +14,10 @@ module FacilitiesApi
     attribute :specialty_description, String
 
     def initialize(attr = {})
-      super(attr)
       new_attr = attr.dup.transform_keys { |k| k.to_s.snakecase.to_sym }
       new_attr[:specialty_code] ||= new_attr.delete(:coded_specialty)
 
-      self.attributes = new_attr
+      super(new_attr)
     end
   end
 end

--- a/modules/facilities_api/app/services/facilities_api/v2/mobile_covid/response.rb
+++ b/modules/facilities_api/app/services/facilities_api/v2/mobile_covid/response.rb
@@ -1,22 +1,27 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module FacilitiesApi
   module V2
     module MobileCovid
-      class Response < Common::Base
+      class Response
+        include Vets::Model
+
         attribute :body, String
-        attribute :core_settings, Array
+        attribute :core_settings, Hash, array: true
         attribute :id, String
         attribute :parsed_body, Hash
         attribute :status, Integer
 
         def initialize(body, status)
           super()
-          self.body = body
-          self.status = status
-          self.parsed_body = JSON.parse(body)
-          self.id = parsed_body['id']
-          self.core_settings = parsed_body['coreSettings']
+
+          @body = body
+          @status = status
+          @parsed_body = JSON.parse(body)
+          @id = parsed_body['id']
+          @core_settings = parsed_body['coreSettings']
         end
 
         def covid_online_scheduling_available?

--- a/modules/facilities_api/app/services/facilities_api/v2/ppms/response.rb
+++ b/modules/facilities_api/app/services/facilities_api/v2/ppms/response.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
 
 module FacilitiesApi
   module V2
     module PPMS
-      class Response < Common::Base
-        attribute :body, String
+      class Response
+        include Vets::Model
+
+        attribute :body, Hash, array: true
         attribute :current_page, Integer
         attribute :per_page, Integer
         attribute :offset, Integer
@@ -15,11 +17,11 @@ module FacilitiesApi
         def initialize(response, params = {})
           super()
 
-          self.body = response.body.fetch('value')
+          @body = response.body.fetch('value')
 
-          self.current_page = Integer(response.body['PageNumber'] || params[:page] || 1)
-          self.per_page =     Integer(response.body['PageSize'] || params[:per_page] || 10)
-          self.total_entries = Integer(response.body['TotalResults'] || (current_page * per_page))
+          @current_page = Integer(response.body['PageNumber'] || params[:page] || 1)
+          @per_page =     Integer(response.body['PageSize'] || params[:per_page] || 10)
+          @total_entries = Integer(response.body['TotalResults'] || (current_page * per_page))
 
           trim_response_attributes!
         end

--- a/modules/facilities_api/spec/services/facilities_api/v2/lighthouse/client_spec.rb
+++ b/modules/facilities_api/spec/services/facilities_api/v2/lighthouse/client_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe FacilitiesApi::V2::Lighthouse::Client, team: :facilities, vcr: vc
       instructions = ['More hours are available for some services. To learn more, call our main phone number.',
                       'If you need to talk to someone or get advice right away, call the Vet Center anytime at ' \
                       '1-877-WAR-VETS (1-877-927-8387).']
-      expect(r[:operational_hours_special_instructions]).to eql(instructions)
+      expect(r.operational_hours_special_instructions).to eql(instructions)
     end
 
     it 'returns a 404 error' do


### PR DESCRIPTION
## Summary

- Virtus is being replace with `Vets::Model`. Differences include:
    - There's no hash access for attributes `form[:attribute]` only dot notation `form.attribute`
    - Syntax change for Array attributes
    - Sorting uses a class method: `default_sort_by`
    - booleans are temporarily `Bool`, until Virtus is completely gone
- This PR replaces `Common::Base` with `Vets::Model` and updates the _attributes_ and _implementation_ accordingly. 
- This change should not affect any functionality.

One change in the vets lib is to correct Boolean to String casting with `BooleanSafeString`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92444

## Testing done

- [x] Manual testing for similar output

## Acceptance criteria

- [x] Common::Base models are now Vets::Model
- [x] No functional change