### PR TITLE
Revert dependabot's waterdrop version bump

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -172,7 +172,7 @@ gem 'utf8-cleaner'
 gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', branch: 'master'
 gem 'virtus'
 gem 'warden-github'
-gem 'waterdrop', '2.8.6' # to temporarily undo dependabot commit https://github.com/department-of-veterans-affairs/vets-api/commit/1fd3c5de899081010bbb27b7bfcedb8f27be2a53
+gem 'waterdrop', '2.8.6' # to temporarily undo dependabot commit 1fd3c5de899081010bbb27b7bfcedb8f27be2a53
 gem 'will_paginate'
 gem 'with_advisory_lock'
 

--- a/Gemfile
+++ b/Gemfile
@@ -106,6 +106,7 @@ gem 'json-schema'
 gem 'json_schemer'
 gem 'jwe'
 gem 'jwt'
+gem 'karafka-core', '2.5.5' # Temporary lock until new release of karafka-rdkafka (dependency of karafka-core) is available
 gem 'kms_encrypted'
 gem 'liquid'
 gem 'lockbox'
@@ -171,7 +172,7 @@ gem 'utf8-cleaner'
 gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', branch: 'master'
 gem 'virtus'
 gem 'warden-github'
-gem 'waterdrop'
+gem 'waterdrop', '2.8.6' # to temporarily undo dependabot commit https://github.com/department-of-veterans-affairs/vets-api/commit/1fd3c5de899081010bbb27b7bfcedb8f27be2a53
 gem 'will_paginate'
 gem 'with_advisory_lock'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -656,24 +656,16 @@ GEM
       base64
     jwt (2.10.2)
       base64
-    karafka-core (2.5.6)
-      karafka-rdkafka (>= 0.20.0)
+    karafka-core (2.5.5)
+      karafka-rdkafka (>= 0.19.2, < 0.21.0)
       logger (>= 1.6.0)
-    karafka-rdkafka (0.21.0)
+    karafka-rdkafka (0.20.1)
       ffi (~> 1.15)
-      json (> 2.0)
       logger
       mini_portile2 (~> 2.6)
       rake (> 12)
-    karafka-rdkafka (0.21.0-aarch64-linux-gnu)
+    karafka-rdkafka (0.20.1-x86_64-linux-gnu)
       ffi (~> 1.15)
-      json (> 2.0)
-      logger
-      mini_portile2 (~> 2.6)
-      rake (> 12)
-    karafka-rdkafka (0.21.0-x86_64-linux-gnu)
-      ffi (~> 1.15)
-      json (> 2.0)
       logger
       mini_portile2 (~> 2.6)
       rake (> 12)
@@ -1181,7 +1173,7 @@ GEM
       addressable
       faraday (>= 1.9, < 3)
       nokogiri (>= 1.13.9)
-    waterdrop (2.8.7)
+    waterdrop (2.8.6)
       karafka-core (>= 2.4.9, < 3.0.0)
       karafka-rdkafka (>= 0.20.0)
       zeitwerk (~> 2.3)
@@ -1324,6 +1316,7 @@ DEPENDENCIES
   jsonapi-serializer
   jwe
   jwt
+  karafka-core (= 2.5.5)
   kms_encrypted
   liquid
   lockbox
@@ -1436,7 +1429,7 @@ DEPENDENCIES
   vre!
   vye!
   warden-github
-  waterdrop
+  waterdrop (= 2.8.6)
   web-console
   webmock
   webrick


### PR DESCRIPTION
## Summary

Dependabot [recently upgraded](https://github.com/department-of-veterans-affairs/vets-api/commit/1fd3c5de899081010bbb27b7bfcedb8f27be2a53) the `waterdrop` gem version from `2.8.6` to `2.8.7`. 

This caused several dependencies to be bumped as well which led to SSL cert location errors in the Kafka producer:

```
sasl_ssl://b-2.eventbuskafkasandb.xpmf9m.c3.kafka.us-gov-west-1.amazonaws.com:9098/bootstrap: kafka: error:80000002:system library::No such file or directory: calling stat(/tmp/static-openssl-3.0.16/ssl/certs)
```
and
```
rdkafka: [thrd:sasl_ssl://b-2.eventbuskafkasandb.xpmf9m.c3.kafka.us-gov-west-1]: sasl_ssl://b-2.eventbuskafkasandb.xpmf9m.c3.kafka.us-gov-west-1.amazonaws.com:9098/bootstrap: kafka: error:16000069:STORE routines::unregistered scheme: scheme=file
```

This is a `rdkafka-ruby` (a dependency of `waterdrop` and `karafka-core`) issue that has been [recorded](https://github.com/karafka/rdkafka-ruby/issues/690) and already fixed on the main branch of the library. I have for now locked both the `waterdrop` and the `karafka-core` versions until a new release of the `rdkafka-ruby` library exists.

## What areas of the site does it impact?
The Kafka producer is currently not working in dev, staging, and sandbox. This feature is not in production yet but is planned to be released into production by 09/30/25.