### PR TITLE
[#112315] Added GET Travel Pay Claim Details Mobile Endpoint 

### DIFF
--- a/modules/mobile/config/routes.rb
+++ b/modules/mobile/config/routes.rb
@@ -90,6 +90,7 @@ Mobile::Engine.routes.draw do
     get '/translations/download', to: 'translations#download'
     post '/travel-pay/claims', to: 'travel_pay_claims#create'
     get '/travel-pay/claims', to: 'travel_pay_claims#index'
+    get '/travel-pay/claims/:id', to: 'travel_pay_claims#show'
     get '/user', to: 'users#show'
     get '/user/authorized-services', to: 'authorized_services#index'
     get '/user/contact-info', to: 'contact_info#show'

--- a/modules/mobile/docs/openapi.yaml
+++ b/modules/mobile/docs/openapi.yaml
@@ -4177,6 +4177,45 @@ paths:
       security:
         - Bearer: [ ]
       summary: /v0/travel-pay/claims
+  /v0/travel-pay/claims/{id}:
+    get:
+      description: Retrieve details for a specific travel pay claim by ID.
+      parameters:
+        - $ref: '#/components/parameters/InflectionHeader'
+        - description: The unique identifier for the travel pay claim
+          example: '3fa85f64-5717-4562-b3fc-2c963f66afa6'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TravelPayClaimSummary'
+          description: Travel pay claim details retrieved successfully
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
+        '502':
+          $ref: '#/components/responses/502'
+        '503':
+          $ref: '#/components/responses/503'
+        '504':
+          $ref: '#/components/responses/504'
+      security:
+        - Bearer: []
+      summary: /v0/travel-pay/claims/{id}
   /v0/user:
     get:
       description: |

--- a/modules/mobile/spec/requests/mobile/v0/travel_pay_claims_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/travel_pay_claims_spec.rb
@@ -120,6 +120,84 @@ RSpec.describe 'Mobile::V0::TravelPayClaims', type: :request do
     end
   end
 
+  describe '#show' do
+    context 'happy path' do
+      it 'returns claim details for a valid claim ID' do
+        allow_any_instance_of(TravelPay::AuthManager).to receive(:authorize)
+          .and_return({ veis_token: 'vt', btsss_token: 'bt' })
+
+        VCR.use_cassette('travel_pay/show/success_details', match_requests_on: %i[method path]) do
+          claim_id = '3fa85f64-5717-4562-b3fc-2c963f66afa6'
+
+          get("/mobile/v0/travel-pay/claims/#{claim_id}", headers: sis_headers)
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to match_json_schema('travel_pay_smoc_response')
+
+          json = response.parsed_body
+          claim_data = json['data']['attributes']
+          
+          expect(claim_data['id']).to eq(claim_id)
+          expect(claim_data['claimNumber']).to be_present
+          expect(claim_data['claimStatus']).to be_present
+          expect(claim_data['appointmentDateTime']).to be_present
+          expect(claim_data['facilityId']).to be_present
+          expect(claim_data['facilityName']).to be_present
+        end
+      end
+    end
+
+    context 'failure paths' do
+      it 'returns not found when claim does not exist' do
+        allow_any_instance_of(TravelPay::AuthManager).to receive(:authorize)
+          .and_return({ veis_token: 'vt', btsss_token: 'bt' })
+        allow_any_instance_of(TravelPay::ClaimsService).to receive(:get_claim_details)
+          .and_return(nil)
+
+        non_existent_claim_id = 'aa0f63e0-5fa7-4d74-a17a'
+
+        get("/mobile/v0/travel-pay/claims/#{non_existent_claim_id}", headers: sis_headers)
+
+        expect(response).to have_http_status(:not_found)
+        json = response.parsed_body
+        expect(json['errors'].first['title']).to eq('Resource not found')
+        expect(json['errors'].first['detail']).to include("Claim not found. ID provided: #{non_existent_claim_id}")
+        expect(json['errors'].first['status']).to eq('404')
+      end
+
+      it 'returns bad request for invalid claim ID format' do
+        allow_any_instance_of(TravelPay::AuthManager).to receive(:authorize)
+          .and_return({ veis_token: 'vt', btsss_token: 'bt' })
+        allow_any_instance_of(TravelPay::ClaimsService).to receive(:get_claim_details)
+          .and_raise(ArgumentError.new('Expected claim id to be a valid UUID, got invalid-id.'))
+
+        invalid_claim_id = '123abc'
+
+        get("/mobile/v0/travel-pay/claims/#{invalid_claim_id}", headers: sis_headers)
+
+        expect(response).to have_http_status(:bad_request)
+        json = response.parsed_body
+        expect(json['errors'].first['title']).to eq('Bad request')
+        expect(json['errors'].first['detail']).to include('Expected claim id to be a valid UUID')
+      end
+
+      it 'returns internal server error when Travel Pay API fails while fetching claim details' do
+        allow_any_instance_of(TravelPay::AuthManager).to receive(:authorize)
+          .and_return({ veis_token: 'vt', btsss_token: 'bt' })
+        allow_any_instance_of(TravelPay::ClaimsService).to receive(:get_claim_details)
+          .and_raise(Common::Exceptions::ExternalServerInternalServerError.new(
+                       errors: [{ title: 'Something went wrong.', status: 500 }]
+                     ))
+
+        claim_id = '3fa85f64-5717-4562-b3fc-2c963f66afa6'
+
+        get("/mobile/v0/travel-pay/claims/#{claim_id}", headers: sis_headers)
+
+        expect(response).to have_http_status(:internal_server_error)
+      end
+    end
+  end
+
   describe '#create' do
     before do
       allow(Flipper).to receive(:enabled?).with(:travel_pay_submit_mileage_expense, instance_of(User)).and_return(true)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): No
- Added a new `GET` endpoint `/mobile/v0/travel-pay/claims/:id` to allow users to retrieve claim details on a specific claim.
- *(What is the solution, why is this the solution?)*
    - Users will now be able to get claim details on a specific claim in mobile
- Travel Pay team
- (If introducing a flipper, what is the success criteria being targeted?)
   - Not a flipper, but a flag passed from the FE (which is reliant upon the remote config feature flag)
   
### Changes Made
**New API Endpoint**
- Route: `GET /mobile/v0/travel-pay/claims/:id` --> `modules/mobile/config/routes.rb`

Sample response below: 
```json
{
    "data": {
        "id": "6ea23179-e87c-44ae-a20a-f31fb2c782fb",
        "type": "travelPayClaimSummary",
        "attributes": {
            "id": "6ea23179-e87c-44ae-a20a-f31fb2c782fb",
            "claimNumber": "string",
            "claimStatus": "Pre approved for payment",
            "appointmentDateTime": "2025-04-15T16:26:13.163Z",
            "facilityId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
            "facilityName": "string",
            "totalCostRequested": 0,
            "reimbursementAmount": 0,
            "createdOn": "2025-04-15T16:26:13.163Z",
            "modifiedOn": "2025-04-15T16:26:13.163Z"
        }
    }
}
```

**Files Added/Modified**
**Controller**
`modules/mobile/app/controllers/mobile/v0/travel_pay_claims_controller.rb`
- Added `show` method

**Testing**
`modules/mobile/spec/requests/mobile/v0/travel_pay_claims_spec.rb`
- Added happy path and failure path tests for new `GET` endpoint

**Documentation**
`modules/mobile/docs/openapi.yaml`

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/112315

## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
   - Prior to this change, the mobile API did not have a `GET` endpoint to fetch individual claim details. 
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
    - Not hooked up to anything. Running full test test suite is the only way to verify.
`bundle exec rspec modules/mobile/spec/requests/mobile/v0/travel_pay_claims_spec.rb`

## Screenshots
**GET request for travel pay claim details MOBILE endpoint in Postman**
<img width="1136" height="754" alt="Screenshot 2025-09-04 at 1 32 51 PM" src="https://github.com/user-attachments/assets/5d149d7e-4db3-465c-b310-87a3ccbd57cf" />


## What areas of the site does it impact?
Travel Pay module, used by Mobile and VAOS appointments modules

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [X]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
