### PR TITLE
Add user hash to claim group

### DIFF
--- a/modules/dependents_benefits/app/controllers/dependents_benefits/v0/claims_controller.rb
+++ b/modules/dependents_benefits/app/controllers/dependents_benefits/v0/claims_controller.rb
@@ -5,6 +5,7 @@ require 'dependents_benefits/claim_processor'
 require 'dependents_benefits/generators/claim674_generator'
 require 'dependents_benefits/generators/claim686c_generator'
 require 'dependents_benefits/monitor'
+require 'dependents_benefits/user_data'
 
 module DependentsBenefits
   module V0
@@ -37,8 +38,11 @@ module DependentsBenefits
 
         raise Common::Exceptions::ValidationErrors, claim unless claim.save
 
+        user_data = DependentsBenefits::UserData.new(current_user, claim.parsed_form)
+
         # Matching parent_claim_id and saved_claim_id indicates this is a parent claim
-        SavedClaimGroup.new(claim_group_guid: claim.guid, parent_claim_id: claim.id, saved_claim_id: claim.id).save!
+        SavedClaimGroup.new(claim_group_guid: claim.guid, parent_claim_id: claim.id, saved_claim_id: claim.id,
+                            user_data: user_data.get_user_json).save!
         form_data = claim.parsed_form
 
         raise Common::Exceptions::ValidationErrors if !claim.submittable_686? && !claim.submittable_674?

--- a/modules/dependents_benefits/app/models/dependents_benefits/form_profiles/va_686c674.rb
+++ b/modules/dependents_benefits/app/models/dependents_benefits/form_profiles/va_686c674.rb
@@ -114,7 +114,7 @@ module DependentsBenefits
       @va_file_number
     rescue => e
       monitor.track_prefill_warning('Failed to retrieve VA file number', 'file_number_error',
-                                    { error: e&.message })
+                                    error: e&.message)
       user.ssn.presence
     end
 
@@ -143,13 +143,10 @@ module DependentsBenefits
         response = pension_award_service.get_awards_pension
         response.try(:body)&.dig('awards_pension')&.transform_keys(&:to_sym)
       rescue => e
-        payload = {
-          user_account_uuid: user&.user_account_uuid,
-          error: e.message,
-          form_id:
-        }
         monitor.track_prefill_warning('Failed to retrieve awards pension data', 'awards_pension_error',
-                                      payload)
+                                      user_account_uuid: user&.user_account_uuid,
+                                      error: e.message,
+                                      form_id:)
         {}
       end
     end
@@ -169,7 +166,7 @@ module DependentsBenefits
       end
     rescue => e
       monitor.track_prefill_warning('Failed to retrieve dependents information', 'dependents_error',
-                                    { error: e&.message })
+                                    error: e&.message)
       @dependents_information = []
     end
 

--- a/modules/dependents_benefits/lib/dependents_benefits/monitor.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits/monitor.rb
@@ -64,6 +64,16 @@ module DependentsBenefits
       track_warning_event(message, PREFILL_STATS_KEY, **context)
     end
 
+    def track_user_data_error(message, action, options = {})
+      options[:tags] = ["action:user_data.#{action}"]
+      track_error_event(message, CLAIM_STATS_KEY, options)
+    end
+
+    def track_user_data_warning(message, action, options = {})
+      options[:tags] = ["action:user_data.#{action}"]
+      track_warning_event(message, CLAIM_STATS_KEY, options)
+    end
+
     private
 
     # append tags to the context being logged

--- a/modules/dependents_benefits/lib/dependents_benefits/monitor.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits/monitor.rb
@@ -64,14 +64,14 @@ module DependentsBenefits
       track_warning_event(message, PREFILL_STATS_KEY, **context)
     end
 
-    def track_user_data_error(message, action, options = {})
-      options[:tags] = ["action:user_data.#{action}"]
-      track_error_event(message, CLAIM_STATS_KEY, options)
+    def track_user_data_error(message, action, **context)
+      context = append_tags(context, action:)
+      track_error_event(message, CLAIM_STATS_KEY, **context)
     end
 
-    def track_user_data_warning(message, action, options = {})
-      options[:tags] = ["action:user_data.#{action}"]
-      track_warning_event(message, CLAIM_STATS_KEY, options)
+    def track_user_data_warning(message, action, **context)
+      context = append_tags(context, action:)
+      track_warning_event(message, CLAIM_STATS_KEY, **context)
     end
 
     private

