### PR TITLE
Fix Settings Spacing

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -711,7 +711,7 @@ lighthouse:
     access_token:
       aud_claim_url: <%= ENV['lighthouse__healthcare_cost_and_coverage__access_token__aud_claim_url'] %>
       client_id: <%= ENV['lighthouse__healthcare_cost_and_coverage__access_token__client_id'] %>
-      rsa_key:   <%= ENV['lighthouse__healthcare_cost_and_coverage__access_token__rsa_key'] %>
+      rsa_key: <%= ENV['lighthouse__healthcare_cost_and_coverage__access_token__rsa_key'] %>
     host: <%= ENV['lighthouse__healthcare_cost_and_coverage__host'] %>
     scopes:
       - system/ChargeItem.read


### PR DESCRIPTION
## Summary

- Settings spacing was causing `db-migrate` to fail 

> YAML syntax error occurred while parsing /app/config/settings.yml. Please note that YAML must be consistently indented using spaces. Tabs are not allowed. Error: (<unknown>): could not find expected ':' while scanning a simple key at line 715 column 1