### PR TITLE
Stub PDF overflow tracking in tests

### DIFF
--- a/modules/dependents_benefits/spec/controllers/dependents_benefits/v0/claims_controller_spec.rb
+++ b/modules/dependents_benefits/spec/controllers/dependents_benefits/v0/claims_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe DependentsBenefits::V0::ClaimsController do
   before do
     sign_in_as(user)
     allow(Flipper).to receive(:enabled?).with(:dependents_module_enabled, instance_of(User)).and_return(true)
+    allow_any_instance_of(SavedClaim).to receive(:pdf_overflow_tracking)
   end
 
   describe '#show' do
@@ -62,8 +63,6 @@ RSpec.describe DependentsBenefits::V0::ClaimsController do
       end
 
       it 'logs the success' do
-        expect(Rails.logger).to receive(:info).with(match(/Skipping tracking PDF overflow/),
-                                                    instance_of(Hash)).at_least(:once)
         expect(Rails.logger).to receive(:info).with(match(/TODO: Link claim \d+ to parent/)).at_least(:once)
         expect(Rails.logger).to receive(:info).with(match(/Successfully created claim/),
                                                     include({ statsd: 'api.dependents_application.create_success' }))

--- a/modules/dependents_benefits/spec/lib/dependents_benefits/claim_processor_spec.rb
+++ b/modules/dependents_benefits/spec/lib/dependents_benefits/claim_processor_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe DependentsBenefits::ClaimProcessor, type: :model do
     allow(DependentsBenefits::Monitor).to receive(:new).and_return(mock_monitor)
     allow(mock_monitor).to receive(:track_processor_info)
     allow(mock_monitor).to receive(:track_processor_error)
+
+    allow_any_instance_of(SavedClaim).to receive(:pdf_overflow_tracking)
   end
 
   describe '.enqueue_submissions' do

--- a/modules/dependents_benefits/spec/lib/dependents_benefits/generators/claim674_generator_spec.rb
+++ b/modules/dependents_benefits/spec/lib/dependents_benefits/generators/claim674_generator_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe DependentsBenefits::Generators::Claim674Generator, type: :model d
   let(:parent_id) { 123 }
   let(:generator) { described_class.new(form_data, parent_id, student_data) }
 
+  before do
+    allow_any_instance_of(SavedClaim).to receive(:pdf_overflow_tracking)
+  end
+
   describe '#extract_form_data' do
     let(:extracted_data) { generator.send(:extract_form_data) }
 
@@ -62,7 +66,6 @@ RSpec.describe DependentsBenefits::Generators::Claim674Generator, type: :model d
     end
 
     it 'logs a TODO message for claim linking' do
-      expect(Rails.logger).to receive(:info).with(match('Stamping PDF')).at_least(:once)
       expect(Rails.logger).to receive(:info).with(match("TODO: Link claim \\d+ to parent #{parent_id}"))
       generator.generate
     end

--- a/modules/dependents_benefits/spec/lib/dependents_benefits/generators/claim686c_generator_spec.rb
+++ b/modules/dependents_benefits/spec/lib/dependents_benefits/generators/claim686c_generator_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe DependentsBenefits::Generators::Claim686cGenerator, type: :model 
   let(:parent_id) { 123 }
   let(:generator) { described_class.new(form_data, parent_id) }
 
+  before do
+    allow_any_instance_of(SavedClaim).to receive(:pdf_overflow_tracking)
+  end
+
   describe '#extract_form_data' do
     let(:extracted_data) { generator.send(:extract_form_data) }
 
@@ -51,9 +55,6 @@ RSpec.describe DependentsBenefits::Generators::Claim686cGenerator, type: :model 
     end
 
     it 'logs a TODO message for claim linking' do
-      expect(Rails.logger).to receive(:info).with(match(/Skipping tracking PDF overflow/),
-                                                  instance_of(Hash)).at_least(:once)
-      expect(Rails.logger).to receive(:info).with(match(/Stamping PDF/)).at_least(:once)
       expect(Rails.logger).to receive(:info).with(match(/TODO: Link claim \d+ to parent #{parent_id}/)).once
       generator.generate
     end

--- a/modules/dependents_benefits/spec/lib/dependents_benefits/generators/claim_generator_integration_spec.rb
+++ b/modules/dependents_benefits/spec/lib/dependents_benefits/generators/claim_generator_integration_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe 'DependentsBenefits Claim Generator Integration', type: :model do
   let(:parent_claim_id) { 123 }
   let(:form_data) { create(:dependents_claim).parsed_form }
 
+  before do
+    allow_any_instance_of(SavedClaim).to receive(:pdf_overflow_tracking)
+  end
+
   describe 'Creating 686c and 674 claims from combined form data' do
     before do
       allow(Rails.logger).to receive(:info)

--- a/modules/dependents_benefits/spec/lib/dependents_benefits/generators/dependent_claim_generator_spec.rb
+++ b/modules/dependents_benefits/spec/lib/dependents_benefits/generators/dependent_claim_generator_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe DependentsBenefits::Generators::DependentClaimGenerator, type: :m
 
   before do
     allow(generator).to receive(:claim_class).and_return(DependentsBenefits::SavedClaim)
+
+    allow_any_instance_of(SavedClaim).to receive(:pdf_overflow_tracking)
   end
 
   describe 'initialization' do

--- a/modules/dependents_benefits/spec/lib/dependents_benefits/monitor_spec.rb
+++ b/modules/dependents_benefits/spec/lib/dependents_benefits/monitor_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe DependentsBenefits::Monitor do
   let(:current_user) { create(:user) }
   let(:monitor_error) { create(:monitor_error) }
 
+  before do
+    allow_any_instance_of(SavedClaim).to receive(:pdf_overflow_tracking)
+  end
+
   def base_payload(extras = {})
     {
       confirmation_number: claim.confirmation_number,

--- a/modules/dependents_benefits/spec/lib/dependents_benefits/sidekiq/dependent_submission_job_spec.rb
+++ b/modules/dependents_benefits/spec/lib/dependents_benefits/sidekiq/dependent_submission_job_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe DependentsBenefits::DependentSubmissionJob, type: :job do
   let(:saved_claim) { create(:dependents_claim) }
   let(:job) { described_class.new }
 
+  before do
+    allow_any_instance_of(SavedClaim).to receive(:pdf_overflow_tracking)
+  end
+
   describe '#perform' do
     context 'when claim group has already failed' do
       before do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Testing change only
- The PDF overflow tracking functionality is long-running and adds significant overhead to rspec tests. Stubbing it out except when explicitly testing it reduces the time for tests to run. 
- Reduces Dependents Benefits module test run time from 2min 9s to 2.12 seconds

## Testing done

No new code, only unit test changes

## Screenshots
<img width="565" height="221" alt="Screenshot 2025-09-22 at 10 31 57 AM" src="https://github.com/user-attachments/assets/d1f15c1e-7d65-4d93-8d3d-5fc5b6aa61e9" />
<img width="967" height="207" alt="Screenshot 2025-09-22 at 10 41 01 AM" src="https://github.com/user-attachments/assets/22162924-162b-47a1-8f56-df038bcd2263" />

## What areas of the site does it impact?
Dependents Benefits

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
