### PR TITLE
API-48805-error-handling-update-in-poa-verification-file

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
@@ -83,9 +83,12 @@ module ClaimsApi
         valid_poa_code_for_current_user?(poa_code_to_verify)
       rescue ::Common::Exceptions::UnprocessableEntity
         raise
+      rescue ::Common::Exceptions::Unauthorized => e
+        ClaimsApi::Logger.log 'poa_verification', level: :error, detail: e.message, error_class: e.class.name
+        raise e, detail: 'Cannot validate Power of Attorney'
       rescue => e
         ClaimsApi::Logger.log 'poa_verification', level: :error, detail: e.message, error_class: e.class.name
-        raise ::Common::Exceptions::Unauthorized, detail: 'Cannot validate Power of Attorney'
+        raise e
       end
 
       def poa_code_in_organization?(poa_code)


### PR DESCRIPTION
## Summary
* Adjusts the error handling so we do not just raise a 401 in the event of any error

## Related issue(s)
[API-48805](https://jira.devops.va.gov/browse/API-48805)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/controllers/concerns/claims_api/poa_verification.rb
	modified:   modules/claims_api/spec/concerns/claims_api/poa_verification_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
