### PR TITLE
Pass isOhMessage from upstream to VAHB App

### DIFF
--- a/modules/mobile/app/serializers/mobile/v0/messages_serializer.rb
+++ b/modules/mobile/app/serializers/mobile/v0/messages_serializer.rb
@@ -10,7 +10,7 @@ module Mobile
 
       attributes :category, :subject, :body, :attachment, :sent_date,
                  :sender_id, :sender_name, :recipient_id, :recipient_name, :read_receipt,
-                 :triage_group_name, :proxy_sender_name
+                 :triage_group_name, :proxy_sender_name, :is_oh_message
 
       attribute :message_id, &:id
 

--- a/modules/mobile/docs/schemas/GetSecureMessageDetail.yml
+++ b/modules/mobile/docs/schemas/GetSecureMessageDetail.yml
@@ -32,6 +32,7 @@ properties:
       - readReceipt
       - triageGroupName
       - proxySenderName
+      - isOhMessage
     properties:
       messageId:
         type: integer
@@ -77,6 +78,9 @@ properties:
         type: string
         nullable: true
         example: "SMITH, JOHN"
+      isOhMessage:
+        type: boolean
+        example: true
   relationships:
     type: object
     additionalProperties: false

--- a/spec/support/schemas_camelized/message.json
+++ b/spec/support/schemas_camelized/message.json
@@ -37,7 +37,8 @@
             "senderName",
             "recipientId",
             "recipientName",
-            "readReceipt"
+            "readReceipt",
+            "isOhMessage"
           ],
           "properties": {
             "messageId": {
@@ -90,6 +91,9 @@
                 "null",
                 "string"
               ]
+            },
+            "isOhMessage": {
+              "type": "boolean"
             }
           }
         },

--- a/spec/support/schemas_camelized/message_with_attachment.json
+++ b/spec/support/schemas_camelized/message_with_attachment.json
@@ -38,7 +38,8 @@
             "senderName",
             "recipientId",
             "recipientName",
-            "readReceipt"
+            "readReceipt",
+            "isOhMessage"
           ],
           "properties": {
             "messageId": {
@@ -91,6 +92,9 @@
                 "null",
                 "string"
               ]
+            },
+            "isOhMessage": {
+              "type": "boolean"
             }
           }
         },

--- a/spec/support/schemas_camelized/messages_thread.json
+++ b/spec/support/schemas_camelized/messages_thread.json
@@ -40,7 +40,8 @@
                   "senderName",
                   "recipientId",
                   "recipientName",
-                  "readReceipt"
+                  "readReceipt",
+                  "isOhMessage"
                 ],
                 "properties": {
                   "messageId": {
@@ -93,6 +94,9 @@
                       "null",
                       "string"
                     ]
+                  },
+                  "isOhMessage": {
+                    "type": "boolean"
                   }
                 }
               },

--- a/spec/support/vcr_cassettes/mobile/messages/gets_a_message_with_id_and_attachment.yml
+++ b/spec/support/vcr_cassettes/mobile/messages/gets_a_message_with_id_and_attachment.yml
@@ -35,7 +35,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"id":573059,"category":"OTHER","subject":"Quote test: &ldquo;test&rdquo;","body":"Einstein once said: &ldquo;Profound quote contents here&rdquo;. \n\nThat was supposed to show a regular quote but it didn&rsquo;t display like it did in the compose form.\n\nLet&rsquo;s try out more symbols here:\n\nSingle quote: &lsquo; contents&rsquo;\nQuestion mark: ?\nColon: :\nDash: -\nLess than: &lt;\nGreat then: &gt;\nEquals: =\nAsterisk: *\nAnd symbol: &amp;\nDollar symbol: $\nDivide symbol: %\nAt symbol: @\nParentheses: ( contents )\nBrackets: [ contents ]\nCurly braces: { contents }\nSemicolon: ;\nSlash: /\nPlus: +\nUp symbol: ^\nPound key: #\nExclamation: !","attachment":true,"attachments":{"attachment":[{"id":674847,"name":"sm_file1.jpg","attachmentSize":210000},{"id":674848,"name":"sm_file2.jpg","attachmentSize":210000},{"id":674849,"name":"sm_file3.jpg","attachmentSize":210000},{"id":674850,"name":"sm_file4.jpg","attachmentSize":210000}]},"sentDate":"Mon,
         11 Apr 2016 15:49:39 GMT","senderId":384939,"senderName":"MVIONE, TEST","recipientId":345468,"recipientName":"WORKLOAD
-        CAPTURE_Mohammad","readReceipt":"READ"}'
+        CAPTURE_Mohammad","readReceipt":"READ", "isOhMessage":"false"}'
     http_version: 
   recorded_at: Tue, 31 Jan 2017 21:30:45 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary
We need to pass this value to the app so it can send it back when sending/replying to a message in order to handle OH messages correctly. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/120354

## Testing done
Updated schemas to enforce new field 

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
