### PR TITLE
API-49796 - Update `claims_api_record_metadata` table with new columns

### DIFF
--- a/db/migrate/20250919161741_add_details_to_record_metadata.rb
+++ b/db/migrate/20250919161741_add_details_to_record_metadata.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddDetailsToRecordMetadata < ActiveRecord::Migration[7.2]
+  def change
+    add_column :claims_api_record_metadata, :request_url_ciphertext, :string
+    add_column :claims_api_record_metadata, :request_ciphertext, :text
+    add_column :claims_api_record_metadata, :response_ciphertext, :text
+    add_column :claims_api_record_metadata, :request_headers_ciphertext, :text
+  end
+end

--- a/db/migrate/20250919163644_remove_record_type_from_record_metadata.rb
+++ b/db/migrate/20250919163644_remove_record_type_from_record_metadata.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveRecordTypeFromRecordMetadata < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured { remove_column :claims_api_record_metadata, :record_type, :string }
+  end
+end

--- a/db/migrate/20250919163720_remove_record_id_from_record_metadata.rb
+++ b/db/migrate/20250919163720_remove_record_id_from_record_metadata.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveRecordIdFromRecordMetadata < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured { remove_column :claims_api_record_metadata, :record_id, :uuid }
+  end
+end

--- a/db/migrate/20250919164027_allow_null_metadata_for_record_metadata.rb
+++ b/db/migrate/20250919164027_allow_null_metadata_for_record_metadata.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AllowNullMetadataForRecordMetadata < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :claims_api_record_metadata, :metadata_ciphertext, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_16_114106) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_19_164027) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -642,15 +642,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_16_114106) do
   end
 
   create_table "claims_api_record_metadata", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.text "metadata_ciphertext", null: false
-    t.string "record_type", null: false
-    t.uuid "record_id", null: false
+    t.text "metadata_ciphertext"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "encrypted_kms_key"
     t.boolean "needs_kms_rotation", default: false, null: false
+    t.string "request_url_ciphertext"
+    t.text "request_ciphertext"
+    t.text "response_ciphertext"
+    t.text "request_headers_ciphertext"
     t.index ["needs_kms_rotation"], name: "index_claims_api_record_metadata_on_needs_kms_rotation"
-    t.index ["record_type", "record_id"], name: "index_record_metadata_on_type_and_id"
   end
 
   create_table "claims_api_supporting_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
## Summary

This PR updates a (currently unused) database table with new columns. It also removes some previously existing columns that don't suit our needs.

This is part of a larger effort to track failed SOAP requests within claims_api. For all upcoming changes, see this [draft](https://github.com/department-of-veterans-affairs/vets-api/pull/24236/files).

## Related issue(s)

|[Jira ticket](https://jira.devops.va.gov/browse/API-49779)|
| - |
|<img width="1269" height="515" alt="Screenshot 2025-09-09 at 16 46 36" src="https://github.com/user-attachments/assets/c478db8f-a7c8-46eb-b2e8-48db8f53e5ae" />|

## Testing done

There's not much to test yet. In an upcoming PR, I'll add in a corrected version of the model deleted here, along with some specs.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

```
db/migrate/20250919161741_add_details_to_record_metadata.rb
db/migrate/20250919163644_remove_record_type_from_record_metadata.rb
db/migrate/20250919163720_remove_record_id_from_record_metadata.rb
db/migrate/20250919164027_allow_null_metadata_for_record_metadata.rb
db/schema.rb
```

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA