### PR TITLE
RES/fix-ch31-form-mock

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1177,9 +1177,9 @@ reports:
 res:
   api_key: <%= ENV['res__api_key'] %>
   base_url: <%= ENV['res__base_url'] %>
-  mock_ch_31: <%= ENV['res__mock_ch31'] %>
   ch_31_eligibility:
     mock: <%= ENV['res__ch_31_eligibility__mock']%>
+  mock_ch_31: <%= ENV['res__mock_ch31'] %>
 review_instance_slug: <%= ENV['review_instance_slug'] %>
 rrd:
   alerts:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1178,6 +1178,8 @@ res:
   api_key: <%= ENV['res__api_key'] %>
   base_url: <%= ENV['res__base_url'] %>
   mock_ch_31: <%= ENV['res__mock_ch31'] %>
+  ch_31_eligibility:
+    mock: <%= ENV['res__ch_31_eligibility__mock']%>
 review_instance_slug: <%= ENV['review_instance_slug'] %>
 rrd:
   alerts:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1194,6 +1194,8 @@ res:
   api_key: ~
   base_url: https://fake_url.com
   mock_ch_31: ~
+  ch_31_eligibility:
+    mock: ~
 review_instance_slug: ~
 rrd:
   alerts:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1193,9 +1193,9 @@ reports:
 res:
   api_key: ~
   base_url: https://fake_url.com
-  mock_ch_31: ~
   ch_31_eligibility:
     mock: ~
+  mock_ch_31: ~
 review_instance_slug: ~
 rrd:
   alerts:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1192,9 +1192,9 @@ reports:
 res:
   api_key: fake_auth
   base_url: https://fake_url.com
-  mock_ch_31: ~
   ch_31_eligibility:
     mock: ~
+  mock_ch_31: ~
 review_instance_slug: ~
 rrd:
   alerts:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1193,6 +1193,8 @@ res:
   api_key: fake_auth
   base_url: https://fake_url.com
   mock_ch_31: ~
+  ch_31_eligibility:
+    mock: ~
 review_instance_slug: ~
 rrd:
   alerts:

--- a/modules/vre/app/services/vre/ch31_eligibility/configuration.rb
+++ b/modules/vre/app/services/vre/ch31_eligibility/configuration.rb
@@ -17,6 +17,12 @@ module VRE
       def service_name
         'RES_CH31_ELIGIBILITY'
       end
+
+      private
+
+      def mock_enabled?
+        Settings.res.ch_31_eligibility.mock || false
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- *(Summarize the changes that have been made to the platform)* New ch 31 eligibility status request has been added to vre module in addition to the ch 31 form. Separating mock setting for each feature to avoid collision.
- *(If bug, how to reproduce)* Enabling for one could break the other if no mock responses exist
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)* RES, yes