### PR TITLE
feat(arp): use environment-based frontend_base_url for POA request links

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,7 +10,7 @@ accredited_representative_portal:
       base_uri: https://api.github.com
       path: <%= ENV['accredited_representative_portal__allow_list__github__path'] %>
       repo: department-of-veterans-affairs/va.gov-team-sensitive
-  frontend_base_url: <%= ENV["accredited_representative_portal__frontend_base_url"] %>
+  frontend_base_url: <%= ENV['accredited_representative_portal__frontend_base_url'] %>
 adapted_housing:
   prefill: true
 argocd:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,11 +10,7 @@ accredited_representative_portal:
       base_uri: https://api.github.com
       path: <%= ENV['accredited_representative_portal__allow_list__github__path'] %>
       repo: department-of-veterans-affairs/va.gov-team-sensitive
-  frontend_base_url: <%= case (ENV["accredited_representative_portal__app_env"] || Rails.env)
-    when "staging" then "https://staging.va.gov/representative"
-    when "production" then "https://va.gov/representative"
-    else "http://localhost:3001"
-  end %>
+  frontend_base_url: <%= ENV["accredited_representative_portal__base_url"] || 'http://localhost:3001' %>
 adapted_housing:
   prefill: true
 argocd:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,6 +10,11 @@ accredited_representative_portal:
       base_uri: https://api.github.com
       path: <%= ENV['accredited_representative_portal__allow_list__github__path'] %>
       repo: department-of-veterans-affairs/va.gov-team-sensitive
+  frontend_base_url: <%= case (ENV["accredited_representative_portal__app_env"] || Rails.env)
+    when "staging" then "https://staging.va.gov/representative"
+    when "production" then "https://va.gov/representative"
+    else "http://localhost:3001"
+  end %>
 adapted_housing:
   prefill: true
 argocd:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,7 +10,7 @@ accredited_representative_portal:
       base_uri: https://api.github.com
       path: <%= ENV['accredited_representative_portal__allow_list__github__path'] %>
       repo: department-of-veterans-affairs/va.gov-team-sensitive
-  frontend_base_url: <%= ENV["accredited_representative_portal__base_url"] || 'http://localhost:3001' %>
+  frontend_base_url: <%= ENV["accredited_representative_portal__base_url"] %>
 adapted_housing:
   prefill: true
 argocd:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,7 +10,7 @@ accredited_representative_portal:
       base_uri: https://api.github.com
       path: <%= ENV['accredited_representative_portal__allow_list__github__path'] %>
       repo: department-of-veterans-affairs/va.gov-team-sensitive
-  frontend_base_url: <%= ENV["accredited_representative_portal__base_url"] %>
+  frontend_base_url: <%= ENV["accredited_representative_portal__frontend_base_url"] %>
 adapted_housing:
   prefill: true
 argocd:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -10,6 +10,7 @@ accredited_representative_portal:
       base_uri: ~
       path: ~
       repo: ~
+  frontend_base_url: http://localhost:3001/representative
 adapted_housing:
   prefill: true
 argocd:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -9,6 +9,7 @@ accredited_representative_portal:
       base_uri: https://not.real.com
       path: not_real.csv
       repo: faked/fakeness
+  frontend_base_url: http://localhost:3001/representative
 adapted_housing:
   prefill: true
 argocd:

--- a/modules/accredited_representative_portal/app/sidekiq/accredited_representative_portal/email_personalisations.rb
+++ b/modules/accredited_representative_portal/app/sidekiq/accredited_representative_portal/email_personalisations.rb
@@ -103,10 +103,10 @@ module AccreditedRepresentativePortal
       private
 
       def poa_request_url
-        base_url = Settings.accredited_representative_portal.frontend_base_url
-        request_path = "/poa_requests/#{@notification.power_of_attorney_request.id}"
-
-        base_url + request_path
+        base = Settings.accredited_representative_portal.frontend_base_url
+        uri  = URI.parse(base)
+        uri.path = File.join(uri.path.presence || '/', 'poa_requests', @notification.power_of_attorney_request.id.to_s)
+        uri.to_s
       end
     end
 

--- a/modules/accredited_representative_portal/app/sidekiq/accredited_representative_portal/email_personalisations.rb
+++ b/modules/accredited_representative_portal/app/sidekiq/accredited_representative_portal/email_personalisations.rb
@@ -103,9 +103,10 @@ module AccreditedRepresentativePortal
       private
 
       def poa_request_url
-        AccreditedRepresentativePortal::Engine.routes.url_helpers.v0_power_of_attorney_request_url(
-          @notification.power_of_attorney_request
-        )
+        base_url = Settings.accredited_representative_portal.frontend_base_url
+        request_path = "/poa_requests/#{@notification.power_of_attorney_request.id}"
+
+        base_url + request_path
       end
     end
 

--- a/modules/accredited_representative_portal/spec/sidekiq/accredited_representative_portal/email_personalisations_spec.rb
+++ b/modules/accredited_representative_portal/spec/sidekiq/accredited_representative_portal/email_personalisations_spec.rb
@@ -245,8 +245,6 @@ RSpec.describe AccreditedRepresentativePortal::EmailPersonalisations do
                                                           })
 
       allow(user_account).to receive(:registration_numbers).and_return({ 'veteran_service_officer' => '1234' })
-      AccreditedRepresentativePortal::Engine.routes.default_url_options[:host] = 'http://test.host'
-
       AccreditedRepresentativePortal::PowerOfAttorneyRequestDecision.create_declination!(
         creator: user_account,
         power_of_attorney_request: poa_request,
@@ -256,10 +254,7 @@ RSpec.describe AccreditedRepresentativePortal::EmailPersonalisations do
 
     it 'returns the correct URL' do
       result = personalisation.generate
-      expected_url = AccreditedRepresentativePortal::Engine
-                     .routes
-                     .url_helpers
-                     .v0_power_of_attorney_request_url(poa_request)
+      expected_url = "http://localhost:3001/poa_requests/#{poa_request.id}"
       expect(result['poa_request_url']).to eq(expected_url)
     end
 

--- a/modules/accredited_representative_portal/spec/sidekiq/accredited_representative_portal/email_personalisations_spec.rb
+++ b/modules/accredited_representative_portal/spec/sidekiq/accredited_representative_portal/email_personalisations_spec.rb
@@ -254,8 +254,15 @@ RSpec.describe AccreditedRepresentativePortal::EmailPersonalisations do
 
     it 'returns the correct URL' do
       result = personalisation.generate
-      expected_url = "http://localhost:3001/poa_requests/#{poa_request.id}"
-      expect(result['poa_request_url']).to eq(expected_url)
+
+      base = Settings.accredited_representative_portal.frontend_base_url
+      expected = begin
+        u = URI.parse(base)
+        u.path = File.join(u.path.presence || '/', 'poa_requests', poa_request.id.to_s)
+        u.to_s
+      end
+
+      expect(result['poa_request_url']).to eq(expected)
     end
 
     it 'returns the first name' do


### PR DESCRIPTION
- Added `frontend_base_url` to `settings.yml`, resolving to staging, production, or localhost based on `accredited_representative_portal__base_url` or Rails.env.
- Updated `EmailPersonalisations#poa_request_url` to build links using this base URL instead of `Engine.routes.url_helpers`.
- Adjusted specs to expect URLs built from `frontend_base_url`.

Note: there is no staging.yml because the app is in production mode even in staging. Config gem relies on Rails.env to determine current environment so we need our own env var for this.


## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/98668

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
