### PR TITLE
adds SiS cerner cookie check

### DIFF
--- a/spec/controllers/v0/sign_in_controller_authorize_basic_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_authorize_basic_spec.rb
@@ -48,5 +48,61 @@ RSpec.describe V0::SignInController, type: :controller do
         it_behaves_like 'authorize_error_response'
       end
     end
+
+    context 'cerner eligibility check' do
+      let(:client_id_value) { client_config.client_id }
+      let(:type_value) { 'idme' }
+      let(:acr_value) { 'loa3' }
+      let(:expected_log_message) { '[SignInService] [V0::SignInController] check_cerner_eligibility' }
+      let(:expected_log_payload) { { eligible:, cookie_action: } }
+
+      before do
+        cookies[SignIn::Constants::Auth::ACCESS_TOKEN_COOKIE_NAME] = 'some-token'
+        allow(Rails.logger).to receive(:info)
+      end
+
+      context 'when cerner eligible cookie is present' do
+        let(:cookie_action) { :found }
+
+        before do
+          cookies.signed[V0::SignInController::CERNER_ELIGIBLE_COOKIE_NAME] = eligible.to_s
+        end
+
+        context 'when cerner eligible cookie is true' do
+          let(:eligible) { true }
+
+          it 'logs the cerner eligibility' do
+            subject
+
+            expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
+          end
+        end
+
+        context 'when cerner eligible cookie is false' do
+          let(:eligible) { false }
+
+          it 'logs the cerner eligibility' do
+            subject
+
+            expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
+          end
+        end
+      end
+
+      context 'when cerner eligible cookie is not present' do
+        let(:cookie_action) { :not_found }
+        let(:eligible) { :unknown }
+
+        before do
+          cookies.delete(V0::SignInController::CERNER_ELIGIBLE_COOKIE_NAME)
+        end
+
+        it 'logs the cerner eligibility' do
+          subject
+
+          expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Adds check for `CERNER_ELIGIBLE` cookie to SiS new `/authorize` attempts

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/760
- https://github.com/department-of-veterans-affairs/vets-api/pull/22138

## Testing done

- [x] *New code is covered by unit tests*
- Clear your browser's `CERNER_ELIGIBLE` if it is set & perform a new SiS authentication, you should see
    `[SignInService] [V0::SignInController] check_cerner_eligibility -- { :eligible => :unknown, :cookie_action => :not_found }`
- Obtain a `CERNER_ELIGIBLE` cookie by performing an SSOe login, then attempt a SiS login again, you should see
    `[SignInService] [V0::SignInController] check_cerner_eligibility -- { :eligible => false, :cookie_action => :found }`
