### PR TITLE
Add gateway feature flags for ep310, ep600, ep930

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -166,6 +166,12 @@ features:
     description: "Gateway: Enable decision letter email notifications for EP120 reopened pension claims"
   event_bus_gateway_ep180_decision_letter_notifications:
     description: "Gateway: Enable decision letter email notifications for EP180 initial pension claims"
+  event_bus_gateway_ep310_decision_letter_notifications:
+    description: "Gateway: Enable decision letter email notifications for EP310 higher level reviews"
+  event_bus_gateway_ep600_decision_letter_notifications:
+    description: "Gateway: Enable decision letter email notifications for EP600 higher level reviews"
+  event_bus_gateway_ep930_decision_letter_notifications:
+    description: "Gateway: Enable decision letter email notifications for EP930 higher level reviews"
   hca_browser_monitoring_enabled:
     actor_type: user
     description: Enables browser monitoring for the health care application.


### PR DESCRIPTION
## Summary
This PR adds three new feature flags in preparation  for eventbus-gateway decision letter email notifications  for higher level reviews ep310, ep180 & ep930.  

## Related issue(s)
[Implement Higher Level Reviews (EP310, 600, 930) decision letter email notifications
[#119722](https://github.com/department-of-veterans-affairs/va.gov-team/issues/119722)](https://github.com/orgs/department-of-veterans-affairs/projects/1549/views/3?pane=issue&itemId=129289218&issue=department-of-veterans-affairs%7Cva.gov-team%7C119722)
