### PR TITLE
Replace Virtus with Vets::Model - MebApi

### DIFF
--- a/modules/meb_api/app/controllers/meb_api/v0/education_benefits_controller.rb
+++ b/modules/meb_api/app/controllers/meb_api/v0/education_benefits_controller.rb
@@ -20,7 +20,7 @@ module MebApi
 
       def eligibility
         claimant_response = claimant_service.get_claimant_info(@form_type)
-        claimant_id = claimant_response['claimant_id']
+        claimant_id = claimant_response.claimant_id
 
         eligibility_response = eligibility_service.get_eligibility(claimant_id)
 
@@ -32,7 +32,7 @@ module MebApi
 
       def claim_status
         claimant_response = claimant_service.get_claimant_info(@form_type)
-        claimant_id = claimant_response['claimant_id']
+        claimant_id = claimant_response.claimant_id
 
         claim_status_response = claim_status_service.get_claim_status(params, claimant_id, @form_type)
 
@@ -44,7 +44,7 @@ module MebApi
 
       def claim_letter
         claimant_response = claimant_service.get_claimant_info(@form_type)
-        claimant_id = claimant_response['claimant_id']
+        claimant_id = claimant_response.claimant_id
         claim_status_response = claim_status_service.get_claim_status(params, claimant_id, @form_type)
         claim_letter_response = claim_letters_service.get_claim_letter(claimant_id, @form_type)
         is_eligible = claim_status_response.claim_status == 'ELIGIBLE'
@@ -85,7 +85,7 @@ module MebApi
 
       def enrollment
         claimant_response = claimant_service.get_claimant_info(@form_type)
