### PR TITLE
API-49103-update-custom-error-handler-for-fes

### DIFF
--- a/modules/claims_api/app/services/claims_api/disability_compensation/docker_container_service.rb
+++ b/modules/claims_api/app/services/claims_api/disability_compensation/docker_container_service.rb
@@ -10,6 +10,7 @@ module ClaimsApi
   module DisabilityCompensation
     class DockerContainerService < ServiceBase
       LOG_TAG = '526_v2_Docker_Container_service'
+      ASYNC = false
 
       def upload(claim_id) # rubocop:disable Metrics/MethodLength
         auto_claim = get_claim(claim_id)
@@ -21,7 +22,7 @@ module ClaimsApi
         if Flipper.enabled?(:lighthouse_claims_api_v2_enable_FES)
           fes_data = get_fes_data(auto_claim)
           log_job_progress(claim_id, 'Submitting mapped data to FES', auto_claim.transaction_id)
-          fes_res = fes_service.submit(auto_claim, fes_data)
+          fes_res = fes_service.submit(auto_claim, fes_data, ASYNC)
           log_job_progress(claim_id, "Successfully submitted to FES with response: #{fes_res}",
                            auto_claim.transaction_id)
           # update with the evss_id returned
@@ -29,7 +30,7 @@ module ClaimsApi
         else
           evss_data = get_evss_data(auto_claim)
           log_job_progress(claim_id, 'Submitting mapped data to Docker container', auto_claim.transaction_id)
-          evss_res = evss_service.submit(auto_claim, evss_data, false)
+          evss_res = evss_service.submit(auto_claim, evss_data, ASYNC)
           log_job_progress(claim_id, "Successfully submitted to Docker container with response: #{evss_res}",
                            auto_claim.transaction_id)
           # update with the evss_id returned

--- a/modules/claims_api/lib/claims_api/v2/error/lighthouse_error_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/error/lighthouse_error_mapper.rb
@@ -25,14 +25,14 @@ module ClaimsApi
         end
 
         def get_details
-          key = if @error[:key].include?('form526')
+          key = if @error[:key]&.include?('form526')
                   @error[:key][8..].gsub('.', '_')
                 else
-                  @error[:key].gsub('.', '_')
+                  @error[:key]&.gsub('.', '_')
                 end
           err_info = @error[:detail] || @error[:text]
-          if LIGHTHOUSE_ERROR_DICTIONARY[key.to_sym].presence
-            LIGHTHOUSE_ERROR_DICTIONARY[key.to_sym]
+          if LIGHTHOUSE_ERROR_DICTIONARY[key&.to_sym].presence
+            LIGHTHOUSE_ERROR_DICTIONARY[key&.to_sym]
           else
             "The claim could not be established - #{err_info}."
           end

--- a/modules/claims_api/lib/custom_error.rb
+++ b/modules/claims_api/lib/custom_error.rb
@@ -98,7 +98,8 @@ module ClaimsApi
     def error_sources
       [
         @original_body&.dig(:messages),
-        @original_body&.dig(:errors)
+        @original_body&.dig(:errors),
+        @original_body&.dig(:data)&.dig(:errors)
       ].compact.flatten
     end
   end

--- a/modules/claims_api/lib/custom_error.rb
+++ b/modules/claims_api/lib/custom_error.rb
@@ -61,7 +61,7 @@ module ClaimsApi
     def get_error_info
       all_errors = []
 
-      (@original_body&.dig(:messages) || []).each do |err|
+      error_sources.each do |err|
         symbolized_error = err.deep_symbolize_keys
         all_errors << munge_error(symbolized_error) unless symbolized_error[:severity] == 'WARN'
       end
@@ -93,6 +93,13 @@ module ClaimsApi
 
     def get_original_body
       @detail ||= @error&.original_body if @error&.methods&.include?(:original_body)
+    end
+
+    def error_sources
+      [
+        @original_body&.dig(:messages),
+        @original_body&.dig(:errors)
+      ].compact.flatten
     end
   end
 end

--- a/modules/claims_api/lib/fes_service/base.rb
+++ b/modules/claims_api/lib/fes_service/base.rb
@@ -14,7 +14,9 @@ module ClaimsApi
         @use_mock = use_mock.nil? ? Rails.env.test? : use_mock
       end
 
