### PR TITLE
update certificate error handling

### DIFF
--- a/app/models/sign_in/certificate.rb
+++ b/app/models/sign_in/certificate.rb
@@ -17,6 +17,8 @@ module SignIn
     scope :expired,  -> { select(&:expired?) }
     scope :expiring, -> { select(&:expiring?) }
 
+    normalizes :pem, with: ->(value) { value.present? ? "#{value.chomp}\n" : value }
+
     validates :pem, presence: true
     validate :validate_certificate!
 

--- a/app/models/sign_in/client_config.rb
+++ b/app/models/sign_in/client_config.rb
@@ -5,15 +5,10 @@ module SignIn
     attribute :access_token_duration, :interval
     attribute :refresh_token_duration, :interval
 
-    has_many :config_certificates, as: :config, dependent: :destroy, inverse_of: :config
-    has_many :certs, through: :config_certificates,
-                     class_name: 'SignIn::Certificate',
-                     inverse_of: :client_configs,
-                     index_errors: true
+    has_many :config_certificates, as: :config, dependent: :destroy, inverse_of: :config, index_errors: true
+    has_many :certs, through: :config_certificates, source: :cert, index_errors: true
 
-    accepts_nested_attributes_for :certs,
-                                  allow_destroy: true,
-                                  reject_if: ->(attrs) { attrs['pem'].blank? && attrs['id'].blank? }
+    accepts_nested_attributes_for :config_certificates, allow_destroy: true
 
     validates :anti_csrf, inclusion: [true, false]
     validates :redirect_uri, presence: true
@@ -73,20 +68,29 @@ module SignIn
       cookie_auth? && shared_sessions
     end
 
-    def certs_attributes=(certs_attributes)
-      certs_attributes.each do |cert_attributes|
-        id = cert_attributes[:id].to_s
-        pem = cert_attributes[:pem].to_s
-        destroy = ActiveModel::Type::Boolean.new.cast(cert_attributes[:_destroy])
+    def certs_attributes=(attributes)
+      normalized_attributes = attributes.is_a?(Hash) ? attributes.values : Array(attributes)
+      self.config_certificates_attributes = normalized_attributes.map do |cert_attrs|
+        cert_attrs = cert_attrs.to_h.symbolize_keys
+        should_destroy = ActiveModel::Type::Boolean.new.cast(cert_attrs[:_destroy])
 
-        if destroy && id.present?
-          cert = certs.find(id)
-          certs.destroy(cert)
+        if should_destroy
+          config_cert_id = find_config_certificate_for_destruction(cert_attrs)
+          { id: config_cert_id, _destroy: true }.compact
         else
-          cert = SignIn::Certificate.find_or_initialize_by(pem:)
-          certs << cert unless certs.include?(cert)
+          { cert_attributes: { id: cert_attrs[:id].presence, pem: cert_attrs[:pem].to_s }.compact }
         end
       end
+    end
+
+    def find_config_certificate_for_destruction(cert_attrs)
+      certificate_id = cert_attrs[:id].presence
+      return config_certificates.where(certificate_id:).pick(:id) if certificate_id
+
+      pem = cert_attrs[:pem].to_s.strip
+      return if pem.blank?
+
+      config_certificates.joins(:cert).where(sign_in_certificates: { pem: }).pick(:id)
     end
 
     def as_json(options = {})

--- a/app/models/sign_in/config_certificate.rb
+++ b/app/models/sign_in/config_certificate.rb
@@ -6,5 +6,22 @@ module SignIn
 
     belongs_to :config, polymorphic: true
     belongs_to :cert, class_name: 'SignIn::Certificate', foreign_key: :certificate_id, inverse_of: :config_certificates
+    accepts_nested_attributes_for :cert
+    validates_associated :cert
+
+    def cert_attributes=(attrs)
+      attrs = attrs.to_h.symbolize_keys
+      pem = attrs[:pem]
+
+      if pem.present?
+        existing_cert = SignIn::Certificate.find_by(pem:)
+        if existing_cert
+          self.cert = existing_cert
+          return
+        end
+      end
+
+      super
+    end
   end
 end

--- a/app/models/sign_in/service_account_config.rb
+++ b/app/models/sign_in/service_account_config.rb
@@ -4,15 +4,10 @@ module SignIn
   class ServiceAccountConfig < ApplicationRecord
     attribute :access_token_duration, :interval
 
-    has_many :config_certificates, as: :config, dependent: :destroy, inverse_of: :config
-    has_many :certs, through: :config_certificates,
-                     class_name: 'SignIn::Certificate',
-                     inverse_of: :service_account_configs,
-                     index_errors: true
+    has_many :config_certificates, as: :config, dependent: :destroy, inverse_of: :config, index_errors: true
+    has_many :certs, through: :config_certificates, source: :cert, index_errors: true
 
-    accepts_nested_attributes_for :certs,
-                                  allow_destroy: true,
-                                  reject_if: ->(attrs) { attrs['pem'].blank? && attrs['id'].blank? }
+    accepts_nested_attributes_for :config_certificates, allow_destroy: true
 
     validates :service_account_id, presence: true, uniqueness: true
     validates :description, presence: true
@@ -22,20 +17,29 @@ module SignIn
               inclusion: { in: Constants::ServiceAccountAccessToken::VALIDITY_LENGTHS, allow_nil: false }
     validates :access_token_user_attributes, inclusion: { in: Constants::ServiceAccountAccessToken::USER_ATTRIBUTES }
 
-    def certs_attributes=(certs_attributes)
-      certs_attributes.each do |cert_attributes|
-        id = cert_attributes[:id].to_s
-        pem = cert_attributes[:pem].to_s
-        destroy = ActiveModel::Type::Boolean.new.cast(cert_attributes[:_destroy])
+    def certs_attributes=(attributes)
+      normalized_attributes = attributes.is_a?(Hash) ? attributes.values : Array(attributes)
+      self.config_certificates_attributes = normalized_attributes.map do |cert_attrs|
+        cert_attrs = cert_attrs.to_h.symbolize_keys
+        should_destroy = ActiveModel::Type::Boolean.new.cast(cert_attrs[:_destroy])
 
-        if destroy && id.present?
-          cert = certs.find(id)
-          certs.destroy(cert)
+        if should_destroy
+          config_cert_id = find_config_certificate_for_destruction(cert_attrs)
+          { id: config_cert_id, _destroy: true }.compact
         else
-          cert = SignIn::Certificate.find_or_initialize_by(pem:)
-          certs << cert unless certs.include?(cert)
+          { cert_attributes: { id: cert_attrs[:id].presence, pem: cert_attrs[:pem].to_s }.compact }
         end
       end
+    end
+
+    def find_config_certificate_for_destruction(cert_attrs)
+      certificate_id = cert_attrs[:id].presence
+      return config_certificates.where(certificate_id:).pick(:id) if certificate_id
+
+      pem = cert_attrs[:pem].to_s.strip
+      return if pem.blank?
+
+      config_certificates.joins(:cert).where(sign_in_certificates: { pem: }).pick(:id)
     end
 
     def as_json(options = {})

--- a/spec/controllers/sign_in/client_configs_controller_spec.rb
+++ b/spec/controllers/sign_in/client_configs_controller_spec.rb
@@ -113,7 +113,8 @@ RSpec.describe SignIn::ClientConfigsController, type: :controller do
           post :create, params: { client_config: valid_attributes.merge(certs_attributes: [cert.attributes]) },
                         as: :json
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(response_body.dig('errors', 'certs[0].pem')).to include('not a valid X.509 certificate')
+          expect(response_body.dig('errors',
+                                   'config_certificates[0].cert.pem')).to include('not a valid X.509 certificate')
         end
       end
     end

--- a/spec/sidekiq/sign_in/certificate_checker_job_spec.rb
+++ b/spec/sidekiq/sign_in/certificate_checker_job_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe SignIn::CertificateCheckerJob, type: :job do
 
           before do
             expired_certificate.save(validate: false)
-            config.certs << expired_certificate
+            config_certificate = config.config_certificates.new(cert: expired_certificate, config:)
+            config_certificate.save(validate: false)
             config.save(validate: false)
           end
 
@@ -143,7 +144,8 @@ RSpec.describe SignIn::CertificateCheckerJob, type: :job do
 
             before do
               expired_certificate.save(validate: false)
-              config.certs << expired_certificate
+              config_certificate = config.config_certificates.new(cert: expired_certificate, config:)
+              config_certificate.save(validate: false)
               config.save(validate: false)
             end
 
@@ -169,7 +171,10 @@ RSpec.describe SignIn::CertificateCheckerJob, type: :job do
           before do
             expired_cert1.save(validate: false)
             expired_cert2.save(validate: false)
-            config.certs << expired_cert1 << expired_cert2
+            config_certificate1 = config.config_certificates.new(cert: expired_cert1, config:)
+            config_certificate2 = config.config_certificates.new(cert: expired_cert2, config:)
+            config_certificate1.save(validate: false)
+            config_certificate2.save(validate: false)
             config.save(validate: false)
           end
 


### PR DESCRIPTION
## Summary

- Update error handling so when certs are saved and have errors they show properly
## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/581

# Testing
## Setup
migrate and seed the database
- `rails db:migrate`
- `rails db:seed`

Start the server
- `rails s`
- start a rails console - `rails c`

Update the service account config used to request an access token
- `rails c`
```ruby
SignIn::ServiceAccountConfig.find_by(service_account_id: 'sample_sts_service_account').update!(scopes: ['http://localhost:3000/sign_in/service_account_configs', 'http://localhost:3000/sign_in/client_configs'])
```

## Service Account Configs:

Run these requests in the rails console - `rails c`
**Note:** if your token expires just request a new one

### Request access token
```ruby
assertion_payload = {
  iss: 'http://localhost:3000',
  sub: 'vets.gov.user+0@gmail.com',
  aud: 'http://localhost:3000/v0/sign_in/token',
  iat: Time.zone.now.to_i,
  exp: Time.zone.now.to_i + 1000,
  scopes: ['http://localhost:3000/sign_in/service_account_configs'],
  service_account_id: 'sample_sts_service_account'
}

private_key = OpenSSL::PKey::RSA.new(File.read('spec/fixtures/sign_in/sts_client.pem'))
assertion = JWT.encode(assertion_payload, private_key, 'RS256')

# Generate Token
token_query_params = {
  grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
  assertion: assertion
}

token_uri = URI.parse('http://localhost:3000/v0/sign_in/token')
token_uri.query = token_query_params.to_query

http = Net::HTTP.new(token_uri.host, token_uri.port)
token_request = Net::HTTP::Post.new(token_uri.request_uri)
token = JSON.parse(http.request(token_request).body)['data']['access_token']
```
### Test `certs` Errors
```ruby
uri = URI.parse('http://localhost:3000/sign_in/service_account_configs')
request = Net::HTTP::Post.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  service_account_config: {
    service_account_id: 'sample_sts_service_account_new2',
    description: 'Sample STS service account',
    access_token_audience: 'http://localhost:3000',
    access_token_duration: 300,
    scopes: [],
    certs_attributes: [
      {
         pem: 'bad_pem'
      }
    ]
  }
}.to_json

response = http.request(request)
JSON.parse(response.body) # you should get the correct nested error for certs
```

### POST - Create config with certs
```ruby
uri = URI.parse('http://localhost:3000/sign_in/service_account_configs')
request = Net::HTTP::Post.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  service_account_config: {
    service_account_id: 'sample_sts_service_account_new2',
    description: 'Sample STS service account',
    access_token_audience: 'http://localhost:3000',
    access_token_duration: 300,
    scopes: [],
    certs_attributes: [
      {
         pem: File.read('spec/fixtures/sign_in/identity_dashboard_service_account.crt')
      }
    ]
  }
}.to_json

response = http.request(request)
JSON.parse(response.body) # you should see certs array in the response
```

### PUT - update config - Delete a cert. Should destroy the join table relation not the certificate itself
```ruby
service_account_id = 'sample_sts_service_account_new2'
uri = URI.parse("http://localhost:3000/sign_in/service_account_configs/#{service_account_id}")
request = Net::HTTP::Put.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  service_account_config: {
    certs_attributes: [
      {
        id: "0f54112f-e8ac-4aa2-a5aa-5af981e11626", # replace this with the cert ID in POST response
        _destroy: "true"
      }
    ]
  }
}.to_json

response = http.request(request)
JSON.parse(response.body) 
```

## Client Configs:

Run these requests in the rails console
**Note:** if your token expires just request a new one

### Request access token
```ruby
assertion_payload = {
  iss: 'http://localhost:3000',
  sub: 'vets.gov.user+0@gmail.com',
  aud: 'http://localhost:3000/v0/sign_in/token',
  iat: Time.zone.now.to_i,
  exp: Time.zone.now.to_i + 1000,
  scopes: ['http://localhost:3000/sign_in/client_configs'],
  service_account_id: 'sample_sts_service_account'
}

private_key = OpenSSL::PKey::RSA.new(File.read('spec/fixtures/sign_in/sts_client.pem'))
assertion = JWT.encode(assertion_payload, private_key, 'RS256')

# Generate Token
token_query_params = {
  grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
  assertion: assertion
}

token_uri = URI.parse('http://localhost:3000/v0/sign_in/token')
token_uri.query = token_query_params.to_query

http = Net::HTTP.new(token_uri.host, token_uri.port)
token_request = Net::HTTP::Post.new(token_uri.request_uri)
token = JSON.parse(http.request(token_request).body)['data']['access_token']
```
### Test `certs` errors
```ruby
uri = URI.parse('http://localhost:3000/sign_in/client_configs')
request = Net::HTTP::Post.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  client_config: {
    client_id: 'sample_client_config_new2',
    description: 'Sample Client Config',
    authentication: 'cookie',
    anti_csrf: true,
    redirect_uri: 'http://localhost:3000/sessions/callback',
    access_token_duration: 300,
    refresh_token_duration: 1800,
    logout_redirect_uri: 'http://localhost:3000/sessions/logout_callback',
    pkce: true,
    certs_attributes: [
      {
         pem: 'bad_pem'
      }
    ]
  }
}.to_json

response = http.request(request)
JSON.parse(response.body) # you should get the correct nested error for certs
```

### POST - Create config with certs
```ruby
uri = URI.parse('http://localhost:3000/sign_in/client_configs')
request = Net::HTTP::Post.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  client_config: {
    client_id: 'sample_client_config_new2',
    description: 'Sample Client Config',
    authentication: 'cookie',
    anti_csrf: true,
    redirect_uri: 'http://localhost:3000/sessions/callback',
    access_token_duration: 300,
    refresh_token_duration: 1800,
    logout_redirect_uri: 'http://localhost:3000/sessions/logout_callback',
    pkce: true,
    certs_attributes: [
      {
         pem: File.read('spec/fixtures/sign_in/identity_dashboard_service_account.crt')
      }
    ]
  }
}.to_json

response = http.request(request)
JSON.parse(response.body)
```

### PUT - update config - Delete a cert. Should destroy the join table relation not the certificate itself
```ruby
client_id = 'sample_client_config_new2'
uri = URI.parse("http://localhost:3000/sign_in/client_configs/#{client_id}")
request = Net::HTTP::Put.new(uri.request_uri)
request['Authorization'] = "Bearer #{token}"
request['Content-Type'] = 'application/json'
request.body = {
  client_config: {
    certs_attributes: [
      {
        id: "0f54112f-e8ac-4aa2-a5aa-5af981e11626", # replace this with the cert ID in POST response
        _destroy: "true"
      }
    ]
  }
}.to_json

response = http.request(request)
JSON.parse(response.body)
```

## What areas of the site does it impact?
Sign-in service

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

