### PR TITLE
[BIO] added 21p-530a stubs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,6 +68,7 @@ app/controllers/v0/form1010_ezrs_controller.rb @department-of-veterans-affairs/h
 app/controllers/v0/form1010cg/attachments_controller.rb @department-of-veterans-affairs/health-apps-backend @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/form1095_bs_controller.rb @department-of-veterans-affairs/va-iir @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/form210779_controller.rb @department-of-veterans-affairs/benefits-optimization-aquia @department-of-veterans-affairs/backend-review-group
+app/controllers/v0/form21p530a_controller.rb @department-of-veterans-affairs/benefits-optimization-aquia @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/forms_controller.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/vfs-public-websites-frontend
 app/controllers/v0/gi_bill_feedbacks_controller.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/govcio-vfep-codereviewers
 app/controllers/v0/gids @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
@@ -535,6 +536,7 @@ app/swagger/swagger/requests/form1010_ezrs.rb @department-of-veterans-affairs/he
 app/swagger/swagger/requests/form1010cg @department-of-veterans-affairs/health-apps-backend @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/form1095_bs.rb @department-of-veterans-affairs/va-iir @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/form210779.rb @department-of-veterans-affairs/benefits-optimization-aquia @department-of-veterans-affairs/backend-review-group
+app/swagger/swagger/requests/form21p530a.rb @department-of-veterans-affairs/benefits-optimization-aquia @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/forms.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/vfs-public-websites-frontend
 app/swagger/swagger/requests/gibct @department-of-veterans-affairs/backend-review-group
 app/swagger/swagger/requests/gibct/calculator_constants.rb @department-of-veterans-affairs/backend-review-group
@@ -1128,6 +1130,7 @@ spec/controllers/v0/form1010_ezr_attachments_controller_spec.rb @department-of-v
 spec/controllers/v0/form1010cg @department-of-veterans-affairs/health-apps-backend @department-of-veterans-affairs/backend-review-group
 spec/controllers/v0/form1010cg/attachments_controller_spec.rb @department-of-veterans-affairs/health-apps-backend @department-of-veterans-affairs/backend-review-group
 spec/controllers/v0/form210779_controller_spec.rb @department-of-veterans-affairs/benefits-optimization-aquia @department-of-veterans-affairs/backend-review-group
+spec/controllers/v0/form21p530a_controller_spec.rb @department-of-veterans-affairs/benefits-optimization-aquia @department-of-veterans-affairs/backend-review-group
 spec/controllers/v0/forms_controller_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/vfs-public-websites-frontend
 spec/controllers/v0/gi_bill_feedbacks_controller_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/govcio-vfep-codereviewers
 spec/controllers/v0/hca_attachments_controller_spec.rb @department-of-veterans-affairs/health-apps-backend @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/v0/apidocs_controller.rb
+++ b/app/controllers/v0/apidocs_controller.rb
@@ -150,6 +150,7 @@ module V0
       Swagger::Requests::Form1010Ezrs,
       Swagger::Requests::Form1095Bs,
       Swagger::Requests::Form210779,
+      Swagger::Requests::Form21p530a,
       Swagger::Requests::Forms,
       Swagger::Requests::Gibct::CalculatorConstants,
       Swagger::Requests::Gibct::Institutions,

--- a/app/controllers/v0/form21p530a_controller.rb
+++ b/app/controllers/v0/form21p530a_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Temporary stub implementation for Form 21P-530a to enable parallel frontend development
+# This entire file will be replaced with the full implementation in Phase 1
+
+module V0
+  class Form21p530aController < ApplicationController
+    service_tag 'burial-allowance-state-tribal'
+    skip_before_action :authenticate
+
+    def create
+      confirmation_number = SecureRandom.uuid
+      submitted_at = Time.current
+
+      render json: {
+        data: {
+          id: '12345',
+          type: 'saved_claims',
+          attributes: {
+            submitted_at: submitted_at.iso8601,
+            regional_office: [
+              'Department of Veterans Affairs',
+              'Pension Management Center',
+              'P.O. Box 5365',
+              'Janesville, WI 53547-5365'
+            ],
+            confirmation_number:,
+            guid: confirmation_number,
+            form: '21P-530a'
+          }
+        }
+      }, status: :ok
+    end
+
+    def download_pdf
+      render json: {
+        message: 'PDF download stub - not yet implemented'
+      }, status: :ok
+    end
+  end
+end

--- a/app/swagger/swagger/requests/form21p530a.rb
+++ b/app/swagger/swagger/requests/form21p530a.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+module Swagger
+  module Requests
+    class Form21p530a
+      include Swagger::Blocks
+
+      swagger_schema :Form21p530aFullName do
+        key :type, :object
+        property :first, type: :string, example: 'John'
+        property :middle, type: :string, example: 'M'
+        property :last, type: :string, example: 'Doe'
+        property :suffix, type: :string, example: 'Jr'
+      end
+
+      swagger_schema :Form21p530aPlaceOfBirth do
+        key :type, :object
+        property :city, type: :string, example: 'Springfield'
+        property :state, type: :string, example: 'IL'
+        property :country, type: :string, example: 'USA'
+      end
+
+      swagger_schema :Form21p530aServicePeriod do
+        key :type, :object
+        property :serviceBranch, type: :string, example: 'Army'
+        property :dateEnteredService, type: :string, format: :date, example: '1960-01-15'
+        property :placeEnteredService, type: :string, example: 'Fort Benning, GA'
+        property :rankAtSeparation, type: :string, example: 'E-5'
+        property :dateLeftService, type: :string, format: :date, example: '1965-12-31'
+        property :placeLeftService, type: :string, example: 'Fort Hood, TX'
+      end
+
+      swagger_schema :Form21p530aServiceUnderOtherName do
+        key :type, :object
+        property :used, type: :boolean, example: false
+        property :fullName do
+          key :$ref, :Form21p530aFullName
+        end
+        property :serviceRendered, type: :string, example: 'Army, 1960-1965'
+      end
+
+      swagger_schema :Form21p530aCemeteryLocation do
+        key :type, :object
+        property :street, type: :string, example: '1000 Memorial Drive'
+        property :city, type: :string, example: 'Springfield'
+        property :state, type: :string, example: 'IL'
+        property :postalCode, type: :string, example: '62701'
+      end
+
+      swagger_schema :Form21p530aPlaceOfBurial do
+        key :type, :object
+        property :cemeteryName, type: :string, example: 'Springfield Veterans Cemetery'
+        property :cemeteryLocation do
+          key :$ref, :Form21p530aCemeteryLocation
+        end
+      end
+
+      swagger_schema :Form21p530aOrganizationAddress do
+        key :type, :object
+        property :street, type: :string, example: '401 Capitol Ave'
+        property :street2, type: :string, example: 'Suite 100'
+        property :city, type: :string, example: 'Springfield'
+        property :state, type: :string, example: 'IL'
+        property :postalCode, type: :string, example: '62701'
+        property :country, type: :string, example: 'USA'
+      end
+
+      swagger_path '/v0/form21p530a' do
+        operation :post do
+          extend Swagger::Responses::SavedForm
+
+          key :description,
+              'Submit a 21P-530a form (Application for Burial Allowance - State/Tribal Organizations)'
+          key :operationId, 'submitForm21p530a'
+          key :tags, %w[benefits_forms]
+
+          parameter do
+            key :name, :form21p530a
+            key :in, :body
+            key :description, 'Form 21P-530a submission data'
+            key :required, true
+
+            schema do
+              key :type, :object
+
+              property :veteranFullName do
+                key :$ref, :Form21p530aFullName
+                key :required, %i[first last]
+              end
+              property :veteranSocialSecurityNumber, type: :string, example: '123456789'
+              property :veteranServiceNumber, type: :string, example: 'RA12345678'
+              property :vaFileNumber, type: :string, example: '987654321'
+              property :veteranDateOfBirth, type: :string, format: :date, example: '1940-05-15'
+              property :placeOfBirth do
+                key :$ref, :Form21p530aPlaceOfBirth
+              end
+              property :deathDate, type: :string, format: :date, example: '2023-12-01'
+
+              property :servicePeriods do
+                key :type, :array
+                items do
+                  key :$ref, :Form21p530aServicePeriod
+                end
+              end
+
+              property :serviceUnderOtherName do
+                key :$ref, :Form21p530aServiceUnderOtherName
+              end
+
+              property :cemeteryOrganizationName,
+                       type: :string,
+                       example: 'Illinois Department of Veterans Affairs'
+              property :placeOfBurial do
+                key :$ref, :Form21p530aPlaceOfBurial
+              end
+              property :burialDate, type: :string, format: :date, example: '2023-12-05'
+              property :recipientOrganizationName,
+                       type: :string,
+                       example: 'Illinois Department of Veterans Affairs'
+              property :recipientOrganizationPhoneNumber, type: :string, example: '217-555-0123'
+              property :recipientOrganizationContactEmail, type: :string, example: 'burials@illinois.gov'
+              property :recipientOrganizationAddress do
+                key :$ref, :Form21p530aOrganizationAddress
+              end
+              property :certificationSignature, type: :string, example: 'Jane Smith'
+              property :certificationTitle, type: :string, example: 'Cemetery Director'
+              property :certificationDate, type: :string, format: :date, example: '2024-01-15'
+              property :remarks, type: :string, example: 'Veteran served honorably during Vietnam War'
+            end
+          end
+
+          response 200 do
+            key :description, 'Form successfully submitted'
+            schema do
+              key :$ref, :SavedForm
+            end
+          end
+        end
+      end
+
+      swagger_path '/v0/form21p530a/download_pdf' do
+        operation :get do
+          key :description, 'Download a pre-filled 21P-530a PDF form'
+          key :operationId, 'downloadForm21p530aPdf'
+          key :tags, %w[benefits_forms]
+          key :produces, ['application/pdf']
+
+          parameter do
+            key :name, :form
+            key :in, :query
+            key :description, 'Form data for PDF generation (JSON string)'
+            key :required, true
+            key :type, :string
+          end
+
+          response 200 do
+            key :description, 'PDF file download'
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,12 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :form21p530a, only: [:create] do
+      collection do
+        get :download_pdf
+      end
+    end
+
     get 'form1095_bs/download_pdf/:tax_year', to: 'form1095_bs#download_pdf'
     get 'form1095_bs/download_txt/:tax_year', to: 'form1095_bs#download_txt'
     get 'form1095_bs/available_forms', to: 'form1095_bs#available_forms'

--- a/spec/controllers/v0/form21p530a_controller_spec.rb
+++ b/spec/controllers/v0/form21p530a_controller_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe V0::Form21p530aController, type: :controller do
+  describe 'POST #create' do
+    it 'returns expected response structure' do
+      form_data = {
+        veteranFullName: { first: 'John', last: 'Doe' },
+        veteranSocialSecurityNumber: '123456789',
+        deathDate: '2023-12-01',
+        cemeteryOrganizationName: 'Illinois Department of Veterans Affairs'
+      }
+
+      post(:create, params: { form21p530a: form_data })
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      expect(json['data']['type']).to eq('saved_claims')
+      expect(json['data']['attributes']['form']).to eq('21P-530a')
+      expect(json['data']['attributes']['confirmation_number']).to be_present
+      expect(json['data']['attributes']['submitted_at']).to be_present
+      expect(json['data']['attributes']['guid']).to be_present
+      expect(json['data']['attributes']['regional_office']).to include('Pension Management Center')
+    end
+
+    it 'returns a unique confirmation number for each request' do
+      form_data = {
+        veteranFullName: { first: 'John', last: 'Doe' },
+        cemeteryOrganizationName: 'Illinois Department of Veterans Affairs'
+      }
+
+      post(:create, params: { form21p530a: form_data })
+      first_confirmation = JSON.parse(response.body)['data']['attributes']['confirmation_number']
+
+      post(:create, params: { form21p530a: form_data })
+      second_confirmation = JSON.parse(response.body)['data']['attributes']['confirmation_number']
+
+      expect(first_confirmation).not_to eq(second_confirmation)
+    end
+
+    it 'returns a valid UUID as confirmation number' do
+      form_data = {
+        veteranFullName: { first: 'John', last: 'Doe' },
+        cemeteryOrganizationName: 'Illinois Department of Veterans Affairs'
+      }
+
+      post(:create, params: { form21p530a: form_data })
+
+      json = JSON.parse(response.body)
+      confirmation = json['data']['attributes']['confirmation_number']
+
+      expect(confirmation).to be_a_uuid
+    end
+
+    it 'returns ISO 8601 formatted timestamp' do
+      form_data = {
+        veteranFullName: { first: 'John', last: 'Doe' },
+        cemeteryOrganizationName: 'Illinois Department of Veterans Affairs'
+      }
+
+      post(:create, params: { form21p530a: form_data })
+
+      json = JSON.parse(response.body)
+      submitted_at = json['data']['attributes']['submitted_at']
+
+      expect { DateTime.iso8601(submitted_at) }.not_to raise_error
+    end
+
+    it 'does not require authentication' do
+      form_data = {
+        veteranFullName: { first: 'John', last: 'Doe' },
+        cemeteryOrganizationName: 'Illinois Department of Veterans Affairs'
+      }
+
+      # Post without signing in
+      post(:create, params: { form21p530a: form_data })
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'GET #download_pdf' do
+    it 'returns stub message' do
+      get(:download_pdf, params: { form: '{}' })
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      expect(json['message']).to eq('PDF download stub - not yet implemented')
+    end
+
+    it 'does not require authentication' do
+      get(:download_pdf, params: { form: '{}' })
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/swagger_spec.rb
+++ b/spec/requests/swagger_spec.rb
@@ -2457,6 +2457,81 @@ RSpec.describe 'the v0 API documentation', order: :defined, type: %i[apivore req
       end
     end
 
+    describe 'Form 21P-530a' do
+      context 'submitting a 21P-530a form' do
+        let(:valid_form_data) do
+          {
+            form21p530a: {
+              veteranFullName: {
+                first: 'John',
+                middle: 'M',
+                last: 'Doe',
+                suffix: 'Jr'
+              },
+              veteranSocialSecurityNumber: '123456789',
+              veteranServiceNumber: 'RA12345678',
+              vaFileNumber: '987654321',
+              veteranDateOfBirth: '1940-05-15',
+              placeOfBirth: {
+                city: 'Springfield',
+                state: 'IL',
+                country: 'USA'
+              },
+              deathDate: '2023-12-01',
+              servicePeriods: [
+                {
+                  serviceBranch: 'Army',
+                  dateEnteredService: '1960-01-15',
+                  placeEnteredService: 'Fort Benning, GA',
+                  rankAtSeparation: 'E-5',
+                  dateLeftService: '1965-12-31',
+                  placeLeftService: 'Fort Hood, TX'
+                }
+              ],
+              serviceUnderOtherName: {
+                used: false
+              },
+              cemeteryOrganizationName: 'Illinois Department of Veterans Affairs',
+              placeOfBurial: {
+                cemeteryName: 'Springfield Veterans Cemetery',
+                cemeteryLocation: {
+                  street: '1000 Memorial Drive',
+                  city: 'Springfield',
+                  state: 'IL',
+                  postalCode: '62701'
+                }
+              },
+              burialDate: '2023-12-05',
+              recipientOrganizationName: 'Illinois Department of Veterans Affairs',
+              recipientOrganizationPhoneNumber: '217-555-0123',
+              recipientOrganizationContactEmail: 'burials@illinois.gov',
+              recipientOrganizationAddress: {
+                street: '401 Capitol Ave',
+                street2: 'Suite 100',
+                city: 'Springfield',
+                state: 'IL',
+                postalCode: '62701',
+                country: 'USA'
+              },
+              certificationSignature: 'Jane Smith',
+              certificationTitle: 'Cemetery Director',
+              certificationDate: '2024-01-15',
+              remarks: 'Veteran served honorably during Vietnam War'
+            }
+          }
+        end
+
+        it 'successfully submits a 21P-530a form' do
+          expect(subject).to validate(
+            :post,
+            '/v0/form21p530a',
+            200,
+            '_data' => valid_form_data
+          )
+        end
+      end
+    end
+
     describe '1095-B' do
       let(:user) { build(:user, :loa3, icn: '3456787654324567') }
       let(:headers) { { '_headers' => { 'Cookie' => sign_in(user, nil, true) } } }
@@ -3296,6 +3371,7 @@ RSpec.describe 'the v0 API documentation', order: :defined, type: %i[apivore req
       subject.untested_mappings.delete('/v0/coe/document_download/{id}')
       subject.untested_mappings.delete('/v0/caregivers_assistance_claims/download_pdf')
       subject.untested_mappings.delete('/v0/health_care_applications/download_pdf')
+      subject.untested_mappings.delete('/v0/form21p530a/download_pdf')
       subject.untested_mappings.delete('/v0/form0969')
       subject.untested_mappings.delete('/v0/form210779/download_pdf')
       subject.untested_mappings.delete('/travel_pay/v0/claims/{claimId}/documents/{docId}')


### PR DESCRIPTION
## Summary

- **This work is behind a feature toggle (flipper): NO** (Phase 0 stub implementation)
- This PR implements **Phase 0 (stub implementation) for VA Form 21P-530a** ("State Application for Interment Allowance Under 38 U.S.C. Chapter 23"). This stub creates functional API endpoints that return mock responses, enabling the frontend team to begin parallel development while the full backend implementation is completed in subsequent phases.
- **What was implemented:**
  - Stub controller with `create` and `download_pdf` actions that return expected response structures
  - Routes for `POST /v0/form21p530a` and `GET /v0/form21p530a/download_pdf`
  - Swagger API documentation defining the complete schema for the form
  - Basic controller tests validating response structure
  - CODEOWNERS entries for all new files
- **Why this approach:** Phase 0 allows frontend development to proceed immediately without waiting for the full backend infrastructure (SavedClaim model, validators, PDF generation, Lighthouse integration) to be built. The stub returns properly formatted responses that match what the real implementation will provide.
- **Team:** Benefits Optimization Aquia (@department-of-veterans-affairs/benefits-optimization-aquia) - This team will own maintenance of this form integration
- **Form details:**
  - **Purpose:** Form 21P-530a is completed by state or tribal cemetery officials (not veterans) to apply for burial allowances for eligible veterans buried in state veterans' cemeteries or on tribal trust land
  - **Authentication:** Public access (no authentication required) - cemetery officials can submit via public link
  - **Business Line:** Pension Management Center (PMC)
  - **Submission:** Will ultimately route to VBMS via Lighthouse Benefits Intake API (in later phases)
  - **Notable:** Supports multiple service periods as veterans may have served in different branches

## Related issue(s)

[Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/120092)

## Testing done

- [x] **New code is covered by unit tests**
- **Old behavior:** No endpoints existed for Form 21P-530a
- **New behavior:** 
  - `POST /v0/form21p530a` returns a properly structured mock response including:
    - Generated UUID confirmation number
    - Current timestamp
    - Pension Management Center regional office address
    - Form type identifier (`21P-530a`)
  - `GET /v0/form21p530a/download_pdf` returns stub message
  - Both endpoints are publicly accessible (no authentication required)
- **Verification steps:**
  1. Run specs: `bundle exec rspec spec/controllers/v0/form21p530a_controller_spec.rb`
  2. Verify all tests pass
  3. Check Swagger documentation is accessible and properly formatted
  4. Manual test: Send POST request to `/v0/form21p530a` with form data - should return 200 with proper structure
  5. Verify no authentication is required for endpoint access
- **Swagger validation:**
  - Navigate to `/api-docs` and verify Form 21P-530a endpoints appear
  - Confirm schema includes all required fields (veteran info, service periods array, cemetery organization, recipient organization, certification)
  - Validate example requests/responses are clear

## What areas of the site does it impact?

- **New functionality** - adds new public API endpoints under `/v0/form21p530a`
- No impact on existing functionality
- Enables frontend development for state/tribal cemetery officials to submit burial allowance applications

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable)
- [x] No error nor warning in the console
- [x] Events are being sent to the appropriate logging solution
- [x] Documentation has been updated (Swagger docs added)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Feature/bug has a monitor built into Datadog (will be added in later phases for production implementation)
- [x] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected (N/A - public endpoints, no authentication)
- [ ] I added a screenshot of the developed feature (N/A - API endpoints)

## Requested Feedback

**Important notes for reviewers:**
- This is a **stub implementation only** (Phase 0). The full implementation with SavedClaim model, validators, PDF generation, and Lighthouse integration will come in subsequent phases.
- The stub controller will be completely replaced in Phase 1 - this is intentional and documented in code comments.
- Primary goal is to unblock frontend development with properly structured mock responses.
- Please verify the response structure matches expectations for the SavedClaim pattern used elsewhere in vets-api.
- Confirm Swagger documentation is clear and includes example showing multiple service periods (veterans can have multiple periods of active duty).