### PR TITLE
Remove cst_smooth_loading_experience feature flag after successful rollout

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -492,11 +492,7 @@ features:
     description: When enabled, benefits_claims/get_claims service filters 290 EP code claims from the response
   cst_filter_ep_960:
     actor_type: user
-    description: When enabled, benefits_claims/get_claims service filters certain ep codes based on issue 90936 research from the response
-  cst_smooth_loading_experience:
-    actor_type: user
-    description: When enabled, the UI of the CST app will have a smoother loading experience
-    enable_in_development: true
+    description: When enabled, benefits_claims/get_claims service filters 960 EP code claims from the response
   cst_claim_letters_use_lighthouse_api_provider:
     actor_type: user
     description: When enabled, claims_letters from the Lighthouse API Provider


### PR DESCRIPTION
## ⚠️ Merge Order Dependency
**This PR should be merged AFTER the companion vets-website PR**: department-of-veterans-affairs/vets-website#38642

The vets-website PR removes the code that uses this feature flag. This vets-api PR removes the flag definition itself.

## Summary

- **This work is behind a feature toggle (flipper): NO** - This removes a feature flag
- Removed the `cst_smooth_loading_experience` feature flag after successful Epic completion
- The smooth loading experience feature has been successfully tested and rolled out to production
- This feature flag definition is no longer needed as the feature is now permanently enabled in vets-website
- Claims Status team maintains this component
- N/A - removing a flipper, not introducing one

## Related issue(s)

- Epic: department-of-veterans-affairs/va.gov-team#107801
- Original PR adding this flag: department-of-veterans-affairs/vets-api#22758
- **Companion vets-website PR (merge first)**: department-of-veterans-affairs/vets-website#38642

## Testing done

- [x] No new code requiring unit tests (this is a deletion only)
- The smooth loading experience was successfully tested and rolled out in production
- This change simply removes the feature flag definition from config/features.yml
- The feature is now permanently enabled on the frontend (vets-website)
- No tests needed for flipper on/off scenarios as we're removing the flipper entirely

## Screenshots
_N/A - Configuration file change only_

## What areas of the site does it impact?
Claims Status application - specifically the feature flag configuration. The actual functionality remains unchanged as it's now permanently enabled in vets-website.

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable) - N/A for flag removal
- [x] No error nor warning in the console - Configuration change only
- [x] Events are being sent to the appropriate logging solution - No changes to logging
- [x] Documentation has been updated - Removing the flag IS the documentation update
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Feature/bug has a monitor built into Datadog (if applicable) - N/A
- [x] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected - No authentication impact
- N/A I added a screenshot of the developed feature - Config file change only

## Requested Feedback

This is cleanup work to remove the feature flag after successful rollout. The flag is no longer needed as the smooth loading experience is now the permanent default behavior in vets-website.