### PR TITLE
[118697] DisabilityCompensationFormsController uses Disability monitor

### DIFF
--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -15,11 +15,6 @@ module V0
     before_action :auth_rating_info, only: [:rating_info]
     before_action :validate_name_part, only: [:suggested_conditions]
 
-    def initialize
-      @monitor = DisabilityCompensation::Loggers::Monitor.new
-      super()
-    end
-
     def rated_disabilities
       invoker = 'V0::DisabilityCompensationFormsController#rated_disabilities'
       api_provider = ApiProviderFactory.call(
@@ -169,7 +164,7 @@ module V0
           in_progress_form =
             @current_user ? InProgressForm.form_for_user(FormProfiles::VA526ez::FORM_ID, @current_user) : nil
         ensure
-          @monitor.track_saved_claim_save_error(
+          monitor.track_saved_claim_save_error(
             # Array of ActiveModel::Error instances from the claim that failed to save
             claim&.errors&.errors,
             in_progress_form&.id,
@@ -182,7 +177,7 @@ module V0
     end
 
     def log_success(claim)
-      @monitor.track_saved_claim_save_success(
+      monitor.track_saved_claim_save_success(
         claim,
         @current_user.uuid
       )
@@ -275,5 +270,9 @@ module V0
       )
     end
     # END TEMPORARY
+
+    def monitor
+      @monitor ||= DisabilityCompensation::Loggers::Monitor.new
+    end
   end
 end

--- a/app/controllers/v0/disability_compensation_forms_controller.rb
+++ b/app/controllers/v0/disability_compensation_forms_controller.rb
@@ -15,6 +15,11 @@ module V0
     before_action :auth_rating_info, only: [:rating_info]
     before_action :validate_name_part, only: [:suggested_conditions]
 
+    def initialize
+      @monitor = DisabilityCompensation::Loggers::Monitor.new
+      super()
+    end
+
     def rated_disabilities
       invoker = 'V0::DisabilityCompensationFormsController#rated_disabilities'
       api_provider = ApiProviderFactory.call(
@@ -75,6 +80,7 @@ module V0
       if Flipper.enabled?(:disability_compensation_sync_modern0781_flow_metadata) && form_content['form526'].present?
         saved_claim.metadata = add_0781_metadata(form_content['form526'])
       end
+
       saved_claim.save ? log_success(saved_claim) : log_failure(saved_claim)
       submission = create_submission(saved_claim)
       # if jid = 0 then the submission was prevented from going any further in the process
@@ -159,13 +165,11 @@ module V0
 
     def log_failure(claim)
       if Flipper.enabled?(:disability_526_track_saved_claim_error) && claim&.errors
-        monitor = DisabilityCompensation::Loggers::Monitor.new
-
         begin
           in_progress_form =
             @current_user ? InProgressForm.form_for_user(FormProfiles::VA526ez::FORM_ID, @current_user) : nil
         ensure
-          monitor.track_saved_claim_save_error(
+          @monitor.track_saved_claim_save_error(
             # Array of ActiveModel::Error instances from the claim that failed to save
             claim&.errors&.errors,
             in_progress_form&.id,
@@ -174,13 +178,14 @@ module V0
         end
       end
 
-      StatsD.increment("#{stats_key}.failure")
       raise Common::Exceptions::ValidationErrors, claim
     end
 
     def log_success(claim)
-      StatsD.increment("#{stats_key}.success")
-      Rails.logger.info "ClaimID=#{claim.confirmation_number} Form=#{claim.class::FORM}"
+      @monitor.track_saved_claim_save_success(
+        claim,
+        @current_user.uuid
+      )
     end
 
     def validate_name_part

--- a/lib/disability_compensation/loggers/monitor.rb
+++ b/lib/disability_compensation/loggers/monitor.rb
@@ -47,8 +47,7 @@ module DisabilityCompensation
       # Logs SavedClaim ActiveRecord save successes
       #
       # We use these logs to track when
-      # SavedClaim::DisabilityCompensation::Form526AllClaim saves to the database. Includes in_progress_form_id, since
-      # we can use it to inspect Veteran's form choices in the production console
+      # SavedClaim::DisabilityCompensation::Form526AllClaim saves to the database.
       #
       # @param claim [SavedClaim::DisabilityCompensation::Form526AllClaim] the claim that was successfully saved
       # @param user_account_uuid [uuid] uuid of the user attempting to save the claim
@@ -57,6 +56,7 @@ module DisabilityCompensation
           :info,
           "ClaimID=#{claim.confirmation_number} Form=#{claim.class::FORM}",
           "#{claim_stats_key}.success",
+          claim:,
           user_account_uuid:,
           form_id: claim_stats_key
         )

--- a/lib/disability_compensation/loggers/monitor.rb
+++ b/lib/disability_compensation/loggers/monitor.rb
@@ -58,7 +58,7 @@ module DisabilityCompensation
           "#{claim_stats_key}.success",
           claim:,
           user_account_uuid:,
-          form_id: claim_stats_key
+          form_id:
         )
       end
 

--- a/lib/disability_compensation/loggers/monitor.rb
+++ b/lib/disability_compensation/loggers/monitor.rb
@@ -39,7 +39,7 @@ module DisabilityCompensation
           "#{claim_stats_key}.failure",
           in_progress_form_id:,
           user_account_uuid:,
-          form_id: claim_stats_key,
+          form_id:,
           errors: format_active_model_errors(errors)
         )
       end

--- a/lib/disability_compensation/loggers/monitor.rb
+++ b/lib/disability_compensation/loggers/monitor.rb
@@ -36,10 +36,10 @@ module DisabilityCompensation
         submit_event(
           :error,
           "#{self.class.name} Form526 SavedClaim save error",
-          "#{claim_stats_key}.failure",
+          "#{self.class::CLAIM_STATS_KEY}.failure",
           in_progress_form_id:,
           user_account_uuid:,
-          form_id:,
+          form_id: self.class::FORM_ID,
           errors: format_active_model_errors(errors)
         )
       end
@@ -55,10 +55,10 @@ module DisabilityCompensation
         submit_event(
           :info,
           "ClaimID=#{claim.confirmation_number} Form=#{claim.class::FORM}",
-          "#{claim_stats_key}.success",
+          "#{self.class::CLAIM_STATS_KEY}.success",
           claim:,
           user_account_uuid:,
-          form_id:
+          form_id: self.class::FORM_ID
         )
       end
 

--- a/lib/disability_compensation/loggers/monitor.rb
+++ b/lib/disability_compensation/loggers/monitor.rb
@@ -13,10 +13,10 @@ module DisabilityCompensation
 
     class Monitor < ::Logging::BaseMonitor
       SERVICE_NAME = 'disability-compensation'
-      FORM_ID = '21-526EZ'
+      FORM_ID = '21-526EZ-ALLCLAIMS'
 
       # Metrics prefixes for SavedClaim and Form526Submission events, respectively
-      CLAIM_STATS_KEY = 'api.disability_compensation.claim'
+      CLAIM_STATS_KEY = 'api.disability_compensation'
       SUBMISSION_STATS_KEY = 'api.disability_compensation.submission'
 
       def initialize
@@ -31,16 +31,34 @@ module DisabilityCompensation
       #
       # @param saved_claim_errors [Array<ActiveModel::Error>] array of error objects from SavedClaim that failed to save
       # @param in_progress_form_id [Integer] ID of the InProgressForm for this claim
-      # @param user_uuid [uuid] uuid of the user attempting to save the claim
-      def track_saved_claim_save_error(errors, in_progress_form_id, user_uuid)
+      # @param user_account_uuid [uuid] uuid of the user attempting to save the claim
+      def track_saved_claim_save_error(errors, in_progress_form_id, user_account_uuid)
         submit_event(
           :error,
           "#{self.class.name} Form526 SavedClaim save error",
-          self.class::CLAIM_STATS_KEY,
+          "#{claim_stats_key}.failure",
           in_progress_form_id:,
-          user_account_uuid: user_uuid,
-          form_id: '21-526EZ-ALLCLAIMS',
+          user_account_uuid:,
+          form_id: claim_stats_key,
           errors: format_active_model_errors(errors)
+        )
+      end
+
+      # Logs SavedClaim ActiveRecord save successes
+      #
+      # We use these logs to track when
+      # SavedClaim::DisabilityCompensation::Form526AllClaim saves to the database. Includes in_progress_form_id, since
+      # we can use it to inspect Veteran's form choices in the production console
+      #
+      # @param claim [SavedClaim::DisabilityCompensation::Form526AllClaim] the claim that was successfully saved
+      # @param user_account_uuid [uuid] uuid of the user attempting to save the claim
+      def track_saved_claim_save_success(claim, user_account_uuid)
+        submit_event(
+          :info,
+          "ClaimID=#{claim.confirmation_number} Form=#{claim.class::FORM}",
+          "#{claim_stats_key}.success",
+          user_account_uuid:,
+          form_id: claim_stats_key
         )
       end
 

--- a/spec/lib/disability_compensation/loggers/monitor_spec.rb
+++ b/spec/lib/disability_compensation/loggers/monitor_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe DisabilityCompensation::Loggers::Monitor do
         :error,
         "#{described_class} Form526 SavedClaim save error",
         "#{described_class::CLAIM_STATS_KEY}.failure",
-        form_id: '21-526EZ-ALLCLAIMS',
+        form_id: described_class::FORM_ID,
         in_progress_form_id: in_progress_form.id,
         errors: [{ form: mock_form_error }].to_s,
         user_account_uuid: user.uuid
@@ -87,19 +87,14 @@ RSpec.describe DisabilityCompensation::Loggers::Monitor do
 
   describe('#track_saved_claim_save_success') do
     let(:user) { build(:disabilities_compensation_user, icn: '123498767V234859') }
-    let(:in_progress_form) { create(:in_progress_form) }
-
-    let(:claim) do
-      claim = SavedClaim::DisabilityCompensation::Form526AllClaim.new
-      claim
-    end
+    let(:claim) { create(:fake_saved_claim, form_id: described_class::FORM_ID, confirmation_number: '1234') }
 
     it 'logs the success' do
       expect(monitor).to receive(:submit_event).with(
         :info,
         "ClaimID=#{claim.confirmation_number} Form=#{claim.class::FORM}",
         "#{described_class::CLAIM_STATS_KEY}.success",
-        form_id: '21-526EZ-ALLCLAIMS',
+        form_id: described_class::FORM_ID,
         user_account_uuid: user.uuid
       )
 

--- a/spec/lib/disability_compensation/loggers/monitor_spec.rb
+++ b/spec/lib/disability_compensation/loggers/monitor_spec.rb
@@ -87,15 +87,16 @@ RSpec.describe DisabilityCompensation::Loggers::Monitor do
 
   describe('#track_saved_claim_save_success') do
     let(:user) { build(:disabilities_compensation_user, icn: '123498767V234859') }
-    let(:claim) { create(:fake_saved_claim, form_id: described_class::FORM_ID, confirmation_number: '1234') }
+    let(:claim) { build(:fake_saved_claim, form_id: described_class::FORM_ID, guid: '1234') }
 
     it 'logs the success' do
       expect(monitor).to receive(:submit_event).with(
         :info,
         "ClaimID=#{claim.confirmation_number} Form=#{claim.class::FORM}",
         "#{described_class::CLAIM_STATS_KEY}.success",
-        form_id: described_class::FORM_ID,
-        user_account_uuid: user.uuid
+        claim:,
+        user_account_uuid: user.uuid,
+        form_id: described_class::FORM_ID
       )
 
       monitor.track_saved_claim_save_success(

--- a/spec/lib/disability_compensation/loggers/monitor_spec.rb
+++ b/spec/lib/disability_compensation/loggers/monitor_spec.rb
@@ -84,4 +84,31 @@ RSpec.describe DisabilityCompensation::Loggers::Monitor do
       )
     end
   end
+
+  describe('#track_saved_claim_save_success') do
+    let(:user) { build(:disabilities_compensation_user, icn: '123498767V234859') }
+    let(:in_progress_form) { create(:in_progress_form) }
+
+    let(:claim) do
+      claim = SavedClaim::DisabilityCompensation::Form526AllClaim.new
+      claim
+    end
+
+    it 'logs the success' do
+      expect(monitor).to receive(:submit_event).with(
+        :info,
+        "ClaimID=#{claim.confirmation_number} Form=#{claim.class::FORM}",
+        "#{described_class::CLAIM_STATS_KEY}.success",
+        form_id: '21-526EZ-ALLCLAIMS',
+        user_account_uuid: user.uuid
+      )
+
+      monitor.track_saved_claim_save_success(
+        claim,
+        in_progress_form.id,
+        user.uuid
+      )
+    end
+
+  end
 end

--- a/spec/lib/disability_compensation/loggers/monitor_spec.rb
+++ b/spec/lib/disability_compensation/loggers/monitor_spec.rb
@@ -105,10 +105,8 @@ RSpec.describe DisabilityCompensation::Loggers::Monitor do
 
       monitor.track_saved_claim_save_success(
         claim,
-        in_progress_form.id,
         user.uuid
       )
     end
-
   end
 end

--- a/spec/lib/disability_compensation/loggers/monitor_spec.rb
+++ b/spec/lib/disability_compensation/loggers/monitor_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe DisabilityCompensation::Loggers::Monitor do
       expect(monitor).to receive(:submit_event).with(
         :error,
         "#{described_class} Form526 SavedClaim save error",
-        described_class::CLAIM_STATS_KEY,
+        "#{described_class::CLAIM_STATS_KEY}.failure",
         form_id: '21-526EZ-ALLCLAIMS',
         in_progress_form_id: in_progress_form.id,
         errors: [{ form: mock_form_error }].to_s,


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO

- Refactored logic of existing `DisabilityCompensation::Loggers::Monitor` to improve consistency across code syntax, log messaging, and Datadog metric naming
- added new method to track saved claim success
- implemented use of track_saved_claim_success in controller

## Related issue(s)

closes department-of-veterans-affairs/va.gov-team#118697

## Testing done

- [x] *New code is covered by unit tests*


## Screenshots
n/a

## What areas of the site does it impact?
- calls to disability compensation forms controller submit_all_claim action

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback


