### PR TITLE
Fix codowners syntax on one line

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -254,7 +254,7 @@ app/models/persistent_attachment.rb @department-of-veterans-affairs/benefits-non
 app/models/persistent_attachments/claim_evidence.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-lifestage
 app/models/persistent_attachments/dependency_claim.rb @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/backend-review-group
 app/models/persistent_attachments/lgy_claim.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group
-app/models/persistent_attachments/military_records.rb @department-of-veterans-affairs/backend-review-group @platform-va-product-forms
+app/models/persistent_attachments/military_records.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/platform-va-product-forms
 app/models/persistent_attachments/va_form_documentation.rb @department-of-veterans-affairs/backend-review-group
 app/models/persistent_attachments/va_form.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/backend-review-group
 app/models/personal_information_log.rb @department-of-veterans-affairs/backend-review-group


### PR DESCRIPTION
## Summary

This PR fixes a syntax error on line 257 of CODEOWNERS. 

## Related issue(s)

none. saw while on support.

## Testing done
see screenshots

## Screenshots
Before:
<img width="562" height="151" alt="image" src="https://github.com/user-attachments/assets/2eb169c8-5574-4141-907c-ff997f166fa1" />

After:
<img width="209" height="51" alt="image" src="https://github.com/user-attachments/assets/05437045-8319-4981-8929-df9c6495075a" />


## What areas of the site does it impact?
CODEOWNERS
