### PR TITLE
DR 105976: Remove SC toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2255,10 +2255,6 @@ features:
   nod_browser_monitoring_enabled:
     actor_type: user
     description: NOD Datadog RUM monitoring
-  sc_new_form:
-    actor_type: user
-    description: Supplemental Claim new form updates
-    enable_in_development: true
   hlr_browser_monitoring_enabled:
     actor_type: user
     description: HLR Datadog RUM monitoring


### PR DESCRIPTION
## Summary

Removal of `sc_new_form` toggle as we are also getting rid of all the related front end code, ending with [this vets-website PR](https://github.com/department-of-veterans-affairs/vets-website/pull/39096).

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/105976