### PR TITLE
BMT3/114813 - add empty state text feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -157,6 +157,10 @@ features:
   dv_email_notification:
     actor_type: user
     description: Enables dependents verification emails
+  empty_state_benefit_letters:
+    actor_type: user
+    description: Enables text if no benefit letters exist
+    enable_in_development: true
   event_bus_gateway_ep030_decision_letter_notifications:
     description: "Gateway: Enable decision letter email notifications for EP030 higher level reviews"
   event_bus_gateway_ep040_decision_letter_notifications:


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- This work adds feature flag to be used in vets-website for text when no letters are available. The feature flag will allow for the text to appear. If the flag is toggled off, the current state will remain, with a header for the decision letters and an empty line beneath.
- Team: BMT-3

## Related issue(s)

- Ticket: [department-of-veterans-affairs/va.gov-team/issues/114813
](https://github.com/department-of-veterans-affairs/va.gov-team/issues/114813)
- Epic: [department-of-veterans-affairs/va.gov-team/issues/97937](https://github.com/department-of-veterans-affairs/va.gov-team/issues/97937)
- [Corresponding PR](https://github.com/department-of-veterans-affairs/vets-website/pull/39378) for actual work in vets-website, this also includes images of the view with the flag off and on

## Testing done

- Testing has been done within vets-website with the flag off and on.  And cypress tests have been added within vets-website.

## Screenshots
- Screenshots have been added to the vets-website PR linked to above.

## What areas of the site does it impact?
*This added feature flag will be used in vets-website

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
