### PR TITLE
Replace Virtus with Vets::Model - modules/pensions

### DIFF
--- a/modules/pensions/app/models/pensions/form_military_information.rb
+++ b/modules/pensions/app/models/pensions/form_military_information.rb
@@ -7,7 +7,7 @@ module Pensions
   # Extends FormMilitaryInformation to add additional military information fields to Pension prefill
   # @see app/models/form_profile.rb FormMilitaryInformation
   class FormMilitaryInformation < ::FormMilitaryInformation
-    include Virtus.model
+    include Vets::Model
 
     attribute :first_uniformed_entry_date, String
     attribute :last_active_discharge_date, String


### PR DESCRIPTION
## Summary

- Virtus is being replace with `Vets::Model`. Differences include:
    - There's no hash access for attributes `form[:attribute]` only dot notation `form.attribute`
    - Syntax change for Array attributes
    - Sorting uses a class method: `default_sort_by`
    - booleans are temporarily `Bool`, until Virtus is completely gone
- This PR replaces `Virtus` with `Vets::Model` and updates the _attributes_ and _implementation_ accordingly. 
- This change should not affect any functionality.

One change in the vets lib is to allow valid iso8601 to pass without casting

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111518

## Testing done

- [x] Manual testing for similar output

## Acceptance criteria

- [x] Virtus models are now Vets::Model
- [x] No functional change