### PR TITLE
118397: Add logger with flipper to test flow; fix param list

### DIFF
--- a/app/controllers/v0/intent_to_files_controller.rb
+++ b/app/controllers/v0/intent_to_files_controller.rb
@@ -68,7 +68,7 @@ module V0
 
       if %w[pension survivor].include? type
         form_id = ITF_FORM_IDS[type]
-        validate_data(@current_user, 'post', type, form_id)
+        validate_data(@current_user, 'post', form_id, type)
 
         monitor.track_submit_itf(form_id, type, @current_user.uuid)
         itf = BenefitsClaims::Service.new(@current_user.icn).create_intent_to_file(type, @current_user.ssn, nil)
@@ -127,7 +127,19 @@ module V0
         TYPES.include?(params[:itf_type])
     end
 
+    # This is temporary. Testing logged data to ensure this is being hit properly
+    # rubocop:disable Metrics/MethodLength
     def validate_data(user, method, form_id, itf_type)
+      if Flipper.enabled?(:pension_itf_validate_data_logger, user)
+        context = {
+          user_icn: user.icn.present?,
+          user_participant_id: user.participant_id.present?,
+          itf_type:,
+          user_uuid: user.uuid
+        }
+        Rails.logger.info('IntentToFilesController ITF Validate Data', context)
+      end
+
       user_uuid = user.uuid
 
       if user.icn.blank?
@@ -149,6 +161,7 @@ module V0
         raise InvalidITFTypeError, error_message
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     def monitor
       @monitor ||= BenefitsClaims::IntentToFile::Monitor.new

--- a/config/features.yml
+++ b/config/features.yml
@@ -1538,6 +1538,10 @@ features:
   pension_persistent_attachment_error_email_notification:
     actor_type: cookie_id
     description: Toggle sending of the Persistent Attachment Error email notification
+  pension_itf_validate_data_loggeer:
+    actor_type: user
+    description: Toggle sending of the ITF Validate Data to Rails Logger
+    enable_in_development: true
   pre_entry_covid19_screener:
     actor_type: user
     description: >

--- a/spec/requests/v0/intent_to_file_spec.rb
+++ b/spec/requests/v0/intent_to_file_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe 'V0::IntentToFile', type: :request do
         it 'tracks missing participant ID' do
           user_no_pid = build(:disabilities_compensation_user, participant_id: nil)
 
-          expect { subject.send(:validate_data, user_no_pid, 'get', 'form_id', 'survivor') }
+          expect { subject.send(:validate_data, user_no_pid, 'get', '21P-534EZ', 'survivor') }
             .not_to raise_error
 
           expect(monitor).to have_received(:track_missing_user_pid_itf_controller)
@@ -167,6 +167,28 @@ RSpec.describe 'V0::IntentToFile', type: :request do
             .to raise_error V0::IntentToFilesController::InvalidITFTypeError
 
           expect(monitor).to have_received(:track_invalid_itf_type_itf_controller)
+        end
+
+        it 'logs validation data when pension_itf_validate_data_logger flipper is enabled' do
+          allow(Flipper).to receive(:enabled?).with(:pension_itf_validate_data_logger, user).and_return(true)
+          expect(Rails.logger).to receive(:info).with(
+            'IntentToFilesController ITF Validate Data',
+            {
+              user_icn: true,
+              user_participant_id: true,
+              itf_type: 'pension',
+              user_uuid: user.uuid
+            }
+          )
+
+          subject.send(:validate_data, user, 'get', '21P-527EZ', 'pension')
+        end
+
+        it 'does not log validation data when pension_itf_validate_data_logger flipper is disabled' do
+          allow(Flipper).to receive(:enabled?).with(:pension_itf_validate_data_logger, user).and_return(false)
+          expect(Rails.logger).not_to receive(:info).with('IntentToFilesController ITF Validate Data', anything)
+
+          subject.send(:validate_data, user, 'get', '21P-527EZ', 'pension')
         end
       end
     end
@@ -196,7 +218,9 @@ RSpec.describe 'V0::IntentToFile', type: :request do
       it 'matches the respective intent to file schema' do
         expect_any_instance_of(BenefitsClaims::Service).to receive(:create_intent_to_file)
           .with(itf_type, user.ssn, nil).and_return(intent_to_file)
-        expect(monitor).to receive(:track_submit_itf)
+
+        form_id = { 'pension' => '21P-527EZ', 'survivor' => '21P-534EZ' }[itf_type]
+        expect(monitor).to receive(:track_submit_itf).with(form_id, itf_type, user.uuid)
 
         post "/v0/intent_to_file/#{itf_type}"
 


### PR DESCRIPTION
The ITF dashboard hasn't been properly recording _possible_ failures. This PR is to add some straight logging into the controller to ensure its properly being hit.

## Summary

- Add feature flag `pension_itf_validate_data_logger`
- Update ITF controller to use a new flipper `pension_itf_validate_data_logger`
- Update param list order for POST.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118397

## Testing done

- [ ] *New code is covered by unit tests*