### PR TITLE
Add additional logging for form pdf change detection job

### DIFF
--- a/app/sidekiq/form_pdf_change_detection_job.rb
+++ b/app/sidekiq/form_pdf_change_detection_job.rb
@@ -31,6 +31,7 @@ class FormPdfChangeDetectionJob
   def perform
     return unless Flipper.enabled?(:form_pdf_change_detection)
 
+    Rails.logger.info("[#{self.class.name}] - Job started.")
     forms = fetch_forms_data
 
     cache_keys, current_sha_map = get_current_form_data(forms)
@@ -38,8 +39,10 @@ class FormPdfChangeDetectionJob
 
     log_form_revisions(current_sha_map, cached_sha_map)
     update_cached_values(current_sha_map)
+
+    Rails.logger.info("[#{self.class.name}] - Job finished successfully.")
   rescue => e
-    Rails.logger.error "Error in #{self.class.name}: #{e.message}"
+    Rails.logger.error "[#{self.class.name}] - Job raised an error: #{e.message}"
     raise e
   end
 

--- a/spec/sidekiq/form_pdf_change_detection_job_spec.rb
+++ b/spec/sidekiq/form_pdf_change_detection_job_spec.rb
@@ -63,6 +63,10 @@ RSpec.describe FormPdfChangeDetectionJob, type: :job do
         expect(Rails.cache).not_to receive(:write_multi)
         expect(StatsD).not_to receive(:increment)
 
+        expect(Rails.logger).not_to receive(:info).with(
+          "[#{described_class.name}] - Job started."
+        )
+
         subject.perform
       end
     end
@@ -88,6 +92,12 @@ RSpec.describe FormPdfChangeDetectionJob, type: :job do
       end
 
       it 'completes successfully with valid form data' do
+        expect(Rails.logger).to receive(:info).with(
+          "[#{described_class.name}] - Job started."
+        )
+        expect(Rails.logger).to receive(:info).with(
+          "[#{described_class.name}] - Job finished successfully."
+        )
         expect { subject.perform }.not_to raise_error
       end
 
@@ -131,6 +141,13 @@ RSpec.describe FormPdfChangeDetectionJob, type: :job do
         it 'logs revision information' do
           form = forms_response['data'][0]
           attributes = form['attributes']
+          expect(Rails.logger).to receive(:info).with(
+            "[#{described_class.name}] - Job started."
+          )
+
+          expect(Rails.logger).to receive(:info).with(
+            "[#{described_class.name}] - Job finished successfully."
+          )
 
           expect(Rails.logger).to receive(:info).with(
             a_string_including(
@@ -177,8 +194,14 @@ RSpec.describe FormPdfChangeDetectionJob, type: :job do
         end
 
         it 'logs the error and re-raises' do
+          expect(Rails.logger).to receive(:info).with(
+            "[#{described_class.name}] - Job started."
+          )
+          expect(Rails.logger).not_to receive(:info).with(
+            "[#{described_class.name}] - Job finished successfully."
+          )
           expect(Rails.logger).to receive(:error)
-            .with('Error in FormPdfChangeDetectionJob: API Error')
+            .with("[#{described_class.name}] - Job raised an error: API Error")
 
           expect { subject.perform }.to raise_error(StandardError, 'API Error')
         end


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- Add additional logging for when the job starts/ends/fails to make tracking it running easier since it will be run daily. 
- 1010 Health Apps
- `form_pdf_change_detection` flipper toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117843

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
