### PR TITLE
[118572] Update backend logic for approximateDate in new disability benefits workflow

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,17 +135,6 @@ PATH
     vye (0.1.0)
 
 GEM
-  remote: https://enterprise.contribsys.com/
-  specs:
-    sidekiq-ent (7.3.4)
-      einhorn (~> 1.0)
-      gserver
-      sidekiq (>= 7.3.7, < 8)
-      sidekiq-pro (>= 7.3.4, < 8)
-    sidekiq-pro (7.3.6)
-      sidekiq (>= 7.3.7, < 8)
-
-GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (2.0.1)
@@ -435,7 +424,6 @@ GEM
       dry-initializer (~> 3.2)
       dry-schema (~> 1.14)
       zeitwerk (~> 2.6)
-    einhorn (1.0.0)
     erb (5.0.2)
     erb (5.0.2-java)
     erubi (1.13.1)
@@ -576,7 +564,6 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    gserver (0.0.1)
     guard (2.18.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -1401,8 +1388,6 @@ DEPENDENCIES
   shoulda-matchers
   shrine
   sidekiq
-  sidekiq-ent!
-  sidekiq-pro!
   sign_in_service
   simple_forms_api!
   simplecov

--- a/lib/disability_compensation/requests/form526_request_body.rb
+++ b/lib/disability_compensation/requests/form526_request_body.rb
@@ -89,6 +89,7 @@ module Requests
     include Vets::Model
 
     attribute :name, String
+    attribute :approximate_date, String
     attribute :disability_action_type, String
     attribute :classification_code, String
     attribute :service_relevance, String
@@ -99,6 +100,7 @@ module Requests
 
     attribute :disability_action_type, String
     attribute :name, String
+    attribute :approximate_date, String
     attribute :classification_code, String
     attribute :service_relevance, String
     attribute :is_related_to_toxic_exposure, Bool

--- a/lib/disability_compensation/responses/rated_disabilities_response.rb
+++ b/lib/disability_compensation/responses/rated_disabilities_response.rb
@@ -19,6 +19,7 @@ module DisabilityCompensation
       attribute :diagnostic_code, Integer
       attribute :hyphenated_diagnostic_code, Integer
       attribute :name, String
+      attribute :approximate_date, String
       attribute :effective_date, DateTime
       attribute :rated_disability_id, String
       attribute :rating_decision_id, String

--- a/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
+++ b/lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb
@@ -606,39 +606,68 @@ module EVSS
       # @param approximate_date_source Hash EVSS format data object
       # @param short boolean (optional) return a shortened date YYYY-MM
       def convert_approximate_date(approximate_date_source, short: false)
-        approximate_date = approximate_date_source['year'].to_s
-        approximate_date += "-#{approximate_date_source['month']}" if approximate_date_source['month']
+        year  = approximate_date_source['year'].to_s.strip
+        month = approximate_date_source['month'].to_s.strip
+        day   = approximate_date_source['day'].to_s.strip
 
-        # returns YYYY-MM if only "short" date is requested
+        # Treat blanks and "XX" placeholders as absent
+        month = nil if month.blank? || month == 'XX'
+        day   = nil if day.blank?   || day == 'XX'
+
+        approximate_date = year
+        approximate_date += "-#{month}" if month
+
         return approximate_date if short
 
-        approximate_date += "-#{approximate_date_source['day']}" if approximate_date_source['day']
-
+        approximate_date += "-#{day}" if day
         approximate_date
       end
 
       def transform_disabilities(disabilities_source, toxic_exposure_conditions)
-        disabilities_source.map do |disability_source|
+        tox_present = toxic_exposure_conditions.present?
+
+        disabilities_source.map do |src|
           dis = Requests::Disability.new
-          dis.disability_action_type = disability_source['disabilityActionType']
-          dis.name = disability_source['name']
-          if toxic_exposure_conditions.present? && toxic_exposure_conditions.any?
-            dis.is_related_to_toxic_exposure = related_to_toxic_exposure?(dis.name, toxic_exposure_conditions)
+          dis.disability_action_type = src['disabilityActionType']
+          dis.name = src['name']
+
+          if tox_present
+            dis.is_related_to_toxic_exposure =
+              related_to_toxic_exposure(dis.name, toxic_exposure_conditions)
           end
-          dis.classification_code = disability_source['classificationCode'] if disability_source['classificationCode']
-          dis.service_relevance = disability_source['serviceRelevance'] || ''
-          dis.rated_disability_id = disability_source['ratedDisabilityId'] if disability_source['ratedDisabilityId']
-          dis.diagnostic_code = disability_source['diagnosticCode'] if disability_source['diagnosticCode']
-          if disability_source['secondaryDisabilities']
-            dis.secondary_disabilities = transform_secondary_disabilities(disability_source)
-          end
-          if disability_source['cause'].present?
-            dis.exposure_or_event_or_injury = format_exposure_text(disability_source['cause'],
-                                                                   dis.is_related_to_toxic_exposure)
-          end
+
+          dis.classification_code = src['classificationCode'] if src['classificationCode']
+          dis.service_relevance   = src['serviceRelevance'] || ''
+          dis.rated_disability_id = src['ratedDisabilityId'] if src['ratedDisabilityId']
+          dis.diagnostic_code     = src['diagnosticCode'] if src['diagnosticCode']
+
+          assign_secondary(dis, src)
+          assign_exposure(dis, src)
+          assign_approximate_date(dis, src)
 
           dis
         end
+      end
+
+      def assign_secondary(dis, src)
+        return unless src['secondaryDisabilities']
+
+        dis.secondary_disabilities = transform_secondary_disabilities(src)
+      end
+
+      def assign_exposure(dis, src)
+        cause = src['cause']
+        return if cause.blank?
+
+        dis.exposure_or_event_or_injury =
+          format_exposure_text(cause, dis.is_related_to_toxic_exposure)
+      end
+
+      def assign_approximate_date(dis, src)
+        approx = src['approximateDate']
+        return if approx.blank?
+
+        dis.approximate_date = convert_approximate_date(approx)
       end
 
       def format_exposure_text(cause, related_to_toxic_exposure)
@@ -646,7 +675,7 @@ module EVSS
         related_to_toxic_exposure ? cause_text.sub!(/[.]?$/, '; toxic exposure.') : cause_text
       end
 
-      def related_to_toxic_exposure?(condition_name, toxic_exposure_conditions)
+      def related_to_toxic_exposure(condition_name, toxic_exposure_conditions)
         regex_non_word = /[^\w]/
         normalized_condition_name = condition_name.gsub(regex_non_word, '').downcase
         toxic_exposure_conditions[normalized_condition_name].present?

--- a/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb
@@ -339,6 +339,46 @@ RSpec.describe EVSS::DisabilityCompensationForm::Form526ToLighthouseTransform do
       # last condition is not a toxic exposure condition
       expect(results.last.exposure_or_event_or_injury).to eq(cause_map[:SECONDARY])
     end
+
+    context 'when approximateDate is provided' do
+      let(:base_source) { data_without_te.first.deep_dup }
+
+      it 'leaves approximate_date nil when approximateDate is absent' do
+        source = base_source.except('approximateDate')
+        result = transformer.send(:transform_disabilities, [source], nil).first
+        expect(result.approximate_date).to be_nil
+      end
+
+      it 'sets YYYY when only year is provided' do
+        source = base_source.merge('approximateDate' => { 'year' => '1973' })
+        result = transformer.send(:transform_disabilities, [source], nil).first
+        expect(result.approximate_date).to eq('1973')
+      end
+
+      it 'sets YYYY-MM when year and month are provided' do
+        source = base_source.merge('approximateDate' => { 'year' => '1973', 'month' => '03' })
+        result = transformer.send(:transform_disabilities, [source], nil).first
+        expect(result.approximate_date).to eq('1973-03')
+      end
+
+      it 'sets YYYY-MM-DD when year, month, and day are provided' do
+        source = base_source.merge('approximateDate' => { 'year' => '1973', 'month' => '03', 'day' => '22' })
+        result = transformer.send(:transform_disabilities, [source], nil).first
+        expect(result.approximate_date).to eq('1973-03-22')
+      end
+
+      it 'leaves approximate_date nil when approximateDate is an empty hash' do
+        source = base_source.merge('approximateDate' => {})
+        result = transformer.send(:transform_disabilities, [source], nil).first
+        expect(result.approximate_date).to be_nil
+      end
+
+      it 'ignores blank month/day strings' do
+        source = base_source.merge('approximateDate' => { 'year' => '1973', 'month' => '', 'day' => '' })
+        result = transformer.send(:transform_disabilities, [source], nil).first
+        expect(result.approximate_date).to eq('1973')
+      end
+    end
   end
 
   describe 'transform direct deposit' do

--- a/spec/support/schemas/rated_disability_base.json
+++ b/spec/support/schemas/rated_disability_base.json
@@ -28,6 +28,9 @@
     "name": {
       "type": "string"
     },
+    "approximate_date": { 
+      "type": ["string", "null"] 
+    },
     "effective_date": {
       "type": "datetime"
     },

--- a/spec/support/schemas_camelized/rated_disability_base.json
+++ b/spec/support/schemas_camelized/rated_disability_base.json
@@ -28,6 +28,9 @@
     "name": {
       "type": "string"
     },
+    "approximateDate": { 
+      "type": ["string", "null"] 
+    },
     "effectiveDate": {
       "type": "datetime"
     },


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): NO*

