### PR TITLE
[731] Log missing sec_id PCE status when authenticating on sign in service

### DIFF
--- a/app/services/sign_in/attribute_validator.rb
+++ b/app/services/sign_in/attribute_validator.rb
@@ -68,7 +68,7 @@ module SignIn
     def validate_sec_id
       return if sec_id.present?
 
-      sign_in_logger.info('mpi record missing sec_id', icn: verified_icn)
+      sign_in_logger.info('mpi record missing sec_id', icn: verified_icn, pce_status: sec_id_pce_status)
     end
 
     def add_mpi_user
@@ -200,6 +200,10 @@ module SignIn
 
     def sec_id
       @sec_id ||= mpi_response_profile.sec_id
+    end
+
+    def sec_id_pce_status
+      @sec_id_pce_status ||= mpi_response_profile.full_mvi_ids.any? { |id| id.include? '200PROV^USDVA^PCE' }
     end
 
     def credential_uuid

--- a/spec/services/sign_in/attribute_validator_spec.rb
+++ b/spec/services/sign_in/attribute_validator_spec.rb
@@ -295,15 +295,34 @@ RSpec.describe SignIn::AttributeValidator do
                 birth_date:,
                 given_names: [first_name],
                 family_name: last_name,
-                sec_id:)
+                sec_id:,
+                full_mvi_ids:)
         end
 
         shared_examples 'a missing sec_id' do
           let(:expected_sec_id_log) { 'mpi record missing sec_id' }
 
-          it 'logs that the sec_id is missing' do
-            subject
-            expect(sign_in_logger).to have_received(:info).with(a_string_including(expected_sec_id_log), icn:)
+          context 'and sec_id identifier is completely missing' do
+            let(:expected_pce_status) { false }
+
+            it 'logs that the sec_id is missing' do
+              subject
+              expect(sign_in_logger).to have_received(:info).with(a_string_including(expected_sec_id_log),
+                                                                  icn:,
+                                                                  pce_status: expected_pce_status)
+            end
+          end
+
+          context 'and sec_id identifier is missing due to PCE status' do
+            let(:expected_pce_status) { true }
+            let(:full_mvi_ids) { ['some-sec-id^PN^200PROV^USDVA^PCE'] }
+
+            it 'logs that the sec_id is missing' do
+              subject
+              expect(sign_in_logger).to have_received(:info).with(a_string_including(expected_sec_id_log),
+                                                                  icn:,
+                                                                  pce_status: expected_pce_status)
+            end
           end
         end
 
@@ -315,6 +334,7 @@ RSpec.describe SignIn::AttributeValidator do
         let(:participant_ids) { ['some-participant-id'] }
         let(:birls_ids) { ['some-birls-id'] }
         let(:sec_id) { 'some-sec-id' }
+        let(:full_mvi_ids) { ['some-full-mvi-ids'] }
 
         context 'and mpi record exists for user' do
           it_behaves_like 'mpi attribute validations'


### PR DESCRIPTION
## Summary

- This PR adds a boolean to the existing 'missing sec_id' log that is triggered when a user authenticates on Sign in Service and does not have a sec_id. This change shows whether the sec_id is truly missing, or is detected as missing because it's in PCE status

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/731

## Testing done

- [ ] Mocked a MPI record to have missing sec_id and mocked a MPI record to have sec_id but in PCE status.
- [ ] Authenticated with both users, confirmed a `mpi record missing sec_id` log was triggered. Confirmed user with missing sec_id had `pce_status: false`, user with PCE status sec_id had `pce_status: true`

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- Mock two users that you are able to authenticate with, for one user, remove any identifiers with `200PROV` to simulate missing sec_id. For the other user, update an existing `200PROV` identifier to end with `^PCE` instead of `^A`
- Authenticate with both users on Sign in Service, user with missing sec_id should create log: `mpi record missing sec_id, icn: xxxxx, pce_status: false`. User with PCE status sec_id should create log: ``mpi record missing sec_id, icn: xxxxx, pce_status: true`
