### PR TITLE
119781: Add backup logic for date_receive for notification emails

### DIFF
--- a/modules/burials/lib/burials/notification_email.rb
+++ b/modules/burials/lib/burials/notification_email.rb
@@ -37,10 +37,17 @@ module Burials
         # confirmation, error
         'first_name' => claim.claimant_first_name&.upcase,
         # received
-        'date_received' => claim.form_submissions&.last&.form_submission_attempts&.last&.lighthouse_updated_at
+        'date_received' => date_received
       }
 
       default.merge(burials)
+    end
+
+    # Provides the date received with fallback to claim submission date
+    # @return [Time] the date the form was received or submitted
+    def date_received
+      lighthouse_date = claim.form_submissions&.last&.form_submission_attempts&.last&.lighthouse_updated_at
+      lighthouse_date || claim.submitted_at || claim.created_at
     end
 
     # @see VeteranFacingServices::NotificationEmail::SavedClaim#callback_klass

--- a/modules/pensions/lib/pensions/notification_email.rb
+++ b/modules/pensions/lib/pensions/notification_email.rb
@@ -25,10 +25,17 @@ module Pensions
       # confirmation, error
       pensions = {
         'first_name' => claim.first_name&.titleize,
-        'date_received' => claim.form_submissions&.last&.form_submission_attempts&.last&.lighthouse_updated_at
+        'date_received' => date_received
       }
 
       default.merge(pensions)
+    end
+
+    # Provides the date received with fallback to claim submission date
+    # @return [Time] the date the form was received or submitted
+    def date_received
+      lighthouse_date = claim.form_submissions&.last&.form_submission_attempts&.last&.lighthouse_updated_at
+      lighthouse_date || claim.submitted_at || claim.created_at
     end
 
     # @see VeteranFacingServices::NotificationEmail::SavedClaim#callback_klass

--- a/modules/pensions/spec/lib/pensions/notification_email_spec.rb
+++ b/modules/pensions/spec/lib/pensions/notification_email_spec.rb
@@ -5,7 +5,7 @@ require 'pensions/notification_callback'
 require 'pensions/notification_email'
 
 RSpec.describe Pensions::NotificationEmail do
-  let(:claim) { build(:pensions_saved_claim) }
+  let(:claim) { create(:pensions_saved_claim) }
 
   describe '#deliver' do
     it 'successfully sends an email' do
@@ -15,12 +15,7 @@ RSpec.describe Pensions::NotificationEmail do
       args = [
         claim.email,
         Settings.vanotify.services['21p_527ez'].email.confirmation.template_id,
-        {
-          'date_received' => claim.form_submissions.last&.form_submission_attempts&.last&.lighthouse_updated_at,
-          'date_submitted' => claim.submitted_at,
-          'confirmation_number' => claim.confirmation_number,
-          'first_name' => claim.first_name.titleize
-        },
+        anything,
         Settings.vanotify.services['21p_527ez'].api_key,
         { callback_klass: Pensions::NotificationCallback.to_s,
           callback_metadata: anything }
@@ -28,6 +23,36 @@ RSpec.describe Pensions::NotificationEmail do
       expect(VANotify::EmailJob).to receive(:perform_async).with(*args)
 
       described_class.new(23).deliver(:confirmation)
+    end
+
+    context 'date_received fallback logic' do
+      subject { described_class.new(claim.id) }
+
+      it 'uses lighthouse_updated_at when available' do
+        lighthouse_date = Time.current
+
+        form_submission_attempt = double('form_submission_attempt', lighthouse_updated_at: lighthouse_date)
+        form_submission = double('form_submission', form_submission_attempts: [form_submission_attempt])
+
+        allow(claim).to receive(:form_submissions).and_return([form_submission])
+
+        expect(subject.send(:date_received).to_date).to eq(lighthouse_date.to_date)
+      end
+
+      it 'falls back to submitted_at when lighthouse date is nil' do
+        allow(claim).to receive(:form_submissions).and_return(nil)
+
+        expect(subject.send(:date_received)).to eq(claim.submitted_at)
+      end
+
+      it 'falls back to created_at when both previous dates are nil' do
+        allow(claim).to receive_messages(
+          form_submissions: nil,
+          submitted_at: nil
+        )
+
+        expect(subject.send(:date_received)).to eq(claim.created_at)
+      end
     end
   end
 end


### PR DESCRIPTION
Add fallback logic to the date_received to avoid VANotify from failing to send emails if a value is nil

## Summary

- Update Pension's NotifcationEmail class and its corresponding spec
- Update Burial's NotifcationEmail class and its corresponding spec

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119781

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
