### PR TITLE
Add production-bypass branch for code freeze deploys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,14 +75,26 @@ jobs:
             ${{ steps.ecr-login.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:${{ github.event.workflow_run.head_commit.id }}
           cache-from: type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY
           cache-to: type=inline
-  deploy:
+  deploy_dev_staging:
     needs: build_and_push
     if: ${{ github.event.workflow_run.head_branch == 'master' && github.event.workflow_run.conclusion == 'success' }}
     uses: department-of-veterans-affairs/vets-api/.github/workflows/deploy-template.yml@master
     with:
       ecr_repository: "vets-api"
       manifests_directory: "vets-api"
-      auto_deploy_envs: "dev staging prod sandbox"
+      auto_deploy_envs: "dev staging"
+      commit_sha: ${{ github.event.workflow_run.head_commit.id }}
+    secrets:
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  deploy_prod_sandbox:
+    needs: build_and_push
+    if: ${{ github.event.workflow_run.head_branch == 'production-bypass' && github.event.workflow_run.conclusion == 'success' }}
+    uses: department-of-veterans-affairs/vets-api/.github/workflows/deploy-template.yml@master
+    with:
+      ecr_repository: "vets-api"
+      manifests_directory: "vets-api"
+      auto_deploy_envs: "prod sandbox"
       commit_sha: ${{ github.event.workflow_run.head_commit.id }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -1,7 +1,7 @@
 name: Code Checks
 on:
   push:
-    branches: [master]
+    branches: [master, production-bypass]
   pull_request:
     types: [opened, reopened, synchronize]
 permissions:

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -39,7 +39,7 @@ jobs:
           echo "environments=${{ env.environments }}" >> $GITHUB_OUTPUT
   release:
     needs: [prepare-values]
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/production-bypass'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
Implements the production-bypass branch infrastructure for the shutdown code freeze.

- **master branch** → deploys to `dev` and `staging` only
- **production-bypass branch** → deploys to `prod` and `sandbox` only

## Changes
- Split `build.yml` deploy job into two separate jobs (`deploy_dev_staging` and `deploy_prod_sandbox`)
- Added `check_branch_protection` job with guardrail messaging
- Updated `code_checks.yml` to run on both `master` and `production-bypass` branches
- Updated `deploy-template.yml` to allow releases from `production-bypass` branch

## Testing Plan
- [ ] Verify master commit deploys to dev and staging only
- [x] Verify prod and sandbox jobs block when source is master
- [x] Create `production-bypass` branch with proper protections
- [ ] Simulate hotfix: merge to master, cherry-pick to production-bypass, deploy to sandbox

## Related
Refs department-of-veterans-affairs/va.gov-team#121134
See: https://vfs.atlassian.net/wiki/spaces/LEAD/pages/4378460179/Production+Bypass+Deploy+Plan+Shutdown+Code+Freeze