### PR TITLE
RES/ch31 eligibility maintenance windows

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -865,6 +865,7 @@ maintenance:
     vetext_vaccine: <%= ENV['maintenance__services__vetext_vaccine'] %>
     vic: <%= ENV['maintenance__services__vic'] %>
     vre: <%= ENV['maintenance__services__vre'] %>
+    vre_ch31_eligibility: <%= ENV['maintenance__services__vre_ch31_eligibility'] %>
 mcp:
   notifications:
     batch_size: 10

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -873,6 +873,7 @@ maintenance:
     vetext_vaccine: P9PG8HG
     vic: P7LW3MS
     vre: ~
+    vre_ch31_eligibility: ~
 mcp:
   notifications:
     batch_size: 10

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -872,6 +872,7 @@ maintenance:
     vetext_vaccine: P9PG8HG
     vic: P7LW3MS
     vre: ~
+    vre_ch31_eligibility: ~
 mcp:
   notifications:
     batch_size: 100


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- *(Summarize the changes that have been made to the platform)* Adding pager duty services for RES Ch31 Eligibility to list of maintenance windows. Necessary env vars have been added to param store
- *(Which team do you work for, does your team own the maintenance of this component?)*: RES, yes

## Related issue(s)

- https://jira.devops.va.gov/browse/RES-17097