### PR TITLE
Champva 119138 added logging to help confirm that the backend sets attachment ids correctly

### DIFF
--- a/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
@@ -70,6 +70,8 @@ module IvcChampva
       @metadata['attachment_ids'].zip(@file_paths).map do |attachment_id, file_path|
         next if file_path.blank?
 
+        Rails.logger.info "IVC Champva Forms - FileUploader: Starting upload with attachment_id: #{attachment_id}"
+
         file_name = File.basename(file_path).gsub('-tmp', '')
         response_status = upload(file_name, file_path, metadata_for_s3(attachment_id))
         insert_form(file_name, response_status.to_s) if @insert_db_row
@@ -91,6 +93,8 @@ module IvcChampva
 
         attachment_id = @form_id
         file_name = File.basename(merged_pdf_path)
+
+        Rails.logger.info "IVC Champva Forms - FileUploader: Starting upload with attachment_id: #{attachment_id}"
 
         # Upload the combined PDF
         response_status = upload(file_name, merged_pdf_path, metadata_for_s3(attachment_id))
@@ -175,6 +179,8 @@ module IvcChampva
       meta_file_name = "#{@metadata['uuid']}_#{@form_id}_metadata.json"
       meta_file_path = "tmp/#{meta_file_name}"
       File.write(meta_file_path, @metadata.to_json)
+
+      Rails.logger.info 'IVC Champva Forms - FileUploader: Starting upload of metadata json'
       meta_upload_status, meta_upload_error_message = upload(meta_file_name, meta_file_path)
 
       if meta_upload_status == 200

--- a/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
@@ -70,7 +70,9 @@ module IvcChampva
       @metadata['attachment_ids'].zip(@file_paths).map do |attachment_id, file_path|
         next if file_path.blank?
 
-        Rails.logger.info "IVC Champva Forms - FileUploader: Starting upload with attachment_id: #{attachment_id}"
+        Rails.logger.info "IVC Champva Forms - FileUploader: Starting upload with attachment_id: #{attachment_id.gsub(
+          /[^a-zA-Z0-9\s_-]/, ''
+        )}"
 
         file_name = File.basename(file_path).gsub('-tmp', '')
         response_status = upload(file_name, file_path, metadata_for_s3(attachment_id))
@@ -94,7 +96,9 @@ module IvcChampva
         attachment_id = @form_id
         file_name = File.basename(merged_pdf_path)
 
-        Rails.logger.info "IVC Champva Forms - FileUploader: Starting upload with attachment_id: #{attachment_id}"
+        Rails.logger.info "IVC Champva Forms - FileUploader: Starting upload with attachment_id: #{attachment_id.gsub(
+          /[^a-zA-Z0-9\s_-]/, ''
+        )}"
 
         # Upload the combined PDF
         response_status = upload(file_name, merged_pdf_path, metadata_for_s3(attachment_id))

--- a/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/file_uploader.rb
@@ -70,9 +70,9 @@ module IvcChampva
       @metadata['attachment_ids'].zip(@file_paths).map do |attachment_id, file_path|
         next if file_path.blank?
 
-        Rails.logger.info "IVC Champva Forms - FileUploader: Starting upload with attachment_id: #{attachment_id.gsub(
-          /[^a-zA-Z0-9\s_-]/, ''
-        )}"
+        Rails.logger.info "IVC Champva Forms - FileUploader: Starting upload with attachment_id: #{
+          sanitize_for_logging(attachment_id)
+        }"
 
         file_name = File.basename(file_path).gsub('-tmp', '')
         response_status = upload(file_name, file_path, metadata_for_s3(attachment_id))
@@ -96,9 +96,9 @@ module IvcChampva
         attachment_id = @form_id
         file_name = File.basename(merged_pdf_path)
 
-        Rails.logger.info "IVC Champva Forms - FileUploader: Starting upload with attachment_id: #{attachment_id.gsub(
-          /[^a-zA-Z0-9\s_-]/, ''
-        )}"
+        Rails.logger.info "IVC Champva Forms - FileUploader: Starting upload with attachment_id: #{
+          sanitize_for_logging(attachment_id)
+        }"
 
         # Upload the combined PDF
         response_status = upload(file_name, merged_pdf_path, metadata_for_s3(attachment_id))
@@ -236,6 +236,13 @@ module IvcChampva
       return nil unless email.present? && email.match?(/\A[\w+\-.]+@[a-z\d-]+(\.[a-z]+)*\.[a-z]+\z/i)
 
       email
+    end
+
+    # Returns sanitized string that is safe for logging
+    # @param [String, nil] value to sanitize
+    # @return [String, nil] Sanitized value
+    def sanitize_for_logging(value)
+      (value || '').to_s.gsub(/[^a-zA-Z0-9\s_-]/, '').slice(0, 100)
     end
 
     ##


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- This work is behind a feature toggle (flipper): No
- Added logging to help confirm that the backend sets attachment ids correctly
- This is the solution because it adds visibility into which attachment ids are passed to downstream systems
- I work for the IVC Forms team and we own this module

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119138

## Testing done

- [ ] New code is covered by unit tests
- Prior to this change the attachment ids were not being logged
- To verify that these changes are working as expected, submit form 10-10d then check Datadog logs to confirm new logging

## Screenshots
None

## What areas of the site does it impact?
This impacts CHAMPVA form submissions

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
None
