### PR TITLE
Add eventbus gateway feature flags for ep120 and ep180

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -165,6 +165,10 @@ features:
     description: Enables dependents verification emails
   event_bus_gateway_ep040_decision_letter_notifications:
     description: "Gateway: Enable decision letter email notifications for EP040 claims"
+  event_bus_gateway_ep120_decision_letter_notifications:
+    description: "Gateway: Enable decision letter email notifications for EP120 reopened pension claims"
+  event_bus_gateway_ep180_decision_letter_notifications:
+    description: "Gateway: Enable decision letter email notifications for EP180 initial pension claims"
   hca_browser_monitoring_enabled:
     actor_type: user
     description: Enables browser monitoring for the health care application.


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary
This PR adds two additional feature flags for use in eventbus-gateway
- `event_bus_gateway_ep120_decision_letter_notifications`
- `event_bus_gateway_ep180_decision_letter_notifications`

## Related issue(s)
- Implement Pension Claims (EP120 & EP180) decision letter email notifications
[#115352](https://github.com/department-of-veterans-affairs/va.gov-team/issues/115352)

