### PR TITLE
Chore: fix enum syntax dep warning rails 8.0

### DIFF
--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_decision.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_decision.rb
@@ -5,7 +5,7 @@ module AccreditedRepresentativePortal
     self.inheritance_column = nil
     include PowerOfAttorneyRequestResolution::Resolving
 
-    enum declination_reason: {
+    enum :declination_reason, {
       HEALTH_RECORDS_WITHHELD: 0,
       ADDRESS_CHANGE_WITHHELD: 1,
       BOTH_WITHHELD: 2,

--- a/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_notification.rb
+++ b/modules/accredited_representative_portal/app/models/accredited_representative_portal/power_of_attorney_request_notification.rb
@@ -14,9 +14,9 @@ module AccreditedRepresentativePortal
                primary_key: 'notification_id',
                optional: true
 
-    enum type: PERMITTED_TYPES.index_with { |v| v }
+    enum(:type, PERMITTED_TYPES.index_with { |v| v })
 
-    enum recipient_type: PERMITTED_RECIPIENTS.index_with { |v| v }
+    enum(:recipient_type, PERMITTED_RECIPIENTS.index_with { |v| v })
 
     delegate :accredited_individual, :accredited_organization, to: :power_of_attorney_request
 


### PR DESCRIPTION
## Summary

Resolve the following deprecation warning:

```
DEPRECATION WARNING: Defining enums with keyword arguments is deprecated and will be 
removed in Rails 8.0. Positional arguments should be used instead
```

```
# bad
enum status: { active: 0, archived: 1 }

# good
enum :status, { active: 0, archived: 1 }
```

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/121651

## Testing done

- [x] CI spec testing

## Acceptance criteria

- [x] the specs pass