### PR TITLE
[#119416] Travel Pay, Change placeholder receipt to a bmp

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/expenses_service.rb
+++ b/modules/travel_pay/app/services/travel_pay/expenses_service.rb
@@ -76,12 +76,14 @@ module TravelPay
     # @return [Hash] The minimal placeholder receipt data
     #
     def build_placeholder_receipt
-      placeholder_data = 'placeholder'
+      # Minimal valid BMP (1x1 white pixel) - 58 bytes
+      bmp_base64 = 'Qk06AAAAAAAAADYAAAAoAAAAAQAAAAEAAAABABgAAAAAAAQAAAATCwAAEwsAAAAAAAAAAAAA////AA=='
+
       {
-        'contentType' => 'text/plain',
-        'length' => placeholder_data.length,
-        'fileName' => 'placeholder.txt',
-        'fileData' => Base64.strict_encode64(placeholder_data)
+        'contentType' => 'image/bmp',
+        'length' => 58,
+        'fileName' => 'placeholder.bmp',
+        'fileData' => bmp_base64
       }
     end
 

--- a/modules/travel_pay/spec/services/expenses_service_spec.rb
+++ b/modules/travel_pay/spec/services/expenses_service_spec.rb
@@ -53,10 +53,10 @@ describe TravelPay::ExpensesService do
           'costRequested' => 125.50,
           'expenseType' => 'lodging',
           'expenseReceipt' => {
-            'contentType' => 'text/plain',
-            'length' => 11,
-            'fileName' => 'placeholder.txt',
-            'fileData' => 'cGxhY2Vob2xkZXI='
+            'contentType' => 'image/bmp',
+            'length' => 58,
+            'fileName' => 'placeholder.bmp',
+            'fileData' => 'Qk06AAAAAAAAADYAAAAoAAAAAQAAAAEAAAABABgAAAAAAAQAAAATCwAAEwsAAAAAAAAAAAAA////AA=='
           }
         }
 
@@ -85,10 +85,10 @@ describe TravelPay::ExpensesService do
           'costRequested' => 15.75,
           'expenseType' => 'meal',
           'expenseReceipt' => {
-            'contentType' => 'text/plain',
-            'length' => 11,
-            'fileName' => 'placeholder.txt',
-            'fileData' => 'cGxhY2Vob2xkZXI='
+            'contentType' => 'image/bmp',
+            'length' => 58,
+            'fileName' => 'placeholder.bmp',
+            'fileData' => 'Qk06AAAAAAAAADYAAAAoAAAAAQAAAAEAAAABABgAAAAAAAQAAAATCwAAEwsAAAAAAAAAAAAA////AA=='
           }
         }
 
@@ -117,10 +117,10 @@ describe TravelPay::ExpensesService do
           'costRequested' => 10.00,
           'expenseType' => 'other',
           'expenseReceipt' => {
-            'contentType' => 'text/plain',
-            'length' => 11,
-            'fileName' => 'placeholder.txt',
-            'fileData' => 'cGxhY2Vob2xkZXI='
+            'contentType' => 'image/bmp',
+            'length' => 58,
+            'fileName' => 'placeholder.bmp',
+            'fileData' => 'Qk06AAAAAAAAADYAAAAoAAAAAQAAAAEAAAABABgAAAAAAAQAAAATCwAAEwsAAAAAAAAAAAAA////AA=='
           }
         }
 
@@ -205,10 +205,10 @@ describe TravelPay::ExpensesService do
             'costRequested' => 10.00,
             'expenseType' => 'other',
             'expenseReceipt' => {
-              'contentType' => 'text/plain',
-              'length' => 11,
-              'fileName' => 'placeholder.txt',
-              'fileData' => 'cGxhY2Vob2xkZXI='
+              'contentType' => 'image/bmp',
+              'length' => 58,
+              'fileName' => 'placeholder.bmp',
+              'fileData' => 'Qk06AAAAAAAAADYAAAAoAAAAAQAAAAEAAAABABgAAAAAAAQAAAATCwAAEwsAAAAAAAAAAAAA////AA=='
             }
           }
 


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): YES*
Tweaking previous work adding a placeholder receipt for expenses to make that placeholder a `.BMP` file rather than a `.txt` -- which it turns out is not supported by the API we're calling here. 

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/119416

## Testing done

- [x] *New code is covered by unit tests*

## What areas of the site does it impact?
Travel pay

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected