### PR TITLE
Iir1684 ch31 remove v1 schema

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -110,7 +110,7 @@ app/controllers/v0/user @department-of-veterans-affairs/octo-identity
 app/controllers/v0/user_actions_controller.rb @department-of-veterans-affairs/octo-identity
 app/controllers/v0/users_controller.rb @department-of-veterans-affairs/octo-identity
 app/controllers/v0/veteran_onboardings_controller.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
-app/controllers/v0/veteran_readiness_employment_claims_controller.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
+app/controllers/v0/veteran_readiness_employment_claims_controller.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
 app/controllers/v1/apidocs_controller.rb @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/gids @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/post911_gi_bill_statuses_controller.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/govcio-vfep-codereviewers
@@ -283,7 +283,7 @@ app/models/saved_claim/education_career_counseling_claim.rb @department-of-veter
 app/models/saved_claim/higher_level_review.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 app/models/saved_claim/notice_of_disagreement.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 app/models/saved_claim/supplemental_claim.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
-app/models/saved_claim/veteran_readiness_employment_claim.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
+app/models/saved_claim/veteran_readiness_employment_claim.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
 app/models/schema_contract @department-of-veterans-affairs/backend-review-group
 app/models/secondary_appeal_form.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 app/models/session.rb @department-of-veterans-affairs/octo-identity
@@ -559,7 +559,7 @@ app/swagger/swagger/requests/terms_of_use_agreements.rb @department-of-veterans-
 app/swagger/swagger/requests/travel_pay.rb @department-of-veterans-affairs/travel-pay-integration @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/upload_supporting_evidence.rb @department-of-veterans-affairs/disability-benefits @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/user.rb @department-of-veterans-affairs/octo-identity
-app/swagger/swagger/requests/veteran_readiness_employment_claims.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
+app/swagger/swagger/requests/veteran_readiness_employment_claims.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
 app/swagger/swagger/responses/authentication_error.rb @department-of-veterans-affairs/octo-identity
 app/swagger/swagger/responses/service_unavailable_error.rb @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/schemas/appeals @department-of-veterans-affairs/backend-review-group
@@ -1163,7 +1163,7 @@ spec/controllers/v0/user @department-of-veterans-affairs/octo-identity
 spec/controllers/v0/user_actions_controller_spec.rb @department-of-veterans-affairs/octo-identity
 spec/controllers/v0/users_controller_spec.rb @department-of-veterans-affairs/octo-identity
 spec/controllers/v0/veteran_onboardings_controller_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
-spec/controllers/v0/veteran_readiness_employment_claims_controller_spec.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
+spec/controllers/v0/veteran_readiness_employment_claims_controller_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
 spec/controllers/v1/gids @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v1/post911_gi_bill_statuses_controller_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/govcio-vfep-codereviewers
 spec/controllers/v1/profile @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
@@ -1302,7 +1302,7 @@ spec/factories/va526ez.rb @department-of-veterans-affairs/govcio-vfep-codereview
 spec/factories/va5490.rb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 spec/factories/va5495.rb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 spec/factories/veteran_onboardings.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
-spec/factories/veteran_readiness_employment_claim.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
+spec/factories/veteran_readiness_employment_claim.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
 spec/fixtures/ask @department-of-veterans-affairs/backend-review-group
 spec/fixtures/ask/minimal.json @department-of-veterans-affairs/backend-review-group
 spec/fixtures/bgs @department-of-veterans-affairs/backend-review-group
@@ -1479,7 +1479,7 @@ spec/lib/periodic_jobs_spec.rb @department-of-veterans-affairs/govcio-vfep-coder
 spec/lib/persistent_attachments/sanitizer_spec.rb @department-of-veterans-affairs/benefits-lifestage @department-of-veterans-affairs/pensions @department-of-veterans-affairs/burials @department-of-veterans-affairs/backend-review-group
 spec/lib/post911_sob @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 spec/lib/preneeds @department-of-veterans-affairs/bah-mbs-selfserv @department-of-veterans-affairs/backend-review-group
-spec/lib/res/ch31_form_spec.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
+spec/lib/res/ch31_form_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
 spec/lib/rx @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/backend-review-group
 spec/lib/rx/client_request_spec.rb @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/mobile-api-team
 spec/lib/saml @department-of-veterans-affairs/octo-identity

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -110,7 +110,7 @@ app/controllers/v0/user @department-of-veterans-affairs/octo-identity
 app/controllers/v0/user_actions_controller.rb @department-of-veterans-affairs/octo-identity
 app/controllers/v0/users_controller.rb @department-of-veterans-affairs/octo-identity
 app/controllers/v0/veteran_onboardings_controller.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
-app/controllers/v0/veteran_readiness_employment_claims_controller.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group
+app/controllers/v0/veteran_readiness_employment_claims_controller.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
 app/controllers/v1/apidocs_controller.rb @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/gids @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 app/controllers/v1/post911_gi_bill_statuses_controller.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/govcio-vfep-codereviewers
@@ -283,7 +283,7 @@ app/models/saved_claim/education_career_counseling_claim.rb @department-of-veter
 app/models/saved_claim/higher_level_review.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 app/models/saved_claim/notice_of_disagreement.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 app/models/saved_claim/supplemental_claim.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
-app/models/saved_claim/veteran_readiness_employment_claim.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group
+app/models/saved_claim/veteran_readiness_employment_claim.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
 app/models/schema_contract @department-of-veterans-affairs/backend-review-group
 app/models/secondary_appeal_form.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 app/models/session.rb @department-of-veterans-affairs/octo-identity
@@ -559,7 +559,7 @@ app/swagger/swagger/requests/terms_of_use_agreements.rb @department-of-veterans-
 app/swagger/swagger/requests/travel_pay.rb @department-of-veterans-affairs/travel-pay-integration @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/upload_supporting_evidence.rb @department-of-veterans-affairs/disability-benefits @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/user.rb @department-of-veterans-affairs/octo-identity
