### PR TITLE
ARP - hotfix - remove POA instrumentation on /user

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_users_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/representative_users_controller.rb
@@ -9,25 +9,22 @@ module AccreditedRepresentativePortal
         # TODO: Once we figure out how we're handling serialization and which
         # library we're using, moving this serialization logic out to to a
         # serialization layer.
-        ar_monitoring.trace('ar.users.show',
-                            tags: { 'users_show.poa_codes' => poa_codes }) do |_span|
-          render json: {
-            account: {
-              accountUuid: @current_user.user_account_uuid
+        render json: {
+          account: {
+            accountUuid: @current_user.user_account_uuid
+          },
+          profile: {
+            firstName: @current_user.first_name,
+            lastName: @current_user.last_name,
+            verified: @current_user.user_account.verified?,
+            signIn: {
+              serviceName: @current_user.sign_in[:service_name]
             },
-            profile: {
-              firstName: @current_user.first_name,
-              lastName: @current_user.last_name,
-              verified: @current_user.user_account.verified?,
-              signIn: {
-                serviceName: @current_user.sign_in[:service_name]
-              },
-              loa: @current_user.loa
-            },
-            prefillsAvailable: [],
-            inProgressForms: in_progress_forms
-          }
-        end
+            loa: @current_user.loa
+          },
+          prefillsAvailable: [],
+          inProgressForms: in_progress_forms
+        }
       end
 
       def authorize_as_representative
@@ -45,20 +42,6 @@ module AccreditedRepresentativePortal
             lastUpdated: form.updated_at.to_i
           }
         end
-      end
-
-      def ar_monitoring
-        @ar_monitoring ||= AccreditedRepresentativePortal::Monitoring.new(
-          AccreditedRepresentativePortal::Monitoring::NAME,
-          default_tags: [
-            "controller:#{controller_name}",
-            "action:#{action_name}"
-          ].compact
-        )
-      end
-
-      def poa_codes
-        current_user.power_of_attorney_holders.map(&:poa_code)
       end
     end
   end

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/user_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/user_spec.rb
@@ -13,18 +13,7 @@ RSpec.describe 'AccreditedRepresentativePortal::V0::User', type: :request do
     end
 
     context 'when authenticated' do
-      let(:poa_code) { '00A' }
-      let(:representative_email) { Faker::Internet.email.downcase }
-
-      before do
-        login_as(user)
-        create(:organization, poa: poa_code)
-        create(
-          :representative, :vso,
-          email: representative_email,
-          poa_codes: [poa_code]
-        )
-      end
+      before { login_as(user) }
 
       context 'as a user with an in progress form' do
         let(:first_name_value) { Faker::Name.first_name }
@@ -43,9 +32,7 @@ RSpec.describe 'AccreditedRepresentativePortal::V0::User', type: :request do
               first_name: first_name_value,
               last_name: last_name_value,
               sign_in_service_name: sign_in_service_name_value,
-              in_progress_form_id: in_progress_form_id_value,
-              email: representative_email,
-              all_emails: [representative_email]
+              in_progress_form_id: in_progress_form_id_value
             }
           )
         end


### PR DESCRIPTION
ARP has signed in users who do not have any POA codes. By attempting to instrument all calls to /user with POA codes, we were triggering a code path which inappropriately chooses to raise an exception that corresponds semantically to 403. Tests were updated to remove the "authenticated but fully unauthorized" scenario which should 200 but turned into a 403. This change undoes that change.

This PR is fixing an issue that was introduced in a PR for this ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/115975