### PR TITLE
fix form version manager writing incorrect docType when feature enabled

### DIFF
--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
@@ -799,9 +799,8 @@ module IvcChampva
                       filler.generate
                     end
 
-        # Get validated metadata and ensure docType uses legacy form ID for backwards compatibility
+        # Get validated metadata
         metadata = IvcChampva::MetadataValidator.validate(form.metadata)
-        metadata['docType'] = legacy_form_id if IvcChampva::FormVersionManager.versioned_form?(actual_form_id)
 
         file_paths = form.handle_attachments(file_path)
 

--- a/modules/ivc_champva/spec/services/ivc_champva/form_version_manager_spec.rb
+++ b/modules/ivc_champva/spec/services/ivc_champva/form_version_manager_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe IvcChampva::FormVersionManager do
       end
 
       def metadata
-        { 'docType' => 'test_base_form', 'uuid' => @uuid }
+        { 'uuid' => @uuid, 'docType' => @data['form_number'] }
       end
 
       def track_user_identity; end
@@ -44,7 +44,7 @@ RSpec.describe IvcChampva::FormVersionManager do
       end
 
       def metadata
-        { 'docType' => 'test_versioned_form', 'uuid' => @uuid, 'formExpiration' => '12/31/2025' }
+        { 'uuid' => @uuid, 'docType' => @data['form_number'], 'formExpiration' => '12/31/2025' }
       end
 
       def track_user_identity; end
@@ -258,8 +258,8 @@ RSpec.describe IvcChampva::FormVersionManager do
 
           expect(file_paths).to include(file_path)
           expect(metadata['attachment_ids']).to include('test_base_form')
-          # DocType should match the form's metadata since no legacy mapping is applied
-          expect(metadata['docType']).to eq('test_base_form')
+          # DocType should use the original user-facing form number for database records
+          expect(metadata['docType']).to eq('TEST-FORM')
         end
       end
 
@@ -274,8 +274,8 @@ RSpec.describe IvcChampva::FormVersionManager do
           expect(file_paths).to include(file_path)
           # Attachment IDs should be mapped to legacy form ID for downstream services
           expect(metadata['attachment_ids']).to include('test_base_form')
-          # DocType should be mapped to legacy form ID for backwards compatibility
-          expect(metadata['docType']).to eq('test_base_form')
+          # DocType should use the original user-facing form number for database records
+          expect(metadata['docType']).to eq('TEST-FORM')
         end
       end
     end


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): YES*
- Testing in staging revealed form_number in DB and metadata file sent to Pega was incorrect when this feature was enabled, preventing files from showing up in Pega; updating to send correct value.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/116085

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