-app/swagger/swagger/requests/veteran_readiness_employment_claims.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group
+app/swagger/swagger/requests/veteran_readiness_employment_claims.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
 app/swagger/swagger/responses/authentication_error.rb @department-of-veterans-affairs/octo-identity
 app/swagger/swagger/responses/service_unavailable_error.rb @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/schemas/appeals @department-of-veterans-affairs/backend-review-group
@@ -1163,7 +1163,7 @@ spec/controllers/v0/user @department-of-veterans-affairs/octo-identity
 spec/controllers/v0/user_actions_controller_spec.rb @department-of-veterans-affairs/octo-identity
 spec/controllers/v0/users_controller_spec.rb @department-of-veterans-affairs/octo-identity
 spec/controllers/v0/veteran_onboardings_controller_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
-spec/controllers/v0/veteran_readiness_employment_claims_controller_spec.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group
+spec/controllers/v0/veteran_readiness_employment_claims_controller_spec.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
 spec/controllers/v1/gids @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 spec/controllers/v1/post911_gi_bill_statuses_controller_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/govcio-vfep-codereviewers
 spec/controllers/v1/profile @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
@@ -1302,7 +1302,7 @@ spec/factories/va526ez.rb @department-of-veterans-affairs/govcio-vfep-codereview
 spec/factories/va5490.rb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 spec/factories/va5495.rb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 spec/factories/veteran_onboardings.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
-spec/factories/veteran_readiness_employment_claim.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group
+spec/factories/veteran_readiness_employment_claim.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
 spec/fixtures/ask @department-of-veterans-affairs/backend-review-group
 spec/fixtures/ask/minimal.json @department-of-veterans-affairs/backend-review-group
 spec/fixtures/bgs @department-of-veterans-affairs/backend-review-group
@@ -1479,7 +1479,7 @@ spec/lib/periodic_jobs_spec.rb @department-of-veterans-affairs/govcio-vfep-coder
 spec/lib/persistent_attachments/sanitizer_spec.rb @department-of-veterans-affairs/benefits-lifestage @department-of-veterans-affairs/pensions @department-of-veterans-affairs/burials @department-of-veterans-affairs/backend-review-group
 spec/lib/post911_sob @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 spec/lib/preneeds @department-of-veterans-affairs/bah-mbs-selfserv @department-of-veterans-affairs/backend-review-group
-spec/lib/res/ch31_form_spec.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group
+spec/lib/res/ch31_form_spec.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
 spec/lib/rx @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/backend-review-group
 spec/lib/rx/client_request_spec.rb @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/mobile-api-team
 spec/lib/saml @department-of-veterans-affairs/octo-identity

--- a/app/models/saved_claim/veteran_readiness_employment_claim.rb
+++ b/app/models/saved_claim/veteran_readiness_employment_claim.rb
@@ -7,7 +7,6 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
   include Vets::SharedLogging
 
   FORM = '28-1900'
-  FORMV2 = '28-1900_V2' # use full country name instead of abbreviation ("USA" -> "United States")
   # We will be adding numbers here and eventually completeley removing this and the caller to open up VRE submissions
   # to all vets
   PERMITTED_OFFICE_LOCATIONS = %w[].freeze
@@ -248,33 +247,10 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
   def form_matches_schema
     return unless form_is_string
 
-    if form_id == self.class::FORM
-      validate_form_v1
-    else
-      validate_form_v2
-    end
+    validate_form
   end
 
-  def validate_form_v1
-    schema = VetsJsonSchema::SCHEMAS[self.class::FORM]
-    schema_v2 = VetsJsonSchema::SCHEMAS[self.class::FORMV2]
-
-    schema_errors = validate_schema(schema)
-    validation_errors = validate_form(schema)
-
-    if validation_errors.length.positive? && validation_errors.any? { |e| e[:fragment].end_with?('/country') }
-      schema_v2_errors = validate_schema(schema_v2)
-      v2_errors = validate_form(schema_v2)
-      add_errors_from_form_validation(v2_errors)
-      return schema_v2_errors.empty? && v2_errors.empty?
-    end
-
-    add_errors_from_form_validation(validation_errors)
-
-    schema_errors.empty? && validation_errors.empty?
-  end
-
-  def validate_form_v2
+  def validate_form
     validate_required_fields
     validate_string_fields
     validate_boolean_fields

--- a/modules/vre/spec/jobs/vre_submit1900_job_spec.rb
+++ b/modules/vre/spec/jobs/vre_submit1900_job_spec.rb
@@ -65,10 +65,10 @@ describe VRE::VRESubmit1900Job do
           exhaustion_msg['args'] = [claim.id, encrypted_user]
           expect(monitor).to receive(:track_submission_exhaustion).with(exhaustion_msg, claim.parsed_form['email'])
           expect(VANotify::EmailJob).to receive(:perform_async).with(
-            'test@gmail.xom',
+            'email@test.com',
             'form1900_action_needed_email_template_id',
             {
-              'first_name' => 'Homer',
+              'first_name' => 'First',
               'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
               'confirmation_number' => claim.confirmation_number
             }

--- a/spec/controllers/v0/veteran_readiness_employment_claims_controller_spec.rb
+++ b/spec/controllers/v0/veteran_readiness_employment_claims_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe V0::VeteranReadinessEmploymentClaimsController, type: :controller
     build(:veteran_readiness_employment_claim)
   end
   let(:new_test_form) do
-    build(:new_veteran_readiness_employment_claim)
+    build(:veteran_readiness_employment_claim)
   end
 
   let(:no_veteran_info) do

--- a/spec/factories/veteran_readiness_employment_claim.rb
+++ b/spec/factories/veteran_readiness_employment_claim.rb
@@ -2,58 +2,6 @@
 
 FactoryBot.define do
   factory :veteran_readiness_employment_claim, class: 'SavedClaim::VeteranReadinessEmploymentClaim' do
-    form_id { '28-1900' }
-
-    transient do
-      regional_office { '317 - St. Petersburg' }
-      country { 'USA' }
-      first { 'Homer' }
-    end
-
-    form {
-      {
-        'useEva' => true,
-        'useTelecounseling' => true,
-        'appointmentTimePreferences' => {
-          'morning' => true,
-          'midDay' => true,
-          'afternoon' => false
-        },
-        'yearsOfEducation' => '17',
-        'isMoving' => true,
-        'newAddress' => {
-          'country' => country,
-          'street' => '1019 Robin Cir',
-          'city' => 'Arroyo Grande',
-          'state' => 'CA',
-          'postalCode' => '93420'
-        },
-        'veteranAddress' => {
-          'country' => country,
-          'street' => '9417 Princess Palm',
-          'city' => 'Tampa',
-          'state' => 'FL',
-          'postalCode' => '33928'
-        },
-        'mainPhone' => '5555555555',
-        'email' => 'test@gmail.xom',
-        'veteranInformation' => {
-          'fullName' => {
-            'first' => first,
-            'middle' => 'John',
-            'last' => 'Simpson'
-          },
-          'dob' => '1998-01-02',
-          'pid' => '600036503',
-          'edipi' => '1005354478',
-          'vet360ID' => nil,
-          'regionalOffice' => regional_office
-        }
-      }.to_json
-    }
-  end
-
-  factory :new_veteran_readiness_employment_claim, class: 'SavedClaim::VeteranReadinessEmploymentClaim' do
     form_id { '28-1900-V2' }
 
     transient do
@@ -108,7 +56,7 @@ FactoryBot.define do
     }
   end
 
