### PR TITLE
Enhance BenefitsClaimsController to filter evidence submissions that …

### DIFF
--- a/app/controllers/v0/benefits_claims_controller.rb
+++ b/app/controllers/v0/benefits_claims_controller.rb
@@ -209,7 +209,7 @@ module V0
         nil
       end
     rescue JSON::ParserError, TypeError
-      ::Rails.logger.warn(
+      ::Rails.logger.error(
         '[BenefitsClaimsController] Error parsing evidence submission metadata',
         { evidence_submission_id: evidence_submission.id }
       )

--- a/spec/controllers/v0/benefits_claims_controller_spec.rb
+++ b/spec/controllers/v0/benefits_claims_controller_spec.rb
@@ -977,7 +977,7 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
 
           expect(result).to eq([evidence_submission_invalid])
           expect(result).not_to include(evidence_submission1)
-          expect(Rails.logger).to have_received(:warn).with(
+          expect(Rails.logger).to have_received(:error).with(
             '[BenefitsClaimsController] Error parsing evidence submission metadata',
             { evidence_submission_id: 4 }
           )


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

# Prevent Duplicate Evidence Submissions in Benefits Claims Status Tool

## Summary

- *This work is behind a feature toggle (flipper): YES* - Uses existing `cst_show_document_upload_status` flipper
- This PR implements duplicate prevention logic for evidence submissions in the Benefits Claims Status Tool to prevent documents from appearing in "files in progress" when they already exist as successfully received documents
- **Problem**: When users upload documents through the Claims Status Tool, the uploaded documents could appear in both the "received documents" section (when successfully processed) AND the "files in progress" section, creating confusion about document status
- **Solution**: Added `filter_duplicate_evidence_submissions` method that compares evidence submission file names with existing supporting document file names and filters out duplicates. The solution includes robust error handling for JSON parsing failures and nil metadata scenarios
- **Team**: BMT Team 2 (Bee's Knees) owns and maintains the Document Status component
- **Flipper Success Criteria**: Existing flipper controls visibility of document upload status features; this change improves accuracy of the displayed information

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/121301

## Testing done

- [x] *New code is covered by unit tests*
- **Old behavior**: Evidence submissions would appear in "files in progress" even when the same file name already existed in the claim's supporting documents, leading to duplicate display of the same document
- **New behavior**: Evidence submissions are filtered out if their file name matches an existing supporting document, preventing duplicates in the UI
- **Testing steps to verify changes**:
  1. Create an evidence submission with a specific file name
  2. Ensure the claim has a supporting document with the same file name in `originalFileName`
  3. Call the `show` endpoint for the claim
  4. Verify the evidence submission does NOT appear in the `evidenceSubmissions` response
  5. Test with evidence submission that has a unique file name and verify it DOES appear
  6. Test error scenarios (invalid JSON metadata, nil metadata) to ensure graceful handling
- **Flipper testing**: Tests cover both flipper enabled scenarios (existing behavior) and the new duplicate prevention logic
- **Edge case testing**: Comprehensive tests for nil metadata, invalid JSON, missing supporting documents, and nil originalFileName values

## Screenshots
_Note: Optional_

N/A - Backend API change with no UI modifications

## What areas of the site does it impact?

- **Primary Impact**: Benefits Claims Controller (`V0::BenefitsClaimsController`) - specifically the evidence submission filtering logic in the `show` action
- **API Endpoint**: `GET /v0/benefits_claims/:id` response structure (reduces items in `evidenceSubmissions` array when duplicates detected)
- **Feature Area**: Claims Status Tool document upload status display
- **Dependencies**: Relies on Lighthouse Benefits Claims API data structure for `supportingDocuments` and evidence submission metadata format
- **No impact** on other areas of the site - this is an isolated improvement to the claims status functionality

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution (warning logs for metadata parsing errors)
- [ ] Documentation has been updated (link to documentation)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Feature/bug has a monitor built into Datadog (if applicable)
- [x] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ] I added a screenshot of the developed feature

