### PR TITLE
Replace Virtus with Vets::Model - lib/lighthouse

### DIFF
--- a/lib/lighthouse/benefits_education/amendment.rb
+++ b/lib/lighthouse/benefits_education/amendment.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
 
 module BenefitsEducation
   ##
@@ -19,7 +19,9 @@ module BenefitsEducation
   # @!attribute change_effective_date
   #   @return [String] The date the amendment takes effect
   #
-  class Amendment < Common::Base
+  class Amendment
+    include Vets::Model
+
     attribute :on_campus_hours, Float
     attribute :online_hours, Float
     attribute :yellow_ribbon_amount, Float

--- a/lib/lighthouse/benefits_education/enrollment.rb
+++ b/lib/lighthouse/benefits_education/enrollment.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
 require 'lighthouse/benefits_education/amendment'
 
 module BenefitsEducation
@@ -39,15 +39,17 @@ module BenefitsEducation
   #   @return [String] The enrollment status
   # @!attribute amendments
   #   @return [Array[Amendment]] Any amendments made to this enrollment
-  class Enrollment < Common::Base
+  class Enrollment
+    include Vets::Model
+
     attribute :begin_date, DateTime
     attribute :end_date, DateTime
     attribute :facility_code, String
     attribute :facility_name, String
-    attribute :participant_id
-    attribute :training_type
-    attribute :term_id
-    attribute :hour_type
+    attribute :participant_id, String
+    attribute :training_type, String
+    attribute :term_id, String
+    attribute :hour_type, String
     attribute :full_time_hours, Integer
     attribute :full_time_credit_hour_under_grad, Integer
     attribute :vacation_day_count, Integer
@@ -55,7 +57,7 @@ module BenefitsEducation
     attribute :online_hours, Float
     attribute :yellow_ribbon_amount, Float
     attribute :status, String
-    attribute :amendments, Array[Amendment]
+    attribute :amendments, Amendment, array: true
 
     def initialize(attributes)
       key_mapping = { 'begin_date_time' => 'begin_date', 'end_date_time' => 'end_date' }

--- a/lib/lighthouse/benefits_education/entitlement.rb
+++ b/lib/lighthouse/benefits_education/entitlement.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
 
 module BenefitsEducation
   ##
@@ -10,7 +10,9 @@ module BenefitsEducation
   #   @return [Integer] Number of months in the entitlement
   # @!attribute days
   #   @return [Integer] Number of days in the entitlement
-  class Entitlement < Common::Base
+  class Entitlement
+    include Vets::Model
+
     attribute :months, Integer
     attribute :days, Integer
   end

--- a/lib/lighthouse/benefits_education/response.rb
+++ b/lib/lighthouse/benefits_education/response.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
 require 'lighthouse/benefits_education/enrollment'
 require 'lighthouse/benefits_education/entitlement'
 
@@ -38,7 +38,8 @@ module BenefitsEducation
   #   @return [Boolean] Is the user on active duty
   # @!attribute enrollments
   #   @return [Array[Enrollment]] An array of the user's enrollments
-  class Response < Common::Base
+  class Response
+    include Vets::Model
     include SentryLogging
 
     attribute :first_name, String
@@ -53,9 +54,9 @@ module BenefitsEducation
     attribute :original_entitlement, Entitlement
     attribute :used_entitlement, Entitlement
     attribute :remaining_entitlement, Entitlement
-    attribute :veteran_is_eligible, Boolean
-    attribute :active_duty, Boolean
-    attribute :enrollments, Array[Enrollment]
+    attribute :veteran_is_eligible, Bool
+    attribute :active_duty, Bool
+    attribute :enrollments, Enrollment, array: true
 
     def initialize(_status, response = nil)
       @response = response

--- a/lib/lighthouse/facilities/facility.rb
+++ b/lib/lighthouse/facilities/facility.rb
@@ -1,48 +1,48 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
+
 # Facility Model
 module Lighthouse
   module Facilities
-    class Facility < Common::Base
-      include ActiveModel::Serializers::JSON
+    class Facility
+      include Vets::Model
 
-      attribute :access, Object
+      attribute :access, Hash
       attribute :active_status, String
-      attribute :address, Object
+      attribute :address, Hash
       attribute :classification, String
-      attribute :detailed_services, Object
+      attribute :detailed_services, Hash
       attribute :distance, Float
       attribute :facility_type, String
       attribute :facility_type_prefix, String
-      attribute :feedback, Object
-      attribute :hours, Object
+      attribute :feedback, Hash
+      attribute :hours, Hash
       attribute :id, String
       attribute :lat, Float
       attribute :long, Float
-      attribute :mobile, Boolean
+      attribute :mobile, Bool
       attribute :name, String
-      attribute :operating_status, Object
+      attribute :operating_status, Hash
       attribute :operational_hours_special_instructions, String
