### PR TITLE
117721 add care systems to the /allrecipients reponse metadata

### DIFF
--- a/modules/my_health/app/controllers/my_health/v1/all_triage_teams_controller.rb
+++ b/modules/my_health/app/controllers/my_health/v1/all_triage_teams_controller.rb
@@ -11,6 +11,7 @@ module MyHealth
         end
 
         resource = resource.sort(params.permit(:sort)[:sort])
+        resource.metadata[:care_systems] = client.get_unique_care_systems(resource.records)
 
         # Even though this is a collection action we are not going to paginate
         render json: AllTriageTeamsSerializer.new(resource.data, { meta: resource.metadata })

--- a/modules/my_health/spec/requests/my_health/v1/messaging/allrecipients_spec.rb
+++ b/modules/my_health/spec/requests/my_health/v1/messaging/allrecipients_spec.rb
@@ -43,7 +43,9 @@ RSpec.describe 'MyHealth::V1::Messaging::Allrecipients', type: :request do
 
     it 'responds to GET #index' do
       VCR.use_cassette('sm_client/triage_teams/gets_a_collection_of_all_triage_team_recipients') do
-        get '/my_health/v1/messaging/allrecipients'
+        VCR.use_cassette('sm_client/get_unique_care_systems') do
+          get '/my_health/v1/messaging/allrecipients'
+        end
       end
 
       expect(response).to be_successful
@@ -53,7 +55,9 @@ RSpec.describe 'MyHealth::V1::Messaging::Allrecipients', type: :request do
 
     it 'responds to GET #index when camel-inflected' do
       VCR.use_cassette('sm_client/triage_teams/gets_a_collection_of_all_triage_team_recipients') do
-        get '/my_health/v1/messaging/allrecipients', headers: { 'X-Key-Inflection' => 'camel' }
+        VCR.use_cassette('sm_client/get_unique_care_systems') do
+          get '/my_health/v1/messaging/allrecipients', headers: { 'X-Key-Inflection' => 'camel' }
+        end
       end
 
       expect(response).to be_successful
@@ -79,7 +83,9 @@ RSpec.describe 'MyHealth::V1::Messaging::Allrecipients', type: :request do
 
       VCR.use_cassette('sm_client/session_require_oh') do
         VCR.use_cassette('sm_client/triage_teams/gets_a_collection_of_all_triage_team_recipients_require_oh') do
-          get '/my_health/v1/messaging/allrecipients'
+          VCR.use_cassette('sm_client/get_unique_care_systems') do
+            get '/my_health/v1/messaging/allrecipients'
+          end
         end
       end
 

--- a/spec/support/schemas/my_health/messaging/v1/all_triage_teams.json
+++ b/spec/support/schemas/my_health/messaging/v1/all_triage_teams.json
@@ -33,6 +33,9 @@
         "associated_blocked_triage_groups": {
           "type": "integer"
         },
+        "care_systems":{
+          "type":"array"
+        },
         "sort": {
           "type": "object"
         }

--- a/spec/support/schemas_camelized/my_health/messaging/v1/all_triage_teams.json
+++ b/spec/support/schemas_camelized/my_health/messaging/v1/all_triage_teams.json
@@ -33,6 +33,9 @@
         "associatedBlockedTriageGroups": {
           "type": "integer"
         },
+        "careSystems":{
+          "type":"array"
+        },
         "sort": {
           "type": "object"
         }

--- a/spec/support/vcr_cassettes/sm_client/get_unique_care_systems.yml
+++ b/spec/support/vcr_cassettes/sm_client/get_unique_care_systems.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-api.va.gov/services/va_facilities/v1/facilities?facilityIds=vha_979
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Apikey:
+      - "<LIGHTHOUSE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 30 Sep 2025 17:10:42 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Remaining-Minute:
+      - '46'
+      X-Ratelimit-Limit-Minute:
+      - '60'
+      Ratelimit-Remaining:
+      - '46'
+      Ratelimit-Reset:
+      - '18'
+      Ratelimit-Limit:
+      - '60'
+      X-Oneagent-Js-Injection:
+      - 'true'
+      Server-Timing:
+      - dtRpid;desc="-1731258138", dtSInfo;desc="0"
+      X-Envoy-Upstream-Service-Time:
+      - '7'
+      Access-Control-Allow-Origin:
+      - "*"
+      Correlation-Id:
+      - dc8608fe-f0c8-4539-be9b-d6f3085b34d2#358743
+      Cache-Control:
+      - ''
+      - no-cache, no-store
+      X-Frame-Options:
+      - SAMEORIGIN
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+    body:
+      encoding: ASCII-8BIT
+      string: '{"links":{"self":"<LIGHTHOUSE_CLAIMS_API_HOST>/services/va_facilities/v1/facilities?facilityIds=vha_979&page=1&per_page=10","first":"<LIGHTHOUSE_CLAIMS_API_HOST>/services/va_facilities/v1/facilities?facilityIds=vha_979&page=1&per_page=10","last":"<LIGHTHOUSE_CLAIMS_API_HOST>/services/va_facilities/v1/facilities?facilityIds=vha_979&page=1&per_page=10"},"meta":{"pagination":{"currentPage":1,"perPage":10,"totalPages":1,"totalEntries":0}}}'
+  recorded_at: Mon, 01 May 2017 19:25:00 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
## Summary
We want to incorporate related care systems metadata into the `/my_health/v1/messaging/allrecipients` response. [This is already being done on mobile](https://github.com/department-of-veterans-affairs/vets-api/blob/a97e1f90c1b050e95e5da52136d7a4886e6d37aa/modules/mobile/app/controllers/mobile/v0/recipients_controller.rb#L25), so the path forward is fairly straightforward.

## Related issue(s)
[117721](https://github.com/department-of-veterans-affairs/va.gov-team/issues/117721)

## Testing done
specs updated to account for the additional http request

## What areas of the site does it impact?
SM application

## Acceptance criteria
[ ]  When hitting `/my_health/v1/messaging/allrecipients` the response should look like this:
```
{
  data: [...],
  meta: {
    care_systems: [{"station_number"=>"...", "health_care_system_name"=>"..."}]
  }
}
```