--- a/modules/dependents_benefits/lib/dependents_benefits/sidekiq/dependent_submission_job.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits/sidekiq/dependent_submission_job.rb
@@ -108,7 +108,7 @@ module DependentsBenefits
         end
       end
     rescue => e
-      monitor.track_submission_error('Error handling job success', 'success_failure', { error: e })
+      monitor.track_submission_error('Error handling job success', 'success_failure', error: e)
     end
 
     def all_child_groups_succeeded?
@@ -117,7 +117,7 @@ module DependentsBenefits
 
     # Distinguishes permanent vs transient failures for retry logic
     def handle_job_failure(error)
-      monitor.track_submission_error("Error submitting #{self.class}", 'error', { error: })
+      monitor.track_submission_error("Error submitting #{self.class}", 'error', error:)
       mark_submission_attempt_failed(error)
 
       if permanent_failure?(error)

--- a/modules/dependents_benefits/lib/dependents_benefits/user_data.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits/user_data.rb
@@ -33,7 +33,7 @@ module DependentsBenefits
       @va_file_number = get_file_number || ssn
     rescue => e
       monitor.track_user_data_error('DependentsBenefits::UserData#initialize error',
-                                    'user_hash.failure', { error: e })
+                                    'user_hash.failure', error: e)
       raise Common::Exceptions::UnprocessableEntity.new(detail: 'Could not initialize user data')
     end
 
@@ -56,7 +56,7 @@ module DependentsBenefits
       { 'veteran_information' => veteran_information }.to_json
     rescue => e
       monitor.track_user_data_error('DependentsBenefits::UserData#get_user_hash error',
-                                    'user_hash.failure', { error: e })
+                                    'user_hash.failure', error: e)
       raise Common::Exceptions::UnprocessableEntity.new(detail: 'Could not generate user hash')
     end
 
@@ -77,7 +77,7 @@ module DependentsBenefits
     rescue
       monitor.track_user_data_warning('DependentsBenefits::UserData#get_file_number error',
                                       'file_number_lookup.failure',
-                                      { error: 'Could not retrieve file number from BGS' })
+                                      error: 'Could not retrieve file number from BGS')
       nil
     end
 

--- a/modules/dependents_benefits/lib/dependents_benefits/user_data.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits/user_data.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'dependents_benefits/monitor'
+
+module DependentsBenefits
+  class UserData
+    attr_reader :first_name,
+                :middle_name,
+                :last_name,
+                :ssn,
+                :birth_date,
+                :common_name,
+                :email,
+                :va_profile_email,
+                :icn,
+                :participant_id,
+                :uuid,
+                :va_file_number
+
+    def initialize(user, claim_data)
+      @first_name = user.first_name.presence || claim_data.dig('veteran_information', 'full_name', 'first')
+      @middle_name = user.middle_name.presence || claim_data.dig('veteran_information', 'full_name', 'middle')
+      @last_name = user.last_name.presence || claim_data.dig('veteran_information', 'full_name', 'last')
+      @ssn = user.ssn.presence
+      @uuid = user.uuid.presence
+      @birth_date = user.birth_date.presence || claim_data.dig('veteran_information', 'birth_date')
+      @common_name = user.common_name.presence
+      @email = user.email.presence || claim_data.dig('veteran_contact_information', 'email_address')
+      @icn = user.icn.presence
+      @participant_id = user.participant_id.presence
+      @va_profile_email = user.va_profile_email.presence
+
+      @va_file_number = get_file_number || ssn
+    rescue => e
+      monitor.track_user_data_error('DependentsBenefits::UserData#initialize error',
+                                    'user_hash.failure', { error: e })
+      raise Common::Exceptions::UnprocessableEntity.new(detail: 'Could not initialize user data')
+    end
+
+    def get_user_json
+      full_name = { 'first' => first_name, 'middle' => middle_name, 'last' => last_name }.compact
+
+      veteran_information = {
+        'full_name' => full_name,
+        'common_name' => common_name,
+        'va_profile_email' => va_profile_email,
+        'email' => email,
+        'participant_id' => participant_id,
+        'ssn' => ssn,
+        'va_file_number' => va_file_number,
+        'birth_date' => birth_date,
+        'uuid' => uuid,
+        'icn' => icn
+      }.compact
+
+      { 'veteran_information' => veteran_information }.to_json
+    rescue => e
+      monitor.track_user_data_error('DependentsBenefits::UserData#get_user_hash error',
+                                    'user_hash.failure', { error: e })
+      raise Common::Exceptions::UnprocessableEntity.new(detail: 'Could not generate user hash')
+    end
+
+    private
+
+    def get_file_number
+      # include ssn in call to BGS for mocks
+      bgs_person = service.people.find_person_by_ptcpnt_id(participant_id, ssn) || service.people.find_by_ssn(ssn) # rubocop:disable Rails/DynamicFindBy
+      va_file_number = bgs_person[:file_nbr]
+      # BGS's file number is supposed to be an eight or nine-digit string, and
+      # our code is built upon the assumption that this is the case. However,
+      # we've seen cases where BGS returns a file number with dashes
+      # (e.g. XXX-XX-XXXX). In this case specifically, we can simply strip out
+      # the dashes and proceed with form submission.
+      va_file_number = va_file_number.delete('-') if va_file_number =~ /\A\d{3}-\d{2}-\d{4}\z/
+
+      va_file_number
+    rescue
+      monitor.track_user_data_warning('DependentsBenefits::UserData#get_file_number error',
+                                      'file_number_lookup.failure',
+                                      { error: 'Could not retrieve file number from BGS' })
+      nil
+    end
+
+    def service
+      @service ||= BGS::Services.new(external_uid: icn, external_key:)
+    end
+
+    def external_key
+      @external_key ||= begin
+        key = common_name.presence || email
+        key.first(BGS::Constants::EXTERNAL_KEY_MAX_LENGTH)
+      end
+    end
+
+    def monitor
+      @monitor ||= DependentsBenefits::Monitor.new
+    end
+  end
+end

