### PR TITLE
Fix multipart file upload in DocumentsClient#add_document and improved tests/coverage

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/documents_client.rb
+++ b/modules/travel_pay/app/services/travel_pay/documents_client.rb
@@ -73,11 +73,13 @@ module TravelPay
             req.headers['Authorization'] = "Bearer #{veis_token}"
             req.headers['BTSSS-Access-Token'] = btsss_token
             req.headers['X-Correlation-ID'] = correlation_id
-            req.headers.merge!(claim_headers)
-
+            # Remove the content-type from the claim_headers so that we dont override the multipart/form-data header
+            req.headers.merge!(claim_headers.except('Content-Type'))
             # Use capital 'Document' key for Swagger compliance
             req.body = {
-              'Document' => Faraday::Multipart::FilePart.new(document.path, document.content_type)
+              'Document' => Faraday::Multipart::FilePart.new(
+                document.path, document.content_type, document.original_filename
+              )
             }
           end
       end


### PR DESCRIPTION
## Summary

Updated add_document logic in `modules/travel_pay/app/services/travel_pay/documents_client.rb`:
 - Removed `Content-Type` from the claim_headers, so Faraday correctly sets the multipart/form-data boundary and its no longer overridden by claim_headers.
 - Included `document.original_filename` in Faraday::Multipart::FilePart.

Updated tests in `modules/travel_pay/spec/services/documents_client_spec.rb` to reflect these changes:
- we now check that the content type is `multipart/form-data` with boundary
- ensure `document.original_filename` is passed correctly
- Added a regression test to confirm undefined method 'bytesize' for Hash no longer occurs.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117053

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Travel Pay
## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
