### PR TITLE
UAE 117241 - Logging for missing telehealth link updated - changes to logging limits and fields

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -995,6 +995,8 @@ module VAOS
             vvsVistaVideoAppt: appointment.dig(:extension, :vvs_vista_video_appt),
             facilityId: appointment[:location_id],
             clinicId: appointment[:clinic],
+            primaryStopCode: appointment.dig(:extension, :clinic, :primary_stop_code),
+            secondaryStopCode: appointment.dig(:extension, :clinic, :secondary_stop_code),
             afterFiveBeforeStart: time_now >= start_time - 5.minutes
           }
           Rails.logger.warn('VAOS video telehealth issue', context.to_json) if context[:telehealthUrl].blank? &&

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -981,6 +981,7 @@ module VAOS
         appointment[:future] = future?(appointment)
       end
 
+      # rubocop:disable Metrics/MethodLength
       def log_telehealth_issue(appointment)
         if appointment[:start]
           start_time = appointment[:start].to_datetime
@@ -1004,6 +1005,7 @@ module VAOS
                                                                                time_now <= fifteen_after
         end
       end
+      # rubocop:enable Metrics/MethodLength
 
       def log_modality_failure(appointment)
         context = {

--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -983,8 +983,10 @@ module VAOS
 
       def log_telehealth_issue(appointment)
         if appointment[:start]
-          fifteen_before = appointment[:start].to_datetime - 15.minutes
-          fifteen_after = appointment[:start].to_datetime + 15.minutes
+          start_time = appointment[:start].to_datetime
+          time_now = Time.now.utc
+          fifteen_before = start_time - 15.minutes
+          fifteen_after = start_time + 15.minutes
           context = {
             displayLink: appointment.dig(:telehealth, :display_link),
             kind: appointment[:kind],
@@ -993,11 +995,11 @@ module VAOS
             vvsVistaVideoAppt: appointment.dig(:extension, :vvs_vista_video_appt),
             facilityId: appointment[:location_id],
             clinicId: appointment[:clinic],
-            afterFiveBeforeStart: Time.now.utc >= appointment[:start].to_datetime - 5.minutes
+            afterFiveBeforeStart: time_now >= start_time - 5.minutes
           }
           Rails.logger.warn('VAOS video telehealth issue', context.to_json) if context[:telehealthUrl].blank? &&
-                                                                               Time.now.utc >= fifteen_before &&
-                                                                               Time.now.utc <= fifteen_after
+                                                                               time_now >= fifteen_before &&
+                                                                               time_now <= fifteen_after
         end
       end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Updates so that logging happens only if URL is missing and within 15 minutes of start time and adds fields to help diagnose why link may be missing (clinic/facility id and start time related boolean).
- UAE- Appointments team 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117241

## Testing done

- [ ] *New code is covered by unit tests*
- Logged before, but not within time frame to help diagnose. Added more fields

## Screenshots
N/A

## What areas of the site does it impact?

Adds logging when processing appointment information for user, within a time frame around the appointment

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
Check that logs are correct in Datadog or rails console on staging/lower env