### PR TITLE
[10-10EZ] Add statsD metrics for InProgressForm deletes

### DIFF
--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -120,7 +120,7 @@ module V0
       in_progress_form_before = nil
       if Flipper.enabled?(:hca_in_progress_form_logging)
         in_progress_form_before = InProgressForm.form_for_user(FORM_ID, current_user)
-        Rails.logger.info("[10-10EZ][#{user_uuid},#{user_account_id}][#{log_hca_id}, " \
+        Rails.logger.info("[10-10EZ][#{user_uuid},#{user_account_id}][#{hca_id}, " \
                           "form_submission_id: #{health_care_application.form_submission_id_string}] - " \
                           "InProgressForm exists before attempted delete: #{!in_progress_form_before.nil?}")
 
@@ -130,13 +130,13 @@ module V0
 
       if Flipper.enabled?(:hca_in_progress_form_logging) && in_progress_form_before
         in_progress_form_after = InProgressForm.form_for_user(FORM_ID, current_user)
-        Rails.logger.info("[10-10EZ][#{user_uuid},#{user_account_id}][#{log_hca_id}] - " \
+        Rails.logger.info("[10-10EZ][#{user_uuid},#{user_account_id}][#{hca_id}] - " \
                           "InProgressForm successfully deleted: #{in_progress_form_after.nil?}")
 
         increment_in_progress_metric(in_progress_form_after)
       end
     rescue => e
-      Rails.logger.warn("[10-10EZ][#{user_uuid},#{user_account_id}][#{log_hca_id}] - " \
+      Rails.logger.warn("[10-10EZ][#{user_uuid},#{user_account_id}][#{hca_id}] - " \
                         "Failed to clear saved form: #{e.message}")
     end
 
@@ -147,10 +147,10 @@ module V0
                       'in_progress_form_not_deleted'
                     end
       StatsD.increment("#{HCA::Service::STATSD_KEY_PREFIX}.#{metric_text}",
-                       tags: ["health_care_application_id:#{health_care_application.id}"])
+                       tags: [hca_id])
     end
 
-    def log_hca_id
+    def hca_id
       "health_care_application_id:#{health_care_application.id}"
     end
 

--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -130,9 +130,9 @@ module V0
 
       if Flipper.enabled?(:hca_in_progress_form_logging) && in_progress_form_before
         in_progress_form_after = InProgressForm.form_for_user(FORM_ID, current_user)
-        Rails.logger.info("[10-10EZ][#{user_uuid},#{user_account_id}][#{hca_id}] - " \
-                          "InProgressForm successfully deleted: #{in_progress_form_after.nil?}")
-
+        Rails.logger.info("[10-10EZ][#{user_uuid},#{user_account_id}][#{hca_id}]" \
+                          "[ipf_id_before:#{in_progress_form_before&.id}, ipf_id_after:#{in_progress_form_after&.id}]" \
+                          " - InProgressForm successfully deleted: #{in_progress_form_after.nil?}")
         increment_in_progress_metric(in_progress_form_after)
       end
     rescue => e

--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -147,7 +147,7 @@ module V0
                       'in_progress_form_not_deleted'
                     end
       StatsD.increment("#{HCA::Service::STATSD_KEY_PREFIX}.#{metric_text}",
-                       tags: [hca_id])
+                       tags: [hca_id, user_uuid, user_account_id])
     end
 
     def hca_id

--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -112,7 +112,7 @@ module V0
       return unless Flipper.enabled?(:hca_in_progress_form_logging)
 
       in_progress_form = InProgressForm.form_for_user(FORM_ID, current_user)
-      Rails.logger.info("[10-10EZ][#{log_user_uuid}] " \
+      Rails.logger.info("[10-10EZ][#{user_uuid},#{user_account_id}] " \
                         "- HealthCareApplication has InProgressForm: #{!in_progress_form.nil?}")
     end
 
@@ -120,7 +120,7 @@ module V0
       in_progress_form_before = nil
       if Flipper.enabled?(:hca_in_progress_form_logging)
         in_progress_form_before = InProgressForm.form_for_user(FORM_ID, current_user)
-        Rails.logger.info("[10-10EZ][#{log_user_uuid}][#{log_hca_id}, " \
+        Rails.logger.info("[10-10EZ][#{user_uuid},#{user_account_id}][#{log_hca_id}, " \
                           "form_submission_id: #{health_care_application.form_submission_id_string}] - " \
                           "InProgressForm exists before attempted delete: #{!in_progress_form_before.nil?}")
 
@@ -130,22 +130,40 @@ module V0
 
       if Flipper.enabled?(:hca_in_progress_form_logging) && in_progress_form_before
         in_progress_form_after = InProgressForm.form_for_user(FORM_ID, current_user)
-        Rails.logger.info("[10-10EZ][#{log_user_uuid}][#{log_hca_id}] - " \
+        Rails.logger.info("[10-10EZ][#{user_uuid},#{user_account_id}][#{log_hca_id}] - " \
                           "InProgressForm successfully deleted: #{in_progress_form_after.nil?}")
+
+        increment_in_progress_metric(in_progress_form_after)
       end
     rescue => e
-      Rails.logger.warn("[10-10EZ][#{log_user_uuid}][#{log_hca_id}] - Failed to clear saved form: #{e.message}")
+      Rails.logger.warn("[10-10EZ][#{user_uuid},#{user_account_id}][#{log_hca_id}] - " \
+                        "Failed to clear saved form: #{e.message}")
+    end
+
+    def increment_in_progress_metric(in_progress_form_after)
+      metric_text = if in_progress_form_after.nil?
+                      'in_progress_form_deleted'
+                    else
+                      'in_progress_form_not_deleted'
+                    end
+      StatsD.increment("#{HCA::Service::STATSD_KEY_PREFIX}.#{metric_text}",
+                       tags: ["health_care_application_id:#{health_care_application.id}"])
     end
 
     def log_hca_id
-      "HCA id: #{health_care_application.id}"
+      "health_care_application_id:#{health_care_application.id}"
     end
 
-    def log_user_uuid
+    def user_uuid
       user_uuid = current_user.uuid || 'none'
+
+      "user_uuid:#{user_uuid}"
+    end
+
+    def user_account_id
       user_account_id = current_user&.user_account&.id || 'none'
 
-      "User uuid: #{user_uuid}, UserAccount id: #{user_account_id}"
+      "user_account_id:#{user_account_id}"
     end
 
     def health_care_application

--- a/spec/requests/v0/health_care_applications_spec.rb
+++ b/spec/requests/v0/health_care_applications_spec.rb
@@ -493,8 +493,8 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
 
             logger_regex = [
               /\[10-10EZ\]/,
-              /\[User uuid: #{current_user.uuid}, UserAccount id: none\]/,
-              /\[HCA id: \d+\]/,
+              /\[user_uuid:#{current_user.uuid},user_account_id:none\]/,
+              /\[helath_care_application_id:\d+\]/,
               /  - Failed to clear saved form: Database connection failed/
             ]
             expect(Rails.logger).to receive(:warn).with(
@@ -518,13 +518,13 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
 
                 allow(Rails.logger).to receive(:info)
                 expect(Rails.logger).to receive(:info)
-                  .with("[10-10EZ][User uuid: #{current_user.uuid}, UserAccount id: none]" \
+                  .with("[10-10EZ][user_uuid:#{current_user.uuid},user_account_id:none]" \
                         ' - HealthCareApplication has InProgressForm: false')
 
                 logger_regex = [
                   /\[10-10EZ\]/,
-                  /\[User uuid: #{current_user.uuid}, UserAccount id: none\]/,
-                  /\[HCA id: \d+, form_submission_id: 436426340\]/,
+                  /\[user_uuid:#{current_user.uuid},user_account_id:none\]/,
+                  /\[helath_care_application_id:\d+, form_submission_id: 436426340\]/,
                   / - InProgressForm exists before attempted delete: false/
                 ]
                 expect(Rails.logger).to receive(:info).with(
@@ -545,8 +545,8 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
 
                 logger_regex = [
                   /\[10-10EZ\]/,
-                  /\[User uuid: #{current_user.uuid}, UserAccount id: none\]/,
-                  /\[HCA id: \d+\]/,
+                  /\[user_uuid:#{current_user.uuid},user_account_id:none\]/,
+                  /\[helath_care_application_id:\d+\]/,
                   / - Failed to clear saved form: Database connection failed/
                 ]
                 expect(Rails.logger).to receive(:warn).with(
@@ -562,19 +562,21 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
           context 'has InProgressForm' do
             let!(:in_progress_form) { create(:in_progress_form, user_uuid: current_user.uuid, form_id: '1010ez') }
 
+            before { allow(StatsD).to receive(:increment) }
+
             it 'renders success and delete the saved form', run_at: '2017-01-31' do
               VCR.use_cassette('hca/submit_auth', match_requests_on: [:body]) do
                 expect_any_instance_of(HealthCareApplication).to receive(:prefill_fields)
 
                 allow(Rails.logger).to receive(:info)
                 expect(Rails.logger).to receive(:info)
-                  .with("[10-10EZ][User uuid: #{current_user.uuid}, UserAccount id: none]" \
+                  .with("[10-10EZ][user_uuid:#{current_user.uuid},user_account_id:none]" \
                         ' - HealthCareApplication has InProgressForm: true')
 
                 logger_regex_before = [
                   /\[10-10EZ\]/,
-                  /\[User uuid: #{current_user.uuid}, UserAccount id: none\]/,
-                  /\[HCA id: \d+, form_submission_id: 436426340\]/,
+                  /\[user_uuid:#{current_user.uuid},user_account_id:none\]/,
+                  /\[helath_care_application_id:\d+, form_submission_id: 436426340\]/,
                   / - InProgressForm exists before attempted delete: true/
                 ]
                 expect(Rails.logger).to receive(:info).with(
@@ -583,8 +585,8 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
 
                 logger_regex_after = [
                   /\[10-10EZ\]/,
-                  /\[User uuid: #{current_user.uuid}, UserAccount id: none\]/,
-                  /\[HCA id: \d+\]/,
+                  /\[user_uuid:#{current_user.uuid},user_account_id:none\]/,
+                  /\[helath_care_application_id:\d+\]/,
                   / - InProgressForm successfully deleted: true/
                 ]
 
@@ -592,8 +594,56 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
                   a_string_matching(Regexp.union(logger_regex_after))
                 )
 
+                expect(StatsD).to receive(:increment).with('api.1010ez.in_progress_form_deleted', anything)
+
                 subject
                 expect(JSON.parse(response.body)).to eq(body)
+              end
+            end
+
+            context 'form is not deleted' do
+              before do
+                allow(InProgressForm).to receive(:form_for_user)
+                  .with('1010ez', anything)
+                  .and_return(in_progress_form, in_progress_form)
+              end
+
+              it 'renders success and logs InProgressForm delete info', run_at: '2017-01-31' do
+                VCR.use_cassette('hca/submit_auth', match_requests_on: [:body]) do
+                  expect_any_instance_of(HealthCareApplication).to receive(:prefill_fields)
+
+                  allow(Rails.logger).to receive(:info)
+                  expect(Rails.logger).to receive(:info)
+                    .with("[10-10EZ][user_uuid:#{current_user.uuid},user_account_id:none]" \
+                          ' - HealthCareApplication has InProgressForm: true')
+
+                  logger_regex_before = [
+                    /\[10-10EZ\]/,
+                    /\[user_uuid:#{current_user.uuid},user_account_id:none\]/,
+                    /\[helath_care_application_id:\d+, form_submission_id: 436426340\]/,
+                    / - InProgressForm exists before attempted delete: true/
+                  ]
+                  expect(Rails.logger).to receive(:info).with(
+                    a_string_matching(Regexp.union(logger_regex_before))
+                  )
+
+                  logger_regex_after = [
+                    /\[10-10EZ\]/,
+                    /\[user_uuid:#{current_user.uuid},user_account_id:none\]/,
+                    /\[helath_care_application_id:\d+\]/,
+                    / - InProgressForm successfully deleted: false/
+                  ]
+
+                  expect(Rails.logger).to receive(:info).with(
+                    a_string_matching(Regexp.union(logger_regex_after))
+                  )
+
+                  expect(StatsD).to receive(:increment).with('api.1010ez.in_progress_form_not_deleted',
+                                                             anything)
+
+                  subject
+                  expect(JSON.parse(response.body)).to eq(body)
+                end
               end
             end
 
@@ -606,8 +656,8 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
 
                 logger_regex = [
                   /\[10-10EZ\]/,
-                  /\[User uuid: #{current_user.uuid}, UserAccount id: none\]/,
-                  /\[HCA id: \d+\]/,
+                  /\[user_uuid:#{current_user.uuid},user_account_id:none\]/,
+                  /\[helath_care_application_id:\d+\]/,
                   / - Failed to clear saved form: Database connection failed/
                 ]
 

--- a/spec/requests/v0/health_care_applications_spec.rb
+++ b/spec/requests/v0/health_care_applications_spec.rb
@@ -494,7 +494,7 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
             logger_regex = [
               /\[10-10EZ\]/,
               /\[user_uuid:#{current_user.uuid},user_account_id:none\]/,
-              /\[helath_care_application_id:\d+\]/,
+              /\[health_care_application_id:\d+\]/,
               /  - Failed to clear saved form: Database connection failed/
             ]
             expect(Rails.logger).to receive(:warn).with(
@@ -524,7 +524,7 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
                 logger_regex = [
                   /\[10-10EZ\]/,
                   /\[user_uuid:#{current_user.uuid},user_account_id:none\]/,
-                  /\[helath_care_application_id:\d+, form_submission_id: 436426340\]/,
+                  /\[health_care_application_id:\d+, form_submission_id: 436426340\]/,
                   / - InProgressForm exists before attempted delete: false/
                 ]
                 expect(Rails.logger).to receive(:info).with(
@@ -546,7 +546,7 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
                 logger_regex = [
                   /\[10-10EZ\]/,
                   /\[user_uuid:#{current_user.uuid},user_account_id:none\]/,
-                  /\[helath_care_application_id:\d+\]/,
+                  /\[health_care_application_id:\d+\]/,
                   / - Failed to clear saved form: Database connection failed/
                 ]
                 expect(Rails.logger).to receive(:warn).with(
@@ -576,7 +576,7 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
                 logger_regex_before = [
                   /\[10-10EZ\]/,
                   /\[user_uuid:#{current_user.uuid},user_account_id:none\]/,
-                  /\[helath_care_application_id:\d+, form_submission_id: 436426340\]/,
+                  /\[health_care_application_id:\d+, form_submission_id: 436426340\]/,
                   / - InProgressForm exists before attempted delete: true/
                 ]
                 expect(Rails.logger).to receive(:info).with(
@@ -586,7 +586,7 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
                 logger_regex_after = [
                   /\[10-10EZ\]/,
                   /\[user_uuid:#{current_user.uuid},user_account_id:none\]/,
-                  /\[helath_care_application_id:\d+\]/,
+                  /\[health_care_application_id:\d+\]/,
                   / - InProgressForm successfully deleted: true/
                 ]
 
@@ -620,7 +620,7 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
                   logger_regex_before = [
                     /\[10-10EZ\]/,
                     /\[user_uuid:#{current_user.uuid},user_account_id:none\]/,
-                    /\[helath_care_application_id:\d+, form_submission_id: 436426340\]/,
+                    /\[health_care_application_id:\d+, form_submission_id: 436426340\]/,
                     / - InProgressForm exists before attempted delete: true/
                   ]
                   expect(Rails.logger).to receive(:info).with(
@@ -630,7 +630,7 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
                   logger_regex_after = [
                     /\[10-10EZ\]/,
                     /\[user_uuid:#{current_user.uuid},user_account_id:none\]/,
-                    /\[helath_care_application_id:\d+\]/,
+                    /\[health_care_application_id:\d+\]/,
                     / - InProgressForm successfully deleted: false/
                   ]
 
@@ -657,7 +657,7 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
                 logger_regex = [
                   /\[10-10EZ\]/,
                   /\[user_uuid:#{current_user.uuid},user_account_id:none\]/,
-                  /\[helath_care_application_id:\d+\]/,
+                  /\[health_care_application_id:\d+\]/,
                   / - Failed to clear saved form: Database connection failed/
                 ]
 

--- a/spec/requests/v0/health_care_applications_spec.rb
+++ b/spec/requests/v0/health_care_applications_spec.rb
@@ -587,6 +587,7 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
                   /\[10-10EZ\]/,
                   /\[user_uuid:#{current_user.uuid},user_account_id:none\]/,
                   /\[health_care_application_id:\d+\]/,
+                  /\[ipf_id_before:\d+,ipf_id_after:\d+\]/,
                   / - InProgressForm successfully deleted: true/
                 ]
 
@@ -631,6 +632,7 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
                     /\[10-10EZ\]/,
                     /\[user_uuid:#{current_user.uuid},user_account_id:none\]/,
                     /\[health_care_application_id:\d+\]/,
+                    /\[ipf_id_before:\d+,ipf_id_after:\d+\]/,
                     / - InProgressForm successfully deleted: false/
                   ]
 


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- Update new logging and add statsD metrics to debug why some InProgressForms seem to not be getting deleted when they should. 
- I considered pulling out the logging to a concern, but the current plan is to turn this on in production and see if it is helpful. If we don't find anything we will just remove it. 
- 1010 Health Apps
- `hca_in_progress_form_logging`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114338

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature