### PR TITLE
Revert "RES/ch31 eligibility maintenance windows"

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -875,7 +875,6 @@ maintenance:
     vetext_vaccine: <%= ENV['maintenance__services__vetext_vaccine'] %>
     vic: <%= ENV['maintenance__services__vic'] %>
     vre: <%= ENV['maintenance__services__vre'] %>
-    vre_ch31_eligibility: <%= ENV['maintenance__services__vre_ch31_eligibility'] %>
 mcp:
   notifications:
     batch_size: 10

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -883,7 +883,6 @@ maintenance:
     vetext_vaccine: P9PG8HG
     vic: P7LW3MS
     vre: ~
-    vre_ch31_eligibility: ~
 mcp:
   notifications:
     batch_size: 10

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -882,7 +882,6 @@ maintenance:
     vetext_vaccine: P9PG8HG
     vic: P7LW3MS
     vre: ~
-    vre_ch31_eligibility: ~
 mcp:
   notifications:
     batch_size: 100


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#24653

**Maint window created:**
<img width="813" height="226" alt="image" src="https://github.com/user-attachments/assets/73e09f06-b700-47de-b47f-023f4b784f8c" />

**Created failures** [in Datadog](https://vagov.ddog-gov.com/logs?query=service%3Avets-api%20%28%22Invalid%20arguments%20sent%20to%20PagerDuty%22%20OR%20%22Querying%20PagerDuty%20for%20maintenance%20windows%20failed%22%29%20-name%3Adsva-vetsgov-review&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1760986271938&to_ts=1760989871938&live=true):
```
Querying PagerDuty for maintenance windows failed with the error: BackendServiceException: {:status=>403, :detail=>nil, :code=>"VA900", :source=>nil}
```