### PR TITLE
Fixed the `retry_email` method to use `notification.notification_id` …

### DIFF
--- a/app/sidekiq/event_bus_gateway/va_notify_email_status_callback.rb
+++ b/app/sidekiq/event_bus_gateway/va_notify_email_status_callback.rb
@@ -23,7 +23,7 @@ module EventBusGateway
     end
 
     def self.retry_email(notification)
-      ebg_noti = find_notification_by_va_notify_id(notification.id)
+      ebg_noti = find_notification_by_va_notify_id(notification.notification_id)
       return handle_exhausted_retries(notification, ebg_noti) if ebg_noti.attempts >= Constants::MAX_EMAIL_ATTEMPTS
 
       schedule_retry_job(ebg_noti)
@@ -62,6 +62,7 @@ module EventBusGateway
     end
 
     def self.handle_retry_failure(error)
+      Rails.logger.error(name, error.message)
       tags = Constants::DD_TAGS + ["function: #{error.message}"]
       StatsD.increment("#{STATSD_METRIC_PREFIX}.queued_retry_failure", tags:)
     end

--- a/spec/sidekiq/event_bus_gateway/letter_ready_email_end_to_end_spec.rb
+++ b/spec/sidekiq/event_bus_gateway/letter_ready_email_end_to_end_spec.rb
@@ -52,9 +52,9 @@ RSpec.describe 'EventBusGateway Letter Ready Email End-to-End Flow', type: :feat
   # Helper method to create notification doubles
   def create_notification_double(va_notify_id, status, options = {})
     double('notification',
-           id: va_notify_id,
+           id: options[:id] || SecureRandom.random_number(1_000_000),
            status:,
-           notification_id: options[:notification_id] || SecureRandom.uuid,
+           notification_id: va_notify_id,
            source_location: options[:source_location] || 'test',
            status_reason: options[:status_reason] || "test #{status}",
            notification_type: options[:notification_type] || 'email')

--- a/spec/sidekiq/event_bus_gateway/va_notify_email_status_callback_spec.rb
+++ b/spec/sidekiq/event_bus_gateway/va_notify_email_status_callback_spec.rb
@@ -90,7 +90,7 @@ describe EventBusGateway::VANotifyEmailStatusCallback do
           let(:mpi_profile_response) { create(:find_profile_response, profile: mpi_profile) }
           let(:user_account) { create(:user_account, icn: mpi_profile_response.profile.icn) }
           let(:ebg_noti) do
-            create(:event_bus_gateway_notification, user_account:, va_notify_id: notification_record.id)
+            create(:event_bus_gateway_notification, user_account:, va_notify_id: notification_record.notification_id)
           end
 
           before do


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): YES* - Works with existing `event_bus_gateway_retry_emails` flipper
- This PR fixes a critical bug in the `VANotifyEmailStatusCallback` where the callback was using the wrong notification identifier (`notification.id` instead of `notification.notification_id`) when looking up EventBusGateway notifications for retry logic
- **How to reproduce the bug**: When an email temporary failure occurs and retry is attempted, the callback throws `EventBusGatewayNotificationNotFoundError` because it cannot find the notification record in the database
- **Solution**: Changed the callback to use `notification.notification_id` which matches the `va_notify_id` field stored in the `EventBusGatewayNotification` table in the `LetterReadyEmailJob`.
- **Team**: Benefits Management Tools team owns the maintenance of this component
- **Flipper success criteria**: Email retry functionality works correctly when `event_bus_gateway_retry_emails` is enabled

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119277

## Testing done

- [x] *New code is covered by unit tests*
- **Old behavior**: When a temporary email failure occurred and retry was enabled, the callback would throw `EventBusGatewayNotificationNotFoundError` because it could not locate the notification record using the wrong identifier
- **Verification steps**:
  1. Run unit tests: `rspec spec/sidekiq/event_bus_gateway/va_notify_email_status_callback_spec.rb` - All pass
  2. Run end-to-end tests: `rspec spec/sidekiq/event_bus_gateway/letter_ready_email_end_to_end_spec.rb` - All pass
  3. Run full test suite: `rspec spec/sidekiq/event_bus_gateway/` - All 29 tests pass
  4. Verify retry logic works correctly when flipper is enabled vs disabled
- **Flipper testing**:
  - Tests cover both flipper on and flipper off scenarios
  - When flipper is off: No retry attempts are made (existing behavior preserved)
  - When flipper is on: Retry attempts now work correctly using proper notification identifier
  - **Rollout testing plan**: Monitor error rates in DataDog for `EventBusGatewayNotificationNotFoundError` exceptions - should decrease significantly

## Screenshots
_Not applicable for this backend bug fix_

## What areas of the site does it impact?

- **Primary Impact**: EventBusGateway email retry functionality for temporary failures during VA Notify email status callback processing
- **Components touched**:
  - `app/sidekiq/event_bus_gateway/va_notify_email_status_callback.rb`
  - Related test files in `spec/sidekiq/event_bus_gateway/`
- **No other areas of the site are impacted** - this is an isolated bug fix in the callback processing logic

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution
- [ ] Documentation has been updated (link to documentation) - *N/A - internal bug fix*
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Feature/bug has a monitor built into Datadog (if applicable) - *Existing DataDog monitors will show reduced error rates*
- [ ] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected - *N/A - backend callback processing*
- [ ] I added a screenshot of the developed feature - *N/A - backend bug fix*

