### PR TITLE
fix: remove Sidekiq::Testing.disable! from EmailVerificationJob spec

### DIFF
--- a/spec/sidekiq/email_verification_job_spec.rb
+++ b/spec/sidekiq/email_verification_job_spec.rb
@@ -17,10 +17,6 @@ RSpec.describe EmailVerificationJob, type: :job do
     allow(Rails.logger).to receive(:error)
   end
 
-  after do
-    Sidekiq::Testing.disable!
-  end
-
   describe '#perform' do
     context 'when feature flag is enabled' do
       before do


### PR DESCRIPTION
## Summary
Fixes 3 test failures in Test Group 20 caused by Sidekiq testing state leakage.

## Background
The EmailVerificationJob spec added in #24549 included an `after` hook that called `Sidekiq::Testing.disable!`. This global setting change caused state leakage to other specs running in the same test group during parallel test execution.

## Failing Tests (before fix)
- `Representatives::QueueUpdates#perform` - Jobs wouldn't queue (expected 3, got 0)
- `Sidekiq::ErrorTag` - Sentry tagging wouldn't work  
- `FormSubmissionAttempt` - Jobs and metrics wouldn't work

## Root Cause
In CI, `parallel_test` groups specs by filesize and runs them sequentially in the same process. After EmailVerificationJob specs finished, the `after` hook disabled Sidekiq testing mode globally, affecting all subsequent specs in Test Group 20.

## Fix
Removed the problematic `after` hook. The `before` hook already sets `Sidekiq::Testing.fake!` for each test, so there's no need to explicitly disable it afterwards.

## Test Plan
- [x] Run EmailVerificationJob specs locally - all pass
- [x] Run previously failing specs together - all pass
- [ ] Verify Test Group 20 passes in CI

## Related
- Original PR: #24549
- Fixes failures introduced in commit 78281ca30e