### PR TITLE
Prevented Ready-for-review  workflow from exiting when gh command ret…

### DIFF
--- a/.github/workflows/ready_for_review.yml
+++ b/.github/workflows/ready_for_review.yml
@@ -148,8 +148,9 @@ jobs:
 
           for WORKFLOW in "${WORKFLOWS[@]}"; do
             # Check if there's any in-progress run for this workflow
+
             IN_PROGRESS=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow="$WORKFLOW" --status=in_progress --json headBranch,event,headSha -q \
-              ".[] | select(.headBranch == \"${pr_branch}\" and .event == \"pull_request\") | .headSha" | head -n 1)
+              ".[] | select(.headBranch == \"${pr_branch}\" and .event == \"pull_request\") | .headSha" | head -n 1 || true)
 
             if [ -n "$IN_PROGRESS" ]; then
               echo "$WORKFLOW is still in progress."
@@ -157,7 +158,8 @@ jobs:
             else
               # Check if the latest completed run was successful
               SUCCESSFUL=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow="$WORKFLOW" --status=completed --json headBranch,event,conclusion,headSha -q \
-                ".[] | select(.headBranch == \"${pr_branch}\" and .event == \"pull_request\") | select(.conclusion == \"success\") | .headSha" | head -n 1)
+                ".[] | select(.headBranch == \"${pr_branch}\" and .event == \"pull_request\") | select(.conclusion == \"success\") | .headSha" | head -n 1 || true)
+
               if [ -z "$SUCCESSFUL" ]; then
                 echo "$WORKFLOW did not complete successfully."
                 ((unsuccessful_count++))


### PR DESCRIPTION
…urns nothing

Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

This PR updates the workflow-check script to prevent it from exiting early when no workflow runs are found for a branch. Previously, the script used set -e (or -e in the shell) which caused the process to fail with exit code 1 if gh run list returned nothing.

**Changes:**
- Added || true to gh run list commands to safely handle cases where no runs exist.
- Ensures the script continues to check all workflows and correctly reports failures.
- Maintains existing logic for detecting in-progress and unsuccessful workflow runs.

**Impact:**
- PR checks will no longer fail incorrectly when no workflows are in progress.
- The failures_detected output remains accurate.




## Testing done
[testing only - Removed override_address_pou flipper](https://github.com/department-of-veterans-affairs/vets-api/pull/24198#top) was used for testing when all workflows have successfully completed and the workflow was failing:
- [x] Verified against branches with no workflow runs and with partially completed runs. 
- [x] Confirmed failures_detected outputs true or false correctly.


## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
