### PR TITLE
Decision Reviews: Fix status updater bug discovered in staging testing

### DIFF
--- a/modules/decision_reviews/app/sidekiq/decision_reviews/saved_claim_status_updater_job.rb
+++ b/modules/decision_reviews/app/sidekiq/decision_reviews/saved_claim_status_updater_job.rb
@@ -186,9 +186,9 @@ module DecisionReviews
 
           handle_secondary_form_status_metrics_and_logging(form, attributes['status'])
           update_secondary_form_status_enhanced(form, attributes)
+          current_status = attributes
         end
 
-        # Monitor ALL forms stuck in a non-final error state
         monitor_temporary_error_form(form, current_status)
       end
 

--- a/modules/decision_reviews/spec/sidekiq/sc_status_updater_job_spec.rb
+++ b/modules/decision_reviews/spec/sidekiq/sc_status_updater_job_spec.rb
@@ -964,7 +964,6 @@ RSpec.describe DecisionReviews::ScStatusUpdaterJob, type: :job do
             )
           end
 
-
           it 'does NOT log warning when form transitions to final_status: true' do
             allow(benefits_intake_service).to receive(:get_status)
               .with(uuid: secondary_form.guid).and_return(response_error_final)
@@ -990,7 +989,7 @@ RSpec.describe DecisionReviews::ScStatusUpdaterJob, type: :job do
             secondary_form.reload
             parsed_status = JSON.parse(secondary_form.status)
             expect(parsed_status['status']).to eq('error')
-            expect(parsed_status['final_status']).to eq(true)
+            expect(parsed_status['final_status']).to be(true)
             expect(parsed_status['detail']).to eq('Document processing failed')
           end
 

--- a/modules/decision_reviews/spec/sidekiq/sc_status_updater_job_spec.rb
+++ b/modules/decision_reviews/spec/sidekiq/sc_status_updater_job_spec.rb
@@ -844,8 +844,17 @@ RSpec.describe DecisionReviews::ScStatusUpdaterJob, type: :job do
             # Reload to ensure we have the actual database value
             secondary_form.reload
 
+            # Create response that keeps the form in error state with final_status: false
+            response_error_non_final = JSON.parse(
+              File.read('spec/fixtures/supplemental_claims/SC_4142_show_response_200.json')
+            )
+            response_error_non_final['data']['attributes']['status'] = 'error'
+            response_error_non_final['data']['attributes']['final_status'] = false
+            response_error_non_final['data']['attributes']['detail'] = 'Temporary processing error'
+            error_non_final_response = instance_double(Faraday::Response, body: response_error_non_final)
+
             allow(benefits_intake_service).to receive(:get_status)
-              .with(uuid: secondary_form.guid).and_return(response_processing)
+              .with(uuid: secondary_form.guid).and_return(error_non_final_response)
 
             allow(Rails.logger).to receive(:info).and_call_original
           end
@@ -937,6 +946,70 @@ RSpec.describe DecisionReviews::ScStatusUpdaterJob, type: :job do
           end
         end
 
+        context 'when form transitions from temporary to permanent error (final_status: false -> true)' do
+          let(:twenty_days_ago) { frozen_time - 20.days }
+          let(:response_error_final) do
+            response = JSON.parse(File.read('spec/fixtures/supplemental_claims/SC_4142_show_response_200.json'))
+            response['data']['attributes']['status'] = 'error'
+            response['data']['attributes']['final_status'] = true
+            response['data']['attributes']['detail'] = 'Document processing failed'
+            instance_double(Faraday::Response, body: response)
+          end
+
+          before do
+            secondary_form.update!(
+              created_at: twenty_days_ago,
+              status: { status: 'error', final_status: false }.to_json,
+              status_updated_at: twenty_days_ago
+            )
+          end
+
+
+          it 'does NOT log warning when form transitions to final_status: true' do
+            allow(benefits_intake_service).to receive(:get_status)
+              .with(uuid: secondary_form.guid).and_return(response_error_final)
+
+            Timecop.freeze(frozen_time) do
+              subject.new.perform
+            end
+
+            expect(Rails.logger).not_to have_received(:info).with(
+              'DecisionReviews::SavedClaimScStatusUpdaterJob secondary form stuck in non-final error state',
+              anything
+            )
+          end
+
+          it 'updates the form with final_status: true' do
+            allow(benefits_intake_service).to receive(:get_status)
+              .with(uuid: secondary_form.guid).and_return(response_error_final)
+
+            Timecop.freeze(frozen_time) do
+              subject.new.perform
+            end
+
+            secondary_form.reload
+            parsed_status = JSON.parse(secondary_form.status)
+            expect(parsed_status['status']).to eq('error')
+            expect(parsed_status['final_status']).to eq(true)
+            expect(parsed_status['detail']).to eq('Document processing failed')
+          end
+
+          it 'does not continue polling after transition to final status' do
+            allow(benefits_intake_service).to receive(:get_status)
+              .with(uuid: secondary_form.guid).and_return(response_error_final)
+
+            # Run the job twice to ensure polling stops
+            Timecop.freeze(frozen_time) do
+              subject.new.perform
+              subject.new.perform
+            end
+
+            # Should only call API once since final_status becomes true
+            expect(benefits_intake_service).to have_received(:get_status)
+              .with(uuid: secondary_form.guid).once
+          end
+        end
+
         context 'multiple forms with mixed statuses' do
           let!(:form_temp_error_old) do
             create(:secondary_appeal_form4142_module,
@@ -965,6 +1038,15 @@ RSpec.describe DecisionReviews::ScStatusUpdaterJob, type: :job do
                    created_at: frozen_time - 25.days)
           end
 
