### PR TITLE
Revert "API-50205 - Update V2 FES mapper to handle secondary disabilities"

### DIFF
--- a/modules/claims_api/lib/claims_api/v2/disability_compensation_fes_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v2/disability_compensation_fes_mapper.rb
@@ -237,26 +237,9 @@ module ClaimsApi
       def disabilities
         return if @data[:disabilities].blank?
 
-        # Extract all primary disabilities and their secondaries
-        primary_disabilities = @data[:disabilities]
-        all_disabilities = []
-
-        primary_disabilities.each do |disability|
-          # Add transformed primary disability
-          primary = disability.deep_dup
-          secondary_disabilities = primary.delete(:secondaryDisabilities) || []
-          all_disabilities << transform_disability_values!(primary)
-
-          # Pull any nested secondary disabilities up into the main disabilities array
-          secondary_disabilities.each do |secondary|
-            transformed_secondary = transform_disability_values!(secondary.deep_dup)
-            # Override the action type so it's always 'NEW':
-            transformed_secondary.merge!(disabilityActionType: 'NEW')
-            all_disabilities << transformed_secondary
-          end
+        @fes_claim[:disabilities] = @data[:disabilities].map do |disability|
+          transform_disability_values!(disability.deep_dup)
         end
-
-        @fes_claim[:disabilities] = all_disabilities
       end
 
       def transform_disability_values!(disability)

--- a/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_fes_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v2/disability_compensation_fes_mapper_spec.rb
@@ -238,36 +238,6 @@ describe ClaimsApi::V2::DisabilityCompensationFesMapper do
           expect(date[:day]).to eq(15)
         end
 
-        context 'when secondary disabilities are present' do
-          it 'extracts and flattens secondary disabilities' do
-            # Add secondary disabilities to the test data
-            form_data['data']['attributes']['disabilities'][0]['secondaryDisabilities'] = [
-              {
-                'name' => 'Secondary Condition',
-                'disabilityActionType' => 'SECONDARY',
-                'diagnosticCode' => 5002,
-                'isRelatedToToxicExposure' => false
-              }
-            ]
-
-            auto_claim = create(:auto_established_claim,
-                                form_data: form_data['data']['attributes'],
-                                auth_headers: { 'va_eauth_pid' => '600061742' })
-
-            fes_data = ClaimsApi::V2::DisabilityCompensationFesMapper.new(auto_claim).map_claim
-
-            disabilities = fes_data[:data][:form526][:disabilities]
-            # Three primary disabilities and newly elevated secondary disability
-            expect(disabilities.count).to eq(4)
-
-            # Check the secondary condition
-            secondary = disabilities.find { |d| d[:name] == 'Secondary Condition' }
-            expect(secondary).to be_present
-            expect(secondary[:disabilityActionType]).to eq('NEW')
-            expect(secondary[:diagnosticCode]).to eq(5002)
-          end
-        end
-
         context 'PACT special issue' do
           it 'adds PACT special issue for toxic exposure when action type is NEW' do
             expect(disabilities.first[:specialIssues]).to include('PACT')
@@ -297,36 +267,6 @@ describe ClaimsApi::V2::DisabilityCompensationFesMapper do
 
             special_issues = fes_data[:data][:form526][:disabilities].first[:specialIssues]
             expect(special_issues).to contain_exactly('POW', 'EMP', 'PACT')
-          end
-
-          it 'applies PACT special issue to secondary disabilities when appropriate' do
-            form_data['data']['attributes']['disabilities'][0]['secondaryDisabilities'] = [
-              {
-                'name' => 'Secondary With PACT',
-                'disabilityActionType' => 'SECONDARY',
-                'isRelatedToToxicExposure' => true
-              },
-              {
-                'name' => 'Secondary Without PACT',
-                'disabilityActionType' => 'SECONDARY',
-                'isRelatedToToxicExposure' => false
-              }
-            ]
-
-            auto_claim = create(:auto_established_claim,
-                                form_data: form_data['data']['attributes'],
-                                auth_headers: { 'va_eauth_pid' => '600061742' })
-            fes_data = ClaimsApi::V2::DisabilityCompensationFesMapper.new(auto_claim).map_claim
-
-            disabilities = fes_data[:data][:form526][:disabilities]
-
-            # Find the secondaries
-            with_pact = disabilities.find { |d| d[:name] == 'Secondary With PACT' }
-            without_pact = disabilities.find { |d| d[:name] == 'Secondary Without PACT' }
-
-            # Verify special issues
-            expect(with_pact[:specialIssues]).to include('PACT')
-            expect(without_pact[:specialIssues]).to be_nil
           end
         end
       end


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#24408

Reverting because we're supposed to hold off on merges to master while a potential gov shutdown is in the works.