### PR TITLE
Reset needs_kms_rotation after rotation

### DIFF
--- a/app/sidekiq/kms_key_rotation/rotate_keys_job.rb
+++ b/app/sidekiq/kms_key_rotation/rotate_keys_job.rb
@@ -11,9 +11,14 @@ module KmsKeyRotation
       records = GlobalID::Locator.locate_many gids
 
       records.each do |r|
+        original_key = r.encrypted_kms_key
         r.rotate_kms_key!
+        rotated_key = r.encrypted_kms_key
+
         # rubocop is disabled because the updated_at field MUST stay the same
-        r.update_column('needs_kms_rotation', false) # rubocop:disable Rails/SkipsModelValidations
+        # rubocop:disable Rails/SkipsModelValidations
+        r.update_column('needs_kms_rotation', false) unless original_key == rotated_key
+        # rubocop:enable Rails/SkipsModelValidations
       rescue => e
         Rails.logger.error("Error rotating record (id: #{r.to_global_id}): #{e.message}")
       end


### PR DESCRIPTION
## Summary

- `KmsKeyRotation` jobs are run with records based on `needs_kms_rotation` 
- `needs_kms_rotation` was not reset (back to false) after rotation
- This resets each individual record after key rotation
- the `updated_at` field must remain the same
- Rails/SkipsModelValidations is disabled because the updated_at field MUST stay the same

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122492

## Testing done

- [x] manual testing
 
``` 
# before 
<AppealSubmission id: 1, updated_at: "2025-10-17 12:23:45.023177000 +0000", encrypted_kms_key: "v2025:insecure+data+A6WFRyNmx1eG9hU0ZOTld0V1VBS1pk...", needs_kms_rotation: true>

 # after
<AppealSubmission id: 1, updated_at: "2025-10-17 12:23:45.023177000 +0000", encrypted_kms_key: "v2025:insecure+data+A6MzQzalNrV2NvV0prUUszMGFrV1ZI...", needs_kms_rotation: false>
```

## Acceptance criteria

- [x] Record's `needs_kms_rotation` field is reset to false after key rotation
- [x] Record's `updated_at` doesn't change
- [x] `KmsKeyRotation::RotateKeysJob` doesn't rotates a thousands of keys tomorrow
