### PR TITLE
1927: make eligible benefits statsd tag legible

### DIFF
--- a/app/sidekiq/lighthouse/benefits_discovery/log_eligible_benefits_job.rb
+++ b/app/sidekiq/lighthouse/benefits_discovery/log_eligible_benefits_job.rb
@@ -42,7 +42,7 @@ module Lighthouse
       # datadog converts most non-alphanumeric characters into underscores
       # this series of substitutions is being done to make the tag more readable
       def format_benefits(sorted)
-        sorted.to_h.to_s.tr('\"{}=>', '').tr('[', '/').gsub('], ', '/').gsub(', ', ':').tr(']', '/')
+        sorted.to_h.to_s.tr('\/"{}=>', '').tr('[', '/').gsub('], ', '/').gsub(', ', ':').tr(']', '/')
       end
     end
   end

--- a/app/sidekiq/lighthouse/benefits_discovery/log_eligible_benefits_job.rb
+++ b/app/sidekiq/lighthouse/benefits_discovery/log_eligible_benefits_job.rb
@@ -24,8 +24,8 @@ module Lighthouse
         execution_time = Time.current - start_time
         StatsD.measure(self.class.name, execution_time)
         sorted_benefits = sort_benefits(eligible_benefits)
-        formatted_benefits = sorted_benefits.to_h.to_s.tr('\"', '').tr(' ', '')
-        StatsD.increment('benefits_discovery.logging', tags: [formatted_benefits])
+        formatted_benefits = format_benefits(sorted_benefits)
+        StatsD.increment('benefits_discovery_logging', tags: ["eligible_benefits:#{formatted_benefits}"])
       rescue => e
         Rails.logger.error("Failed to process eligible benefits for user: #{user_uuid}, error: #{e.message}")
         raise e
@@ -37,6 +37,12 @@ module Lighthouse
         benefit_recommendations.transform_values do |benefits|
           benefits.map { |benefit| benefit['benefit_name'] }.sort
         end.sort
+      end
+
+      # datadog converts most non-alphanumeric characters into underscores
+      # this series of substitutions is being done to make the tag more readable
+      def format_benefits(sorted)
+        sorted.to_h.to_s.tr('\"{}=>', '').tr('[', '/').gsub('], ', '/').gsub(', ', ':').tr(']', '/')
       end
     end
   end

--- a/lib/lighthouse/benefits_discovery/params.rb
+++ b/lib/lighthouse/benefits_discovery/params.rb
@@ -50,7 +50,10 @@ module BenefitsDiscovery
 
     def disability_rating
       # guard should be moved to controller once this is being called from a controller
-      return nil unless @user.authorize(:lighthouse, :access?)
+      unless @user.authorize(:lighthouse, :access?)
+        Rails.logger.info('BenefitsDiscoveryParams: user does not have lighthouse access')
+        return nil
+      end
 
       service = VeteranVerification::Service.new
       response = service.get_rated_disabilities(@user.icn)

--- a/spec/sidekiq/lighthouse/benefits_discovery/log_eligible_benefits_job_spec.rb
+++ b/spec/sidekiq/lighthouse/benefits_discovery/log_eligible_benefits_job_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe Lighthouse::BenefitsDiscovery::LogEligibleBenefitsJob, type: :job
 
       it 'processes benefits discovery successfully' do
         expect(StatsD).to receive(:measure).with(described_class.name, be_a(Float))
-        expected_tags = '{not_recommended=>[],recommended=>[Health,LifeInsurance(VALife)],undetermined=>[]}'
-        expect(StatsD).to receive(:increment).with('benefits_discovery.logging', { tags: [expected_tags] })
+        expected_tags = 'eligible_benefits:not_recommended//recommended/Health:Life Insurance (VALife)/undetermined//'
+        expect(StatsD).to receive(:increment).with('benefits_discovery_logging', { tags: [expected_tags] })
         described_class.new.perform(user.uuid, prepared_service_history)
       end
 
@@ -113,14 +113,14 @@ RSpec.describe Lighthouse::BenefitsDiscovery::LogEligibleBenefitsJob, type: :job
             }
           ]
         }
-        expected_tags = '{not_recommended=>[Health,LifeInsurance(VALife)],recommended=>[Childcare,Education],' \
-                        'undetermined=>[JobAssistance,Wealth]}'
+        expected_tags = 'eligible_benefits:not_recommended/Health:Life Insurance (VALife)' \
+                        '/recommended/Childcare:Education/undetermined/Job Assistance:Wealth/'
         allow(service_instance).to receive(:get_eligible_benefits).and_return(benefits)
-        expect(StatsD).to receive(:increment).with('benefits_discovery.logging', { tags: [expected_tags] })
+        expect(StatsD).to receive(:increment).with('benefits_discovery_logging', { tags: [expected_tags] })
         described_class.new.perform(user.uuid, prepared_service_history)
 
         allow(service_instance).to receive(:get_eligible_benefits).and_return(reordered_benefits)
-        expect(StatsD).to receive(:increment).with('benefits_discovery.logging', { tags: [expected_tags] })
+        expect(StatsD).to receive(:increment).with('benefits_discovery_logging', { tags: [expected_tags] })
         described_class.new.perform(user.uuid, prepared_service_history)
       end
     end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES
- Changes logging format and adds another logging event. 
- I work for the IIR. We do maintain this.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-iir/issues/1927

## Testing done

- [x] *New code is covered by unit tests*
- Previously, statsd tag was being formatted weirdly on DD. This makes it easier to read. 

## Screenshots

## What areas of the site does it impact?

Only the benefits logging background job, which has no actual impact at this time. It's only being used for exploring API results at this time. 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback


