### PR TITLE
Replace Virtus with Vets::Model - IVC Champva

### DIFF
--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_10d.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module IvcChampva
   class VHA1010d
     ADDITIONAL_PDF_KEY = 'applicants'
     ADDITIONAL_PDF_COUNT = 3
     STATS_KEY = 'api.ivc_champva_form.10_10d'
 
-    include Virtus.model(nullify_blank: true)
+    include Vets::Model
     include Attachments
 
-    attribute :data
+    attribute :data, Hash
     attr_reader :form_id
 
     def initialize(data)

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959a.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module IvcChampva
   class VHA107959a
     ADDITIONAL_PDF_KEY = 'claims'
     ADDITIONAL_PDF_COUNT = 1
     STATS_KEY = 'api.ivc_champva_form.10_7959a'
 
-    include Virtus.model(nullify_blank: true)
+    include Vets::Model
     include Attachments
 
-    attribute :data
+    attribute :data, Hash
     attr_reader :form_id
 
     def initialize(data)

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module IvcChampva
   class VHA107959c
     STATS_KEY = 'api.ivc_champva_form.10_7959c'
 
-    include Virtus.model(nullify_blank: true)
+    include Vets::Model
     include Attachments
 
-    attribute :data
+    attribute :data, Hash
     attr_reader :form_id
 
     def initialize(data)

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c_rev2025.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959c_rev2025.rb
@@ -7,14 +7,17 @@
 #
 # This version of the form is used with the new 10-10d/10-7959c merged form
 # experience (e.g., "10-10D-EXTENDED").
+
+require 'vets/model'
+
 module IvcChampva
   class VHA107959cRev2025
     STATS_KEY = 'api.ivc_champva_form.10_7959c_rev2025'
 
-    include Virtus.model(nullify_blank: true)
+    include Vets::Model
     include Attachments
 
-    attribute :data
+    attribute :data, Hash
     attr_reader :form_id
 
     def initialize(data)

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_1.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_1.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module IvcChampva
   class VHA107959f1
     STATS_KEY = 'api.ivc_champva_form.10_7959f_1'
 
-    include Virtus.model(nullify_blank: true)
+    include Vets::Model
     include Attachments
 
-    attribute :data
+    attribute :data, Hash
     attr_reader :form_id
 
     def initialize(data)

--- a/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_2.rb
+++ b/modules/ivc_champva/app/models/ivc_champva/vha_10_7959f_2.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
+require 'vets/model'
+
 module IvcChampva
   class VHA107959f2
     STATS_KEY = 'api.ivc_champva_form.10_7959f_2'
 
-    include Virtus.model(nullify_blank: true)
+    include Vets::Model
     include Attachments
 
-    attribute :data
+    attribute :data, Hash
     attr_reader :form_id
 
     def initialize(data)

--- a/modules/ivc_champva/lib/tasks/forms.rake
+++ b/modules/ivc_champva/lib/tasks/forms.rake
@@ -62,11 +62,13 @@ namespace :ivc_champva do
     File.open(new_model_file, 'w') do |f|
       f.puts '# frozen_string_literal: true'
       f.puts ''
+      f.puts 'require \'vets/model\''
+      f.puts ''
       f.puts 'module IvcChampva'
       f.puts "  class #{form_name.upcase.gsub('_', '')}"
-      f.puts '    include Virtus.model(nullify_blank: true)'
+      f.puts '    include Vets::Model'
       f.puts ''
-      f.puts '    attribute :data'
+      f.puts '    attribute :data, Hash'
 
       # Attributes are not yet needed. Their advantage is that they provide datatypes that can manipulated such as
       # formatting dates. This is also a bit overkill for only central mail


### PR DESCRIPTION
## Summary

- Virtus is being replace with `Vets::Model`. Differences include:
    - There's no hash access for attributes `form[:attribute]` only dot notation `form.attribute`
    - Syntax change for Array attributes
    - Sorting uses a class method: `default_sort_by`
    - booleans are temporarily `Bool`, until Virtus is completely gone
- This PR replaces `Virtus.model` with `Vets::Model` and updates the _attributes_ and _implementation_ accordingly. 
- This change should not affect any functionality.

nullify_blank didn't seem to affect the blank hashes, so I didn't make any changes for that

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92446

## Testing done

- [x] Manual testing for similar output

## Acceptance criteria

- [x] Virtus models are now Vets::Model
- [x] No functional change