### PR TITLE
105761: Remove intent_to_file_synchronous_enabled flipper

### DIFF
--- a/app/controllers/v0/in_progress_forms_controller.rb
+++ b/app/controllers/v0/in_progress_forms_controller.rb
@@ -72,9 +72,8 @@ module V0
 
     def itf_creation(form)
       itf_valid_form = Lighthouse::CreateIntentToFileJob::ITF_FORMS.include?(form.form_id)
-      itf_synchronous = Flipper.enabled?(:intent_to_file_synchronous_enabled, @current_user)
 
-      if itf_valid_form && itf_synchronous
+      if itf_valid_form
         itf_monitor.track_create_itf_initiated(form.form_id, form.created_at, @current_user.uuid, form.id)
 
         begin

--- a/config/features.yml
+++ b/config/features.yml
@@ -2162,9 +2162,6 @@ features:
   income_and_assets_persistent_attachment_error_email_notification:
     actor_type: cookie_id
     description: Toggle sending of the Persistent Attachment Error email notification
-  intent_to_file_synchronous_enabled:
-    actor_type: user
-    description: Enable ITF synchronous call logic
   central_mail_benefits_intake_submission:
     actor_type: user
     description: Enable central mail claims submission uses Benefits Intake API

--- a/spec/requests/v0/in_progress_forms_controller_spec.rb
+++ b/spec/requests/v0/in_progress_forms_controller_spec.rb
@@ -400,9 +400,6 @@ RSpec.describe V0::InProgressFormsController do
           end
 
           it 'calls synchronous CreateIntentToFileJob for newly created forms' do
-            expect(Flipper).to receive(:enabled?).with(:intent_to_file_synchronous_enabled,
-                                                       instance_of(User)).and_return(true)
-
             put v0_in_progress_form_url('21P-527EZ'),
                 params: {
                   formData: new_form.form_data,


### PR DESCRIPTION
Remove `intent_to_file_synchronous_enabled` flipper and its usage in IPF controller/spec

## Summary

- Removed flipper from features
- Removed from conditional in controller
- Updated spec

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/105761

## Testing done

- [ ] *New code is covered by unit tests*