### PR TITLE
Add single condition endpoint to v2 conditions API

### DIFF
--- a/lib/unified_health_data/service.rb
+++ b/lib/unified_health_data/service.rb
@@ -62,6 +62,25 @@ module UnifiedHealthData
       end
     end
 
+    def get_single_condition(condition_id)
+      with_monitoring do
+        headers = { 'Authorization' => fetch_access_token, 'x-api-key' => config.x_api_key }
+        patient_id = @user.icn
+
+        start_date = '1900-01-01'
+        end_date = Time.zone.today.to_s
+
+        path = "#{config.base_path}conditions?patientId=#{patient_id}&startDate=#{start_date}&endDate=#{end_date}"
+        response = perform(:get, path, nil, headers)
+        body = parse_response_body(response.body)
+
+        combined_records = fetch_combined_records(body)
+        conditions = conditions_adapter.parse(combined_records)
+        
+        conditions.find { |condition| condition.id == condition_id }
+      end
+    end
+
     def get_care_summaries_and_notes
       with_monitoring do
         patient_id = @user.icn

--- a/modules/my_health/app/controllers/my_health/v2/conditions_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v2/conditions_controller.rb
@@ -18,6 +18,21 @@ module MyHealth
         handle_error(e)
       end
 
+      def show
+        condition = service.get_single_condition(params[:id])
+        if condition
+          render json: UnifiedHealthData::Serializers::ConditionSerializer.new(condition),
+                 status: :ok
+        else
+          render json: { errors: [{ title: 'Condition not found', status: '404', code: '404' }] },
+                 status: :not_found
+        end
+      rescue Common::Client::Errors::ClientError,
+             Common::Exceptions::BackendServiceException,
+             StandardError => e
+        handle_error(e)
+      end
+
       private
 
       def handle_error(error)

--- a/modules/my_health/config/routes.rb
+++ b/modules/my_health/config/routes.rb
@@ -6,7 +6,7 @@ MyHealth::Engine.routes.draw do
       resources :clinical_notes, only: %i[index show], defaults: { format: :json }
       resources :labs_and_tests, only: %i[index], defaults: { format: :json }
       resources :immunizations, only: %i[index show], defaults: { format: :json }
-      resources :conditions, only: %i[index], defaults: { format: :json }
+      resources :conditions, only: %i[index show], defaults: { format: :json }
     end
   end
 

--- a/modules/my_health/spec/requests/my_health/v2/conditions_spec.rb
+++ b/modules/my_health/spec/requests/my_health/v2/conditions_spec.rb
@@ -25,6 +25,29 @@ RSpec.describe 'MyHealth::V2::ConditionsController', :skip_json_api_validation, 
       parsed_response = JSON.parse(response.body)
       expect(parsed_response).to have_key('data')
       expect(parsed_response['data']).to be_an(Array)
+
+      if parsed_response['data'].any?
+        condition = parsed_response['data'].first
+        expect(condition).to have_key('id')
+        expect(condition).to have_key('type')
+        expect(condition).to have_key('attributes')
+        expect(condition['type']).to eq('condition')
+
+        attributes = condition['attributes']
+        expect(attributes).to have_key('id')
+        expect(attributes).to have_key('name')
+        expect(attributes).to have_key('date')
+        expect(attributes).to have_key('provider')
+        expect(attributes).to have_key('facility')
+        expect(attributes).to have_key('comments')
+
+        expect(attributes['id']).to be_a(String)
+        expect(attributes['name']).to be_a(String)
+        expect(attributes['date']).to be_a(String).or(be_nil)
+        expect(attributes['provider']).to be_a(String).or(be_nil)
+        expect(attributes['facility']).to be_a(String).or(be_nil)
+        expect(attributes['comments']).to be_an(Array).or(be_nil)
+      end
     end
 
     it 'returns empty array when no conditions found' do
@@ -46,6 +69,66 @@ RSpec.describe 'MyHealth::V2::ConditionsController', :skip_json_api_validation, 
       expect(response).to have_http_status(:internal_server_error)
       parsed_response = JSON.parse(response.body)
       expect(parsed_response).to have_key('errors')
+    end
+  end
+
+  describe 'GET /my_health/v2/medical_records/conditions/:id' do
+    let(:show_path) { "#{path}/condition-12345" }
+
+    it 'returns a single condition successfully' do
+      VCR.use_cassette('unified_health_data/get_conditions_200', match_requests_on: %i[method path]) do
+        get show_path, headers: { 'X-Key-Inflection' => 'camel' }
+      end
+
+      expect(response).to have_http_status(:ok)
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response).to have_key('data')
+      expect(parsed_response['data']).to be_a(Hash)
+      expect(parsed_response['data']['id']).to eq('condition-12345')
+
+      condition = parsed_response['data']
+      expect(condition).to have_key('id')
+      expect(condition).to have_key('type')
+      expect(condition).to have_key('attributes')
+      expect(condition['type']).to eq('condition')
+
+      attributes = condition['attributes']
+      expect(attributes).to have_key('id')
+      expect(attributes).to have_key('name')
+      expect(attributes).to have_key('date')
+      expect(attributes).to have_key('provider')
+      expect(attributes).to have_key('facility')
+      expect(attributes).to have_key('comments')
+
+      expect(attributes['id']).to be_a(String)
+      expect(attributes['name']).to be_a(String)
+      expect(attributes['date']).to be_a(String).or(be_nil)
+      expect(attributes['provider']).to be_a(String).or(be_nil)
+      expect(attributes['facility']).to be_a(String).or(be_nil)
+      expect(attributes['comments']).to be_an(Array).or(be_nil)
+    end
+
+    it 'returns 404 when condition not found' do
+      VCR.use_cassette('unified_health_data/get_conditions_200', match_requests_on: %i[method path]) do
+        get "#{path}/nonexistent-id", headers: { 'X-Key-Inflection' => 'camel' }
+      end
+
+      expect(response).to have_http_status(:not_found)
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response).to have_key('errors')
+      expect(parsed_response['errors'].first['title']).to eq('Condition not found')
+    end
+
+    it 'returns error response when there is a client error' do
+      allow_any_instance_of(UnifiedHealthData::Service).to receive(:get_single_condition)
+        .and_raise(Common::Client::Errors::ClientError.new(Faraday::ClientError.new))
+
+      # This cassette doesn't matter since we're stubbing the service call to raise an error
+      VCR.use_cassette('unified_health_data/get_conditions_200') do
+        get show_path, headers: { 'X-Key-Inflection' => 'camel' }
+      end
+
+      expect(response).to have_http_status(:bad_gateway)
     end
   end
 end

--- a/spec/lib/unified_health_data/service_spec.rb
+++ b/spec/lib/unified_health_data/service_spec.rb
@@ -1379,5 +1379,44 @@ describe UnifiedHealthData::Service, type: :service do
       expect { service.get_conditions }.not_to raise_error
       expect(service.get_conditions).to be_an(Array)
     end
+
+    describe '#get_single_condition' do
+      let(:condition_id) { '2b4de3e7-0ced-43c6-9a8a-336b9171f4df' }
+
+      it 'returns a single condition when found' do
+        allow(service).to receive_messages(
+          perform: double(body: conditions_sample_response),
+          parse_response_body: conditions_sample_response
+        )
+
+        condition = service.get_single_condition(condition_id)
+        expect(condition).to be_a(UnifiedHealthData::Condition)
+        expect(condition.id).to eq(condition_id)
+        expect(condition.name).to eq('Major depressive disorder, recurrent, moderate')
+        expect(condition.provider).to eq('BORLAND,VICTORIA A')
+        expect(condition.facility).to eq('CHYSHR TEST LAB')
+      end
+
+      it 'returns nil when condition not found' do
+        allow(service).to receive_messages(
+          perform: double(body: conditions_empty_response),
+          parse_response_body: conditions_empty_response
+        )
+
+        condition = service.get_single_condition('nonexistent-id')
+        expect(condition).to be_nil
+      end
+
+      it 'handles malformed responses gracefully' do
+        allow(service).to receive_messages(
+          perform: double(body: 'invalid'),
+          parse_response_body: nil
+        )
+
+        expect { service.get_single_condition(condition_id) }.not_to raise_error
+        condition = service.get_single_condition(condition_id)
+        expect(condition).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- Added a single condition endpoint (GET /my_health/v2/medical_records/conditions/:id) to the v2 conditions API to allow fetching individual condition records by ID
- Enhanced the UnifiedHealthData::Service with a get_single_condition method that filters conditions by ID
- Added comprehensive test coverage validating both response structure and data types
- Team: MHV Medical Records - Yes, our team owns the maintenance of this component

## Related issue(s)

- https://github.com/orgs/department-of-veterans-affairs/projects/1728/views/3?pane=issue&itemId=128337915&issue=department-of-veterans-affairs%7Cva.gov-team%7C119217
- https://github.com/department-of-veterans-affairs/vets-api/pull/23800

## Testing done

- [x] *New code is covered by unit tests*
- Old behavior: Only index endpoint was available - users could only fetch all conditions at once
- New behavior: Users can now fetch individual conditions by ID with proper 404 handling when condition not found
- Testing steps to verify changes:
Start local server with rails server
Make GET request to /my_health/v2/medical_records/conditions to verify existing functionality still works
Make GET request to /my_health/v2/medical_records/conditions/{valid_id} to verify single condition retrieval
Make GET request to /my_health/v2/medical_records/conditions/invalid-id to verify 404 response
Verify response structure matches JSON:API format with proper attributes

## What areas of the site does it impact?
- MyHealth V2 Conditions API - adds new show endpoint
- UnifiedHealthData::Service - adds new method for single condition retrieval
- No other areas impacted - changes are isolated to conditions functionality

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature
- [x] No error nor warning in the console
- [x] Events are being sent to the appropriate logging solution (existing error logging maintained)
- [x] No sensitive information is captured in logging, hardcoded, or specs
- [x] Feature has proper error handling and monitoring through existing patterns
- [x] All authenticated routes work as expected (tested locally)
- [x] Comprehensive test coverage validates response structure and data types

