### PR TITLE
121029 exclude test files

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -54,7 +54,8 @@ module VSPDanger
     EXCLUSIONS = %w[
       *.csv *.json *.tsv *.txt *.md Gemfile.lock app/swagger modules/mobile/docs spec/fixtures/ spec/support/vcr_cassettes/
       modules/mobile/spec/support/vcr_cassettes/ db/seeds modules/vaos/app/docs modules/meb_api/app/docs
-      modules/appeals_api/app/swagger/ *.bru *.pdf modules/*/spec/fixtures/* modules/*/spec/factories/*
+      modules/appeals_api/app/swagger/ *.bru *.pdf modules/*/spec/fixtures/* modules/*/spec/factories/* 
+      modules/*/spec/**/*.rb
     ].freeze
     PR_SIZE = { recommended: 200, maximum: 500 }.freeze
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -55,7 +55,7 @@ module VSPDanger
       *.csv *.json *.tsv *.txt *.md Gemfile.lock app/swagger modules/mobile/docs spec/fixtures/ spec/support/vcr_cassettes/
       modules/mobile/spec/support/vcr_cassettes/ db/seeds modules/vaos/app/docs modules/meb_api/app/docs
       modules/appeals_api/app/swagger/ *.bru *.pdf modules/*/spec/fixtures/* modules/*/spec/factories/*
-      modules/*/spec/**/*.rb
+      modules/*/spec/**/*.rb spec/**/*.rb
     ].freeze
     PR_SIZE = { recommended: 200, maximum: 500 }.freeze
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -54,7 +54,7 @@ module VSPDanger
     EXCLUSIONS = %w[
       *.csv *.json *.tsv *.txt *.md Gemfile.lock app/swagger modules/mobile/docs spec/fixtures/ spec/support/vcr_cassettes/
       modules/mobile/spec/support/vcr_cassettes/ db/seeds modules/vaos/app/docs modules/meb_api/app/docs
-      modules/appeals_api/app/swagger/ *.bru *.pdf modules/*/spec/fixtures/* modules/*/spec/factories/* 
+      modules/appeals_api/app/swagger/ *.bru *.pdf modules/*/spec/fixtures/* modules/*/spec/factories/*
       modules/*/spec/**/*.rb
     ].freeze
     PR_SIZE = { recommended: 200, maximum: 500 }.freeze


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): **NO**
- Updated the Dangerfile `ChangeLimiter` to exclude spec files from PR line count checks
- **Problem:** Spec files can be verbose, causing developers to hit PR size limits even when adding appropriate test coverage alongside feature changes
- **Solution:** Added `spec/**/*.rb` and `modules/*/spec/**/*.rb` to the `EXCLUSIONS` array so all spec files are ignored in line count calculations (similar to existing exclusions for fixtures, factories, and VCR cassettes)
- **Team:** Backend Platform / discussed in Backend CoP on 9/15

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/121029

## Testing done

- [ ] New code is covered by unit tests
- **Old behavior:** Spec files counted toward the 200-line warning and 500-line error thresholds
- **New behavior:** Spec files are excluded from line counts, allowing developers to add comprehensive tests without triggering size warnings
- Uploaded larger (over 500 line) section of JUST TESTS and did not observe any warning about 500 lines of code (or even 200)

## What areas of the site does it impact?

This impacts CI checks for all pull requests - specifically the Danger bot's PR size validation.

## Acceptance criteria

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No error nor warning in the console.
- [ ] Documentation has been updated (if necessary - consider updating any docs that reference PR size limits and exclusions)
- [ ] Verified the Dangerfile runs successfully in CI

## Requested Feedback

Please verify the exclusion patterns make sense and won't have unintended side effects on PR size calculations.