### PR TITLE
VES 5442 Update Kafka status mapping for Datadog monitoring

### DIFF
--- a/lib/kafka/enhanced_listener.rb
+++ b/lib/kafka/enhanced_listener.rb
@@ -8,7 +8,7 @@ module Kafka
     BROKER_STATUS_MAPPING = {
       'UP' => Datadog::Statsd::OK,
       'INIT' => Datadog::Statsd::WARNING,
-      'TRY_CONNECT' => Datadog::Statsd::WARNING,
+      'CONNECT' => Datadog::Statsd::WARNING,
       'DOWN' => Datadog::Statsd::CRITICAL
     }.freeze
 

--- a/spec/lib/kafka/enhanced_listener_spec.rb
+++ b/spec/lib/kafka/enhanced_listener_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Kafka::EnhancedListener do
     end
 
     context 'when broker state is INIT or TRY_CONNECT' do
-      %w[INIT TRY_CONNECT].each do |state|
+      %w[INIT CONNECT].each do |state|
         context "with state #{state}" do
           before do
             event[:statistics]['brokers']['localhost:9092/1001']['state'] = state


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): YES*
- This PR updates which states of vets-api's connection to Kafka are treated as warnings per team discussions/recommendations.
- The recommendation from our partner team, the Event Bus team, is to warn when the connection to Kafka is in the `CONNECT` state.
- VES Submission Traceability. We do own this code/feature.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/VES/issues/5442

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
None at the moment as it is not a Veteran-facing feature right now.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [N/A]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [N/A]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [N/A]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
