### PR TITLE
Disable Dependents Benefits module in development by default

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -631,7 +631,7 @@ features:
   dependents_module_enabled:
     actor_type: user
     description: Enables new Dependents module
-    enable_in_development: true
+    enable_in_development: false
   dependents_pension_check:
     actor_type: user
     description: Manage whether or not Pension check is enabled for the 686/674


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- This pull request makes a small configuration change to the `dependents_module_enabled` feature flag in `config/features.yml`. The feature will now be disabled by default in development environments. This is because the module isn't close enough to finished for standard use.

## What areas of the site does it impact?
Dependents Benefits

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