-      attribute :phone, Object
-      attribute :services, Object
+      attribute :phone, Hash
+      attribute :services, Hash
       attribute :type, String
       attribute :unique_id, String
       attribute :visn, String
       attribute :website, String
-      attribute :parent, Object
+      attribute :parent, Hash
+
+      alias mobile? mobile
 
       def initialize(fac)
-        super(fac)
-        fac['attributes'].each_key do |key|
-          self[key] = fac['attributes'][key] if attributes.include?(key.to_sym)
-        end
+        @id = fac['id']
+        @type = fac['type']
+        @feedback = fac['attributes']['satisfaction']
+        @access = fac['attributes']['wait_times']
+        @facility_type_prefix, @unique_id = fac['id'].split('_')
 
-        self.id = fac['id']
-        self.type = fac['type']
-        self.feedback = fac['attributes']['satisfaction']
-        self.access = fac['attributes']['wait_times']
-        self.facility_type_prefix, self.unique_id = fac['id'].split('_')
+        super(fac['attributes'])
       end
     end
   end

--- a/lib/lighthouse/facilities/nearby_facility.rb
+++ b/lib/lighthouse/facilities/nearby_facility.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
+
 # Model for responses from Lighthouse facilities "nearby" endpoint which
 # only returns facility ID and drivetime band information, and for health
 # facilities only
 module Lighthouse
   module Facilities
-    class NearbyFacility < Common::Base
-      include ActiveModel::Serializers::JSON
+    class NearbyFacility
+      include Vets::Model
 
       attribute :id, String
       attribute :min_time, Integer
@@ -16,9 +17,9 @@ module Lighthouse
       def initialize(fac)
         super(fac)
 
-        self.id = fac['id']
-        self.min_time = fac['attributes']['min_time']
-        self.max_time = fac['attributes']['max_time']
+        @id = fac['id']
+        @min_time = fac['attributes']['min_time']
+        @max_time = fac['attributes']['max_time']
       end
     end
   end

--- a/lib/lighthouse/facilities/nearby_response.rb
+++ b/lib/lighthouse/facilities/nearby_response.rb
@@ -1,28 +1,30 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
 require_relative 'nearby_facility'
 
 module Lighthouse
   module Facilities
-    class NearbyResponse < Common::Base
+    class NearbyResponse
+      include Vets::Model
+
       attribute :body, String
       attribute :current_page, Integer
-      attribute :data, Object
-      attribute :links, Object
-      attribute :meta, Object
+      attribute :data, Hash, array: true
+      attribute :links, Hash
+      attribute :meta, Hash
       attribute :per_page, Integer
       attribute :status, Integer
       attribute :total_entries, Integer
 
       def initialize(body, status)
         super()
-        self.body = body
-        self.status = status
+        @body = body
+        @status = status
         parsed_body = JSON.parse(body)
-        self.data = parsed_body['data']
-        self.meta = parsed_body['meta']
-        self.links = parsed_body['links']
+        @data = Array.wrap(parsed_body['data']) # normalize data to array
+        @meta = parsed_body['meta']
+        @links = parsed_body['links']
         # This endpoint is not currently responding with a JSONAPI meta element
       end
 

--- a/lib/lighthouse/facilities/response.rb
+++ b/lib/lighthouse/facilities/response.rb
@@ -1,32 +1,34 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
 require_relative 'facility'
 
 module Lighthouse
   module Facilities
-    class Response < Common::Base
+    class Response
+      include Vets::Model
+
       attribute :body, String
       attribute :current_page, Integer
-      attribute :data, Object
-      attribute :links, Object
-      attribute :meta, Object
+      attribute :data, Hash, array: true
+      attribute :links, Hash
+      attribute :meta, Hash
       attribute :per_page, Integer
       attribute :status, Integer
       attribute :total_entries, Integer
 
       def initialize(body, status)
         super()
-        self.body = body
-        self.status = status
+        @body = body
+        @status = status
         parsed_body = JSON.parse(body)
-        self.data = parsed_body['data']
-        self.meta = parsed_body['meta']
-        self.links = parsed_body['links']
+        @data = Array.wrap(parsed_body['data']) # normalize data to array
+        @meta = parsed_body['meta']
+        @links = parsed_body['links']
         if meta
-          self.current_page = meta['pagination']['current_page']
-          self.per_page = meta['pagination']['per_page']
-          self.total_entries = meta['pagination']['total_entries']
+          @current_page = meta['pagination']['current_page']
+          @per_page = meta['pagination']['per_page']
+          @total_entries = meta['pagination']['total_entries']
         end
       end
 
@@ -44,7 +46,7 @@ module Lighthouse
       end
 
       def facility
-        Lighthouse::Facilities::Facility.new(data)
+        Lighthouse::Facilities::Facility.new(data.first)
       end
     end
   end

--- a/lib/lighthouse/facilities/v1/response.rb
+++ b/lib/lighthouse/facilities/v1/response.rb
@@ -1,33 +1,35 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
 require_relative '../facility'
 
 module Lighthouse
   module Facilities
     module V1
-      class Response < Common::Base
+      class Response
+        include Vets::Model
+
         attribute :body, String
         attribute :current_page, Integer
-        attribute :data, Object
-        attribute :links, Object
-        attribute :meta, Object
+        attribute :data, Hash, array: true
+        attribute :links, Hash
+        attribute :meta, Hash
         attribute :per_page, Integer
         attribute :status, Integer
         attribute :total_entries, Integer
 
         def initialize(body, status)
           super()
-          self.body = body
-          self.status = status
+          @body = body
+          @status = status
           parsed_body = JSON.parse(body)
-          self.data = parsed_body['data'] || []
-          self.meta = parsed_body['meta']
-          self.links = parsed_body['links']
+          @data = Array.wrap(parsed_body['data']) # normalize data to array
+          @meta = parsed_body['meta']
+          @links = parsed_body['links']
           if meta
-            self.current_page = meta['pagination']['currentPage']
-            self.per_page = meta['pagination']['perPage']
-            self.total_entries = meta['pagination']['totalEntries']
+            @current_page = meta['pagination']['currentPage']
+            @per_page = meta['pagination']['perPage']
+            @total_entries = meta['pagination']['totalEntries']
           end
         end
 
@@ -46,7 +48,7 @@ module Lighthouse
         end
 
         def facility
-          Lighthouse::Facilities::Facility.new(data)
+          Lighthouse::Facilities::Facility.new(data.first)
         end
       end
     end

--- a/spec/lib/lighthouse/benefits_education/service_spec.rb
+++ b/spec/lib/lighthouse/benefits_education/service_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe BenefitsEducation::Service do
             response = service.get_gi_bill_status
 
             # assertions that the data returned will match our test user
-            expect(response['first_name']).to eq('Tamara')
-            expect(response['last_name']).to eq('Ellis')
-            expect(response['date_of_birth']).to start_with('1967-06-19')
+            expect(response.first_name).to eq('Tamara')
+            expect(response.last_name).to eq('Ellis')
+            expect(response.date_of_birth).to start_with('1967-06-19')
           end
         end
       end

--- a/spec/lib/lighthouse/facilities/client_spec.rb
+++ b/spec/lib/lighthouse/facilities/client_spec.rb
@@ -119,11 +119,11 @@ RSpec.describe Lighthouse::Facilities::Client, team: :facilities, vcr: vcr_optio
 
     it 'has operational_hours_special_instructions' do
       r = facilities_client.get_by_id('vc_0617V')
-      expect(r[:operational_hours_special_instructions]).to eql('Expanded or Nontraditional hours are available for ' \
-                                                                'some services on a routine and or requested basis. ' \
-                                                                'Please call our main phone number for details. | ' \
-                                                                'Vet Center after hours assistance is available by ' \
-                                                                'calling 1-877-WAR-VETS (1-877-927-8387).')
+      expect(r.operational_hours_special_instructions).to eql('Expanded or Nontraditional hours are available for ' \
+                                                              'some services on a routine and or requested basis. ' \
+                                                              'Please call our main phone number for details. | ' \
+                                                              'Vet Center after hours assistance is available by ' \
+                                                              'calling 1-877-WAR-VETS (1-877-927-8387).')
     end
 
     it 'returns a 404 error' do

--- a/spec/lib/lighthouse/facilities/v1/response_spec.rb
+++ b/spec/lib/lighthouse/facilities/v1/response_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Lighthouse::Facilities::V1::Response, type: :model do
 
     it 'creates facilities with underscore attributes' do
       facility = subject.facilities.first
-      expect(facility.attributes.keys).to include(:name, :facility_type)
+      expect(facility.attributes.keys).to include('name', 'facility_type')
     end
 
     context 'data is nil' do


### PR DESCRIPTION
## Summary

- Virtus is being replace with `Vets::Model`. Differences include:
    - There's no hash access for attributes `form[:attribute]` only dot notation `form.attribute`
    - Syntax change for Array attributes
    - Sorting uses a class method: `default_sort_by`
    - booleans are temporarily `Bool`, until Virtus is completely gone
- This PR replaces `Virtus` with `Vets::Model` and updates the _attributes_ and _implementation_ accordingly. 
- This change should not affect any functionality.

One change in the vets lib is to allow valid iso8601 to pass without casting

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111518

## Testing done

- [x] Manual testing for similar output

## Acceptance criteria

- [x] Virtus models are now Vets::Model
- [x] No functional change