### PR TITLE
## Add StatsD Service Tags to SiS Callback Error Methods

### DIFF
--- a/app/controllers/v0/sign_in_controller.rb
+++ b/app/controllers/v0/sign_in_controller.rb
@@ -78,15 +78,23 @@ module V0
         create_login_code(state_payload, user_info, credential_level)
       end
     rescue SignIn::Errors::StandardError => e
-      sign_in_logger.info('callback error', { errors: e.message,
-                                              client_id: state_payload&.client_id,
-                                              type: state_payload&.type,
-                                              acr: state_payload&.acr })
-      StatsD.increment(SignIn::Constants::Statsd::STATSD_SIS_CALLBACK_FAILURE)
+      error_details = {
+        type: state_payload&.type,
+        client_id: state_payload&.client_id,
+        acr: state_payload&.acr
+      }
+      sign_in_logger.info('callback error', error_details.merge(errors: e.message))
+      StatsD.increment(SignIn::Constants::Statsd::STATSD_SIS_CALLBACK_FAILURE,
+                       tags: ["type:#{error_details[:type]}",
+                              "client_id:#{error_details[:client_id]}",
+                              "acr:#{error_details[:acr]}"])
       handle_pre_login_error(e, state_payload&.client_id)
     rescue => e
       log_message_to_sentry(e.message, :error)
-      StatsD.increment(SignIn::Constants::Statsd::STATSD_SIS_CALLBACK_FAILURE)
+      StatsD.increment(SignIn::Constants::Statsd::STATSD_SIS_CALLBACK_FAILURE,
+                       tags: ["type:#{state_payload&.type}",
+                              "client_id:#{state_payload&.client_id}",
+                              "acr:#{state_payload&.acr}"])
       handle_pre_login_error(e, state_payload&.client_id)
     end
 

--- a/spec/support/sign_in/shared_examples/callback/api_error_response.rb
+++ b/spec/support/sign_in/shared_examples/callback/api_error_response.rb
@@ -8,6 +8,9 @@ RSpec.shared_examples 'callback_api_error_response' do
   let(:expected_error_message) do
     { errors: expected_error, client_id:, type:, acr: }
   end
+  let(:expected_statsd_tags) do
+    ["type:#{type || ''}", "client_id:#{client_id || ''}", "acr:#{acr || ''}"]
+  end
 
   it 'renders expected error' do
     expect(JSON.parse(subject.body)).to eq(expected_error_json)
@@ -23,6 +26,6 @@ RSpec.shared_examples 'callback_api_error_response' do
   end
 
   it 'updates StatsD with a callback request failure' do
-    expect { subject }.to trigger_statsd_increment(statsd_callback_failure)
+    expect { subject }.to trigger_statsd_increment(statsd_callback_failure, tags: expected_statsd_tags)
   end
 end

--- a/spec/support/sign_in/shared_examples/callback/error_response.rb
+++ b/spec/support/sign_in/shared_examples/callback/error_response.rb
@@ -4,6 +4,9 @@ RSpec.shared_examples 'callback_error_response' do
   let(:expected_error_json) { { 'errors' => expected_error } }
   let(:expected_error_status) { :bad_request }
   let(:statsd_callback_failure) { SignIn::Constants::Statsd::STATSD_SIS_CALLBACK_FAILURE }
+  let(:expected_statsd_tags) do
+    ["type:#{type || ''}", "client_id:#{client_id || ''}", "acr:#{acr || ''}"]
+  end
 
   context 'and client_id maps to a web based configuration' do
     let(:authentication) { SignIn::Constants::Auth::COOKIE }
@@ -48,7 +51,7 @@ RSpec.shared_examples 'callback_error_response' do
     end
 
     it 'updates StatsD with a callback request failure' do
-      expect { subject }.to trigger_statsd_increment(statsd_callback_failure)
+      expect { subject }.to trigger_statsd_increment(statsd_callback_failure, tags: expected_statsd_tags)
     end
   end
 


### PR DESCRIPTION
### Summary
This PR adds service tags to StatsD metrics for SignIn controller callback failures to improve observability and debugging capabilities.

### Changes Made
- **Controller**: Fixed StatsD tag generation in `V0::SignInController#callback` error handling
- **Tests**: Updated shared examples to expect StatsD tags in callback error scenarios

### Technical Details
- Added tags: `type`, `client_id`, `acr` to `api.sis.callback.failure` metric
- Fixed bug where `error_details` hash was accessed incorrectly (`.type` → `[:type]`)
- Updated test expectations to validate tag presence'

### Manual Testing

1. **Start monitoring StatsD logs:**
   ```bash
   tail -f log/statsd.log
   ```

2. **Trigger callback failures:**
   ```bash
   # Missing state parameter
   curl "http://localhost:3000/v0/sign_in/callback?code=some_code"
   
   # Invalid state JWT  
   curl "http://localhost:3000/v0/sign_in/callback?code=invalid&state=invalid"
   
   # Missing code parameter
   curl "http://localhost:3000/v0/sign_in/callback?state=some_state"
   ```

3. **Verify StatsD output:**
   Look for lines like:
   ```
   [StatsD] api.sis.callback.failure:1|c|#type:,client_id:,acr:
   ```