### PR TITLE
118335 Update MHVJwtSessionClient redis caching to use appropriate values (with flag)

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1439,6 +1439,10 @@ features:
     actor_type: user
     description: Enables/disables the use of pre-transformed vital objects
     enable_in_development: true
+  mhv_medical_records_uuid_for_jwt_session_locking:
+    actor_type: user
+    description: Use UUID instead of ICN for locking MHV JWT sessions
+    enable_in_development: true
   mhv_medications_display_documentation_content:
     actor_type: user
     description: Enables/disables documentation-related content for Medications on VA.gov

--- a/lib/common/client/concerns/mhv_fhir_session_client.rb
+++ b/lib/common/client/concerns/mhv_fhir_session_client.rb
@@ -124,7 +124,8 @@ module Common
         # @return [MedicalRecords::ClientSession] the updated session
         #
         def save_session
-          new_session = @session.class.new(user_id: session.user_id.to_s,
+          new_session = @session.class.new(user_uuid: session.user_uuid,
+                                           user_id: session.user_id.to_s,
                                            patient_fhir_id: session.patient_fhir_id,
                                            icn: session.icn,
                                            expires_at: session.expires_at,

--- a/lib/common/client/concerns/mhv_jwt_session_client.rb
+++ b/lib/common/client/concerns/mhv_jwt_session_client.rb
@@ -20,7 +20,7 @@ module Common
         protected
 
         def user_key
-          session.icn
+          session.user_uuid
         end
 
         def session_config_key

--- a/lib/common/client/concerns/mhv_jwt_session_client.rb
+++ b/lib/common/client/concerns/mhv_jwt_session_client.rb
@@ -20,7 +20,11 @@ module Common
         protected
 
         def user_key
-          session.user_uuid
+          if Flipper.enabled?(:mhv_medical_records_uuid_for_jwt_session_locking)
+            session.user_uuid
+          else
+            session.icn
+          end
         end
 
         def session_config_key

--- a/lib/medical_records/client_session.rb
+++ b/lib/medical_records/client_session.rb
@@ -4,6 +4,7 @@ require 'common/client/session'
 
 module MedicalRecords
   class ClientSession < Common::Client::Session
+    attribute :user_uuid, String
     attribute :patient_fhir_id, Integer
     attribute :icn, String
     attribute :refresh_time, Date

--- a/modules/my_health/app/controllers/my_health/mr_controller.rb
+++ b/modules/my_health/app/controllers/my_health/mr_controller.rb
@@ -61,7 +61,8 @@ module MyHealth
 
     def create_medical_records_client
       medical_records_client = MedicalRecords::Client.new(
-        session: { user_id: current_user.mhv_correlation_id,
+        session: { user_uuid: current_user.user_account_uuid,
+                   user_id: current_user.mhv_correlation_id,
                    icn: current_user.icn }
       )
       if Flipper.enabled?(:mhv_accelerated_delivery_uhd_vista_lab_type_logging_enabled, @current_user)

--- a/spec/lib/common/client/concerns/mhv_jwt_session_client_spec.rb
+++ b/spec/lib/common/client/concerns/mhv_jwt_session_client_spec.rb
@@ -43,9 +43,26 @@ describe Common::Client::Concerns::MHVJwtSessionClient do
   describe '#user_key' do
     let(:session_data) { OpenStruct.new(user_uuid: '12345', icn: 'ABC') }
 
-    it 'returns the user UUID' do
-      user_key = dummy_instance.test_user_key
-      expect(user_key).to eq('12345')
+    context 'when feature flag is enabled' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:mhv_medical_records_uuid_for_jwt_session_locking).and_return(true)
+      end
+
+      it 'returns the user UUID' do
+        user_key = dummy_instance.test_user_key
+        expect(user_key).to eq('12345')
+      end
+    end
+
+    context 'when feature flag is disabled' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:mhv_medical_records_uuid_for_jwt_session_locking).and_return(false)
+      end
+
+      it 'returns the user UUID' do
+        user_key = dummy_instance.test_user_key
+        expect(user_key).to eq('ABC')
+      end
     end
   end
 

--- a/spec/lib/common/client/concerns/mhv_jwt_session_client_spec.rb
+++ b/spec/lib/common/client/concerns/mhv_jwt_session_client_spec.rb
@@ -21,20 +21,6 @@ describe Common::Client::Concerns::MHVJwtSessionClient do
       def config
         OpenStruct.new(app_token: 'sample_token')
       end
-
-      # The following methods are wrappers around private/protected methods, so they can be tested here.
-
-      def test_user_key
-        user_key
-      end
-
-      def test_get_jwt_from_headers(headers)
-        get_jwt_from_headers(headers)
-      end
-
-      def test_decode_jwt_token(jwt_token)
-        decode_jwt_token(jwt_token)
-      end
     end
   end
 
@@ -49,7 +35,7 @@ describe Common::Client::Concerns::MHVJwtSessionClient do
       end
 
       it 'returns the user UUID' do
-        user_key = dummy_instance.test_user_key
+        user_key = dummy_instance.send(:user_key)
         expect(user_key).to eq('12345')
       end
     end
@@ -59,8 +45,8 @@ describe Common::Client::Concerns::MHVJwtSessionClient do
         allow(Flipper).to receive(:enabled?).with(:mhv_medical_records_uuid_for_jwt_session_locking).and_return(false)
       end
 
-      it 'returns the user UUID' do
-        user_key = dummy_instance.test_user_key
+      it 'returns the user ICN' do
+        user_key = dummy_instance.send(:user_key)
         expect(user_key).to eq('ABC')
       end
     end
@@ -105,7 +91,7 @@ describe Common::Client::Concerns::MHVJwtSessionClient do
     context 'when authorization header is properly formatted' do
       it 'returns the JWT token' do
         headers = { 'x-amzn-remapped-authorization' => 'Bearer sample.jwt.token' }
-        token = dummy_instance.test_get_jwt_from_headers(headers)
+        token = dummy_instance.send(:get_jwt_from_headers, headers)
         expect(token).to eq('sample.jwt.token')
       end
     end
@@ -113,7 +99,7 @@ describe Common::Client::Concerns::MHVJwtSessionClient do
     context 'when authorization header is missing' do
       it 'raises an Unauthorized exception' do
         headers = {}
-        expect { dummy_instance.test_get_jwt_from_headers(headers) }
+        expect { dummy_instance.send(:get_jwt_from_headers, headers) }
           .to raise_error(Common::Exceptions::Unauthorized)
       end
     end
@@ -121,7 +107,7 @@ describe Common::Client::Concerns::MHVJwtSessionClient do
     context 'when authorization header does not start with Bearer' do
       it 'raises an Unauthorized exception' do
         headers = { 'authorization' => 'sample.jwt.token' }
-        expect { dummy_instance.test_get_jwt_from_headers(headers) }
+        expect { dummy_instance.send(:get_jwt_from_headers, headers) }
           .to raise_error(Common::Exceptions::Unauthorized)
       end
     end
@@ -138,20 +124,18 @@ describe Common::Client::Concerns::MHVJwtSessionClient do
       end
 
       it 'decodes the JWT token successfully' do
-        expect(dummy_instance.test_decode_jwt_token(valid_jwt_token)).to eq([{ 'some' => 'data' }])
+        expect(dummy_instance.send(:decode_jwt_token, valid_jwt_token)).to eq([{ 'some' => 'data' }])
       end
     end
 
     context 'when token is invalid' do
       before do
-        allow(JWT).to receive(:decode).with(invalid_jwt_token, nil, false)
-                                      .and_raise(JWT::DecodeError.new)
+        allow(JWT).to receive(:decode).with(invalid_jwt_token, nil, false).and_raise(JWT::DecodeError.new)
       end
 
       it 'raises an Unauthorized exception' do
-        expect do
-          dummy_instance.test_decode_jwt_token(invalid_jwt_token)
-        end.to raise_error(Common::Exceptions::Unauthorized)
+        expect { dummy_instance.send(:decode_jwt_token, invalid_jwt_token) }
+          .to raise_error(Common::Exceptions::Unauthorized)
       end
     end
   end

--- a/spec/lib/common/client/concerns/mhv_jwt_session_client_spec.rb
+++ b/spec/lib/common/client/concerns/mhv_jwt_session_client_spec.rb
@@ -15,14 +15,18 @@ describe Common::Client::Concerns::MHVJwtSessionClient do
       end
 
       def session
-        @session || OpenStruct.new(icn: 'ABC')
+        @session || OpenStruct.new(user_uuid: '12345', icn: 'ABC')
       end
 
       def config
         OpenStruct.new(app_token: 'sample_token')
       end
 
-      # The following methods are wrappers around private methods, so they can be tested here.
+      # The following methods are wrappers around private/protected methods, so they can be tested here.
+
+      def test_user_key
+        user_key
+      end
 
       def test_get_jwt_from_headers(headers)
         get_jwt_from_headers(headers)
@@ -35,6 +39,15 @@ describe Common::Client::Concerns::MHVJwtSessionClient do
   end
 
   let(:dummy_instance) { dummy_class.new(session: session_data) }
+
+  describe '#user_key' do
+    let(:session_data) { OpenStruct.new(user_uuid: '12345', icn: 'ABC') }
+
+    it 'returns the user UUID' do
+      user_key = dummy_instance.test_user_key
+      expect(user_key).to eq('12345')
+    end
+  end
 
   describe '#validate_session_params' do
     context 'when icn and app_token are present' do

--- a/spec/lib/medical_records/client_spec.rb
+++ b/spec/lib/medical_records/client_spec.rb
@@ -18,7 +18,8 @@ describe MedicalRecords::Client do
         VCR.use_cassette 'mr_client/session' do
           VCR.use_cassette 'mr_client/get_a_patient_by_identifier' do
             @client ||= begin
-              client = MedicalRecords::Client.new(session: { user_id: '22406991', icn: '1013868614V792025' })
+              client = MedicalRecords::Client.new(session: { user_uuid: '12345', user_id: '22406991',
+                                                             icn: '1013868614V792025' })
               client.authenticate
               client
             end
@@ -642,10 +643,9 @@ describe MedicalRecords::Client do
                        match_requests_on: %i[method sm_user_ignoring_path_param]) do
         VCR.use_cassette 'mr_client/session' do
           VCR.use_cassette 'mr_client/get_a_patient_by_identifier_not_found' do
