### PR TITLE
Conditionally run the facilities import job so we can disable it in m…

### DIFF
--- a/app/sidekiq/hca/std_institution_import_job.rb
+++ b/app/sidekiq/hca/std_institution_import_job.rb
@@ -79,6 +79,8 @@ module HCA
     end
 
     def perform
+      return unless Flipper.enabled?(:hca_health_facilities_update_job)
+
       Rails.logger.info("[HCA] - Job started with #{StdInstitutionFacility.count} existing facilities.")
 
       ActiveRecord::Base.transaction do

--- a/config/features.yml
+++ b/config/features.yml
@@ -177,7 +177,7 @@ features:
     description: Enables override of enrollment status for a user, to allow multiple submissions with same user.
   hca_insurance_v2_enabled:
     actor_type: user
-    description: Enables the the upgraded insurance section of the Health Care Application
+    description: Enables the upgraded insurance section of the Health Care Application
     enable_in_development: true
   hca_in_progress_form_logging:
     actor_type: user
@@ -193,6 +193,10 @@ features:
   hca_ez_kafka_submission_enabled:
     actor_type: cookie_id
     description: Enables the 10-10EZ Kafka Event Bus submission
+  hca_health_facilities_update_job:
+    actor_type: user
+    description: Enables the health facilities import job - should only run daily by default in prod, staging, and sandbox.
+    enable_in_development: false
   ezr_prod_enabled:
     actor_type: user
     description: Enables access to the 10-10EZR application in prod for the purposes of conducting user reasearch

--- a/spec/sidekiq/hca/std_institution_import_job_spec.rb
+++ b/spec/sidekiq/hca/std_institution_import_job_spec.rb
@@ -34,115 +34,129 @@ RSpec.describe HCA::StdInstitutionImportJob, type: :worker do
   end
 
   describe '#perform' do
-    context 'actual records' do
-      let(:csv_data) do
-        <<~CSV
-          ID,ACTIVATIONDATE,DEACTIVATIONDATE,NAME,STATIONNUMBER,VISTANAME,AGENCY_ID,STREETCOUNTRY_ID,STREETADDRESSLINE1,STREETADDRESSLINE2,STREETADDRESSLINE3,STREETCITY,STREETSTATE_ID,STREETCOUNTY_ID,STREETPOSTALCODE,MAILINGCOUNTRY_ID,MAILINGADDRESSLINE1,MAILINGADDRESSLINE2,MAILINGADDRESSLINE3,MAILINGCITY,MAILINGSTATE_ID,MAILINGCOUNTY_ID,MAILINGPOSTALCODE,FACILITYTYPE_ID,MFN_ZEG_RECIPIENT,PARENT_ID,REALIGNEDFROM_ID,REALIGNEDTO_ID,VISN_ID,VERSION,CREATED,UPDATED,CREATEDBY,UPDATEDBY
-          1000250,,,AUDIE L. MURPHY MEMORIAL HOSP,671,AUDIE L. MURPHY MEMORIAL HOSP,1009121,1006840,7400 MERTON MINTER BLVD,,,SAN ANTONIO,1009348,,78229-4404,1006840,7400 MERTON MINTER BLVD,,,SAN ANTONIO,1009348,,78229-4404,1009231,1,1002217,,,1002217,0,2004-06-04 13:18:48 +0000,2015-12-28 10:05:46 +0000,Initial Load,DataBroker - CQ# 0938 12/09/2015
-          1000090,,1969-12-31 00:00:00 +0000,CRAWFORD COUNTY CBOC (420),420,ZZ CRAWFORD COUNTY CBOC,1009121,1006840,,,,,1009342,,,,,,,,,,,1009197,0,,,,,0,2004-06-04 13:18:48 +0000,2007-05-07 10:18:36 +0000,Initial Load,Cleanup For Inactive Rows
-        CSV
-      end
+    context 'when :hca_health_facilities_update_job is disabled' do
+      it 'does nothing' do
+        allow(Flipper).to receive(:enabled?).with(:hca_health_facilities_update_job).and_return(false)
 
-      it 'populates institutions with the relevant attributes' do
-        allow_any_instance_of(HCA::StdInstitutionImportJob).to receive(:fetch_csv_data).and_return(csv_data)
-
-        expect do
-          described_class.new.perform
-        end.to change(StdInstitutionFacility, :count).by(2)
-
-        san_antonio_facility = StdInstitutionFacility.find_by(station_number: '671')
-        expect(san_antonio_facility.name).to eq 'AUDIE L. MURPHY MEMORIAL HOSP'
-        expect(san_antonio_facility.deactivation_date).to be_nil
-
-        deacrivated_crawford_facility = StdInstitutionFacility.find_by(station_number: '420')
-        expect(deacrivated_crawford_facility.name).to eq 'CRAWFORD COUNTY CBOC (420)'
-        expect(deacrivated_crawford_facility.deactivation_date).to eq Date.new(1969, 12, 31)
-      end
-
-      it 'logs newly created facilities' do
-        allow_any_instance_of(HCA::StdInstitutionImportJob).to receive(:fetch_csv_data).and_return(csv_data)
-
-        expect(Rails.logger).to receive(:info).with('[HCA] - Job started with 0 existing facilities.')
-        expect(Rails.logger).to receive(:info).with('[HCA] - 2 new institutions: [1000250, 1000090]')
-        expect(Rails.logger).to receive(:info).with('[HCA] - Job ended with 2 existing facilities.')
-
-        expect do
-          described_class.new.perform
-        end.to change(StdInstitutionFacility, :count).by(2)
-      end
-
-      it 'logs when receiving preexisting facilities' do
-        allow_any_instance_of(HCA::StdInstitutionImportJob).to receive(:fetch_csv_data).and_return(csv_data)
-
-        expect(Rails.logger).to receive(:info).with('[HCA] - Job started with 0 existing facilities.')
-        expect(Rails.logger).to receive(:info).with('[HCA] - 2 new institutions: [1000250, 1000090]')
-        expect(Rails.logger).to receive(:info).with('[HCA] - Job started with 2 existing facilities.')
-        expect(Rails.logger).to receive(:info).with('[HCA] - Job ended with 2 existing facilities.').twice
-
-        expect do
-          described_class.new.perform
-        end.to change(StdInstitutionFacility, :count).by(2)
-        expect do
-          described_class.new.perform
-        end.not_to change(StdInstitutionFacility, :count)
-      end
-    end
-
-    context 'maximum record' do
-      it 'sets the attributes correctly' do
-        csv_data = <<~CSV
-          ID,ACTIVATIONDATE,DEACTIVATIONDATE,NAME,STATIONNUMBER,VISTANAME,AGENCY_ID,STREETCOUNTRY_ID,STREETADDRESSLINE1,STREETADDRESSLINE2,STREETADDRESSLINE3,STREETCITY,STREETSTATE_ID,STREETCOUNTY_ID,STREETPOSTALCODE,MAILINGCOUNTRY_ID,MAILINGADDRESSLINE1,MAILINGADDRESSLINE2,MAILINGADDRESSLINE3,MAILINGCITY,MAILINGSTATE_ID,MAILINGCOUNTY_ID,MAILINGPOSTALCODE,FACILITYTYPE_ID,MFN_ZEG_RECIPIENT,PARENT_ID,REALIGNEDFROM_ID,REALIGNEDTO_ID,VISN_ID,VERSION,CREATED,UPDATED,CREATEDBY,UPDATEDBY
-          1001304,2001-05-21 00:00:00 +0000,2015-06-30 00:00:00 +0000,ZZ-SENECA CLINIC,589GT,ZZ-SENECA CLINIC,1009121,1006840,1600 COMMUNITY DRIVE,,,SENECA,1009320,,66538-9739,1006840,1600 COMMUNITY DRIVE,,,SENECA,1009320,,66538-9739,1009148,0,1001263,1001956,,1002215,0,2004-06-04 13:18:48 +0000,2021-04-12 14:58:11 +0000,Initial Load,DataBroker - CQ# 0998 3/02/2021
-        CSV
-        allow_any_instance_of(HCA::StdInstitutionImportJob).to receive(:fetch_csv_data).and_return(csv_data)
+        expect(Rails.logger).not_to receive(:info)
 
         described_class.new.perform
-
-        facility = StdInstitutionFacility.find_by(station_number: '589GT')
-        expect(facility.id).to eq 1_001_304
-        expect(facility.activation_date).to eq Date.new(2001, 5, 21)
-        expect(facility.deactivation_date).to eq Date.new(2015, 6, 30)
-        expect(facility.name).to eq 'ZZ-SENECA CLINIC'
-        expect(facility.station_number).to eq '589GT'
-        expect(facility.vista_name).to eq 'ZZ-SENECA CLINIC'
-        expect(facility.agency_id).to eq 1_009_121
-        expect(facility.street_country_id).to eq 1_006_840
-        expect(facility.street_address_line1).to eq '1600 COMMUNITY DRIVE'
-        expect(facility.street_address_line2).to be_nil
-        expect(facility.street_address_line3).to be_nil
-        expect(facility.street_city).to eq 'SENECA'
-        expect(facility.street_state_id).to eq 1_009_320
-        expect(facility.street_county_id).to be_nil
-        expect(facility.street_postal_code).to eq '66538-9739'
-        expect(facility.mailing_country_id).to eq 1_006_840
-        expect(facility.mailing_address_line1).to eq '1600 COMMUNITY DRIVE'
-        expect(facility.mailing_address_line2).to be_nil
-        expect(facility.mailing_address_line3).to be_nil
-        expect(facility.mailing_city).to eq 'SENECA'
-        expect(facility.mailing_state_id).to eq 1_009_320
-        expect(facility.mailing_county_id).to be_nil
-        expect(facility.mailing_postal_code).to eq '66538-9739'
-        expect(facility.facility_type_id).to eq 1_009_148
-        expect(facility.mfn_zeg_recipient).to eq 0
-        expect(facility.parent_id).to eq 1_001_263
-        expect(facility.realigned_from_id).to eq 1_001_956
-        expect(facility.realigned_to_id).to be_nil
-        expect(facility.visn_id).to eq 1_002_215
-        expect(facility.version).to eq 0
-        expect(facility.created).to eq '2004-06-04 13:18:48 +0000'
-        expect(facility.updated).to eq '2021-04-12 14:58:11 +0000'
-        expect(facility.created_by).to eq 'Initial Load'
-        expect(facility.updated_by).to eq 'DataBroker - CQ# 0998 3/02/2021'
       end
     end
 
-    context 'when fetch_csv_data returns nil' do
-      it 'raises an error' do
-        allow_any_instance_of(HCA::StdInstitutionImportJob).to receive(:fetch_csv_data).and_return(nil)
+    context 'when :hca_health_facilities_update_job is enabled' do
+      before { allow(Flipper).to receive(:enabled?).with(:hca_health_facilities_update_job).and_return(true) }
 
