### PR TITLE
ci: add documentation format to rspec for test visibility

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -216,7 +216,7 @@ jobs:
           TEST_ENV_NUMBER: ${{ matrix.test_group }}
         run: >
           ${{ env.COMPOSE_BASH_CMD }}
-          "TEST_ENV_NUMBER=${{ matrix.test_group }} TMPDIR=tmp/systmp bundle exec parallel_test spec modules --group-by filesize --type rspec --only-group ${{ matrix.test_group }} -n 24"
+          "TEST_ENV_NUMBER=${{ matrix.test_group }} TMPDIR=tmp/systmp bundle exec parallel_test spec modules --group-by filesize --type rspec --only-group ${{ matrix.test_group }} -n 24 -o '--format documentation'"
 
       - name: Prepare SimpleCov shard payload
         if: always()


### PR DESCRIPTION
## Summary
Add `--format documentation` to the rspec command in CI to show each test description as it runs. Since [containerizing our parallelization](https://github.com/department-of-veterans-affairs/vets-api/pull/24419), our test logs are 1/24 the size previously allowing us to use the more useful verbose output.

## Motivation
When CI tests timeout, there's currently no output showing which test was running when the timeout occurred. This makes [debugging timeouts very difficult](https://dsva.slack.com/archives/CBU0KDSB1/p1759251128678749).

## Changes
- Added `-o '--format documentation'` to the `parallel_test` command in the code_checks workflow
- Tests will now output their descriptions as they run, making it easy to identify hanging tests

## Line counts

Top 5 test groups by total lines:
- Group 16: 22,177 lines (12,167 test output)
- Group 14: 13,341 lines (3,337 test output)
- Group 8: 13,039 lines (3,058 test output)
- Group 20: 13,013 lines (3,026 test output)
- Group 7: 12,763 lines (2,778 test output)

22k lines is well within GitHub's 1 million line limit and doesn't not seem to have performance issues in Safari or Chrome.