### PR TITLE
API-50200-fix-federal-activation-bug-in-mapper

### DIFF
--- a/modules/claims_api/lib/claims_api/v1/disability_compensation_pdf_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v1/disability_compensation_pdf_mapper.rb
@@ -575,7 +575,7 @@ module ClaimsApi
           anticipated_separation_date_data, anticipated_separation_date_data.length
         )
 
-        @pdf_data[:data][:attributes][:serviceInformation][:reservesNationalGuardService][:federalActivation] = {
+        @pdf_data[:data][:attributes][:serviceInformation][:federalActivation] = {
           activationDate: activation_date,
           anticipatedSeparationDate: anticipated_separation_date
         }

--- a/modules/claims_api/spec/lib/claims_api/v1/disability_compensation_pdf_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v1/disability_compensation_pdf_mapper_spec.rb
@@ -909,12 +909,13 @@ describe ClaimsApi::V1::DisabilityCompensationPdfMapper do
         mapper.map_claim
 
         reserves_base = pdf_data[:data][:attributes][:serviceInformation][:reservesNationalGuardService]
+        service_info_base = pdf_data[:data][:attributes][:serviceInformation]
 
         expect(reserves_base[:unitPhoneNumber]).to eq('1231231234')
         expect(reserves_base[:receivingInactiveDutyTrainingPay]).to be('NO')
-        expect(reserves_base[:federalActivation][:activationDate]).to eq({ year: '2023', month: '01', day: '01' })
-        expect(reserves_base[:federalActivation][:anticipatedSeparationDate]).to eq({ year: '2025', month: '12',
-                                                                                      day: '01' })
+        expect(service_info_base[:federalActivation][:activationDate]).to eq({ year: '2023', month: '01', day: '01' })
+        expect(service_info_base[:federalActivation][:anticipatedSeparationDate]).to eq({ year: '2025', month: '12',
+                                                                                          day: '01' })
       end
     end
 


### PR DESCRIPTION
## Summary
* Fixes placement of `federalActivation` in the mapped output.
	* It was nested inside the reserves object, but needs to be outside of it

## Related issue(s)


## Testing done

- [x] *New code is covered by unit tests*

#### Testing Notes
* This should be a viable `serviceInformation` block to include federal activation
```
        "serviceInformation":{
            "servicePeriods":[
               {
                  "activeDutyEndDate":"2008-01-02",
                  "serviceBranch":"Army",
                  "activeDutyBeginDate":"2007-02-05"
               }
            ],
            "confinements":[
               {
                  "confinementBeginDate":"2007-08-01",
                  "confinementEndDate":"2007-09-01"
               },
               {
                  "confinementBeginDate":"2007-10-01",
                  "confinementEndDate":"2007-12-01"
               }
            ],
            "reservesNationalGuardService":{
               "title10Activation":{
                  "anticipatedSeparationDate":"2025-12-01",
                  "title10ActivationDate":"2023-01-01"
               },
               "obligationTermOfServiceFromDate":"2023-01-01",
               "obligationTermOfServiceToDate":"2023-12-01",
               "unitName":"Unit Name",
               "unitPhone":{
                  "areaCode":"123",
                  "phoneNumber":"1231234"
               },
               "receivingInactiveDutyTrainingPay":false
            },
            "alternateNames":[
               {
                  "firstName":"Jane",
                  "middleName":"E",
                  "lastName":"Doe"
               }
            ]
         },
```

* That block should produce the matching mapping
```
     :serviceInformation=>
      {:mostRecentActiveService=>{:start=>{:year=>"2007", :month=>"02", :day=>"05"}, :end=>{:year=>"2008", :month=>"01", :day=>"02"}},
       :branchOfService=>{:branch=>"Army"},
       :additionalPeriodsOfService=>[],
       :prisonerOfWarConfinement=>
        {:confinementDates=>
          [{:start=>{:year=>"2007", :month=>"08", :day=>"01"}, :end=>{:year=>"2007", :month=>"09", :day=>"01"}},
           {:start=>{:year=>"2007", :month=>"10", :day=>"01"}, :end=>{:year=>"2007", :month=>"12", :day=>"01"}}]},
       :reservesNationalGuardService=>
        {:unitName=>"Unit Name",
         :obligationTermsOfService=>{:start=>{:year=>"2023", :month=>"01", :day=>"01"}, :end=>{:year=>"2023", :month=>"12", :day=>"01"}},
         :unitPhoneNumber=>"1231231234",
         :receivingInactiveDutyTrainingPay=>"NO"},
       :federalActivation=>
        {:activationDate=>{:year=>"2023", :month=>"01", :day=>"01"}, :anticipatedSeparationDate=>{:year=>"2025", :month=>"12", :day=>"01"}},
       :alternateNames=>["Jane E Doe"]}}}}
```
 
## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/lib/claims_api/v1/disability_compensation_pdf_mapper.rb
	modified:   modules/claims_api/spec/lib/claims_api/v1/disability_compensation_pdf_mapper_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
