### PR TITLE
API-50202-v1-pdf-mapper-direct-deposit

### DIFF
--- a/modules/claims_api/lib/claims_api/v1/disability_compensation_pdf_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v1/disability_compensation_pdf_mapper.rb
@@ -20,6 +20,7 @@ module ClaimsApi
         section_5_treatment_centers
         section_6_service_information
         section_7_service_pay
+        section_8_direct_deposit
       ].freeze
 
       HOMELESSNESS_RISK_SITUATION_TYPES = {
@@ -690,6 +691,37 @@ module ClaimsApi
         return if @pdf_data[:data][:attributes][:servicePay]&.key?(:separationSeverancePay)
 
         @pdf_data[:data][:attributes][:servicePay][:separationSeverancePay] = {}
+      end
+
+      # if 'drectDeposit' is included
+      # 'accountType', 'accountNumber' & 'routingNumber' are required via the schema
+      def section_8_direct_deposit
+        return unless lookup_in_auto_claim(:direct_deposit)
+
+        set_direct_deposit_pdf_data
+
+        direct_deposit_required_fields
+        direct_deposit_optional_fields if lookup_in_auto_claim(:direct_deposit_bank_name)
+      end
+
+      def direct_deposit_required_fields
+        @pdf_data[:data][:attributes][:directDepositInformation][:accountType] =
+          lookup_in_auto_claim(:direct_deposit_account_type)
+        @pdf_data[:data][:attributes][:directDepositInformation][:accountNumber] =
+          lookup_in_auto_claim(:direct_deposit_account_number)
+        @pdf_data[:data][:attributes][:directDepositInformation][:routingNumber] =
+          lookup_in_auto_claim(:direct_deposit_routing_number)
+      end
+
+      def direct_deposit_optional_fields
+        @pdf_data[:data][:attributes][:directDepositInformation][:financialInstitutionName] =
+          lookup_in_auto_claim(:direct_deposit_bank_name)
+      end
+
+      def set_direct_deposit_pdf_data
+        return if @pdf_data[:data][:attributes]&.key?(:directDepositInformation)
+
+        @pdf_data[:data][:attributes][:directDepositInformation] = {}
       end
     end
   end

--- a/modules/claims_api/lib/claims_api/v1/mapper_helpers/auto_claim_lookup.rb
+++ b/modules/claims_api/lib/claims_api/v1/mapper_helpers/auto_claim_lookup.rb
@@ -3,7 +3,7 @@
 module ClaimsApi
   module V1
     module AutoClaimLookup
-      # Paths used to navigate elements in the auto_claim variable
+      # Paths used to navigate elements in the auto_claim variable, these match what is in the 526.json schema
       AUTO_CLAIM_PATHS = {
         standard_claim: %w[standardClaim],
         # Veteran information paths
@@ -41,7 +41,13 @@ module ClaimsApi
         service_pay_separation_or_severance_pay_received: %w[servicePay separationPay received],
         separation_pay_received_date: %w[servicePay separationPay receivedDate],
         separation_pay_branch_of_service: %w[servicePay separationPay payment serviceBranch],
-        separation_pay_amount: %w[servicePay separationPay payment amount]
+        separation_pay_amount: %w[servicePay separationPay payment amount],
+        # SECTION 8: Direct Deposit
+        direct_deposit: %w[directDeposit],
+        direct_deposit_account_type: %w[directDeposit accountType],
+        direct_deposit_account_number: %w[directDeposit accountNumber],
+        direct_deposit_routing_number: %w[directDeposit routingNumber],
+        direct_deposit_bank_name: %w[directDeposit bankName]
       }.freeze
 
       def lookup_in_auto_claim(path_key)

--- a/modules/claims_api/spec/lib/claims_api/v1/disability_compensation_pdf_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v1/disability_compensation_pdf_mapper_spec.rb
@@ -1032,4 +1032,56 @@ describe ClaimsApi::V1::DisabilityCompensationPdfMapper do
       expect(service_pay_base[:favorMilitaryRetiredPay]).to be(true)
     end
   end
+
+  context 'section 8 direct deposit' do
+    let(:direct_deposit_data) do
+      {
+        'accountType' => 'CHECKING',
+        'accountNumber' => '123123123123',
+        'routingNumber' => '123123123',
+        'bankName' => 'ABC Bank'
+      }
+    end
+
+    let(:min_direct_deposit_data) do
+      {
+        'accountType' => 'SAVINGS',
+        'accountNumber' => '123123123124',
+        'routingNumber' => '123123124'
+      }
+    end
+
+    it 'maps nothing if not included on the submission' do
+      form_attributes['directDeposit'] = nil
+      mapper.map_claim
+
+      claim_data_base = pdf_data[:data][:attributes]
+
+      expect(claim_data_base).not_to have_key(:directDepositInformation)
+    end
+
+    it 'maps the attributes' do
+      form_attributes['directDeposit'] = direct_deposit_data
+      mapper.map_claim
+
+      direct_deposit_base = pdf_data[:data][:attributes][:directDepositInformation]
+
+      expect(direct_deposit_base).not_to be_nil
+      expect(direct_deposit_base[:accountType]).to eq('CHECKING')
+      expect(direct_deposit_base[:accountNumber]).to eq('123123123123')
+      expect(direct_deposit_base[:routingNumber]).to eq('123123123')
+      expect(direct_deposit_base[:financialInstitutionName]).to eq('ABC Bank')
+    end
+
+    it 'handles mapping optional attributes' do
+      form_attributes['directDeposit'] = min_direct_deposit_data
+      mapper.map_claim
+
+      direct_deposit_base = pdf_data[:data][:attributes][:directDepositInformation]
+      expect(direct_deposit_base[:accountType]).to eq('SAVINGS')
+      expect(direct_deposit_base[:accountNumber]).to eq('123123123124')
+      expect(direct_deposit_base[:routingNumber]).to eq('123123124')
+      expect(direct_deposit_base).not_to have_key(:financialInstitutionName)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
* Map the `directDeposit` attributes

## Related issue(s)
[API-50202](https://jira.devops.va.gov/browse/API-50202)

## Testing done

- [x] *New code is covered by unit tests*

#### Testing Notes
* the only value that is optional if `directDeposit` is included is the bank name.
* Adding this object:
```
         "directDeposit":{
            "accountType":"CHECKING",
            "accountNumber":"123123123123",
            "routingNumber":"123123123",
            "bankName":"ABC Bank"
         }
```

* Should produce this mapping
```
:directDepositInformation=>
      {:accountType=>"CHECKING", :accountNumber=>"123123123123", :routingNumber=>"123123123", :financialInstitutionName=>"ABC Bank"}}}}
```

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/lib/claims_api/v1/disability_compensation_pdf_mapper.rb
	modified:   modules/claims_api/lib/claims_api/v1/mapper_helpers/auto_claim_lookup.rb
	modified:   modules/claims_api/spec/lib/claims_api/v1/disability_compensation_pdf_mapper_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