-            partial_client = MedicalRecords::Client.new(session: {
-                                                          user_id: '22406991',
-                                                          icn: '1013868614V792025'
-                                                        })
+            partial_client = MedicalRecords::Client.new(session: { user_uuid: '12345',
+                                                                   user_id: '22406991',
+                                                                   icn: '1013868614V792025' })
             partial_client.authenticate
 
             VCR.use_cassette 'mr_client/get_a_list_of_allergies' do

--- a/spec/support/mr_client_helpers.rb
+++ b/spec/support/mr_client_helpers.rb
@@ -7,7 +7,8 @@ module MedicalRecords
     TOKEN = 'SESSION_TOKEN'
 
     def authenticated_client
-      MedicalRecords::Client.new(session: { user_id: 11_898_795,
+      MedicalRecords::Client.new(session: { user_uuid: '12345',
+                                            user_id: 11_898_795,
                                             icn: '123ABC',
                                             patient_fhir_id: 2952,
                                             expires_at: Time.current + (60 * 60),


### PR DESCRIPTION
## Summary

- Previously, MHV FHIR sessions were keyed by ICN. I have updated this to now be keyed by `current_user.uuid`.
- I am now persisting `user_uuid` when saving the session in `MhvFhirSessionClient`
- This is now behind a feature flag, `mhv_medical_records_uuid_for_jwt_session_locking`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118335

## Testing done

- [x] *New code is covered by unit tests*
- This change should be fully transparent to the user.
- Accessing MHV Medical Records should work normally.
- Specs were added/updated to accommodate the change.
- Feature flag is tested on and off

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
MHV Medical Records

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
