### PR TITLE
Fix Kafka exhaustion error 

### DIFF
--- a/lib/kafka/sidekiq/event_bus_submission_job.rb
+++ b/lib/kafka/sidekiq/event_bus_submission_job.rb
@@ -15,7 +15,7 @@ module Kafka
       monitor = Kafka::Monitor.new
       payload = msg['args'].first
       use_test_topic = msg['args'].second
-      topic = get_topic(use_test_topic:)
+      topic = Kafka.get_topic(use_test_topic:)
       redacted_payload = Kafka.redact_icn(payload)
 
       monitor.track_submission_exhaustion(msg, topic, redacted_payload)

--- a/spec/lib/kafka/event_bus_submission_job_spec.rb
+++ b/spec/lib/kafka/event_bus_submission_job_spec.rb
@@ -52,9 +52,8 @@ RSpec.describe Kafka::EventBusSubmissionJob, type: :job do
     end
 
     it 'tracks submission exhaustion and emits StatsD metric' do
-      described_class.within_sidekiq_retries_exhausted_block(exhaustion_msg) do
-        expect(StatsD).to receive(:increment).with('api.kafka_service.exhausted', tags: anything)
-      end
+      expect(StatsD).to receive(:increment).with('api.kafka_service.exhausted', tags: anything)
+      described_class.sidekiq_retries_exhausted_block.call(exhaustion_msg)
     end
   end
 end

--- a/spec/lib/kafka/event_bus_submission_job_spec.rb
+++ b/spec/lib/kafka/event_bus_submission_job_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe Kafka::EventBusSubmissionJob, type: :job do
     end
 
     it 'tracks submission exhaustion and emits StatsD metric' do
-
       described_class.within_sidekiq_retries_exhausted_block(exhaustion_msg) do
         expect(StatsD).to receive(:increment).with('api.kafka_service.exhausted', tags: anything)
       end

--- a/spec/lib/kafka/event_bus_submission_job_spec.rb
+++ b/spec/lib/kafka/event_bus_submission_job_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Kafka::EventBusSubmissionJob, type: :job do
 
   describe '#perform' do
     before do
+      allow(Kafka::Monitor).to receive(:new).and_return(monitor)
       allow(Kafka::AvroProducer).to receive(:new).and_return(producer)
       allow(producer).to receive(:produce)
-      allow(Kafka::Monitor).to receive(:new).and_return(monitor)
       allow(monitor).to receive(:track_submission_success)
       allow(monitor).to receive(:track_submission_failure)
     end


### PR DESCRIPTION
## Summary
- In the sidekiq_retries_exhausted block of Kafka::EventBusSubmissionJob, the code was calling get_topic(use_test_topic:) as an instance method, but get_topic is defined as a class method on the Kafka module. This caused a NoMethodError when the exhausted callback executed, preventing the metric from being emitted.

## Related issue(s)

- https://github.com/orgs/department-of-veterans-affairs/projects/1509/views/23?pane=issue&itemId=127917984&issue=department-of-veterans-affairs%7CVES%7C5383

## Testing done

- Added spec to test exhaustion block 

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
