### PR TITLE
[Claims-API-43968] Remove Flipper Special-issues-Updater-Uses-Local-Bgs

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -395,10 +395,6 @@ features:
     actor_type: user
     description: Enables users to access the claim letters page
     enable_in_development: true
-  claims_api_special_issues_updater_uses_local_bgs:
-    actor_type: user
-    description: Enables special issues updater to use local_bgs
-    enable_in_development: true
   claims_api_flash_updater_uses_local_bgs:
     actor_type: user
     description: Enables flash updater to use local_bgs

--- a/modules/claims_api/app/sidekiq/claims_api/special_issue_updater.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/special_issue_updater.rb
@@ -17,11 +17,7 @@ module ClaimsApi
 
       contention_id.symbolize_keys!
       validate_contention_id_structure(contention_id)
-      service = if Flipper.enabled?(:claims_api_special_issues_updater_uses_local_bgs)
-                  contention_service(user)
-                else
-                  bgs_ext_service(user).contention
-                end
+      service = contention_service(user)
 
       claims = service.find_contentions_by_ptcpnt_id(user['participant_id'])[:benefit_claims] || []
       claim = claim_from_contention_id(claims, contention_id)

--- a/modules/claims_api/spec/sidekiq/special_issue_updater_spec.rb
+++ b/modules/claims_api/spec/sidekiq/special_issue_updater_spec.rb
@@ -6,321 +6,314 @@ require 'bgs_service/contention_service'
 RSpec.describe ClaimsApi::SpecialIssueUpdater, type: :job do
   subject { described_class }
 
-  [true, false].each do |flipped|
-    before do
-      allow(Flipper).to receive(:enabled?).with(:claims_api_special_issues_updater_uses_local_bgs).and_return(flipped)
-      Sidekiq::Job.clear_all
-      @clazz = if flipped
-                 ClaimsApi::ContentionService
-               else
-                 BGS::ContentionService
-               end
-    end
+  before do
+    Sidekiq::Job.clear_all
+    @clazz = ClaimsApi::ContentionService
+  end
 
-    let(:user) do
-      user_mock = create(:evss_user, :loa3)
-      {
-        'ssn' => user_mock.ssn
-      }
-    end
-    let(:contention_id) { { claim_id: '123', code: '200', name: 'contention-name-here' } }
-    let(:claim_record) { create(:auto_established_claim, :special_issues) }
-    let(:special_issues) { claim_record.special_issues }
+  let(:user) do
+    user_mock = create(:evss_user, :loa3)
+    {
+      'ssn' => user_mock.ssn
+    }
+  end
+  let(:contention_id) { { claim_id: '123', code: '200', name: 'contention-name-here' } }
+  let(:claim_record) { create(:auto_established_claim, :special_issues) }
+  let(:special_issues) { claim_record.special_issues }
 
-    it 'submits successfully' do
+  it 'submits successfully' do
+    expect do
+      subject.perform_async(contention_id, special_issues, claim_record.id)
+    end.to change(subject.jobs, :size).by(1)
+  end
+
+  context 'when no matching claim is found' do
+    let(:claims) { { benefit_claims: [] } }
+
+    it 'job fails and retries later' do
+      expect_any_instance_of(@clazz).to receive(:find_contentions_by_ptcpnt_id)
+        .and_return(claims)
+
       expect do
-        subject.perform_async(contention_id, special_issues, claim_record.id)
-      end.to change(subject.jobs, :size).by(1)
+        subject.new.perform(contention_id, special_issues, claim_record.id)
+      end.to raise_error(StandardError)
+    end
+  end
+
+  context 'when a matching claim is found using' do
+    before do
+      expect_any_instance_of(@clazz).to receive(:find_contentions_by_ptcpnt_id)
+        .and_return(claims)
     end
 
-    context 'when no matching claim is found' do
-      let(:claims) { { benefit_claims: [] } }
+    context 'when no matching contention is found' do
+      let(:claims) do
+        {
+          benefit_claims: [
+            {
+              contentions: [
+                { clm_id: '321', clsfcn_id: '333', clmnt_txt: 'different-name-here' }
+              ]
+            }
+          ]
+        }
+      end
 
       it 'job fails and retries later' do
