### PR TITLE
Update Cerner appointment post-processing

### DIFF
--- a/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointment.rb
+++ b/modules/mobile/app/models/mobile/v0/adapters/vaos_v2_appointment.rb
@@ -118,7 +118,8 @@ module Mobile
             best_time_to_call: appointment[:preferred_times_for_phone_call],
             friendly_location_name:,
             service_category_name: appointment.dig(:service_category, 0, :text),
-            show_schedule_link: appointment[:show_schedule_link]
+            show_schedule_link: appointment[:show_schedule_link],
+            is_cerner: appointment[:is_cerner]
           }
 
           if appointment[:travelPayClaim]

--- a/modules/mobile/app/models/mobile/v0/appointment.rb
+++ b/modules/mobile/app/models/mobile/v0/appointment.rb
@@ -79,6 +79,7 @@ module Mobile
       end
       attribute? :travel_pay_eligible, Types::Bool
       attribute :show_schedule_link, Types::Bool.optional
+      attribute :is_cerner, Types::Bool.optional
 
       # On staging, some upstream services use different facility ids for the same facility.
       # These methods convert between the two sets of ids.

--- a/modules/mobile/app/serializers/mobile/v0/appointment_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/appointment_serializer.rb
@@ -33,7 +33,8 @@ module Mobile
                  :service_category_name,
                  :travelPayClaim,
                  :travel_pay_eligible,
-                 :show_schedule_link
+                 :show_schedule_link,
+                 :is_cerner
     end
   end
 end

--- a/modules/mobile/docs/openapi.json
+++ b/modules/mobile/docs/openapi.json
@@ -10009,6 +10009,11 @@
                 "type": "boolean",
                 "nullable": true,
                 "example": true
+              },
+              "isCerner": {
+                "type": "boolean",
+                "nullable": true,
+                "example": true
               }
             }
           }

--- a/modules/mobile/docs/schemas/Appointment.yml
+++ b/modules/mobile/docs/schemas/Appointment.yml
@@ -227,7 +227,7 @@ properties:
       travelPayClaim:
         type: object
         nullable: true
-        description: This is the travel pay claim object. 
+        description: This is the travel pay claim object.
         additionalProperties: false
         properties:
           metadata:
@@ -285,11 +285,11 @@ properties:
                 type: string
                 nullable: false
                 example: '2023-02-23T22:22:52.549Z'
-              facilityId: 
+              facilityId:
                 type: string
                 nullable: false
                 example: '3fa85f64-5717-4562-b3fc-2c963f66afa6'
-              facilityName: 
+              facilityName:
                 type: string
                 nullable: false
                 example: 'Tomah VA Medical Center'
@@ -301,15 +301,19 @@ properties:
                 type: float
                 nullable: false
                 example: 0
-              createdOn:  
+              createdOn:
                 type: string
                 nullable: false
                 example: '2023-02-24T22:22:52.549Z'
               modifiedOn:
                 type: string
                 nullable: false
-                example: '2023-02-26T22:22:52.549Z' 
+                example: '2023-02-26T22:22:52.549Z'
       showScheduleLink:
+        type: boolean
+        nullable: true
+        example: true
+      isCerner:
         type: boolean
         nullable: true
         example: true

--- a/modules/mobile/spec/models/adapters/appointments_vaos_v2_adapter_spec.rb
+++ b/modules/mobile/spec/models/adapters/appointments_vaos_v2_adapter_spec.rb
@@ -25,6 +25,7 @@ describe Mobile::V0::Adapters::VAOSV2Appointments, :aggregate_failures do
   let(:future_request_date_appt_id) { '53359' }
   let(:telehealth_onsite_id) { '50097' }
   let(:missing_vvs_kind_id) { '50101' }
+  let(:cerner_va_id) { 'CERN129377263' }
 
   def appointment_data(index = nil)
     appts = index ? raw_data[index] : raw_data
@@ -58,7 +59,7 @@ describe Mobile::V0::Adapters::VAOSV2Appointments, :aggregate_failures do
 
   it 'returns a list of Mobile::V0::Appointments at the expected size' do
     adapted_appointments = subject.parse(appointment_data)
-    expect(adapted_appointments.size).to eq(17)
+    expect(adapted_appointments.size).to eq(18)
     expect(adapted_appointments.map(&:class).uniq).to match_array(Mobile::V0::Appointment)
   end
 
@@ -112,7 +113,8 @@ describe Mobile::V0::Adapters::VAOSV2Appointments, :aggregate_failures do
                                  'best_time_to_call' => nil,
                                  'friendly_location_name' => 'Cheyenne VA Medical Center',
                                  'service_category_name' => nil,
-                                 'show_schedule_link' => nil
+                                 'show_schedule_link' => nil,
+                                 'is_cerner' => nil
                                })
   end
 
@@ -722,6 +724,15 @@ describe Mobile::V0::Adapters::VAOSV2Appointments, :aggregate_failures do
         appt = appointment_by_id(booked_va_id)
         expect(appt.show_schedule_link).to be_nil
       end
+    end
+  end
+
+  describe 'is_cerner' do
+    it 'passes through the proper boolean value' do
+      appt = appointment_by_id(booked_va_id)
+      expect(appt.is_cerner).to be_nil
+      appt = appointment_by_id(cerner_va_id)
+      expect(appt.is_cerner).to be(true)
     end
   end
 end

--- a/modules/mobile/spec/support/fixtures/VAOS_v2_appointments.json
+++ b/modules/mobile/spec/support/fixtures/VAOS_v2_appointments.json
@@ -1151,5 +1151,66 @@
     "telehealth": {
       "url": "http://www.meeting.com"
     }
+  },
+  {
+    "id": "CERN129377263",
+    "identifier": [
+        {
+            "system": "urn:va.gov:cfa:cerner:appointment",
+            "value": "Appointment/129377263"
+        }
+    ],
+    "kind": "clinic",
+    "type": "VA",
+    "status": "cancelled",
+    "service_type": "foodAndNutrition",
+    "reason_for_appointment": "Routine Follow-up",
+    "reason_code": {
+      "coding": [
+        {
+          "code": "Routine Follow-up"
+        }
+      ]
+    },
+    "patient_icn": "1012845331V153043",
+    "location_id": "442",
+    "location": {
+      "id": "442",
+      "name": "Cheyenne VA Medical Center",
+      "time_zone": {
+        "time_zone_id": "America/Denver"
+      },
+      "physical_address": {
+        "type": "physical",
+        "line": [
+          "2360 East Pershing Boulevard"
+        ],
+        "city": "Cheyenne",
+        "state": "WY",
+        "postal_code": "82001-5356"
+      },
+      "lat": 41.148026,
+      "long": -104.786255,
+      "phone": {
+        "main": "307-778-7550"
+      },
+      "url": null,
+      "code": null
+    },
+    "requested_periods": [
+        {
+            "start": "2025-09-30T20:00:00Z",
+            "end": "2025-09-30T20:30:00Z"
+        }
+    ],
+    "start": "2025-09-30T20:00:00Z",
+    "end": "2025-09-30T20:30:00Z",
+    "cancellable": false,
+    "modality": "vaInPerson",
+    "pending": false,
+    "past": true,
+    "future": false,
+    "show_schedule_link": false,
+    "is_cerner": true
   }
 ]

--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -196,26 +196,6 @@ module VAOS
         appointments_service.post_appointment(create_params)
       end
 
-      # Checks if the appointment is associated with cerner. It looks through each identifier and checks if the system
-      # contains cerner. If it does, it returns true. Otherwise, it returns false.
-      #
-      # @param appt [Hash] the appointment to check
-      # @return [Boolean] true if the appointment is associated with cerner, false otherwise
-      def cerner?(appt)
-        return false if appt.nil?
-
-        identifiers = appt[:identifier]
-
-        return false if identifiers.nil?
-
-        identifiers.each do |identifier|
-          system = identifier[:system]
-          return true if system.include?('cerner')
-        end
-
-        false
-      end
-
       def scrape_appt_comments_and_log_details(appt, appt_method, comment_key)
         if appt&.[](:reason)&.include? comment_key
           log_appt_comment_data(appt, appt_method, appt&.[](:reason), comment_key, REASON)

