### PR TITLE
Remove redundant code owner entries for benefits-admin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -509,7 +509,7 @@ app/swagger/readme.md @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/appeals @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/backend_statuses.rb @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/banners.rb @department-of-veterans-affairs/backend-review-group
-app/swagger/swagger/requests/benefits_claims.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-admin
+app/swagger/swagger/requests/benefits_claims.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/benefits_reference_data.rb @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/caregivers_assistance_claims.rb @department-of-veterans-affairs/health-apps-backend @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/claim_documents.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group
@@ -565,7 +565,7 @@ app/swagger/swagger/responses/service_unavailable_error.rb @department-of-vetera
 app/swagger/swagger/schemas/appeals @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/schemas/async_transaction @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/schemas/async_transaction/vet360.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
-app/swagger/swagger/schemas/benefits_claims.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-admin
+app/swagger/swagger/schemas/benefits_claims.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/schemas/connected_applications.rb @department-of-veterans-affairs/lighthouse-pivot
 app/swagger/swagger/schemas/contacts.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/schemas/dependents_verifications.rb @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/backend-review-group
@@ -1693,7 +1693,7 @@ spec/requests/statsd_middleware_spec.rb @department-of-veterans-affairs/vfs-mhv-
 spec/requests/swagger_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/requests/v0/appeals_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/requests/v0/appointments_spec.rb @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/backend-review-group
-spec/requests/v0/benefits_claims_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-admin
+spec/requests/v0/benefits_claims_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/backend-review-group
 spec/requests/v0/backend_status_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/requests/v0/caregivers_assistance_claims_spec.rb @department-of-veterans-affairs/health-apps-backend @department-of-veterans-affairs/backend-review-group
 spec/requests/v0/claim_documents_spec.rb @department-of-veterans-affairs/disability-benefits @department-of-veterans-affairs/backend-review-group
@@ -2029,7 +2029,7 @@ spec/support/schemas/evss_claim.json @department-of-veterans-affairs/vfs-authent
 spec/support/schemas/evss_claims_async.json @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 spec/support/schemas/evss_claims_service.json @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 spec/support/schemas/evss_claims.json @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
-spec/support/schemas/failed_evidence_submissions.json @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-admin
+spec/support/schemas/failed_evidence_submissions.json @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/backend-review-group
 spec/support/schemas/folder_search.json @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/backend-review-group
 spec/support/schemas/folder.json @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/backend-review-group
 spec/support/schemas/folders.json @department-of-veterans-affairs/vfs-vaos @department-of-veterans-affairs/backend-review-group


### PR DESCRIPTION
## Summary

The `benefits-admin` group was removed in https://github.com/department-of-veterans-affairs/vets-api/pull/24318. (The `benefits-admin` group was redundant since the entries are already covered by our team's `benefits-management-tools-be` group.)

This PR cleans up four remaining references to `benefits-admin` that were still present in `CODEOWNERS` and causing the file to fail validation.

Currently on `master` the GitHub UI shows `This CODEOWNERS file contains errors`:

```
Unknown owner on line 512: make sure the team @department-of-veterans-affairs/benefits-admin exists, is publicly visible, and has write access to the repository
…-affairs/backend-review-group @department-of-veterans-affairs/benefits-admin
Unknown owner on line 568: make sure the team @department-of-veterans-affairs/benefits-admin exists, is publicly visible, and has write access to the repository
…-affairs/backend-review-group @department-of-veterans-affairs/benefits-admin
Unknown owner on line 1696: make sure the team @department-of-veterans-affairs/benefits-admin exists, is publicly visible, and has write access to the repository
…-affairs/backend-review-group @department-of-veterans-affairs/benefits-admin
Unknown owner on line 2032: make sure the team @department-of-veterans-affairs/benefits-admin exists, is publicly visible, and has write access to the repository
…-affairs/backend-review-group @department-of-veterans-affairs/benefits-admin
```

## Related issue(s)

- #24318 

## Testing done

- [x] Removed `benefits-admin` entries on feature branch.
- [x] GitHub UI now shows `This CODEOWNERS file is valid.`

## What areas of the site does it impact?

None
