### PR TITLE
Added Unique User Metrics flipper

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2440,3 +2440,8 @@ features:
     actor_type: user
     description: Enables substance use disorder as care related to mental health appointments with new codes
     enable_in_development: true
+  unique_user_metrics_logging:
+    # System level feature flag
+    actor_type:
+    description: Enables unique user metrics logging for MHV Portal analytics. When disabled, no events will be recorded to database or sent to StatsD.
+    enable_in_development: true


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Added Unique User Metrics flipper. Note this flipper is not user or cookie based, just 100% on or off.
- Team: MHV Horizon

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/117473

## Testing done
N/A

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

