### PR TITLE
Restore safe error logging for 686C-674 VBMS upload flow

### DIFF
--- a/app/services/bgs/dependent_service.rb
+++ b/app/services/bgs/dependent_service.rb
@@ -107,10 +107,11 @@ module BGS
 
       @monitor.track_event('info', 'BGS::DependentService#submit_pdf_job completed',
                            "#{STATS_KEY}.submit_pdf.completed")
-    rescue
+    rescue => e
+      error = Flipper.enabled?(:dependents_log_vbms_errors) ? e.message : '[REDACTED]'
       @monitor.track_event('warn',
                            'BGS::DependentService#submit_pdf_job failed, submitting to Lighthouse Benefits Intake',
-                           "#{STATS_KEY}.submit_pdf.failure")
+                           "#{STATS_KEY}.submit_pdf.failure", { error: })
       raise PDFSubmissionError
     end
 

--- a/app/services/bgs/dependent_v2_service.rb
+++ b/app/services/bgs/dependent_v2_service.rb
@@ -141,10 +141,11 @@ module BGS
 
       @monitor.track_event('info', 'BGS::DependentV2Service#submit_pdf_job completed',
                            "#{STATS_KEY}.submit_pdf.completed")
-    rescue
+    rescue => e
+      error = Flipper.enabled?(:dependents_log_vbms_errors) ? e.message : '[REDACTED]'
       @monitor.track_event('warn',
                            'BGS::DependentV2Service#submit_pdf_job failed, submitting to Lighthouse Benefits Intake',
-                           "#{STATS_KEY}.submit_pdf.failure")
+                           "#{STATS_KEY}.submit_pdf.failure", { error: })
       raise PDFSubmissionError
     end
 

--- a/app/sidekiq/vbms/submit_dependents_pdf_job.rb
+++ b/app/sidekiq/vbms/submit_dependents_pdf_job.rb
@@ -15,9 +15,9 @@ module VBMS
 
     STATSD_KEY = 'worker.submit_dependents_pdf'
 
-    sidekiq_retries_exhausted do |msg, error|
+    sidekiq_retries_exhausted do |msg, _error|
       Rails.logger.error('VBMS::SubmitDependentsPdfJob failed, retries exhausted!',
-                         { saved_claim_id: msg['args'][0], error: })
+                         { saved_claim_id: msg['args'][0] })
     end
 
     # Generates PDF for 686c form and uploads to VBMS
@@ -34,9 +34,10 @@ module VBMS
 
       generate_pdf(submittable_686_form, submittable_674_form)
       monitor.track_event('info', 'VBMS::SubmitDependentsPdfJob succeeded!', "#{STATSD_KEY}.success")
-    rescue
+    rescue => e
+      error = Flipper.enabled?(:dependents_log_vbms_errors) ? e.message : '[REDACTED]'
       monitor.track_event('error', 'VBMS::SubmitDependentsPdfJob failed!',
-                          "#{STATSD_KEY}.failure")
+                          "#{STATSD_KEY}.failure", { error: })
       @saved_claim_id = saved_claim_id
       raise
     end

--- a/app/sidekiq/vbms/submit_dependents_pdf_v2_job.rb
+++ b/app/sidekiq/vbms/submit_dependents_pdf_v2_job.rb
@@ -15,9 +15,9 @@ module VBMS
 
     STATSD_KEY = 'worker.submit_dependents_pdf'
 
-    sidekiq_retries_exhausted do |msg, error|
+    sidekiq_retries_exhausted do |msg, _error|
       Rails.logger.error('VBMS::SubmitDependentsPdfJob failed, retries exhausted!',
-                         { saved_claim_id: msg['args'][0], error: })
+                         { saved_claim_id: msg['args'][0] })
     end
 
     # Generates PDF for 686c form and uploads to VBMS
@@ -34,9 +34,10 @@ module VBMS
 
       generate_pdf(submittable_686_form, submittable_674_form)
       monitor.track_event('info', 'VBMS::SubmitDependentsPdfJob succeeded!', "#{STATSD_KEY}.success")
-    rescue
+    rescue => e
+      error = Flipper.enabled?(:dependents_log_vbms_errors) ? e.message : '[REDACTED]'
       monitor.track_event('error', 'VBMS::SubmitDependentsPdfJob failed!',
-                          "#{STATSD_KEY}.failure")
+                          "#{STATSD_KEY}.failure", { error: })
       @saved_claim_id = saved_claim_id
       raise
     end

--- a/config/features.yml
+++ b/config/features.yml
@@ -656,6 +656,10 @@ features:
     actor_type: user
     description: Manage whether the enqueued job for 686c and 674 will be with a User model or the new User struct
     enable_in_development: true
+  dependents_log_vbms_errors:
+    actor_type: user
+    description: Log VBMS errors when submitting 686c and 674
+    enable_in_development: true
   dependents_module_enabled:
     actor_type: user
     description: Enables new Dependents module

