### PR TITLE
Add form_id and organization to DD tracing in AR Form Uploads

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_form_upload_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_form_upload_controller.rb
@@ -186,15 +186,10 @@ module AccreditedRepresentativePortal
       end
 
       def organization
-        return @organization if defined?(@organization)
-
-        poa = claimant_representative&.to_h&.[](:power_of_attorney_holder_poa_code)
-        return (@organization = nil) if poa.blank?
-
-        @organization = Veteran::Service::Organization.find_by(poa:)&.name
+        claimant_representative&.to_h&.[](:power_of_attorney_holder_poa_code)
       rescue => e
         Rails.logger.warn("Org lookup failed: #{e.class} #{e.message}")
-        @organization = nil
+        nil
       end
 
       def trace_key_tags(span, **tags)

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/representative_form_uploads_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/representative_form_uploads_spec.rb
@@ -220,10 +220,10 @@ RSpec.describe AccreditedRepresentativePortal::V0::RepresentativeFormUploadContr
           expect(response).to have_http_status(:ok)
 
           expect(span_double).to have_received(:set_tag).with(satisfy { |k| k.to_s == 'form_id' }, form_number)
-          expect(span_double).to have_received(:set_tag).with(satisfy { |k| k.to_s == 'org' }, 'Org Name')
+          expect(span_double).to have_received(:set_tag).with(satisfy { |k| k.to_s == 'org' }, '067')
 
           expect(trace_double).to have_received(:set_tag).with(satisfy { |k| k.to_s == 'form_id' }, form_number)
-          expect(trace_double).to have_received(:set_tag).with(satisfy { |k| k.to_s == 'org' }, 'Org Name')
+          expect(trace_double).to have_received(:set_tag).with(satisfy { |k| k.to_s == 'org' }, '067')
         end
       end
 


### PR DESCRIPTION
This PR cleans up and standardizes Datadog tracing in the RepresentativeFormUploadController.
	•	Introduces a trace_key_tags helper to apply tags consistently to both span- and trace-level contexts.
	•	Adds organization lookup with error handling and includes org in default tags for monitoring.
	•	Ensures form_id and org are tagged across submit and attachment upload actions.
	•	Refactors attachment upload to tag form_upload.form_id (from the attachment) alongside request-level form_id.
	•	Simplifies JSON rendering by making the render target explicit.
	•	General cleanup: removes redundant inline tagging, compacts default tags, improves readability.


## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/116287

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
