### PR TITLE
Revert "Updating saved_claim to include user_account_id"

### DIFF
--- a/modules/income_and_assets/app/controllers/income_and_assets/v0/claims_controller.rb
+++ b/modules/income_and_assets/app/controllers/income_and_assets/v0/claims_controller.rb
@@ -37,7 +37,7 @@ module IncomeAndAssets
 
       # POST creates and validates an instance of `claim_class`
       def create
-        claim = claim_class.new(form: filtered_params[:form], user_account_id: current_user&.user_account_uuid)
+        claim = claim_class.new(form: filtered_params[:form])
         monitor.track_create_attempt(claim, current_user)
 
         in_progress_form = current_user ? InProgressForm.form_for_user(claim.form_id, current_user) : nil
@@ -51,7 +51,7 @@ module IncomeAndAssets
 
         process_attachments(in_progress_form, claim)
 
-        IncomeAndAssets::BenefitsIntake::SubmitClaimJob.perform_async(claim.id)
+        IncomeAndAssets::BenefitsIntake::SubmitClaimJob.perform_async(claim.id, current_user&.user_account_uuid)
 
         monitor.track_create_success(in_progress_form, claim, current_user)
 

--- a/modules/income_and_assets/lib/income_and_assets/benefits_intake/submit_claim_job.rb
+++ b/modules/income_and_assets/lib/income_and_assets/benefits_intake/submit_claim_job.rb
@@ -33,11 +33,12 @@ module IncomeAndAssets
       # Process income and assets pdfs and upload to Benefits Intake API
       #
       # @param saved_claim_id [Integer] the pension claim id
+      # @param user_account_uuid [UUID] the user submitting the form
       #
       # @return [UUID] benefits intake upload uuid
       #
-      def perform(saved_claim_id)
-        init(saved_claim_id)
+      def perform(saved_claim_id, user_account_uuid = nil)
+        init(saved_claim_id, user_account_uuid)
 
         # generate and validate claim pdf documents
         @form_path = process_document(@claim.to_pdf(@claim.id, { extras_redesign: true,
@@ -49,11 +50,11 @@ module IncomeAndAssets
         upload_document
 
         send_submitted_email
-        monitor.track_submission_success(@claim, @intake_service, @claim.user_account_id)
+        monitor.track_submission_success(@claim, @intake_service, @user_account_uuid)
 
         @intake_service.uuid
       rescue => e
-        monitor.track_submission_retry(@claim, @intake_service, @claim&.user_account_id, e)
+        monitor.track_submission_retry(@claim, @intake_service, @user_account_uuid, e)
         @lighthouse_submission_attempt&.fail!
         raise e
       ensure
@@ -63,16 +64,16 @@ module IncomeAndAssets
       private
 
       # Instantiate instance variables for _this_ job
-      def init(saved_claim_id)
+      def init(saved_claim_id, user_account_uuid)
+        @user_account_uuid = user_account_uuid
+        @user_account = UserAccount.find(@user_account_uuid) if @user_account_uuid.present?
+        # UserAccount.find will raise an error if unable to find the user_account record
+
         @claim = IncomeAndAssets::SavedClaim.find(saved_claim_id)
         unless @claim
           raise IncomeAndAssetsBenefitIntakeError,
                 "Unable to find IncomeAndAssets::SavedClaim #{saved_claim_id}"
         end
-
-        # Check to make sure that the user_account_id points to an actual user_account record
-        # UserAccount.find will raise an error if unable to find the user_account record
-        UserAccount.find(@claim.user_account_id) if @claim.user_account_id.present?
 
         @intake_service = ::BenefitsIntake::Service.new
       end
@@ -124,7 +125,7 @@ module IncomeAndAssets
       # Upload generated pdf to Benefits Intake API
       def upload_document
         @intake_service.request_upload
-        monitor.track_submission_begun(@claim, @intake_service, @claim.user_account_id)
+        monitor.track_submission_begun(@claim, @intake_service, @user_account_uuid)
         lighthouse_submission_polling
 
         payload = {
@@ -134,7 +135,7 @@ module IncomeAndAssets
           attachments: @attachment_paths
         }
 
-        monitor.track_submission_attempted(@claim, @intake_service, @claim.user_account_id, payload)
+        monitor.track_submission_attempted(@claim, @intake_service, @user_account_uuid, payload)
         response = @intake_service.perform_upload(**payload)
         raise IncomeAndAssetsBenefitIntakeError, response.to_s unless response.success?
       end
@@ -161,7 +162,7 @@ module IncomeAndAssets
       def send_submitted_email
         IncomeAndAssets::NotificationEmail.new(@claim.id).deliver(:submitted)
       rescue => e
-        monitor.track_send_email_failure(@claim, @intake_service, @claim.user_account_id, 'submitted', e)
+        monitor.track_send_email_failure(@claim, @intake_service, @user_account_uuid, 'submitted', e)
       end
 
       # Delete temporary stamped PDF files for this instance.
@@ -169,7 +170,7 @@ module IncomeAndAssets
         Common::FileHelpers.delete_file_if_exists(@form_path) if @form_path
         @attachment_paths&.each { |p| Common::FileHelpers.delete_file_if_exists(p) }
       rescue => e
-        monitor.track_file_cleanup_error(@claim, @intake_service, @claim&.user_account_id, e)
+        monitor.track_file_cleanup_error(@claim, @intake_service, @user_account_uuid, e)
       end
     end
   end

--- a/modules/income_and_assets/spec/e2e_spec.rb
+++ b/modules/income_and_assets/spec/e2e_spec.rb
@@ -26,9 +26,7 @@ RSpec.describe 'Income and Assets End to End', type: :request do
 
   it 'successfully completes the submission process' do
     # form submission
-    # NOTE: This e2e test assumes that the user is NOT authenticated
-    expect(IncomeAndAssets::SavedClaim).to receive(:new).with(form: form.form,
-                                                              user_account_id: nil).and_call_original
+    expect(IncomeAndAssets::SavedClaim).to receive(:new).with(form: form.form).and_call_original
     expect(monitor).to receive(:track_create_attempt).and_call_original
     expect(SavedClaimSerializer).to receive(:new).and_call_original
     expect(PersistentAttachment).to receive(:where).with(guid: anything).and_call_original

--- a/modules/income_and_assets/spec/factories/income_and_assets/income_and_assets_claim.rb
+++ b/modules/income_and_assets/spec/factories/income_and_assets/income_and_assets_claim.rb
@@ -3,7 +3,6 @@
 FactoryBot.define do
   factory :income_and_assets_claim, class: 'IncomeAndAssets::SavedClaim' do
     form_id { '21P-0969' }
-    user_account_id { '123' }
     form do
       {
         veteranFullName: {


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#24252. Need to update the `saved_claims` DB tables' `user_account_id` column to be a UUID instead of a BigInt but can't do the update without reverting this PR