### PR TITLE
fix: update uri gem to 1.0.4 to address CVE-2025-61594

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1153,7 +1153,7 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
-    uri (1.0.3)
+    uri (1.0.4)
     useragent (0.16.11)
     utf8-cleaner (1.0.0)
       activesupport


### PR DESCRIPTION
Updates the `uri` gem from 1.0.3 to 1.0.4 to address CVE-2025-61594, a credential leakage bypass vulnerability.

## Issue
- **CVE**: CVE-2025-61594
- **Title**: URI Credential Leakage Bypass over CVE-2025-27221
- **URL**: https://www.ruby-lang.org/en/news/2025/10/07/uri-cve-2025-61594

## Changes
- Updated `uri` gem to version 1.0.4 in Gemfile.lock