-      def validate(claim, claim_data)
+      #  rubocop:disable Style/OptionalBooleanParameter
+      def validate(claim, claim_data, async = false)
+        @async = async
         @auth_headers = claim.auth_headers
         request_body = claim_data
 
@@ -32,8 +34,11 @@ module ClaimsApi
           error_handler(e, detail)
         end
       end
+      # rubocop:enable Style/OptionalBooleanParameter
 
-      def submit(claim, claim_data)
+      # rubocop:disable Style/OptionalBooleanParameter
+      def submit(claim, claim_data, async = false)
+        @async = async
         @auth_headers = claim.auth_headers
         request_body = claim_data
 
@@ -51,6 +56,7 @@ module ClaimsApi
           error_handler(e, detail)
         end
       end
+      # rubocop:enable Style/OptionalBooleanParameter
 
       private
 
@@ -95,7 +101,7 @@ module ClaimsApi
       end
 
       def error_handler(error, detail)
-        ClaimsApi::CustomError.new(error, detail, true).build_error
+        ClaimsApi::CustomError.new(error, detail, @async).build_error
       end
 
       def get_error_message(error)

--- a/modules/claims_api/spec/lib/fes_service/base_spec.rb
+++ b/modules/claims_api/spec/lib/fes_service/base_spec.rb
@@ -61,12 +61,14 @@ describe ClaimsApi::FesService::Base do
     claim.save
     claim
   end
+  let(:async) { true }
+  let(:not_async) { false }
 
   describe '#validate' do
     context 'successful validation' do
       it 'returns validation success' do
         VCR.use_cassette('/claims_api/fes/validate/success') do
-          response = service.validate(fes_claim, min_fes_mapped_data)
+          response = service.validate(fes_claim, min_fes_mapped_data, not_async)
 
           expect(response[:valid]).to be(true)
           expect(response).to have_key(:success)
@@ -78,7 +80,7 @@ describe ClaimsApi::FesService::Base do
       it 'returns a 400' do
         VCR.use_cassette('/claims_api/fes/validate/bad_request') do
           expect do
-            service.validate(claim, invalid_form_data)
+            service.validate(claim, invalid_form_data, not_async)
           end.to raise_error(
             ClaimsApi::Common::Exceptions::Lighthouse::BackendServiceException
           )
@@ -90,7 +92,7 @@ describe ClaimsApi::FesService::Base do
       it 'raises backend service exception' do
         VCR.use_cassette('/claims_api/fes/validate/bad_request') do
           expect do
-            service.validate(claim, invalid_form_data)
+            service.validate(claim, invalid_form_data, not_async)
           end.to raise_error(
             ClaimsApi::Common::Exceptions::Lighthouse::BackendServiceException
           )
@@ -103,7 +105,7 @@ describe ClaimsApi::FesService::Base do
     context 'successful submission' do
       it 'returns submission success' do
         VCR.use_cassette('/claims_api/fes/submit/success') do
-          response = service.submit(fes_claim, min_fes_mapped_data)
+          response = service.submit(fes_claim, min_fes_mapped_data, not_async)
 
           expect(response[:claimId]).to eq(600781884) # rubocop:disable Style/NumericLiterals
           expect(response[:requestId]).not_to be_nil
@@ -117,7 +119,7 @@ describe ClaimsApi::FesService::Base do
         invalid_data[:data][:form526][:serviceInformation][:servicePeriods][0][:serviceBranch] = 'AIR\n Force'
 
         VCR.use_cassette('/claims_api/fes/submit/invalid_request') do
-          expect { service.submit(claim, invalid_form_data) }
+          expect { service.submit(claim, invalid_form_data, not_async) }
             .to raise_error(ClaimsApi::Common::Exceptions::Lighthouse::BackendServiceException)
         end
       end
@@ -126,7 +128,7 @@ describe ClaimsApi::FesService::Base do
     context 'invalid data format' do
       it 'returns a 400' do
         VCR.use_cassette('/claims_api/fes/submit/bad_request') do
