### PR TITLE
API-50406-updates-to-fes-mapper-participant-id-data-type

### DIFF
--- a/modules/claims_api/lib/claims_api/v1/disability_compensation_fes_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v1/disability_compensation_fes_mapper.rb
@@ -101,14 +101,14 @@ module ClaimsApi
 
       def extract_veteran_participant_id
         # Try auth_headers first, then fall back to other sources
-        @auto_claim.auth_headers&.dig('va_eauth_pid') ||
-          @auto_claim.auth_headers&.dig('participant_id')
+        @auto_claim.auth_headers&.dig('va_eauth_pid')&.to_i ||
+          @auto_claim.auth_headers&.dig('participant_id')&.to_i
       end
 
       def extract_claimant_participant_id
         # For dependent claims, use dependent participant ID
         if @auto_claim.auth_headers&.dig('dependent', 'participant_id').present?
-          @auto_claim.auth_headers.dig('dependent', 'participant_id')
+          @auto_claim.auth_headers.dig('dependent', 'participant_id')&.to_i
         else
           # Otherwise, claimant is the veteran
           extract_veteran_participant_id

--- a/modules/claims_api/spec/lib/claims_api/v1/disability_compensation_fes_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v1/disability_compensation_fes_mapper_spec.rb
@@ -41,11 +41,16 @@ describe ClaimsApi::V1::DisabilityCompensationFesMapper do
           expect(fes_data[:data]).to have_key(:form526)
         end
 
+        it 'casts the participant IDs as integers' do
+          expect(fes_data[:data][:veteranParticipantId]).to eq(600_061_742)
+          expect(fes_data[:data][:claimantParticipantId]).to eq(600_061_742)
+        end
+
         it 'finds the dependent participant_id as expected' do
           auth_headers['dependent'] = {}
           auth_headers['dependent']['participant_id'] = '8675309'
 
-          expect(fes_data[:data][:claimantParticipantId]).to eq('8675309')
+          expect(fes_data[:data][:claimantParticipantId]).to eq(8_675_309)
         end
       end
 


### PR DESCRIPTION
## Summary
* Updates participant IDs to be integers which is the data type expected by FES

## Related issue(s)


## Testing done

- [x] *New code is covered by unit tests*


## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/lib/claims_api/v1/disability_compensation_fes_mapper.rb
	modified:   modules/claims_api/spec/lib/claims_api/v1/disability_compensation_fes_mapper_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
