### PR TITLE
118433 MHV SM passthrough `ohTriageGroup` attribute from sm upstream

### DIFF
--- a/app/models/all_triage_teams.rb
+++ b/app/models/all_triage_teams.rb
@@ -25,6 +25,7 @@ class AllTriageTeams
   attribute :sub_group_type_enum_val, String
   attribute :group_type_patient_display, String
   attribute :sub_group_type_patient_display, String
+  attribute :oh_triage_group, Bool, default: false
 
   default_sort_by name: :asc
 end

--- a/modules/my_health/app/serializers/my_health/v1/all_triage_teams_serializer.rb
+++ b/modules/my_health/app/serializers/my_health/v1/all_triage_teams_serializer.rb
@@ -12,7 +12,7 @@ module MyHealth
                  :blocked_status, :preferred_team, :relation_type, :lead_provider_name,
                  :location_name, :team_name, :suggested_name_display, :health_care_system_name,
                  :group_type_enum_val, :sub_group_type_enum_val, :group_type_patient_display,
-                 :sub_group_type_patient_display
+                 :sub_group_type_patient_display, :oh_triage_group
     end
   end
 end

--- a/modules/my_health/spec/serializer/v1/all_triage_teams_serializer_spec.rb
+++ b/modules/my_health/spec/serializer/v1/all_triage_teams_serializer_spec.rb
@@ -73,4 +73,8 @@ describe MyHealth::V1::AllTriageTeamsSerializer, type: :serializer do
   it 'includes :sub_group_type_patient_display' do
     expect(attributes['sub_group_type_patient_display']).to eq triage_team.sub_group_type_patient_display
   end
+
+  it 'includes :oh_triage_group' do
+    expect(attributes['oh_triage_group']).to eq triage_team.oh_triage_group
+  end
 end

--- a/spec/models/all_triage_teams_spec.rb
+++ b/spec/models/all_triage_teams_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AllTriageTeams, type: :model do
+  subject { described_class.new }
+
+  describe 'attributes' do
+    it 'has the expected attributes' do
+      expect(subject.attributes.keys).to include(
+        'triage_team_id',
+        'name',
+        'station_number',
+        'blocked_status',
+        'preferred_team',
+        'relation_type',
+        'lead_provider_name',
+        'location_name',
+        'team_name',
+        'suggested_name_display',
+        'health_care_system_name',
+        'group_type_enum_val',
+        'sub_group_type_enum_val',
+        'group_type_patient_display',
+        'sub_group_type_patient_display',
+        'oh_triage_group'
+      )
+    end
+
+    it 'has default values for boolean attributes' do
+      expect(subject.blocked_status).to be false
+      expect(subject.preferred_team).to be false
+    end
+  end
+
+  describe 'sorting' do
+    it 'has default sort configured' do
+      # The model has default_sort_by name: :asc configured
+      expect(described_class.instance_variable_get(:@default_sort_criteria)).to eq(name: :asc)
+    end
+  end
+
+  describe 'vets model' do
+    it 'includes Vets::Model module' do
+      expect(described_class.included_modules).to include(Vets::Model)
+    end
+  end
+end

--- a/spec/support/schemas/my_health/messaging/v1/all_triage_team.json
+++ b/spec/support/schemas/my_health/messaging/v1/all_triage_team.json
@@ -16,7 +16,8 @@
     "group_type_enum_val",
     "sub_group_type_enum_val",
     "group_type_patient_display",
