### PR TITLE
Unique User Metric library checks feature flag before logging event

### DIFF
--- a/lib/unique_user_events.rb
+++ b/lib/unique_user_events.rb
@@ -27,6 +27,8 @@ module UniqueUserEvents
   # @example
   #   UniqueUserEvents.log_event(user_id: user.uuid, event_name: 'appointments_viewed')
   def self.log_event(user_id:, event_name:)
+    return false unless Flipper.enabled?(:unique_user_metrics_logging)
+
     start_time = Time.current
     result = Service.log_event(user_id:, event_name:)
     duration = (Time.current - start_time) * 1000.0 # Convert to milliseconds
@@ -42,7 +44,7 @@ module UniqueUserEvents
   #
   # @param user_id [String] UUID of the user
   # @param event_name [String] Name of the event to check
-  # @return [Boolean] true if event exists, false otherwise or if feature disabled
+  # @return [Boolean] true if event exists, false otherwise
   # @raise [ArgumentError] if parameters are invalid
   #
   # @example

--- a/spec/lib/unique_user_events_spec.rb
+++ b/spec/lib/unique_user_events_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe UniqueUserEvents do
 
   describe '.log_event' do
     before do
+      allow(Flipper).to receive(:enabled?).with(:unique_user_metrics_logging).and_return(true)
       allow(UniqueUserEvents::Service).to receive(:log_event)
       allow(StatsD).to receive(:measure) # Stub StatsD calls that aren't being tested
     end
@@ -29,6 +30,40 @@ RSpec.describe UniqueUserEvents do
 
       expect(result).to be(false)
       expect(UniqueUserEvents::Service).to have_received(:log_event).with(user_id:, event_name:)
+    end
+
+    context 'when feature flag is enabled' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:unique_user_metrics_logging).and_return(true)
+        allow(UniqueUserEvents::Service).to receive(:log_event).and_return(true)
+      end
+
+      it 'calls service and returns result' do
+        result = described_class.log_event(user_id:, event_name:)
+
+        expect(result).to be(true)
+        expect(UniqueUserEvents::Service).to have_received(:log_event).with(user_id:, event_name:)
+      end
+    end
+
+    context 'when feature flag is disabled' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:unique_user_metrics_logging).and_return(false)
+        allow(UniqueUserEvents::Service).to receive(:log_event)
+      end
+
+      it 'returns false without calling service' do
+        result = described_class.log_event(user_id:, event_name:)
+
+        expect(result).to be(false)
+        expect(UniqueUserEvents::Service).not_to have_received(:log_event)
+      end
+
+      it 'does not measure performance metrics when disabled' do
+        expect(StatsD).not_to receive(:measure)
+
+        described_class.log_event(user_id:, event_name:)
+      end
     end
   end
 
@@ -60,6 +95,7 @@ RSpec.describe UniqueUserEvents do
 
   describe 'performance metrics' do
     before do
+      allow(Flipper).to receive(:enabled?).with(:unique_user_metrics_logging).and_return(true)
       allow(UniqueUserEvents::Service).to receive(:log_event).and_return(true)
     end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- If the `unique_user_metrics_logging` is disabled then don't log an event in the library. The UUM controller checks this flag already, but other controllers/code in `vets-api` can use this library and we want to make sure events are not logged if this flag is off. 
- Team: MHV Horizon

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/117472

## Testing done
- [X] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

