### PR TITLE
Submit dependents pdf job spec

### DIFF
--- a/spec/sidekiq/vbms/submit_dependents_pdf_job_spec.rb
+++ b/spec/sidekiq/vbms/submit_dependents_pdf_job_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe VBMS::SubmitDependentsPdfJob do
 
       expect(Rails.logger).to have_received(:error).with(
         'VBMS::SubmitDependentsPdfJob failed, retries exhausted!',
-        hash_including(saved_claim_id: 12_345, error: exception)
+        hash_including(saved_claim_id: 12_345)
       )
     end
   end


### PR DESCRIPTION
## Summary
This is a minor refactor of submit_dependents_pdf_job_spec.rb to reduce the runtime and add code coverage. No live code is touched.

- *This work is behind a feature toggle (flipper): YES/NO* NO
- *(Summarize the changes that have been made to the platform)* Change to spec file
- *(If bug, how to reproduce)* Not a bug per se. Spec takes longer to run than is necessary.
- *(What is the solution, why is this the solution?)* Helps to reduce the overall runtime of the entire spec suite.
- *(Which team do you work for, does your team own the maintenance of this component?)* VFEP/No
- *(If introducing a flipper, what is the success criteria being targeted?)* N/A

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
  [Benchmark vets-api test times #114024](https://github.com/department-of-veterans-affairs/va.gov-team/issues/114024)
- *Link to previous change of the code/bug (if applicable)* N/A
- *Link to epic if not included in ticket*

## Testing done
See before and after screenshots below and code coverage screenshot.

## Screenshots
runtime before
<img width="1354" height="577" alt="RuntimeBefore" src="https://github.com/user-attachments/assets/f0203fa1-0568-42bc-b921-332a0d3a1680" />

runtime after
<img width="1009" height="331" alt="RuntimeAfter" src="https://github.com/user-attachments/assets/a3bc8ab4-ac53-4b4f-b6a0-b3b38cebe4cc" />

Code Coverage report before
<img width="1920" height="1160" alt="CoverageBefore" src="https://github.com/user-attachments/assets/caa66118-d85b-46b8-9fbd-869cccf0d006" />

Code Coverage report after
<img width="1920" height="1160" alt="CoverageAfter" src="https://github.com/user-attachments/assets/714d1c24-cd52-47f5-ade9-044226aa362a" />

## What areas of the site does it impact?
Running of the spec suite. Overall code coverage metrics

## Acceptance criteria

- [x]  Reduce runtime of spec which contributes to overall reduction of suite runtime.
- [x]  Increase coverage of the code base which increases the likelihood of catching bugs before they get to production. 

