### PR TITLE
Dependents Module | Add claim groups to submission job

### DIFF
--- a/modules/dependents_benefits/lib/dependents_benefits/claim_behavior.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits/claim_behavior.rb
@@ -20,6 +20,13 @@ module DependentsBenefits
       add_disabled_child
     ].freeze
 
+    # Checks if the claim was successfully submitted by checking the status of submission attempts
+    # @return [Boolean] true if all submission attempts succeeded, false otherwise
+    def submissions_succeeded?
+      # TODO: Add checks for each submission type for claim
+      false
+    end
+
     ##
     # Validates whether the form matches the expected VetsJsonSchema::JSON schema
     #

--- a/modules/dependents_benefits/lib/dependents_benefits/claim_processor.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits/claim_processor.rb
@@ -91,10 +91,15 @@ module DependentsBenefits
                                     { parent_claim_id:, error: error.message })
 
       parent_claim_group = SavedClaimGroup.find_by!(parent_claim_id:, saved_claim_id: parent_claim_id)
-      parent_claim_group.update!(status: 'failure')
+      parent_claim_group.update!(status: SavedClaimGroup::STATUSES[:FAILURE])
     rescue => e
       monitor.track_processor_error('Failed to update ClaimGroup status', 'status_update',
                                     { parent_claim_id:, error: e.message, original_error: error.message })
+    end
+
+    def record_enqueue_completion(claim_id)
+      claim_group = SavedClaimGroup.find_by(parent_claim_id:, saved_claim_id: claim_id)
+      claim_group&.update!(status: SavedClaimGroup::STATUSES[:ACCEPTED])
     end
 
     def monitor

--- a/modules/dependents_benefits/lib/dependents_benefits/monitor.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits/monitor.rb
@@ -52,6 +52,16 @@ module DependentsBenefits
       track_info_event(message, PROCESSOR_STATS_KEY, options)
     end
 
+    def track_submission_info(message, action, options = {})
+      options[:tags] = ["action:#{action}"]
+      track_info_event(message, SUBMISSION_STATS_KEY, options)
+    end
+
+    def track_submission_error(message, action, options = {})
+      options[:tags] = ["action:#{action}"]
+      track_error_event(message, SUBMISSION_STATS_KEY, options)
+    end
+
     private
 
     ##

--- a/modules/dependents_benefits/lib/dependents_benefits/sidekiq/dependent_submission_job.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits/sidekiq/dependent_submission_job.rb
@@ -33,7 +33,7 @@ module DependentsBenefits
       @proc_id = proc_id
 
       # Early exit optimization - prevents unnecessary service calls
-      return if claim_group_failed?
+      return if parent_group_failed?
 
       create_form_submission_attempt
       response = submit_to_service
@@ -41,7 +41,7 @@ module DependentsBenefits
       if response&.success?
         handle_job_success
       else
-        handle_job_failure(response)
+        handle_job_failure(response.error)
       end
     rescue => e
       handle_job_failure(e)
@@ -71,17 +71,10 @@ module DependentsBenefits
       raise NotImplementedError, 'Subclasses must implement create_form_submission_attempt'
     end
 
-    # Memoized accessor for service-specific SavedClaim subclass record
-    # @return [Class<DependentsBenefits::SavedClaim>] DependentsBenefits::SavedClaim subclass
-    def saved_claim
-      raise NotImplementedError, 'Subclasses must implement saved_claim'
-    end
-
     # Service-specific success logic
     # Update submission attempt and form submission records
-    # Update claim group status for this child claim if all form submission jobs succeeded
-    def mark_job_succeeded
-      raise NotImplementedError, 'Subclasses must implement mark_job_succeeded'
+    def mark_submission_succeeded
+      raise NotImplementedError, 'Subclasses must implement mark_submission_succeeded'
     end
 
     # Service-specific failure logic
@@ -99,23 +92,53 @@ module DependentsBenefits
     # Atomic updates prevent partial state corruption
     def handle_job_success
       ActiveRecord::Base.transaction do
-        mark_job_succeeded
-        update_parent_if_appropriate
+        parent_group.with_lock do
+          mark_submission_succeeded # update attempt and submission records (ie FormSubmission)
+
+          # update current child claim group if all its submissions succeeded
+          mark_current_group_succeeded if all_current_group_submissions_succeeded?
+
+          # if all of the child claim groups succeeded, and the parent claim group hasn't failed
+          if all_child_groups_succeeded? && !parent_group_completed?
+            # update parent claim group status
+            mark_parent_group_succeeded
+            # notify user of overall success
+            send_success_notification
+          end
+        end
       end
+    rescue => e
+      monitor.track_submission_error('Error handling job success', 'success_failure', { error: e })
+    end
+
+    def all_child_groups_succeeded?
+      SavedClaimGroup.where(parent_claim_id: parent_group.parent_claim_id)
+                     .where.not(saved_claim_id: parent_group.parent_claim_id)
+                     .all?(&:succeeded?)
     end
 
     # Distinguishes permanent vs transient failures for retry logic
     def handle_job_failure(error)
+      monitor.track_submission_error("Error submitting #{self.class}", 'error', { error: })
+      mark_submission_attempt_failed(error)
+
       if permanent_failure?(error)
         # Skip Sidekiq retries for permanent failures
         handle_permanent_failure(claim_id, error)
         raise Sidekiq::JobRetry::Skip
       end
 
-      mark_submission_attempt_failed(error)
-
-      # Re-raise for Sidekiq retry mechanism
-      raise error
+      case error
+      when Exception
+        # Re-raise actual exceptions for Sidekiq retry mechanism
+        raise error
+      when nil
+        # Handle nil case
+        raise StandardError, 'Unknown error occurred during job execution'
+      else
+        # Handle non-exception errors
+        raise StandardError, error
+      end
     end
 
     # Called from retries_exhausted callback OR permanent failure detection
@@ -124,26 +147,35 @@ module DependentsBenefits
       # Reset claim_id class variable for if this was called from sidekiq_retries_exhausted
       @claim_id = claim_id
       ActiveRecord::Base.transaction do
-        mark_submission_attempt_failed(exception)
-        mark_submission_failed(exception)
-        mark_claim_groups_failed_and_notify
-      end
+        parent_group.with_lock do
+          mark_submission_failed(exception)
+          mark_current_group_failed
 
-      monitor.log_silent_failure_avoided({ claim_id: })
-    rescue
-      # Last resort if database updates fail
-      monitor.log_silent_failure({ claim_id: })
+          unless parent_group_completed?
+            mark_parent_group_failed
+            send_backup_job
+          end
+        end
+      end
+    rescue => e
+      begin
+        send_failure_notification
+        monitor.log_silent_failure_avoided({ claim_id:, error: e })
+      rescue => e
+        # Last resort notification fails
+        monitor.log_silent_failure({ claim_id:, error: e })
+      end
     end
 
     # Prevents wasted work when sibling jobs have determined failure
-    def claim_group_failed?
-      # TODO: Implement actual check against ClaimGroup model
-      false
+    # If the parent claim group is already failed, all jobs are considered failed
+    def parent_group_failed?
+      parent_group&.failed?
     end
 
-    def claim_group_completed?
-      # TODO: Implement actual check against ClaimGroup model (failed or succeeded)
-      false
+    # Check if parent claim group already completed (failed or succeeded)
+    def parent_group_completed?
+      parent_group&.completed?
     end
 
     # Override for service-specific permanent failures (INVALID_SSN, DUPLICATE_CLAIM, etc)
@@ -153,50 +185,52 @@ module DependentsBenefits
       false # Base: assume all errors are transient
     end
 
