### PR TITLE
Update comment in filter_parameter_logging.rb

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -2,7 +2,8 @@
 
 # Be sure to restart your server when you modify this file.
 
-# Configure sensitive parameters which will be filtered from the log file.
+# Adding a key here unfilters ALL params with that name across ALL of vets-api.
+# Do NOT add keys that can contain PII/PHI/secrets.
 ALLOWLIST = %w[
   action
   benefits_intake_uuid
@@ -70,6 +71,7 @@ ALLOWLIST = %w[
   user_account_uuid
 ].freeze
 
+# Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters = [
   lambda do |k, v|
     case v


### PR DESCRIPTION
## Summary
This PR adds a comment before the `ALLOWLIST` to make it clear that listing a key here disables filtering for that key across all of vets-api. 

## Related issue(s)
This was discussed at the Backend CoP meeting. Meeting notes: https://vfs.atlassian.net/wiki/spaces/BCP/pages/4292280321/8+25+25

## Testing done
N/A
