### PR TITLE
(BIO) Misc: Turn on FF in dev for 0779, 4192, 530a, and 2680

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2665,13 +2665,17 @@ features:
       Owned by Simple Forms API team.
   form_0779_enabled:
     actor_type: user
+    enable_in_development: true
     description: Enables form 21-0779 on vets-website 
   form_530a_enabled:
     actor_type: user
+    enable_in_development: true
     description: Enables form 21P-530a on vets-website 
   form_4192_enabled:
     actor_type: user
+    enable_in_development: true
     description: Enables form 21-4192 on vets-website 
   form_2680_enabled:
     actor_type: user
+    enable_in_development: true
     description: Enables form 21-2680 on vets-website 


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): YES*
- Adds `enable_in_development: true` to four Simple Forms API feature flags (form_0779_enabled, form_530a_enabled, form_4192_enabled, form_2680_enabled) to enable these Benefits Intake Optimization forms by default in the development environment.
- This change allows developers to test forms 21-0779 (Nursing Home Information), 21P-530a (Burial Allowance), 21-4192 (Employment Verification), and 21-2680 (Place of Burial Request) without manually enabling feature flags.
- The solution enables these feature flags in development by default so developers can easily test these forms during development. This is necessary because these forms are currently behind feature flags and developers need to test them without having to manually enable the flags each time.
- Benefits Intake Team / Simple Forms API Team owns the maintenance of this component.

## Related issue(s)

- Link to ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/123293

## Testing done

- [ ] *New code is covered by unit tests*
- The previous behavior required developers to manually enable these feature flags in development to test the forms.
- No code changes were made, only configuration changes in `config/features.yml`. The feature flags work as expected when enabled through the UI. Developers can now test these forms without manual flag toggling.
- All four feature flags (form_0779_enabled, form_530a_enabled, form_4192_enabled, form_2680_enabled) are enabled in development by default as of this change.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*This change only impacts the development environment. It enables four Benefits Intake Optimization form feature flags by default in development, allowing developers to test forms 21-0779, 21P-530a, 21-4192, and 21-2680 without manual intervention.*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

_(OPTIONAL)_ Configuration change only - enables four feature flags in development by default to improve developer experience when testing Benefits Intake Optimization forms.