### PR TITLE
API-49108-pdf-generator-test-coverage-increase

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/v2/disability_compensation_pdf_generator.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/v2/disability_compensation_pdf_generator.rb
@@ -17,7 +17,7 @@ module ClaimsApi
         auto_claim = get_claim(claim_id)
 
         if Settings.claims_api.benefits_documents.use_mocks
-          start_docker_container_job(auto_claim&.id, perform_async)
+          start_docker_container_job(auto_claim&.id)
           return
         end
 


### PR DESCRIPTION
## Summary
* Takes the test coverage up to 100% for this file
	* This file went unused when the sidekiq jobs for 526 moved to synchronous.  so we are removing the dust on this file
* Fixes a typo/bug added inside the method call when mocking
	modified:   modules/claims_api/app/sidekiq/claims_api/v2/disability_compensation_pdf_generator.rb
	modified:   modules/claims_api/spec/sidekiq/v2/disability_compensation_pdf_generator_spec.rb

## Related issue(s)


## Testing done

- [x] *No new code, this brings the existing file up to 100%s*


## Screenshots


## What areas of the site does it impact?
	modified:   modules/claims_api/app/sidekiq/claims_api/v2/disability_compensation_pdf_generator.rb
	modified:   modules/claims_api/spec/sidekiq/v2/disability_compensation_pdf_generator_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
