### PR TITLE
Update OH telehealth modality logic

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -1027,8 +1027,12 @@ module VAOS
         elsif %w[ADHOC MOBILE_ANY MOBILE_ANY_GROUP MOBILE_GFE].include?(vvs_kind)
           'vaVideoCareAtHome'
         elsif vvs_kind.nil?
-          vvs_video_appt = appointment.dig(:extension, :vvs_vista_video_appt)
-          vvs_video_appt.to_s.downcase == 'true' ? 'vaVideoCareAtHome' : 'vaInPerson'
+          if VAOS::AppointmentsHelper.cerner?(appointment)
+            appointment.dig(:telehealth, :url).nil? ? 'vaInPerson' : 'vaVideoCareAtHome'
+          else
+            vvs_video_appt = appointment.dig(:extension, :vvs_vista_video_appt)
+            vvs_video_appt.to_s.downcase == 'true' ? 'vaVideoCareAtHome' : 'vaInPerson'
+          end
         end
       end
 

--- a/modules/vaos/spec/factories/v2/appointment_forms.rb
+++ b/modules/vaos/spec/factories/v2/appointment_forms.rb
@@ -389,5 +389,19 @@ FactoryBot.define do
         }
       end
     end
+
+    trait :cerner_telehealth do
+      va_proposed_base
+      kind { 'telehealth' }
+    end
+
+    trait :cerner_telehealth_url do
+      cerner_telehealth
+      telehealth do
+        {
+          url: 'https://vvc.va.gov/clinical/guest/appointment/52499028'
+        }
+      end
+    end
   end
 end

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -2421,17 +2421,49 @@ describe VAOS::V2::AppointmentsService do
       end
     end
 
-    it 'is vaInPerson for nil vvsKind and false vvsVistaVideoAppt' do
+    it 'is vaInPerson for nil vvsKind, non-cerner and false vvsVistaVideoAppt' do
       appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth, :vistaVideoFalse).attributes
       appt[:telehealth][:vvs_kind] = nil
       subject.send(:set_modality, appt)
       expect(appt[:modality]).to eq('vaInPerson')
     end
 
-    it 'is vaVideoCareAtHome for nil vvsKind and true vvsVistaVideoAppt' do
+    it 'is vaVideoCareAtHome for nil vvsKind, non-cerner and true vvsVistaVideoAppt' do
       appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :telehealth, :vistaVideoTrue).attributes
       appt[:telehealth][:vvs_kind] = nil
       subject.send(:set_modality, appt)
+      expect(appt[:modality]).to eq('vaVideoCareAtHome')
+    end
+
+    it 'is vaInPerson for nil vvsKind, cerner and url not available' do
+      appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :cerner_telehealth).attributes
+      appt[:identifier] = [
+        {
+          system: 'urn:va.gov:masv2:cerner:appointment',
+          value: 'Appointment/52499028'
+        }
+      ]
+      subject.send(:set_modality, appt)
+      expect(appt[:kind]).to eq('telehealth')
+      expect(appt.dig(:telehealth, :vvs_kind)).to be_nil
+      expect(VAOS::AppointmentsHelper.cerner?(appt)).to be(true)
+      expect(appt.dig(:telehealth, :url)).to be_nil
+      expect(appt[:modality]).to eq('vaInPerson')
+    end
+
+    it 'is vaVideoCareAtHome for nil vvsKind, cerner and url available' do
+      appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text, :cerner_telehealth_url).attributes
+      appt[:identifier] = [
+        {
+          system: 'urn:va.gov:masv2:cerner:appointment',
+          value: 'Appointment/52499028'
+        }
+      ]
+      subject.send(:set_modality, appt)
+      expect(appt[:kind]).to eq('telehealth')
+      expect(appt.dig(:telehealth, :vvs_kind)).to be_nil
+      expect(VAOS::AppointmentsHelper.cerner?(appt)).to be(true)
+      expect(appt.dig(:telehealth, :url)).not_to be_nil
       expect(appt[:modality]).to eq('vaVideoCareAtHome')
     end
 


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- We need to update how Cerner (OH) telehealth appointment modalities are set. In these cases, when vvs_kind is not available, we should set the modality to 'vaVideoCareAtHome' if the telehealth url is available and 'vaInPerson' when it is not.
- Unified Appointments Experience

## Related issue(s)

- *https://github.com/department-of-veterans-affairs/va.gov-team/issues/121324

## Testing done

- [x] *New code is covered by unit tests*
- Existing behavior should be maintained for VistA appointments and new tests are added to validate the updated behavior for Cerner appointments

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