-        expect do
+      context 'actual records' do
+        let(:csv_data) do
+          <<~CSV
+            ID,ACTIVATIONDATE,DEACTIVATIONDATE,NAME,STATIONNUMBER,VISTANAME,AGENCY_ID,STREETCOUNTRY_ID,STREETADDRESSLINE1,STREETADDRESSLINE2,STREETADDRESSLINE3,STREETCITY,STREETSTATE_ID,STREETCOUNTY_ID,STREETPOSTALCODE,MAILINGCOUNTRY_ID,MAILINGADDRESSLINE1,MAILINGADDRESSLINE2,MAILINGADDRESSLINE3,MAILINGCITY,MAILINGSTATE_ID,MAILINGCOUNTY_ID,MAILINGPOSTALCODE,FACILITYTYPE_ID,MFN_ZEG_RECIPIENT,PARENT_ID,REALIGNEDFROM_ID,REALIGNEDTO_ID,VISN_ID,VERSION,CREATED,UPDATED,CREATEDBY,UPDATEDBY
+            1000250,,,AUDIE L. MURPHY MEMORIAL HOSP,671,AUDIE L. MURPHY MEMORIAL HOSP,1009121,1006840,7400 MERTON MINTER BLVD,,,SAN ANTONIO,1009348,,78229-4404,1006840,7400 MERTON MINTER BLVD,,,SAN ANTONIO,1009348,,78229-4404,1009231,1,1002217,,,1002217,0,2004-06-04 13:18:48 +0000,2015-12-28 10:05:46 +0000,Initial Load,DataBroker - CQ# 0938 12/09/2015
+            1000090,,1969-12-31 00:00:00 +0000,CRAWFORD COUNTY CBOC (420),420,ZZ CRAWFORD COUNTY CBOC,1009121,1006840,,,,,1009342,,,,,,,,,,,1009197,0,,,,,0,2004-06-04 13:18:48 +0000,2007-05-07 10:18:36 +0000,Initial Load,Cleanup For Inactive Rows
+          CSV
+        end
+
+        it 'populates institutions with the relevant attributes' do
+          allow_any_instance_of(HCA::StdInstitutionImportJob).to receive(:fetch_csv_data).and_return(csv_data)
+
+          expect do
+            described_class.new.perform
+          end.to change(StdInstitutionFacility, :count).by(2)
+
+          san_antonio_facility = StdInstitutionFacility.find_by(station_number: '671')
+          expect(san_antonio_facility.name).to eq 'AUDIE L. MURPHY MEMORIAL HOSP'
+          expect(san_antonio_facility.deactivation_date).to be_nil
+
+          deacrivated_crawford_facility = StdInstitutionFacility.find_by(station_number: '420')
+          expect(deacrivated_crawford_facility.name).to eq 'CRAWFORD COUNTY CBOC (420)'
+          expect(deacrivated_crawford_facility.deactivation_date).to eq Date.new(1969, 12, 31)
+        end
+
+        it 'logs newly created facilities' do
+          allow_any_instance_of(HCA::StdInstitutionImportJob).to receive(:fetch_csv_data).and_return(csv_data)
+
+          expect(Rails.logger).to receive(:info).with('[HCA] - Job started with 0 existing facilities.')
+          expect(Rails.logger).to receive(:info).with('[HCA] - 2 new institutions: [1000250, 1000090]')
+          expect(Rails.logger).to receive(:info).with('[HCA] - Job ended with 2 existing facilities.')
+
+          expect do
+            described_class.new.perform
+          end.to change(StdInstitutionFacility, :count).by(2)
+        end
+
+        it 'logs when receiving preexisting facilities' do
+          allow_any_instance_of(HCA::StdInstitutionImportJob).to receive(:fetch_csv_data).and_return(csv_data)
+
+          expect(Rails.logger).to receive(:info).with('[HCA] - Job started with 0 existing facilities.')
+          expect(Rails.logger).to receive(:info).with('[HCA] - 2 new institutions: [1000250, 1000090]')
+          expect(Rails.logger).to receive(:info).with('[HCA] - Job started with 2 existing facilities.')
+          expect(Rails.logger).to receive(:info).with('[HCA] - Job ended with 2 existing facilities.').twice
+
+          expect do
+            described_class.new.perform
+          end.to change(StdInstitutionFacility, :count).by(2)
+          expect do
+            described_class.new.perform
+          end.not_to change(StdInstitutionFacility, :count)
+        end
+      end
+
+      context 'maximum record' do
+        it 'sets the attributes correctly' do
+          csv_data = <<~CSV
+            ID,ACTIVATIONDATE,DEACTIVATIONDATE,NAME,STATIONNUMBER,VISTANAME,AGENCY_ID,STREETCOUNTRY_ID,STREETADDRESSLINE1,STREETADDRESSLINE2,STREETADDRESSLINE3,STREETCITY,STREETSTATE_ID,STREETCOUNTY_ID,STREETPOSTALCODE,MAILINGCOUNTRY_ID,MAILINGADDRESSLINE1,MAILINGADDRESSLINE2,MAILINGADDRESSLINE3,MAILINGCITY,MAILINGSTATE_ID,MAILINGCOUNTY_ID,MAILINGPOSTALCODE,FACILITYTYPE_ID,MFN_ZEG_RECIPIENT,PARENT_ID,REALIGNEDFROM_ID,REALIGNEDTO_ID,VISN_ID,VERSION,CREATED,UPDATED,CREATEDBY,UPDATEDBY
+            1001304,2001-05-21 00:00:00 +0000,2015-06-30 00:00:00 +0000,ZZ-SENECA CLINIC,589GT,ZZ-SENECA CLINIC,1009121,1006840,1600 COMMUNITY DRIVE,,,SENECA,1009320,,66538-9739,1006840,1600 COMMUNITY DRIVE,,,SENECA,1009320,,66538-9739,1009148,0,1001263,1001956,,1002215,0,2004-06-04 13:18:48 +0000,2021-04-12 14:58:11 +0000,Initial Load,DataBroker - CQ# 0998 3/02/2021
+          CSV
+          allow_any_instance_of(HCA::StdInstitutionImportJob).to receive(:fetch_csv_data).and_return(csv_data)
+
           described_class.new.perform
