### PR TITLE
Added Confirm Contact Email Interstitial Feature Flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1121,7 +1121,7 @@ features:
   kendra_enabled_for_resources_and_support_search:
     actor_type: user
     description: Enable/disable Amazon Kendra for Resources and Support search
-    enable_in_development: true 
+    enable_in_development: true
   letters_page_new_design:
     actor_type: user
     description: Enables ability to show updated letter page design
@@ -1830,6 +1830,10 @@ features:
   sign_in_modal_v2:
     actor_type: user
     description: Enables new page design of Sign In modal and USiP
+    enable_in_development: false
+  confirm_contact_email_interstitial_enabled:
+    actor_type: user
+    description: Enables users with emails tied to MHV classic accounts to be redirected to the confirm contact email interstitial page (Identity)
     enable_in_development: false
   dslogon_interstitial_redirect:
     actor_type: user


### PR DESCRIPTION
## Summary
Adds the `confirm_contact_email_interstitial_enabled` feature flag, which controls when users with emails tied to MHV classic accounts are redirected to the confirm contact email interstitial page.

## Related issue(s)

[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/680)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
This only impacts feature toggles and the subsequent confirm contact email interstitial page on the frontend.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature