### PR TITLE
Enhance BenefitsClaimsController to filter evidence submissions that are already in supporting documents.

### DIFF
--- a/spec/controllers/v0/benefits_claims_controller_spec.rb
+++ b/spec/controllers/v0/benefits_claims_controller_spec.rb
@@ -768,4 +768,240 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
       end
     end
   end
+
+  describe 'duplicate prevention integration tests' do
+    let(:claim_id) { 600_383_363 }
+
+    context 'when :cst_show_document_upload_status is enabled' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(
+          :cst_show_document_upload_status,
+          instance_of(User)
+        ).and_return(true)
+      end
+
+      context 'when evidence submission exists without duplicates' do
+        let(:tracked_item_id) { 394_443 } # This is a tracked item in the VCR cassette
+        let(:file_name) { 'unique_document.pdf' }
+
+        before do
+          # Create an evidence submission that should appear in "files in progress"
+          create(:bd_evidence_submission_pending,
+                 claim_id:,
+                 tracked_item_id:,
+                 user_account:,
+                 template_metadata: {
+                   personalisation: {
+                     file_name:,
+                     document_type: 'Medical Record'
+                   }
+                 }.to_json)
+        end
+
+        it 'includes the evidence submission in the response' do
+          VCR.use_cassette('lighthouse/benefits_claims/show/200_response') do
+            get(:show, params: { id: claim_id })
+          end
+
+          expect(response).to have_http_status(:ok)
+          parsed_body = JSON.parse(response.body)
+          evidence_submissions = parsed_body.dig('data', 'attributes', 'evidenceSubmissions')
+
+          # The evidence submission should be included because no duplicate exists in VCR cassette
+          expect(evidence_submissions.size).to eq(1)
+          expect(evidence_submissions[0]['file_name']).to eq(file_name)
+          expect_metric('show', 'IN_PROGRESS', 1)
+        end
+      end
+
+      context 'when filter_duplicate_evidence_submissions is called directly' do
+        let(:controller) { described_class.new }
+        let(:mock_evidence_submission) do
+          double('EvidenceSubmission',
+                 id: 1,
+                 template_metadata: {
+                   personalisation: {
+                     file_name: 'test_document.pdf'
+                   }
+                 }.to_json)
+        end
+
+        it 'correctly filters duplicates when supporting documents match' do
+          claim_data = {
+            'attributes' => {
+              'supportingDocuments' => [
+                { 'originalFileName' => 'test_document.pdf' },
+                { 'originalFileName' => 'other_document.pdf' }
+              ]
+            }
+          }
+
+          result = controller.send(:filter_duplicate_evidence_submissions, [mock_evidence_submission], claim_data)
+          expect(result).to be_empty
+        end
+
+        it 'correctly includes evidence submissions when no duplicates exist' do
+          claim_data = {
+            'attributes' => {
+              'supportingDocuments' => [
+                { 'originalFileName' => 'different_document.pdf' },
+                { 'originalFileName' => 'other_document.pdf' }
+              ]
+            }
+          }
+
+          result = controller.send(:filter_duplicate_evidence_submissions, [mock_evidence_submission], claim_data)
+          expect(result).to eq([mock_evidence_submission])
+        end
+      end
+    end
+  end
+
+  describe 'private methods' do
+    let(:controller) { described_class.new }
+    let(:claim_id) { '600383363' }
+
+    describe '#filter_duplicate_evidence_submissions' do
+      let(:evidence_submission1) do
+        double('EvidenceSubmission',
+               id: 1,
+               template_metadata: { personalisation: { file_name: 'document1.pdf' } }.to_json)
+      end
+      let(:evidence_submission2) do
+        double('EvidenceSubmission',
+               id: 2,
+               template_metadata: { personalisation: { file_name: 'document2.pdf' } }.to_json)
+      end
+      let(:evidence_submission3) do
+        double('EvidenceSubmission',
+               id: 3,
+               template_metadata: { personalisation: { file_name: 'document3.pdf' } }.to_json)
+      end
+      let(:evidence_submissions) { [evidence_submission1, evidence_submission2, evidence_submission3] }
+
+      let(:claim_data) do
+        {
+          'id' => claim_id,
+          'attributes' => {
+            'supportingDocuments' => supporting_documents
+          }
+        }
+      end
+
+      context 'when no supporting documents exist' do
+        let(:supporting_documents) { [] }
+
+        it 'returns all evidence submissions unchanged' do
+          result = controller.send(:filter_duplicate_evidence_submissions, evidence_submissions, claim_data)
+          expect(result).to eq(evidence_submissions)
+        end
+      end
+
+      context 'when supportingDocuments is nil' do
+        let(:claim_data) do
+          {
+            'id' => claim_id,
+            'attributes' => {}
+          }
+        end
+
+        it 'returns all evidence submissions unchanged' do
+          result = controller.send(:filter_duplicate_evidence_submissions, evidence_submissions, claim_data)
+          expect(result).to eq(evidence_submissions)
+        end
+      end
+
+      context 'when supporting documents exist but no file names match' do
+        let(:supporting_documents) do
+          [
+            { 'originalFileName' => 'different1.pdf' },
+            { 'originalFileName' => 'different2.pdf' }
+          ]
+        end
+
+        it 'returns all evidence submissions unchanged' do
+          result = controller.send(:filter_duplicate_evidence_submissions, evidence_submissions, claim_data)
+          expect(result).to eq(evidence_submissions)
+        end
+      end
+
+      context 'when supporting documents contain matching file names' do
+        let(:supporting_documents) do
+          [
+            { 'originalFileName' => 'document1.pdf' },  # matches evidence_submission1
+            { 'originalFileName' => 'different.pdf' },
+            { 'originalFileName' => 'document3.pdf' }   # matches evidence_submission3
+          ]
+        end
+
+        it 'filters out evidence submissions with matching file names' do
+          result = controller.send(:filter_duplicate_evidence_submissions, evidence_submissions, claim_data)
+          expect(result).to eq([evidence_submission2])
+          expect(result).not_to include(evidence_submission1)
+          expect(result).not_to include(evidence_submission3)
+        end
+      end
+
+      context 'when supporting documents have nil originalFileName' do
+        let(:supporting_documents) do
+          [
+            { 'originalFileName' => nil },
+            { 'originalFileName' => 'document2.pdf' }
+          ]
+        end
+
+        it 'handles nil originalFileName gracefully and filters matching files' do
+          result = controller.send(:filter_duplicate_evidence_submissions, evidence_submissions, claim_data)
+          expect(result).to eq([evidence_submission1, evidence_submission3])
+          expect(result).not_to include(evidence_submission2)
+        end
+      end
+
+      context 'when evidence submission has invalid JSON metadata' do
+        let(:evidence_submission_invalid) do
+          double('EvidenceSubmission',
+                 id: 4,
+                 template_metadata: 'invalid json')
+        end
+        let(:evidence_submissions) { [evidence_submission1, evidence_submission_invalid] }
+        let(:supporting_documents) do
+          [{ 'originalFileName' => 'document1.pdf' }]
+        end
+
+        before do
+          allow(Rails.logger).to receive(:warn)
+        end
+
+        it 'logs warning but does not filter out submission with invalid metadata' do
+          result = controller.send(:filter_duplicate_evidence_submissions, evidence_submissions, claim_data)
+
+          expect(result).to eq([evidence_submission_invalid])
+          expect(result).not_to include(evidence_submission1)
+          expect(Rails.logger).to have_received(:warn).with(
+            '[BenefitsClaimsController] Error parsing evidence submission metadata',
+            { evidence_submission_id: 4 }
+          )
+        end
+      end
+
+      context 'when evidence submission has nil template_metadata' do
+        let(:evidence_submission_nil) do
+          double('EvidenceSubmission',
+                 id: 5,
+                 template_metadata: nil)
+        end
+        let(:evidence_submissions) { [evidence_submission1, evidence_submission_nil] }
+        let(:supporting_documents) do
+          [{ 'originalFileName' => 'document1.pdf' }]
+        end
+
+        it 'does not filter out submission with nil metadata' do
+          result = controller.send(:filter_duplicate_evidence_submissions, evidence_submissions, claim_data)
+
+          expect(result).to eq([evidence_submission_nil])
+          expect(result).not_to include(evidence_submission1)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

