### PR TITLE
CC-117401: Add new variables to eps class

### DIFF
--- a/modules/vaos/app/models/vaos/v2/eps_appointment.rb
+++ b/modules/vaos/app/models/vaos/v2/eps_appointment.rb
@@ -42,7 +42,13 @@ module VAOS
           referral_id: @referral_id,
           referral: @referral,
           provider_service_id: @provider_service_id,
-          provider_name: @provider_name
+          provider_name: @provider_name,
+          # EPS appointments are community care by definition
+          kind: 'cc',
+          type: eps_type,
+          pending: request_type?,
+          past: past_appointment?,
+          future: future_appointment?
         }.compact
       end
 
@@ -74,6 +80,27 @@ module VAOS
 
       def determine_status(status)
         status == 'booked' ? 'booked' : 'proposed'
+      end
+
+      def eps_type
+        @start.present? ? 'COMMUNITY_CARE_APPOINTMENT' : 'COMMUNITY_CARE_REQUEST'
+      end
+
+      def request_type?
+        %w[REQUEST COMMUNITY_CARE_REQUEST].include?(eps_type)
+      end
+
+      def past_appointment?
+        return nil if @start.blank?
+
+        # Community care follows the non-telehealth rule (+60 minutes grace window)
+        (@start.to_datetime + 60.minutes) < Time.now.utc
+      end
+
+      def future_appointment?
+        return false if @start.blank?
+
+        !request_type? && !past_appointment?
       end
     end
   end

--- a/modules/vaos/spec/models/v2/eps_appointment_spec.rb
+++ b/modules/vaos/spec/models/v2/eps_appointment_spec.rb
@@ -34,22 +34,29 @@ describe VAOS::V2::EpsAppointment do
   end
 
   describe '#serializable_hash' do
-    it 'returns a hash with the correct attributes' do
-      expected_hash = {
-        id: '1',
-        status: 'booked',
-        patient_icn: '1234567890V123456',
-        created: '2023-10-01T00:00:00Z',
-        location_id: 'network_1',
-        clinic: 'clinic_1',
-        start: '2023-10-10T10:00:00Z',
-        contact: 'contact_info',
-        referral_id: '12345',
-        referral: { referral_number: '12345' },
-        provider_service_id: 'clinic_1',
-        provider_name: 'unknown'
-      }
-      expect(subject.serializable_hash).to eq(expected_hash)
+    it 'returns a hash with the correct attributes including derived fields' do
+      Timecop.freeze(Time.zone.parse('2023-10-10T12:00:00Z')) do
+        expected_hash = {
+          id: '1',
+          status: 'booked',
+          patient_icn: '1234567890V123456',
+          created: '2023-10-01T00:00:00Z',
+          location_id: 'network_1',
+          clinic: 'clinic_1',
+          start: '2023-10-10T10:00:00Z',
+          contact: 'contact_info',
+          referral_id: '12345',
+          referral: { referral_number: '12345' },
+          provider_service_id: 'clinic_1',
+          provider_name: 'unknown',
+          kind: 'cc',
+          type: 'COMMUNITY_CARE_APPOINTMENT',
+          pending: false,
+          past: true,
+          future: false
+        }
+        expect(subject.serializable_hash).to eq(expected_hash)
+      end
     end
   end
 

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -1506,6 +1506,32 @@ describe VAOS::V2::AppointmentsService do
         end
       end
 
+      it 'sets future and past flags on eps appointments based on start time' do
+        VCR.use_cassette('vaos/eps/get_vaos_appointments_200_with_merge',
+                         match_requests_on: %i[method path query], allow_playback_repeats: true, tag: :force_utf8) do
+          Timecop.freeze(Time.zone.parse('2024-12-02T12:01:00Z')) do
+            allow_any_instance_of(Eps::AppointmentService).to receive(:get_appointments).and_return(eps_appointments)
+
+            result = subject.get_appointments(start_date, end_date, nil, {}, { eps: true })
+            data = result[:data]
+
+            eps_124 = data.find { |a| a.dig(:referral, :referral_number) == 'ref124' }
+            eps_125 = data.find { |a| a.dig(:referral, :referral_number) == 'ref125' }
+
+            expect(eps_124).not_to be_nil
+            expect(eps_125).not_to be_nil
+
+            # 2024-12-02T10:00:00Z should be past at 12:01Z (past true, future false)
+            expect(eps_124[:past]).to be(true)
+            expect(eps_124[:future]).to be(false)
+
+            # 2024-12-03T10:00:00Z should be future at 2024-12-02T12:01Z
+            expect(eps_125[:past]).to be(false)
+            expect(eps_125[:future]).to be(true)
+          end
+        end
+      end
+
       it 'merges provider data correctly' do
         VCR.use_cassette('vaos/eps/token/token_200',
                          match_requests_on: %i[method path],

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -1515,19 +1515,19 @@ describe VAOS::V2::AppointmentsService do
             result = subject.get_appointments(start_date, end_date, nil, {}, { eps: true })
             data = result[:data]
 
-            eps_124 = data.find { |a| a.dig(:referral, :referral_number) == 'ref124' }
-            eps_125 = data.find { |a| a.dig(:referral, :referral_number) == 'ref125' }
+            eps124 = data.find { |a| a.dig(:referral, :referral_number) == 'ref124' }
+            eps125 = data.find { |a| a.dig(:referral, :referral_number) == 'ref125' }
 
-            expect(eps_124).not_to be_nil
-            expect(eps_125).not_to be_nil
+            expect(eps124).not_to be_nil
+            expect(eps125).not_to be_nil
 
             # 2024-12-02T10:00:00Z should be past at 12:01Z (past true, future false)
-            expect(eps_124[:past]).to be(true)
-            expect(eps_124[:future]).to be(false)
+            expect(eps124[:past]).to be(true)
+            expect(eps124[:future]).to be(false)
 
             # 2024-12-03T10:00:00Z should be future at 2024-12-02T12:01Z
-            expect(eps_125[:past]).to be(false)
-            expect(eps_125[:future]).to be(true)
+            expect(eps125[:past]).to be(false)
+            expect(eps125[:future]).to be(true)
           end
         end
       end


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): No
- *(Summarize the changes that have been made to the platform)* : Adding new values to the EPS appointment class. These values are required on the frontend to enable rendering in the appointments list.
- *(Which team do you work for, does your team own the maintenance of this component?)* - Hydra/CC - yes.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117401

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change* EPS appointments were delivered to the frontend without `past` and `future` keys. This prevents the appointment from being rendering on the appointment list.

## What areas of the site does it impact?
Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback


