### PR TITLE
Updating typo in URL for SSOe get traits service

### DIFF
--- a/config/identity_settings/environments/staging.yml
+++ b/config/identity_settings/environments/staging.yml
@@ -72,4 +72,4 @@ ssoe_eauth_cookie:
 ssoe_get_traits:
   client_cert_path: /etc/pki/tls/certs/vetsgov-mvi-cert.pem
   client_key_path: /etc/pki/tls/private/vetsgov-mvi.key
-  url: https://sqa.services.eauth.va.gov:9303/psim_webservice/IdMSSOeWebService
+  url: https://sqa.services.eauth.va.gov:9303/psim_webservice/sqa/IdMSSOeWebService


### PR DESCRIPTION
## Summary

- This PR updates a simple typo in the SSOe get traits service. This service is not live, and this only impacts a staging setting, so this has no production impact

## Testing done

- Cannot test this change until it is deployed on staging. I took a cURL to the service at this new URL and tested manually on an argo pod