### PR TITLE
Add VFF monitoring to BenefitsIntakeStatusJob

### DIFF
--- a/lib/vff/monitor.rb
+++ b/lib/vff/monitor.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'zero_silent_failures/monitor'
+
+module VFF
+  #
+  # Monitor functions for Rails logging and StatsD for VFF (Vets Forms Frontend) forms
+  #
+  class Monitor < ::ZeroSilentFailures::Monitor
+    # VFF (Vets Forms Frontend) form IDs that are processed through SimpleFormsApi
+    VFF_FORM_IDS = %w[21-0966 21-4142 21-10210 21-0972 21P-0847 20-10206 20-10207 21-0845].freeze
+
+    def initialize
+      super('vff-application')
+    end
+
+    # Check if a form ID is a VFF form
+    #
+    # @param form_id [String] the form ID to check
+    # @return [Boolean] true if the form is a VFF form
+    def self.vff?(form_id)
+      VFF_FORM_IDS.include?(form_id)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

  - *This work is behind a feature toggle (flipper): NO*
  - Added VFF::Monitor support to BenefitsIntakeStatusJob to ensure VFF (Simple Forms) failures are tracked in the ZeroSilentFailures monitoring system
  - Previously, VFF forms lacked monitoring coverage when benefits intake processing failed, creating a gap in failure tracking
  - The solution adds VFF::Monitor.log_silent_failure_no_confirmation to the monitor_failure method, which increments that a silent failure was avoided (an email was enqueued to be sent), but since there's no callback for VA Notify, emails can not be confirmed. 
  - Team: Benefits Engineering - this component is shared across multiple teams, but Benefits Engineering maintains the BenefitsIntakeStatusJob

## Details

The VFF::Monitor addition fills a monitoring gap for VFF forms in the ZeroSilentFailures system. While VFF forms already
had proper email notification handling via AASM transitions, they were missing a metric call (`silent_failure_avoided_no_confirmation`) to allow them to show up on the [Silent Failure Dashboard](https://vagov.ddog-gov.com/dashboard/n6c-twn-swr/silent-failure-tracker?fromUser=false&refresh_mode=sliding&from_ts=1757526063231&to_ts=1757612463231&live=true). The log/metric flow for VFF in`BenefitsIntakeStatusJob` with this addition is:

1. BenefitsIntakeStatusJob Startup
    - **Log**: `Rails.logger.info('BenefitsIntakeStatusJob started')` _(line 28)_
    - **Log**: `Rails.logger.info("Received bulk status response: #{response.body}")` _(line 51)_
2. Processing Individual Submissions
    - **Log**: `Rails.logger.info("Processing submission UUID: #{uuid}, Status: #{status}")` _(line 92)_
3. Failure Detection (status == 'expired' or 'error')
    - **Metric**: `api.benefits_intake.submission_status.${form_id}.failure` _(line 133)_
    - **Metric**: `api.benefits_intake.submission_status.all_forms.failure` _(line 134)_
    - **Log**:`Rails.logger.error('BenefitsIntakeStatusJob', result:, form_id:, uuid:, time_to_transition:, error_message:)` _(line
  136)_
4. AASM State Transition (`form_submission_attempt.fail!`)
    - **Log**: `Rails.logger.info('Preparing to send Form Submission Attempt error email', log_info)` _(
  FormSubmissionAttempt:43)_
    - **Log**: State change logging via `log_status_change` _(FormSubmissionAttempt:92)_
5. **VFF::Monitor Integration (NEW ADDITION)**
    - **Location**: `BenefitsIntakeStatusJob.monitor_failure` _(line 196)_
    - **Call**: `VFF::Monitor.new.log_silent_failure_no_confirmation(context, call_location:) rescue nil`
    - **Metric**: `silent_failure_avoided_no_confirmation` _(inherited from ZeroSilentFailures::Monitor:80)_
6. Email Notification Queuing (AASM after callback)
    - **Log**: `Rails.logger.info('Queuing SimpleFormsAPI notification email to VaNotify', form_number:, benefits_intake_uuid:)` _(FormSubmissionAttempt:145)_
    - **Log**: `Rails.logger.info('Queuing SimpleFormsAPI notification email to VaNotify completed', jid:, form_number:, benefits_intake_uuid:)` _(FormSubmissionAttempt:147)_
7. SimpleFormsApi Email Processing
    - **Log**: `Rails.logger.info('Simple Forms - Email job enqueued', email_job_id:, confirmation_number:)` _(
  SimpleFormsApi::Notification::Email:43)_
    - **Metric**: `silent_failure` (async email job was not performed)

  ## Related issue(s)

  - [Watch Officer 1065: Technical Review of VFF](https://github.com/orgs/department-of-veterans-affairs/projects/1431/views/2?filterQuery=1065&pane=issue&itemId=123374456&issue=department-of-veterans-affairs%7Cocto_watchofficer%7C1065)
  - [Watch Officer 1094: Identify where logging can be added to VFF forms](https://github.com/orgs/department-of-veterans-affairs/projects/1431/views/2?filterQuery=VFF&pane=issue&itemId=125383030&issue=department-of-veterans-affairs%7Cocto_watchofficer%7C1094)

  ## Testing done

  - [x] *New code is covered by unit tests* - existing spec coverage found in spec/sidekiq/benefits_intake_status_job_spec.rb with tests for VFF::Monitor invocation
  - Old behavior: VFF forms had no ZeroSilentFailures monitoring when benefits intake processing failed
  - New behavior: VFF forms are now tracked in ZeroSilentFailures system with proper context (form_id, claim_id, benefits_intake_uuid)
  - Verification: VFF::Monitor.log_silent_failure_no_confirmation is called when VFF forms encounter 'expired' or 'error' status in benefits intake processing
  - The monitoring call is wrapped with `rescue nil` to ensure monitoring failures don't interrupt the main job processing

  ## Screenshots
  _Note: Optional_

  ## What areas of the site does it impact?
  - Benefits intake status processing for VFF forms (Simple Forms): 21-0966, 21-4142, 21-10210, 21-0972, 21P-0847, 20-10206, 20-10207, 21-0845
  - ZeroSilentFailures monitoring and alerting system
  - No user-facing changes - this is backend monitoring infrastructure

  ## Acceptance criteria

  - [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
  - [x] No error nor warning in the console.
  - [x] Events are being sent to the appropriate logging solution
  - [ ] Documentation has been updated (link to documentation)
  - [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
  - [x] Feature/bug has a monitor built into Datadog (if applicable)
  - [ ] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
  - [ ] I added a screenshot of the developed feature

  ## Requested Feedback

Validate this assumption is correct: `VFF::Monitor.log_silent_failure_no_confirmation` should be called from `BenefitsIntakeStatusJob.monitor_failure` rather than in the FormSubmissionAttempt AASM failure for these reasons:

  1. **Context preservation**: The job has full context needed for monitoring (form_id, claim_id, benefits_intake_uuid) that would be harder to reconstruct in the model
  2. **Call location accuracy**: `caller_locations.first` correctly identifies the originating job as the source of failure detection
  3. **Monitoring intent**: ZeroSilentFailures tracks where failures are *detected*, not where emails are *sent*
  4. **Pattern consistency**: Other form types (Dependents, PCPG, VRE) also perform monitoring in the same location

VFF forms use a different notification pattern than other forms - emails are sent automatically via AASM transitions in FormSubmissionAttempt.fail! rather than direct email calls, but the monitoring needs to capture the detection context at the source.
