### PR TITLE
fix: prevent ready_for_review workflow from running on protected branches

### DIFF
--- a/.github/workflows/ready_for_review.yml
+++ b/.github/workflows/ready_for_review.yml
@@ -5,6 +5,9 @@ on:
   workflow_run:
     workflows: ["Code Checks", "Check CODEOWNERS Entries", "Service Tags", "CodeQL"]
     types: [completed]
+    branches-ignore:
+      - master
+      - production-bypass
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Add `branches-ignore` filter to workflow_run trigger to prevent the workflow from running when Code Checks, Check CODEOWNERS Entries, Service Tags, or CodeQL workflows complete on master or production-bypass branches
- This prevents unnecessary workflow runs and failures when PRs are merged to these protected branches

## Test plan
- [ ] Merge a PR to master and verify the ready_for_review workflow doesn't run
- [ ] Open a PR and verify the workflow still runs normally