### PR TITLE
Minor log fixes

### DIFF
--- a/modules/vaos/app/services/eps/appointment_service.rb
+++ b/modules/vaos/app/services/eps/appointment_service.rb
@@ -127,6 +127,8 @@ module Eps
       return [] if appointments.nil?
 
       provider_ids = appointments.pluck(:provider_service_id).compact.uniq
+      return appointments if provider_ids.empty?
+
       providers = provider_services.get_provider_services_by_ids(provider_ids:)
 
       appointments.each do |appointment|

--- a/modules/vaos/app/services/eps/provider_service.rb
+++ b/modules/vaos/app/services/eps/provider_service.rb
@@ -26,7 +26,7 @@ module Eps
     def get_provider_services_by_ids(provider_ids:)
       if provider_ids.blank?
         log_no_params_metric('get_provider_services_by_ids')
-        raise ArgumentError, 'provider_ids is required and cannot be blank'
+        return OpenStruct.new(provider_services: [])
       end
 
       with_monitoring do

--- a/modules/vaos/spec/services/eps/provider_service_spec.rb
+++ b/modules/vaos/spec/services/eps/provider_service_spec.rb
@@ -223,7 +223,7 @@ describe Eps::ProviderService do
     end
 
     context 'when provider_ids parameter is missing or blank' do
-      it 'raises ArgumentError and logs StatsD metric and Rails warning when provider_ids is nil' do
+      it 'returns empty provider_services and logs StatsD metric and Rails warning when provider_ids is nil' do
         expect(StatsD).to receive(:increment).with(
           'api.vaos.provider_service.no_params',
           tags: ['service:community_care_appointments']
@@ -236,12 +236,11 @@ describe Eps::ProviderService do
           )
         )
 
-        expect do
-          service.get_provider_services_by_ids(provider_ids: nil)
-        end.to raise_error(ArgumentError, 'provider_ids is required and cannot be blank')
+        result = service.get_provider_services_by_ids(provider_ids: nil)
+        expect(result).to eq(OpenStruct.new(provider_services: []))
       end
 
-      it 'raises ArgumentError and logs StatsD metric and Rails warning when provider_ids is empty array' do
+      it 'returns empty provider_services and logs StatsD metric and Rails warning when provider_ids is empty array' do
         expect(StatsD).to receive(:increment).with(
           'api.vaos.provider_service.no_params',
           tags: ['service:community_care_appointments']
@@ -254,9 +253,8 @@ describe Eps::ProviderService do
           )
         )
 
-        expect do
-          service.get_provider_services_by_ids(provider_ids: [])
-        end.to raise_error(ArgumentError, 'provider_ids is required and cannot be blank')
+        result = service.get_provider_services_by_ids(provider_ids: [])
+        expect(result).to eq(OpenStruct.new(provider_services: []))
       end
     end
   end


### PR DESCRIPTION
## Summary

- **This work is behind a feature toggle (flipper):** NO
- **Summary:**  
  Minor logging-related fixes to provider service handling.  
  - The `get_provider_services_by_ids` method now returns an empty provider_services object instead of raising an exception when given a blank or nil provider_ids.
  - The logic in `merge_provider_data_with_appointments` short-circuits and returns early if provider_ids is empty.
  - Corresponding spec expectations updated to reflect new behavior.
- **Bug reproduction steps:**  
  Call the provider service with blank or nil provider_ids.
- **Solution:**  
  Returning an empty provider_services object improves robustness and avoids unnecessary errors for empty input, while still logging/monitoring the event.
- **Team ownership:**  
  VAOS team; this component is maintained by our team.
- **Flipper:**  
  Not introducing a flipper/feature toggle.

---

## Related issue(s)

- https://dsva.slack.com/archives/CMNQT72LX/p1758547891921549

---

## Testing done

- [x] New code is covered by unit tests
- **Old behavior:**  
  Raised an `ArgumentError` if provider_ids was nil or blank.
- **Verification steps:**  
  - Call `get_provider_services_by_ids` with `nil` and with `[]` and confirm an empty provider_services object is returned.
  - Confirm StatsD metric and Rails warning are still logged.
  - Ensure `merge_provider_data_with_appointments` returns appointments unchanged if provider_ids is empty.
  - Specs for these cases are added/updated.
- **If this work is behind a flipper:**  
  N/A

---

## What areas of the site does it impact?

- VAOS backend: EPS provider service and appointment service logic.  
  No UI changes; only backend/service behavior is affected.

---

## Acceptance criteria

- [x]  I fixed/updated/added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution.
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