-    "sub_group_type_patient_display"
+    "sub_group_type_patient_display",
+    "oh_triage_group"
   ],
   "properties": {
     "triage_team_id": {
@@ -37,7 +38,7 @@
     "relation_type": {
       "type": "string"
     },
-    "location_name":{
+    "location_name": {
       "type": "string"
     },
     "lead_provider_name": {
@@ -46,7 +47,7 @@
     "team_name": {
       "type": "string"
     },
-    "suggested_name_display":{
+    "suggested_name_display": {
       "type": "string"
     },
     "health_care_system_name": {
@@ -63,6 +64,9 @@
     },
     "sub_group_type_patient_display": {
       "type": "string"
+    },
+    "oh_triage_group": {
+      "type": "boolean"
     }
   }
 }

--- a/spec/support/schemas_camelized/my_health/messaging/v1/all_triage_team.json
+++ b/spec/support/schemas_camelized/my_health/messaging/v1/all_triage_team.json
@@ -16,7 +16,8 @@
     "groupTypeEnumVal",
     "subGroupTypeEnumVal",
     "groupTypePatientDisplay",
-    "subGroupTypePatientDisplay"
+    "subGroupTypePatientDisplay",
+    "ohTriageGroup"
   ],
   "properties": {
     "triageTeamId": {
@@ -63,6 +64,9 @@
     },
     "subGroupTypePatientDisplay": {
       "type": "string"
+    },
+    "ohTriageGroup": {
+      "type": "boolean"
     }
   }
 }

--- a/spec/support/vcr_cassettes/sm_client/triage_teams/gets_a_collection_of_all_triage_team_recipients.yml
+++ b/spec/support/vcr_cassettes/sm_client/triage_teams/gets_a_collection_of_all_triage_team_recipients.yml
@@ -1,56 +1,56 @@
 ---
 http_interactions:
-- request:
-    method: get
-    uri: "<MHV_SM_HOST>/v1/sm/patient/alltriageteams"
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Vets.gov Agent
-      Token: "<SESSION_TOKEN>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 06 Mar 2025 15:16:36 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '4323'
-      X-Amzn-Requestid:
-      - 4bb8e19d-6835-43f2-a188-0e1511103f5e
-      X-Xss-Protection:
-      - '0'
-      X-Frame-Options:
-      - DENY
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amz-Apigw-Id:
-      - HApdOHJvvHMFnkA=
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Expires:
-      - '0'
-      X-Content-Type-Options:
-      - nosniff
-      Pragma:
-      - no-cache
-      X-Amzn-Remapped-Date:
-      - Thu, 06 Mar 2025 15:16:36 GMT
-      Strict-Transport-Security:
-      - max-age=16000000; includeSubDomains; preload;
-    body:
-      encoding: ASCII-8BIT
-      string: '[{"associatedTriageGroups":9,"friendlyTriageTeamPilotFacilities":"979","associatedBlockedTriageGroups":0},{"triageTeam":[{"triageTeamId":4399547,"name":"589GR Pharmacy Ask a pharmacist SLC10 JAMES, DON","stationNumber":"979","blockedStatus":false,"preferredTeam":true,"locationName":"Robert J. Dole VA Medical And Regional Office Center","leadProviderName":"James, Donald","teamName":"SLC10","suggestedNameDisplay":"Robert J. Dole VA Medical And Regional Office Center | Pharmacy | Ask a pharmacist | SLC10 - James, Donald Sr","healthCareSystemName":"VA Wichita Health Care","groupTypeEnumVal":"PHARMACY","subGroupTypeEnumVal":"ASK_A_PHARMACIST","groupTypePatientDisplay":"Pharmacy","subGroupTypePatientDisplay":"Ask a pharmacist","relationType":"PATIENT"}]}]'
-  recorded_at: Thu, 06 Mar 2025 15:16:35 GMT
+  - request:
+      method: get
+      uri: "<MHV_SM_HOST>/v1/sm/patient/alltriageteams"
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Vets.gov Agent
+        Token: "<SESSION_TOKEN>"
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Thu, 06 Mar 2025 15:16:36 GMT
+        Content-Type:
+          - application/json
+        Content-Length:
+          - "4323"
+        X-Amzn-Requestid:
+          - 4bb8e19d-6835-43f2-a188-0e1511103f5e
+        X-Xss-Protection:
+          - "0"
+        X-Frame-Options:
+          - DENY
+        X-Amzn-Remapped-Connection:
+          - keep-alive
+        X-Amz-Apigw-Id:
+          - HApdOHJvvHMFnkA=
+        Cache-Control:
+          - no-cache, no-store, max-age=0, must-revalidate
+        Expires:
+          - "0"
+        X-Content-Type-Options:
+          - nosniff
+        Pragma:
+          - no-cache
+        X-Amzn-Remapped-Date:
+          - Thu, 06 Mar 2025 15:16:36 GMT
+        Strict-Transport-Security:
+          - max-age=16000000; includeSubDomains; preload;
+      body:
+        encoding: ASCII-8BIT
+        string: '[{"associatedTriageGroups":9,"friendlyTriageTeamPilotFacilities":"979","associatedBlockedTriageGroups":0},{"triageTeam":[{"triageTeamId":4399547,"name":"589GR Pharmacy Ask a pharmacist SLC10 JAMES, DON","stationNumber":"979","blockedStatus":false,"preferredTeam":true,"locationName":"Robert J. Dole VA Medical And Regional Office Center","leadProviderName":"James, Donald","teamName":"SLC10","suggestedNameDisplay":"Robert J. Dole VA Medical And Regional Office Center | Pharmacy | Ask a pharmacist | SLC10 - James, Donald Sr","healthCareSystemName":"VA Wichita Health Care","groupTypeEnumVal":"PHARMACY","subGroupTypeEnumVal":"ASK_A_PHARMACIST","groupTypePatientDisplay":"Pharmacy","subGroupTypePatientDisplay":"Ask a pharmacist","relationType":"PATIENT","ohTriageGroup":false}]}]'
+    recorded_at: Thu, 06 Mar 2025 15:16:35 GMT
 recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/sm_client/triage_teams/gets_a_collection_of_all_triage_team_recipients_require_oh.yml
+++ b/spec/support/vcr_cassettes/sm_client/triage_teams/gets_a_collection_of_all_triage_team_recipients_require_oh.yml
@@ -1,56 +1,56 @@
 ---
 http_interactions:
-- request:
-    method: get
-    uri: "<MHV_SM_HOST>/v1/sm/patient/alltriageteams?requiresOHTriageGroup=1"
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Vets.gov Agent
-      Token: "<SESSION_TOKEN>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 06 Mar 2025 15:16:36 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '4323'
-      X-Amzn-Requestid:
-      - 5c42419b-233f-4214-87c5-13c47cae2f82
-      X-Xss-Protection:
-      - '0'
-      X-Frame-Options:
-      - DENY
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amz-Apigw-Id:
-      - HApdUHGoPHMFhiA=
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Expires:
-      - '0'
-      X-Content-Type-Options:
-      - nosniff
-      Pragma:
-      - no-cache
-      X-Amzn-Remapped-Date:
-      - Thu, 06 Mar 2025 15:16:36 GMT
-      Strict-Transport-Security:
-      - max-age=16000000; includeSubDomains; preload;
-    body:
-      encoding: ASCII-8BIT
-      string: '[{"associatedTriageGroups":9,"friendlyTriageTeamPilotFacilities":"979","associatedBlockedTriageGroups":0},{"triageTeam":[{"triageTeamId":4399547,"name":"589GR Pharmacy Ask a pharmacist SLC10 JAMES, DON","stationNumber":"979","blockedStatus":false,"preferredTeam":true,"locationName":"Robert J. Dole VA Medical And Regional Office Center","leadProviderName":"James, Donald","teamName":"SLC10","suggestedNameDisplay":"Robert J. Dole VA Medical And Regional Office Center | Pharmacy | Ask a pharmacist | SLC10 - James, Donald Sr","healthCareSystemName":"VA Wichita Health Care","groupTypeEnumVal":"PHARMACY","subGroupTypeEnumVal":"ASK_A_PHARMACIST","groupTypePatientDisplay":"Pharmacy","subGroupTypePatientDisplay":"Ask a pharmacist","relationType":"PATIENT"}]}]'
-  recorded_at: Thu, 06 Mar 2025 15:16:36 GMT
+  - request:
+      method: get
+      uri: "<MHV_SM_HOST>/v1/sm/patient/alltriageteams?requiresOHTriageGroup=1"
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Vets.gov Agent
+        Token: "<SESSION_TOKEN>"
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Thu, 06 Mar 2025 15:16:36 GMT
+        Content-Type:
+          - application/json
+        Content-Length:
+          - "4323"
+        X-Amzn-Requestid:
+          - 5c42419b-233f-4214-87c5-13c47cae2f82
+        X-Xss-Protection:
+          - "0"
+        X-Frame-Options:
+          - DENY
+        X-Amzn-Remapped-Connection:
+          - keep-alive
+        X-Amz-Apigw-Id:
+          - HApdUHGoPHMFhiA=
+        Cache-Control:
+          - no-cache, no-store, max-age=0, must-revalidate
+        Expires:
+          - "0"
+        X-Content-Type-Options:
+          - nosniff
+        Pragma:
+          - no-cache
+        X-Amzn-Remapped-Date:
+          - Thu, 06 Mar 2025 15:16:36 GMT
+        Strict-Transport-Security:
+          - max-age=16000000; includeSubDomains; preload;
+      body:
+        encoding: ASCII-8BIT
+        string: '[{"associatedTriageGroups":9,"friendlyTriageTeamPilotFacilities":"979","associatedBlockedTriageGroups":0},{"triageTeam":[{"triageTeamId":4399547,"name":"589GR Pharmacy Ask a pharmacist SLC10 JAMES, DON","stationNumber":"979","blockedStatus":false,"preferredTeam":true,"locationName":"Robert J. Dole VA Medical And Regional Office Center","leadProviderName":"James, Donald","teamName":"SLC10","suggestedNameDisplay":"Robert J. Dole VA Medical And Regional Office Center | Pharmacy | Ask a pharmacist | SLC10 - James, Donald Sr","healthCareSystemName":"VA Wichita Health Care","groupTypeEnumVal":"PHARMACY","subGroupTypeEnumVal":"ASK_A_PHARMACIST","groupTypePatientDisplay":"Pharmacy","subGroupTypePatientDisplay":"Ask a pharmacist","relationType":"PATIENT","ohTriageGroup":false }]}]'
+    recorded_at: Thu, 06 Mar 2025 15:16:36 GMT
 recorded_with: VCR 6.3.1


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): NO*
- This pull request adds support for a new boolean attribute, `oh_triage_group`, to the `AllTriageTeams` model and related serialization, schema, and test files. This change ensures that the `oh_triage_group` property is properly handled throughout the backend, including API responses, schema validation, and test coverage.

### Model and Serialization Updates

* Added the `oh_triage_group` boolean attribute (with default value `false`) to the `AllTriageTeams` model (`app/models/all_triage_teams.rb`) and included it in the serializer (`modules/my_health/app/serializers/my_health/v1/all_triage_teams_serializer.rb`). [[1]](diffhunk://#diff-b34ca3cd12d0089568a17f424b999f4da797a5c45b9a1acf580579464f3102e5R28) [[2]](diffhunk://#diff-a790f91dd150ddfc7905e0ebeb95e95ba0040cec4ff47768e9c19b70da069b80L15-R15)

### Schema Updates

* Updated both snake_case and camelCase JSON schemas to include the new `oh_triage_group`/`ohTriageGroup` boolean property, ensuring API contract consistency (`spec/support/schemas/my_health/messaging/v1/all_triage_team.json`, `spec/support/schemas_camelized/my_health/messaging/v1/all_triage_team.json`). [[1]](diffhunk://#diff-31fd56e8573d232095cb98633e33526bc0fcd84753ec7a3538c51e62666c10c5L19-R20) [[2]](diffhunk://#diff-31fd56e8573d232095cb98633e33526bc0fcd84753ec7a3538c51e62666c10c5R67-R69) [[3]](diffhunk://#diff-5d23e9cbbfc81c5f7f41cec43a98ca7936fc6c732f6d6e8f25030412645029adL19-R20) [[4]](diffhunk://#diff-5d23e9cbbfc81c5f7f41cec43a98ca7936fc6c732f6d6e8f25030412645029adR67-R69)

### Test Coverage

* Added and updated model and serializer specs to verify the presence and default value of `oh_triage_group` (`spec/models/all_triage_teams_spec.rb`, `modules/my_health/spec/serializer/v1/all_triage_teams_serializer_spec.rb`). [[1]](diffhunk://#diff-36fd0d8459b8157347a512441e4be593920f0a2473c43b0a177e117d8edb37c4R1-R48) [[2]](diffhunk://#diff-a7ad7ff83b2733890abcdd133dde541ad201975ffc7eaa82770644540c45e9a4R76-R79)

### VCR Cassette Updates

* Updated VCR cassettes to include the new `ohTriageGroup` property in mocked API responses, and normalized YAML formatting for consistency (`spec/support/vcr_cassettes/sm_client/triage_teams/gets_a_collection_of_all_triage_team_recipients.yml`, `spec/support/vcr_cassettes/sm_client/triage_teams/gets_a_collection_of_all_triage_team_recipients_require_oh.yml`). [[1]](diffhunk://#diff-204ea3cf41413747376494b0c5e935247d050b917a2ec323bb9c6066184125d7L8-R8) [[2]](diffhunk://#diff-204ea3cf41413747376494b0c5e935247d050b917a2ec323bb9c6066184125d7L29-R33) [[3]](diffhunk://#diff-204ea3cf41413747376494b0c5e935247d050b917a2ec323bb9c6066184125d7L43-R43) [[4]](diffhunk://#diff-204ea3cf41413747376494b0c5e935247d050b917a2ec323bb9c6066184125d7L54-R54) [[5]](diffhunk://#diff-abacec5745e8b12d2f946a4347219b197c9c528f65f5dc91edecb54740c817e7L8-R8) [[6]](diffhunk://#diff-abacec5745e8b12d2f946a4347219b197c9c528f65f5dc91edecb54740c817e7L29-R33) [[7]](diffhunk://#diff-abacec5745e8b12d2f946a4347219b197c9c528f65f5dc91edecb54740c817e7L43-R43) [[8]](diffhunk://#diff-abacec5745e8b12d2f946a4347219b197c9c528f65f5dc91edecb54740c817e7L54-R54)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118433

## Testing done

- [x] *New code is covered by unit tests*


## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
