### PR TITLE
TEST 1: Remove columns with model ignored_columns (should WARN)

### DIFF
--- a/app/models/form_submission_test.rb
+++ b/app/models/form_submission_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# TEST FILE: This is a copy of form_submission.rb with ignored_columns added
+# For testing the MigrationIsolator Dangerfile changes
+# DO NOT MERGE THIS FILE - For testing only
+
+class FormSubmissionTest < ApplicationRecord
+  self.table_name = 'form_submissions'
+
+  # Strong Migrations pattern: ignore columns before removing them
+  self.ignored_columns += %w[legacy_data old_status deprecated_at]
+
+  has_kms_key
+  has_encrypted :form_data, key: :kms_key, **lockbox_options
+
+  has_many :form_submission_attempts, dependent: :destroy
+  belongs_to :saved_claim, optional: true
+  belongs_to :user_account, optional: true
+
+  validates :form_type, presence: true
+
+  # Rest of the model code remains the same...
+end

--- a/db/migrate/20250111120001_remove_deprecated_fields_from_form_submissions.rb
+++ b/db/migrate/20250111120001_remove_deprecated_fields_from_form_submissions.rb
@@ -1,0 +1,9 @@
+class RemoveDeprecatedFieldsFromFormSubmissions < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      remove_column :form_submissions, :legacy_data, :jsonb
+      remove_column :form_submissions, :old_status, :string
+      remove_column :form_submissions, :deprecated_at, :datetime
+    end
+  end
+end


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

  This PR contains:
  - ✅ Improved Dangerfile with MigrationIsolator
  - ✅ Migration removing columns (20250111120001_remove_deprecated_fields_from_form_submissions.rb)
  - ✅ Model with ignored_columns (app/models/form_submission_test.rb)

  Expected Danger result: ⚠️ WARNING message that says this follows Strong Migrations patterns and is allowed.

## Related issue(s)

- [issue: 108084](https://github.com/department-of-veterans-affairs/va.gov-team/issues/108084)

## Testing done

** DO NOT MERGE test files**
- [x] Adds new temporary test files
Scenario 1:   
  - ✅ Migration removing columns (20250111120001_remove_deprecated_fields_from_form_submissions.rb)
  - ✅ Model with ignored_columns (app/models/form_submission_test.rb)