### PR TITLE
HOTFIX - add URL to dev settings so that betamocks config is valid

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1176,7 +1176,7 @@ reports:
       - adam.freemer@accenturefederal.com
 res:
   api_key: ~
-  base_url: ~
+  base_url: https://fake_url.com
   mock_ch_31: ~
 review_instance_slug: ~
 rrd:


### PR DESCRIPTION
New betamocks config was added [here](https://github.com/department-of-veterans-affairs/vets-api/pull/24153/files#diff-361aea2cb9abc0d76b40a1d32229b7e4961f17dfc827dc382fad1da894f22966) without corresponding dev settings, causing betamocks config to not parse. This prevents devs from starting server or console locally.