### PR TITLE
Add my health api from code.va.gov with $text change

### DIFF
--- a/modules/my_health/catalog-info.yaml
+++ b/modules/my_health/catalog-info.yaml
@@ -1,0 +1,26 @@
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  annotations:
+    github.com/project-slug: department-of-veterans-affairs/vets-api
+    backstage.io/edit-url: https://github.com/department-of-veterans-affairs/platform-pst-console-ui-configuration/edit/main/backend-review-group/apis/my-health-api.yaml
+    backstage.io/source-location: url:https://github.com/department-of-veterans-affairs/vets-api/tree/master/modules/my_health/
+    backstage.io/view-url: https://github.com/department-of-veterans-affairs/platform-pst-console-ui-configuration/blob/main/backend-review-group/apis/my-health-api.yaml
+  description: APIs for My_Health
+  namespace: vagov-platform
+  name: my-health-api
+  tags:
+  - ruby
+  - rails
+  title: VA.gov My Health Api
+spec:
+  definition: |
+   $text: https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/my_health/docs/openapi_merged.yaml
+    info:
+      title: My Health Api
+      version: 1.0.0
+    swagger: "2.0"
+  lifecycle: production
+  owner: backend-review-group
+  system: vets-api
+  type: openapi


### PR DESCRIPTION
## Summary

Add .yaml file with new link to openapi_merged.yaml file from [platform-pst-console-ui-configuration]

After merge will then point to this .yaml file on code.va.gov

## Related issue(s)

[[Meds / Documentation] Update API spec on code.va.gov /v1/prescriptions data](https://github.com/department-of-veterans-affairs/va.gov-team/issues/119850) va.gov-team#119850

## Testing done
To verify:

Make sure new .yaml file matches my-health-api.yaml with the new $text change
platform-pst-console-ui-configuration/backend-review-group/apis/my-health-api.yaml

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*  No parts of va.gov are affected by this change.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