-    # Pessimistic locking prevents race conditions with sibling jobs
-    def update_parent_if_appropriate
-      return false if claim_group_completed?
-
-      # TODO: Implement actual parent claim group update logic.
-      # Should LOCK the claim group record to prevent race conditions
-      # Should send success email notification
-      # Should NOT update parent claim if its status is already FAILED
-      true
+    def all_current_group_submissions_succeeded?
+      saved_claim.submissions_succeeded?
     end
 
-    # Coordinates failure across child and parent claim groups
-    def mark_claim_groups_failed_and_notify
-      # TODO: Implement actual claim group failure logic
-      # Should update this claim group status to FAILED
-      # Should update parent claim group status to FAILED
-      # If parent already FAILED, do not update
-      # Should LOCK the claim group record to prevent race conditions
-      # Should send failure email notification
-      true
+    def mark_current_group_succeeded
+      current_group&.update!(status: SavedClaimGroup::STATUSES[:SUCCESS])
     end
 
-    def form_submission
-      @form_submission ||= find_or_create_form_submission
+    def mark_current_group_failed
+      current_group&.update!(status: SavedClaimGroup::STATUSES[:FAILURE])
     end
 
-    def form_submission_attempt
-      @form_submission_attempt ||= create_form_submission_attempt
+    def mark_parent_group_succeeded
+      parent_group&.update!(status: SavedClaimGroup::STATUSES[:SUCCESS])
     end
 
-    def claim_group
-      # TODO: Return ClaimGroup model instance for this claim
+    def mark_parent_group_failed
+      parent_group&.update!(status: SavedClaimGroup::STATUSES[:FAILURE])
     end
 
-    def parent_claim_group
-      # TODO: Return parent ClaimGroup model instance
+    def send_success_notification
+      # TODO
+    end
+
+    def send_failure_notification
+      # TODO
+    end
+
+    def send_backup_job
+      # TODO
+    end
+
+    def current_group
+      SavedClaimGroup.find_by!(saved_claim_id: claim_id)
+    end
+
+    def parent_group
+      SavedClaimGroup.find_by!(saved_claim_id: current_group&.parent_claim_id)
+    end
+
+    def saved_claim
+      @saved_claim ||= ::SavedClaim.find(claim_id)
     end
 
     def monitor
       @monitor ||= DependentsBenefits::Monitor.new
-    end
-
-    def stats_key
-      'api.dependents_benefits.submission_job'
     end
   end
 end

--- a/modules/dependents_benefits/lib/dependents_benefits/sidekiq/dependent_submission_job.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits/sidekiq/dependent_submission_job.rb
@@ -112,9 +112,7 @@ module DependentsBenefits
     end
 
     def all_child_groups_succeeded?
-      SavedClaimGroup.where(parent_claim_id: parent_group.parent_claim_id)
-                     .where.not(saved_claim_id: parent_group.parent_claim_id)
-                     .all?(&:succeeded?)
+      SavedClaimGroup.child_claims_for(parent_claim_id).all?(&:succeeded?)
     end
 
     # Distinguishes permanent vs transient failures for retry logic
@@ -218,11 +216,11 @@ module DependentsBenefits
     end
 
     def current_group
-      SavedClaimGroup.find_by!(saved_claim_id: claim_id)
+      SavedClaimGroup.by_saved_claim_id(claim_id)&.first
     end
 
     def parent_group
-      SavedClaimGroup.find_by!(saved_claim_id: current_group&.parent_claim_id)
+      SavedClaimGroup.by_saved_claim_id(parent_claim_id)&.first
     end
 
     def saved_claim
@@ -231,6 +229,10 @@ module DependentsBenefits
 
     def monitor
       @monitor ||= DependentsBenefits::Monitor.new
+    end
+
+    def parent_claim_id
+      @parent_claim_id ||= current_group&.parent_claim_id
     end
   end
 end

--- a/modules/dependents_benefits/spec/lib/dependents_benefits/sidekiq/dependent_submission_job_spec.rb
+++ b/modules/dependents_benefits/spec/lib/dependents_benefits/sidekiq/dependent_submission_job_spec.rb
@@ -2,54 +2,94 @@
 
 require 'rails_helper'
 require 'dependents_benefits/sidekiq/dependent_submission_job'
+require 'dependents_benefits/monitor'
+require 'sidekiq/job_retry'
 
 RSpec.describe DependentsBenefits::DependentSubmissionJob, type: :job do
+  let(:saved_claim) { create(:dependents_claim) }
   let(:claim_id) { saved_claim.id }
   let(:proc_id) { 'test-proc-123' }
-  let(:saved_claim) { create(:dependents_claim) }
   let(:job) { described_class.new }
+  let(:parent_claim) { create(:dependents_claim) }
+  let(:child_claim) { create(:add_remove_dependents_claim) }
+  let(:sibling_claim) { create(:student_claim) }
+  let(:failed_response) { double('ServiceResponse', success?: false, error: 'Service unavailable') }
+  let(:successful_response) { double('ServiceResponse', success?: true) }
+  let(:monitor) { instance_double(DependentsBenefits::Monitor) }
 
   before do
     allow_any_instance_of(SavedClaim).to receive(:pdf_overflow_tracking)
+    allow(DependentsBenefits::Monitor).to receive(:new).and_return(monitor)
+    allow(job).to receive(:create_form_submission_attempt)
   end
 
   describe '#perform' do
     context 'when claim group has already failed' do
-      before do
-        allow(job).to receive(:claim_group_failed?).and_return(true)
-      end
+      let!(:parent_claim_group) { create(:parent_claim_group, parent_claim:, status: SavedClaimGroup::STATUSES[:FAILURE]) }
+      let!(:child_claim_group) { create(:saved_claim_group, saved_claim: child_claim, parent_claim:) }
 
       it 'skips submission without creating form submission attempt' do
         expect(job).not_to receive(:submit_to_service)
-        job.perform(claim_id, proc_id)
+        job.perform(child_claim.id)
       end
     end
 
-    it 'assigns claim_id and proc_id from perform arguments' do
-      allow(job).to receive(:claim_group_failed?).and_return(true)
+    it 'assigns claim_id from perform arguments' do
+      create(:parent_claim_group, parent_claim:)
+      create(:saved_claim_group, saved_claim: child_claim, parent_claim:)
 
-      job.perform(claim_id, proc_id)
+      allow(job).to receive(:submit_to_service).and_return(successful_response)
+      allow(job).to receive(:handle_job_success)
 
-      expect(job.instance_variable_get(:@claim_id)).to eq(claim_id)
-      expect(job.instance_variable_get(:@proc_id)).to eq(proc_id)
+      job.perform(child_claim.id)
+
+      expect(job.instance_variable_get(:@claim_id)).to eq(child_claim.id)
     end
 
     context 'when all validations pass' do
       let(:mock_response) { double('ServiceResponse', success?: true) }
 
       before do
-        allow(job).to receive_messages(claim_group_failed?: false, submit_to_service: mock_response)
-        allow(job).to receive(:create_form_submission_attempt)
+        allow(job).to receive(:submit_to_service).and_return(mock_response)
         allow(job).to receive(:handle_job_success)
       end
 
       it 'follows expected execution order' do
-        expect(job).to receive(:claim_group_failed?).ordered
-        expect(job).to receive(:create_form_submission_attempt).ordered
+        create(:parent_claim_group, parent_claim:)
+        create(:saved_claim_group, saved_claim: child_claim, parent_claim:)
         expect(job).to receive(:submit_to_service).ordered
         expect(job).to receive(:handle_job_success).ordered
 
-        job.perform(claim_id, proc_id)
+        job.perform(child_claim.id)
+      end
+    end
+
+    context 'with claim groups' do
+      let!(:parent_claim_group) { create(:parent_claim_group, parent_claim:) }
+      let!(:child_claim_group) { create(:saved_claim_group, saved_claim: child_claim, parent_claim:) }
+
+      it 'skips processing if the parent group failed' do
+        parent_claim_group.update!(status: SavedClaimGroup::STATUSES[:FAILURE])
+        expect(job).not_to receive(:submit_to_service)
+        job.perform(child_claim.id)
+      end
+
+      it 'handles successful submissions' do
+        allow(job).to receive(:submit_to_service).and_return(successful_response)
+        expect(job).to receive(:handle_job_success)
+        job.perform(child_claim.id)
+      end
+
+      it 'handles failed submissions' do
+        allow(job).to receive(:submit_to_service).and_return(failed_response)
+        expect(job).to receive(:handle_job_failure).with(failed_response.error)
+        job.perform(child_claim.id)
+      end
+
+      it 'handles errors' do
+        allow(job).to receive(:submit_to_service).and_raise(StandardError, 'Unexpected error')
+        expect(job).to receive(:handle_job_failure).with(instance_of(StandardError))
+        job.perform(child_claim.id)
       end
     end
   end
@@ -57,30 +97,16 @@ RSpec.describe DependentsBenefits::DependentSubmissionJob, type: :job do
   describe 'exception handling' do
     context 'when submit_to_service raises exception with message' do
       let(:exception) { StandardError.new('BGS Error: SSN 123-45-6789 invalid') }
+      let!(:parent_claim_group) { create(:parent_claim_group, parent_claim:) }
+      let!(:child_claim_group) { create(:saved_claim_group, saved_claim: child_claim, parent_claim:) }
 
       before do
-        allow(job).to receive(:claim_group_failed?).and_return(false)
-        allow(job).to receive(:create_form_submission_attempt)
         allow(job).to receive(:submit_to_service).and_raise(exception)
       end
 
       it 'passes exception object to handle_job_failure, not string' do
         expect(job).to receive(:handle_job_failure).with(exception)
-        job.perform(claim_id, proc_id)
-      end
-    end
-  end
-
-  describe 'query methods' do
-    describe '#claim_group_failed?' do
-      it 'returns false by default' do
-        expect(job.send(:claim_group_failed?)).to be false
-      end
-    end
-
-    describe '#claim_group_completed?' do
-      it 'returns false by default' do
-        expect(job.send(:claim_group_completed?)).to be false
+        job.perform(child_claim.id)
       end
     end
   end
@@ -108,30 +134,18 @@ RSpec.describe DependentsBenefits::DependentSubmissionJob, type: :job do
   end
 
   describe 'error handling edge cases' do
-    context 'when create_form_submission_attempt fails' do
-      before do
-        allow(job).to receive(:claim_group_failed?).and_return(false)
-        allow(job).to receive(:create_form_submission_attempt).and_raise(ActiveRecord::RecordInvalid)
-      end
-
-      it 'handles creation failure gracefully' do
-        expect(job).to receive(:handle_job_failure)
-        job.perform(claim_id, proc_id)
-      end
-    end
-
     context 'when submit_to_service raises unexpected error' do
       let(:timeout_error) { Timeout::Error.new }
+      let!(:parent_claim_group) { create(:parent_claim_group, parent_claim:) }
+      let!(:child_claim_group) { create(:saved_claim_group, saved_claim: child_claim, parent_claim:) }
 
       before do
-        allow(job).to receive(:claim_group_failed?).and_return(false)
-        allow(job).to receive(:create_form_submission_attempt)
         allow(job).to receive(:submit_to_service).and_raise(timeout_error)
       end
 
       it 'catches and handles timeout errors' do
         expect(job).to receive(:handle_job_failure).with(timeout_error)
-        job.perform(claim_id, proc_id)
+        job.perform(child_claim.id)
       end
     end
   end
@@ -150,9 +164,178 @@ RSpec.describe DependentsBenefits::DependentSubmissionJob, type: :job do
     end
 
     it 'raises NotImplementedError for create_form_submission_attempt' do