-  factory :new_veteran_readiness_employment_claim_minimal, class: 'SavedClaim::VeteranReadinessEmploymentClaim' do
+  factory :veteran_readiness_employment_claim_minimal, class: 'SavedClaim::VeteranReadinessEmploymentClaim' do
     form_id { '28-1900-V2' }
 
     form {

--- a/spec/lib/res/ch31_form_spec.rb
+++ b/spec/lib/res/ch31_form_spec.rb
@@ -5,12 +5,10 @@ require 'res/ch31_form'
 
 RSpec.describe RES::Ch31Form do
   let(:claim) { create(:veteran_readiness_employment_claim) }
-  let(:claim_with_new_form) { create(:new_veteran_readiness_employment_claim) }
-  let(:claim_with_new_form_minimal) { create(:new_veteran_readiness_employment_claim_minimal) }
+  let(:claim_with_minimal_form) { create(:veteran_readiness_employment_claim_minimal) }
   let(:user) { create(:evss_user, :loa3) }
   let(:service) { RES::Ch31Form.new(user:, claim:) }
-  let(:service_with_new_form) { RES::Ch31Form.new(user:, claim: claim_with_new_form) }
-  let(:service_with_new_form_minimal) { RES::Ch31Form.new(user:, claim: claim_with_new_form_minimal) }
+  let(:service_with_minimal_form) { RES::Ch31Form.new(user:, claim: claim_with_minimal_form) }
   let(:new_address_hash) do
     {
       newAddress: {
@@ -35,7 +33,7 @@ RSpec.describe RES::Ch31Form do
       allow(faraday_response).to receive(:env)
     end
 
-    context 'with a successful old form submission' do
+    context 'with a successful form submission' do
       before do
         allow(service).to receive(:send_to_res).and_return(success_message)
       end
@@ -43,22 +41,6 @@ RSpec.describe RES::Ch31Form do
       it 'adds a new address if the user is moving within 30 days' do
         expect(service).to receive(:new_address) { new_address_hash }
         service.submit
-      end
-    end
-
-    context 'with a successful new form submission' do
-      it 'adds a new address if the user is moving within 30 days' do
-        allow(service_with_new_form).to receive(:send_to_res).and_return(success_message)
-        expect(service_with_new_form).to receive(:new_address) { new_address_hash }
-
-        service_with_new_form.submit
-      end
-
-      it 'accepts only required fields' do
-        allow(service_with_new_form_minimal).to receive(:send_to_res).and_return(success_message)
-        expect(service_with_new_form_minimal).to receive(:mapped_address_hash).and_return(nil)
-
-        service_with_new_form_minimal.submit
       end
     end
 
@@ -77,7 +59,7 @@ RSpec.describe RES::Ch31Form do
           internationalNumber: '+4444444444',
           email: 'email@test.com',
           documentId: nil,
-          receivedDate: claim_with_new_form.created_at.iso8601,
+          receivedDate: claim.created_at.iso8601,
           veteranAddress: {
             country: 'USA',
             street: '12 usa street',
@@ -105,7 +87,7 @@ RSpec.describe RES::Ch31Form do
         }.to_json
         expect_any_instance_of(RES::Service).to receive(:send_to_res).with(payload:).and_return(success_message)
 
-        service_with_new_form.submit
+        service.submit
       end
     end
 
@@ -124,7 +106,7 @@ RSpec.describe RES::Ch31Form do
           internationalNumber: nil,
           email: 'email@test.com',
           documentId: nil,
-          receivedDate: claim_with_new_form_minimal.created_at.iso8601,
+          receivedDate: claim_with_minimal_form.created_at.iso8601,
           veteranAddress: nil,
           veteranInformation: {
             fullName: {
@@ -137,23 +119,14 @@ RSpec.describe RES::Ch31Form do
         }.to_json
         expect_any_instance_of(RES::Service).to receive(:send_to_res).with(payload:).and_return(success_message)
 
-        service_with_new_form_minimal.submit
+        service_with_minimal_form.submit
       end
     end
 
     context 'with an unsuccessful submission' do
-      context 'with old form' do
-        it 'does not successfully send to RES' do
-          allow(service).to receive(:send_to_res).and_return(OpenStruct.new(body: { 'error' => 'Error' }))
-          expect { service.submit }.to raise_error(Ch31Error)
-        end
-      end
-
-      context 'with new form' do
-        it 'does not successfully send to RES' do
-          allow(service_with_new_form).to receive(:send_to_res).and_return(OpenStruct.new(body: { 'error' => 'Error' }))
-          expect { service_with_new_form.submit }.to raise_error(Ch31Error)
-        end
+      it 'does not successfully send to RES' do
+        allow(service).to receive(:send_to_res).and_return(OpenStruct.new(body: { 'error' => 'Error' }))
+        expect { service.submit }.to raise_error(Ch31Error)
       end
 
       it 'handles nil claim' do

--- a/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
+++ b/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
@@ -23,239 +23,169 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
   end
   let(:encrypted_user) { KmsEncrypted::Box.new.encrypt(user_struct.to_h.to_json) }
   let(:user) { OpenStruct.new(JSON.parse(KmsEncrypted::Box.new.decrypt(encrypted_user))) }
+  let(:claim) { create(:veteran_readiness_employment_claim) }
 
   before do
     allow_any_instance_of(RES::Ch31Form).to receive(:submit).and_return(true)
   end
 
-  %w[v1 v2].each do |form_type|
-    describe '#form_id' do
-      context "with #{form_type}" do
-        let(:claim) { create_claim(form_type) }
+  describe '#form_id' do
+    it 'returns the correct form ID' do
+      expect(claim.form_id).to eq('28-1900-V2')
+    end
+  end
 
-        it 'returns the correct form ID' do
-          expect(claim.form_id).to eq(form_type == 'v1' ? '28-1900' : '28-1900-V2')
-        end
+  describe '#after_create_metrics' do
+    it 'increments StatsD saved_claim.create' do
+      allow(StatsD).to receive(:increment)
+      claim.save!
+
+      tags = ['form_id:28-1900-V2']
+      expect(StatsD).to have_received(:increment).with('saved_claim.create', { tags: })
+    end
+  end
+
+  describe '#add_claimant_info' do
+    it 'adds veteran information' do
+      claim.add_claimant_info(user_object)
+      claimant_keys = %w[fullName dob pid edipi vet360ID regionalOffice regionalOfficeName stationId VAFileNumber
+                         ssn]
+      form_data = {
+        'fullName' => {
+          'first' => 'First',
+          'middle' => 'Middle',
+          'last' => 'Last',
+          'suffix' => 'III'
+        },
+        'dob' => '1986-05-06'
+      }
+      expect(claim.parsed_form['veteranInformation']).to include(form_data)
+      expect(claim.parsed_form['veteranInformation']).to include(*claimant_keys)
+    end
+
+    it 'does not obtain va_file_number' do
+      people_service_object = double('people_service')
+      allow(people_service_object).to receive(:find_person_by_participant_id)
+      allow(BGS::People::Request).to receive(:new) { people_service_object }
+
+      claim.add_claimant_info(user_object)
+      expect(claim.parsed_form['veteranInformation']).to include('VAFileNumber' => nil)
+    end
+  end
+
+  describe '#send_to_vre' do
+    it 'propagates errors from send_to_lighthouse!' do
+      allow(claim).to receive(:process_attachments!).and_raise(StandardError, 'Attachment error')
+
+      expect do
+        claim.send_to_lighthouse!(user_object)
+      end.to raise_error(StandardError, 'Attachment error')
+    end
+
+    context 'when VBMS response is VBMSDownForMaintenance' do
+      before do
+        allow(OpenSSL::PKCS12).to receive(:new).and_return(double.as_null_object)
+        @vbms_client = FakeVBMS.new
+        allow(VBMS::Client).to receive(:from_env_vars).and_return(@vbms_client)
+      end
+
+      it 'calls #send_to_lighthouse!' do
+        expect(claim).to receive(:send_to_lighthouse!)
+        claim.send_to_vre(user_object)
+      end
+
+      it 'does not raise an error' do
+        allow(claim).to receive(:send_to_lighthouse!)
+        expect { claim.send_to_vre(user_object) }.not_to raise_error
       end
     end
 
-    describe '#after_create_metrics' do
-      let(:claim) { create_claim(form_type) }
+    context 'when VBMS upload is successful' do
+      before { expect(ClaimsApi::VBMSUploader).to receive(:new) { OpenStruct.new(upload!: {}) } }
 
-      it 'increments StatsD saved_claim.create' do
-        allow(StatsD).to receive(:increment)
-        claim.save!
-
-        tags = form_type == 'v1' ? ['form_id:28-1900'] : ['form_id:28-1900-V2']
-        tags += ["doctype:#{claim.doctype}"]
-        expect(StatsD).to have_received(:increment).with('saved_claim.create', tags:)
-      end
-    end
-
-    describe '#add_claimant_info' do
-      context "with #{form_type}" do
-        let(:claim) { create_claim(form_type) }
-
-        it 'adds veteran information' do
-          claim.add_claimant_info(user_object)
-          claimant_keys = %w[fullName dob pid edipi vet360ID regionalOffice regionalOfficeName stationId VAFileNumber
-                             ssn]
-          old_form_data = {
-            'fullName' => {
-              'first' => 'Homer',
-              'middle' => 'John',
-              'last' => 'Simpson'
-            },
-            'dob' => '1986-05-06'
-          }
-          new_form_data = {
-            'fullName' => {
-              'first' => 'First',
-              'middle' => 'Middle',
-              'last' => 'Last',
-              'suffix' => 'III'
-            },
-            'dob' => '1986-05-06'
-          }
-          expect(claim.parsed_form['veteranInformation']).to include(
-            form_type == 'v1' ? old_form_data : new_form_data
-          )
-          expect(claim.parsed_form['veteranInformation']).to include(*claimant_keys)
-        end
-
-        it 'does not obtain va_file_number' do
-          people_service_object = double('people_service')
-          allow(people_service_object).to receive(:find_person_by_participant_id)
-          allow(BGS::People::Request).to receive(:new) { people_service_object }
-
-          claim.add_claimant_info(user_object)
-          expect(claim.parsed_form['veteranInformation']).to include('VAFileNumber' => nil)
-        end
-      end
-    end
-
-    describe '#send_to_vre' do
-      context "with #{form_type} form" do
-        let(:claim) { create_claim(form_type) }
-
-        it 'propagates errors from send_to_lighthouse!' do
-          allow(claim).to receive(:process_attachments!).and_raise(StandardError, 'Attachment error')
-
-          expect do
-            claim.send_to_lighthouse!(user_object)
-          end.to raise_error(StandardError, 'Attachment error')
-        end
-
-        context 'when VBMS response is VBMSDownForMaintenance' do
-          before do
-            allow(OpenSSL::PKCS12).to receive(:new).and_return(double.as_null_object)
-            @vbms_client = FakeVBMS.new
-            allow(VBMS::Client).to receive(:from_env_vars).and_return(@vbms_client)
-          end
-
-          it 'calls #send_to_lighthouse!' do
-            expect(claim).to receive(:send_to_lighthouse!)
-            claim.send_to_vre(user_object)
-          end
-
-          it 'does not raise an error' do
-            allow(claim).to receive(:send_to_lighthouse!)
-            expect { claim.send_to_vre(user_object) }.not_to raise_error
-          end
-        end
-
-        context 'when VBMS upload is successful' do
-          before { expect(ClaimsApi::VBMSUploader).to receive(:new) { OpenStruct.new(upload!: {}) } }
-
-          context 'submission to VRE' do
-            before do
-              # As the PERMITTED_OFFICE_LOCATIONS constant at
-              # the top of: app/models/saved_claim/veteran_readiness_employment_claim.rb gets changed, you
-              # may need to change this mock below and maybe even move it into different 'it'
-              # blocks if you need to test different routing offices
-              expect_any_instance_of(BGS::RORoutingService).to receive(:get_regional_office_by_zip_code).and_return(
-                { regional_office: { number: '325' } }
-              )
-            end
-
-            it 'sends confirmation email' do
-              expect(claim).to receive(:send_vbms_lighthouse_confirmation_email)
-                .with('VBMS', :confirmation_vbms, 'ch31_vbms_fake_template_id')
-
-              claim.send_to_vre(user_object)
-            end
-          end
-
-          # We want all submission to go through with RES
-          context 'non-submission to VRE' do
-            context 'flipper enabled' do
-              it 'stops submission if location is not in list' do
-                expect_any_instance_of(RES::Ch31Form).to receive(:submit)
-                claim.add_claimant_info(user_object)
-
-                claim.send_to_vre(user_object)
-              end
-            end
-          end
-        end
-
-        context 'when user has no PID' do
-          let(:user_object) { create(:unauthorized_evss_user) }
-
-          it 'PDF is sent to Central Mail and not VBMS' do
-            expect(claim).to receive(:process_attachments!)
-            expect(claim).to receive(:send_to_lighthouse!).with(user_object).once.and_call_original
-            expect(claim).to receive(:send_vbms_lighthouse_confirmation_email)
-            expect(claim).not_to receive(:upload_to_vbms)
-            expect(VeteranReadinessEmploymentMailer).to receive(:build).with(
-              user_object.participant_id, 'VRE.VBAPIT@va.gov', true
-            ).and_call_original
-            claim.send_to_vre(user_object)
-          end
-        end
-      end
-    end
-
-    describe '#regional_office' do
-      context "with #{form_type}" do
-        let(:claim) { create_claim(form_type) }
-
-        it 'returns an empty array' do
-          expect(claim.regional_office).to be_empty
-        end
-      end
-    end
-
-    describe '#send_vbms_lighthouse_confirmation_email' do
-      let(:user) do
-        OpenStruct.new(
-          edipi: '1007697216',
-          participant_id: '600061742',
-          first_name: 'WESLEY',
-          va_profile_email: 'test@example.com',
-          flipper_id: 'test-user-id'
-        )
-      end
-      let(:claim) { create_claim(form_type) }
-
-      context 'Legacy notification strategy' do
+      context 'submission to VRE' do
         before do
-          allow(Flipper).to receive(:enabled?)
-            .with(:vre_use_new_vfs_notification_library)
-            .and_return(false)
-        end
-
-        it 'calls the VA notify email job' do
-          expect(VANotify::EmailJob).to receive(:perform_async).with(
-            claim.email,
-            'ch31_vbms_fake_template_id',
-            {
-              'date' => Time.zone.today.strftime('%B %d, %Y'),
-              'first_name' => claim.parsed_form['veteranInformation']['fullName']['first']
-            }
+          # As the PERMITTED_OFFICE_LOCATIONS constant at
+          # the top of: app/models/saved_claim/veteran_readiness_employment_claim.rb gets changed, you
+          # may need to change this mock below and maybe even move it into different 'it'
+          # blocks if you need to test different routing offices
+          expect_any_instance_of(BGS::RORoutingService).to receive(:get_regional_office_by_zip_code).and_return(
+            { regional_office: { number: '325' } }
           )
-
-          claim.send_vbms_lighthouse_confirmation_email('VBMS', :confirmation_vbms, 'ch31_vbms_fake_template_id')
         end
+
+        it 'sends confirmation email' do
+          expect(claim).to receive(:send_vbms_lighthouse_confirmation_email)
+            .with('VBMS', :confirmation_vbms, 'ch31_vbms_fake_template_id')
+
+          claim.send_to_vre(user_object)
+        end
+      end
+
+      # We want all submission to go through with RES
+      context 'non-submission to VRE' do
+        context 'flipper enabled' do
+          it 'stops submission if location is not in list' do
+            expect_any_instance_of(RES::Ch31Form).to receive(:submit)
+            claim.add_claimant_info(user_object)
+
+            claim.send_to_vre(user_object)
+          end
+        end
+      end
+    end
+
+    context 'when user has no PID' do
+      let(:user_object) { create(:unauthorized_evss_user) }
+
+      it 'PDF is sent to Central Mail and not VBMS' do
+        expect(claim).to receive(:process_attachments!)
+        expect(claim).to receive(:send_to_lighthouse!).with(user_object).once.and_call_original
+        expect(claim).to receive(:send_vbms_lighthouse_confirmation_email)
+        expect(claim).not_to receive(:upload_to_vbms)
+        expect(VeteranReadinessEmploymentMailer).to receive(:build).with(
+          user_object.participant_id, 'VRE.VBAPIT@va.gov', true
+        ).and_call_original
+        claim.send_to_vre(user_object)
       end
     end
   end
 
-  describe '#form_matches_schema' do
-    it 'rejects invalid country format' do
-      claim = build(:veteran_readiness_employment_claim, country: 'Invalid')
+  describe '#regional_office' do
+    it 'returns an empty array' do
+      expect(claim.regional_office).to be_empty
+    end
+  end
 
-      expect(claim).not_to be_valid
-      expect(claim.errors.attribute_names).to contain_exactly(:'/veteranAddress/country', :'/newAddress/country')
+  describe '#send_vbms_lighthouse_confirmation_email' do
+    let(:user) do
+      OpenStruct.new(
+        edipi: '1007697216',
+        participant_id: '600061742',
+        first_name: 'WESLEY',
+        va_profile_email: 'test@example.com',
+        flipper_id: 'test-user-id'
+      )
     end
 
-    ['USA', 'United States'].each do |country|
-      context "with #{country} format" do
-        let(:claim) { build(:veteran_readiness_employment_claim, country:) }
-
-        describe 'country validation' do
-          it 'accepts valid country format' do
-            expect(claim).to be_valid
-          end
-
-          it 'validates other fields independently of country format' do
-            claim_data = JSON.parse(claim.form)
-            claim_data['veteranInformation']['fullName'] = {} # Invalid name
-            claim.form = claim_data.to_json
-
-            expect(claim).not_to be_valid
-            expect(claim.errors.attribute_names).to include(:'/veteranInformation/fullName')
-          end
-        end
+    context 'Legacy notification strategy' do
+      before do
+        allow(Flipper).to receive(:enabled?)
+          .with(:vre_use_new_vfs_notification_library)
+          .and_return(false)
       end
-    end
 
-    context 'when first name is invalid' do
-      it 'fails validation' do
-        claim = build(:veteran_readiness_employment_claim, first: '')
+      it 'calls the VA notify email job' do
+        expect(VANotify::EmailJob).to receive(:perform_async).with(
+          claim.email,
+          'ch31_vbms_fake_template_id',
+          {
+            'date' => Time.zone.today.strftime('%B %d, %Y'),
+            'first_name' => claim.parsed_form['veteranInformation']['fullName']['first']
+          }
+        )
 
-        expect(claim).not_to be_valid
-        expect(claim.errors.attribute_names).to include(:'/veteranInformation/fullName/first')
+        claim.send_vbms_lighthouse_confirmation_email('VBMS', :confirmation_vbms, 'ch31_vbms_fake_template_id')
       end
     end
   end
@@ -263,8 +193,6 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
   describe '#check_form_v2_validations' do
     ['', [], nil, {}].each do |address|
       context "with empty #{address} input" do
-        let(:claim) { build(:new_veteran_readiness_employment_claim) }
-
         describe 'address validation' do
           it 'accepts empty address format as not required' do
             claim_data = JSON.parse(claim.form)
@@ -278,7 +206,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
     end
 
     context 'when address is not empty' do
-      let(:claim) { build(:new_veteran_readiness_employment_claim) }
+      let(:claim) { build(:veteran_readiness_employment_claim) }
 
       it 'passes validation with only street and city' do
         claim_data = JSON.parse(claim.form)
@@ -396,7 +324,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
 
     ['USA', 'United States'].each do |country|
       context "with #{country} format" do
-        let(:claim) { build(:new_veteran_readiness_employment_claim, country:) }
+        let(:claim) { build(:veteran_readiness_employment_claim, country:) }
 
         describe 'country validation' do
           it 'accepts valid country format' do
@@ -419,7 +347,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
     ['', ' ', nil].each do |invalid_input|
       context 'when required field is empty' do
         it 'fails validation' do
-          claim = build(:new_veteran_readiness_employment_claim, email: invalid_input, is_moving: invalid_input,
+          claim = build(:veteran_readiness_employment_claim, email: invalid_input, is_moving: invalid_input,
                                                                  years_of_ed: invalid_input, first: invalid_input,
                                                                  last: invalid_input, dob: invalid_input,
                                                                  privacyAgreementAccepted: invalid_input)
@@ -438,7 +366,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
     [0, true, ['data']].each do |invalid_type|
       context "when string field receives #{invalid_type} data type" do
         it 'fails validation' do
-          claim = build(:new_veteran_readiness_employment_claim, main_phone: invalid_type, cell_phone: invalid_type,
+          claim = build(:veteran_readiness_employment_claim, main_phone: invalid_type, cell_phone: invalid_type,
                                                                  international_number: invalid_type,
                                                                  email: invalid_type, years_of_ed: invalid_type,
                                                                  first: invalid_type, middle: invalid_type,
@@ -461,7 +389,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
     ['true', 1, 0, [], nil].each do |invalid_type|
       context "when isMoving receives #{invalid_type} data type" do
         it 'fails validation' do
-          claim = build(:new_veteran_readiness_employment_claim, is_moving: invalid_type)
+          claim = build(:veteran_readiness_employment_claim, is_moving: invalid_type)
 
           expect(claim).not_to be_valid
           expect(claim.errors.attribute_names).to include(:'/isMoving')
@@ -472,7 +400,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
     context 'when name field is allowed length' do
       it 'passes validation' do
         name = 'a' * 30
-        claim = build(:new_veteran_readiness_employment_claim, first: name, middle: name, last: name)
+        claim = build(:veteran_readiness_employment_claim, first: name, middle: name, last: name)
         expect(claim).to be_valid
       end
     end
@@ -480,7 +408,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
     context 'when name field is too long' do
       it 'fails validation' do
         long_name = 'a' * 31
-        claim = build(:new_veteran_readiness_employment_claim, first: long_name, middle: long_name, last: long_name)
+        claim = build(:veteran_readiness_employment_claim, first: long_name, middle: long_name, last: long_name)
 
         expect(claim).not_to be_valid
         expect(claim.errors.attribute_names).to include(:'/veteranInformation/fullName/first')
@@ -492,7 +420,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
     context 'when email field is allowed length' do
       it 'passes validation' do
         email = "#{'a' * 244}@example.com"
-        claim = build(:new_veteran_readiness_employment_claim, email:)
+        claim = build(:veteran_readiness_employment_claim, email:)
         expect(claim).to be_valid
       end
     end
@@ -500,7 +428,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
     context 'when email field is too long' do
       it 'fails validation' do
         email = "#{'a' * 245}@example.com"
-        claim = build(:new_veteran_readiness_employment_claim, email:)
+        claim = build(:veteran_readiness_employment_claim, email:)
 
         expect(claim).not_to be_valid
         expect(claim.errors.attribute_names).to include(:'/email')
@@ -510,7 +438,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
     ['email.com', '@email.com', 'email', '@.com'].each do |email|
       context 'when email field is not properly formatted' do
         it 'fails validation' do
-          claim = build(:new_veteran_readiness_employment_claim, email:)
+          claim = build(:veteran_readiness_employment_claim, email:)
 
           expect(claim).not_to be_valid
           expect(claim.errors.attribute_names).to include(:'/email')
@@ -521,7 +449,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
     ['1', '123456789', '12345678901', 'a' * 10].each do |invalid_phone|
       context 'when phone field is not 10 digits' do
         it 'fails validation' do
-          claim = build(:new_veteran_readiness_employment_claim, main_phone: invalid_phone,
+          claim = build(:veteran_readiness_employment_claim, main_phone: invalid_phone,
                                                                  cell_phone: invalid_phone)
 
           expect(claim).not_to be_valid
@@ -534,7 +462,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
     %w[10-30-1990 30-10-1990 90-10-30 1990-10-1 1990-9-9].each do |invalid_dob|
       context 'when dob field does not match YYYY-MM-DD format' do
         it 'fails validation' do
-          claim = build(:new_veteran_readiness_employment_claim, dob: invalid_dob)
+          claim = build(:veteran_readiness_employment_claim, dob: invalid_dob)
 
           expect(claim).not_to be_valid
           expect(claim.errors.attribute_names).to include(:'/veteranInformation/dob')
@@ -546,19 +474,11 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
   ['true', 1, 0, [], nil].each do |invalid_type|
     context "when privacyAgreementAccepted receives #{invalid_type} data type" do
       it 'fails validation' do
-        claim = build(:new_veteran_readiness_employment_claim, privacyAgreementAccepted: invalid_type)
+        claim = build(:veteran_readiness_employment_claim, privacyAgreementAccepted: invalid_type)
 
         expect(claim).not_to be_valid
         expect(claim.errors.attribute_names).to include(:'/privacyAgreementAccepted')
       end
-    end
-  end
-
-  def create_claim(form_type)
-    if form_type == 'v1'
-      create(:veteran_readiness_employment_claim)
-    else
-      create(:new_veteran_readiness_employment_claim)
     end
   end
 end

--- a/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
+++ b/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
       allow(StatsD).to receive(:increment)
       claim.save!
 
-      tags = ['form_id:28-1900-V2']
+      tags = ['form_id:28-1900-V2', "doctype:10"]
       expect(StatsD).to have_received(:increment).with('saved_claim.create', { tags: })
     end
   end

--- a/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
+++ b/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
       allow(StatsD).to receive(:increment)
       claim.save!
 
-      tags = ['form_id:28-1900-V2', "doctype:10"]
+      tags = ['form_id:28-1900-V2', 'doctype:10']
       expect(StatsD).to have_received(:increment).with('saved_claim.create', { tags: })
     end
   end

--- a/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
+++ b/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
@@ -348,9 +348,9 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
       context 'when required field is empty' do
         it 'fails validation' do
           claim = build(:veteran_readiness_employment_claim, email: invalid_input, is_moving: invalid_input,
-                                                                 years_of_ed: invalid_input, first: invalid_input,
-                                                                 last: invalid_input, dob: invalid_input,
-                                                                 privacyAgreementAccepted: invalid_input)
+                                                             years_of_ed: invalid_input, first: invalid_input,
+                                                             last: invalid_input, dob: invalid_input,
+                                                             privacyAgreementAccepted: invalid_input)
 
           expect(claim).not_to be_valid
           expect(claim.errors.attribute_names).to include(:'/email')
@@ -367,10 +367,10 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
       context "when string field receives #{invalid_type} data type" do
         it 'fails validation' do
           claim = build(:veteran_readiness_employment_claim, main_phone: invalid_type, cell_phone: invalid_type,
-                                                                 international_number: invalid_type,
-                                                                 email: invalid_type, years_of_ed: invalid_type,
-                                                                 first: invalid_type, middle: invalid_type,
-                                                                 last: invalid_type, dob: invalid_type)
+                                                             international_number: invalid_type,
+                                                             email: invalid_type, years_of_ed: invalid_type,
+                                                             first: invalid_type, middle: invalid_type,
+                                                             last: invalid_type, dob: invalid_type)
 
           expect(claim).not_to be_valid
           expect(claim.errors.attribute_names).to include(:'/mainPhone')
@@ -450,7 +450,7 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
       context 'when phone field is not 10 digits' do
         it 'fails validation' do
           claim = build(:veteran_readiness_employment_claim, main_phone: invalid_phone,
-                                                                 cell_phone: invalid_phone)
+                                                             cell_phone: invalid_phone)
 
           expect(claim).not_to be_valid
           expect(claim.errors.attribute_names).to include(:'/mainPhone')

--- a/spec/sidekiq/vre/submit1900_job_spec.rb
+++ b/spec/sidekiq/vre/submit1900_job_spec.rb
@@ -26,87 +26,70 @@ describe VRE::Submit1900Job do
     { 'args' => [], 'class' => 'VRE::Submit1900Job', 'error_message' => 'An error occurred',
       'queue' => 'default' }
   end
+  let(:claim) { create(:veteran_readiness_employment_claim) }
 
-  %w[v1 v2].each do |form_type|
-    context "with #{form_type}" do
-      describe '#perform' do
-        subject { described_class.new.perform(claim.id, encrypted_user) }
+  describe '#perform' do
+    subject { described_class.new.perform(claim.id, encrypted_user) }
 
-        let(:claim) { create_claim(form_type) }
+    before do
+      allow(SavedClaim::VeteranReadinessEmploymentClaim).to receive(:find).and_return(claim)
+    end
 
-        before do
-          allow(SavedClaim::VeteranReadinessEmploymentClaim).to receive(:find).and_return(claim)
-        end
+    after do
+      subject
+    end
 
-        after do
-          subject
-        end
+    it 'calls claim.add_claimant_info' do
+      allow(claim).to receive(:send_to_lighthouse!)
+      allow(claim).to receive(:send_to_res)
 
-        it 'calls claim.add_claimant_info' do
-          allow(claim).to receive(:send_to_lighthouse!)
-          allow(claim).to receive(:send_to_res)
+      expect(claim).to receive(:add_claimant_info).with(user)
+    end
 
-          expect(claim).to receive(:add_claimant_info).with(user)
-        end
+    it 'calls claim.send_to_vre' do
+      expect(claim).to receive(:send_to_vre).with(user)
+    end
+  end
 
-        it 'calls claim.send_to_vre' do
-          expect(claim).to receive(:send_to_vre).with(user)
-        end
-      end
+  describe 'raises an exception with email flipper on' do
+    before do
+      allow(SavedClaim::VeteranReadinessEmploymentClaim).to receive(:find).and_return(claim)
+      allow(VRE::Monitor).to receive(:new).and_return(monitor)
+      allow(monitor).to receive :track_submission_exhaustion
+    end
 
-      describe 'raises an exception with email flipper on' do
-        let(:claim) { create_claim(form_type) }
-
-        before do
-          allow(SavedClaim::VeteranReadinessEmploymentClaim).to receive(:find).and_return(claim)
-          allow(VRE::Monitor).to receive(:new).and_return(monitor)
-          allow(monitor).to receive :track_submission_exhaustion
-        end
-
-        it 'when queue is exhausted' do
-          VRE::Submit1900Job.within_sidekiq_retries_exhausted_block({ 'args' => [claim.id, encrypted_user] }) do
-            exhaustion_msg['args'] = [claim.id, encrypted_user]
-            expect(monitor).to receive(:track_submission_exhaustion).with(exhaustion_msg, claim.parsed_form['email'])
-            expect(VANotify::EmailJob).to receive(:perform_async).with(
-              form_type == 'v1' ? 'test@gmail.xom' : 'email@test.com',
-              'form1900_action_needed_email_template_id',
-              {
-                'first_name' => form_type == 'v1' ? 'Homer' : 'First',
-                'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-                'confirmation_number' => claim.confirmation_number
-              }
-            )
-          end
-        end
-      end
-
-      describe 'raises an exception with no email' do
-        let(:claim) { create_claim(form_type) }
-
-        before do
-          allow(SavedClaim::VeteranReadinessEmploymentClaim).to receive(:find).and_return(claim)
-          allow(VRE::Monitor).to receive(:new).and_return(monitor)
-          allow(monitor).to receive :track_submission_exhaustion
-          user_struct.va_profile_email = nil
-        end
-
-        it 'when queue is exhausted with no email' do
-          VRE::Submit1900Job.within_sidekiq_retries_exhausted_block({ 'args' => [claim.id, encrypted_user] }) do
-            expect(SavedClaim).to receive(:find).with(claim.id).and_return(claim)
-            exhaustion_msg['args'] = [claim.id, encrypted_user]
-            allow(claim).to receive(:email).and_return(nil)
-            expect(monitor).to receive(:track_submission_exhaustion).with(exhaustion_msg, nil)
-          end
-        end
+    it 'when queue is exhausted' do
+      VRE::Submit1900Job.within_sidekiq_retries_exhausted_block({ 'args' => [claim.id, encrypted_user] }) do
+        exhaustion_msg['args'] = [claim.id, encrypted_user]
+        expect(monitor).to receive(:track_submission_exhaustion).with(exhaustion_msg, claim.parsed_form['email'])
+        expect(VANotify::EmailJob).to receive(:perform_async).with(
+          'email@test.com',
+          'form1900_action_needed_email_template_id',
+          {
+            'first_name' => 'First',
+            'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
+            'confirmation_number' => claim.confirmation_number
+          }
+        )
       end
     end
   end
 
-  def create_claim(form_type)
-    if form_type == 'v1'
-      create(:veteran_readiness_employment_claim)
-    else
-      create(:new_veteran_readiness_employment_claim)
+  describe 'raises an exception with no email' do
+    before do
+      allow(SavedClaim::VeteranReadinessEmploymentClaim).to receive(:find).and_return(claim)
+      allow(VRE::Monitor).to receive(:new).and_return(monitor)
+      allow(monitor).to receive :track_submission_exhaustion
+      user_struct.va_profile_email = nil
+    end
+
+    it 'when queue is exhausted with no email' do
+      VRE::Submit1900Job.within_sidekiq_retries_exhausted_block({ 'args' => [claim.id, encrypted_user] }) do
+        expect(SavedClaim).to receive(:find).with(claim.id).and_return(claim)
+        exhaustion_msg['args'] = [claim.id, encrypted_user]
+        allow(claim).to receive(:email).and_return(nil)
+        expect(monitor).to receive(:track_submission_exhaustion).with(exhaustion_msg, nil)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- This PR removes the old schema and validation that was used on the old version of the Ch. 31 form. All forms have been processing through the new version of validation with success since August, so here is the change to clean up the code that was left behind. There was also an update to the model factory which caused several other files to need to be updated.
- I work on the CVE team and we currently own Ch. 31


## Related issue(s)

- [1684](https://github.com/department-of-veterans-affairs/va-iir/issues/1684)

## Testing done

- [s] *New code is covered by unit tests*
- This change is focused on deletion, removing unused methods and specs. The updated validations have specs in place, and testing will be conducted on staging to make sure these changes aren't causing issues.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
This only impacts Ch. 31.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
