### PR TITLE
`VSOReloader::DECREASE_THRESHOLD` from `0.20` to `0.50`

### DIFF
--- a/modules/veteran/app/sidekiq/veteran/vso_reloader.rb
+++ b/modules/veteran/app/sidekiq/veteran/vso_reloader.rb
@@ -10,7 +10,7 @@ module Veteran
 
     # The total number of representatives and organizations parsed from the ingested .ASP files
     # must not decrease by more than this percentage from the previous count
-    DECREASE_THRESHOLD = 0.20 # 20% maximum decrease allowed
+    DECREASE_THRESHOLD = 0.50 # 50% maximum decrease allowed
 
     # User type constants
     USER_TYPE_ATTORNEY = 'attorney'

--- a/modules/veteran/spec/sidekiq/veteran/vso_reloader_spec.rb
+++ b/modules/veteran/spec/sidekiq/veteran/vso_reloader_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe Veteran::VSOReloader, type: :job do
       end
 
       it 'blocks updates when decrease exceeds threshold' do
-        # 75 attorneys is a 25% decrease, which exceeds 20% threshold
+        # 45 attorneys is a 55% decrease, which exceeds 50% threshold
         expect(reloader.send(:valid_count?, :attorneys, 45)).to be false
       end
 

--- a/modules/veteran/spec/sidekiq/veteran/vso_reloader_spec.rb
+++ b/modules/veteran/spec/sidekiq/veteran/vso_reloader_spec.rb
@@ -208,15 +208,15 @@ RSpec.describe Veteran::VSOReloader, type: :job do
 
       it 'blocks updates when decrease exceeds threshold' do
         # 75 attorneys is a 25% decrease, which exceeds 20% threshold
-        expect(reloader.send(:valid_count?, :attorneys, 75)).to be false
+        expect(reloader.send(:valid_count?, :attorneys, 45)).to be false
       end
 
       it 'notifies slack when the decrease exceeds threshold' do
         allow(reloader).to receive(:notify_threshold_exceeded)
         expect(reloader).to receive(:notify_threshold_exceeded).with(
-          :attorneys, 100, 75, anything, anything
+          :attorneys, 100, 45, anything, anything
         )
-        reloader.send(:valid_count?, :attorneys, 75)
+        reloader.send(:valid_count?, :attorneys, 45)
       end
 
       it 'allows updates when decrease is within threshold' do


### PR DESCRIPTION
The VSOReloader running in a daily job has been failing since late July, causing VSO reps and organizations to not be updated.

It fails because we automatically exit the job if we detect more than a 20% change in the count of organizations. We looked into the data, and in this case the organizations being removed were correctly being removed, they are mostly mock data or inactive organizations.

There is a manual bypass task that is defined to bypass this alert, but it appears to run too long to feasibly succeed in an ArgoCD session, probably by a significant degree. We were not able to run the task successfully on staging.

Secondly, we believe that the VSOReloader job does not actually remove organization records - we tested `Veteran::Service::Organization.import` and it appears to ingest new records but keep the old ones. So over time, our belief is that the count of organizations will only go up over time, which means this check can't function correctly.

We are going to migrate to the Accreditation API, after which we can remove all this code, but need to unblock data updates until then.

Therefore, we're changing the maximum change in organizations to 50%, which should still flag some severe issues if they were to occur.
