### PR TITLE
add feature toggle for contention classification ml classifier

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,17 +135,6 @@ PATH
     vye (0.1.0)
 
 GEM
-  remote: https://enterprise.contribsys.com/
-  specs:
-    sidekiq-ent (7.3.4)
-      einhorn (~> 1.0)
-      gserver
-      sidekiq (>= 7.3.7, < 8)
-      sidekiq-pro (>= 7.3.4, < 8)
-    sidekiq-pro (7.3.6)
-      sidekiq (>= 7.3.7, < 8)
-
-GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (2.0.1)
@@ -435,7 +424,6 @@ GEM
       dry-initializer (~> 3.2)
       dry-schema (~> 1.14)
       zeitwerk (~> 2.6)
-    einhorn (1.0.0)
     erb (5.0.2)
     erb (5.0.2-java)
     erubi (1.13.1)
@@ -576,7 +564,6 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    gserver (0.0.1)
     guard (2.18.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -1408,8 +1395,6 @@ DEPENDENCIES
   shoulda-matchers
   shrine
   sidekiq
-  sidekiq-ent!
-  sidekiq-pro!
   sign_in_service
   simple_forms_api!
   simplecov

--- a/config/features.yml
+++ b/config/features.yml
@@ -2441,3 +2441,7 @@ features:
     actor_type: user
     description: Enables substance use disorder as care related to mental health appointments with new codes
     enable_in_development: true
+  contention_classification_ml_classifier:
+    actor_type: user
+    description: enables the machine learning classifier for contention classification by calling the hybrid endpoint instead of expanded endpoint.
+    enable_in_development: true


### PR DESCRIPTION
## Summary

This PR introduces a new feature toggle for the Conditions and Content Classification team. The toggle will control which 
classifier strategy is used: the legacy or the experimental. 

## Related issue(s)

- *Link to [ticket](https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/869)*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots

### Ensure feature toggle appears at localhost:3000/flipper/features

<img width="1433" height="137" alt="image" src="https://github.com/user-attachments/assets/5e8bc1cf-3c60-438b-95e6-eda3fa91fe8b" />

### Ensure clicking on the feature toggle displays ability en disable or enable it

<img width="1413" height="291" alt="image" src="https://github.com/user-attachments/assets/91860ea9-fa6a-41b2-b69c-d93b6322e42c" />


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature