### PR TITLE
switch to passing record id rather than full record to mailer

### DIFF
--- a/app/mailers/school_certifying_officials_mailer.rb
+++ b/app/mailers/school_certifying_officials_mailer.rb
@@ -7,8 +7,8 @@ class SchoolCertifyingOfficialsMailer < TransactionalEmailMailer
   GA_LABEL = 'school-certifying-officials-10203-submission-notification'
   TEMPLATE = 'school_certifying_officials'
 
-  def build(applicant, recipients, ga_client_id)
-    @applicant = applicant
+  def build(claim_id, recipients, ga_client_id)
+    @applicant = SavedClaim::EducationBenefits::VA10203.find(claim_id).open_struct_form
     super(recipients, ga_client_id, {})
   end
 end

--- a/app/mailers/stem_applicant_sco_mailer.rb
+++ b/app/mailers/stem_applicant_sco_mailer.rb
@@ -7,8 +7,8 @@ class StemApplicantScoMailer < TransactionalEmailMailer
   GA_LABEL = 'school-certifying-officials-10203-submission-notification'
   TEMPLATE = 'stem_applicant_sco'
 
-  def build(applicant, ga_client_id)
-    @applicant = applicant
-    super([applicant.email], ga_client_id, {})
+  def build(claim_id, ga_client_id)
+    @applicant = SavedClaim::EducationBenefits::VA10203.find(claim_id).open_struct_form
+    super([@applicant.email], ga_client_id, {})
   end
 end

--- a/app/sidekiq/education_form/send_school_certifying_officials_email.rb
+++ b/app/sidekiq/education_form/send_school_certifying_officials_email.rb
@@ -60,8 +60,8 @@ module EducationForm
 
       if emails.any?
         StatsD.increment("#{stats_key}.success")
-        SchoolCertifyingOfficialsMailer.build(@claim.open_struct_form, emails, nil).deliver_now
-        StemApplicantScoMailer.build(@claim.open_struct_form, nil).deliver_now
+        SchoolCertifyingOfficialsMailer.build(@claim.id, emails, nil).deliver_now
+        StemApplicantScoMailer.build(@claim.id, nil).deliver_now
         @claim.email_sent(true)
       else
         StatsD.increment("#{stats_key}.failure")

--- a/spec/mailers/school_certifying_officials_mailer_spec.rb
+++ b/spec/mailers/school_certifying_officials_mailer_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 
 RSpec.describe SchoolCertifyingOfficialsMailer, type: [:mailer] do
   subject do
-    described_class.build(applicant, recipients, ga_client_id).deliver_now
+    described_class.build(education_benefits_claim.id, recipients, ga_client_id).deliver_now
   end
 
-  let(:education_benefits_claim) { build(:va10203) }
+  let(:education_benefits_claim) { create(:va10203) }
   let(:applicant) { education_benefits_claim.open_struct_form }
   let(:recipients) { ['foo@example.com'] }
   let(:ga_client_id) { '123456543' }

--- a/spec/mailers/stem_applicant_sco_mailer_spec.rb
+++ b/spec/mailers/stem_applicant_sco_mailer_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 
 RSpec.describe StemApplicantScoMailer, type: [:mailer] do
   subject do
-    described_class.build(applicant, ga_client_id).deliver_now
+    described_class.build(education_benefits_claim.id, ga_client_id).deliver_now
   end
 
-  let(:education_benefits_claim) { build(:va10203) }
+  let(:education_benefits_claim) { create(:va10203) }
   let(:applicant) { education_benefits_claim.open_struct_form }
   let(:ga_client_id) { '123456543' }
 


### PR DESCRIPTION
## Summary

When Rails sends an email (via ActionMailer) it generates a log of the form "SomeClass#some_method processed outbound mail in X.Xms". This is fine, but Datadog listens to this log event (https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/tracing/contrib/action_mailer/events/process.rb) and 'helpfully' appends a bunch of span-related payload data to it. In this case the payload is the arguments passed to the `build` method of the mailer, which includes a bunch of PII like a users bank account info. That's not great.

This PR changes the logic slightly so that only the record id is passed to the mailer rather than the whole object. Hopefully this means that only the record id is attached in datadog and not all that sensitive stuff.

Out of scope for this PR but worth considering: is there a way to disable this behavior in datadog? Datadog configuration appears to include something similar for the 'deliver' event (https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/tracing/contrib/action_mailer/events/deliver.rb#L47-L50) which lets us opt-out of adding extra payload context. But the 'process' event doesn't appear to have such an option.

- *This work is behind a feature toggle (flipper): YES/NO* No
- *(Summarize the changes that have been made to the platform)*
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)*
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
