### PR TITLE
bmt1/119176: update the defaults to "Claim for disability compensation" when claimType is null

### DIFF
--- a/lib/benefits_claims/title_generator.rb
+++ b/lib/benefits_claims/title_generator.rb
@@ -104,7 +104,7 @@ module BenefitsClaims
         end
 
         # Priority 4: Return default for missing data (triggers frontend fallback)
-        { display_title: 'disability compensation', claim_type_base: 'disability compensation claim' }
+        { display_title: 'Claim for disability compensation', claim_type_base: 'disability compensation claim' }
       end
 
       def update_claim_title(claim)

--- a/spec/controllers/v0/benefits_claims_controller_spec.rb
+++ b/spec/controllers/v0/benefits_claims_controller_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe V0::BenefitsClaimsController, type: :controller do
 
         # Check that both claims with claimTypeCode get default titles (since these codes aren't in our mapping)
         code_only_claims.each do |claim|
-          expect(claim['attributes']['displayTitle']).to eq('disability compensation')
+          expect(claim['attributes']['displayTitle']).to eq('Claim for disability compensation')
           expect(claim['attributes']['claimTypeBase']).to eq('disability compensation claim')
         end
       end

--- a/spec/lib/benefits_claims/title_generator_spec.rb
+++ b/spec/lib/benefits_claims/title_generator_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe BenefitsClaims::TitleGenerator do
         result = described_class.generate_titles(nil, nil)
 
         expect(result).to eq({
-                               display_title: 'disability compensation',
+                               display_title: 'Claim for disability compensation',
                                claim_type_base: 'disability compensation claim'
                              })
       end
@@ -136,7 +136,7 @@ RSpec.describe BenefitsClaims::TitleGenerator do
         result = described_class.generate_titles('', '')
 
         expect(result).to eq({
-                               display_title: 'disability compensation',
+                               display_title: 'Claim for disability compensation',
                                claim_type_base: 'disability compensation claim'
                              })
       end
@@ -145,7 +145,7 @@ RSpec.describe BenefitsClaims::TitleGenerator do
         result = described_class.generate_titles('', 'UNKNOWN_CODE')
 
         expect(result).to eq({
-                               display_title: 'disability compensation',
+                               display_title: 'Claim for disability compensation',
                                claim_type_base: 'disability compensation claim'
                              })
       end
@@ -165,7 +165,7 @@ RSpec.describe BenefitsClaims::TitleGenerator do
         result = described_class.generate_titles('   ', nil)
 
         expect(result).to eq({
-                               display_title: 'disability compensation',
+                               display_title: 'Claim for disability compensation',
                                claim_type_base: 'disability compensation claim'
                              })
       end
@@ -245,7 +245,7 @@ RSpec.describe BenefitsClaims::TitleGenerator do
 
         described_class.update_claim_title(claim)
 
-        expect(claim['attributes']['displayTitle']).to eq('disability compensation')
+        expect(claim['attributes']['displayTitle']).to eq('Claim for disability compensation')
         expect(claim['attributes']['claimTypeBase']).to eq('disability compensation claim')
       end
     end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES
- update the defaults to "Claim for disability compensation" when claimType is null

## Related issue(s)

- 

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
