### PR TITLE
Form4142 processor 2024 support spec

### DIFF
--- a/spec/lib/evss/disability_compensation_form/form4142_processor_2024_support_spec.rb
+++ b/spec/lib/evss/disability_compensation_form/form4142_processor_2024_support_spec.rb
@@ -30,14 +30,6 @@ describe EVSS::DisabilityCompensationForm::Form4142Processor do
 
   let(:file_path) { 'tmp/pdfs/mock_form_final.pdf' }
 
-  around do |example|
-    puts "\nStarting: #{example.description}"
-    start_time = Time.now
-    example.run
-    duration = Time.now - start_time
-    puts "Finished: #{example.description} (#{duration.round(2)}s)\n\n"
-  end
-
   describe '#initialize' do
     let(:mock_digest) { instance_double(Digest::SHA256, hexdigest: 'mocked_sha256_digest') }
     let(:mock_page)   { instance_double(PDF::Reader::Page) }
@@ -47,7 +39,7 @@ describe EVSS::DisabilityCompensationForm::Form4142Processor do
       allow(Flipper).to receive(:enabled?).with(:disability_526_form4142_validate_schema).and_return(false)
 
       # Mock expensive PDF operations to avoid file I/O
-      allow(PdfFill::Filler).to receive(:fill_form).and_return(file_path)
+      allow(PdfFill::Filler).to receive(:fill_ancillary_form).and_return(file_path)
       allow(Common::FileHelpers).to receive(:delete_file_if_exists)
       datestamp_instance = instance_double(PDFUtilities::DatestampPdf, run: file_path)
       allow(PDFUtilities::DatestampPdf).to receive(:new).and_return(datestamp_instance)


### PR DESCRIPTION
## Summary
This is a minor refactor of spec/lib/evss/disablity_compensation_form/form4142_processor_2024_support_spec to reduce the runtime.

- *This work is behind a feature toggle (flipper): YES/NO* NO
- *(Summarize the changes that have been made to the platform)* Change to spec file.
- *(If bug, how to reproduce)* Not a bug per se. Spec takes longer to run than is necessary.
- *(What is the solution, why is this the solution?)* Helps to reduce the overall runtime of the entire spec suite.
- *(Which team do you work for, does your team own the maintenance of this component?)* VFEP/No
- *(If introducing a flipper, what is the success criteria being targeted?)* N/A

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
  [Benchmark vets-api test times #114024](https://github.com/department-of-veterans-affairs/va.gov-team/issues/114024)
- *Link to previous change of the code/bug (if applicable)* N/A
- *Link to epic if not included in ticket*

## Testing done
See screenshots below and code coverage screenshot.

## Screenshots
runtime before
<img width="1108" height="257" alt="runtime_before" src="https://github.com/user-attachments/assets/96ec49c7-4600-42d5-97d1-68dbda9ec83f" />

runtime after
<img width="1132" height="311" alt="runtime_after" src="https://github.com/user-attachments/assets/65915506-30e9-4fc8-9752-6fd4bfef178e" />

Coverage report
<img width="1920" height="1160" alt="CoverageReport" src="https://github.com/user-attachments/assets/0fd80ebc-bcdf-4c81-9774-ddf64e7b4927" />

## What areas of the site does it impact?
Running of the spec suite.

## Acceptance criteria

- [x]  Reduces runtime of spec which contributes to overall reduction of suite runtime.

