### PR TITLE
fix: remove empty actor_type from unique_user_metrics_logging feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2457,6 +2457,5 @@ features:
     enable_in_development: true
   unique_user_metrics_logging:
     # System level feature flag
-    actor_type:
     description: Enables unique user metrics logging for MHV Portal analytics. When disabled, no events will be recorded to database or sent to StatsD.
     enable_in_development: true


### PR DESCRIPTION
The unique_user_metrics_logging feature flag was added with an empty
actor_type: field, causing a nil value that broke the feature toggles
service with "NoMethodError: undefined method 'length' for nil".

Fixes the 500 errors on /v0/feature_toggles endpoint in staging.
