### PR TITLE
Add four toggles for upcoming appointments features

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2034,7 +2034,19 @@ features:
   va_online_scheduling_list_view_clinic_info:
     actor_type: user
     enable_in_development: true
-    description: Toggle to to display clinic name and location on appointment list and print views.
+    description: Toggle to display clinic name and location on appointment list and print views.
+  va_online_scheduling_add_OH_avs:
+    actor_type: user
+    enable_in_development: true
+    description: Toggle to include After Visit Summary in Oracle Health appointments.
+  va_online_scheduling_immediate_care_alert:
+    actor_type: user
+    enable_in_development: true
+    description: Toggle for using the new immediate care alert page at the start of the scheduling flow.
+  va_online_scheduling_remove_facility_config_check:
+    actor_type: user
+    enable_in_development: true
+    description: Toggle to remove the redundant call to facility configurations when determining patient eligibility.
   vaos_appointment_notification_callback:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
## Summary

- This adds the following feature toggles: 
  - va_online_scheduling_list_view_clinic_info
  - va_online_scheduling_add_OH_avs
  - va_online_scheduling_immediate_care_alert
  - va_online_scheduling_remove_facility_config_check
- United Appointments Experience

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119203
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119730
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119630
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119738

## Testing done

N/A

## Screenshots
N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
