### PR TITLE
feat(arp): allow sync execution of POA failure email job

### DIFF
--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/poa_request_failure_notifier.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/poa_request_failure_notifier.rb
@@ -6,7 +6,7 @@ module AccreditedRepresentativePortal
       @poa_request = poa_request
     end
 
-    def call
+    def call(async: true)
       raise ArgumentError, 'PoaRequest is required' unless @poa_request.is_a?(PowerOfAttorneyRequest)
 
       recipient_types.each do |recipient_type|
@@ -14,7 +14,12 @@ module AccreditedRepresentativePortal
           type: 'enqueue_failed',
           recipient_type: recipient_type.to_s
         )
-        PowerOfAttorneyRequestEmailJob.perform_async(notification.id)
+
+        if async
+          PowerOfAttorneyRequestEmailJob.perform_async(notification.id)
+        else
+          PowerOfAttorneyRequestEmailJob.new.perform(notification.id)
+        end
       end
     end
 


### PR DESCRIPTION
Add `async: true` keyword arg to `PoaRequestFailureNotifier#call`. When `async` is false, run `PowerOfAttorneyRequestEmailJob` inline via `.new.perform(notification.id)` instead of enqueuing.

- Default remains async for production behavior
- Enables deterministic runs in dev/console and tests without Sidekiq
- No change to recipients or notification payload

Usage: PoaRequestFailureNotifier.new(req).call(async: false)

This is to enable easier QA testing in staging



## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
