### PR TITLE
Changed UUM feature disabled HTTP code to 2xx

### DIFF
--- a/modules/my_health/app/controllers/my_health/v1/unique_user_metrics_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/unique_user_metrics_controller.rb
@@ -11,7 +11,6 @@ module MyHealth
     class UniqueUserMetricsController < ApplicationController
       service_tag 'mhv-metrics'
       before_action :authenticate
-      before_action :check_feature_enabled
 
       ##
       # Creates unique user metric events for the authenticated user.
@@ -23,7 +22,7 @@ module MyHealth
       #     "event_names": ["mhv_landing_page_accessed", "secure_messaging_accessed"]
       #   }
       #
-      # @example Success response (200 OK or 201 Created)
+      # @example Success response when feature enabled (200 OK or 201 Created)
       #   {
       #     "results": [
       #       { "event_name": "mhv_landing_page_accessed", "status": "created", "new_event": true },
@@ -31,9 +30,20 @@ module MyHealth
       #     ]
       #   }
       #
+      # @example Success response when feature disabled (200 OK)
+      #   {
+      #     "results": [
+      #       { "event_name": "mhv_landing_page_accessed", "status": "disabled", "new_event": false },
+      #       { "event_name": "secure_messaging_accessed", "status": "disabled", "new_event": false }
+      #     ]
+      #   }
+      #
       def create
         user_id = current_user.user_account_uuid
         event_names = metrics_params[:event_names]
+
+        # Check if feature is enabled
+        return handle_disabled_feature(event_names) unless Flipper.enabled?(:unique_user_metrics_logging)
 
         # Process all events and collect results
         results = event_names.map do |event_name|
@@ -87,6 +97,25 @@ module MyHealth
       end
 
       ##
+      # Handles the case when the feature flag is disabled.
+      # Returns a 200 OK response with disabled status for all events.
+      #
+      # @param event_names [Array<String>] Array of event names to mark as disabled
+      # @return [void] Renders JSON response and returns
+      #
+      def handle_disabled_feature(event_names)
+        results = event_names.map do |event_name|
+          {
+            event_name:,
+            status: 'disabled',
+            new_event: false
+          }
+        end
+
+        render json: { results: }, status: :ok
+      end
+
+      ##
       # Validates input parameters and user authentication.
       #
       # @raise [Common::Exceptions::ParameterMissing] if event_names missing
@@ -112,18 +141,6 @@ module MyHealth
             raise Common::Exceptions::InvalidFieldValue.new('event_names', 'must contain non-empty strings')
           end
         end
-      end
-
-      ##
-      # Validates that the feature flag is enabled.
-      #
-      # @raise [Common::Exceptions::NotImplemented] if feature is disabled
-      #
-      def check_feature_enabled
-        return if Flipper.enabled?(:unique_user_metrics_logging)
-
-        raise Common::Exceptions::NotImplemented,
-              detail: 'Unique user metrics logging is not currently available'
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Changed UUM feature disabled HTTP code to 2xx. This allow us to disable the feature without having to include feature flag checks in the FE and not getting flooded with errors in the monitoring.
- Team: MHV Horizon

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/117473

## Testing done
- [X] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
UUM Metrics

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