--- a/lib/dependents/monitor.rb
+++ b/lib/dependents/monitor.rb
@@ -113,6 +113,14 @@ module Dependents
                                e, user_account_uuid)
     end
 
+    def track_pdf_upload_error
+      metric = "#{CLAIM_STATS_KEY}.upload_pdf.failure"
+      metric = "#{metric}.v2" if @use_v2
+      payload = default_payload.merge({ statsd: metric })
+
+      track_event('error', 'DependencyClaim error in upload_to_vbms method', metric, payload)
+    end
+
     def track_to_pdf_failure(e, form_id)
       metric = "#{CLAIM_STATS_KEY}.to_pdf.failure"
       metric = "#{metric}.v2" if @use_v2


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES* 
- This PR restores targeted error logging using PII redaction capabilities added in #23760

## Background
On August 14, we discovered PII leaks in logs when error messages from VBMS (third-party service) were logged directly. As an immediate mitigation, we removed all error logging in the VBMS upload flow, which stopped PII leaks but eliminated crucial debugging context.

## Problem
The current implementation prevents PII leaks but makes debugging difficult:

- Unable to distinguish between application errors and third-party service failures
- Loss of error context throughout the entire 686C-674 submission flow
- Overly broad removal of logging beyond just the VBMS response handling

## Solution
This PR restores targeted error logging using PII redaction capabilities added in #23760:
- Restore error logging throughout the 686C-674 VBMS submission flow using monitor methods that apply regex-based PII redaction
- Maintain PII protection - the actual VBMS call remains in a rescue block that does NOT log or re-raise third-party error messages
- Improve debugging - developers can now identify whether failures originate from our code or external services

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117796

## Testing done

- [ ] *New code is covered by unit tests*
- [ ] Verified PII redaction works correctly with monitor logging
 - [ ] Confirmed VBMS errors do not leak third-party error messages
 - [ ] Validated error context is now available for debugging

## Example Log Output
Note that tthe initial log doesn't record the VBMS error, and the followign logs have received the generic `"VBMS Upload Error"`.
```
2025-09-15 14:46:40.314625 E [46187:puma srv tp 002 monitor.rb:37] Rails -- DependencyClaim error in upload_to_vbms method -- { :statsd => "dependent-change.upload_pdf.failure.v2", :service => "dependents-application", :function => "track_event", :file => "/Users/taicorraggio/Desktop/Projects/vets-api/lib/dependents/monitor.rb", :line => 149, :context => { :confirmation_number => "3d551e9b-71ed-48c1-9edf-371bb1b3e65e", :user_account_uuid => nil, :claim_id => 71, :form_id => "686C-674-V2", :tags => [ "service:dependents-application", "v2:true" ], :service => "dependents-application", :use_v2 => true, :statsd => "dependent-change.upload_pdf.failure.v2" } }
2025-09-15 14:46:40.315767 D [46187:puma srv tp 002] ActiveRecord::Base --   Flipper::Adapters::ActiveRecord::Gate Pluck (0.7ms)  SELECT "flipper_gates"."key", "flipper_gates"."value" FROM "flipper_gates" WHERE "flipper_gates"."feature_key" = $1  [["feature_key", "dependents_log_vbms_errors"]]
2025-09-15 14:46:40.315977 D [46187:puma srv tp 002] ActiveRecord::Base --   ↳ app/sidekiq/vbms/submit_dependents_pdf_v2_job.rb:38:in `rescue in perform'
2025-09-15 14:46:40.316392 E [46187:puma srv tp 002 monitor.rb:37] Rails -- VBMS::SubmitDependentsPdfJob failed! -- { :statsd => "worker.submit_dependents_pdf.failure", :service => "dependents-application", :function => "track_event", :file => "/Users/taicorraggio/Desktop/Projects/vets-api/lib/dependents/monitor.rb", :line => 149, :context => { :confirmation_number => "3d551e9b-71ed-48c1-9edf-371bb1b3e65e", :user_account_uuid => nil, :claim_id => 71, :form_id => "686C-674-V2", :tags => [ "service:dependents-application", "v2:true" ], :service => "dependents-application", :use_v2 => true, :error => "VBMS Upload Error" } }
2025-09-15 14:46:40.316747 W [46187:puma srv tp 002] Rails -- BGS::DependentV2Service#submit_pdf_job failed, submitting to Lighthouse Benefits Intake -- { :statsd => "bgs.dependent_service.submit_pdf.failure", :service => "dependents-application", :function => "track_event", :file => "/Users/taicorraggio/Desktop/Projects/vets-api/lib/dependents/monitor.rb", :line => 149, :context => { :confirmation_number => "3d551e9b-71ed-48c1-9edf-371bb1b3e65e", :user_account_uuid => nil, :claim_id => 71, :form_id => "686C-674-V2", :tags => [ "service:dependents-application", "v2:true" ], :service => "dependents-application", :use_v2 => true, :error => "VBMS Upload Error" } }
```

## What areas of the site does it impact?
Dependents Benefits

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

