### PR TITLE
publish metrics for duration between form creation time and pega upda…

### DIFF
--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
@@ -166,17 +166,16 @@ module IvcChampva
         return unless form_files.any?
 
         # Calculate and publish metrics for first matching form file
-        form_files.first do |form|
-          duration_seconds = (Time.current - form.created_at).to_i
+        form = form_files.first
+        duration_seconds = (Time.current - form.created_at).to_i
 
-          tags = [
-            'service:veteran-ivc-champva-forms',
-            "form_number:#{form.form_number}"
-          ]
+        tags = [
+          'service:veteran-ivc-champva-forms',
+          "form_number:#{form.form_number}"
+        ]
 
-          # Publish the duration metric
-          StatsD.histogram('champva.submit_to_callback.duration_seconds', duration_seconds, tags:)
-        end
+        # Publish the duration metric
+        StatsD.histogram('champva.submit_to_callback.duration_seconds', duration_seconds, tags:)
       rescue => e
         Rails.logger.error "Error tracking submit to callback duration: #{e.message}"
         # Don't raise the error to avoid disrupting the main callback flow

--- a/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/status_updates_spec.rb
+++ b/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/status_updates_spec.rb
@@ -389,6 +389,147 @@ RSpec.describe 'IvcChampva::V1::Forms::StatusUpdates', type: :request do
       end
     end
 
+    context 'tracking submit to callback duration metrics' do
+      let(:form_uuid) { '12345678-1234-5678-1234-567812345678' }
+      let(:created_time) { 30.minutes.ago }
+
+      before do
+        allow_any_instance_of(IvcChampva::Email).to receive(:valid_environment?).and_return(true)
+        allow(StatsD).to receive(:histogram)
+        IvcChampvaForm.delete_all
+      end
+
+      it 'tracks duration metrics for main form files when status is Processed' do
+        # Create main form file (should be tracked)
+        IvcChampvaForm.create!(
+          form_uuid:,
+          email: 'test@email.com',
+          first_name: 'Veteran',
+          last_name: 'Surname',
+          form_number: '10-10D',
+          file_name: "#{form_uuid}_vha_10_10d.pdf",
+          s3_status: 'Submitted',
+          pega_status: nil,
+          case_id: nil,
+          email_sent: false,
+          created_at: created_time
+        )
+
+        # Create supporting document (should not be tracked)
+        IvcChampvaForm.create!(
+          form_uuid:,
+          email: 'test@email.com',
+          first_name: 'Veteran',
+          last_name: 'Surname',
+          form_number: '10-10D',
+          file_name: "#{form_uuid}_vha_10_10d_supporting_doc-1.pdf",
+          s3_status: 'Submitted',
+          pega_status: nil,
+          case_id: nil,
+          email_sent: false,
+          created_at: created_time
+        )
+
+        payload = {
+          'form_uuid' => form_uuid,
+          'file_names' => [
+            "#{form_uuid}_vha_10_10d.pdf",
+            "#{form_uuid}_vha_10_10d_supporting_doc-1.pdf"
+          ],
+          'case_id' => 'ABC-1234',
+          'status' => 'Processed'
+        }
+
+        post '/ivc_champva/v1/forms/status_updates', params: payload
+
+        # Verify StatsD was called with correct parameters
+        expect(StatsD).to have_received(:histogram).with(
+          'champva.submit_to_callback.duration_seconds',
+          be_within(60).of(1800), # ~30 minutes in seconds
+          tags: [
+            'service:veteran-ivc-champva-forms',
+            'form_number:10-10D'
+          ]
+        )
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'does not track duration metrics when status is Not Processed' do
+        # Create main form file
+        IvcChampvaForm.create!(
+          form_uuid:,
+          email: 'test@email.com',
+          first_name: 'Veteran',
+          last_name: 'Surname',
+          form_number: '10-10D',
+          file_name: "#{form_uuid}_vha_10_10d.pdf",
+          s3_status: 'Submitted',
+          pega_status: nil,
+          case_id: nil,
+          email_sent: false,
+          created_at: created_time
+        )
+
+        payload = {
+          'form_uuid' => form_uuid,
+          'file_names' => ["#{form_uuid}_vha_10_10d.pdf"],
+          'case_id' => 'ABC-1234',
+          'status' => 'Not Processed'
+        }
+
+        post '/ivc_champva/v1/forms/status_updates', params: payload
+
+        # Verify StatsD was not called for duration tracking
+        expect(StatsD).not_to have_received(:histogram).with(
+          'champva.submit_to_callback.duration_seconds',
+          anything,
+          anything
+        )
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'handles tracking errors gracefully without disrupting callback flow' do
+        # Create main form file
+        IvcChampvaForm.create!(
+          form_uuid:,
+          email: 'test@email.com',
+          first_name: 'Veteran',
+          last_name: 'Surname',
+          form_number: '10-10D',
+          file_name: "#{form_uuid}_vha_10_10d.pdf",
+          s3_status: 'Submitted',
+          pega_status: nil,
+          case_id: nil,
+          email_sent: false,
+          created_at: created_time
+        )
+
+        # Make StatsD raise an error
+        allow(StatsD).to receive(:histogram).and_raise(StandardError, 'StatsD error')
+        allow(Rails.logger).to receive(:error)
+
+        payload = {
+          'form_uuid' => form_uuid,
+          'file_names' => ["#{form_uuid}_vha_10_10d.pdf"],
+          'case_id' => 'ABC-1234',
+          'status' => 'Processed'
+        }
+
+        post '/ivc_champva/v1/forms/status_updates', params: payload
+
+        # Verify error was logged but callback still succeeded
+        expect(Rails.logger).to have_received(:error).with(/Error tracking submit to callback duration/)
+        expect(response).to have_http_status(:ok)
+
+        # Verify the form was still updated despite tracking error
+        updated_form = IvcChampvaForm.find_by(form_uuid:)
+        expect(updated_form.pega_status).to eq('Processed')
+        expect(updated_form.case_id).to eq('ABC-1234')
+      end
+    end
+
     context 'with invalid payload' do
       let(:invalid_payload) { { status: 'invalid' } }
 


### PR DESCRIPTION
…te call

Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): YES*
- Measure the duration between the form creation time from the `submit` call and the Pega callback and publish metrics.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117775

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
