### PR TITLE
Bug user lookup failing mobile sm oh flipper

### DIFF
--- a/app/policies/mhv_messaging_policy.rb
+++ b/app/policies/mhv_messaging_policy.rb
@@ -14,7 +14,7 @@ MHVMessagingPolicy = Struct.new(:user, :mhv_messaging) do
   def mobile_access?
     return false unless user.mhv_correlation_id && user.va_patient?
 
-    client = Mobile::V0::Messaging::Client.new(session: { user_id: user.mhv_correlation_id })
+    client = Mobile::V0::Messaging::Client.new(session: { user_id: user.mhv_correlation_id, user_uuid: user.uuid })
     validate_client(client)
   end
 

--- a/modules/mobile/app/controllers/mobile/messaging_controller.rb
+++ b/modules/mobile/app/controllers/mobile/messaging_controller.rb
@@ -12,7 +12,8 @@ module Mobile
     protected
 
     def client
-      @client ||= Mobile::V0::Messaging::Client.new(session: { user_id: current_user.mhv_correlation_id })
+      @client ||= Mobile::V0::Messaging::Client.new(session: { user_id: current_user.mhv_correlation_id,
+                                                               user_uuid: current_user.uuid })
     end
 
     def authorize

--- a/modules/mobile/spec/requests/mobile/v0/messaging/health/all_recipients_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/messaging/health/all_recipients_spec.rb
@@ -59,6 +59,24 @@ RSpec.describe 'Mobile::V0::Messaging::Health::AllRecipients', type: :request do
       expect(response).to match_camelized_response_schema('all_triage_teams')
     end
 
+    it 'responds to GET #index with requires_oh flipper enabled' do
+      allow(Flipper).to receive(:enabled?)
+        .with(:mhv_secure_messaging_cerner_pilot, anything)
+        .and_return(true)
+      allow_any_instance_of(Mobile::V0::Messaging::Client).to receive(:get_unique_care_systems).and_return(
+        care_systems_stub
+      )
+      VCR.use_cassette('sm_client/session_require_oh') do
+        VCR.use_cassette('sm_client/triage_teams/gets_a_collection_of_all_triage_team_recipients_require_oh') do
+          get '/mobile/v0/messaging/health/allrecipients', headers: sis_headers
+        end
+      end
+
+      expect(response).to be_successful
+      expect(response.body).to be_a(String)
+      expect(response).to match_camelized_response_schema('all_triage_teams')
+    end
+
     context 'when there are cached triage teams' do
       let(:params) { { useCache: true } }
 


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary
Mobile API messaging controller was not adding uuid to the session so current_user = User.find(session.user_uuid) is failing making it so regardless of the OH flipper being on mobile never includes the path param for the upstream to actually fetch the data. Take 2 - this time with tests

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/120991

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
