### PR TITLE
eps logs and preventing sending no params

### DIFF
--- a/modules/vaos/app/services/eps/provider_service.rb
+++ b/modules/vaos/app/services/eps/provider_service.rb
@@ -11,7 +11,7 @@ module Eps
     #
     def get_provider_service(provider_id:)
       if provider_id.blank?
-        log_no_params_metric
+        log_no_params_metric('get_provider_service')
         raise ArgumentError, 'provider_id is required and cannot be blank'
       end
 
@@ -25,7 +25,7 @@ module Eps
 
     def get_provider_services_by_ids(provider_ids:)
       if provider_ids.blank?
-        log_no_params_metric
+        log_no_params_metric('get_provider_services_by_ids')
         raise ArgumentError, 'provider_ids is required and cannot be blank'
       end
 
@@ -137,10 +137,22 @@ module Eps
     private
 
     ##
-    # Logs StatsD metric for provider service calls with no parameters
+    # Logs StatsD metric and Rails log for provider service calls with no parameters
     #
-    def log_no_params_metric
+    # @param method_name [String] The name of the method being called
+    #
+    def log_no_params_metric(method_name)
+      # Log StatsD metric for monitoring
       StatsD.increment(PROVIDER_SERVICE_NO_PARAMS_METRIC, tags: [COMMUNITY_CARE_SERVICE_TAG])
+
+      # Log Rails warning with context
+      log_data = {
+        method: method_name,
+        service: 'eps_provider_service'
+      }
+      log_data[:user_uuid] = @user.uuid if @user&.uuid
+
+      Rails.logger.warn("#{CC_APPOINTMENTS}: Provider service called with no parameters", log_data)
     end
 
     ##
@@ -165,7 +177,7 @@ module Eps
     #
     def fetch_provider_services(npi)
       if npi.blank?
-        log_no_params_metric
+        log_no_params_metric('fetch_provider_services')
         raise ArgumentError, 'npi is required and cannot be blank'
       end
 

--- a/modules/vaos/app/services/eps/provider_service.rb
+++ b/modules/vaos/app/services/eps/provider_service.rb
@@ -2,12 +2,19 @@
 
 module Eps
   class ProviderService < BaseService
+    # StatsD metrics for provider service calls with no parameters
+    PROVIDER_SERVICE_NO_PARAMS_METRIC = "#{STATSD_PREFIX}.provider_service.no_params".freeze
     ##
     # Get provider data from EPS
     #
     # @return OpenStruct response from EPS provider endpoint
     #
     def get_provider_service(provider_id:)
+      if provider_id.blank?
+        log_no_params_metric
+        raise ArgumentError, 'provider_id is required and cannot be blank'
+      end
+
       with_monitoring do
         response = perform(:get, "/#{config.base_path}/provider-services/#{provider_id}",
                            {}, request_headers_with_correlation_id)
@@ -17,6 +24,11 @@ module Eps
     end
 
     def get_provider_services_by_ids(provider_ids:)
