### PR TITLE
[ID-674] - Update cerner eligibility check

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -473,7 +473,7 @@ class User < Common::RedisStore
   end
 
   def cerner_eligible?
-    loa3? && (cerner_id.present? || cerner_facility_ids.present?)
+    loa3? && cerner_id.present?
   end
 
   def can_create_mhv_account?

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -828,9 +828,8 @@ RSpec.describe V1::SessionsController, type: :controller do
       end
 
       context 'when cerner eligibility is checked' do
-        let(:user) { build(:user, :loa3, cerner_id:, cerner_facility_ids:) }
+        let(:user) { build(:user, :loa3, cerner_id:) }
         let(:cerner_id) { 'some-cerner-id' }
-        let(:cerner_facility_ids) { ['some-facility-id'] }
         let(:cerner_eligible_cookie) { 'CERNER_ELIGIBLE' }
         let(:expected_log_message) { '[SessionsController] Cerner Eligibility' }
         let(:previous_value) { nil }
@@ -860,7 +859,6 @@ RSpec.describe V1::SessionsController, type: :controller do
 
           context 'when the user is not cerner eligible' do
             let(:cerner_id) { nil }
-            let(:cerner_facility_ids) { [] }
             let(:eligible) { false }
 
             it 'sets the cookie and logs the cerner eligibility' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1621,30 +1621,19 @@ RSpec.describe User, type: :model do
   end
 
   describe '#cerner_eligible?' do
-    let(:user) { build(:user, :loa3, cerner_id:, cerner_facility_ids:) }
+    let(:user) { build(:user, :loa3, cerner_id:) }
 
     context 'when the user is loa3' do
       context 'when the user has a cerner_id' do
         let(:cerner_id) { 'some-cerner-id' }
-        let(:cerner_facility_ids) { [] }
 
         it 'returns true' do
           expect(user.cerner_eligible?).to be true
         end
       end
 
-      context 'when the user has cerner_facility_ids' do
+      context 'when the user does not have a cerner_id' do
         let(:cerner_id) { nil }
-        let(:cerner_facility_ids) { ['some-cerner-facility-id'] }
-
-        it 'returns true' do
-          expect(user.cerner_eligible?).to be true
-        end
-      end
-
-      context 'when the user does not have a cerner_id nor cerner_facility_ids' do
-        let(:cerner_id) { nil }
-        let(:cerner_facility_ids) { [] }
 
         it 'returns false' do
           expect(user.cerner_eligible?).to be false


### PR DESCRIPTION
## Summary

- Only check for `cerner_id` for cerner eligibility 

## Related issue(s)
- https://github.com/department-of-veterans-affairs/identity-documentation/issues/674
- https://github.com/department-of-veterans-affairs/identity-documentation/issues/545

## Testing 
### Test eligibility check
- Login
- Find user and check eligibility if they have a 
  - if they have a `cerner_id` returns `true`
  - if they don't have a `cerner_id` returns `false`

```ruby
user = User.find(uuid)

user.cerner_eligible?
```

## What areas of the site does it impact?
Cerner eligibility 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