-          expect { service.submit(claim, invalid_form_data) }
+          expect { service.submit(claim, invalid_form_data, not_async) }
             .to raise_error(ClaimsApi::Common::Exceptions::Lighthouse::BackendServiceException)
         end
       end

--- a/modules/claims_api/spec/sidekiq/claim_custom_error_spec.rb
+++ b/modules/claims_api/spec/sidekiq/claim_custom_error_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe ClaimsApi::CustomError, type: :job do
     let(:response_values) do
       { status: 400, detail: nil, code: 'VA_400', source: nil }
     end
-    let(:detail) do
+    let(:bad_request_detail) do
       { errors: [
         {
           detail: 'Http Message Not Readable (Unrecognized Property)', status: 400, title: 'Bad Request',
@@ -231,19 +231,44 @@ RSpec.describe ClaimsApi::CustomError, type: :job do
         }
       ] }
     end
-
-    # (key = nil, response_values = {}, original_status = nil, original_body = nil)
-    let(:backend_error) do
-      Common::Exceptions::BackendServiceException.new('VA_400', response_values, 400, detail)
+    let(:invalid_data_detail) do
+      { data: {
+        valid: false,
+        errors: [
+          { status: '400', title: 'Invalid service period branch name',
+            detail: 'Provided service period branch name is not valid: AIR\\n Force',
+            source: {
+              pointer: '/data/form526/serviceInformation/servicePeriods/0/serviceBranch'
+            } }
+        ]
+      } }
     end
 
-    it 'handles returning a message when errors is inside the original_body not messages' do
-      ClaimsApi::CustomError.new(backend_error, detail, false).build_error
+    # (key = nil, response_values = {}, original_status = nil, original_body = nil)
+    let(:bad_request) do
+      Common::Exceptions::BackendServiceException.new('VA_400', response_values, 400, bad_request_detail)
+    end
+
+    let(:invalid_data) do
+      Common::Exceptions::BackendServiceException.new('VA_400', response_values, 400, invalid_data_detail)
+    end
+
+    it 'handles returning a message when :errors is inside the original_body not :messages' do
+      ClaimsApi::CustomError.new(bad_request, bad_request_detail, false).build_error
     rescue => e
       expect(e.errors[0][:status]).to eq('422') # standards require this to be a string
       expect(e.errors[0][:title]).to eq('Backend Service Exception')
       expect(e.errors[0][:detail]).to eq('The claim could not be established - Http Message Not Readable ' \
                                          '(Unrecognized Property).')
+    end
+
+    it 'handles returning a message when :errors is inside :data in the original_body not :messages' do
+      ClaimsApi::CustomError.new(invalid_data, invalid_data_detail, false).build_error
+    rescue => e
+      expect(e.errors[0][:status]).to eq('422') # standards require this to be a string
+      expect(e.errors[0][:title]).to eq('Backend Service Exception')
+      expect(e.errors[0][:detail]).to eq('The claim could not be established - Provided service period branch ' \
+                                         'name is not valid: AIR\\n Force.')
     end
   end
 end


### PR DESCRIPTION
## Summary
* Updates `get_error_info` to handle returning the text if `:errors` is the top key in `@original_body`
	* Previously only `:messages` was handled, everything returned an empty array.
* Refactors the async flag so it is passed in correctly to the job instead of a default value being to the `custom_error_handler` since this service will be shared between v1 & v2

## Related issue(s)
[API-49013](https://jira.devops.va.gov/browse/API-49013)

## Testing done

- [x] *New code is covered by unit tests*

#### Testing Notes
* You can manually test the errors by sending the data into FES that mimics the errors recorded in the following VCR cassettes:
    *  `/claims_api/fes/submit/invalid_request`
    * `/claims_api/fes/submit/bad_request` <--- For this one you will need to place that data in for `claim_data` in fes_service/base.rb to mimic it correctly
  
## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/services/claims_api/disability_compensation/docker_container_service.rb
	modified:   modules/claims_api/lib/claims_api/v2/error/lighthouse_error_mapper.rb
	modified:   modules/claims_api/lib/custom_error.rb
	modified:   modules/claims_api/lib/fes_service/base.rb
	modified:   modules/claims_api/spec/lib/fes_service/base_spec.rb
	modified:   modules/claims_api/spec/sidekiq/claim_custom_error_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
