### PR TITLE
API 49191 - Fix incorrect `transactionId` mapping for FES

### DIFF
--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_fes_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_fes_mapper.rb
@@ -289,16 +289,12 @@ module ClaimsApi
       def wrap_in_request_structure
         {
           data: {
-            serviceTransactionId: generate_service_transaction_id,
+            serviceTransactionId: @auto_claim.auth_headers['va_eauth_service_transaction_id'],
             claimantParticipantId: extract_claimant_participant_id,
             veteranParticipantId: extract_veteran_participant_id,
             form526: @fes_claim
           }
         }
-      end
-
-      def generate_service_transaction_id
-        "claims-api-#{@auto_claim.id}-#{Time.now.to_i}"
       end
 
       def format_address_line(street, unit)

--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_fes_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_fes_mapper_spec.rb
@@ -23,7 +23,8 @@ describe ClaimsApi::V2::DisabilityCompensationFesMapper do
       let(:auto_claim) do
         create(:auto_established_claim,
                form_data: form_data['data']['attributes'],
-               auth_headers: { 'va_eauth_pid' => '600061742' })
+               auth_headers: { 'va_eauth_pid' => '600061742',
+                               'va_eauth_service_transaction_id' => 'vagov-6db8f189-9529-400f-ab6f-3272155c3683' })
       end
       let(:fes_data) do
         ClaimsApi::V2::DisabilityCompensationFesMapper.new(auto_claim).map_claim
@@ -43,8 +44,22 @@ describe ClaimsApi::V2::DisabilityCompensationFesMapper do
           expect(fes_data[:data][:veteranParticipantId]).to eq('600061742')
         end
 
-        it 'generates a unique service transaction ID' do
-          expect(fes_data[:data][:serviceTransactionId]).to match(/claims-api-#{auto_claim.id}-\d+/)
+        it 'maps the transaction ID provided in headers to the serviceTransactionId' do
+          expect(fes_data[:data][:serviceTransactionId]).to match(
+            auto_claim.auth_headers['va_eauth_service_transaction_id']
+          )
+        end
+
+        context 'when auto claim has no transaction ID in headers' do
+          let(:auto_claim) do
+            create(:auto_established_claim,
+                   form_data: form_data['data']['attributes'],
+                   auth_headers: { 'va_eauth_pid' => '600061742' })
+          end
+
+          it 'sets serviceTransactionId to nil' do
+            expect(fes_data[:data][:serviceTransactionId]).to be_nil
+          end
         end
       end
 


### PR DESCRIPTION
## Summary

This PR updates the recently added FES mapper so that it uses the pre-existing `va_eauth_service_transaction_id` as the `serviceTransactionId` rather than generating a new value.

## Related issue(s)

|[Jira ticket](https://jira.devops.va.gov/browse/API-49191)|
|-|
|<img width="1042" height="546" alt="Screenshot 2025-09-02 at 14 06 30" src="https://github.com/user-attachments/assets/48af4ff1-2cd2-4ef6-b5d9-ddf3cb6d495c" />|

## Testing done

- [X] *New code is covered by unit tests*
- Previously, the mapper class was generating a new `serviceTransactionId`, but this was redundant as there was already a transaction ID provided in the `auth_headers`. Now, we take the id from the auth headers and map it into the data rather than generate a new value.
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