+      if provider_ids.blank?
+        log_no_params_metric
+        raise ArgumentError, 'provider_ids is required and cannot be blank'
+      end
+
       with_monitoring do
         query_object_array = provider_ids.map { |id| "id=#{id}" }
         response = perform(:get, "/#{config.base_path}/provider-services",
@@ -125,6 +137,13 @@ module Eps
     private
 
     ##
+    # Logs StatsD metric for provider service calls with no parameters
+    #
+    def log_no_params_metric
+      StatsD.increment(PROVIDER_SERVICE_NO_PARAMS_METRIC, tags: [COMMUNITY_CARE_SERVICE_TAG])
+    end
+
+    ##
     # Validates required search parameters
     #
     # @param npi [String] Provider NPI
@@ -145,6 +164,11 @@ module Eps
     # @return [Object] Response from EPS API
     #
     def fetch_provider_services(npi)
+      if npi.blank?
+        log_no_params_metric
+        raise ArgumentError, 'npi is required and cannot be blank'
+      end
+
       with_monitoring do
         query_params = { npi:, isSelfSchedulable: true }
         perform(:get, "/#{config.base_path}/provider-services", query_params,

--- a/modules/vaos/spec/services/eps/provider_service_spec.rb
+++ b/modules/vaos/spec/services/eps/provider_service_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe Eps::ProviderService do
   let(:service) { described_class.new(user) }
-  let(:user) { double('User', account_uuid: '1234') }
+  let(:user) { double('User', account_uuid: '1234', uuid: 'user-uuid-123') }
 
   before do
     allow(Rails.logger).to receive(:info)
@@ -64,10 +64,18 @@ describe Eps::ProviderService do
     end
 
     context 'when provider_id parameter is missing or blank' do
-      it 'raises ArgumentError and logs StatsD metric when provider_id is nil' do
+      it 'raises ArgumentError and logs StatsD metric and Rails warning when provider_id is nil' do
         expect(StatsD).to receive(:increment).with(
           'api.vaos.provider_service.no_params',
           tags: ['service:community_care_appointments']
+        )
+        expect(Rails.logger).to receive(:warn).with(
+          'Community Care Appointments: Provider service called with no parameters',
+          hash_including(
+            method: 'get_provider_service',
+            service: 'eps_provider_service',
+            user_uuid: 'user-uuid-123'
+          )
         )
 
         expect do
@@ -75,10 +83,18 @@ describe Eps::ProviderService do
         end.to raise_error(ArgumentError, 'provider_id is required and cannot be blank')
       end
 
-      it 'raises ArgumentError and logs StatsD metric when provider_id is empty string' do
+      it 'raises ArgumentError and logs StatsD metric and Rails warning when provider_id is empty string' do
         expect(StatsD).to receive(:increment).with(
           'api.vaos.provider_service.no_params',
           tags: ['service:community_care_appointments']
+        )
+        expect(Rails.logger).to receive(:warn).with(
+          'Community Care Appointments: Provider service called with no parameters',
+          hash_including(
+            method: 'get_provider_service',
+            service: 'eps_provider_service',
+            user_uuid: 'user-uuid-123'
+          )
         )
 
         expect do
@@ -86,10 +102,18 @@ describe Eps::ProviderService do
         end.to raise_error(ArgumentError, 'provider_id is required and cannot be blank')
       end
 
-      it 'raises ArgumentError and logs StatsD metric when provider_id is blank' do
+      it 'raises ArgumentError and logs StatsD metric and Rails warning when provider_id is blank' do
         expect(StatsD).to receive(:increment).with(
           'api.vaos.provider_service.no_params',
           tags: ['service:community_care_appointments']
+        )
+        expect(Rails.logger).to receive(:warn).with(
+          'Community Care Appointments: Provider service called with no parameters',
+          hash_including(
+            method: 'get_provider_service',
+            service: 'eps_provider_service',
+            user_uuid: 'user-uuid-123'
+          )
         )
 
         expect do
@@ -161,13 +185,13 @@ describe Eps::ProviderService do
 
     context 'when the request is successful' do
       let(:response) do
-        double('Response', status: 200, body: { 
-          count: 2,
-          provider_services: [
-            { id: 'provider1', name: 'Provider 1' },
-            { id: 'provider2', name: 'Provider 2' }
-          ]
-        }, response_headers: { 'Content-Type' => 'application/json' })
+        double('Response', status: 200, body: {
+                 count: 2,
+                 provider_services: [
+                   { id: 'provider1', name: 'Provider 1' },
+                   { id: 'provider2', name: 'Provider 2' }
+                 ]
+               }, response_headers: { 'Content-Type' => 'application/json' })
       end
 
       before do
@@ -199,10 +223,17 @@ describe Eps::ProviderService do
     end
 
     context 'when provider_ids parameter is missing or blank' do
-      it 'raises ArgumentError and logs StatsD metric when provider_ids is nil' do
+      it 'raises ArgumentError and logs StatsD metric and Rails warning when provider_ids is nil' do
         expect(StatsD).to receive(:increment).with(
           'api.vaos.provider_service.no_params',
           tags: ['service:community_care_appointments']
+        )
+        expect(Rails.logger).to receive(:warn).with(
+          'Community Care Appointments: Provider service called with no parameters',
+          hash_including(
+            method: 'get_provider_services_by_ids',
+            service: 'eps_provider_service'
+          )
         )
 
         expect do
@@ -210,10 +241,17 @@ describe Eps::ProviderService do
         end.to raise_error(ArgumentError, 'provider_ids is required and cannot be blank')
       end
 
-      it 'raises ArgumentError and logs StatsD metric when provider_ids is empty array' do
+      it 'raises ArgumentError and logs StatsD metric and Rails warning when provider_ids is empty array' do
         expect(StatsD).to receive(:increment).with(
           'api.vaos.provider_service.no_params',
           tags: ['service:community_care_appointments']
+        )
+        expect(Rails.logger).to receive(:warn).with(
+          'Community Care Appointments: Provider service called with no parameters',
+          hash_including(
+            method: 'get_provider_services_by_ids',
+            service: 'eps_provider_service'
+          )
         )
 
         expect do
@@ -1389,11 +1427,11 @@ describe Eps::ProviderService do
     context 'when the request is successful' do
       let(:response) do
         double('Response', status: 200, body: {
-          count: 1,
-          provider_services: [
-            { id: 'provider1', npi:, name: 'Provider 1' }
-          ]
-        }, response_headers: { 'Content-Type' => 'application/json' })
+                 count: 1,
+                 provider_services: [
+                   { id: 'provider1', npi:, name: 'Provider 1' }
+                 ]
+               }, response_headers: { 'Content-Type' => 'application/json' })
       end
 
       before do
@@ -1436,10 +1474,17 @@ describe Eps::ProviderService do
     end
 
     context 'when npi parameter is missing or blank' do
-      it 'raises ArgumentError and logs StatsD metric when npi is nil' do
+      it 'raises ArgumentError and logs StatsD metric and Rails warning when npi is nil' do
         expect(StatsD).to receive(:increment).with(
           'api.vaos.provider_service.no_params',
           tags: ['service:community_care_appointments']
+        )
+        expect(Rails.logger).to receive(:warn).with(
+          'Community Care Appointments: Provider service called with no parameters',
+          hash_including(
+            method: 'fetch_provider_services',
+            service: 'eps_provider_service'
+          )
         )
 
         expect do
@@ -1447,10 +1492,17 @@ describe Eps::ProviderService do
         end.to raise_error(ArgumentError, 'npi is required and cannot be blank')
       end
 
-      it 'raises ArgumentError and logs StatsD metric when npi is empty string' do
+      it 'raises ArgumentError and logs StatsD metric and Rails warning when npi is empty string' do
         expect(StatsD).to receive(:increment).with(
           'api.vaos.provider_service.no_params',
           tags: ['service:community_care_appointments']
+        )
+        expect(Rails.logger).to receive(:warn).with(
+          'Community Care Appointments: Provider service called with no parameters',
+          hash_including(
+            method: 'fetch_provider_services',
+            service: 'eps_provider_service'
+          )
         )
 
         expect do
@@ -1458,10 +1510,17 @@ describe Eps::ProviderService do
         end.to raise_error(ArgumentError, 'npi is required and cannot be blank')
       end
 
-      it 'raises ArgumentError and logs StatsD metric when npi is blank' do
+      it 'raises ArgumentError and logs StatsD metric and Rails warning when npi is blank' do
         expect(StatsD).to receive(:increment).with(
           'api.vaos.provider_service.no_params',
           tags: ['service:community_care_appointments']
+        )
+        expect(Rails.logger).to receive(:warn).with(
+          'Community Care Appointments: Provider service called with no parameters',
+          hash_including(
+            method: 'fetch_provider_services',
+            service: 'eps_provider_service'
+          )
         )
 
         expect do


### PR DESCRIPTION
# eps logs and preventing sending no params

Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper):* **NO**
- *Summary of changes:*  
  - Adds logging to StatsD for calls to EPS ProviderService endpoints when required parameters are missing or blank.
  - Prevents sending requests to EPS provider-services endpoints without required parameters (`provider_id`, `provider_ids`, or `npi`) by raising an `ArgumentError` earlier in the service layer.
  - Updates and adds unit tests to confirm that missing/blank parameters result in both metric logging and an immediate error, rather than an external request.
- *If bug, how to reproduce:*  
  - Previously, calling provider service methods with missing/blank parameters would send malformed requests to EPS and potentially cause hard-to-trace errors.
- *What is the solution, why is this the solution?*  
  - By validating parameters and logging a StatsD metric before making an external call, we protect downstream systems, improve debuggability, and enable better monitoring of improper usage patterns.
- *Which team do you work for, does your team own the maintenance of this component?*  
  - VAOS team; yes, we own this component.
- *If introducing a flipper, what is the success criteria being targeted?*  
  - N/A (no flipper introduced).

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119631

## Testing done

- [x] *New code is covered by unit tests*
- *Old behavior:*  
  - No explicit validation for required parameters—requests with missing/blank params could reach EPS.
- *Verification steps:*  
  1. Call `get_provider_service` with `provider_id: nil`, empty string, or whitespace.
  2. Call `get_provider_services_by_ids` with `provider_ids: nil` or empty array.
  3. Call `fetch_provider_services` with `npi: nil`, empty string, or whitespace.
  4. Confirm that an `ArgumentError` is raised and a StatsD metric with the correct tag is logged.
  5. Confirm that no HTTP request is sent to EPS in these cases.
  6. Confirm that all existing and new specs pass.
- *If this work is behind a flipper:*  
  - N/A

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

- Only backend service code (`ProviderService`) for VAOS EPS interactions. There is no direct user-facing impact, but any consumers of these endpoints (e.g., scheduling flows) will now receive immediate errors for missing parameters.

## Acceptance criteria

- [x]  I fixed/updated/added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution (StatsD increment with correct tags).
- [ ]  Documentation has been updated (link to documentation) *(update if applicable)*
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs.
- [x]  Feature/bug has a monitor built into Datadog (if applicable).
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected *(not directly user-facing but tested via specs)*.
- [ ]  I added a screenshot of the developed feature *(not applicable)*.