### PR TITLE
[#119416] Travel Pay, Expense receipt placeholder

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2273,6 +2273,12 @@ features:
       A switch that toggles the availability of the expense and document submission features for travel pay claims. This feature flag can be retired when the feature is deployed to 100% of logged-in users in production for > 30 days.
       Enabled - Requests are handled as normal. Users can submit various types of expenses (mileage, lodging, meal, other) to their travel pay claims. Users can upload documents to their travel claims.
       Disabled - Requests are not handled. Server returns a 503 (Service Unavailable) until re-enabled.
+  travel_pay_exclude_expense_placeholder_receipt:
+    actor_type: user
+    enable_in_development: false
+    description: >-
+      Excludes the placeholder expenseReceipt object on Travel Pay expense create when enabled.
+      When disabled (default), placeholder receipt is included.
   travel_pay_submit_mileage_expense:
     actor_type: user
     enable_in_development: true

--- a/config/features.yml
+++ b/config/features.yml
@@ -2277,8 +2277,9 @@ features:
     actor_type: user
     enable_in_development: false
     description: >-
-      Excludes the placeholder expenseReceipt object on Travel Pay expense create when enabled.
-      When disabled (default), placeholder receipt is included.
+      A switch for a workaround for the API's requirement of receipts with expenses.
+      Enabled - Excludes the placeholder expenseReceipt object on Travel Pay expense create
+      Disabled - Placeholder receipt is included
   travel_pay_submit_mileage_expense:
     actor_type: user
     enable_in_development: true

--- a/modules/travel_pay/app/services/travel_pay/expenses_service.rb
+++ b/modules/travel_pay/app/services/travel_pay/expenses_service.rb
@@ -58,7 +58,7 @@ module TravelPay
         'claimId' => params['claim_id'],
         'dateIncurred' => params['purchase_date'],
         'description' => params['description'],
-        'amount' => params['cost_requested'],
+        'costRequested' => params['cost_requested'],
         'expenseType' => params['expense_type']
       }
 

--- a/modules/travel_pay/app/services/travel_pay/expenses_service.rb
+++ b/modules/travel_pay/app/services/travel_pay/expenses_service.rb
@@ -53,12 +53,33 @@ module TravelPay
     # @return [Hash] The formatted request body
     #
     def build_expense_request_body(params)
-      {
+      request_body = {
         'claimId' => params['claim_id'],
         'dateIncurred' => params['purchase_date'],
         'description' => params['description'],
         'amount' => params['cost_requested'],
         'expenseType' => params['expense_type']
+      }
+
+      # Include placeholder receipt unless feature flag is enabled to exclude it
+      unless Flipper.enabled?(:travel_pay_exclude_expense_placeholder_receipt)
+        request_body['expenseReceipt'] = build_placeholder_receipt
+      end
+
+      request_body
+    end
+
+    ##
+    # Builds the smallest possible placeholder receipt that satisfies the client contract
+    #
+    # @return [Hash] The minimal placeholder receipt data
+    #
+    def build_placeholder_receipt
+      {
+        'contentType' => '',
+        'length' => 0,
+        'fileName' => '',
+        'fileData' => ''
       }
     end
 

--- a/modules/travel_pay/app/services/travel_pay/expenses_service.rb
+++ b/modules/travel_pay/app/services/travel_pay/expenses_service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'securerandom'
+require 'base64'
 
 module TravelPay
   class ExpensesService
@@ -75,11 +76,12 @@ module TravelPay
     # @return [Hash] The minimal placeholder receipt data
     #
     def build_placeholder_receipt
+      placeholder_data = 'placeholder'
       {
-        'contentType' => '',
-        'length' => 0,
-        'fileName' => '',
-        'fileData' => ''
+        'contentType' => 'text/plain',
+        'length' => placeholder_data.length,
+        'fileName' => 'placeholder.txt',
+        'fileData' => Base64.strict_encode64(placeholder_data)
       }
     end
 

--- a/modules/travel_pay/spec/services/expenses_service_spec.rb
+++ b/modules/travel_pay/spec/services/expenses_service_spec.rb
@@ -53,10 +53,10 @@ describe TravelPay::ExpensesService do
           'amount' => 125.50,
           'expenseType' => 'lodging',
           'expenseReceipt' => {
-            'contentType' => '',
-            'length' => 0,
-            'fileName' => '',
-            'fileData' => ''
+            'contentType' => 'text/plain',
+            'length' => 11,
+            'fileName' => 'placeholder.txt',
+            'fileData' => 'cGxhY2Vob2xkZXI='
           }
         }
 
