### PR TITLE
use Timecop to freeze date

### DIFF
--- a/modules/medical_expense_reports/spec/lib/medical_expense_reports/pdf_fill/va21p8416_spec.rb
+++ b/modules/medical_expense_reports/spec/lib/medical_expense_reports/pdf_fill/va21p8416_spec.rb
@@ -12,29 +12,31 @@ describe MedicalExpenseReports::PdfFill::Va21p8416 do
 
   describe '#to_pdf' do
     it 'merges the right keys' do
-      files = %w[diffs kitchen-sink_us-number]
-      files.map do |file|
-        f1 = File.read File.join(__dir__, 'input', "21p-8416_#{file}.json")
+      Timecop.freeze(Time.zone.parse('2025-10-21')) do
+        files = %w[diffs kitchen-sink_us-number]
+        files.map do |file|
+          f1 = File.read File.join(__dir__, 'input', "21p-8416_#{file}.json")
 
-        claim = MedicalExpenseReports::SavedClaim.new(form: f1)
+          claim = MedicalExpenseReports::SavedClaim.new(form: f1)
 
-        form_id = MedicalExpenseReports::FORM_ID
-        form_class = MedicalExpenseReports::PdfFill::Va21p8416
-        fill_options = {
-          created_at: '2025-10-08'
-        }
-        merged_form_data = form_class.new(claim.parsed_form).merge_fields(fill_options)
-        submit_date = Utilities::DateParser.parse(
-          fill_options[:created_at]
-        )
+          form_id = MedicalExpenseReports::FORM_ID
+          form_class = MedicalExpenseReports::PdfFill::Va21p8416
+          fill_options = {
+            created_at: '2025-10-08'
+          }
+          merged_form_data = form_class.new(claim.parsed_form).merge_fields(fill_options)
+          submit_date = Utilities::DateParser.parse(
+            fill_options[:created_at]
+          )
 
-        hash_converter = PdfFill::Filler.make_hash_converter(form_id, form_class, submit_date, fill_options)
-        new_hash = hash_converter.transform_data(form_data: merged_form_data, pdftk_keys: form_class::KEY)
+          hash_converter = PdfFill::Filler.make_hash_converter(form_id, form_class, submit_date, fill_options)
+          new_hash = hash_converter.transform_data(form_data: merged_form_data, pdftk_keys: form_class::KEY)
 
-        f2 = File.read File.join(__dir__, 'output', "21p-8416_#{file}.json")
-        data = JSON.parse(f2)
+          f2 = File.read File.join(__dir__, 'output', "21p-8416_#{file}.json")
+          data = JSON.parse(f2)
 
-        expect(new_hash).to eq(data)
+          expect(new_hash).to eq(data)
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
Tests started failing today. Example test run: https://github.com/department-of-veterans-affairs/vets-api/actions/runs/18723598146/job/53402516934?pr=24758

## Related issue(s)
None. Saw while on support.
https://dsva.slack.com/archives/CBU0KDSB1/p1761153668797839

## Testing done
```
rebeccatolmach ~/git/vets-api be rspec modules/medical_expense_reports/spec/lib/medical_expense_reports/pdf_fill/va21p8416_spec.rb
.

Finished in 0.19757 seconds (files took 8.92 seconds to load)
1 example, 0 failures
```

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
One spec in the medical expense reports module. 

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
