### PR TITLE
[619] adds service tag logging to controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,6 +23,8 @@ class ApplicationController < ActionController::API
   skip_before_action :authenticate, only: %i[cors_preflight routing_error]
   skip_before_action :verify_authenticity_token, only: :routing_error
 
+  around_action :tag_with_service_tag
+
   VERSION_STATUS = {
     draft: 'Draft Version',
     current: 'Current Version',
@@ -60,5 +62,12 @@ class ApplicationController < ActionController::API
 
   def render_job_id(jid)
     render json: { job_id: jid }, status: :accepted
+  end
+
+  def tag_with_service_tag(&)
+    service_tag = trace_service_tag
+    return yield if service_tag.blank?
+
+    SemanticLogger.named_tagged(service_tag:, &)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::API
   skip_before_action :authenticate, only: %i[cors_preflight routing_error]
   skip_before_action :verify_authenticity_token, only: :routing_error
 
-  around_action :tag_with_service_tag
+  around_action :tag_with_controller_name
 
   VERSION_STATUS = {
     draft: 'Draft Version',

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -63,11 +63,4 @@ class ApplicationController < ActionController::API
   def render_job_id(jid)
     render json: { job_id: jid }, status: :accepted
   end
-
-  def tag_with_service_tag(&)
-    service_tag = trace_service_tag
-    return yield if service_tag.blank?
-
-    SemanticLogger.named_tagged(service_tag:, &)
-  end
 end

--- a/app/controllers/concerns/traceable.rb
+++ b/app/controllers/concerns/traceable.rb
@@ -43,10 +43,9 @@ module Traceable
   end
 
   # Wraps controller methods with the service tag.
-  def tag_with_service_tag(&)
-    service_tag = trace_service_tag
-    return yield if service_tag.blank?
+  def tag_with_controller_name(&)
+    return yield if controller_name.blank?
 
-    SemanticLogger.named_tagged(service_tag:, &)
+    SemanticLogger.named_tagged(controller_name:, &)
   end
 end

--- a/app/controllers/concerns/traceable.rb
+++ b/app/controllers/concerns/traceable.rb
@@ -42,7 +42,7 @@ module Traceable
     Rails.logger.error('Error setting service tag', class: self.class.name, message: e.message)
   end
 
-  # Wraps controller methods with the service tag.
+  # Wraps controller methods with the controller name.
   def tag_with_controller_name(&)
     return yield if controller_name.blank?
 

--- a/app/controllers/concerns/traceable.rb
+++ b/app/controllers/concerns/traceable.rb
@@ -41,4 +41,12 @@ module Traceable
   rescue => e
     Rails.logger.error('Error setting service tag', class: self.class.name, message: e.message)
   end
+
+  # Wraps controller methods with the service tag.
+  def tag_with_service_tag(&)
+    service_tag = trace_service_tag
+    return yield if service_tag.blank?
+
+    SemanticLogger.named_tagged(service_tag:, &)
+  end
 end

--- a/app/controllers/sign_in/application_controller.rb
+++ b/app/controllers/sign_in/application_controller.rb
@@ -16,7 +16,7 @@ module SignIn
 
     skip_before_action :authenticate, only: :cors_preflight
 
-    around_action :tag_with_service_tag
+    around_action :tag_with_controller_name
 
     def cors_preflight
       head(:ok)

--- a/app/controllers/sign_in/application_controller.rb
+++ b/app/controllers/sign_in/application_controller.rb
@@ -16,6 +16,8 @@ module SignIn
 
     skip_before_action :authenticate, only: :cors_preflight
 
+    around_action :tag_with_service_tag
+
     def cors_preflight
       head(:ok)
     end
@@ -23,5 +25,12 @@ module SignIn
     private
 
     attr_reader :current_user
+
+    def tag_with_service_tag(&)
+      service_tag = trace_service_tag
+      return yield if service_tag.blank?
+
+      SemanticLogger.named_tagged(service_tag:, &)
+    end
   end
 end

--- a/app/controllers/sign_in/application_controller.rb
+++ b/app/controllers/sign_in/application_controller.rb
@@ -25,12 +25,5 @@ module SignIn
     private
 
     attr_reader :current_user
-
-    def tag_with_service_tag(&)
-      service_tag = trace_service_tag
-      return yield if service_tag.blank?
-
-      SemanticLogger.named_tagged(service_tag:, &)
-    end
   end
 end

--- a/app/services/sign_in/attribute_validator.rb
+++ b/app/services/sign_in/attribute_validator.rb
@@ -72,7 +72,6 @@ module SignIn
     end
 
     def add_mpi_user
-      sign_in_logger.info('add_mpi_user', { idme_uuid:, logingov_uuid:}.compact)
       add_person_response = mpi_service.add_person_implicit_search(first_name:,
                                                                    last_name:,
                                                                    ssn:,
@@ -92,7 +91,6 @@ module SignIn
       return if auto_uplevel
 
       user_attribute_mismatch_checks
-      sign_in_logger.info('update_mpi_correlation_record', { icn: verified_icn, idme_uuid:, logingov_uuid:}.compact)
       update_profile_response = mpi_service.update_profile(last_name:,
                                                            ssn:,
                                                            birth_date:,
@@ -182,7 +180,6 @@ module SignIn
 
     def mpi_response_profile
       @mpi_response_profile ||=
-        sign_in_logger.info('mpi_response_profile', { icn: mhv_icn, idme_uuid:, logingov_uuid:}.compact)
         if mhv_credential_uuid
           mpi_service.find_profile_by_identifier(identifier: mhv_credential_uuid,
                                                  identifier_type: MPI::Constants::MHV_UUID)&.profile

--- a/app/services/sign_in/attribute_validator.rb
+++ b/app/services/sign_in/attribute_validator.rb
@@ -72,6 +72,7 @@ module SignIn
     end
 
     def add_mpi_user
+      sign_in_logger.info('add_mpi_user', { idme_uuid:, logingov_uuid:}.compact)
       add_person_response = mpi_service.add_person_implicit_search(first_name:,
                                                                    last_name:,
                                                                    ssn:,
@@ -91,6 +92,7 @@ module SignIn
       return if auto_uplevel
 
       user_attribute_mismatch_checks
+      sign_in_logger.info('update_mpi_correlation_record', { icn: verified_icn, idme_uuid:, logingov_uuid:}.compact)
       update_profile_response = mpi_service.update_profile(last_name:,
                                                            ssn:,
                                                            birth_date:,
@@ -180,6 +182,7 @@ module SignIn
 
     def mpi_response_profile
       @mpi_response_profile ||=
+        sign_in_logger.info('mpi_response_profile', { icn: mhv_icn, idme_uuid:, logingov_uuid:}.compact)
         if mhv_credential_uuid
           mpi_service.find_profile_by_identifier(identifier: mhv_credential_uuid,
                                                  identifier_type: MPI::Constants::MHV_UUID)&.profile

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -680,6 +680,28 @@ RSpec.describe ApplicationController, type: :controller do
       session_object.to_hash.each { |k, v| session[k] = v }
     end
 
+    context 'with service tag logging' do
+      context 'when controller has a service tag' do
+        before do
+          controller.class.service_tag 'test-service'
+        end
+
+        it 'adds service tag to logs within around_action' do
+          expect(SemanticLogger).to receive(:named_tagged).with(service_tag: 'test-service').and_call_original
+          expect(Rails.logger).to receive(:info).with(expected_result)
+          subject
+        end
+      end
+
+      context 'when controller has no service tag' do
+        it 'does not call SemanticLogger.named_tagged' do
+          expect(SemanticLogger).not_to receive(:named_tagged)
+          expect(Rails.logger).to receive(:info).with(expected_result)
+          subject
+        end
+      end
+    end
+
     context 'when the current user and session object exist' do
       it 'returns the current user session token' do
         expect(Rails.logger).to receive(:info).with(expected_result)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -676,9 +676,9 @@ RSpec.describe ApplicationController, type: :controller do
     before do
       allow(Rails.logger).to receive(:info)
       session_object = Session.create(uuid: user.uuid, token:)
-      user.save!
+      User.create(user)
       session_object.to_hash.each { |k, v| session[k] = v }
-      controller.instance_variable_set(:@current_user, user)
+      sign_in_as(user, session_object.token)
     end
 
     context 'with controller name logging' do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -685,15 +685,13 @@ RSpec.describe ApplicationController, type: :controller do
       context 'when controller has a name' do
         it 'adds controller name to logs within around_action' do
           expect(SemanticLogger).to receive(:named_tagged).with(controller_name: 'anonymous').and_call_original
-          expect(Rails.logger).to receive(:info).with(any_args)
+          expect(Rails.logger).to receive(:info).with(expected_result)
           subject
         end
       end
 
       context 'when controller has no name' do
-        before do
-          allow(controller).to receive(:controller_name).and_return('')
-        end
+        before { allow(controller).to receive(:controller_name).and_return('') }
 
         it 'does not call SemanticLogger.named_tagged' do
           expect(SemanticLogger).not_to receive(:named_tagged)

--- a/spec/controllers/sign_in/application_controller_spec.rb
+++ b/spec/controllers/sign_in/application_controller_spec.rb
@@ -722,17 +722,21 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
   end
 
   describe 'controller name logging' do
-    it 'adds controller name to logs' do
-      expect(SemanticLogger).to receive(:named_tagged).with(controller_name: 'application').and_call_original
-      get :test_logging
-      expect(response).to have_http_status :ok
+    context 'when controller name is present' do
+      it 'adds controller name to logs' do
+        expect(SemanticLogger).to receive(:named_tagged).with(controller_name: 'application').and_call_original
+        get :test_logging
+        expect(response).to have_http_status :ok
+      end
     end
 
-    it 'handles missing controller name gracefully' do
-      allow(controller).to receive(:controller_name).and_return('')
-      expect(SemanticLogger).not_to receive(:named_tagged)
-      get :test_logging
-      expect(response).to have_http_status :ok
+    context 'when controller name is missing' do
+      it 'handles missing controller name gracefully' do
+        allow(controller).to receive(:controller_name).and_return('')
+        expect(SemanticLogger).not_to receive(:named_tagged)
+        get :test_logging
+        expect(response).to have_http_status :ok
+      end
     end
   end
 end

--- a/spec/controllers/sign_in/application_controller_spec.rb
+++ b/spec/controllers/sign_in/application_controller_spec.rb
@@ -738,7 +738,7 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
     end
 
     it 'handles missing service tag gracefully' do
-      controller.class.trace_service_tag = nil
+      allow(controller).to receive(:trace_service_tag).and_return(nil)
       expect(SemanticLogger).not_to receive(:named_tagged)
       expect(Rails.logger).to receive(:info).with('Test log message')
       get :index

--- a/spec/controllers/sign_in/application_controller_spec.rb
+++ b/spec/controllers/sign_in/application_controller_spec.rb
@@ -722,18 +722,23 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
   end
 
   describe 'controller name logging' do
-    context 'when controller name is present' do
-      it 'adds controller name to logs' do
+    let(:expected_result) { 'Test log message' }
+
+    context 'when controller has a name' do
+      it 'adds controller name to logs within around_action' do
         expect(SemanticLogger).to receive(:named_tagged).with(controller_name: 'application').and_call_original
+        expect(Rails.logger).to receive(:info).with(expected_result)
         get :test_logging
         expect(response).to have_http_status :ok
       end
     end
 
-    context 'when controller name is missing' do
-      it 'handles missing controller name gracefully' do
-        allow(controller).to receive(:controller_name).and_return('')
+    context 'when controller has no name' do
+      before { allow(controller).to receive(:controller_name).and_return('') }
+
+      it 'does not call SemanticLogger.named_tagged' do
         expect(SemanticLogger).not_to receive(:named_tagged)
+        expect(Rails.logger).to receive(:info).with(expected_result)
         get :test_logging
         expect(response).to have_http_status :ok
       end


### PR DESCRIPTION
## Summary

Adds structured controller name logging to both SignIn and base ApplicationController to improve observability of MPI service interactions - which area of `vets-api` called the MPI service.

## Changes
- Added `around_action :tag_with_controller_name` to `SignIn::ApplicationController`
- Added `around_action :tag_with_controller_name` to base `ApplicationController`
- Implemented `tag_with_controller_name` method using `SemanticLogger.named_tagged` in `Traceable` concern

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/619

## Testing done

- [ ] *New code is covered by unit tests*

### Config Changes for Testing
To make controller name tags visible in development logs, temporarily modify:

**config/environments/development.rb:**
```ruby
config.rails_semantic_logger.semantic = true   # Enable semantic mode
config.rails_semantic_logger.format = :json    # Use JSON format
```

### 1. Test SignIn Controller Name Tags
- Perform a SiS authentication.
- Look for `"named_tags":{"controller_name":"sign_in"}` in your dev logs.

**Example log entry:**
```json
{"host":"system76","application":"Semantic Logger","environment":"development","timestamp":"2025-09-16T15:51:46.893643Z","level":"info","level_index":2,"pid":21266,"thread":"puma srv tp 001","named_tags":{"controller_name":"sign_in"},"name":"Rails","message":"[SignInService] [SignIn::TokenResponseGenerator] session created","payload":{"uuid":"2aa5656a-6872-48ba-9297-d34341351643","user_uuid":"686336b3-4304-432a-aefe-2724d473304c","session_handle":"4cc8fa36-d14b-4797-ba4f-65502e144739","client_id":"vaweb","audience":["vaweb","vamobile","okta_test","vamock","sample_client_web","sample_client_cert"],"version":"V0","last_regeneration_time":1758037906,"created_time":1758037906,"expiration_time":1758038206}}
```

### 2. Test Base ApplicationController Controller Name Tags
- Make the following request `GET /v0/health_care_applications/healthcheck`
- Look for `"named_tags":{"controller_name":"health_care_applications"}` in your dev logs.

**Example log entry:**
```json
{"host":"system76","application":"Semantic Logger","environment":"development","timestamp":"2025-09-16T15:52:24.871813Z","level":"error","level_index":4,"pid":21266,"thread":"puma srv tp 003","file":"/home/john/Projects/va/vets-api/vendor/bundle/ruby/3.3.0/gems/breakers-1.0/lib/breakers/outage.rb","line":42,"named_tags":{"controller_name":"health_care_applications"},"name":"Rails","payload":{"msg":"Breakers outage beginning","service":"HCA","forced":false}}
```

### 3. MPI Service Logging Context
- MPI calls that originate from a controller, such as during SiS `/callback`, will be covered by the new controller_name logs.
- MPI calls that originate from the `MPIData` model, such as to service user profile information immediately post-authentication, will not be covered by the new controller name log tags.

**SignIn MPI logs (with controller name tags):**
```json
{"host":"system76","application":"Semantic Logger","environment":"development","timestamp":"2025-09-16T15:51:18.118007Z","level":"info","level_index":2,"pid":21266,"thread":"puma srv tp 004","named_tags":{"controller_name":"sign_in"},"name":"Rails","message":"[MPI][Services][FindProfileResponseCreator] find_profile_by_identifier icn=1012667122V019349, transaction_id="}
```

**Non-SignIn MPI logs (without controller name tags):**
```json
{"host":"system76","application":"Semantic Logger","environment":"development","timestamp":"2025-09-16T15:53:01.770319Z","level":"info","level_index":2,"pid":21266,"thread":"puma srv tp 002","name":"Rails","message":"[MPI][Services][FindProfileResponseCreator] find_profile_by_identifier icn=1012667122V019349, transaction_id="}
```