-        end.to raise_error(RuntimeError, 'Failed to fetch CSV data.')
+
+          facility = StdInstitutionFacility.find_by(station_number: '589GT')
+          expect(facility.id).to eq 1_001_304
+          expect(facility.activation_date).to eq Date.new(2001, 5, 21)
+          expect(facility.deactivation_date).to eq Date.new(2015, 6, 30)
+          expect(facility.name).to eq 'ZZ-SENECA CLINIC'
+          expect(facility.station_number).to eq '589GT'
+          expect(facility.vista_name).to eq 'ZZ-SENECA CLINIC'
+          expect(facility.agency_id).to eq 1_009_121
+          expect(facility.street_country_id).to eq 1_006_840
+          expect(facility.street_address_line1).to eq '1600 COMMUNITY DRIVE'
+          expect(facility.street_address_line2).to be_nil
+          expect(facility.street_address_line3).to be_nil
+          expect(facility.street_city).to eq 'SENECA'
+          expect(facility.street_state_id).to eq 1_009_320
+          expect(facility.street_county_id).to be_nil
+          expect(facility.street_postal_code).to eq '66538-9739'
+          expect(facility.mailing_country_id).to eq 1_006_840
+          expect(facility.mailing_address_line1).to eq '1600 COMMUNITY DRIVE'
+          expect(facility.mailing_address_line2).to be_nil
+          expect(facility.mailing_address_line3).to be_nil
+          expect(facility.mailing_city).to eq 'SENECA'
+          expect(facility.mailing_state_id).to eq 1_009_320
+          expect(facility.mailing_county_id).to be_nil
+          expect(facility.mailing_postal_code).to eq '66538-9739'
+          expect(facility.facility_type_id).to eq 1_009_148
+          expect(facility.mfn_zeg_recipient).to eq 0
+          expect(facility.parent_id).to eq 1_001_263
+          expect(facility.realigned_from_id).to eq 1_001_956
+          expect(facility.realigned_to_id).to be_nil
+          expect(facility.visn_id).to eq 1_002_215
+          expect(facility.version).to eq 0
+          expect(facility.created).to eq '2004-06-04 13:18:48 +0000'
+          expect(facility.updated).to eq '2021-04-12 14:58:11 +0000'
+          expect(facility.created_by).to eq 'Initial Load'
+          expect(facility.updated_by).to eq 'DataBroker - CQ# 0998 3/02/2021'
+        end
+      end
+
+      context 'when fetch_csv_data returns nil' do
+        it 'raises an error' do
+          allow_any_instance_of(HCA::StdInstitutionImportJob).to receive(:fetch_csv_data).and_return(nil)
+
+          expect do
+            described_class.new.perform
+          end.to raise_error(RuntimeError, 'Failed to fetch CSV data.')
+        end
       end
     end
 


### PR DESCRIPTION
…ost envs

## Summary

- *This work is behind a feature toggle (flipper): YES* - `hca_health_facilities_update_job`
- This job ran in all environments concurrently, so its two queries clogged up the DB connections.
- This PR makes the job processing conditional on a feature flag, so that can be enabled in the relevant environments only (Production, Staging, Sandbox) while devs and testers can enable it manually for relevant environments like RIs.
- Health Enrollment 1010 EZ/CG
- *(If introducing a flipper, what is the success criteria being targeted?)* This is a permanent functionality switch.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119304

## Testing done

- [x] *New code is covered by unit tests*
- The `process` method now returns immediately unless the flag is enabled.
- I confirmed on local console that the job runs with the flag on, and does nothing with the flag off.

## What areas of the site does it impact?
- 1010 EZ and CG Facilities dropdowns data updates

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
