### PR TITLE
119508: Add backup dates for email

### DIFF
--- a/modules/income_and_assets/lib/income_and_assets/notification_email.rb
+++ b/modules/income_and_assets/lib/income_and_assets/notification_email.rb
@@ -39,10 +39,17 @@ module IncomeAndAssets
         # confirmation, error
         'first_name' => first_name,
         # received
-        'date_received' => claim.form_submissions&.last&.form_submission_attempts&.last&.lighthouse_updated_at
+        'date_received' => date_received
       }
 
       default.merge(template)
+    end
+
+    # Provides the date received with fallback to claim submission date
+    # @return [Time] the date the form was received or submitted
+    def date_received
+      lighthouse_date = claim.form_submissions&.last&.form_submission_attempts&.last&.lighthouse_updated_at
+      lighthouse_date || claim.submitted_at || claim.created_at
     end
 
     # @see VeteranFacingServices::NotificationEmail::SavedClaim#callback_klass

--- a/modules/income_and_assets/spec/lib/income_and_assets/notification_email_spec.rb
+++ b/modules/income_and_assets/spec/lib/income_and_assets/notification_email_spec.rb
@@ -23,5 +23,35 @@ RSpec.describe IncomeAndAssets::NotificationEmail do
 
       described_class.new(23).deliver(:submitted)
     end
+
+    context 'date_received fallback logic' do
+      subject { described_class.new(saved_claim.id) }
+
+      it 'uses lighthouse_updated_at when available' do
+        lighthouse_date = Time.current
+
+        form_submission_attempt = double('form_submission_attempt', lighthouse_updated_at: lighthouse_date)
+        form_submission = double('form_submission', form_submission_attempts: [form_submission_attempt])
+
+        allow(saved_claim).to receive(:form_submissions).and_return([form_submission])
+
+        expect(subject.send(:date_received).to_date).to eq(lighthouse_date.to_date)
+      end
+
+      it 'falls back to submitted_at when lighthouse date is nil' do
+        allow(saved_claim).to receive(:form_submissions).and_return(nil)
+
+        expect(subject.send(:date_received)).to eq(saved_claim.submitted_at)
+      end
+
+      it 'falls back to created_at when both previous dates are nil' do
+        allow(saved_claim).to receive_messages(
+          form_submissions: nil,
+          submitted_at: nil
+        )
+
+        expect(subject.send(:date_received)).to eq(saved_claim.created_at)
+      end
+    end
   end
 end


### PR DESCRIPTION
If a value is missing from VANotify's email template then the email will not send. This PR adds some back up times to the email

## Summary

- Add backup logic to email send
- Update test

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119508

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
