### PR TITLE
Renamed VAProfile::V2::Person to VAProfile::Person::V2

### DIFF
--- a/app/controllers/v0/profile/persons_controller.rb
+++ b/app/controllers/v0/profile/persons_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'va_profile/person/service'
-require 'va_profile/v2/person/service'
+require 'va_profile/person/v2/service'
 
 module V0
   module Profile
@@ -13,7 +13,7 @@ module V0
 
       def initialize_vet360_id
         response = if Flipper.enabled?(:remove_pciu, @current_user)
-                     VAProfile::V2::Person::Service.new(@current_user).init_vet360_id
+                     VAProfile::Person::V2::Service.new(@current_user).init_vet360_id
                    else
                      VAProfile::Person::Service.new(@current_user).init_vet360_id
                    end

--- a/lib/va_profile/person/v2/service.rb
+++ b/lib/va_profile/person/v2/service.rb
@@ -9,8 +9,8 @@ require 'va_profile/stats'
 require 'identity/parsers/gc_ids_constants'
 
 module VAProfile
-  module V2
-    module Person
+  module Person
+    module V2
       class Service < VAProfile::Service
         include Common::Client::Concerns::Monitoring
         include ERB::Util

--- a/modules/mobile/app/sidekiq/mobile/v0/vet360_linking_job.rb
+++ b/modules/mobile/app/sidekiq/mobile/v0/vet360_linking_job.rb
@@ -2,7 +2,7 @@
 
 require 'sidekiq'
 require 'va_profile/person/service'
-require 'va_profile/v2/person/service'
+require 'va_profile/person/v2/service'
 
 # This job is run when a user does not have a vet360_id, which indicates that the user does not have an account on the
 # VAProfile service. The mobile app depends on the VAProfile service for user contact data, and mobile features
@@ -39,7 +39,7 @@ module Mobile
         end
 
         result = if Flipper.enabled?(:remove_pciu)
-                   VAProfile::V2::Person::Service.new(user).init_vet360_id
+                   VAProfile::Person::V2::Service.new(user).init_vet360_id
                  else
                    VAProfile::Person::Service.new(user).init_vet360_id
                  end

--- a/modules/mobile/spec/sidekiq/vet360_linking_spec.rb
+++ b/modules/mobile/spec/sidekiq/vet360_linking_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Mobile::V0::Vet360LinkingJob, type: :job do
           'Mobile Vet360 account linking request failed for user with uuid',
           {
             user_uuid: user.uuid,
-            message: 'BackendServiceException: {:source=>"VAProfile::V2::Person::Service", :code=>"VET360_PERS101"}'
+            message: 'BackendServiceException: {:source=>"VAProfile::Person::V2::Service", :code=>"VET360_PERS101"}'
           }
         )
         subject.perform(user.uuid)

--- a/spec/lib/va_profile/person/v2/service_spec.rb
+++ b/spec/lib/va_profile/person/v2/service_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'va_profile/v2/person/service'
+require 'va_profile/person/v2/service'
 
-describe VAProfile::V2::Person::Service, :skip_vet360 do
+describe VAProfile::Person::V2::Service, :skip_vet360 do
   before { Timecop.freeze('2024-09-16T16:09:37.000Z') }
 
   after  { Timecop.return }


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

**NO LOGIC CHANGES, ONLY RENAMING SERVICES AFTER MIGRATION**

This PR renames VAProfile::V2::Person to VAProfile::Person::V2. The restructuring is part of the effort to deprecate and eventually eliminate the legacy Person V1 services.

The folder separation was intentionally maintained to avoid accidental modifications and reduce confusion during the integration process. Renaming these files improves clarity and helps developers more easily locate and work with the Person V2 configuration.

**Why is this needed?**
- Aligns naming with the long-term goal of removing V1 Person services.
- Provides a clearer, more consistent namespace for developers.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/98928

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