--- a/modules/vaos/app/docs/vaos/v2/vaos_v2.yaml
+++ b/modules/vaos/app/docs/vaos/v2/vaos_v2.yaml
@@ -1147,6 +1147,9 @@ components:
         showScheduleLink:
           type: boolean
           description: If true then this cancelled appointment can be scheduled via the web tool.
+        isCerner:
+          type: boolean
+          description: Whether this appointment is a Cerner (Oracle Health) appointment.
     AppointmentExtensions:
       type: object
       properties:

--- a/modules/vaos/app/schemas/appointments_index.json
+++ b/modules/vaos/app/schemas/appointments_index.json
@@ -272,6 +272,7 @@
           "cancellable": { "type": "boolean" },
           "patient_instruction": { "type": "string" },
           "showScheduleLink": { "type": "boolean" },
+          "isCerner": { "type": "boolean" },
           "telehealth": {
             "type": "object",
             "additionalProperties": false,

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -441,6 +441,7 @@ module VAOS
         get_appointments(start_time, end_time, statuses)[:data].select { |appt| appt.kind == 'clinic' }
       end
 
+      # rubocop:disable Metrics/MethodLength
       def prepare_appointment(appointment, include = {})
         # for CnP, covid, CC and telehealth appointments set cancellable to false per GH#57824, GH#58690, ZH#326
         set_cancellable_false(appointment) if cannot_be_cancelled?(appointment)
@@ -467,7 +468,12 @@ module VAOS
           find_and_merge_provider_name(appointment)
         end
 
-        merge_clinic(appointment) if include[:clinics]
+        if VAOS::AppointmentsHelper.cerner?(appointment)
+          appointment[:is_cerner] = true
+        else
+          appointment[:is_cerner] = false
+          merge_clinic(appointment) if include[:clinics]
+        end
 
         merge_facility(appointment) if include[:facilities]
 
@@ -481,6 +487,7 @@ module VAOS
 
         appointment[:show_schedule_link] = schedulable?(appointment) if appointment[:status] == 'cancelled'
       end
+      # rubocop:enable Metrics/MethodLength
 
       def find_and_merge_provider_name(appointment)
         practitioners_list = appointment[:practitioners]
@@ -655,20 +662,6 @@ module VAOS
       def filter_reason_code_text(request_object_body)
         text = request_object_body&.dig(:reason_code, :text)
         VAOS::Strings.filter_ascii_characters(text) if text.present?
-      end
-
-      # Determines if the appointment is a Cerner (Oracle Health) appointment.
-      # This is determined by the presence of a 'CERN' prefix in the appointment's id.
-      #
-      # @param appt [Hash] the appointment to check
-      # @return [Boolean] true if the appointment is a Cerner appointment, false otherwise
-      #
-      # @raise [ArgumentError] if the appointment is nil
-      #
-      def cerner?(appt)
-        raise ArgumentError, 'Appointment cannot be nil' if appt.nil?
-
-        appt[:id].start_with?('CERN')
       end
 
       # Checks if the appointment is booked.
@@ -901,7 +894,7 @@ module VAOS
       end
 
       def set_type(appointment)
-        type = if cerner?(appointment)
+        type = if VAOS::AppointmentsHelper.cerner?(appointment)
                  cerner_type(appointment)
                else
                  non_cerner_type(appointment)
@@ -1013,7 +1006,7 @@ module VAOS
 
       # This should be called after set_type has been called
       def schedulable?(appointment)
-        return false if cerner?(appointment) || cnp?(appointment) || telehealth?(appointment)
+        return false if VAOS::AppointmentsHelper.cerner?(appointment) || cnp?(appointment) || telehealth?(appointment)
         return appointment[:type] == APPOINTMENT_TYPES[:cc_request] if cc?(appointment)
         return true if appointment[:type] == APPOINTMENT_TYPES[:request]
         if appointment[:type] == APPOINTMENT_TYPES[:va] &&


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- This PR updates the post processing steps for Cerner appointments as per design in the linked issue
  - Use :identifier instead of :id to determine if an appointment is Cerner or not
  - Do not include clinic information (service_name, physical_location) for Cerner appointments
  - Include is_cerner in API response and update Mobile API to pass through the new field
- United Appointments Experience

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117352

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Appointments, Mobile

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
