### PR TITLE
add toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2032,6 +2032,9 @@ features:
   form526_backup_submission_temp_killswitch:
     actor_type: user
     description: Provide a temporary killswitch to disable form526 backup submission if something were to go awry
+  virtual_agent_show_ai_disclaimer:
+    actor_type: user
+    description: Enables a dislaimer for ai generated content - managed by virtual agent team
   virtual_agent_show_floating_chatbot:
     actor_type: user
     description: Enables a floating chatbot on the chatbot page - managed by virtual agent team
@@ -2413,4 +2416,3 @@ features:
     actor_type: user
     description: Enables substance use disorder as care related to mental health appointments with new codes
     enable_in_development: true
-

--- a/config/features.yml
+++ b/config/features.yml
@@ -2034,7 +2034,7 @@ features:
     description: Provide a temporary killswitch to disable form526 backup submission if something were to go awry
   virtual_agent_show_ai_disclaimer:
     actor_type: user
-    description: Enables a dislaimer for ai generated content - managed by virtual agent team
+    description: Enables a disclaimer for ai generated content - managed by virtual agent team
   virtual_agent_show_floating_chatbot:
     actor_type: user
     description: Enables a floating chatbot on the chatbot page - managed by virtual agent team


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Adds a toggle for showing an AI disclaimer to the chatbot/virtual agent
- Will be following up with vets-website PR to connect toggle to show disclaimer in the UI

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-virtual-agent/issues/2531

## Testing done

- No new behavior added other than feature toggle

## Screenshots
NA

## What areas of the site does it impact?
Virtual agent

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
