### PR TITLE
Adds General / Headers validations for v1 fes mapper

### DIFF
--- a/modules/claims_api/lib/claims_api/v1/disability_compensation_fes_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v1/disability_compensation_fes_mapper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module ClaimsApi
+  module V1
+    class DisabilityCompensationFesMapper
+      def initialize(auto_claim)
+        @auto_claim = auto_claim
+        @data = auto_claim&.form_data&.deep_symbolize_keys
+        @fes_claim = {}
+        @veteran_participant_id = auto_claim.auth_headers&.dig('va_eauth_pid')
+        @transaction_id = auto_claim.auth_headers&.dig('va_eauth_service_transaction_id')
+      end
+
+      def map_claim
+        validate_required_fields!
+
+        wrap_in_request_structure
+      end
+
+      private
+
+      def wrap_in_request_structure
+        {
+          data: {
+            serviceTransactionId: @transaction_id,
+            veteranParticipantId: @veteran_participant_id,
+            claimantParticipantId: @veteran_participant_id,
+            form526: {}
+          }
+        }
+      end
+
+      def validate_required_fields!
+        if @veteran_participant_id.blank?
+          raise ArgumentError, 'Missing veteranParticipantId - auth_headers do not contain valid participant ID'
+        end
+        if @transaction_id.blank?
+          raise ArgumentError, 'Missing serviceTransactionId - auth_headers do not contain valid service transaction ID'
+        end
+      end
+    end
+  end
+end

--- a/modules/claims_api/spec/lib/claims_api/v1/disability_compensation_fes_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v1/disability_compensation_fes_mapper_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'claims_api/v1/disability_compensation_fes_mapper'
+
+describe ClaimsApi::V1::DisabilityCompensationFesMapper do
+  let(:veteran_participant_id) { '600049324' }
+  let(:transaction_id) { 'vagov-8a1be4b0' }
+  let(:auth_headers) do
+    {
+      'va_eauth_csid' => 'DSLogon', 'va_eauth_authenticationmethod' => 'DSLogon',
+      'va_eauth_pnidtype' => 'SSN', 'va_eauth_assurancelevel' => '3', 'va_eauth_firstName' => 'Janet',
+      'va_eauth_lastName' => 'Moore', 'va_eauth_issueinstant' => '2025-08-26T21:43:33Z',
+      'va_eauth_dodedipnid' => '1005396162', 'va_eauth_birlsfilenumber' => '123456',
+      'va_eauth_pid' => veteran_participant_id.to_s, 'va_eauth_pnid' => '796127677',
+      'va_eauth_birthdate' => '1949-05-06T00:00:00+00:00',
+      'va_eauth_authorization' => '{Does not matter here}', 'va_eauth_authenticationauthority' => 'eauth',
+      'va_eauth_service_transaction_id' => transaction_id.to_s
+    }
+  end
+  let(:form_data) do
+    JSON.parse(
+      Rails.root.join(
+        'modules',
+        'claims_api',
+        'spec',
+        'fixtures',
+        'form_526_json_api.json'
+      ).read
+    )
+  end
+  let(:auto_claim) do
+    create(:auto_established_claim,
+           form_data: form_data['data']['attributes'],
+           auth_headers:)
+  end
+
+  let(:fes_data) do
+    ClaimsApi::V1::DisabilityCompensationFesMapper.new(auto_claim).map_claim
+  end
+
+  context 'request structure' do
+    it 'wraps data in proper FES request structure' do
+      expect(fes_data).to have_key(:data)
+      expect(fes_data[:data][:serviceTransactionId]).to eq(transaction_id)
+      expect(fes_data[:data][:claimantParticipantId]).to eq(veteran_participant_id)
+      expect(fes_data[:data][:veteranParticipantId]).to eq(veteran_participant_id)
+      expect(fes_data[:data]).to have_key(:form526)
+    end
+
+    context 'with errors' do
+      it 'returns an error if the veteranParticipantId is not present' do
+        headers = auto_claim.auth_headers
+        headers['va_eauth_pid'] = nil
+
+        expect do
+          ClaimsApi::V1::DisabilityCompensationFesMapper.new(auto_claim).map_claim
+        end.to raise_error(ArgumentError, 'Missing veteranParticipantId - ' \
+                                          'auth_headers do not contain valid participant ID')
+      end
+
+      it 'returns an error if the serviceTransactionId is not present' do
+        headers = auto_claim.auth_headers
+        headers['va_eauth_service_transaction_id'] = nil
+
+        expect do
+          ClaimsApi::V1::DisabilityCompensationFesMapper.new(auto_claim).map_claim
+        end.to raise_error(ArgumentError, 'Missing serviceTransactionId - ' \
+                                          'auth_headers do not contain valid service transaction ID')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
* Adds validations for the General / Headers
    * Adds validations for veteran participant ID, transaction ID, claimant participant Id and form526 presence wrapped inside a data key
* [Attribute mapping doc](https://confluence.devops.va.gov/pages/viewpage.action?spaceKey=VAExternal&title=526+Attribute+Mapping)
* See required fields in image below
* One thing to note, _this PR does not yet address actually using the mapper in the workflow of submission, that is the final step, this is just building out the mappe_r.

## Related issue(s)
[API-47336](https://jira.devops.va.gov/browse/API-47336)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
<img width="650" height="533" alt="Screenshot 2025-08-27 094833" src="https://github.com/user-attachments/assets/2ed6e40b-b473-43aa-83ab-72315c7a1295" />

## What areas of the site does it impact?
	new file:   modules/claims_api/lib/claims_api/v1/disability_compensation_fes_mapper.rb
	new file:   modules/claims_api/spec/lib/claims_api/v1/disability_compensation_fes_mapper.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
