### PR TITLE
Removed Terms of Use Feature Flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2261,10 +2261,6 @@ features:
   sc_browser_monitoring_enabled:
     actor_type: user
     description: Supplemental Claim Datadog RUM monitoring
-  terms_of_use:
-    actor_type: user
-    description: This determines whether a user is redirected to the Terms of Use page
-    enable_in_development: true
   burial_browser_monitoring_enabled:
     actor_type: user
     description: Burial Datadog RUM monitoring


### PR DESCRIPTION
## Summary
Removes the outdated Terms of Use feature flag.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/668)

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
This only impacts feature toggles. There is a [related PR](https://github.com/department-of-veterans-affairs/vets-website/pull/39179) to remove this feature toggle from the frontend.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
