### PR TITLE
Revert "API 49489 - Add Federal Activation obligation dates requirement to v2 526 schema"

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/v2/disability_compensation_validation.rb
@@ -1013,8 +1013,8 @@ module ClaimsApi
       # rubocop:disable Metrics/MethodLength
       def validate_required_values_for_federal_activation(activation_date, separation_date)
         activation_form_obj_desc = 'serviceInformation/federalActivation/'
-        reserves_dates_form_obj_desc = 'serviceInformation/reservesNationalGuardService/obligationTermsOfService/'
-        reserves_unit_form_obj_desc = 'serviceInformation/reservesNationalGuardService/'
+        reserves_dates_form_obj_desc = 'serviceInformation/reservesNationalGuardServce/obligationTermsOfService/'
+        reserves_unit_form_obj_desc = 'serviceInformation/reservesNationalGuardServce/'
 
         reserves = form_attributes.dig('serviceInformation', 'reservesNationalGuardService')
         tos_start_date = reserves&.dig('obligationTermsOfService', 'beginDate')

--- a/modules/claims_api/config/schemas/v2/526.json
+++ b/modules/claims_api/config/schemas/v2/526.json
@@ -917,24 +917,6 @@
             }
           }
         }
-      },
-      "if": {
-        "required": ["federalActivation"]
-      },
-      "then": {
-        "required": ["reservesNationalGuardService"],
-        "properties": {
-          "reservesNationalGuardService": {
-            "required": [
-              "obligationTermsOfService"
-            ],
-            "properties": {
-              "obligationTermsOfService": {
-                "required": ["beginDate", "endDate"]
-              }
-            }
-          }
-        }
       }
     },
     "servicePay": {

--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_validation_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_validation_spec.rb
@@ -549,7 +549,7 @@ describe TestDisabilityCompensationValidationClass, vcr: 'brd/countries' do
         validate_field(
           'reservesNationalGuardService.obligationTermsOfService.beginDate',
           'beginDate is missing or blank',
-          'serviceInformation/reservesNationalGuardService/obligationTermsOfService/'
+          'serviceInformation/reservesNationalGuardServce/obligationTermsOfService/'
         )
       end
 
@@ -557,7 +557,7 @@ describe TestDisabilityCompensationValidationClass, vcr: 'brd/countries' do
         validate_field(
           'reservesNationalGuardService.obligationTermsOfService.endDate',
           'endDate is missing or blank',
-          'serviceInformation/reservesNationalGuardService/obligationTermsOfService/'
+          'serviceInformation/reservesNationalGuardServce/obligationTermsOfService/'
         )
       end
 
@@ -565,7 +565,7 @@ describe TestDisabilityCompensationValidationClass, vcr: 'brd/countries' do
         validate_field(
           'reservesNationalGuardService.unitName',
           'unitName is missing or blank',
-          'serviceInformation/reservesNationalGuardService/'
+          'serviceInformation/reservesNationalGuardServce/'
         )
       end
       # rubocop:enable RSpec/NoExpectationExample

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_526_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_526_spec.rb
@@ -554,54 +554,6 @@ describe 'DisabilityCompensation', openapi_spec: Rswag::TextHelpers.new.claims_a
               assert_response_matches_metadata(example.metadata)
             end
           end
-
-          context 'when federalActivation is present but obligationTermsOfService is missing' do
-            def make_request(example)
-              allow(Flipper).to receive(:enabled?).with(:claims_load_testing).and_return false
-
-              with_settings(Settings.claims_api.benefits_documents, use_mocks: true) do
-                VCR.use_cassette('claims_api/disability_comp') do
-                  VCR.use_cassette('claims_api/evss/submit') do
-                    mock_ccg_for_fine_grained_scope(synchronous_scopes) do
-                      submit_request(example.metadata)
-                    end
-                  end
-                end
-              end
-            end
-            let(:anticipated_separation_date) { 2.days.from_now.strftime('%Y-%m-%d') }
-            let(:data) do
-              temp = Rails.root.join('modules', 'claims_api', 'spec', 'fixtures', 'v2', 'veterans',
-                                     'disability_compensation', 'form_526_json_api.json').read
-              temp = JSON.parse(temp)
-              attributes = temp['data']['attributes']
-
-              # Ensure federalActivation is present with proper date
-              attributes['serviceInformation']['federalActivation']['anticipatedSeparationDate'] =
-                anticipated_separation_date
-
-              # Make sure reservesNationalGuardService exists but with empty obligationTermsOfService
-              # This will cause the validation error in the correct format
-              attributes['serviceInformation']['reservesNationalGuardService']['obligationTermsOfService'] = {}
-
-              temp['data']['attributes'] = attributes
-              temp
-            end
-
-            let(:disability_comp_request) { data }
-
-            before do |example|
-              make_request(example)
-            end
-
-            after do |example|
-              append_example_metadata(example, response)
-            end
-
-            it 'returns a 422 response' do |example|
-              assert_response_matches_metadata(example.metadata)
-            end
-          end
         end
       end
     end


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#23910

Need to revert this because we don't want the change to go out on a Friday (which would be the next daily deploy). I'll re-open the original PR on Monday 9/8/25.