### PR TITLE
119240 - Profile - Add email confirmation template ids to env settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1523,6 +1523,9 @@ vanotify:
         career_counseling_confirmation_email: <%= ENV['vanotify__services__va_gov__template_id__career_counseling_confirmation_email'] %>
         ch31_central_mail_form_confirmation_email: <%= ENV['vanotify__services__va_gov__template_id__ch31_central_mail_form_confirmation_email'] %>
         ch31_vbms_form_confirmation_email: <%= ENV['vanotify__services__va_gov__template_id__ch31_vbms_form_confirmation_email'] %>
+        contact_email_address_change_confirmation_needed_email: <%= ENV['vanotify__services__va_gov__template_id__contact_email_address_change_confirmation_needed_email'] %>
+        contact_email_address_confirmation_needed_email: <%= ENV['vanotify__services__va_gov__template_id__contact_email_address_confirmation_needed_email'] %>
+        contact_email_address_confirmed_email: <%= ENV['vanotify__services__va_gov__template_id__contact_email_address_confirmed_email'] %>
         contact_info_change: <%= ENV['vanotify__services__va_gov__template_id__contact_info_change'] %>
         covid_vaccine_registration: <%= ENV['vanotify__services__va_gov__template_id__covid_vaccine_registration'] %>
         direct_deposit: <%= ENV['vanotify__services__va_gov__template_id__direct_deposit'] %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1542,6 +1542,9 @@ vanotify:
         career_counseling_confirmation_email: career_counseling_confirmation_email_template_id
         ch31_central_mail_form_confirmation_email: ch31_central_mail_fake_template_id
         ch31_vbms_form_confirmation_email: ch31_vbms_fake_template_id
+        contact_email_address_change_confirmation_needed_email: contact_email_address_change_confirmation_needed_email_template_id
+        contact_email_address_confirmation_needed_email: contact_email_address_confirmation_needed_email_template_id
+        contact_email_address_confirmed_email: contact_email_address_confirmed_email_template_id
         contact_info_change: fake_template_id
         covid_vaccine_registration: ~
         direct_deposit: direct_deposit_template_id

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1541,6 +1541,9 @@ vanotify:
         career_counseling_confirmation_email: career_counseling_confirmation_email_template_id
         ch31_central_mail_form_confirmation_email: ch31_central_mail_fake_template_id
         ch31_vbms_form_confirmation_email: ch31_vbms_fake_template_id
+        contact_email_address_change_confirmation_needed_email: contact_email_address_change_confirmation_needed_email_template_id
+        contact_email_address_confirmation_needed_email: contact_email_address_confirmation_needed_email_template_id
+        contact_email_address_confirmed_email: contact_email_address_confirmed_email_template_id
         contact_info_change: fake_template_id
         covid_vaccine_registration: ~
         direct_deposit: direct_deposit_template_id


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

VA.gov Profile is introducing an email confirmation feature, which requires the creation of 3 new VA Notify email templates. This PR preemptively adds the template ids to settings.yml, test.yml, and development.yml to prepare the codebase for feature development.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/119240

## Testing done

- [ ] *New code is covered by unit tests*

No tests added since this only updates settings - I ensured the configuration loaded correctly in rails console

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and *if* code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