# Prevent Duplicate Evidence Submissions in Benefits Claims Status Tool

## Summary

- *This work is behind a feature toggle (flipper): YES* - Uses existing `cst_show_document_upload_status` flipper
- This PR implements duplicate prevention logic for evidence submissions in the Benefits Claims Status Tool to prevent documents from appearing in "files in progress" when they already exist as successfully received documents
- **Problem**: When users upload documents through the Claims Status Tool, the uploaded documents could appear in both the "received documents" section (when successfully processed) AND the "files in progress" section, creating confusion about document status
- **Solution**: Added `filter_duplicate_evidence_submissions` method that compares evidence submission file names with existing supporting document file names and filters out duplicates. The solution includes robust error handling for JSON parsing failures and nil metadata scenarios
- **Team**: BMT Team 2 (Bee's Knees) owns and maintains the Document Status component
- **Flipper Success Criteria**: Existing flipper controls visibility of document upload status features; this change improves accuracy of the displayed information

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/121301

## Testing done

- [x] *New code is covered by unit tests*
- **Old behavior**: Evidence submissions would appear in "files in progress" even when the same file name already existed in the claim's supporting documents, leading to duplicate display of the same document
- **New behavior**: Evidence submissions are filtered out if their file name matches an existing supporting document, preventing duplicates in the UI
- **Testing steps to verify changes**:
  1. Create an evidence submission with a specific file name
  2. Ensure the claim has a supporting document with the same file name in `originalFileName`
  3. Call the `show` endpoint for the claim
  4. Verify the evidence submission does NOT appear in the `evidenceSubmissions` response
  5. Test with evidence submission that has a unique file name and verify it DOES appear
  6. Test error scenarios (invalid JSON metadata, nil metadata) to ensure graceful handling
- **Flipper testing**: Tests cover both flipper enabled scenarios (existing behavior) and the new duplicate prevention logic
- **Edge case testing**: Comprehensive tests for nil metadata, invalid JSON, missing supporting documents, and nil originalFileName values

## Screenshots
_Note: Optional_

N/A - Backend API change with no UI modifications

## What areas of the site does it impact?

- **Primary Impact**: Benefits Claims Controller (`V0::BenefitsClaimsController`) - specifically the evidence submission filtering logic in the `show` action
- **API Endpoint**: `GET /v0/benefits_claims/:id` response structure (reduces items in `evidenceSubmissions` array when duplicates detected)
- **Feature Area**: Claims Status Tool document upload status display
- **Dependencies**: Relies on Lighthouse Benefits Claims API data structure for `supportingDocuments` and evidence submission metadata format
- **No impact** on other areas of the site - this is an isolated improvement to the claims status functionality

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution (warning logs for metadata parsing errors)
- [ ] Documentation has been updated (link to documentation)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Feature/bug has a monitor built into Datadog (if applicable)
- [x] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ] I added a screenshot of the developed feature