This PR introduces support for the approximate_date attribute across disability compensation request and response handling. Additionally, laterality has been incorporated into the disability condition name to support new workflow requirements.

- *(Summarize the changes that have been made to the platform)*

The following application files were updated to include `approximate_date` (and laterality in one case):

   - `lib/disability_compensation/requests/form526_request_body.rb`
   - `lib/disability_compensation/responses/rated_disabilities_response.rb`
   - `lib/evss/disability_compensation_form/data_translation_all_claim.rb` (also introduces laterality to condition name)
   - `lib/evss/disability_compensation_form/form526_to_lighthouse_transform.rb`

The following test files were updated to align with the new transformations:

   - `spec/lib/evss/disability_compensation_form/data_translation_all_claim_spec.rb`
   - `spec/lib/evss/disability_compensation_form/form526_to_lighthouse_transform_spec.rb`
   
- *(If bug, how to reproduce)*

Not applicable — this is not a bug fix.

- *(What is the solution, why is this the solution?)*

A new workflow is being introduced in the disabilities chapter of the all-claims process. This workflow requires two new fields: date and laterality. To support this, Rails transformations for disabilities have been updated to correctly handle and pass these attributes through.

This solution ensures consistency between form input, backend processing, and downstream transformations, enabling the new workflow to function without disruption.

