### PR TITLE
Hash the MHV Correlation ID when locking MHV sessions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1387,6 +1387,7 @@ spec/lib/claim_status_tool @department-of-veterans-affairs/benefits-management-t
 spec/lib/common/client/concerns/mhv_fhir_session_client_spec.rb @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/backend-review-group
 spec/lib/common/client/concerns/mhv_jwt_session_client_spec.rb @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/backend-review-group
 spec/lib/common/client/concerns/mhv_locked_session_client_spec.rb @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/backend-review-group
+spec/lib/common/client/concerns/mhv_session_based_client_spec.rb @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/backend-review-group
 spec/lib/common/client/configuration @department-of-veterans-affairs/backend-review-group
 spec/lib/common/client/middleware @department-of-veterans-affairs/backend-review-group
 spec/lib/common/client/session_spec.rb @department-of-veterans-affairs/backend-review-group

--- a/config/features.yml
+++ b/config/features.yml
@@ -1512,6 +1512,10 @@ features:
     actor_type: user
     description: Enables/disables integration with MHV's AAL-creation endpoint
     enable_in_development: true
+  mhv_hash_id_for_mhv_session_locking:
+    actor_type: user
+    description: Hash the MHV Correlation ID when locking MHV sessions
+    enable_in_development: true
   mhv_modern_cta_links:
     actor_type: user
     description: CTA widget links point to va.gov services

--- a/lib/common/client/concerns/mhv_session_based_client.rb
+++ b/lib/common/client/concerns/mhv_session_based_client.rb
@@ -23,7 +23,11 @@ module Common
         attr_reader :session
 
         def user_key
-          session.user_id
+          if Flipper.enabled?(:mhv_hash_id_for_mhv_session_locking)
+            Digest::SHA256.hexdigest(session.user_id)
+          else
+            session.user_id
+          end
         end
 
         def invalid?(session)

--- a/lib/common/client/concerns/mhv_session_based_client.rb
+++ b/lib/common/client/concerns/mhv_session_based_client.rb
@@ -24,7 +24,9 @@ module Common
 
         def user_key
           if Flipper.enabled?(:mhv_hash_id_for_mhv_session_locking)
-            Digest::SHA256.hexdigest(session.user_id)
+            return nil if session.user_id.nil?
+
+            Digest::SHA256.hexdigest(session.user_id.to_s)
           else
             session.user_id
           end

--- a/spec/lib/common/client/concerns/mhv_session_based_client_spec.rb
+++ b/spec/lib/common/client/concerns/mhv_session_based_client_spec.rb
@@ -19,7 +19,7 @@ describe Common::Client::Concerns::MHVSessionBasedClient do
   let(:dummy_instance) { dummy_class.new(session: session_data) }
 
   describe '#user_key' do
-    let(:session_data) { OpenStruct.new(user_id: '00000', icn: 'ABC') }
+    let(:session_data) { OpenStruct.new(user_id: 12_345, icn: 'ABC') }
 
     context 'when feature flag is enabled' do
       before do
@@ -27,7 +27,7 @@ describe Common::Client::Concerns::MHVSessionBasedClient do
       end
 
       it 'returns a hashed user_id' do
-        expected_digest = Digest::SHA256.hexdigest('00000')
+        expected_digest = Digest::SHA256.hexdigest(12_345.to_s)
 
         user_key = dummy_instance.send(:user_key)
         expect(user_key).to eq(expected_digest)
@@ -42,7 +42,7 @@ describe Common::Client::Concerns::MHVSessionBasedClient do
 
       it 'returns the raw user_id' do
         user_key = dummy_instance.send(:user_key)
-        expect(user_key).to eq('00000')
+        expect(user_key).to eq(12_345)
       end
     end
   end

--- a/spec/lib/common/client/concerns/mhv_session_based_client_spec.rb
+++ b/spec/lib/common/client/concerns/mhv_session_based_client_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'medical_records/client_session'
+require_relative '../../../../../lib/common/client/concerns/mhv_session_based_client'
+
+describe Common::Client::Concerns::MHVSessionBasedClient do
+  let(:dummy_class) do
+    Class.new do
+      include Common::Client::Concerns::MHVSessionBasedClient
+
+      # This will override the initialize method in the mixin
+      def initialize(session: nil)
+        @session = session
+      end
+    end
+  end
+
+  let(:dummy_instance) { dummy_class.new(session: session_data) }
+
+  describe '#user_key' do
+    let(:session_data) { OpenStruct.new(user_id: '00000', icn: 'ABC') }
+
+    context 'when feature flag is enabled' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:mhv_hash_id_for_mhv_session_locking).and_return(true)
+      end
+
+      it 'returns a hashed user_id' do
+        expected_digest = Digest::SHA256.hexdigest('00000')
+
+        user_key = dummy_instance.send(:user_key)
+        expect(user_key).to eq(expected_digest)
+        expect(user_key.length).to eq(64) # sanity check: SHA256 hex digest length
+      end
+    end
+
+    context 'when feature flag is disabled' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:mhv_hash_id_for_mhv_session_locking).and_return(false)
+      end
+
+      it 'returns the raw user_id' do
+        user_key = dummy_instance.send(:user_key)
+        expect(user_key).to eq('00000')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Hash the user_key (MHV Correlation ID) when creating MHV sessions to avoid storing PII in Redis
- This work is behind the Flipper `mhv_hash_id_for_mhv_session_locking`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118335

## Testing done

- [X] *New code is covered by unit tests*
- This change should be fully transparent to the user.
- Accessing MHV Medical Records, Secure Messaging, and Medications should work normally.
- A spec was added to test the change.
- Feature flag is tested on and off

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
The impact of this is fairly widespread, as multiple clients and products use the `MHVSessionBasedClient` module to create and manage MHV sessions.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
