### PR TITLE
Update certificate active trait

### DIFF
--- a/app/sidekiq/sign_in/certificate_checker_job.rb
+++ b/app/sidekiq/sign_in/certificate_checker_job.rb
@@ -18,10 +18,10 @@ class SignIn::CertificateCheckerJob
   private
 
   def check_certificates(config)
-    return if config.certs.active.any?
+    return if config.certs.expiring_later.any?
 
-    if config.certs.expiring.any?
-      log_expiring_certs(config)
+    if config.certs.expiring_soon.any?
+      log_expiring_soon_certs(config)
     elsif config.certs.expired.any?
       log_expired_certs(config)
     end
@@ -33,9 +33,9 @@ class SignIn::CertificateCheckerJob
     end
   end
 
-  def log_expiring_certs(config)
-    config.certs.expiring.each do |cert|
-      log_warning('expiring_certificate', config, cert)
+  def log_expiring_soon_certs(config)
+    config.certs.expiring_soon.each do |cert|
+      log_warning('expiring_soon_certificate', config, cert)
     end
   end
 

--- a/spec/factories/sign_in/certificates.rb
+++ b/spec/factories/sign_in/certificates.rb
@@ -74,10 +74,17 @@ FactoryBot.define do
       end
     end
 
-    trait :expiring do
+    trait :expiring_soon do
       transient do
         not_before { 1.month.ago }
         not_after  { 1.month.from_now }
+      end
+    end
+
+    trait :expiring_later do
+      transient do
+        not_before { 1.month.ago }
+        not_after  { 3.months.from_now }
       end
     end
 

--- a/spec/models/sign_in/certificate_spec.rb
+++ b/spec/models/sign_in/certificate_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe SignIn::Certificate, type: :model do
   describe 'scopes' do
     describe '.active' do
       let!(:active_certificate) { create(:sign_in_certificate) }
+      let!(:expiring_soon_certificate) { create(:sign_in_certificate, :expiring_soon) }
       let(:expired_certificate) { build(:sign_in_certificate, :expired) }
 
       before do
@@ -21,7 +22,11 @@ RSpec.describe SignIn::Certificate, type: :model do
       end
 
       it 'returns only active certificates' do
-        expect(SignIn::Certificate.active).to contain_exactly(active_certificate)
+        expect(SignIn::Certificate.active).to include(active_certificate)
+      end
+
+      it 'returns expiring soon certificates' do
+        expect(SignIn::Certificate.active).to include(expiring_soon_certificate)
       end
     end
 
@@ -38,12 +43,12 @@ RSpec.describe SignIn::Certificate, type: :model do
       end
     end
 
-    describe '.expiring' do
-      let!(:expiring_certificate) { create(:sign_in_certificate, :expiring) }
+    describe '.expiring_soon' do
+      let!(:expiring_soon_certificate) { create(:sign_in_certificate, :expiring_soon) }
       let!(:not_expiring_certificate) { create(:sign_in_certificate, not_before: 61.days.ago) }
 
       it 'returns only certificates expiring within 60 days' do
-        expect(SignIn::Certificate.expiring).to contain_exactly(expiring_certificate)
+        expect(SignIn::Certificate.expiring_soon).to contain_exactly(expiring_soon_certificate)
       end
     end
   end
@@ -154,10 +159,10 @@ RSpec.describe SignIn::Certificate, type: :model do
     end
 
     context 'when certificate is expiring' do
-      subject(:certificate) { build(:sign_in_certificate, :expiring) }
+      subject(:certificate) { build(:sign_in_certificate, :expiring_soon) }
 
       it 'returns "expiring"' do
-        expect(certificate.status).to eq('expiring')
+        expect(certificate.status).to eq('expiring_soon')
       end
     end
   end
@@ -214,19 +219,19 @@ RSpec.describe SignIn::Certificate, type: :model do
     end
   end
 
-  describe '#expiring?' do
+  describe '#expiring_soon?' do
     context 'when the certificate is expiring within 60 days' do
-      subject(:certificate) { build(:sign_in_certificate, :expiring) }
+      subject(:certificate) { build(:sign_in_certificate, :expiring_soon) }
 
       it 'returns true' do
-        expect(certificate.expiring?).to be true
+        expect(certificate.expiring_soon?).to be true
       end
 
       context 'when the certificate is not expiring' do
         subject(:certificate) { build(:sign_in_certificate) }
 
         it 'returns false' do
-          expect(certificate.expiring?).to be false
+          expect(certificate.expiring_soon?).to be false
         end
       end
     end


### PR DESCRIPTION
## Summary

- Change `expiring` to `expiring_soon` - expiring in 60 days or less
- Add `expiring_later` - expiring in more than 60 days
- Change `active` to include `expiring_soon` and `expiring_later`


## Testing 
These should all print `true`
```ruby
ActiveRecord::Base.transaction do
  expired = FactoryBot.build(:sign_in_certificate, :expired)
  expired.save(validate: false)
  soon  = FactoryBot.create(:sign_in_certificate, :expiring_soon)
  later = FactoryBot.create(:sign_in_certificate, :expiring_later)

  puts expired.expired?
  puts soon.expiring_soon?
  puts later.expiring_later?
  puts soon.active?
  puts later.active?

  puts SignIn::Certificate.expired.pluck(:id).include?(expired.id)
  puts SignIn::Certificate.expiring_soon.pluck(:id).include?(soon.id)
  puts SignIn::Certificate.expiring_later.pluck(:id).include?(later.id)
  puts SignIn::Certificate.active.pluck(:id).include?(soon.id)
  puts SignIn::Certificate.active.pluck(:id).include?(later.id)

  raise ActiveRecord::Rollback
end

```

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

