### PR TITLE
Handle nil middle name

### DIFF
--- a/app/services/bgs/dependent_v2_service.rb
+++ b/app/services/bgs/dependent_v2_service.rb
@@ -259,13 +259,11 @@ module BGS
     end
 
     def generate_hash_from_details
+      full_name = { 'first' => first_name, 'last' => last_name }
+      full_name['middle'] = middle_name unless middle_name.nil? # nil middle name breaks prod validation
       {
         'veteran_information' => {
-          'full_name' => {
-            'first' => first_name,
-            'middle' => middle_name,
-            'last' => last_name
-          },
+          'full_name' => full_name,
           'common_name' => common_name,
           'va_profile_email' => @va_profile_email,
           'email' => email,


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Claim validation is rerun before submission in several places in our data flow, after we've added veteran information from the user profile. In cases where the user's middle name is `nil`, the validation fails (because nil isn't a string), causing the submission to go to the backup path. Not including nil middle names should prevent this.
- Note: I am able to replicate the validation error in the production rails console, but not in rspec or the local rails console. I haven't been able to identify the cause of the difference in behavior. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/120157

## What areas of the site does it impact?
Dependents Benefits

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
