### PR TITLE
47330 - FES V2 validations - Round2 - Part 1

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/v2/revised_disability_compensation_validation.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/v2/revised_disability_compensation_validation.rb
@@ -172,7 +172,6 @@ module ClaimsApi
         if rng_service['obligationTermOfServiceFromDate'].blank?
           collect_error(
             source: "/serviceInformation/servicePeriods/#{index}/reservesNationalGuardService",
-            title: 'Missing required field',
             detail: 'The service period is missing a required start date for the obligation terms of service'
           )
         end
@@ -180,7 +179,6 @@ module ClaimsApi
         if rng_service['obligationTermOfServiceToDate'].blank?
           collect_error(
             source: "/serviceInformation/servicePeriods/#{index}/reservesNationalGuardService",
-            title: 'Missing required field',
             detail: 'The service period is missing a required end date for the obligation terms of service'
           )
         end
@@ -207,7 +205,6 @@ module ClaimsApi
 
         collect_error(
           source: "/serviceInformation/servicePeriods/#{index}/reservesNationalGuardService/title10Activation",
-          title: 'Missing required field',
           detail: 'Title 10 activation is missing the anticipated separation date'
         )
       end
@@ -217,7 +214,6 @@ module ClaimsApi
 
         collect_error(
           source: "/serviceInformation/servicePeriods/#{index}/reservesNationalGuardService/title10Activation",
-          title: 'Invalid value',
           detail: 'Reserves national guard title 10 activation date ' \
                   "(#{activation['title10ActivationDate']}) is before the earliest active duty begin date " \
                   "(#{period['activeDutyBeginDate']})"
@@ -229,7 +225,6 @@ module ClaimsApi
 
         collect_error(
           source: "/serviceInformation/servicePeriods/#{index}/reservesNationalGuardService/title10Activation",
-          title: 'Invalid value',
           detail: 'Reserves national guard title 10 activation date is in the future: ' \
                   "#{activation['title10ActivationDate']}"
         )
@@ -248,7 +243,6 @@ module ClaimsApi
         if federal_activation['anticipatedSeparationDate'].blank?
           collect_error(
             source: '/serviceInformation/federalActivation',
-            title: 'Missing required field',
             detail: 'anticipatedSeparationDate is missing or blank'
           )
         end
@@ -258,7 +252,6 @@ module ClaimsApi
         if activation_date && activation_date > Date.current
           collect_error(
             source: '/serviceInformation/federalActivation',
-            title: 'Invalid value',
             detail: "Federal activation date is in the future: #{federal_activation['activationDate']}"
           )
         end
@@ -346,7 +339,6 @@ module ClaimsApi
         if mailing_address['city'].blank?
           collect_error(
             source: '/veteranIdentification/mailingAddress/city',
-            title: 'Unprocessable Entity',
             detail: 'City is required'
           )
         end
@@ -355,7 +347,6 @@ module ClaimsApi
         if mailing_address['country'].blank?
           collect_error(
             source: '/veteranIdentification/mailingAddress/country',
-            title: 'Unprocessable Entity',
             detail: 'The country provided is not valid.'
           )
         end
@@ -366,7 +357,6 @@ module ClaimsApi
         if mailing_address['state'].blank?
           collect_error(
             source: '/veteranIdentification/mailingAddress/state',
-            title: 'Missing state',
             detail: 'State is required for USA addresses'
           )
         end
@@ -375,7 +365,6 @@ module ClaimsApi
         if mailing_address['zipFirstFive'].blank?
           collect_error(
             source: '/veteranIdentification/mailingAddress/zipFirstFive',
-            title: 'Missing zipFirstFive',
             detail: 'ZipFirstFive is required for USA addresses'
           )
         end
@@ -385,7 +374,6 @@ module ClaimsApi
 
         collect_error(
           source: '/veteranIdentification/mailingAddress/internationalPostalCode',
-          title: 'Invalid field',
           detail: 'InternationalPostalCode should not be provided for USA addresses'
         )
       end
@@ -423,7 +411,6 @@ module ClaimsApi
         if country != 'USA' && mailing_address['internationalPostalCode'].blank?
           collect_error(
             source: '/veteranIdentification/mailingAddress/internationalPostalCode',
-            title: 'Missing internationalPostalCode',
             detail: 'InternationalPostalCode is required for non-USA addresses'
           )
         end
@@ -445,7 +432,6 @@ module ClaimsApi
         if dates['beginDate'].blank?
           collect_error(
             source: '/changeOfAddress/dates/beginDate',
-            title: 'Missing beginningDate',
             detail: 'beginningDate is required for temporary address'
           )
         end
@@ -453,7 +439,6 @@ module ClaimsApi
         if dates['endDate'].blank?
           collect_error(
             source: '/changeOfAddress/dates/endDate',
-            title: 'Missing endingDate',
             detail: 'EndingDate is required for temporary address'
           )
         end
@@ -464,9 +449,7 @@ module ClaimsApi
         return if change_of_address.dig('dates', 'endDate').blank?
 
         collect_error(
-          source: '/changeOfAddress/dates/endDate',
-          title: 'Cannot provide endingDate',
-          detail: 'EndingDate cannot be provided for a permanent address'
+          source: '/changeOfAddress/dates/endDate', detail: 'EndingDate cannot be provided for a permanent address'
         )
       end
 
@@ -499,9 +482,7 @@ module ClaimsApi
         return if change_of_address['city'].present?
 
         collect_error(
-          source: '/changeOfAddress/city',
-          title: 'Missing city',
-          detail: 'City is required'
+          source: '/changeOfAddress/city', detail: 'City is required'
         )
       end
 
@@ -510,9 +491,7 @@ module ClaimsApi
         return if change_of_address['state'].present?
 
         collect_error(
-          source: '/changeOfAddress/state',
-          title: 'Missing state',
-          detail: 'State is required'
+          source: '/changeOfAddress/state', detail: 'State is required'
         )
       end
 
@@ -521,9 +500,7 @@ module ClaimsApi
         return if change_of_address['zipFirstFive'].present?
 
         collect_error(
-          source: '/changeOfAddress/zipFirstFive',
-          title: 'Missing zipFirstFive',
-          detail: 'ZipFirstFive is required'
+          source: '/changeOfAddress/zipFirstFive',          detail: 'ZipFirstFive is required'
         )
       end
 
@@ -538,9 +515,7 @@ module ClaimsApi
         return if change_of_address['city'].present?
 
         collect_error(
-          source: '/changeOfAddress/city',
-          title: 'Missing city',
-          detail: 'City is required'
+          source: '/changeOfAddress/city', detail: 'City is required'
         )
       end
 
@@ -549,9 +524,7 @@ module ClaimsApi
         return if change_of_address['country'].present?
 
         collect_error(
-          source: '/changeOfAddress/country',
-          title: 'Missing country',
-          detail: 'Country is required'
+          source: '/changeOfAddress/country', detail: 'Country is required'
         )
       end
 
@@ -560,9 +533,7 @@ module ClaimsApi
         return if change_of_address['internationalPostalCode'].present?
 
         collect_error(
-          source: '/changeOfAddress/internationalPostalCode',
-          title: 'Missing internationalPostalCode',
-          detail: 'InternationalPostalCode is required'
+          source: '/changeOfAddress/internationalPostalCode', detail: 'InternationalPostalCode is required'
         )
       end
 
@@ -576,7 +547,6 @@ module ClaimsApi
 
         collect_error(
           source: '/disabilities',
-          title: 'Unprocessable Entity',
           detail: "Number of disabilities (#{disabilities.size}) exceeds maximum allowed (150)"
         )
       end
@@ -592,7 +562,7 @@ module ClaimsApi
         @errors ||= []
       end
 
-      def collect_error(source:, title:, detail:)
+      def collect_error(source:, detail:, title: 'Unprocessable Entity')
         errors_array.push(
           {
             source:,

--- a/modules/claims_api/app/controllers/concerns/claims_api/v2/revised_disability_compensation_validation.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/v2/revised_disability_compensation_validation.rb
@@ -346,7 +346,7 @@ module ClaimsApi
         if mailing_address['city'].blank?
           collect_error(
             source: '/veteranIdentification/mailingAddress/city',
-            title: 'Missing city',
+            title: 'Unprocessable Entity',
             detail: 'City is required'
           )
         end
@@ -355,8 +355,8 @@ module ClaimsApi
         if mailing_address['country'].blank?
           collect_error(
             source: '/veteranIdentification/mailingAddress/country',
-            title: 'Missing country',
-            detail: 'Country is required'
+            title: 'Unprocessable Entity',
+            detail: 'The country provided is not valid.'
           )
         end
       end
@@ -576,7 +576,7 @@ module ClaimsApi
 
         collect_error(
           source: '/disabilities',
-          title: 'Invalid array',
+          title: 'Unprocessable Entity',
           detail: "Number of disabilities (#{disabilities.size}) exceeds maximum allowed (150)"
         )
       end

--- a/modules/claims_api/spec/controllers/concerns/claims_api/v2/revised_disability_compensation_validation_spec.rb
+++ b/modules/claims_api/spec/controllers/concerns/claims_api/v2/revised_disability_compensation_validation_spec.rb
@@ -406,7 +406,7 @@ RSpec.describe ClaimsApi::V2::RevisedDisabilityCompensationValidation do
           errors = subject.validate_form_526_fes_values
           expect(errors).to be_an(Array)
           expect(errors.first[:source]).to eq('/veteranIdentification/mailingAddress/city')
-          expect(errors.first[:title]).to eq('Missing city')
+          expect(errors.first[:title]).to eq('Unprocessable Entity')
           expect(errors.first[:detail]).to eq('City is required')
         end
       end
@@ -430,7 +430,7 @@ RSpec.describe ClaimsApi::V2::RevisedDisabilityCompensationValidation do
           expect(errors).to be_an(Array)
           # Country validation would be checked first in the international validation
           expect(errors.any? { |e| e[:source] == '/veteranIdentification/mailingAddress/country' }).to be true
-          expect(errors.any? { |e| e[:title] == 'Missing country' }).to be true
+          expect(errors.any? { |e| e[:title] == 'Unprocessable Entity' }).to be true
         end
       end
 
@@ -831,7 +831,7 @@ RSpec.describe ClaimsApi::V2::RevisedDisabilityCompensationValidation do
           errors = subject.validate_form_526_fes_values
           expect(errors).to be_an(Array)
           expect(errors.first[:source]).to eq('/disabilities')
-          expect(errors.first[:title]).to eq('Invalid array')
+          expect(errors.first[:title]).to eq('Unprocessable Entity')
           expect(errors.first[:detail]).to eq('Number of disabilities (151) exceeds maximum allowed (150)')
         end
       end

--- a/modules/claims_api/spec/controllers/concerns/claims_api/v2/revised_disability_compensation_validation_spec.rb
+++ b/modules/claims_api/spec/controllers/concerns/claims_api/v2/revised_disability_compensation_validation_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe ClaimsApi::V2::RevisedDisabilityCompensationValidation do
           errors = subject.validate_form_526_fes_values
           expect(errors).to be_an(Array)
           expect(errors.first[:source]).to eq('/veteranIdentification/mailingAddress/state')
-          expect(errors.first[:title]).to eq('Missing state')
+          expect(errors.first[:title]).to eq('Unprocessable Entity')
           expect(errors.first[:detail]).to eq('State is required for USA addresses')
         end
       end
@@ -284,7 +284,7 @@ RSpec.describe ClaimsApi::V2::RevisedDisabilityCompensationValidation do
           errors = subject.validate_form_526_fes_values
           expect(errors).to be_an(Array)
           expect(errors.first[:source]).to eq('/veteranIdentification/mailingAddress/zipFirstFive')
-          expect(errors.first[:title]).to eq('Missing zipFirstFive')
+          expect(errors.first[:title]).to eq('Unprocessable Entity')
           expect(errors.first[:detail]).to eq('ZipFirstFive is required for USA addresses')
         end
       end
@@ -309,7 +309,7 @@ RSpec.describe ClaimsApi::V2::RevisedDisabilityCompensationValidation do
           errors = subject.validate_form_526_fes_values
           expect(errors).to be_an(Array)
           expect(errors.first[:source]).to eq('/veteranIdentification/mailingAddress/internationalPostalCode')
-          expect(errors.first[:title]).to eq('Invalid field')
+          expect(errors.first[:title]).to eq('Unprocessable Entity')
           expect(errors.first[:detail]).to eq('InternationalPostalCode should not be provided for USA addresses')
         end
       end
@@ -534,7 +534,7 @@ RSpec.describe ClaimsApi::V2::RevisedDisabilityCompensationValidation do
           errors = subject.validate_form_526_fes_values
           expect(errors).to be_an(Array)
           expect(errors.first[:source]).to eq('/veteranIdentification/mailingAddress/internationalPostalCode')
-          expect(errors.first[:title]).to eq('Missing internationalPostalCode')
+          expect(errors.first[:title]).to eq('Unprocessable Entity')
           expect(errors.first[:detail]).to eq('InternationalPostalCode is required for non-USA addresses')
         end
       end
@@ -564,7 +564,7 @@ RSpec.describe ClaimsApi::V2::RevisedDisabilityCompensationValidation do
           errors = subject.validate_form_526_fes_values
           expect(errors).to be_an(Array)
           expect(errors.first[:source]).to eq('/changeOfAddress/dates/beginDate')
-          expect(errors.first[:title]).to eq('Missing beginningDate')
+          expect(errors.first[:title]).to eq('Unprocessable Entity')
           expect(errors.first[:detail]).to eq('beginningDate is required for temporary address')
         end
       end
@@ -590,7 +590,7 @@ RSpec.describe ClaimsApi::V2::RevisedDisabilityCompensationValidation do
           errors = subject.validate_form_526_fes_values
           expect(errors).to be_an(Array)
           expect(errors.first[:source]).to eq('/changeOfAddress/dates/endDate')
-          expect(errors.first[:title]).to eq('Missing endingDate')
+          expect(errors.first[:title]).to eq('Unprocessable Entity')
           expect(errors.first[:detail]).to eq('EndingDate is required for temporary address')
         end
       end
@@ -618,7 +618,7 @@ RSpec.describe ClaimsApi::V2::RevisedDisabilityCompensationValidation do
           errors = subject.validate_form_526_fes_values
           expect(errors).to be_an(Array)
           expect(errors.first[:source]).to eq('/changeOfAddress/dates/endDate')
-          expect(errors.first[:title]).to eq('Cannot provide endingDate')
+          expect(errors.first[:title]).to eq('Unprocessable Entity')
           expect(errors.first[:detail]).to eq('EndingDate cannot be provided for a permanent address')
         end
       end


### PR DESCRIPTION
 ## Summary

  Implements FES (Form526 Establishment Service) validations for international mailing addresses and disability count limits in the Claims API v2.

## What's Changed

  - Added validation for international mailing addresses requiring city and country (FES rules 5.b.iii.2 and 5.b.iii.3)
  - Added maximum 150 disabilities validation (FES rule 7.b)
  - Leveraged existing schema validation for minimum 1 disability requirement (FES rule 7.a)

## Validations Implemented

  1. International Mailing Address (5.b.iii)
    - City required for international addresses
    - Country required for international addresses
<img width="291" height="66" alt="Screenshot 2025-09-13 at 12 45 53 AM" src="https://github.com/user-attachments/assets/f6738711-3dfa-4512-b6ff-ddba11ac035d" />

  2. Disabilities Count (7.a-b)
    - Minimum 1 disability (handled by schema)
    - Maximum 150 disabilities (custom validator)
<img width="506" height="35" alt="Screenshot 2025-09-13 at 12 46 12 AM" src="https://github.com/user-attachments/assets/5109f577-dc62-4489-bb14-0f770fb71dde" />
