### PR TITLE
allow direct runs of the job while periodic runs stay flagged

### DIFF
--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -117,7 +117,7 @@ module V0
     end
 
     def import_facilities_if_empty
-      HCA::StdInstitutionImportJob.new.perform unless HealthFacility.exists?
+      HCA::StdInstitutionImportJob.new.import_facilities unless HealthFacility.exists?
     end
 
     def record_submission_attempt

--- a/app/controllers/v0/health_care_applications_controller.rb
+++ b/app/controllers/v0/health_care_applications_controller.rb
@@ -117,7 +117,7 @@ module V0
     end
 
     def import_facilities_if_empty
-      HCA::StdInstitutionImportJob.new.import_facilities unless HealthFacility.exists?
+      HCA::StdInstitutionImportJob.new.import_facilities(run_sync: true) unless HealthFacility.exists?
     end
 
     def record_submission_attempt

--- a/app/sidekiq/hca/std_institution_import_job.rb
+++ b/app/sidekiq/hca/std_institution_import_job.rb
@@ -81,6 +81,10 @@ module HCA
     def perform
       return unless Flipper.enabled?(:hca_health_facilities_update_job)
 
+      import_facilities
+    end
+
+    def import_facilities
       Rails.logger.info("[HCA] - Job started with #{StdInstitutionFacility.count} existing facilities.")
 
       ActiveRecord::Base.transaction do

--- a/app/sidekiq/hca/std_institution_import_job.rb
+++ b/app/sidekiq/hca/std_institution_import_job.rb
@@ -84,7 +84,7 @@ module HCA
       import_facilities
     end
 
-    def import_facilities
+    def import_facilities(run_sync: false)
       Rails.logger.info("[HCA] - Job started with #{StdInstitutionFacility.count} existing facilities.")
 
       ActiveRecord::Base.transaction do
@@ -93,7 +93,7 @@ module HCA
 
         import_institutions_from_csv(data)
 
-        HCA::HealthFacilitiesImportJob.perform_async
+        run_sync ? HCA::HealthFacilitiesImportJob.new.perform : HCA::HealthFacilitiesImportJob.perform_async
         Rails.logger.info("[HCA] - Job ended with #{StdInstitutionFacility.count} existing facilities.")
       end
       StatsD.increment("#{HCA::Service::STATSD_KEY_PREFIX}.ves_facilities_import_complete")

--- a/spec/requests/swagger_spec.rb
+++ b/spec/requests/swagger_spec.rb
@@ -950,6 +950,9 @@ RSpec.describe 'the v0 API documentation', order: :defined, type: %i[apivore req
         before { allow(Flipper).to receive(:enabled?).with(:hca_cache_facilities).and_return(false) }
 
         it 'supports returning list of active facilities' do
+          mock_job = instance_double(HCA::HealthFacilitiesImportJob)
+          expect(HCA::HealthFacilitiesImportJob).to receive(:new).and_return(mock_job)
+          expect(mock_job).to receive(:perform)
           VCR.use_cassette('lighthouse/facilities/v1/200_facilities_facility_ids', match_requests_on: %i[method uri]) do
             expect(subject).to validate(
               :get,

--- a/spec/requests/v0/health_care_applications_spec.rb
+++ b/spec/requests/v0/health_care_applications_spec.rb
@@ -323,7 +323,7 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
 
       import_job = instance_double(HCA::StdInstitutionImportJob)
       expect(HCA::StdInstitutionImportJob).to receive(:new).and_return(import_job)
-      expect(import_job).to receive(:perform)
+      expect(import_job).to receive(:import_facilities)
 
       get(facilities_v0_health_care_applications_path(state: 'OH'))
     end

--- a/spec/requests/v0/health_care_applications_spec.rb
+++ b/spec/requests/v0/health_care_applications_spec.rb
@@ -323,7 +323,7 @@ RSpec.describe 'V0::HealthCareApplications', type: %i[request serializer] do
 
       import_job = instance_double(HCA::StdInstitutionImportJob)
       expect(HCA::StdInstitutionImportJob).to receive(:new).and_return(import_job)
-      expect(import_job).to receive(:import_facilities)
+      expect(import_job).to receive(:import_facilities).with(run_sync: true)
 
       get(facilities_v0_health_care_applications_path(state: 'OH'))
     end

--- a/spec/sidekiq/hca/std_institution_import_job_spec.rb
+++ b/spec/sidekiq/hca/std_institution_import_job_spec.rb
@@ -175,6 +175,16 @@ RSpec.describe HCA::StdInstitutionImportJob, type: :worker do
 
         described_class.new.perform
       end
+
+      it 'runs HCA::HealthFacilitiesImportJob immediately when specified' do
+        allow_any_instance_of(HCA::StdInstitutionImportJob).to receive(:fetch_csv_data).and_return(csv_data)
+
+        mock_health_facilities_job = instance_double(HCA::HealthFacilitiesImportJob)
+        expect(HCA::HealthFacilitiesImportJob).to receive(:new).and_return(mock_health_facilities_job)
+        expect(mock_health_facilities_job).to receive(:perform)
+
+        described_class.new.import_facilities(run_sync: true)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES* - `hca_health_facilities_update_job`
- Still keeps scheduled runs of the job from flooding the Lighthouse DB, but allows individual runs for when the DB is empty and you try to retrieve Facilities.
- Health Enrollment 1010 EZ/CG
- *(If introducing a flipper, what is the success criteria being targeted?)* This is a permanent functionality switch.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119304

## Testing done

- [x] *New code is covered by unit tests*
- The `process` method now returns immediately unless the flag is enabled, but we still run the internal functionality when we can't proceed otherwise.
- I confirmed on local console that the job runs with the flag on, and does nothing with the flag off.

## What areas of the site does it impact?
- 1010 EZ and CG Facilities dropdowns data updates

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