-        expect_any_instance_of(@clazz).to receive(:find_contentions_by_ptcpnt_id)
-          .and_return(claims)
-
         expect do
           subject.new.perform(contention_id, special_issues, claim_record.id)
         end.to raise_error(StandardError)
       end
     end
 
-    context 'when a matching claim is found using' do
-      before do
-        expect_any_instance_of(@clazz).to receive(:find_contentions_by_ptcpnt_id)
-          .and_return(claims)
-      end
-
-      context 'when no matching contention is found' do
-        let(:claims) do
-          {
-            benefit_claims: [
-              {
-                contentions: [
-                  { clm_id: '321', clsfcn_id: '333', clmnt_txt: 'different-name-here' }
-                ]
-              }
-            ]
-          }
-        end
-
-        it 'job fails and retries later' do
-          expect do
-            subject.new.perform(contention_id, special_issues, claim_record.id)
-          end.to raise_error(StandardError)
-        end
-      end
-
-      context 'when a matching contention is found' do
-        context 'when contention does not have existing special issues' do
-          context 'when multiple contentions exist for claim' do
-            let(:claim_id) { '600200323' }
-            let(:claim) do
-              {
-                jrn_dt: '2020-08-17T10:44:43-05:00',
-                bnft_clm_tc: '130DPNEBNADJ',
-                bnft_clm_tn: 'eBenefits Dependency Adjustment',
-                claim_rcvd_dt: '2020-08-17T00:00:00-05:00',
-                clm_id: claim_id,
-                contentions: [
-                  {
-                    clm_id: contention_id[:claim_id],
-                    cntntn_id: '999111',
-                    clsfcn_id: contention_id[:code],
-                    clmnt_txt: contention_id[:name]
-                  },
-                  {
-                    clm_id: '321',
-                    cntntn_id: '123456',
-                    clsfcn_id: '333',
-                    clmnt_txt: 'different-name-here'
-                  }
-                ],
-                lc_stt_rsn_tc: 'OPEN',
-                lc_stt_rsn_tn: 'Open',
-                lctn_id: '322',
-                non_med_clm_desc: 'eBenefits Dependency Adjustment',
-                prirty: '0',
-                ptcpnt_id_clmnt: '600036156',
-                ptcpnt_id_vet: '600036156',
-                ptcpnt_suspns_id: '600276939',
-                soj_lctn_id: '347'
-              }
-            end
-            let(:claims) { { benefit_claims: [claim] } }
-
-            it 'all special issues provided are appended to payload' do
-              expected_claim_options = claim.dup
-              special_issues_payload = special_issues.map { |si| { spis_tc: si } }
-              expected_claim_options[:contentions] = [
-                { clm_id: claim_id, cntntn_id: '999111', special_issues: special_issues_payload },
-                { clm_id: claim_id, cntntn_id: '123456', special_issues: [] }
-              ]
-              expect_any_instance_of(@clazz)
-                .to receive(:manage_contentions).with(expected_claim_options)
-
-              subject.new.perform(contention_id, special_issues, claim_record.id)
-            end
-
-            it 'stores bgs exceptions correctly' do
-              expect_any_instance_of(@clazz).to receive(:manage_contentions)
-                .and_raise(BGS::ShareError.new('failed', 500))
-
-              subject.new.perform(contention_id, special_issues, claim_record.id)
-              expect(ClaimsApi::AutoEstablishedClaim.find(claim_record.id).bgs_special_issue_responses.count).to eq(1)
-            end
-          end
-
-          context 'when a single contention exists for claim' do
-            let(:claim_id) { '600200323' }
-            let(:claim) do
-              {
-                jrn_dt: '2020-08-17T10:44:43-05:00',
-                bnft_clm_tc: '130DPNEBNADJ',
-                bnft_clm_tn: 'eBenefits Dependency Adjustment',
-                claim_rcvd_dt: '2020-08-17T00:00:00-05:00',
-                clm_id: claim_id,
-                contentions: {
+    context 'when a matching contention is found' do
+      context 'when contention does not have existing special issues' do
+        context 'when multiple contentions exist for claim' do
+          let(:claim_id) { '600200323' }
+          let(:claim) do
+            {
+              jrn_dt: '2020-08-17T10:44:43-05:00',
+              bnft_clm_tc: '130DPNEBNADJ',
+              bnft_clm_tn: 'eBenefits Dependency Adjustment',
+              claim_rcvd_dt: '2020-08-17T00:00:00-05:00',
+              clm_id: claim_id,
+              contentions: [
+                {
                   clm_id: contention_id[:claim_id],
                   cntntn_id: '999111',
                   clsfcn_id: contention_id[:code],
                   clmnt_txt: contention_id[:name]
                 },
-                lc_stt_rsn_tc: 'OPEN',
-                lc_stt_rsn_tn: 'Open',
-                lctn_id: '322',
-                non_med_clm_desc: 'eBenefits Dependency Adjustment',
-                prirty: '0',
-                ptcpnt_id_clmnt: '600036156',
-                ptcpnt_id_vet: '600036156',
-                ptcpnt_suspns_id: '600276939',
-                soj_lctn_id: '347'
-              }
-            end
-            let(:claims) { { benefit_claims: [claim] } }
+                {
+                  clm_id: '321',
+                  cntntn_id: '123456',
+                  clsfcn_id: '333',
+                  clmnt_txt: 'different-name-here'
+                }
+              ],
+              lc_stt_rsn_tc: 'OPEN',
+              lc_stt_rsn_tn: 'Open',
+              lctn_id: '322',
+              non_med_clm_desc: 'eBenefits Dependency Adjustment',
+              prirty: '0',
+              ptcpnt_id_clmnt: '600036156',
+              ptcpnt_id_vet: '600036156',
+              ptcpnt_suspns_id: '600276939',
+              soj_lctn_id: '347'
+            }
+          end
+          let(:claims) { { benefit_claims: [claim] } }
 
-            it 'all special issues provided are appended to payload' do
-              expected_claim_options = claim.dup
-              special_issues_payload = special_issues.map { |si| { spis_tc: si } }
-              expected_claim_options[:contentions] = [
-                { clm_id: claim_id, cntntn_id: '999111', special_issues: special_issues_payload }
-              ]
-              expect_any_instance_of(@clazz)
-                .to receive(:manage_contentions).with(expected_claim_options)
+          it 'all special issues provided are appended to payload' do
+            expected_claim_options = claim.dup
+            special_issues_payload = special_issues.map { |si| { spis_tc: si } }
+            expected_claim_options[:contentions] = [
+              { clm_id: claim_id, cntntn_id: '999111', special_issues: special_issues_payload },
+              { clm_id: claim_id, cntntn_id: '123456', special_issues: [] }
+            ]
+            expect_any_instance_of(@clazz)
+              .to receive(:manage_contentions).with(expected_claim_options)
 
-              subject.new.perform(contention_id, special_issues, claim_record.id)
-            end
+            subject.new.perform(contention_id, special_issues, claim_record.id)
+          end
+
+          it 'stores bgs exceptions correctly' do
+            expect_any_instance_of(@clazz).to receive(:manage_contentions)
+              .and_raise(BGS::ShareError.new('failed', 500))
+
+            subject.new.perform(contention_id, special_issues, claim_record.id)
+            expect(ClaimsApi::AutoEstablishedClaim.find(claim_record.id).bgs_special_issue_responses.count).to eq(1)
           end
         end
 
-        context 'when contention does have existing special issues' do
-          context 'when one or more special issue provided is new' do
-            let(:claim_id) { '600200323' }
-            let(:claim) do
-              {
-                jrn_dt: '2020-08-17T10:44:43-05:00',
-                bnft_clm_tc: '130DPNEBNADJ',
-                bnft_clm_tn: 'eBenefits Dependency Adjustment',
-                claim_rcvd_dt: '2020-08-17T00:00:00-05:00',
-                clm_id: claim_id,
-                contentions: [
-                  {
-                    clm_id: contention_id[:claim_id],
-                    cntntn_id: '999111',
-                    clsfcn_id: contention_id[:code],
-                    clmnt_txt: contention_id[:name],
-                    special_issues: [{ spis_tc: 'something-else' }, { spis_tc: 'ALS' }]
-                  }
-                ],
-                lc_stt_rsn_tc: 'OPEN',
-                lc_stt_rsn_tn: 'Open',
-                lctn_id: '322',
-                non_med_clm_desc: 'eBenefits Dependency Adjustment',
-                prirty: '0',
-                ptcpnt_id_clmnt: '600036156',
-                ptcpnt_id_vet: '600036156',
-                ptcpnt_suspns_id: '600276939',
-                soj_lctn_id: '347'
-              }
-            end
-            let(:claims) { { benefit_claims: [claim] } }
-
-            it 'new special issues provided are added while preserving existing special issues' do
-              expected_claim_options = claim.dup
-              special_issues_payload =
-                [{ spis_tc: { 'code' => 9999,
-                              'name' => 'PTSD (post traumatic stress disorder)',
-                              'special_issues' => ['FDC', 'PTSD/2'] } },
-                 { spis_tc: 'something-else' },
-                 { spis_tc: 'ALS' }]
-              expected_claim_options[:contentions] = [
-                { clm_id: claim_id, cntntn_id: '999111', special_issues: special_issues_payload }
-              ]
-              expect_any_instance_of(@clazz)
-                .to receive(:manage_contentions).with(expected_claim_options)
-
-              subject.new.perform(contention_id, special_issues, claim_record.id)
-            end
+        context 'when a single contention exists for claim' do
+          let(:claim_id) { '600200323' }
+          let(:claim) do
+            {
+              jrn_dt: '2020-08-17T10:44:43-05:00',
+              bnft_clm_tc: '130DPNEBNADJ',
+              bnft_clm_tn: 'eBenefits Dependency Adjustment',
+              claim_rcvd_dt: '2020-08-17T00:00:00-05:00',
+              clm_id: claim_id,
+              contentions: {
+                clm_id: contention_id[:claim_id],
+                cntntn_id: '999111',
+                clsfcn_id: contention_id[:code],
+                clmnt_txt: contention_id[:name]
+              },
+              lc_stt_rsn_tc: 'OPEN',
+              lc_stt_rsn_tn: 'Open',
+              lctn_id: '322',
+              non_med_clm_desc: 'eBenefits Dependency Adjustment',
+              prirty: '0',
+              ptcpnt_id_clmnt: '600036156',
+              ptcpnt_id_vet: '600036156',
+              ptcpnt_suspns_id: '600276939',
+              soj_lctn_id: '347'
+            }
           end
+          let(:claims) { { benefit_claims: [claim] } }
 
-          context 'when none of the special issues provided is new' do
-            let(:claim_id) { '600200323' }
-            let(:claim) do
-              {
-                jrn_dt: '2020-08-17T10:44:43-05:00',
-                bnft_clm_tc: '130DPNEBNADJ',
-                bnft_clm_tn: 'eBenefits Dependency Adjustment',
-                claim_rcvd_dt: '2020-08-17T00:00:00-05:00',
-                clm_id: claim_id,
-                contentions: [
-                  {
-                    clm_id: contention_id[:claim_id],
-                    cntntn_id: '999111',
-                    clsfcn_id: contention_id[:code],
-                    clmnt_txt: contention_id[:name],
-                    special_issues: special_issues.map { |si| { spis_tc: si } }
-                  }
-                ],
-                lc_stt_rsn_tc: 'OPEN',
-                lc_stt_rsn_tn: 'Open',
-                lctn_id: '322',
-                non_med_clm_desc: 'eBenefits Dependency Adjustment',
-                prirty: '0',
-                ptcpnt_id_clmnt: '600036156',
-                ptcpnt_id_vet: '600036156',
-                ptcpnt_suspns_id: '600276939',
-                soj_lctn_id: '347'
-              }
-            end
-            let(:claims) { { benefit_claims: [claim] } }
+          it 'all special issues provided are appended to payload' do
+            expected_claim_options = claim.dup
+            special_issues_payload = special_issues.map { |si| { spis_tc: si } }
+            expected_claim_options[:contentions] = [
+              { clm_id: claim_id, cntntn_id: '999111', special_issues: special_issues_payload }
+            ]
+            expect_any_instance_of(@clazz)
+              .to receive(:manage_contentions).with(expected_claim_options)
 
-            it 'existing special issues are left unchanged' do
-              expected_claim_options = claim.dup
-              special_issues_payload = special_issues.map { |si| { spis_tc: si } }
-              expected_claim_options[:contentions] = [
-                { clm_id: claim_id, cntntn_id: '999111', special_issues: special_issues_payload }
-              ]
-              expect_any_instance_of(@clazz)
-                .to receive(:manage_contentions).with(expected_claim_options)
+            subject.new.perform(contention_id, special_issues, claim_record.id)
+          end
+        end
+      end
 
-              subject.new.perform(contention_id, special_issues, claim_record.id)
-            end
+      context 'when contention does have existing special issues' do
+        context 'when one or more special issue provided is new' do
+          let(:claim_id) { '600200323' }
+          let(:claim) do
+            {
+              jrn_dt: '2020-08-17T10:44:43-05:00',
+              bnft_clm_tc: '130DPNEBNADJ',
+              bnft_clm_tn: 'eBenefits Dependency Adjustment',
+              claim_rcvd_dt: '2020-08-17T00:00:00-05:00',
+              clm_id: claim_id,
+              contentions: [
+                {
+                  clm_id: contention_id[:claim_id],
+                  cntntn_id: '999111',
+                  clsfcn_id: contention_id[:code],
+                  clmnt_txt: contention_id[:name],
+                  special_issues: [{ spis_tc: 'something-else' }, { spis_tc: 'ALS' }]
+                }
+              ],
+              lc_stt_rsn_tc: 'OPEN',
+              lc_stt_rsn_tn: 'Open',
+              lctn_id: '322',
+              non_med_clm_desc: 'eBenefits Dependency Adjustment',
+              prirty: '0',
+              ptcpnt_id_clmnt: '600036156',
+              ptcpnt_id_vet: '600036156',
+              ptcpnt_suspns_id: '600276939',
+              soj_lctn_id: '347'
+            }
+          end
+          let(:claims) { { benefit_claims: [claim] } }
+
+          it 'new special issues provided are added while preserving existing special issues' do
+            expected_claim_options = claim.dup
+            special_issues_payload =
+              [{ spis_tc: { 'code' => 9999,
+                            'name' => 'PTSD (post traumatic stress disorder)',
+                            'special_issues' => ['FDC', 'PTSD/2'] } },
+               { spis_tc: 'something-else' },
+               { spis_tc: 'ALS' }]
+            expected_claim_options[:contentions] = [
+              { clm_id: claim_id, cntntn_id: '999111', special_issues: special_issues_payload }
+            ]
+            expect_any_instance_of(@clazz)
+              .to receive(:manage_contentions).with(expected_claim_options)
+
+            subject.new.perform(contention_id, special_issues, claim_record.id)
+          end
+        end
+
+        context 'when none of the special issues provided is new' do
+          let(:claim_id) { '600200323' }
+          let(:claim) do
+            {
+              jrn_dt: '2020-08-17T10:44:43-05:00',
+              bnft_clm_tc: '130DPNEBNADJ',
+              bnft_clm_tn: 'eBenefits Dependency Adjustment',
+              claim_rcvd_dt: '2020-08-17T00:00:00-05:00',
+              clm_id: claim_id,
+              contentions: [
+                {
+                  clm_id: contention_id[:claim_id],
+                  cntntn_id: '999111',
+                  clsfcn_id: contention_id[:code],
+                  clmnt_txt: contention_id[:name],
+                  special_issues: special_issues.map { |si| { spis_tc: si } }
+                }
+              ],
+              lc_stt_rsn_tc: 'OPEN',
+              lc_stt_rsn_tn: 'Open',
+              lctn_id: '322',
+              non_med_clm_desc: 'eBenefits Dependency Adjustment',
+              prirty: '0',
+              ptcpnt_id_clmnt: '600036156',
+              ptcpnt_id_vet: '600036156',
+              ptcpnt_suspns_id: '600276939',
+              soj_lctn_id: '347'
+            }
+          end
+          let(:claims) { { benefit_claims: [claim] } }
+
+          it 'existing special issues are left unchanged' do
+            expected_claim_options = claim.dup
+            special_issues_payload = special_issues.map { |si| { spis_tc: si } }
+            expected_claim_options[:contentions] = [
+              { clm_id: claim_id, cntntn_id: '999111', special_issues: special_issues_payload }
+            ]
+            expect_any_instance_of(@clazz)
+              .to receive(:manage_contentions).with(expected_claim_options)
+
+            subject.new.perform(contention_id, special_issues, claim_record.id)
           end
         end
       end
     end
+  end
 
-    describe 'when an errored job has exhausted its retries' do
-      it 'logs to the ClaimsApi Logger' do
-        error_msg = 'An error occurred from the Special Issue Updater Job'
-        msg = { 'args' => ['value here', 'second value here', claim_record.id],
-                'class' => subject,
-                'error_message' => error_msg }
+  describe 'when an errored job has exhausted its retries' do
+    it 'logs to the ClaimsApi Logger' do
+      error_msg = 'An error occurred from the Special Issue Updater Job'
+      msg = { 'args' => ['value here', 'second value here', claim_record.id],
+              'class' => subject,
+              'error_message' => error_msg }
 
-        described_class.within_sidekiq_retries_exhausted_block(msg) do
-          expect(ClaimsApi::Logger).to receive(:log).with(
-            'claims_api_retries_exhausted',
-            claim_id: claim_record.id,
-            detail: "Job retries exhausted for #{subject}",
-            error: error_msg
-          )
-        end
+      described_class.within_sidekiq_retries_exhausted_block(msg) do
+        expect(ClaimsApi::Logger).to receive(:log).with(
+          'claims_api_retries_exhausted',
+          claim_id: claim_record.id,
+          detail: "Job retries exhausted for #{subject}",
+          error: error_msg
+        )
+      end
+    end
+  end
+
+  describe '#existing_special_issues' do
+    let(:contention) do
+      {
+        call_id: '17', special_issues: {
+          call_id: '17', spis_tc: 'VDC'
+        }
+      }
+    end
+
+    let(:contention_w_multiple_issues) do
+      {
+        call_id: '17', special_issues: [
+          { call_id: '17', spis_tc: 'VDC' },
+          { call_id: '17', spis_tc: 'ABC' }
+        ]
+      }
+    end
+
+    let(:special_issues) { [] }
+
+    context 'with a single contention object' do
+      it 'returns the expected mapping' do
+        res = subject.new.existing_special_issues(contention, special_issues)
+        expect(res).to eq([{ spis_tc: 'VDC' }])
       end
     end
 
-    describe '#existing_special_issues' do
-      let(:contention) do
-        {
-          call_id: '17', special_issues: {
-            call_id: '17', spis_tc: 'VDC'
-          }
-        }
-      end
-
-      let(:contention_w_multiple_issues) do
-        {
-          call_id: '17', special_issues: [
-            { call_id: '17', spis_tc: 'VDC' },
-            { call_id: '17', spis_tc: 'ABC' }
-          ]
-        }
-      end
-
-      let(:special_issues) { [] }
-
-      context 'with a single contention object' do
-        it 'returns the expected mapping' do
-          res = subject.new.existing_special_issues(contention, special_issues)
-          expect(res).to eq([{ spis_tc: 'VDC' }])
-        end
-      end
-
-      context 'with an array contention objects' do
-        it 'returns the expected mapping' do
-          res = subject.new.existing_special_issues(contention_w_multiple_issues, special_issues)
-          expect(res).to match([{ spis_tc: 'VDC' }, { spis_tc: 'ABC' }])
-        end
+    context 'with an array contention objects' do
+      it 'returns the expected mapping' do
+        res = subject.new.existing_special_issues(contention_w_multiple_issues, special_issues)
+        expect(res).to match([{ spis_tc: 'VDC' }, { spis_tc: 'ABC' }])
       end
     end
   end


### PR DESCRIPTION
## Summary

- After successful transition to BD for uploading POA submissions, remove the `**claims_api_special_issues_updater_uses_local_bgs**` feature flag.


## Related issue(s)
[jira-43968](https://jira.devops.va.gov/browse/API-43968)

## Testing done

- Removed specs related to the flipper

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

- config/features.yml
- modules/claims_api/app/sidekiq/claims_api/special_issue_updater.rb
- modules/claims_api/spec/sidekiq/special_issue_updater_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

**OTHER: Making sub-task for removing the flipper from the environments
