### PR TITLE
113542 - Add feature toggle for MyVA redesign switch

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2409,6 +2409,9 @@ features:
   disable_bdn_processing:
     actor_type: user
     description: If enabled, skip all BDN-related processing for VYE
+  my_auth_exp_redesign_available_to_opt_in:
+    actor_type: user
+    description: When enabled, a user will see the option to switch to the redesigned experience of MyVA.
   my_va_auth_exp_redesign_enabled:
     actor_type: user
     description: When enabled, a user will see the redesigned experience of MyVA.


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Simply adding a flipper toggle for use on the frontend
- Authenticated Experience Team AuthentiKnights
- Success: users are able to toggle the new experience on and off

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#113542

## Testing done

- [ ] *New code is covered by unit tests*
- N/A this is just adding the flipper

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
My VA Dashboard only when enabled

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
