### PR TITLE
VEBT-3077/sentry logging cleanup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -113,7 +113,6 @@ app/controllers/v0/veteran_readiness_employment_claims_controller.rb @department
 app/controllers/v1/apidocs_controller.rb @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/gids @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/post911_gi_bill_statuses_controller.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/govcio-vfep-codereviewers
-app/controllers/v1/post911_gi_bill_statuses_controller.rb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/profile @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/sessions_controller.rb @department-of-veterans-affairs/octo-identity
 app/helpers/parameter_filter_helper.rb @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/v1/post911_gi_bill_statuses_controller.rb
+++ b/app/controllers/v1/post911_gi_bill_statuses_controller.rb
@@ -6,7 +6,7 @@ require 'lighthouse/benefits_education/service'
 module V1
   class Post911GIBillStatusesController < ApplicationController
     include IgnoreNotFound
-    include SentryLogging
+
     service_tag 'gibill-statement'
 
     STATSD_KEY_PREFIX = 'api.post911_gi_bill_status'

--- a/app/models/saved_claim/education_benefits/va_10203.rb
+++ b/app/models/saved_claim/education_benefits/va_10203.rb
@@ -4,7 +4,6 @@ require 'lighthouse/benefits_education/service'
 require 'feature_flipper'
 
 class SavedClaim::EducationBenefits::VA10203 < SavedClaim::EducationBenefits
-  include SentryLogging
   add_form_and_validation('22-10203')
 
   class Submit10203Error < StandardError


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): No
- *(Summarize the changes that have been made to the platform)* Per this message from platform [here](https://dsva.slack.com/archives/C0460N83Y9G/p1754069591451589)... Searched codeowners for files the govcio-vfep-codereviewers own and filtered down to files that reference Sentry. Removed `include SentryLogging` from relevant files. There wasn't a need to replace with `Vets::ShareLogging` because there weren't any sentry logging methods being used and so the includes were probably leftover code.
- *(Which team do you work for, does your team own the maintenance of this component?)* VEBT, yes

## Related issue(s)

- https://jira.devops.va.gov/browse/VEBT-3077
- https://jira.devops.va.gov/browse/VEBT-3078