### PR TITLE
account resource service and spec added

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -908,6 +908,7 @@ lib/lgy/configuration.rb @department-of-veterans-affairs/benefits-non-disability
 lib/lgy/service.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group
 lib/lgy/tag_sentry.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group
 lib/lighthouse/healthcare_cost_and_coverage/configuration.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
+lib/lighthouse/healthcare_cost_and_coverage/account/service.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 lib/lighthouse/healthcare_cost_and_coverage/medication_dispense/service.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 lib/lighthouse/healthcare_cost_and_coverage/invoice/service.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 lib/lighthouse/benefits_claims @department-of-veterans-affairs/disability-benefits @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/backend-review-group
@@ -1461,6 +1462,7 @@ spec/lib/lighthouse/letters_generator @department-of-veterans-affairs/benefits-m
 spec/lib/lighthouse/veteran_verification @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/veterans_health @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/healthcare_cost_and_coverage/configuration_spec.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
+spec/lib/lighthouse/healthcare_cost_and_coverage/account/service_spec.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/lib/lighthouse/healthcare_cost_and_coverage/medication_dispense/service_spec.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/lib/logging @department-of-veterans-affairs/benefits-lifestage @department-of-veterans-affairs/backend-review-group
 spec/lib/mail_automation @department-of-veterans-affairs/backend-review-group

--- a/lib/lighthouse/healthcare_cost_and_coverage/account/service.rb
+++ b/lib/lighthouse/healthcare_cost_and_coverage/account/service.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'common/client/base'
+require 'lighthouse/healthcare_cost_and_coverage/configuration'
+require 'lighthouse/service_exception'
+
+module Lighthouse
+  module HealthcareCostAndCoverage
+    module Account
+      class Service < Common::Client::Base
+        configuration Lighthouse::HealthcareCostAndCoverage::Configuration
+        STATSD_KEY_PREFIX = 'api.lighthouse.hccc.account'
+
+        def initialize(icn)
+          @icn = icn
+          raise ArgumentError, 'no ICN passed in for HCCC request' if icn.blank?
+
+          super()
+        end
+
+        def list(id: nil, patient: @icn, **params)
+          endpoint = 'r4/Account'
+          query = {}
+
+          if id
+            query[:_id] = id
+          else
+            query[:patient] = patient
+          end
+
+          query.merge!(params) if params.present?
+          config.get(endpoint, params: query, icn: @icn).body
+        rescue Faraday::TimeoutError, Faraday::ClientError, Faraday::ServerError => e
+          handle_error(e, endpoint)
+        end
+
+        private
+
+        def handle_error(error, endpoint)
+          Lighthouse::ServiceException.send_error(
+            error,
+            self.class.to_s.underscore,
+            nil,
+            "#{config.base_api_path}/#{endpoint}"
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/lighthouse/healthcare_cost_and_coverage/account/service_spec.rb
+++ b/spec/lib/lighthouse/healthcare_cost_and_coverage/account/service_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'lighthouse/healthcare_cost_and_coverage/account/service'
+
+RSpec.describe Lighthouse::HealthcareCostAndCoverage::Account::Service do
+  let(:icn) { '43000199' }
+  let(:service) { described_class.new(icn) }
+  let(:response_body) { { 'resourceType' => 'Bundle', 'entry' => [] } }
+  let(:faraday_response) { double('Faraday::Response', body: response_body) }
+
+  describe '#initialize' do
+    it 'initializes with icn' do
+      expect(service).to be_a(described_class)
+    end
+
+    it 'raises if icn is blank' do
+      expect { described_class.new(nil) }.to raise_error(ArgumentError)
+      expect { described_class.new('') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#list' do
+    before do
+      allow(service.send(:config)).to receive(:get).and_return(faraday_response)
+    end
+
+    it 'returns a FHIR bundle hash' do
+      result = service.list
+      expect(result).to eq(response_body)
+    end
+
+    it 'queries by _id only when id is provided' do
+      expect(service.send(:config)).to receive(:get).with(
+        'r4/Account',
+        params: { _id: '4-1abU4wmNqduNeO' },
+        icn:
+      ).and_return(faraday_response)
+
+      service.list(id: '4-1abU4wmNqduNeO')
+    end
+
+    it 'defaults to patient search when id is not provided' do
+      expect(service.send(:config)).to receive(:get).with(
+        'r4/Account',
+        params: { patient: icn },
+        icn:
+      ).and_return(faraday_response)
+
+      service.list
+    end
+
+    it 'passes through extra query params' do
+      expect(service.send(:config)).to receive(:get).with(
+        'r4/Account',
+        params: { patient: icn, _count: 10, page: 2 },
+        icn:
+      ).and_return(faraday_response)
+
+      service.list(_count: 10, page: 2)
+    end
+
+    it 'uses an explicitly provided patient if given' do
+      expect(service.send(:config)).to receive(:get).with(
+        'r4/Account',
+        params: { patient: 'Patient/43000199' },
+        icn:
+      ).and_return(faraday_response)
+
+      service.list(patient: 'Patient/43000199')
+    end
+
+    context 'when Faraday::TimeoutError is raised' do
+      before do
+        allow(service.send(:config)).to receive(:get).and_raise(Faraday::TimeoutError.new)
+      end
+
+      it 'raises Lighthouse::Service timeout (mapped to Common::Exceptions::Timeout)' do
+        expect { service.list }.to raise_error(Common::Exceptions::Timeout)
+      end
+    end
+
+    context 'when Faraday::ClientError is raised' do
+      before do
+        allow(service.send(:config)).to receive(:get).and_raise(Faraday::ClientError.new('fail'))
+        allow(Lighthouse::ServiceException).to receive(:send_error).and_return(:error_envelope)
+      end
+
+      it 'calls handle_error and returns error envelope' do
+        expect(service.list).to eq(:error_envelope)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): NO*
- Adds logic for fetching account info from lighthouse for the copay history feature
- Financial Management, we own this

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114276

## Testing done

- [x] *New code is covered by unit tests*
- This is a new service
- Verify methods in ruby console

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
