### PR TITLE
Making this more functional for future work

### DIFF
--- a/modules/check_in/app/sidekiq/check_in/constants.rb
+++ b/modules/check_in/app/sidekiq/check_in/constants.rb
@@ -2,9 +2,6 @@
 
 module CheckIn
   module Constants
-    # Delegate to the actual job class for use in services
-    TravelClaimNotificationJob = CheckIn::TravelClaimNotificationJob
-
     # settings for travel claims for vista appts
     STATSD_NOTIFY_ERROR = 'worker.checkin.travel_claim.notify.error'
     STATSD_NOTIFY_SUCCESS = 'worker.checkin.travel_claim.notify.success'

--- a/modules/check_in/spec/services/travel_claim/claim_submission_service_spec.rb
+++ b/modules/check_in/spec/services/travel_claim/claim_submission_service_spec.rb
@@ -668,7 +668,6 @@ RSpec.describe TravelClaim::ClaimSubmissionService do
           template_constants(name) ||
             success_metrics(name) ||
             error_metrics(name) ||
-            job_constant(name) ||
             super
         end
 
@@ -701,16 +700,10 @@ RSpec.describe TravelClaim::ClaimSubmissionService do
           }
           metrics[name]
         end
-
-        def self.job_constant(name)
-          name == :TravelClaimNotificationJob ? CustomNotificationJob : nil
-        end
       end
     end
 
-    let(:custom_notification_job) do
-      class_double(CustomNotificationJob).as_stubbed_const('CustomNotificationJob')
-    end
+    let(:custom_notification_job) { double('CustomNotificationJob') }
 
     before do
       allow(custom_notification_job).to receive(:perform_async)
@@ -743,7 +736,8 @@ RSpec.describe TravelClaim::ClaimSubmissionService do
           appointment_date:,
           facility_type:,
           check_in_uuid:,
-          context_constants: custom_constants
+          context_constants: custom_constants,
+          notification_job_class: custom_notification_job
         )
       end
 


### PR DESCRIPTION
# Refactor TravelClaim::ClaimSubmissionService for Constants Injection

Making this more functional for future work

## Summary

- **This work is behind a feature toggle (flipper): NO**
- Refactored `TravelClaim::ClaimSubmissionService` to accept a configurable `context_constants` parameter instead of hard-coding `CheckIn::Constants` references
- This enables the standalone app to use the service with different constants modules while maintaining backward compatibility
- Converted `ERROR_METRICS` constant to a dynamic `error_metrics` instance method
- Added `TravelClaimNotificationJob` constant delegation to `CheckIn::Constants` module
- All changes are backward compatible - existing code continues to work without modification via default parameter
- No functional changes to claim submission logic

## Related issue(s)

- Ticket #122569 - https://github.com/department-of-veterans-affairs/va.gov-team/issues/122569

## Testing done

- [x] **New code is covered by unit tests**
- **Old behavior:** Service had hard-coded references to `CheckIn::Constants` throughout, preventing reuse by other applications
- **New behavior:** Service accepts an optional `context_constants` parameter (defaults to `CheckIn::Constants`), allowing flexible constant injection
- **Testing performed:**
  - Added comprehensive test suite for custom constants injection (9 new test cases)
  - Tests verify default `CheckIn::Constants` behavior (backward compatibility)
  - Tests verify custom constants module injection works correctly
  - Tests verify correct template IDs for CIE vs OH facility types
  - Tests verify correct StatsD metrics are incremented
  - All existing tests pass without modification
  - RuboCop passes with 0 offenses across all modified files
- **Verification steps:**
  1. Run `bundle exec rspec modules/check_in/spec/services/travel_claim/claim_submission_service_spec.rb`
  2. Verify all 9 new custom constants tests pass
  3. Verify all existing tests continue to pass
  4. Run `rubocop modules/check_in/app/services/travel_claim/claim_submission_service.rb modules/check_in/spec/services/travel_claim/claim_submission_service_spec.rb modules/check_in/app/sidekiq/check_in/constants.rb`
  5. Verify 0 offenses detected

## What areas of the site does it impact?

**Modified files:**
- `modules/check_in/app/services/travel_claim/claim_submission_service.rb` - Service class refactored
- `modules/check_in/spec/services/travel_claim/claim_submission_service_spec.rb` - Test coverage added
- `modules/check_in/app/sidekiq/check_in/constants.rb` - Added TravelClaimNotificationJob constant

**Impact:** 
- No impact on existing functionality - all changes are backward compatible
- Enables future standalone app to use the service with custom constants
- Travel claim submission flow for Check-In and Oracle Health appointments continues to work identically

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution
- [x] Documentation has been updated (inline code documentation added)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Feature/bug has a monitor built into Datadog (existing metrics unchanged)
- [x] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x] RuboCop passes with 0 offenses

## Code Changes Summary

**Service Refactoring:**
- Added `context_constants` parameter to `initialize` with default `CheckIn::Constants`
- Converted `ERROR_METRICS` constant to `error_metrics` instance method
- Replaced all hard-coded `CheckIn::Constants::` references with `@context_constants::`
- Added `template_for_duplicate_error` helper method for RuboCop compliance

**Constants Module:**
- Added `TravelClaimNotificationJob = CheckIn::TravelClaimNotificationJob` delegation

**Test Coverage:**
- 9 new test cases covering default and custom constants scenarios
- Tests verify template IDs, metrics, and notification job usage
- All existing tests preserved and passing

## Requested Feedback

This is a pure refactoring for code flexibility with zero functional changes. All existing behavior is preserved through the default parameter.