### PR TITLE
[BIO] 21-4192 PR1 Fix exception handling and serializer type for saved claims

### DIFF
--- a/app/controllers/concerns/exception_handling.rb
+++ b/app/controllers/concerns/exception_handling.rb
@@ -39,8 +39,9 @@ module ExceptionHandling
         when ActionController::InvalidAuthenticityToken
           Common::Exceptions::Forbidden.new(detail: 'Invalid Authenticity Token')
         when Common::Exceptions::TokenValidationError,
-            Common::Exceptions::BaseError, JsonSchema::JsonApiMissingAttribute,
-          Common::Exceptions::ServiceUnavailable, Common::Exceptions::BadGateway
+          Common::Exceptions::BaseError, JsonSchema::JsonApiMissingAttribute,
+          Common::Exceptions::ServiceUnavailable, Common::Exceptions::BadGateway,
+          Common::Exceptions::RoutingError
           exception
         when ActionController::ParameterMissing
           Common::Exceptions::ParameterMissing.new(exception.param)

--- a/app/serializers/saved_claim_serializer.rb
+++ b/app/serializers/saved_claim_serializer.rb
@@ -3,6 +3,8 @@
 class SavedClaimSerializer
   include JSONAPI::Serializer
 
+  set_type :saved_claims
+
   attributes :submitted_at, :regional_office, :confirmation_number, :guid
 
   attribute :form, &:form_id


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- **This work is behind a feature toggle (flipper): NO**
- This PR fixes two bugs in shared components that improve error handling and API response consistency across the application:
  1. **Exception Handling Bug**: `Common::Exceptions::RoutingError` was being converted to `InternalServerError` (500 status) instead of returning the intended 404 status. This occurred because `RoutingError` wasn't explicitly handled in the `ExceptionHandling` concern's case statement, causing it to fall through to the `else` clause.
  2. **Serializer Type Bug**: `SavedClaimSerializer` was using automatic type inference (singular "saved_claim") instead of the expected plural form ("saved_claims") per JSON:API conventions.
- **Solution**: 
  1. Added `Common::Exceptions::RoutingError` to the case statement in `app/controllers/concerns/exception_handling.rb` to ensure it's passed through unchanged and returns 404.
  2. Added `set_type :saved_claims` to `SavedClaimSerializer` to explicitly define the JSON:API resource type as plural.
- **Team**: Benefits Intake Optimization team. These are shared components used across the platform.
- **Impact**: These fixes restore intended behavior and improve consistency. No breaking changes - existing tests already expected 404 for routing errors and plural types for saved claims.

## Related issue(s)

- Part of Form 21-4192 implementation work
- These bug fixes were discovered during Form 21-4192 testing and are required for proper error handling

## Testing done

- [x] **New code is covered by unit tests** - Existing tests verify the correct behavior
- **Old behavior**: 
  - `Common::Exceptions::RoutingError` returned 500 status instead of 404
  - `SavedClaimSerializer` returned `type: "saved_claim"` (singular) instead of `type: "saved_claims"` (plural)
- **New behavior**: 
  - `Common::Exceptions::RoutingError` now correctly returns 404 status
  - `SavedClaimSerializer` now returns `type: "saved_claims"` (plural) per JSON:API conventions
- **Verification steps**:
  1. Run existing controller specs that test routing errors - they now pass with 404 status
  2. Run existing serializer specs that test saved claim responses - they now pass with plural type
  3. All linting and CI checks pass
- **No flipper involved** - these are direct bug fixes to shared components

## Screenshots
_Not applicable - backend bug fixes_

## What areas of the site does it impact?

- **Exception Handling**: Affects all controllers that raise `Common::Exceptions::RoutingError` (primarily feature flag checks)
- **Serializer**: Affects all API responses that serialize `SavedClaim` objects (various form submission endpoints)
- **Scope**: These are shared components, but the changes restore intended behavior rather than introducing new functionality

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution
- [x] Documentation has been updated (link to documentation) - _N/A for bug fixes_
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Feature/bug has a monitor built into Datadog (if applicable) - _N/A for bug fixes_
- [x] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x] I added a screenshot of the developed feature - _N/A for backend bug fixes_

## Requested Feedback

These are bug fixes discovered during Form 21-4192 implementation. They affect shared components but restore intended behavior:

1. **RoutingError fix**: The system was already designed to return 404 for routing errors (defined in `config/locales/exceptions.en.yml`), but a bug was causing 500 instead. This fix aligns implementation with design.

2. **Serializer fix**: JSON:API best practices recommend plural resource types. Other serializers in the codebase use explicit `set_type` to ensure correct pluralization.

Both changes have minimal risk as they restore expected behavior that existing tests were already written to verify.

**Related PRs**: This is part 1 of 4 PRs for Form 21-4192:
- PR1 (this): Bug fixes for shared components (~10 lines)
- PR2: Form 21-4192 model and validator (~336 lines)
- PR3: Form 21-4192 PDF generation (~629 lines)
- PR4: Form 21-4192 controller and feature flag (~321 lines)