@@ -85,10 +85,10 @@ describe TravelPay::ExpensesService do
           'amount' => 15.75,
           'expenseType' => 'meal',
           'expenseReceipt' => {
-            'contentType' => '',
-            'length' => 0,
-            'fileName' => '',
-            'fileData' => ''
+            'contentType' => 'text/plain',
+            'length' => 11,
+            'fileName' => 'placeholder.txt',
+            'fileData' => 'cGxhY2Vob2xkZXI='
           }
         }
 
@@ -117,10 +117,10 @@ describe TravelPay::ExpensesService do
           'amount' => 10.00,
           'expenseType' => 'other',
           'expenseReceipt' => {
-            'contentType' => '',
-            'length' => 0,
-            'fileName' => '',
-            'fileData' => ''
+            'contentType' => 'text/plain',
+            'length' => 11,
+            'fileName' => 'placeholder.txt',
+            'fileData' => 'cGxhY2Vob2xkZXI='
           }
         }
 
@@ -205,10 +205,10 @@ describe TravelPay::ExpensesService do
             'amount' => 10.00,
             'expenseType' => 'other',
             'expenseReceipt' => {
-              'contentType' => '',
-              'length' => 0,
-              'fileName' => '',
-              'fileData' => ''
+              'contentType' => 'text/plain',
+              'length' => 11,
+              'fileName' => 'placeholder.txt',
+              'fileData' => 'cGxhY2Vob2xkZXI='
             }
           }
 

--- a/modules/travel_pay/spec/services/expenses_service_spec.rb
+++ b/modules/travel_pay/spec/services/expenses_service_spec.rb
@@ -26,6 +26,8 @@ describe TravelPay::ExpensesService do
       auth_manager = object_double(TravelPay::AuthManager.new(123, user), authorize: tokens)
       @expenses_client = instance_double(TravelPay::ExpensesClient)
       @service = TravelPay::ExpensesService.new(auth_manager)
+      # By default, feature flag is disabled (includes receipt)
+      allow(Flipper).to receive(:enabled?).with(:travel_pay_exclude_expense_placeholder_receipt).and_return(false)
     end
 
     context 'with non-mileage expense types' do
@@ -49,7 +51,13 @@ describe TravelPay::ExpensesService do
           'dateIncurred' => '2024-10-02',
           'description' => 'Hotel stay',
           'amount' => 125.50,
-          'expenseType' => 'lodging'
+          'expenseType' => 'lodging',
+          'expenseReceipt' => {
+            'contentType' => '',
+            'length' => 0,
+            'fileName' => '',
+            'fileData' => ''
+          }
         }
 
         allow_any_instance_of(TravelPay::ExpensesClient)
@@ -75,7 +83,13 @@ describe TravelPay::ExpensesService do
           'dateIncurred' => '2024-10-02',
           'description' => 'Lunch during appointment',
           'amount' => 15.75,
-          'expenseType' => 'meal'
+          'expenseType' => 'meal',
+          'expenseReceipt' => {
+            'contentType' => '',
+            'length' => 0,
+            'fileName' => '',
+            'fileData' => ''
+          }
         }
 
         allow_any_instance_of(TravelPay::ExpensesClient)
@@ -101,7 +115,13 @@ describe TravelPay::ExpensesService do
           'dateIncurred' => '2024-10-02',
           'description' => 'Parking fee',
           'amount' => 10.00,
-          'expenseType' => 'other'
+          'expenseType' => 'other',
+          'expenseReceipt' => {
+            'contentType' => '',
+            'length' => 0,
+            'fileName' => '',
+            'fileData' => ''
+          }
         }
 
         allow_any_instance_of(TravelPay::ExpensesClient)
@@ -136,6 +156,70 @@ describe TravelPay::ExpensesService do
                                                                       )
 
         expect { @service.create_expense(params) }.to raise_error(Common::Exceptions::BadRequest)
+      end
+
+      context 'with feature flag travel_pay_exclude_expense_placeholder_receipt' do
+        it 'excludes placeholder receipt when feature flag is enabled' do
+          allow(Flipper).to receive(:enabled?).with(:travel_pay_exclude_expense_placeholder_receipt).and_return(true)
+
+          params = {
+            'claim_id' => '73611905-71bf-46ed-b1ec-e790593b8565',
+            'expense_type' => 'other',
+            'purchase_date' => '2024-10-02',
+            'description' => 'Parking fee',
+            'cost_requested' => 10.00
+          }
+
+          expected_request_body_without_receipt = {
+            'claimId' => '73611905-71bf-46ed-b1ec-e790593b8565',
+            'dateIncurred' => '2024-10-02',
+            'description' => 'Parking fee',
+            'amount' => 10.00,
+            'expenseType' => 'other'
+          }
+
+          allow_any_instance_of(TravelPay::ExpensesClient)
+            .to receive(:add_expense)
+            .with(tokens[:veis_token], tokens[:btsss_token], 'other', expected_request_body_without_receipt)
+            .and_return(general_expense_response)
+
+          result = @service.create_expense(params)
+          expect(result).to eq({ 'id' => 'expense-456' })
+        end
+
+        it 'includes placeholder receipt when feature flag is disabled (default)' do
+          allow(Flipper).to receive(:enabled?).with(:travel_pay_exclude_expense_placeholder_receipt).and_return(false)
+
+          params = {
+            'claim_id' => '73611905-71bf-46ed-b1ec-e790593b8565',
+            'expense_type' => 'other',
+            'purchase_date' => '2024-10-02',
+            'description' => 'Parking fee',
+            'cost_requested' => 10.00
+          }
+
+          expected_request_body_with_receipt = {
+            'claimId' => '73611905-71bf-46ed-b1ec-e790593b8565',
+            'dateIncurred' => '2024-10-02',
+            'description' => 'Parking fee',
+            'amount' => 10.00,
+            'expenseType' => 'other',
+            'expenseReceipt' => {
+              'contentType' => '',
+              'length' => 0,
+              'fileName' => '',
+              'fileData' => ''
+            }
+          }
+
+          allow_any_instance_of(TravelPay::ExpensesClient)
+            .to receive(:add_expense)
+            .with(tokens[:veis_token], tokens[:btsss_token], 'other', expected_request_body_with_receipt)
+            .and_return(general_expense_response)
+
+          result = @service.create_expense(params)
+          expect(result).to eq({ 'id' => 'expense-456' })
+        end
       end
     end
 

--- a/modules/travel_pay/spec/services/expenses_service_spec.rb
+++ b/modules/travel_pay/spec/services/expenses_service_spec.rb
@@ -50,7 +50,7 @@ describe TravelPay::ExpensesService do
           'claimId' => '73611905-71bf-46ed-b1ec-e790593b8565',
           'dateIncurred' => '2024-10-02',
           'description' => 'Hotel stay',
-          'amount' => 125.50,
+          'costRequested' => 125.50,
           'expenseType' => 'lodging',
           'expenseReceipt' => {
             'contentType' => 'text/plain',
@@ -82,7 +82,7 @@ describe TravelPay::ExpensesService do
           'claimId' => '73611905-71bf-46ed-b1ec-e790593b8565',
           'dateIncurred' => '2024-10-02',
           'description' => 'Lunch during appointment',
-          'amount' => 15.75,
+          'costRequested' => 15.75,
           'expenseType' => 'meal',
           'expenseReceipt' => {
             'contentType' => 'text/plain',
@@ -114,7 +114,7 @@ describe TravelPay::ExpensesService do
           'claimId' => '73611905-71bf-46ed-b1ec-e790593b8565',
           'dateIncurred' => '2024-10-02',
           'description' => 'Parking fee',
-          'amount' => 10.00,
+          'costRequested' => 10.00,
           'expenseType' => 'other',
           'expenseReceipt' => {
             'contentType' => 'text/plain',
@@ -174,7 +174,7 @@ describe TravelPay::ExpensesService do
             'claimId' => '73611905-71bf-46ed-b1ec-e790593b8565',
             'dateIncurred' => '2024-10-02',
             'description' => 'Parking fee',
-            'amount' => 10.00,
+            'costRequested' => 10.00,
             'expenseType' => 'other'
           }
 
@@ -202,7 +202,7 @@ describe TravelPay::ExpensesService do
             'claimId' => '73611905-71bf-46ed-b1ec-e790593b8565',
             'dateIncurred' => '2024-10-02',
             'description' => 'Parking fee',
-            'amount' => 10.00,
+            'costRequested' => 10.00,
             'expenseType' => 'other',
             'expenseReceipt' => {
               'contentType' => 'text/plain',


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- Adding a flag for a workaround for expense creation. The TP API requires a receipt for every expense call, but there are scenarios where may not want to include a receipt. This flag allows us to support the current behavior (for demoing) while the requirement is removed.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/119416

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## What areas of the site does it impact?
Travel Pay

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected