### PR TITLE
[ID-739] - Update error handling in mpi_users_controller

### DIFF
--- a/app/controllers/v0/mpi_users_controller.rb
+++ b/app/controllers/v0/mpi_users_controller.rb
@@ -5,30 +5,43 @@ module V0
   class MPIUsersController < ApplicationController
     service_tag 'identity'
     before_action { authorize :mpi, :access_add_person_proxy? }
+    before_action :validate_form!
+    before_action :validate_user_ids!
+
+    ALLOWED_FORM_IDS = ['21-0966', FormProfiles::VA526ez::FORM_ID].freeze
 
     def submit
-      # Caller must be using proxy add in order to complete Intent to File or Disability Compensation forms
-      form_id = params[:id]
-      if ['21-0966', FormProfiles::VA526ez::FORM_ID].exclude?(form_id)
-        raise Common::Exceptions::Forbidden.new(
-          detail: "Action is prohibited with id parameter #{form_id}",
-          source: 'MPIUsersController'
-        )
-      end
-
-      # Scenario indicates serious problems with user data
-      if @current_user.birls_id.nil? && @current_user.participant_id.present?
-        raise Common::Exceptions::UnprocessableEntity.new(
-          detail: 'No birls_id while participant_id present',
-          source: 'MPIUsersController'
-        )
-      end
-
-      # Make request to MVI to gather and update user ids
       add_response = MPIData.for_user(@current_user.identity).add_person_proxy
-      raise add_response.error unless add_response.ok?
 
-      render json: { message: 'Success' }
+      if add_response.ok?
+        render json: { message: 'Success' }
+      else
+        error_message = 'MPI add_person_proxy error'
+        Rails.logger.error('[V0][MPIUsersController] submit error', error_message:)
+
+        render(json: { errors: [{ error_message: }] }, status: :unprocessable_entity)
+      end
+    end
+
+    private
+
+    def validate_form!
+      form_id = params[:id]
+      return if ALLOWED_FORM_IDS.include?(form_id)
+
+      raise Common::Exceptions::Forbidden.new(
+        detail: "Action is prohibited with id parameter #{form_id}",
+        source: 'MPIUsersController'
+      )
+    end
+
+    def validate_user_ids!
+      return unless @current_user.birls_id.nil? && @current_user.participant_id.present?
+
+      raise Common::Exceptions::UnprocessableEntity.new(
+        detail: 'No birls_id while participant_id present',
+        source: 'MPIUsersController'
+      )
     end
   end
 end


### PR DESCRIPTION
## Summary

- When a call to MPI was unsuccessful an error was raised
- Update `#submit` to properly handle and render MPI errors

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/739

## Testing 

## What areas of the site does it impact?
MPIUsersController

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
