### PR TITLE
bmt1/117394: [CST] [BUG] Adobe Acrobat-encrypted PDFs fail with 422 error #117394

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1078,6 +1078,8 @@ features:
     actor_type: user
     description: Enables ability to show updated letter page design
     enable_in_development: true
+  lighthouse_document_convert_to_unlocked_pdf_use_hexapdf:
+    description: Enables the LighthouseDocument class's convert_to_unlocked_pdf method to use hexapdf to unlock encrypted pds
   lighthouse_claims_api_v2_add_person_proxy:
     actor_type: user
     description: Lighthouse Benefits Claims API v2 uses add_person_proxy service when target Veteran is missing a Participant ID


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- create PDF unlocking Strategy 
-- add feature flag to use hexapdf in LighthouseDocument class
-- add method to unlock pdf with hexapdf using Common::PdfHelpers

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/11739

## Testing done

- [ ] *New code is covered by unit tests*
- PDFs encrypted by Adobe Acrobat were failing at uncryption method because our legacy PDFTK unencryption method does not recoginize the encryption type
- With this feature flag on, the PDFs are now unencrypted by HexaPDF Adobe Acrobat encrypted
- Tested on the frontend, va.gov, via the Evidence Upload feature in the CST (Claim Status Tool)

## Screenshots
<img width="1788" height="1672" alt="image" src="https://github.com/user-attachments/assets/0a82daa6-a08b-48ec-acce-4b1461470684" />


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

