### PR TITLE
Add updated pdf form url to log in FormPdfChangeDetectionJob

### DIFF
--- a/app/sidekiq/form_pdf_change_detection_job.rb
+++ b/app/sidekiq/form_pdf_change_detection_job.rb
@@ -92,8 +92,10 @@ class FormPdfChangeDetectionJob
     url = form_attributes['url']
 
     StatsD.increment('form.pdf.change.detected', tags: ["form:#{form_name}", "form_id:#{form_id}"])
-    Rails.logger.info(<<~MESSAGE)
-      PDF form #{form_name} (form_id: #{form_id}) was revised. Last revised on date: #{last_revision_on}. URL: #{url}
-    MESSAGE
+    Rails.logger.info(
+      "PDF form #{form_name} (form_id: #{form_id}) was revised. " \
+      "Last revised on date: #{last_revision_on}. " \
+      "URL: #{url}"
+    )
   end
 end

--- a/app/sidekiq/form_pdf_change_detection_job.rb
+++ b/app/sidekiq/form_pdf_change_detection_job.rb
@@ -71,11 +71,11 @@ class FormPdfChangeDetectionJob
   def log_form_revision(form_attributes, form_id)
     form_name = form_attributes['form_name']
     last_revision_on = form_attributes['last_revision_on']
+    url = form_attributes['url']
 
     StatsD.increment('form.pdf.change.detected', tags: ["form:#{form_name}", "form_id:#{form_id}"])
     Rails.logger.info(<<~MESSAGE)
-      PDF form #{form_name} (form_id: #{form_id}) was revised.
-      Last revised on date: #{last_revision_on}
+      PDF form #{form_name} (form_id: #{form_id}) was revised. Last revised on date: #{last_revision_on}. URL: #{url}
     MESSAGE
   end
 end

--- a/app/sidekiq/form_pdf_change_detection_job.rb
+++ b/app/sidekiq/form_pdf_change_detection_job.rb
@@ -2,6 +2,24 @@
 
 require 'forms/client'
 
+# FormPdfChangeDetectionJob
+#
+# This Sidekiq job monitors VA form PDF revisions by comparing current SHA256 checksums
+# against cached values to detect when forms have been updated.
+#
+# Why:
+# - Enables automated tracking of form revisions for compliance and version management.
+# - Provides metrics and logging for form change analytics and auditing.
+# - Helps maintain awareness of form updates that may affect user experience.
+#
+# How:
+# - Fetches current form data and SHA256 checksums from the VA Lighthouse Forms API.
+# - Compares current checksums against cached values from previous runs.
+# - Logs detected changes with StatsD metrics and detailed logging.
+# - Updates the Rails cache with new checksums for future comparisons.
+#
+# See also: Forms::Client for API integration
+
 class FormPdfChangeDetectionJob
   include Sidekiq::Job
 

--- a/spec/sidekiq/form_pdf_change_detection_job_spec.rb
+++ b/spec/sidekiq/form_pdf_change_detection_job_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe FormPdfChangeDetectionJob, type: :job do
           'attributes' => {
             'form_name' => '10-10EZ',
             'sha256' => 'abc123def456',
-            'last_revision_on' => '2024-01-15'
+            'last_revision_on' => '2024-01-15',
+            'url' => 'some-url.com'
           }
         },
         {
@@ -19,7 +20,8 @@ RSpec.describe FormPdfChangeDetectionJob, type: :job do
           'attributes' => {
             'form_name' => '21-526EZ',
             'sha256' => 'xyz789uvw012',
-            'last_revision_on' => '2024-01-10'
+            'last_revision_on' => '2024-01-10',
+            'url' => 'some-other-url.com'
           }
         }
       ]
@@ -107,8 +109,15 @@ RSpec.describe FormPdfChangeDetectionJob, type: :job do
       end
 
       it 'logs revision information' do
+        form = forms_response['data'][0]
+        attributes = form['attributes']
+
         expect(Rails.logger).to receive(:info).with(
-          a_string_including('PDF form 10-10EZ (form_id: 10-10EZ) was revised')
+          a_string_including(
+            "PDF form #{attributes['form_name']} (form_id: #{form['id']}) was revised. " \
+            "Last revised on date: #{attributes['last_revision_on']}. " \
+            "URL: #{attributes['url']}"
+          )
         )
 
         subject.perform


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Add form pdf url to log when a new version is available. This makes it easier to get the new pdf file. 
- 1010 Health Apps

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/102906

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
