### PR TITLE
refactor: replace PDF forms constants with fresh instance methods

### DIFF
--- a/lib/pdf_fill/filler.rb
+++ b/lib/pdf_fill/filler.rb
@@ -42,11 +42,23 @@ module PdfFill
     class PdfFillerException < StandardError; end
     module_function
 
-    # A PdfForms instance for handling standard PDF forms.
-    PDF_FORMS = PdfForms.new(Settings.binaries.pdftk)
+    ##
+    # Creates a fresh PdfForms instance for handling standard PDF forms.
+    #
+    # @return [PdfForms] A new PdfForms instance configured with the pdftk binary path.
+    #
+    def pdf_forms
+      PdfForms.new(Settings.binaries.pdftk)
+    end
 
-    # A PdfForms instance for handling Unicode PDF forms with XFdf data format.
-    UNICODE_PDF_FORMS = PdfForms.new(Settings.binaries.pdftk, data_format: 'XFdf', utf8_fields: true)
+    ##
+    # Creates a fresh PdfForms instance for handling Unicode PDF forms with XFdf data format.
+    #
+    # @return [PdfForms] A new PdfForms instance configured for Unicode handling.
+    #
+    def unicode_pdf_forms
+      PdfForms.new(Settings.binaries.pdftk, data_format: 'XFdf', utf8_fields: true)
+    end
 
     # A hash mapping form IDs to their corresponding form classes.
     # This constant is intentionally mutable.
@@ -219,7 +231,7 @@ module PdfFill
       template_path = has_template ? form_class::TEMPLATE : "lib/pdf_fill/forms/pdfs/#{form_id}.pdf"
       unicode_pdf_form_list = [SavedClaim::CaregiversAssistanceClaim::FORM,
                                EVSS::DisabilityCompensationForm::SubmitForm0781::FORM_ID_0781V2]
-      (form_id.in?(unicode_pdf_form_list) ? UNICODE_PDF_FORMS : PDF_FORMS).fill_form(
+      (form_id.in?(unicode_pdf_form_list) ? unicode_pdf_forms : pdf_forms).fill_form(
         template_path, file_path, new_hash, flatten: Rails.env.production?
       )
 

--- a/lib/pdf_fill/processors/va2210215_continuation_sheet_processor.rb
+++ b/lib/pdf_fill/processors/va2210215_continuation_sheet_processor.rb
@@ -10,7 +10,14 @@ module PdfFill
 
       def_delegators :@main_form_filler, :make_hash_converter
 
-      PDF_FORMS = PdfForms.new(Settings.binaries.pdftk)
+      ##
+      # Creates a fresh PdfForms instance for handling PDF forms.
+      #
+      # @return [PdfForms] A new PdfForms instance configured with the pdftk binary path.
+      #
+      def self.pdf_forms
+        PdfForms.new(Settings.binaries.pdftk)
+      end
       CONTINUATION_SHEET_FORM_ID = '22-10215a'
       CONTINUATION_SHEET_INTRO_PDF_PATH = 'lib/pdf_fill/forms/pdfs/22-10215a-Intro.pdf'
       CONTINUATION_SHEET_PDF_PATH = 'lib/pdf_fill/forms/pdfs/22-10215a.pdf'
@@ -96,12 +103,12 @@ module PdfFill
         hash_converter = make_hash_converter(form_id, form_class, submit_date, @fill_options)
         new_hash = hash_converter.transform_data(form_data: merged_form_data, pdftk_keys: form_class::KEY)
 
-        PDF_FORMS.fill_form(template_path, output_path, new_hash, flatten: Rails.env.production?)
+        self.class.pdf_forms.fill_form(template_path, output_path, new_hash, flatten: Rails.env.production?)
       end
 
       def combine_pdf_pages
         final_file_path = "#{@folder}/22-10215_#{@file_name_extension}.pdf"
-        PDF_FORMS.cat(*@pdf_files, final_file_path)
+        self.class.pdf_forms.cat(*@pdf_files, final_file_path)
 
         log_completion(final_file_path)
         final_file_path

--- a/lib/pdf_fill/processors/va228794_processor.rb
+++ b/lib/pdf_fill/processors/va228794_processor.rb
@@ -9,7 +9,14 @@ module PdfFill
 
       def_delegators :@main_form_filler, :combine_extras
 
-      PDF_FORMS = PdfForms.new(Settings.binaries.pdftk)
+      ##
+      # Creates a fresh PdfForms instance for handling PDF forms.
+      #
+      # @return [PdfForms] A new PdfForms instance configured with the pdftk binary path.
+      #
+      def self.pdf_forms
+        PdfForms.new(Settings.binaries.pdftk)
+      end
       DEFAULT_TEMPLATE_PATH = 'lib/pdf_fill/forms/pdfs/22-8794.pdf'
       DEFAULT_FORM_OFFICIALS_LIMIT = 7
       DEFAULT_FORM_READ_ONLY_SCO_LIMIT = 4
@@ -42,7 +49,7 @@ module PdfFill
         pdf_data_hash = hash_converter.transform_data(form_data: merged_form_data, pdftk_keys: FORM_CLASS::KEY)
 
         file_path = File.join(TMP_DIR, '22-8794.pdf')
-        PDF_FORMS.fill_form(DEFAULT_TEMPLATE_PATH, file_path, pdf_data_hash, flatten: Rails.env.production?)
+        self.class.pdf_forms.fill_form(DEFAULT_TEMPLATE_PATH, file_path, pdf_data_hash, flatten: Rails.env.production?)
         file_path
       end
 
@@ -74,7 +81,7 @@ module PdfFill
 
         # fill in pdf and append extra pages
         file_path = File.join(TMP_DIR, '22-8794.pdf')
-        PDF_FORMS.fill_form(DEFAULT_TEMPLATE_PATH, file_path, pdf_data_hash, flatten: Rails.env.production?)
+        self.class.pdf_forms.fill_form(DEFAULT_TEMPLATE_PATH, file_path, pdf_data_hash, flatten: Rails.env.production?)
         combine_extras(file_path, hash_converter.extras_generator, FORM_CLASS)
       end
 

--- a/lib/pdf_utilities/datestamp_pdf.rb
+++ b/lib/pdf_utilities/datestamp_pdf.rb
@@ -5,8 +5,14 @@ require 'pdf_utilities/exception_handling'
 
 # Utility classes and functions for VA PDF
 module PDFUtilities
-  # @see https://github.com/jkraemer/pdf-forms
-  PDFTK = PdfForms.new(Settings.binaries.pdftk)
+  ##
+  # Creates a fresh PdfForms instance for PDF utilities.
+  #
+  # @return [PdfForms] A new PdfForms instance configured with the pdftk binary path.
+  #
+  def self.pdftk
+    PdfForms.new(Settings.binaries.pdftk)
+  end
 
   # add a watermark datestamp to an existing pdf
   class DatestampPdf
@@ -141,9 +147,9 @@ module PDFUtilities
       @stamped_pdf = "#{Common::FileHelpers.random_file_path}.pdf"
 
       if multistamp
-        PDFUtilities::PDFTK.multistamp(file_path, stamp_path, stamped_pdf)
+        PDFUtilities.pdftk.multistamp(file_path, stamp_path, stamped_pdf)
       else
-        PDFUtilities::PDFTK.stamp(file_path, stamp_path, stamped_pdf)
+        PDFUtilities.pdftk.stamp(file_path, stamp_path, stamped_pdf)
       end
 
       raise StampGenerationError, 'Stamped PDF was not created' unless File.exist?(stamped_pdf)

--- a/modules/appeals_api/app/services/appeals_api/pdf_construction/generator.rb
+++ b/modules/appeals_api/app/services/appeals_api/pdf_construction/generator.rb
@@ -71,7 +71,7 @@ module AppealsApi
       end
 
       def pdftk
-        @pdftk ||= PdfForms.new(Settings.binaries.pdftk)
+        PdfForms.new(Settings.binaries.pdftk)
       end
 
       def pdf_template_path

--- a/modules/dependents_benefits/lib/dependents_benefits/pdf_fill/filler.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits/pdf_fill/filler.rb
@@ -17,11 +17,23 @@ module DependentsBenefits
       class PdfFillerException < StandardError; end
       module_function
 
-      # A PdfForms instance for handling standard PDF forms.
-      PDF_FORMS = PdfForms.new(Settings.binaries.pdftk)
+      ##
+      # Creates a fresh PdfForms instance for handling standard PDF forms.
+      #
+      # @return [PdfForms] A new PdfForms instance configured with the pdftk binary path.
+      #
+      def pdf_forms
+        PdfForms.new(Settings.binaries.pdftk)
+      end
 
-      # A PdfForms instance for handling Unicode PDF forms with XFdf data format.
-      UNICODE_PDF_FORMS = PdfForms.new(Settings.binaries.pdftk, data_format: 'XFdf', utf8_fields: true)
+      ##
+      # Creates a fresh PdfForms instance for handling Unicode PDF forms with XFdf data format.
+      #
+      # @return [PdfForms] A new PdfForms instance configured for Unicode handling.
+      #
+      def unicode_pdf_forms
+        PdfForms.new(Settings.binaries.pdftk, data_format: 'XFdf', utf8_fields: true)
+      end
 
       # A hash mapping form IDs to their corresponding form classes.
       # This constant is intentionally mutable.
@@ -161,7 +173,7 @@ module DependentsBenefits
         has_template = form_class.const_defined?(:TEMPLATE)
         template_path = has_template ? form_class::TEMPLATE : "lib/pdf_fill/forms/pdfs/#{form_id}.pdf"
 
-        PDF_FORMS.fill_form(
+        pdf_forms.fill_form(
           template_path, file_path, new_hash, flatten: Rails.env.production?
         )
 


### PR DESCRIPTION
Replaces shared PdfForms constants with methods that create fresh instances to reduce CI test flakiness.

## Problem
We're seeing frequent flaky PDF processing test failures in CI, wasting hours of dev time daily with re-runs. Example failure: https://github.com/department-of-veterans-affairs/vets-api/actions/runs/18017844042/job/51268552171

The failing tests are:
- `rspec './spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb[1:4:1:2]'`
- `rspec ./spec/lib/decision_review_v1/processor/form4142_processor_spec.rb:44`

Both fail with `PdfForms::PdftkError` when processing PDF forms, suggesting shared state issues between test runs.

## Solution  
Replace shared constants like `PDF_FORMS = PdfForms.new(...)` with methods that create fresh instances for each operation:

```ruby
# Before
PDF_FORMS = PdfForms.new(Settings.binaries.pdftk)

# After  
def pdf_forms
  PdfForms.new(Settings.binaries.pdftk)
end
```

This eliminates state pollution, thread safety issues, and other problems from sharing instances across tests and operations.

## Changes
- Updated 6 files that had PDF forms constants or memoization
- All usage sites now call methods instead of constants
- Maintains the same API while creating fresh instances