### PR TITLE
Adds treatment details building

### DIFF
--- a/modules/claims_api/lib/claims_api/v1/disability_compensation_pdf_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v1/disability_compensation_pdf_mapper.rb
@@ -371,11 +371,21 @@ module ClaimsApi
       end
 
       def build_treatment_start_date(treatment)
-        make_date_object(treatment['startDate'], treatment['startDate'].length) if treatment['startDate'].present?
+        return if treatment['startDate'].blank?
+
+        start_date = parse_treatment_date(treatment['startDate'])
+        make_date_object(start_date, start_date.length)
+      end
+
+      # The PDF Generator only wants month and year for this field
+      # The date value sent in is in the format of YYYY-MM-DD
+      def parse_treatment_date(date)
+        date.length > 7 ? date[0..-4] : date
       end
 
       def build_treatment_item(treatment_details, treatment_start_date, do_not_have_date)
-        { treatment_details:, dateOfTreatment: treatment_start_date, doNotHaveDate: do_not_have_date }.compact
+        { treatmentDetails: treatment_details, dateOfTreatment: treatment_start_date,
+          doNotHaveDate: do_not_have_date }.compact
       end
     end
   end

--- a/modules/claims_api/spec/lib/claims_api/v1/disability_compensation_pdf_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v1/disability_compensation_pdf_mapper_spec.rb
@@ -571,13 +571,13 @@ describe ClaimsApi::V1::DisabilityCompensationPdfMapper do
 
         treatments_base = pdf_data[:data][:attributes][:claimInformation][:treatments]
 
-        expect(treatments_base[0][:treatment_details]).to eq('Arthritis - Private Facility Name, USA')
-        expect(treatments_base[0][:dateOfTreatment]).to eq({ year: '2020', month: '01', day: '01' })
+        expect(treatments_base[0][:treatmentDetails]).to eq('Arthritis - Private Facility Name, USA')
+        expect(treatments_base[0][:dateOfTreatment]).to eq({ month: '01', year: '2020' })
         expect(treatments_base[0]).not_to have_key(:doNotHaveDate)
-        expect(treatments_base[1][:treatment_details]).to eq('Bad Knee - Another Private Facility Name, USA')
+        expect(treatments_base[1][:treatmentDetails]).to eq('Bad Knee - Another Private Facility Name, USA')
         expect(treatments_base[1][:dateOfTreatment]).to eq({ month: '01', year: '2022' })
         expect(treatments_base[0]).not_to have_key(:doNotHaveDate)
-        expect(treatments_base[2][:treatment_details]).to eq('Bad Elbow - Public Facility Name, USA')
+        expect(treatments_base[2][:treatmentDetails]).to eq('Bad Elbow - Public Facility Name, USA')
         expect(treatments_base[2]).not_to have_key(:dateOfTreatment)
         expect(treatments_base[2][:doNotHaveDate]).to be(true)
       end


### PR DESCRIPTION
## Summary
* Handles the treatment attributes mapping to the PDF
    * The `treatment_details` are a composite string of the treatment name and the center name
    *  If there is a start date then it will be set as the `dateOfTreatment` date object
    * If there is no start then `doNotHaveDate` should be true

## Related issue(s)
[API-49875](https://jira.devops.va.gov/browse/API-49875)

## Testing done

- [x] *New code is covered by unit tests*

#### Testing Notes
* You can test with this `treatments` block. (or any of your own of course). You may need to adjust dates based on the service periods used in your request
```
         "treatments":[
        {
          "startDate": "2020-01-01",
          "endDate": "2022-01-01",
          "treatedDisabilityNames": [
            "Arthritis"
          ],
          "center": {
            "name": "Private Facility Name",
            "country": "USA"
          }
        },
        {
          "startDate": "2022-01-12",
          "treatedDisabilityNames": [
            "Bad Knee"
          ],
          "center": {
            "name": "Another Private Facility Name",
            "country": "USA"
          }
        },
        {
          "treatedDisabilityNames": [
            "Bad Elbow"
          ],
          "center": {
            "name": "Public Facility Name",
            "country": "USA"
          }
        }
      ],
```
* Make sure to have sidekiq rnning locally `bundle exec sidekiq`
* Place a debugger inside the `disability_compensation_pdf_generator.rb` job at line 28 and log out the `mapped_data` to see the treatments information added to the data.

```
...
       :treatments=>
        [{:treatment_details=>"Arthritis - Private Facility Name, USA", :dateOfTreatment=>{:year=>"2020", :month=>"01", :day=>"01"}},
         {:treatment_details=>"Bad Knee - Another Private Facility Name, USA", :dateOfTreatment=>{:year=>"2022", :month=>"01", :day=>"12"}},
         {:treatment_details=>"Bad Elbow - Public Facility Name, USA", :doNotHaveDate=>true}]
```

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/lib/claims_api/v1/disability_compensation_pdf_mapper.rb
	modified:   modules/claims_api/spec/lib/claims_api/v1/disability_compensation_pdf_mapper_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
