### PR TITLE
API-49796 - Add feature flag to control saving failed SOAP requests

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1172,6 +1172,10 @@ features:
     actor_type: user
     description: Lighthouse Benefits Claims API uses MPI birls_id as filenumber parameter to BDS search
     enable_in_development: true
+  lighthouse_claims_api_save_failed_soap_requests:
+    actor_type: user
+    description: Enable saving the request/response of failed SOAP requests made by ClaimsApi
+    enable_in_development: true
   lighthouse_document_convert_to_unlocked_pdf_use_hexapdf:
     description: Enables the LighthouseDocument class's convert_to_unlocked_pdf method to use hexapdf to unlock encrypted pdfs
   log_eligible_benefits:

--- a/modules/claims_api/lib/bgs_service/local_bgs.rb
+++ b/modules/claims_api/lib/bgs_service/local_bgs.rb
@@ -173,12 +173,14 @@ module ClaimsApi
       end
 
       if response.status != 200
-        ClaimsApi::RecordMetadata.create(
-          request_url: url,
-          request_headers: headers&.to_s,
-          request: safe_xml(body),
-          response: safe_xml(response.body)
-        )
+        if Flipper.enabled?(:lighthouse_claims_api_save_failed_soap_requests)
+          ClaimsApi::RecordMetadata.create(
+            request_url: url,
+            request_headers: headers&.to_s,
+            request: safe_xml(body),
+            response: safe_xml(response.body)
+          )
+        end
         errors = soap_error_handler.handle_errors(response)
         return errors
       end


### PR DESCRIPTION
## Summary

This PR introduces a feature toggle that controls the functionality introduced in [this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/24316). No other functionality changes have been introduced.

## Related issue(s)

|[Jira ticket](https://jira.devops.va.gov/browse/API-49779)|
| - |
|<img width="1269" height="515" alt="Screenshot 2025-09-09 at 16 46 36" src="https://github.com/user-attachments/assets/c478db8f-a7c8-46eb-b2e8-48db8f53e5ae" />|

## Testing done

To test this
- Follow the [instructions on this previous PR](https://github.com/department-of-veterans-affairs/vets-api/pull/24316) for testing the request saving.
- Enable/disable the flag `lighthouse_claims_api_save_failed_soap_requests` and note that it controls the functionality.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA
