### PR TITLE
Step by step commit and check to see if everything is backwards compa…

### DIFF
--- a/lib/vets/shared_logging.rb
+++ b/lib/vets/shared_logging.rb
@@ -28,12 +28,22 @@ module Vets
     def log_message_to_rails(message, level, extra_context = {})
       # this can be a drop-in replacement for now, but maybe suggest teams
       # handle extra context on their own and move to a direct Rails.logger call?
+      #
+      ## If level is not supported by Rails.Logger, it will throw an exception
+      # Must be one of: debug, info, warn, error, fatal. Default to Warn
+
+      level = 'warn' unless %w[debug info warn error fatal].include?(level)
       formatted_message = extra_context.empty? ? message : "#{message} : #{extra_context}"
       Rails.logger.send(level, formatted_message)
     end
 
     def log_exception_to_rails(exception, level = 'error')
       level = normalize_shared_level(level, exception)
+      # If level is not supported by Rails.Logger, it will throw an exception
+      # Must be one of: debug, info, warn, error, fatal. Default to Warn
+
+      level = 'warn' unless %w[debug info warn error fatal].include?(level)
+
       if exception.is_a? Common::Exceptions::BackendServiceException
         error_details = exception.errors.first.attributes.compact.reject { |_k, v| v.try(:empty?) }
         log_message_to_rails(exception.message, level, error_details.merge(backtrace: exception.backtrace))

--- a/script/log_test.rb
+++ b/script/log_test.rb
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+# Simple standalone logger smoke test.
+# Usage:
+#   bundle exec ruby script/log_test.rb [optional_message]
+#
+# Loads the Rails environment and emits a few log lines at different levels so you can
+# verify formatting, structured fields, and any log shipping behavior.
+# If you supply an argument, it will be appended to each message.
+
+require_relative '../config/environment'
+
+suffix = ARGV.first ? " :: #{ARGV.first}" : ''
+
+Rails.logger.info  "log_test info#{suffix}"
+Rails.logger.warn  "log_test warn#{suffix}"
+Rails.logger.error "log_test error#{suffix}"
+
+Rails.logger.send('blah')
+# Example structured / semantic logging with rails_semantic_logger
+Rails.logger.info('log_test structured', feature: 'shared_logging', phase: 'demo', timestamp: Time.now.utc.iso8601)
+
+# Simulate logging an exception to compare formatting
+begin
+  raise StandardError, 'intentional test exception'
+rescue => e
+  Rails.logger.error(e)
+end
+
+puts 'Log test messages emitted.'


### PR DESCRIPTION
Please see issue https://github.com/department-of-veterans-affairs/vets-api/issues/24151

Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): YES/NO*. -- NO
- *(Summarize the changes that have been made to the platform)* -- **Among other critical fixes, added checks to prevent throwing exceptions when attempting to log a message, which has caused outages in the past. Also see [issue]( https://github.com/department-of-veterans-affairs/vets-api/issues/24151) for more details . 
- *(If bug, how to reproduce)* : try calling 

```ruby
log_message_to_rails(nil, 'blah blah') # Will raise an exception
```
- *(What is the solution, why is this the solution?)* Added Guards against nils defaulting to reasonable levels AND NOT eating the exception to give developers a chance to fix their error.
- *(Which team do you work for, does your team own the maintenance of this component?)* Watchtower
- *(If introducing a flipper, what is the success criteria being targeted?)* No

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
  -  https://github.com/department-of-veterans-affairs/vets-api/issues/24151
- *Link to previous change of the code/bug (if applicable)* N/A
- *Link to epic if not included in ticket* N/A

## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change* **See Above**
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*

Try calling the following. It shouldn't throw an exception now, defaults to warn
```ruby
log_message_to_rails(nil, 'blah blah')
```

- *If this work is behind a flipper:* N/A
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).* N/A
  - *What is the testing plan for rolling out the feature?* N/A

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)* Platform level

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [X]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

closes #24151 