### PR TITLE
2164 fix timestamps for 21 4138

### DIFF
--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_0972.rb
@@ -42,7 +42,7 @@ module SimpleFormsApi
         },
         {
           coords: [440, 670],
-          text: timestamp.utc.strftime('%H:%M UTC %Y-%m-%d'),
+          text: timestamp.in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 1,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4142.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21_4142.rb
@@ -105,7 +105,7 @@ module SimpleFormsApi
         },
         {
           coords: [440, 690],
-          text: timestamp.utc.strftime('%H:%M UTC %Y-%m-%d'),
+          text: timestamp.in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 0,
           font_size: 12
         }

--- a/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
+++ b/modules/simple_forms_api/app/models/simple_forms_api/vba_21p_0847.rb
@@ -46,7 +46,7 @@ module SimpleFormsApi
         },
         {
           coords: [460, 690],
-          text: timestamp.utc.strftime('%H:%M UTC %Y-%m-%d'),
+          text: timestamp.in_time_zone('UTC').strftime('%H:%M %Z %D'),
           page: 1,
           font_size: 12
         }


### PR DESCRIPTION
## Summary

This work is behind a feature toggle (flipper): NO
Double timestamps were occurring on forms for the bottom verification. Also we determined the top right form with m/d/y is okay for now but if we change out mind it will be a quick fix on each individual timestamp.  

## Related issue(s)

- https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/2164

## Testing done

- [X ] *New code is covered by unit tests*
Old behavior: Method was appending Chicago timezone timestamp to auth text Resulted in double timestamps on PDFs (one from this method + one from PDFUtilities::DatestampPdf)
New behavior: One time stamp with text verification
Verified existing tests pass with format change
<img width="1096" height="68" alt="Screenshot 2025-09-09 at 8 10 22 PM" src="https://github.com/user-attachments/assets/7455f465-8979-4bf2-94dc-dc37a54ec8ef" />
<img width="1095" height="84" alt="Screenshot 2025-09-09 at 8 08 55 PM" src="https://github.com/user-attachments/assets/b72b9347-5cef-4b03-bad4-1c53bd4875ce" />




## What areas of the site does it impact?
The bottom of all these forms.
10207 
0845
10206
4142
10210
0847
0966 not tested because of JWT access 
4138
0972


## Acceptance criteria

- [ X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ X]  No error nor warning in the console.
- [ X]  Events are being sent to the appropriate logging solution
- [ X]  Documentation has been updated (link to documentation)
- [X ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ X]  Feature/bug has a monitor built into Datadog (if applicable)



