### PR TITLE
Revert "#121184 [Benefits Management Team 2] Update JSON schema for appeal issues to allow for `null` descriptions"

### DIFF
--- a/lib/caseflow/schema/appeals_issue.json
+++ b/lib/caseflow/schema/appeals_issue.json
@@ -5,7 +5,7 @@
       "type": "boolean"
     },
     "description": {
-      "type": ["string", "null"]
+      "type": "string"
     },
     "diagnosticCode": {
       "type": ["string", "null"]

--- a/spec/lib/caseflow/service_spec.rb
+++ b/spec/lib/caseflow/service_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Caseflow::Service do
       end
 
       it 'increments a statsd metric, logs the offending appeals, ' \
-         'creates a PersonalInformationLog, and does NOT raise a JSON schema error',
+         'creates a PersonalInformationLog, and raises a JSON schema error',
          run_at: 'Wed, 20 Aug 2025 21:59:18 GMT' do
         VCR.use_cassette(
           'caseflow/appeal_with_null_issue_description',
@@ -50,8 +50,7 @@ RSpec.describe Caseflow::Service do
             error_class: 'Caseflow AppealsWithNullIssueDescriptions'
           )
 
-          result = subject.get_appeals(user)
-          expect(result.status).to eq(200)
+          expect { subject.get_appeals(user) }.to raise_error(JSON::Schema::ValidationError)
         end
       end
     end

--- a/spec/requests/v0/appeals_spec.rb
+++ b/spec/requests/v0/appeals_spec.rb
@@ -39,19 +39,6 @@ RSpec.describe 'V0::Appeals', type: :request do
           expect(response).to match_response_schema('appeals')
         end
       end
-
-      it 'allows null issue descriptions' do
-        VCR.use_cassette('caseflow/appeals') do
-          get appeals_endpoint
-          expect(response).to have_http_status(:ok)
-
-          response_data = JSON.parse(response.body)
-          # Add a null description to the first issue of the first appeal
-          response_data['data'].first['attributes']['issues'].first['description'] = nil
-          # Validate that the modified response still matches the schema
-          expect(response_data).to match_schema('appeals')
-        end
-      end
     end
 
     context 'with a not authorized response' do

--- a/spec/support/schemas/appeals_issue.json
+++ b/spec/support/schemas/appeals_issue.json
@@ -5,7 +5,7 @@
       "type": "boolean"
     },
     "description": {
-      "type": ["string", "null"]
+      "type": "string"
     },
     "diagnosticCode": {
       "type": ["string", "null"]


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#24496

This branch was accidentally deployed to production before testing had been done.

Support ticket thread: https://dsva.slack.com/archives/CBU0KDSB1/p1759768363078149