-        claimant_id = claimant_response['claimant_id']
+        claimant_id = claimant_response.claimant_id
         if claimant_id.nil?
           render json: {
             data: {
@@ -110,7 +110,7 @@ module MebApi
 
       def submit_enrollment_verification
         claimant_response = claimant_service.get_claimant_info(@form_type)
-        claimant_id = claimant_response['claimant_id']
+        claimant_id = claimant_response.claimant_id
 
         if claimant_id.to_i.zero?
           render json: {
@@ -133,7 +133,7 @@ module MebApi
 
       def exclusion_periods
         claimant_response = claimant_service.get_claimant_info(@form_type)
-        claimant_id = claimant_response['claimant_id']
+        claimant_id = claimant_response.claimant_id
         exclusion_response = exclusion_period_service.get_exclusion_periods(claimant_id)
 
         render json: ExclusionPeriodSerializer.new(exclusion_response)

--- a/modules/meb_api/app/controllers/meb_api/v0/forms_controller.rb
+++ b/modules/meb_api/app/controllers/meb_api/v0/forms_controller.rb
@@ -13,7 +13,7 @@ module MebApi
 
       def claim_letter
         claimant_response = claimant_service.get_claimant_info(@form_type)
-        claimant_id = claimant_response['claimant_id']
+        claimant_id = claimant_response.claimant_id
         claim_status_response = claim_status_service.get_claim_status(params, claimant_id, @form_type)
         claim_letter_response = letter_service.get_claim_letter(claimant_id, @form_type)
         is_eligible = claim_status_response.claim_status == 'ELIGIBLE'
@@ -35,7 +35,7 @@ module MebApi
 
       def claim_status
         forms_claimant_response = claimant_service.get_claimant_info(@form_type)
-        claimant_id = forms_claimant_response['claimant_id']
+        claimant_id = forms_claimant_response.claimant_id
 
         if claimant_id.present?
           claim_status_response = claim_status_service.get_claim_status(params, claimant_id, @form_type)

--- a/modules/meb_api/lib/dgi/automation/claimant_response.rb
+++ b/modules/meb_api/lib/dgi/automation/claimant_response.rb
@@ -7,7 +7,7 @@ module MebApi
     module Automation
       class ClaimantResponse < MebApi::DGI::Response
         attribute :claimant, Hash
-        attribute :service_data, Array
+        attribute :service_data, Hash, array: true
 
         def initialize(status, response = nil)
           attributes = {

--- a/modules/meb_api/lib/dgi/contact_info/response.rb
+++ b/modules/meb_api/lib/dgi/contact_info/response.rb
@@ -6,8 +6,8 @@ module MebApi
   module DGI
     module ContactInfo
       class Response < MebApi::DGI::Response
-        attribute :phone, Array
-        attribute :email, Array
+        attribute :phone, Hash, array: true
+        attribute :email, Hash, array: true
 
         def initialize(status, response = nil)
           attributes = {

--- a/modules/meb_api/lib/dgi/eligibility/eligibility_response.rb
+++ b/modules/meb_api/lib/dgi/eligibility/eligibility_response.rb
@@ -6,7 +6,7 @@ module MebApi
   module DGI
     module Eligibility
       class EligibilityResponse < MebApi::DGI::Response
-        attribute :eligibility, Array
+        attribute :eligibility, Hash, array: true
 
         def initialize(status, response = nil)
           attributes = {

--- a/modules/meb_api/lib/dgi/enrollment/enrollment_response.rb
+++ b/modules/meb_api/lib/dgi/enrollment/enrollment_response.rb
@@ -6,9 +6,9 @@ module MebApi
   module DGI
     module Enrollment
       class Response < MebApi::DGI::Response
-        attribute :enrollment_verifications, Array
+        attribute :enrollment_verifications, Hash, array: true
         attribute :last_certified_through_date, String
-        attribute :payment_on_hold, Boolean
+        attribute :payment_on_hold, Bool
 
         def initialize(response = nil)
           attributes = {

--- a/modules/meb_api/lib/dgi/enrollment/submit_enrollment_response.rb
+++ b/modules/meb_api/lib/dgi/enrollment/submit_enrollment_response.rb
@@ -6,7 +6,7 @@ module MebApi
   module DGI
     module SubmitEnrollment
       class Response < MebApi::DGI::Response
-        attribute :enrollment_certify_responses, Array
+        attribute :enrollment_certify_responses, Hash, array: true
 
         def initialize(response = nil)
           attributes = {

--- a/modules/meb_api/lib/dgi/exclusion_period/response.rb
+++ b/modules/meb_api/lib/dgi/exclusion_period/response.rb
@@ -6,7 +6,7 @@ module MebApi
   module DGI
     module ExclusionPeriod
       class Response < MebApi::DGI::Response
-        attribute :exclusion_periods, Array
+        attribute :exclusion_periods, String, array: true
 
         def initialize(response = nil)
           attributes = {

--- a/modules/meb_api/lib/dgi/forms/response/claimant_info_response.rb
+++ b/modules/meb_api/lib/dgi/forms/response/claimant_info_response.rb
@@ -8,7 +8,7 @@ module MebApi
       class ClaimantResponse < MebApi::DGI::Response
         attribute :claimant, Hash
         attribute :toe_sponsors, Hash
-        attribute :service_data, Array
+        attribute :service_data, Hash, array: true
 
         def initialize(status, response = nil)
           attributes = {

--- a/modules/meb_api/lib/dgi/forms/response/sponsor_response.rb
+++ b/modules/meb_api/lib/dgi/forms/response/sponsor_response.rb
@@ -7,7 +7,7 @@ module MebApi
     module Forms
       module Response
         class SponsorResponse < MebApi::DGI::Response
-          attribute :sponsors, Array
+          attribute :sponsors, Hash, array: true
 
           def initialize(response = nil)
             attributes = {

--- a/modules/meb_api/lib/dgi/forms/response/submission_response.rb
+++ b/modules/meb_api/lib/dgi/forms/response/submission_response.rb
@@ -8,7 +8,7 @@ module MebApi
       module Submission
         class Response < MebApi::DGI::Response
           def initialize(status, _response = nil)
-            super(status, attributes)
+            super(status, nil)
           end
         end
       end

--- a/modules/meb_api/lib/dgi/response.rb
+++ b/modules/meb_api/lib/dgi/response.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'common/client/concerns/service_status'
-require 'common/models/base'
+require 'vets/model'
 module MebApi
   module DGI
     ##
@@ -10,14 +10,15 @@ module MebApi
     # @param status [Integer] The HTTP status code from the service
     # @param attributes [Hash] Additional response attributes
     #
-    class Response < Common::Base
+    class Response
+      include Vets::Model
       include Common::Client::Concerns::ServiceStatus
 
       attribute :status, Integer
 
       def initialize(status, attributes = nil)
+        @status = status
         super(attributes) if attributes
-        self.status = status
       end
 
       def ok?

--- a/modules/meb_api/lib/dgi/submission/submit_claim_response.rb
+++ b/modules/meb_api/lib/dgi/submission/submit_claim_response.rb
@@ -7,7 +7,7 @@ module MebApi
     module Submission
       class SubmissionResponse < MebApi::DGI::Response
         def initialize(status, _response = nil)
-          super(status, attributes)
+          super(status, nil)
         end
       end
     end

--- a/modules/meb_api/spec/dgi/automation/service_spec.rb
+++ b/modules/meb_api/spec/dgi/automation/service_spec.rb
@@ -39,7 +39,7 @@ Rspec.describe MebApi::DGI::Automation::Service do
           VCR.use_cassette('dgi/post_claimant_info') do
             response = service.get_claimant_info('Chapter33')
             expect(response.status).to eq(201)
-            expect(response['claimant']['claimant_id']).to eq(600_010_259)
+            expect(response.claimant['claimant_id']).to eq(600_010_259)
           end
         end
       end

--- a/modules/meb_api/spec/dgi/claimant/service_spec.rb
+++ b/modules/meb_api/spec/dgi/claimant/service_spec.rb
@@ -39,7 +39,7 @@ Rspec.describe MebApi::DGI::Claimant::Service do
           VCR.use_cassette('dgi/polling_post_claimant_info') do
             response = service.get_claimant_info('Chapter33')
             expect(response.status).to eq(201)
-            expect(response[:claimant_id]).to be_nil
+            expect(response.claimant_id).to be_nil
           end
         end
       end
@@ -49,7 +49,7 @@ Rspec.describe MebApi::DGI::Claimant::Service do
           VCR.use_cassette('dgi/polling_with_id_post_claimant_info') do
             response = service.get_claimant_info('Chapter33')
             expect(response.status).to eq(201)
-            expect(response[:claimant_id]).to eq('600010259')
+            expect(response.claimant_id).to eq('600010259')
           end
         end
       end

--- a/modules/meb_api/spec/dgi/forms/service/claimant_spec.rb
+++ b/modules/meb_api/spec/dgi/forms/service/claimant_spec.rb
@@ -39,7 +39,7 @@ Rspec.describe MebApi::DGI::Forms::Claimant::Service do
           VCR.use_cassette('dgi/forms/claimant_info') do
             response = service.get_claimant_info('fry')
             expect(response.status).to eq(201)
-            expect(response['claimant']['claimant_id']).to eq(600_010_259)
+            expect(response.claimant['claimant_id']).to eq(600_010_259)
           end
         end
       end

--- a/modules/meb_api/spec/dgi/forms/service/toe_submission_service_spec.rb
+++ b/modules/meb_api/spec/dgi/forms/service/toe_submission_service_spec.rb
@@ -125,7 +125,6 @@ RSpec.describe MebApi::DGI::Forms::Submission::Service do
           VCR.use_cassette('dgi/forms/submit_toe_claim') do
             response = service.submit_claim(ActionController::Parameters.new(claimant_params),
                                             ActionController::Parameters.new(dd_params_lighthouse))
-
             expect(response.status).to eq(200)
           end
         end

--- a/modules/meb_api/spec/requests/meb_api/v0/forms_spec.rb
+++ b/modules/meb_api/spec/requests/meb_api/v0/forms_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe 'MebApi::V0 Forms', type: :request do
   end
 
   describe 'GET /meb_api/v0/forms_claim_letter' do
-    let(:claimant_response) { double('claimant_response', :[] => 600_000_001, status: 200) }
+    let(:claimant_response) { double('claimant_response', claimant_id: 600_000_001, status: 200) }
     let(:claim_status_response) { double('claim_status_response', claim_status: 'ELIGIBLE') }
     let(:letter_response) { double('letter_response', body: 'PDF content here', status: 200) }
     let(:claimant_service) { instance_double(MebApi::DGI::Claimant::Service) }
@@ -172,7 +172,7 @@ RSpec.describe 'MebApi::V0 Forms', type: :request do
     end
 
     context 'when claimant response is invalid' do
-      let(:claimant_response) { double('claimant_response', :[] => nil, status: 404, body: 'Error content') }
+      let(:claimant_response) { double('claimant_response', claimant_id: nil, status: 404, body: 'Error content') }
 
       it 'returns claimant error response' do
         get '/meb_api/v0/forms_claim_letter', params: { type: 'ToeSubmission' }
@@ -276,7 +276,7 @@ RSpec.describe 'MebApi::V0 Forms', type: :request do
       let(:claimant_response) do
         double(
           'claimant_response',
-          :[] => 600_000_001,
+          claimant_id: 600_000_001,
           status: 500,
           body: { error: 'Internal error' },
           claimant: nil,


### PR DESCRIPTION
## Summary

- Virtus is being replace with `Vets::Model`. Differences include:
    - There's no hash access for attributes `form[:attribute]` only dot notation `form.attribute`
    - Syntax change for Array attributes
    - Sorting uses a class method: `default_sort_by`
    - booleans are temporarily `Bool`, until Virtus is completely gone
- This PR replaces `Virtus` with `Vets::Model` and updates the _attributes_ and _implementation_ accordingly. 
- This change should not affect any functionality.

One change in the vets lib is to allow valid iso8601 to pass without casting

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111518

## Testing done

- [x] Manual testing for similar output

## Acceptance criteria

- [x] Virtus models are now Vets::Model
- [x] No functional change