### PR TITLE
Fixing issue with HexaPDF validations causing merge failures in deplo…

### DIFF
--- a/lib/pdf_fill/filler.rb
+++ b/lib/pdf_fill/filler.rb
@@ -137,7 +137,10 @@ module PdfFill
         end
       end
 
-      target.write(new_file_path)
+      # NOTE: In deployed environments we use the `flatten` flag when calling `fill_form`, which removes
+      # all of the form metadata. HexaPDF validation fails when the form metadata has been removed,
+      # so we should not validate the merged document in deployed environments
+      target.write(new_file_path, validate: !Rails.env.production?)
     end
 
     ##


### PR DESCRIPTION
## Summary
In deployed environments we are flattening the form PDF after it is filled (flattening in this case means removing the form metadata from the PDF). This causes issues with HexaPDF when it attempts to merge the form PDF with an overflow file as it validates the presence of the form metadata. This PR turns the validation off in deployed environments and leaves it on in local environment

### Issue Reproduction
This issue is fairly easy to reproduce with the following changes:
1) Change this line (`lib/pdf_fill/filler.rb#L215`):
```ruby
(form_id.in?(unicode_pdf_form_list) ? UNICODE_PDF_FORMS : PDF_FORMS).fill_form(
  template_path, file_path, new_hash, flatten: Rails.env.production?
)
```
to this:
```ruby
(form_id.in?(unicode_pdf_form_list) ? UNICODE_PDF_FORMS : PDF_FORMS).fill_form(
  template_path, file_path, new_hash, flatten: true # <--- THIS is the change
)
```

Start up a rails console with:
```sh
bundle exec rails c
```
and run the following:
```sh
form_data = '{"dateReceivedByVa":true,"claimantType":"VETERAN","email":"x@y.com","claimantPhone":"5555555555","veteranSocialSecurityNumber":"123456780","vaFileNumber":"987654321","veteranFullName":{"first":"John","middle":"A","last":"Doe"},"associatedIncomes":[{"incomeType":"OTHER","otherIncomeType":"Social Security Retirement","grossMonthlyIncome":1234,"accountValue":2345,"payer":"Social Security Administration","recipientRelationship":"VETERAN"}],"assetTransfers":[{"fairMarketValue":1234567,"saleValue":12345,"capitalGainValue":0,"assetTransferredUnderFairMarketValue":false,"transferDate":"2025-04-20","newOwnerName":{"first":"Jane","middle":"B","last":"Doe"},"newOwnerRelationship":"Buyer","saleReportedToIrs":true,"transferMethod":"SOLD","assetType":"Real estate","originalOwnerRelationship":"VETERAN"}],"statementOfTruthCertified":true,"statementOfTruthSignature":"John Doe"}'
IncomeAndAssets::SavedClaim.new(form: form_data).to_pdf
```

This should produce the following error:
```sh
lib/pdf_fill/filler.rb:146:in `merge_pdfs': Validation error for (521,0): Required field Obj is not set (HexaPDF::Error)
	from lib/pdf_fill/filler.rb:106:in `combine_extras'
	from lib/pdf_fill/filler.rb:223:in `process_form'
	from lib/pdf_fill/filler.rb:165:in `fill_form'
```

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
