### PR TITLE
47330 - FES V2 validations - Round2 - Part 4

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/v2/revised_disability_compensation_validation.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/v2/revised_disability_compensation_validation.rb
@@ -582,6 +582,9 @@ module ClaimsApi
 
           # FES Val Section 7.v: HEPC specialIssue validation
           validate_hepc_special_issue!(disability, index)
+
+          # FES Val Section 7.w: POW specialIssue validation
+          validate_pow_special_issue!(disability, index)
         end
       end
 
@@ -617,6 +620,21 @@ module ClaimsApi
           source: "/disabilities/#{index}/specialIssues",
           title: 'Invalid value',
           detail: 'A special issue of HEPC can only exist for the disability Hepatitis'
+        )
+      end
+
+      # FES Val Section 7.w: POW special issue requires confinements
+      def validate_pow_special_issue!(disability, index)
+        special_issues = disability['specialIssues']
+        return unless special_issues&.include?('POW')
+
+        confinements = form_attributes['confinements']
+        return if confinements.present? && !confinements.empty?
+
+        collect_error(
+          source: "/disabilities/#{index}/specialIssues",
+          title: 'Invalid value',
+          detail: 'A prisoner of war must have at least one period of confinement record'
         )
       end
 

--- a/modules/claims_api/app/controllers/concerns/claims_api/v2/revised_disability_compensation_validation.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/v2/revised_disability_compensation_validation.rb
@@ -637,11 +637,20 @@ module ClaimsApi
         )
       end
 
-      # FES Val Section 7.w: POW special issue requires confinements
+      # FES Val Section 7.w: POW special issue requires confinements and cannot be INCREASE
       def validate_pow_special_issue!(disability, index)
         special_issues = disability['specialIssues']
         return unless special_issues&.include?('POW')
 
+        # Check if POW is used with INCREASE action type (not allowed)
+        if disability['disabilityActionType'] == 'INCREASE'
+          collect_error(
+            source: "/disabilities/#{index}/specialIssues",
+            detail: "disabilityActionType (#{index}) cannot be INCREASE if specialIssues includes POW for."
+          )
+        end
+
+        # Check if confinements are present when POW is used
         service_info = form_attributes['serviceInformation']
         confinements = service_info&.dig('confinements')
         return if confinements.present? && !confinements.empty?


### PR DESCRIPTION
## Summary
  1. Section 7.u - Special Issues for INCREASE ✅ Implemented
    - FES Doc: specialIssues must be null for INCREASE unless EMP or RRD
    - Code: Lines 602-621
    - Error: "A Special Issue cannot be added to a primary disability after the disability has been rated"
    - Validates: INCREASE disabilities can only have EMP or RRD special issues
    - Note: RRD is unreachable (schema enum only allows ["POW", "EMP"])

  2. Section 7.v - HEPC Special Issue ✅ Implemented (but unreachable)
    - FES Doc: HEPC special issue only valid for Hepatitis
    - Code: Lines 623-638
    - Error: "A special issue of HEPC can only exist for the disability Hepatitis"
    - Note: HEPC is unreachable (schema enum only allows ["POW", "EMP"])
    - Kept for future compatibility if schema changes

  3. Section 7.w - POW Special Issue ✅ Implemented
  - FES Doc: POW special issue requires confinements
  - Code: Lines 640-662
  - Error: "serviceInformation.confinements (index) is required if specialIssues includes POW."
  - Additional validation from existing code: POW cannot be used with INCREASE
  - Error: "disabilityActionType (index) cannot be INCREASE if specialIssues includes POW for."

  4. Section 7.x - Duplicate Disability Names ✅ Implemented
    - FES Doc: Check for duplicate disability names
    - Code: Lines 664-673
    - Error: "Duplicate disability name found: {name}"
    - Validates: No duplicate disability names allowed (case-insensitive)

  Additional Changes:

  5. POW + INCREASE validation ✅ Added (found missing from original)
    - Added specific check matching existing validation
    - Error matches original: "disabilityActionType (index) cannot be INCREASE if specialIssues includes POW for."
    - This was missing initially but exists in original disability_compensation_validation.rb

  6. BRD Mocking ✅ Inherited from Part 3
    - Uses fetch_countries_list method for local testing
    - Environment variable: MOCK_BRD_COUNTRIES=true