+      # Remove the stub for this specific test
+      allow(job).to receive(:create_form_submission_attempt).and_call_original
       expect do
         job.send(:create_form_submission_attempt)
       end.to raise_error(NotImplementedError, 'Subclasses must implement create_form_submission_attempt')
+    end
+  end
+
+  describe '#handle_job_success' do
+    let!(:parent_claim_group) { create(:parent_claim_group, parent_claim:) }
+    let!(:child_claim_group) { create(:saved_claim_group, saved_claim: child_claim, parent_claim:) }
+    let!(:sibling_claim_group) { create(:saved_claim_group, saved_claim: sibling_claim, parent_claim:) }
+
+    before do
+      allow(job).to receive(:claim_id).and_return(child_claim.id)
+    end
+
+    it 'marks the submission attempt and submission as succeeded' do
+      allow(job).to receive(:all_current_group_submissions_succeeded?).and_return(false)
+      expect(job).to receive(:mark_submission_succeeded)
+      job.send(:handle_job_success)
+    end
+
+    context 'when current_groups are pending' do
+      it 'does not mark claim group as succeeded' do
+        allow(job).to receive(:all_current_group_submissions_succeeded?).and_return(false)
+        allow(job).to receive(:mark_submission_succeeded)
+        expect(job).not_to receive(:mark_current_group_succeeded)
+        job.send(:handle_job_success)
+      end
+    end
+
+    context 'when all current_groups are successful' do
+      before do
+        allow(job).to receive(:all_current_group_submissions_succeeded?).and_return(true)
+        allow(job).to receive(:mark_submission_succeeded)
+      end
+
+      it 'marks the claim group as succeeded' do
+        expect(job).to receive(:mark_current_group_succeeded)
+        job.send(:handle_job_success)
+      end
+
+      context 'when any group is still pending' do
+        it 'does not mark the parent claim group as succeeded' do
+          expect(job).not_to receive(:mark_parent_group_succeeded)
+          expect(job).not_to receive(:send_success_notification)
+          job.send(:handle_job_success)
+        end
+      end
+
+      context 'when all claim jobs have succeeded' do
+        it 'marks the parent claim group as succeeded and notifies user' do
+          sibling_claim_group.update!(status: SavedClaimGroup::STATUSES[:SUCCESS])
+          expect(job).to receive(:mark_parent_group_succeeded).and_call_original
+          expect(job).to receive(:send_success_notification)
+          job.send(:handle_job_success)
+        end
+      end
+    end
+
+    context 'when the parent has failed' do
+      it 'does not mark the claim group or parent claim group as succeeded' do
+        parent_claim_group.update!(status: SavedClaimGroup::STATUSES[:FAILURE])
+        allow(job).to receive(:mark_submission_succeeded)
+        expect(job).not_to receive(:mark_parent_group_succeeded)
+        expect(job).not_to receive(:send_success_notification)
+        job.send(:handle_job_success)
+      end
+    end
+  end
+
+  describe '#handle_job_failure' do
+    let!(:parent_claim_group) { create(:parent_claim_group, parent_claim:) }
+    let!(:child_claim_group) { create(:saved_claim_group, saved_claim: child_claim, parent_claim:) }
+    let!(:sibling_claim_group) { create(:saved_claim_group, saved_claim: sibling_claim, parent_claim:) }
+
+    before do
+      allow(job).to receive(:claim_id).and_return(child_claim.id)
+      allow(monitor).to receive(:track_submission_error)
+    end
+
+    context 'when the failure is permanent' do
+      before do
+        allow(job).to receive(:permanent_failure?).and_return(true)
+        allow(job).to receive(:mark_submission_attempt_failed)
+      end
+
+      it 'calls #handle_permanent_failure' do
+        expect(job).to receive(:mark_submission_attempt_failed)
+        expect(job).to receive(:handle_permanent_failure)
+        expect { job.send(:handle_job_failure, 'Service destroyed') }.to raise_error(Sidekiq::JobRetry::Skip)
+      end
+    end
+
+    context 'when the failure is transient' do
+      before do
+        allow(job).to receive(:permanent_failure?).and_return(false)
+        allow(job).to receive(:mark_submission_attempt_failed)
+      end
+
+      it 'raises the error' do
+        expect(job).to receive(:mark_submission_attempt_failed)
+        expect { job.send(:handle_job_failure, 'Service destroyed') }.to raise_error('Service destroyed')
+      end
+    end
+  end
+
+  describe '#handle_permanent_failure' do
+    let!(:parent_claim_group) { create(:parent_claim_group, parent_claim:) }
+    let!(:child_claim_group) { create(:saved_claim_group, saved_claim: child_claim, parent_claim:) }
+    let!(:sibling_claim_group) { create(:saved_claim_group, saved_claim: sibling_claim, parent_claim:) }
+
+    before do
+      allow(job).to receive(:claim_id).and_return(child_claim.id)
+      allow(monitor).to receive(:track_submission_error)
+    end
+
+    it 'marks the submission and claim group as failed' do
+      expect(job).to receive(:mark_submission_failed)
+      expect(job).to receive(:mark_current_group_failed)
+      job.send(:handle_permanent_failure, child_claim.id, 'Service destroyed')
+    end
+
+    context 'when the parent claim is already failed' do
+      before do
+        allow(job).to receive(:mark_submission_failed)
+        parent_claim_group.update!(status: SavedClaimGroup::STATUSES[:FAILURE])
+      end
+
+      it 'does not notify the user' do
+        expect(job).not_to receive(:mark_parent_group_failed)
+        expect(job).not_to receive(:send_failure_notification)
+        expect(monitor).not_to receive(:log_silent_failure_avoided)
+        job.send(:handle_permanent_failure, child_claim.id, 'Service destroyed')
+      end
+    end
+
+    context 'when the parent claim is pending' do
+      before do
+        allow(job).to receive(:mark_submission_failed)
+      end
+
+      it 'sends the backup job' do
+        expect(job).to receive(:send_backup_job)
+        job.send(:handle_permanent_failure, child_claim.id, 'Service destroyed')
+      end
+    end
+
+    context 'when there is an error in the process' do
+      it 'notifies the user' do
+        allow(job).to receive(:mark_submission_failed)
+        allow(job).to receive(:send_backup_job).and_raise(StandardError, 'Submission not found')
+        expect(monitor).to receive(:log_silent_failure_avoided)
+        job.send(:handle_permanent_failure, child_claim.id, 'Service destroyed')
+      end
+
+      it 'logs a silent failure if notification fails' do
+        allow(job).to receive(:mark_submission_failed).and_raise(StandardError, 'Submission not found')
+        allow(job).to receive(:send_failure_notification).and_raise(StandardError, 'User not found')
+        expect(monitor).to receive(:log_silent_failure)
+        job.send(:handle_permanent_failure, child_claim.id, 'Service destroyed')
+      end
+    end
+  end
+
+  describe '#sidekiq_retries_exhausted' do
+    it 'logs a distinct error when no claim_id provided' do
+      described_class.within_sidekiq_retries_exhausted_block({ 'args' => [child_claim.id, 'proc_id'] }, 'Failure!') do
+        allow(described_class).to receive(:new).and_return(job)
+        expect(job).to receive(:handle_permanent_failure).with(child_claim.id, 'Failure!')
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- This change is in a route not yet in use. 
- This pull request introduces the use of the SavedClaimGroup to the claim submission and tracking logic for dependent benefits. The main changes include adding explicit status constants and helper methods to the `SavedClaimGroup` model, refactoring job handling to improve status updates and error handling, and enhancing monitoring and notification capabilities throughout the submission pipeline.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118683

## Testing done

- [ ] *New code is covered by unit tests*

## What areas of the site does it impact?
Dependents Benefits Module

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
