### PR TITLE
Add submission handler for dependents benefits

### DIFF
--- a/modules/dependents_benefits/lib/dependents_benefits.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits.rb
@@ -8,6 +8,7 @@ require 'dependents_benefits/engine'
 module DependentsBenefits
   # The form_id
   FORM_ID = '686C-674'
+  # FORM_ID_V2 = '686C-674-V2'
   ADD_REMOVE_DEPENDENT = '21-686C'
   SCHOOL_ATTENDANCE_APPROVAL = '21-674'
   PARENT_DEPENDENCY = '21-509'

--- a/modules/dependents_benefits/lib/dependents_benefits.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits.rb
@@ -8,7 +8,7 @@ require 'dependents_benefits/engine'
 module DependentsBenefits
   # The form_id
   FORM_ID = '686C-674'
-  # FORM_ID_V2 = '686C-674-V2'
+  FORM_ID_V2 = '686C-674-V2'
   ADD_REMOVE_DEPENDENT = '21-686C'
   SCHOOL_ATTENDANCE_APPROVAL = '21-674'
   PARENT_DEPENDENCY = '21-509'

--- a/modules/dependents_benefits/lib/dependents_benefits/benefits_intake/submission_handler.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits/benefits_intake/submission_handler.rb
@@ -13,7 +13,7 @@ module DependentsBenefits
       # @return [ActiveRecord::Relation] a relation containing pending submission attempts for form '686C-674-V2'
       def self.pending_attempts
         Lighthouse::SubmissionAttempt.joins(:submission).where(status: 'pending',
-                                                               'lighthouse_submissions.form_id' => "#{DependentsBenefits::FORM_ID}-V2")
+                                                               'lighthouse_submissions.form_id' => DependentsBenefits::FORM_ID_V2)
       end
 
       private

--- a/modules/dependents_benefits/lib/dependents_benefits/benefits_intake/submission_handler.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits/benefits_intake/submission_handler.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'lighthouse/benefits_intake/submission_handler/saved_claim'
+require 'dependents_benefits/monitor'
+
+module DependentsBenefits
+  module BenefitsIntake
+    # @see BenefitsIntake::SubmissionHandler::SavedClaim
+    class SubmissionHandler < ::BenefitsIntake::SubmissionHandler::SavedClaim
+      # Retrieves all pending Lighthouse::SubmissionAttempt records associated with submissions
+      # where the form_id is '686C-674-V2'.
+      #
+      # @return [ActiveRecord::Relation] a relation containing pending submission attempts for form '686C-674-V2'
+      def self.pending_attempts
+        Lighthouse::SubmissionAttempt.joins(:submission).where(status: 'pending',
+                                                               'lighthouse_submissions.form_id' => "#{DependentsBenefits::FORM_ID}-V2")
+      end
+
+      private
+
+      # BenefitsIntake::SubmissionHandler::SavedClaim#claim_class
+      def claim_class
+        DependentsBenefits::SavedClaim
+      end
+
+      # BenefitsIntake::SubmissionHandler::SavedClaim#monitor
+      def monitor
+        @monitor ||= DependentsBenefits::Monitor.new
+      end
+
+      # BenefitsIntake::SubmissionHandler::SavedClaim#notification_email
+      def notification_email
+        # TODO: in #120766
+      end
+
+      # handle a failure result
+      # inheriting class must assign @avoided before calling `super`
+      def on_failure
+        # TODO: in #120766
+      end
+
+      # handle a success result
+      def on_success
+        # TODO: in #120766
+      end
+
+      # handle a stale result
+      def on_stale
+        true
+      end
+    end
+  end
+end

--- a/modules/dependents_benefits/lib/dependents_benefits/engine.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits/engine.rb
@@ -19,5 +19,16 @@ module DependentsBenefits
         end
       end
     end
+
+    initializer 'dependents_benefits.benefits_intake.register_handler' do |app|
+      app.config.to_prepare do
+        require 'lighthouse/benefits_intake/sidekiq/submission_status_job'
+        require 'dependents_benefits/benefits_intake/submission_handler'
+
+        # Register our Pension Benefits Intake Submission Handler
+        ::BenefitsIntake::SubmissionStatusJob.register_handler("#{DependentsBenefits::FORM_ID}-V2",
+                                                               DependentsBenefits::BenefitsIntake::SubmissionHandler)
+      end
+    end
   end
 end

--- a/modules/dependents_benefits/lib/dependents_benefits/engine.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits/engine.rb
@@ -26,7 +26,7 @@ module DependentsBenefits
         require 'dependents_benefits/benefits_intake/submission_handler'
 
         # Register our Pension Benefits Intake Submission Handler
-        ::BenefitsIntake::SubmissionStatusJob.register_handler("#{DependentsBenefits::FORM_ID}-V2",
+        ::BenefitsIntake::SubmissionStatusJob.register_handler(DependentsBenefits::FORM_ID_V2,
                                                                DependentsBenefits::BenefitsIntake::SubmissionHandler)
       end
     end

--- a/modules/dependents_benefits/spec/lib/dependents_benefits/benefits_intake/submission_handler_spec.rb
+++ b/modules/dependents_benefits/spec/lib/dependents_benefits/benefits_intake/submission_handler_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'dependents_benefits/benefits_intake/submission_handler'
+require 'dependents_benefits/monitor'
+
+Rspec.describe DependentsBenefits::BenefitsIntake::SubmissionHandler do
+  let(:handler) { DependentsBenefits::BenefitsIntake::SubmissionHandler }
+  let(:claim) { build(:dependents_claim) }
+  let(:monitor) { double(DependentsBenefits::Monitor) }
+  let(:instance) { handler.new('fake-claim-id') }
+
+  before do
+    allow(DependentsBenefits::SavedClaim).to receive(:find).and_return claim
+    allow(DependentsBenefits::Monitor).to receive(:new).and_return monitor
+  end
+
+  describe '.pending_attempts' do
+    let(:submission_attempt) { double('Lighthouse::SubmissionAttempt') }
+    let(:submission) { double('Lighthouse::Submission', form_id: '686C-674-V2') }
+
+    before do
+      allow(Lighthouse::SubmissionAttempt).to receive(:joins).with(:submission)
+                                                             .and_return(Lighthouse::SubmissionAttempt)
+      allow(Lighthouse::SubmissionAttempt).to receive(:where).with(status: 'pending',
+                                                                   'lighthouse_submissions.form_id' => '686C-674-V2')
+                                                             .and_return([submission_attempt])
+    end
+
+    it 'returns pending submission attempts with the correct form_id' do
+      result = handler.pending_attempts
+      expect(result).to eq([submission_attempt])
+    end
+
+    it 'queries with the correct status and form_id' do
+      expect(Lighthouse::SubmissionAttempt).to receive(:joins).with(:submission)
+      expect(Lighthouse::SubmissionAttempt).to receive(:where).with(status: 'pending',
+                                                                    'lighthouse_submissions.form_id' => '686C-674-V2')
+      handler.pending_attempts
+    end
+  end
+
+  describe '#on_stale' do
+    it 'does nothing' do
+      # pass thru for coverage
+      expect(instance.handle(:stale)).to be true
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- *(Summarize the changes that have been made to the platform)*
  - This work adds `SubmssionHandler` for the backup path for `DependentsBenefits` module. We decided that it's best to keep lighthouse submissions as the combined `686c-674` form since we don't really know if they can process separated submissions correctly
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)*
   - Lifetstage Benefits - Dependents Benefits 
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- *https://github.com/department-of-veterans-affairs/va.gov-team/issues/106768*

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
