### PR TITLE
Revert "Bump karafka-core from 2.5.5 to 2.5.6"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,7 +106,7 @@ gem 'json-schema'
 gem 'json_schemer'
 gem 'jwe'
 gem 'jwt'
-gem 'karafka-core', '2.5.6' # Temporary lock until new release of karafka-rdkafka (dependency of karafka-core) is available
+gem 'karafka-core', '2.5.5' # Temporary lock until new release of karafka-rdkafka (dependency of karafka-core) is available
 gem 'kms_encrypted'
 gem 'liquid'
 gem 'lockbox'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -656,24 +656,16 @@ GEM
       base64
     jwt (2.10.2)
       base64
-    karafka-core (2.5.6)
-      karafka-rdkafka (>= 0.20.0)
+    karafka-core (2.5.5)
+      karafka-rdkafka (>= 0.19.2, < 0.21.0)
       logger (>= 1.6.0)
-    karafka-rdkafka (0.21.0)
+    karafka-rdkafka (0.20.1)
       ffi (~> 1.15)
-      json (> 2.0)
       logger
       mini_portile2 (~> 2.6)
       rake (> 12)
-    karafka-rdkafka (0.21.0-aarch64-linux-gnu)
+    karafka-rdkafka (0.20.1-x86_64-linux-gnu)
       ffi (~> 1.15)
-      json (> 2.0)
-      logger
-      mini_portile2 (~> 2.6)
-      rake (> 12)
-    karafka-rdkafka (0.21.0-x86_64-linux-gnu)
-      ffi (~> 1.15)
-      json (> 2.0)
       logger
       mini_portile2 (~> 2.6)
       rake (> 12)
@@ -1324,7 +1316,7 @@ DEPENDENCIES
   jsonapi-serializer
   jwe
   jwt
-  karafka-core (= 2.5.6)
+  karafka-core (= 2.5.5)
   kms_encrypted
   liquid
   lockbox


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#24024

See thread https://dsva.slack.com/archives/CBU0KDSB1/p1757537737535579