+          let!(:form_transitioning_to_final) do
+            create(:secondary_appeal_form4142_module,
+                   guid: SecureRandom.uuid,
+                   appeal_submission: secondary_form.appeal_submission,
+                   status: { 'status' => 'error', 'final_status' => false }.to_json,
+                   status_updated_at: frozen_time - 18.days,
+                   created_at: frozen_time - 18.days)
+          end
+
           before do
             response_processing = JSON.parse(
               File.read('spec/fixtures/supplemental_claims/SC_4142_show_response_200.json')
@@ -973,10 +1055,57 @@ RSpec.describe DecisionReviews::ScStatusUpdaterJob, type: :job do
             response_processing['data']['attributes']['final_status'] = false
             processing_response = instance_double(Faraday::Response, body: response_processing)
 
+            response_error_non_final = JSON.parse(
+              File.read('spec/fixtures/supplemental_claims/SC_4142_show_response_200.json')
+            )
+            response_error_non_final['data']['attributes']['status'] = 'error'
+            response_error_non_final['data']['attributes']['final_status'] = false
+            response_error_non_final['data']['attributes']['detail'] = 'Still in error state'
+            error_non_final_response = instance_double(Faraday::Response, body: response_error_non_final)
+
+            response_error_final = JSON.parse(
+              File.read('spec/fixtures/supplemental_claims/SC_4142_show_response_200.json')
+            )
+            response_error_final['data']['attributes']['status'] = 'error'
+            response_error_final['data']['attributes']['final_status'] = true
+            error_final_response = instance_double(Faraday::Response, body: response_error_final)
+
+            # Default response for most forms
             allow(benefits_intake_service).to receive(:get_status).and_return(processing_response)
+
+            # Specific response for the old temp error form (should trigger warning)
+            allow(benefits_intake_service).to receive(:get_status)
+              .with(uuid: form_temp_error_old.guid).and_return(error_non_final_response)
+
+            # Specific response for the transitioning form
+            allow(benefits_intake_service).to receive(:get_status)
+              .with(uuid: form_transitioning_to_final.guid).and_return(error_final_response)
           end
 
           it 'only logs warnings for temporary errors exceeding threshold' do
+            expect(Rails.logger).to receive(:info).with(
+              'DecisionReviews::SavedClaimScStatusUpdaterJob secondary form stuck in non-final error state',
+              hash_including(secondary_form_uuid: form_temp_error_old.guid)
+            ).once
+
+            allow(Rails.logger).to receive(:info).with(
+              'SavedClaim::SupplementalClaim Skipping tracking PDF overflow',
+              anything
+            ).and_call_original
+
+            Timecop.freeze(frozen_time) do
+              subject.new.perform
+            end
+          end
+
+          it 'does not log warnings for forms transitioning to final status during same run' do
+            # Should NOT log for the transitioning form even though it's > 15 days old
+            expect(Rails.logger).not_to receive(:info).with(
+              'DecisionReviews::SavedClaimScStatusUpdaterJob secondary form stuck in non-final error state',
+              hash_including(secondary_form_uuid: form_transitioning_to_final.guid)
+            )
+
+            # Should still log for the form that remains in non-final error state
             expect(Rails.logger).to receive(:info).with(
               'DecisionReviews::SavedClaimScStatusUpdaterJob secondary form stuck in non-final error state',
               hash_including(secondary_form_uuid: form_temp_error_old.guid)


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): **YES***
- To reproduce the bug in staging:
  - Have a `SecondaryAppealForm` in error state with final_status: false (or missing) that's over 15 days old
  - When the job runs and polls the Benefits Intake API, the API returns final_status: true (indicating the error is now permanent/final)
  - The form gets updated with the new status containing final_status: true
  - Bug: The monitoring function incorrectly logs "secondary form stuck in non-final error state" even though the form just transitioned to a final state
- Changes made/solution:
  - Updated `process_secondary_forms_enhanced` (behind the feature flag) to use fresh API response data when monitoring secondary forms for stuck error states.
  - After calling the Benefits Intake API and updating a form's status, we now set `current_status = attributes` to ensure `monitor_temporary_error_form` uses the latest data instead of stale data from the beginning of the loop

## Related issue(s)

- [*Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/116462)
- [*Link to previous change of the code/bug (if applicable)*](https://github.com/department-of-veterans-affairs/vets-api/pull/23834)

## Testing done

- [x] *New code is covered by unit tests*
- We will test the fix in staging  

## Screenshots
[Datadog logs](https://vagov.ddog-gov.com/logs?query=env%3Aeks-staging%20%2A%3A%22DecisionReviews%3A%3AScStatusUpdaterJob%2A%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40payload.secondary_form_uuid%2C%40payload.guid%2C%40payload.days_in_error&messageDisplay=inline&refresh_mode=paused&storage=flex_tier&stream_sort=desc&viz=stream&from_ts=1758600000000&to_ts=1758659328138&live=false)
<img width="2418" height="863" alt="Screenshot 2025-09-23 at 4 29 20 PM" src="https://github.com/user-attachments/assets/915f491b-e1c4-4dff-992e-37b53913275e" />
I manually set the final_status of a couple of `SecondaryAppealForm`s to false to trigger the erroneous logging.

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
~~- [ ]  Documentation has been updated (link to documentation)~~
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
~~- []  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected~~
~~- [ ]  I added a screenshot of the developed feature~~