- *(Which team do you work for, does your team own the maintenance of this component?)*

This work is managed by the Veterans Disability Benefits and Contention Classification team.

- *(If introducing a flipper, what is the success criteria being targeted?)*

No flipper is introduced in this work.

Closes `https://github.com/department-of-veterans-affairs/va.gov-team/issues/118572`.

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
   - `https://github.com/department-of-veterans-affairs/va.gov-team/issues/118572`
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*
   - `https://github.com/department-of-veterans-affairs/va.gov-team/issues/116106`

## Testing done

- [ X ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*

### Previous Behavior

In the disabilities chapter of the all-claims workflow, when a veteran entered a new condition or opted to increase a rated disability, no date was requested or captured.

### Current Behavior with Changes

With this update, the workflow now allows the veteran to:
   - Provide a date for when a new condition began
   - Provide a date for when a rated disability worsened
   - Have laterality included in the condition name where applicable
 
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*

### Verification Steps

Unit Tests (completed in this PR)

   - Confirmed via specs that approximate_date and laterality are correctly included in the transformed disability data.

   - Validated transformations in:
      - data_translation_all_claim_spec.rb
      - form526_to_lighthouse_transform_spec.rb

Integration Testing (pending)

   - A full manual verification of the workflow requires coordinated updates across:
      - Schema update (separate [PR](https://github.com/department-of-veterans-affairs/vets-json-schema/pull/1057))
      - vets-website update (separate [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/38626))
      - vets-api update (this PR)

Until all three pieces are merged and deployed to a shared environment (e.g., dev/staging), the form submission cannot be tested end-to-end.

Planned Manual Verification

- Once integrated:
   - Submitting a new condition should show the approximate_date captured in the API payload
   - Submitting an increase to a rated disability should include the approximate_date in the transformed data
   - Disabilities with laterality should show the updated condition name

- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  
  No flipper is associated with this work, so no toggle testing is required.
  
  - *What is the testing plan for rolling out the feature?*

### Criteria:

   - Payloads include approximate_date and laterality as designed
   - Lighthouse accepts well-formed submissions 
   - No regressions in unrelated disabilities claims paths 
   
## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

These changes impact Section 2 of the 526 all-claims online form, which is the disabilities chapter. This is where veterans enter information about:

   - New or existing disability conditions
   - Laterality of conditions (where applicable)
   - Dates related to onset or worsening of conditions
   - Related details such as toxic exposures and additional benefits

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
