### PR TITLE
API-47336-pdf-mapper-section-1

### DIFF
--- a/modules/claims_api/lib/claims_api/pdf_mapper_base.rb
+++ b/modules/claims_api/lib/claims_api/pdf_mapper_base.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module ClaimsApi
+  module PdfMapperBase
+    def concatenate_address(address_line_one, address_line_two, address_line_three)
+      [address_line_one, address_line_two, address_line_three]
+        .compact
+        .map(&:strip)
+        .reject(&:empty?)
+        .join(' ')
+    end
+
+    def concatenate_zip_code(nested_address_object)
+      zip_first_five = nested_address_object&.dig('zipFirstFive') || ''
+      zip_last_four = nested_address_object&.dig('zipLastFour') || ''
+      international_zip = nested_address_object&.dig('internationalPostalCode')
+      if zip_last_four.present?
+        "#{zip_first_five}-#{zip_last_four}"
+      elsif international_zip.present?
+        international_zip
+      else
+        zip_first_five
+      end
+    end
+  end
+end

--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require 'claims_api/v2/disability_compensation_shared_service_module'
+require_relative '../pdf_mapper_base'
 
 module ClaimsApi
   module V2
     class DisabilityCompensationPdfMapper # rubocop:disable Metrics/ClassLength
       include DisabilityCompensationSharedServiceModule
+      include PdfMapperBase
 
       NATIONAL_GUARD_COMPONENTS = {
         'National Guard' => 'NATIONAL_GUARD',
@@ -388,11 +390,6 @@ module ClaimsApi
         abbr_country = country == 'USA' ? 'US' : country
         @pdf_data[:data][:attributes][:identificationInformation][:mailingAddress][:country] = abbr_country
         zip
-      end
-
-      def concatenate_address(address_line_one, address_line_two, address_line_three)
-        concatted = "#{address_line_one || ''} #{address_line_two || ''} #{address_line_three || ''}"
-        concatted.strip
       end
 
       def zip

--- a/modules/claims_api/spec/lib/claims_api/pdf_mapper_base_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/pdf_mapper_base_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'claims_api/pdf_mapper_base'
+
+describe ClaimsApi::PdfMapperBase do
+  subject { test_pdf_mapper_class.new }
+
+  let(:test_pdf_mapper_class) do
+    Class.new do
+      include ClaimsApi::PdfMapperBase
+    end
+  end
+
+  describe '#concatenate_address' do
+    it 'concatenates all three address lines with spaces' do
+      result = subject.concatenate_address('123 Main St', 'Apt 2', 'Floor 3')
+
+      expect(result).to eq('123 Main St Apt 2 Floor 3')
+    end
+
+    it 'handles nil values gracefully' do
+      result = subject.concatenate_address('123 Main St', nil, 'Floor 3')
+
+      expect(result).to eq('123 Main St Floor 3')
+    end
+
+    it 'strips leading and trailing white space' do
+      result = subject.concatenate_address('123 Main St', '', '')
+
+      expect(result).to eq('123 Main St')
+    end
+
+    it 'returns empty string when all parameters are nil' do
+      result = subject.concatenate_address(nil, nil, nil)
+
+      expect(result).to eq('')
+    end
+
+    it 'handles empty strings' do
+      result = subject.concatenate_address('', '456 Oak Ave', '')
+
+      expect(result).to eq('456 Oak Ave')
+    end
+  end
+
+  describe '#concatenate_zip_code' do
+    it 'concatenates first five and last four' do
+      address_object = { 'mailingAddress' => { 'zipFirstFive' => '12345', 'zipLastFour' => '6789' } }
+
+      result = subject.concatenate_zip_code(address_object['mailingAddress'])
+
+      expect(result).to eq('12345-6789')
+    end
+
+    it 'returns just first five when that is all that is present' do
+      address_object = { 'mailingAddress' => { 'zipFirstFive' => nil, 'zipLastFour' => '',
+                                               'internationalPostalCode' => '10431' } }
+
+      result = subject.concatenate_zip_code(address_object['mailingAddress'])
+
+      expect(result).to eq('10431')
+    end
+
+    it 'returns international postal code when present' do
+      address_object = { 'mailingAddress' => { 'zipFirstFive' => '12345' } }
+
+      result = subject.concatenate_zip_code(address_object['mailingAddress'])
+
+      expect(result).to eq('12345')
+    end
+  end
+end

--- a/modules/claims_api/spec/lib/claims_api/v1/disability_compensation_pdf_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v1/disability_compensation_pdf_mapper_spec.rb
@@ -55,4 +55,24 @@ describe ClaimsApi::V1::DisabilityCompensationPdfMapper do
       expect(claim_process_type).to eq('BDD_PROGRAM')
     end
   end
+
+  context '526 section 1, veteran identification' do
+    it 'maps the mailing address' do
+      mapper.map_claim
+      address_base = pdf_data[:data][:attributes][:identificationInformation][:mailingAddress]
+
+      expect(address_base[:numberAndStreet]).to eq('1234 Couch Street Apt. 22')
+      expect(address_base[:city]).to eq('Portland')
+      expect(address_base[:state]).to eq('OR')
+      expect(address_base[:country]).to eq('USA')
+      expect(address_base[:zip]).to eq('12345-6789')
+    end
+
+    it 'maps the currentVAEmployee status' do
+      mapper.map_claim
+      employee_status = pdf_data[:data][:attributes][:identificationInformation][:currentVaEmployee]
+
+      expect(employee_status).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
* Adds mapping for section 1 values for:
	* mailing address
	* current VA employee status
		* note the small spelling difference between the two
* Refactors some shared methods into a shared base module
	*  refactored one method and left another alone.  I felt this refactor made more sense to see in the context of the two mappers but could break it out if  preferred. I suspect this will grow more but it is not really a no regret refactor so I tied it in here.
	* Added a test file for the shared methods module too.

## Related issue(s)


## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	new file:   modules/claims_api/lib/claims_api/pdf_mapper_base.rb
	modified:   modules/claims_api/lib/claims_api/v1/disability_compensation_pdf_mapper.rb
	modified:   modules/claims_api/lib/claims_api/v2/disability_compensation_pdf_mapper.rb
	new file:   modules/claims_api/spec/lib/claims_api/pdf_mapper_base_spec.rb
	modified:   modules/claims_api/spec/lib/claims_api/v1/disability_compensation_pdf_mapper_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
