### PR TITLE
API-50205 - Update V2 FES mapper to handle secondary disabilities

### DIFF
--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_fes_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_fes_mapper_spec.rb
@@ -238,6 +238,36 @@ describe ClaimsApi::V2::DisabilityCompensationFesMapper do
           expect(date[:day]).to eq(15)
         end
 
+        context 'when secondary disabilities are present' do
+          it 'extracts and flattens secondary disabilities' do
+            # Add secondary disabilities to the test data
+            form_data['data']['attributes']['disabilities'][0]['secondaryDisabilities'] = [
+              {
+                'name' => 'Secondary Condition',
+                'disabilityActionType' => 'SECONDARY',
+                'diagnosticCode' => 5002,
+                'isRelatedToToxicExposure' => false
+              }
+            ]
+
+            auto_claim = create(:auto_established_claim,
+                                form_data: form_data['data']['attributes'],
+                                auth_headers: { 'va_eauth_pid' => '600061742' })
+
+            fes_data = ClaimsApi::V2::DisabilityCompensationFesMapper.new(auto_claim).map_claim
+
+            disabilities = fes_data[:data][:form526][:disabilities]
+            # Three primary disabilities and newly elevated secondary disability
+            expect(disabilities.count).to eq(4)
+
+            # Check the secondary condition
+            secondary = disabilities.find { |d| d[:name] == 'Secondary Condition' }
+            expect(secondary).to be_present
+            expect(secondary[:disabilityActionType]).to eq('NEW')
+            expect(secondary[:diagnosticCode]).to eq(5002)
+          end
+        end
+
         context 'PACT special issue' do
           it 'adds PACT special issue for toxic exposure when action type is NEW' do
             expect(disabilities.first[:specialIssues]).to include('PACT')
@@ -267,6 +297,36 @@ describe ClaimsApi::V2::DisabilityCompensationFesMapper do
 
             special_issues = fes_data[:data][:form526][:disabilities].first[:specialIssues]
             expect(special_issues).to contain_exactly('POW', 'EMP', 'PACT')
+          end
+
+          it 'applies PACT special issue to secondary disabilities when appropriate' do
+            form_data['data']['attributes']['disabilities'][0]['secondaryDisabilities'] = [
+              {
+                'name' => 'Secondary With PACT',
+                'disabilityActionType' => 'SECONDARY',
+                'isRelatedToToxicExposure' => true
+              },
+              {
+                'name' => 'Secondary Without PACT',
+                'disabilityActionType' => 'SECONDARY',
+                'isRelatedToToxicExposure' => false
+              }
+            ]
+
+            auto_claim = create(:auto_established_claim,
+                                form_data: form_data['data']['attributes'],
+                                auth_headers: { 'va_eauth_pid' => '600061742' })
+            fes_data = ClaimsApi::V2::DisabilityCompensationFesMapper.new(auto_claim).map_claim
+
+            disabilities = fes_data[:data][:form526][:disabilities]
+
+            # Find the secondaries
+            with_pact = disabilities.find { |d| d[:name] == 'Secondary With PACT' }
+            without_pact = disabilities.find { |d| d[:name] == 'Secondary Without PACT' }
+
+            # Verify special issues
+            expect(with_pact[:specialIssues]).to include('PACT')
+            expect(without_pact[:specialIssues]).to be_nil
           end
         end
       end


### PR DESCRIPTION
## Summary

This PR updates the V2 FES mapper to extract all secondary disabilities nested inside primary disabilities and elevate them to the top-level disabilities array.

This maintains backwards compatibility with submissions that include secondary disabilities while also accounting for FES's lack of support for secondary disabilities.

## Related issue(s)

|[Jira Ticket](https://jira.devops.va.gov/browse/API-50205)|
|-|
|<img width="901" height="730" alt="Screenshot 2025-09-26 at 11 06 32" src="https://github.com/user-attachments/assets/8bdf2367-81b2-4c29-9e7c-39b6dbd530d8" />|

## Testing done

- [X] *New code is covered by unit tests*

To verify, 
- Add a byebug on line 258 of `modules/claims_api/lib/claims_api/v2/disability_compensation_fes_mapper.rb`
- Ensure the lighthouse_claims_api_v2_enable_fes flag is enabled
- Submit a request to `{{uri}}/services/claims/v2/veterans/{{veteran_icn}}/526/synchronous` with disabilities + at least one secondary disability. [Here is some sample data](https://github.com/department-of-veterans-affairs/vets-api/pull/24408#issuecomment-3339397514)
- When the breakpoint is triggered, check the content of `all_disabilities`

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

```
modules/claims_api/lib/claims_api/v2/disability_compensation_fes_mapper.rb
modules/claims_api/spec/lib/claims_api/v2/disability_compensation_fes_mapper_spec.rb
```

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA