### PR TITLE
adding logging to nail down prod issues

### DIFF
--- a/modules/check_in/app/services/travel_claim/service.rb
+++ b/modules/check_in/app/services/travel_claim/service.rb
@@ -51,6 +51,14 @@ module TravelClaim
     #
     # @return [Hash] response hash
     def submit_claim
+      Rails.logger.info('Travel claim validation', {
+        uuid_present: check_in.uuid.present?,
+        icn_present: patient_icn.present?,
+        appointment_date_present: appointment_date.present?,
+        facility_type: facility_type,
+        service: 'travel_claim_debug'
+      })
+
       resp = if token.present?
                client.submit_claim(token:, patient_icn:, appointment_date:)
              else

--- a/modules/check_in/app/services/travel_claim/service.rb
+++ b/modules/check_in/app/services/travel_claim/service.rb
@@ -52,12 +52,12 @@ module TravelClaim
     # @return [Hash] response hash
     def submit_claim
       Rails.logger.info('Travel claim validation', {
-        uuid_present: check_in.uuid.present?,
-        icn_present: patient_icn.present?,
-        appointment_date_present: appointment_date.present?,
-        facility_type: facility_type,
-        service: 'travel_claim_debug'
-      })
+                          uuid_present: check_in.uuid.present?,
+                          icn_present: patient_icn.present?,
+                          appointment_date_present: appointment_date.present?,
+                          facility_type:,
+                          service: 'travel_claim_debug'
+                        })
 
       resp = if token.present?
                client.submit_claim(token:, patient_icn:, appointment_date:)

--- a/modules/check_in/app/sidekiq/check_in/travel_claim_submission_job.rb
+++ b/modules/check_in/app/sidekiq/check_in/travel_claim_submission_job.rb
@@ -22,6 +22,14 @@ module CheckIn
 
     def submit_claim(opts = {})
       uuid, appointment_date, facility_type = opts.values_at(:uuid, :appointment_date, :facility_type)
+      
+      self.class.log_with_context(:info, 'Travel claim job validation', {
+        uuid_present: uuid.present?,
+        appointment_date_present: appointment_date.present?,
+        facility_type: facility_type,
+        service: 'travel_claim_debug'
+      })
+      
       check_in_session = CheckIn::V2::Session.build(data: { uuid: })
 
       claims_resp = TravelClaim::Service.build(check_in: check_in_session,

--- a/modules/check_in/app/sidekiq/check_in/travel_claim_submission_job.rb
+++ b/modules/check_in/app/sidekiq/check_in/travel_claim_submission_job.rb
@@ -22,14 +22,14 @@ module CheckIn
 
     def submit_claim(opts = {})
       uuid, appointment_date, facility_type = opts.values_at(:uuid, :appointment_date, :facility_type)
-      
+
       self.class.log_with_context(:info, 'Travel claim job validation', {
-        uuid_present: uuid.present?,
-        appointment_date_present: appointment_date.present?,
-        facility_type: facility_type,
-        service: 'travel_claim_debug'
-      })
-      
+                                    uuid_present: uuid.present?,
+                                    appointment_date_present: appointment_date.present?,
+                                    facility_type:,
+                                    service: 'travel_claim_debug'
+                                  })
+
       check_in_session = CheckIn::V2::Session.build(data: { uuid: })
 
       claims_resp = TravelClaim::Service.build(check_in: check_in_session,

--- a/modules/check_in/spec/services/travel_claim/service_spec.rb
+++ b/modules/check_in/spec/services/travel_claim/service_spec.rb
@@ -68,7 +68,7 @@ describe TravelClaim::Service do
       end
 
       it 'returns 401 error response' do
-        expect(subject.build.submit_claim).to eq(response)
+        expect(subject.build(check_in:).submit_claim).to eq(response)
       end
     end
 
@@ -120,7 +120,7 @@ describe TravelClaim::Service do
       end
 
       it 'returns 401 error response' do
-        expect(subject.build.submit_claim).to eq(response)
+        expect(subject.build(check_in:).submit_claim).to eq(response)
       end
     end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Added additional logging in the travel claim submission flow (`TravelClaim::Service#submit_claim` and `TravelClaimSubmissionJob#submit_claim`) to capture key state details (uuid presence, icn presence, appointment date presence, facility type, and a static service tag) for debugging production issues.
- This helps us collect more granular information when travel claims are being submitted in production, enabling us to better diagnose and resolve intermittent bugs affecting users.
- The solution adds Rails logger calls in the relevant service and job; these do not affect user-facing behavior, only what is captured in logs.
- Team: Platform Accessibility and Travel Claims. Yes, our team owns the maintenance of this component.
- No new flipper/feature toggle introduced.

## Related issue(s)

- Prod issue logging

## Testing done

- [ ] New code is covered by unit tests
- Previous behavior: Travel claim submission had minimal logging, making it hard to debug in production.
- To verify changes: 
  1. Submit a travel claim in a development or staging environment.
  2. Confirm in Rails logs that `Travel claim validation` and `Travel claim job validation` entries appear with the expected fields (`uuid_present`, `icn_present`, `appointment_date_present`, `facility_type`, `service`).
  3. Test with both valid and missing values to confirm presence booleans are correct.
- No flipper involved in this change.

## Screenshots

_Note: Optional_

## What areas of the site does it impact?

- Impacts travel claim submissions in the Check-In app/service. No other areas affected.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution (Rails logs).
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