--- a/modules/dependents_benefits/spec/controllers/dependents_benefits/v0/claims_controller_spec.rb
+++ b/modules/dependents_benefits/spec/controllers/dependents_benefits/v0/claims_controller_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe DependentsBenefits::V0::ClaimsController do
 
   let(:user) { create(:evss_user) }
   let(:test_form) { build(:dependents_claim).parsed_form }
+  let(:bgs_service) { double('BGS::Services') }
+  let(:bgs_people) { double('BGS::People') }
 
   before do
     sign_in_as(user)
@@ -49,6 +51,9 @@ RSpec.describe DependentsBenefits::V0::ClaimsController do
     context 'with valid params and flipper enabled' do
       before do
         allow_any_instance_of(BGSV2::Service).to receive(:create_proc).and_return({ vnp_proc_id: '21875' })
+        allow(BGS::Services).to receive(:new).and_return(bgs_service)
+        allow(bgs_service).to receive(:people).and_return(bgs_people)
+        allow(bgs_people).to receive(:find_person_by_ptcpnt_id).and_return({ file_nbr: '987654321' })
       end
 
       it 'validates successfully' do
@@ -67,7 +72,28 @@ RSpec.describe DependentsBenefits::V0::ClaimsController do
           ).by(1)
           .and change(
             DependentsBenefits::SchoolAttendanceApproval, :count
-          ).by(1)
+          ).by(1).and change(
+            SavedClaimGroup, :count
+          ).by(3)
+      end
+
+      it 'creates SavedClaimGroup with current user data' do
+        post(:create, params: test_form, as: :json)
+
+        parent_group = SavedClaimGroup.last.parent_claim_group_for_child
+        expected_user = { 'veteran_information' => { 'full_name' => { 'first' => user.first_name,
+                                                                      'last' => user.last_name },
+                                                     'common_name' => user.common_name,
+                                                     'va_profile_email' => user.va_profile_email,
+                                                     'email' => user.email,
+                                                     'participant_id' => user.participant_id,
+                                                     'ssn' => user.ssn,
+                                                     'va_file_number' => '987654321',
+                                                     'birth_date' => user.birth_date,
+                                                     'uuid' => user.uuid,
+                                                     'icn' => user.icn } }
+        user_hash = JSON.parse(parent_group.user_data)
+        expect(user_hash).to eq(expected_user)
       end
 
       it 'calls ClaimProcessor with correct parameters' do

--- a/modules/dependents_benefits/spec/lib/dependents_benefits/user_data_spec.rb
+++ b/modules/dependents_benefits/spec/lib/dependents_benefits/user_data_spec.rb
@@ -1,0 +1,387 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'dependents_benefits/user_data'
+
+RSpec.describe DependentsBenefits::UserData do
+  let(:user) do
+    double(
+      'User',
+      first_name: 'John',
+      middle_name: 'Michael',
+      last_name: 'Doe',
+      ssn: '123456789',
+      uuid: 'user-uuid-123',
+      birth_date: '1980-01-01',
+      common_name: 'John Doe',
+      email: 'john.doe@example.com',
+      icn: 'icn-123',
+      participant_id: 'participant-123',
+      va_profile_email: 'john.doe@va.gov'
+    )
+  end
+
+  let(:claim_data) do
+    {
+      'veteran_information' => {
+        'full_name' => {
+          'first' => 'Jane',
+          'middle' => 'Marie',
+          'last' => 'Smith'
+        },
+        'birth_date' => '1985-05-15'
+      },
+      'veteran_contact_information' => {
+        'email_address' => 'jane.smith@example.com'
+      },
+      'file_number' => 'claim-file-123'
+    }
+  end
+
+  let(:bgs_service) { double('BGS::Services') }
+  let(:bgs_people) { double('BGS::People') }
+  let(:monitor) { double('DependentsBenefits::Monitor') }
+
+  before do
+    allow(BGS::Services).to receive(:new).and_return(bgs_service)
+    allow(bgs_service).to receive(:people).and_return(bgs_people)
+    allow(bgs_people).to receive_messages(find_person_by_ptcpnt_id: nil, find_by_ssn: nil)
+    allow(DependentsBenefits::Monitor).to receive(:new).and_return(monitor)
+    allow(monitor).to receive(:track_user_data_error)
+    allow(monitor).to receive(:track_user_data_warning)
+  end
+
+  describe '#initialize' do
+    context 'with valid user and claim data' do
+      it 'initializes with user data taking precedence' do
+        user_data = described_class.new(user, claim_data)
+
+        expect(user_data.first_name).to eq('John')
+        expect(user_data.middle_name).to eq('Michael')
+        expect(user_data.last_name).to eq('Doe')
+        expect(user_data.ssn).to eq('123456789')
+        expect(user_data.uuid).to eq('user-uuid-123')
+        expect(user_data.birth_date).to eq('1980-01-01')
+        expect(user_data.common_name).to eq('John Doe')
+        expect(user_data.email).to eq('john.doe@example.com')
+        expect(user_data.icn).to eq('icn-123')
+        expect(user_data.participant_id).to eq('participant-123')
+        expect(user_data.va_profile_email).to eq('john.doe@va.gov')
+      end
+    end
+
+    context 'with missing user data' do
+      let(:incomplete_user) do
+        double(
+          'User',
+          first_name: nil,
+          middle_name: nil,
+          last_name: nil,
+          ssn: '123456789',
+          uuid: 'user-uuid-123',
+          birth_date: nil,
+          common_name: 'John Doe',
+          email: nil,
+          icn: 'icn-123',
+          participant_id: 'participant-123',
+          va_profile_email: 'john.doe@va.gov'
+        )
+      end
+
+      it 'falls back to claim data' do
+        user_data = described_class.new(incomplete_user, claim_data)
+
+        expect(user_data.first_name).to eq('Jane')
+        expect(user_data.middle_name).to eq('Marie')
+        expect(user_data.last_name).to eq('Smith')
+        expect(user_data.birth_date).to eq('1985-05-15')
+        expect(user_data.email).to eq('jane.smith@example.com')
+      end
+    end
+
+    context 'when file number lookup succeeds' do
+      before do
+        allow(bgs_people).to receive(:find_person_by_ptcpnt_id).with('participant-123', '123456789')
+                                                               .and_return({ file_nbr: '987-65-4321' })
+      end
+
+      it 'sets va_file_number from BGS' do
+        user_data = described_class.new(user, claim_data)
+        expect(user_data.va_file_number).to eq('987654321')
+      end
+    end
+
+    context 'when file number lookup fails' do
+      before do
+        allow(bgs_people).to receive_messages(find_person_by_ptcpnt_id: nil, find_by_ssn: nil)
+      end
+
+      it 'falls back to ssn' do
+        user_data = described_class.new(user, claim_data)
+        expect(user_data.va_file_number).to eq('123456789')
+      end
+    end
+
+    context 'when initialization fails' do
+      before do
+        allow(user).to receive(:first_name).and_raise(StandardError, 'Database error')
+      end
+
+      it 'tracks error and raises UnprocessableEntity' do
+        expect(monitor).to receive(:track_user_data_error).with(
+          'DependentsBenefits::UserData#initialize error',
+          'user_hash.failure',
+          { error: instance_of(StandardError) }
+        )
+
+        expect do
+          described_class.new(user, claim_data)
+        end.to raise_error(Common::Exceptions::UnprocessableEntity)
+      end
+    end
+  end
+
+  describe '#get_user_json' do
+    before do
+      allow(bgs_people).to receive(:find_person_by_ptcpnt_id).and_return({ file_nbr: '987654321' })
+    end
+
+    it 'returns valid JSON with veteran information' do
+      user_data = described_class.new(user, claim_data)
+      json_string = user_data.get_user_json
+      parsed_json = JSON.parse(json_string)
+
+      veteran_info = parsed_json['veteran_information']
+      expect(veteran_info['full_name']['first']).to eq('John')
+      expect(veteran_info['full_name']['middle']).to eq('Michael')
+      expect(veteran_info['full_name']['last']).to eq('Doe')
+      expect(veteran_info['common_name']).to eq('John Doe')
+      expect(veteran_info['va_profile_email']).to eq('john.doe@va.gov')
+      expect(veteran_info['email']).to eq('john.doe@example.com')
+      expect(veteran_info['participant_id']).to eq('participant-123')
+      expect(veteran_info['ssn']).to eq('123456789')
+      expect(veteran_info['va_file_number']).to eq('987654321')
+      expect(veteran_info['birth_date']).to eq('1980-01-01')
+      expect(veteran_info['uuid']).to eq('user-uuid-123')
+      expect(veteran_info['icn']).to eq('icn-123')
+    end
+
+    it 'compacts nil values from full_name' do
+      user_without_middle = double(
+        'User',
+        first_name: 'John',
+        middle_name: nil,
+        last_name: 'Doe',
+        ssn: '123456789',
+        uuid: 'user-uuid-123',
+        birth_date: '1980-01-01',
+        common_name: 'John Doe',
+        email: 'john.doe@example.com',
+        icn: 'icn-123',
+        participant_id: 'participant-123',
+        va_profile_email: 'john.doe@va.gov'
+      )
+
+      claim_data_with_no_middle = claim_data.dup
+      claim_data_with_no_middle['veteran_information']['full_name'].delete('middle')
+      user_data = described_class.new(user_without_middle, claim_data_with_no_middle)
+      json_string = user_data.get_user_json
+      parsed_json = JSON.parse(json_string)
+
+      full_name = parsed_json['veteran_information']['full_name']
+      expect(full_name).to eq({ 'first' => 'John', 'last' => 'Doe' })
+      expect(full_name).not_to have_key('middle')
+    end
+
+    context 'when JSON generation fails' do
+      let(:user_data) { described_class.new(user, claim_data) }
+
+      before do
+        allow(user_data).to receive(:first_name).and_raise(StandardError, 'Encoding error')
+      end
+
+      it 'tracks error and raises UnprocessableEntity' do
+        expect(monitor).to receive(:track_user_data_error).with(
+          'DependentsBenefits::UserData#get_user_hash error',
+          'user_hash.failure',
+          { error: instance_of(StandardError) }
+        )
+
+        expect do
+          user_data.get_user_json
+        end.to raise_error(Common::Exceptions::UnprocessableEntity)
+      end
+    end
+  end
+
+  describe '#get_file_number' do
+    let(:user_data) { described_class.new(user, claim_data) }
+
+    context 'when BGS returns file number with dashes' do
+      before do
+        allow(bgs_people).to receive(:find_person_by_ptcpnt_id).with('participant-123', '123456789')
+                                                               .and_return({ file_nbr: '123-45-6789' })
+      end
+
+      it 'strips dashes from file number' do
+        file_number = user_data.send(:get_file_number)
+        expect(file_number).to eq('123456789')
+      end
+    end
+
+    context 'when BGS returns normal file number' do
+      before do
+        allow(bgs_people).to receive(:find_person_by_ptcpnt_id).with('participant-123', '123456789')
+                                                               .and_return({ file_nbr: '987654321' })
+      end
+
+      it 'returns file number as-is' do
+        file_number = user_data.send(:get_file_number)
+        expect(file_number).to eq('987654321')
+      end
+    end
+
+    context 'when participant ID lookup fails but SSN lookup succeeds' do
+      before do
+        allow(bgs_people).to receive(:find_person_by_ptcpnt_id).and_return(nil)
+        allow(bgs_people).to receive(:find_by_ssn).with('123456789')
+                                                  .and_return({ file_nbr: '555666777' })
+      end
+
+      it 'falls back to SSN lookup' do
+        file_number = user_data.send(:get_file_number)
+        expect(file_number).to eq('555666777')
+      end
+    end
+
+    context 'when both BGS lookups fail' do
+      before do
+        allow(bgs_people).to receive_messages(find_person_by_ptcpnt_id: nil, find_by_ssn: nil)
+      end
+
+      it 'tracks warning and returns nil' do
+        expect(monitor).to receive(:track_user_data_warning).with(
+          'DependentsBenefits::UserData#get_file_number error',
+          'file_number_lookup.failure',
+          { error: 'Could not retrieve file number from BGS' }
+        )
+
+        file_number = user_data.send(:get_file_number)
+        expect(file_number).to be_nil
+      end
+    end
+
+    context 'when BGS service raises an exception' do
+      before do
+        allow(bgs_people).to receive(:find_person_by_ptcpnt_id).and_raise(StandardError, 'BGS timeout')
+      end
+
+      it 'tracks warning and returns nil' do
+        expect(monitor).to receive(:track_user_data_warning).with(
+          'DependentsBenefits::UserData#get_file_number error',
+          'file_number_lookup.failure',
+          { error: 'Could not retrieve file number from BGS' }
+        )
+
+        file_number = user_data.send(:get_file_number)
+        expect(file_number).to be_nil
+      end
+    end
+  end
+
+  describe '#service' do
+    let(:user_data) { described_class.new(user, claim_data) }
+
+    it 'creates BGS service with ICN and external key' do
+      expect(BGS::Services).to receive(:new).with(
+        external_uid: 'icn-123',
+        external_key: 'John Doe'
+      ).and_return(bgs_service)
+
+      expect(user_data.send(:service)).to eq(bgs_service)
+    end
+
+    it 'memoizes the service instance' do
+      service1 = user_data.send(:service)
+      service2 = user_data.send(:service)
+      expect(service1).to eq(service2)
+    end
+  end
+
+  describe '#external_key' do
+    let(:user_data) { described_class.new(user, claim_data) }
+
+    context 'when common_name is present' do
+      it 'uses common_name' do
+        expect(user_data.send(:external_key)).to eq('John Doe')
+      end
+    end
+
+    context 'when common_name is blank but email is present' do
+      let(:user_without_common_name) do
+        double(
+          'User',
+          first_name: 'John',
+          middle_name: 'Michael',
+          last_name: 'Doe',
+          ssn: '123456789',
+          uuid: 'user-uuid-123',
+          birth_date: '1980-01-01',
+          common_name: '',
+          email: 'john.doe@example.com',
+          icn: 'icn-123',
+          participant_id: 'participant-123',
+          va_profile_email: 'john.doe@va.gov'
+        )
+      end
+
+      it 'falls back to email' do
+        user_data = described_class.new(user_without_common_name, claim_data)
+        expect(user_data.send(:external_key)).to eq('john.doe@example.com')
+      end
+    end
+
+    context 'when external key exceeds max length' do
+      let(:long_name_user) do
+        double(
+          'User',
+          first_name: 'John',
+          middle_name: 'Michael',
+          last_name: 'Doe',
+          ssn: '123456789',
+          uuid: 'user-uuid-123',
+          birth_date: '1980-01-01',
+          common_name: 'A' * 100,
+          email: 'john.doe@example.com',
+          icn: 'icn-123',
+          participant_id: 'participant-123',
+          va_profile_email: 'john.doe@va.gov'
+        )
+      end
+
+      before do
+        stub_const('BGS::Constants::EXTERNAL_KEY_MAX_LENGTH', 10)
+      end
+
+      it 'truncates to max length' do
+        user_data = described_class.new(long_name_user, claim_data)
+        expect(user_data.send(:external_key)).to eq('A' * 10)
+      end
+    end
+  end
+
+  describe '#monitor' do
+    let(:user_data) { described_class.new(user, claim_data) }
+
+    it 'creates DependentsBenefits::Monitor instance' do
+      expect(DependentsBenefits::Monitor).to receive(:new).and_return(monitor)
+      expect(user_data.send(:monitor)).to eq(monitor)
+    end
+
+    it 'memoizes the monitor instance' do
+      monitor1 = user_data.send(:monitor)
+      monitor2 = user_data.send(:monitor)
+      expect(monitor1).to eq(monitor2)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Add the encrypted user hash (as currently passed to Dependents jobs) to the parent saved claim group.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118685

## Testing done

- [ ] *New code is covered by unit tests*
- [ ] With the dependents module on, submit a claim. A parent SavedClaimGroup should be created, and it should have the relevant encrypted user_data field.

## What areas of the site does it impact?
Dependents Benefits module

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
