### PR TITLE
Add credential_attributes_digest to user_verification

### DIFF
--- a/db/migrate/20250915190655_add_credential_attributes_digest_column_to_user_verifications.rb
+++ b/db/migrate/20250915190655_add_credential_attributes_digest_column_to_user_verifications.rb
@@ -1,0 +1,5 @@
+class AddCredentialAttributesDigestColumnToUserVerifications < ActiveRecord::Migration[7.2]
+  def change
+    add_column :user_verifications, :credential_attributes_digest, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1787,6 +1787,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_16_114106) do
     t.datetime "updated_at", null: false
     t.string "backing_idme_uuid"
     t.boolean "locked", default: false, null: false
+    t.string "credential_attributes_digest"
     t.index ["backing_idme_uuid"], name: "index_user_verifications_on_backing_idme_uuid"
     t.index ["dslogon_uuid"], name: "index_user_verifications_on_dslogon_uuid", unique: true
     t.index ["idme_uuid"], name: "index_user_verifications_on_idme_uuid", unique: true


### PR DESCRIPTION
## Summary

- Add `credential_attributes_digest` column to `user_verifications`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/703

## Testing 
- Run migrations - `rails db:migrate`

## What areas of the site does it impact?
user_verifications table