### PR TITLE
fix: add retry logic to cert downloads to resolve SSL handshake failures

### DIFF
--- a/import-va-certs.sh
+++ b/import-va-certs.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 (
     cd /usr/local/share/ca-certificates/
 
-    curl -LO https://cacerts.digicert.com/DigiCertTLSRSASHA2562020CA1-1.crt.pem
-    curl -LO https://digicert.tbs-certificats.com/DigiCertGlobalG2TLSRSASHA2562020CA1.crt
+    curl --retry 3 --retry-delay 5 --connect-timeout 10 --max-time 60 -LO https://cacerts.digicert.com/DigiCertTLSRSASHA2562020CA1-1.crt.pem
+    curl --retry 3 --retry-delay 5 --connect-timeout 10 --max-time 60 -LO https://digicert.tbs-certificats.com/DigiCertGlobalG2TLSRSASHA2562020CA1.crt
 
     # DoD ECA with multiple fallback mechanisms
     (
@@ -38,6 +38,10 @@ set -euo pipefail
 
     echo "Downloading VA certificates..."
     wget \
+        --tries=3 \
+        --waitretry=5 \
+        --timeout=60 \
+        --connect-timeout=10 \
         --level=1 \
         --quiet \
         --recursive \

--- a/spec/scripts/import_va_certs_spec.rb
+++ b/spec/scripts/import_va_certs_spec.rb
@@ -151,8 +151,8 @@ RSpec.describe 'import-va-certs' do # rubocop:disable RSpec/DescribeClass
     it 'downloads DigiCert certificates' do
       script_content = File.read(script_path)
 
-      expect(script_content).to include('curl -LO https://cacerts.digicert.com/DigiCertTLSRSASHA2562020CA1-1.crt.pem')
-      expect(script_content).to include('curl -LO https://digicert.tbs-certificats.com/DigiCertGlobalG2TLSRSASHA2562020CA1.crt')
+      expect(script_content).to include('curl --retry 3 --retry-delay 5 --connect-timeout 10 --max-time 60 -LO https://cacerts.digicert.com/DigiCertTLSRSASHA2562020CA1-1.crt.pem')
+      expect(script_content).to include('curl --retry 3 --retry-delay 5 --connect-timeout 10 --max-time 60 -LO https://digicert.tbs-certificats.com/DigiCertGlobalG2TLSRSASHA2562020CA1.crt')
     end
   end
 


### PR DESCRIPTION
Adds retry and timeout parameters to curl and wget commands in import-va-certs.sh
to handle transient network connectivity issues during Docker builds.

Changes:
- Add --retry 3 --retry-delay 5 --connect-timeout 10 --max-time 60 to curl commands
- Add --tries=3 --waitretry=5 --timeout=60 --connect-timeout=10 to wget command

This addresses SSL handshake failures (exit code 35) seen in GitHub Actions
builds when downloading certificates from digicert.tbs-certificats.com and
other certificate authorities. See [failing workflow][1] for reference.

The retry logic will attempt each download up to 3 times with a 5-second
delay between attempts, preventing build failures due to temporary network
issues or SSL/TLS compatibility problems.

[1]: https://github.com/department-of-veterans-affairs/vets-api/actions/runs/18015820222/job/51260313123
