### PR TITLE
Chore: Resolve Shrine Image Warning

### DIFF
--- a/modules/accredited_representative_portal/spec/lib/monitor_spec.rb
+++ b/modules/accredited_representative_portal/spec/lib/monitor_spec.rb
@@ -10,7 +10,13 @@ RSpec.describe AccreditedRepresentativePortal::Monitor do
   before do
     # This removes: SHRINE WARNING: Error occurred when attempting to extract image dimensions:
     # #<FastImage::UnknownImageType: FastImage::UnknownImageType>
-    allow(FastImage).to receive(:size).with(a_string_ending_with('.pdf')).and_return(nil)
+    allow(FastImage).to receive(:size).and_wrap_original do |original, file|
+      if file.respond_to?(:path) && file.path.end_with?('.pdf')
+        nil
+      else
+        original.call(file)
+      end
+    end
   end
 
   describe '#service_name' do

--- a/modules/accredited_representative_portal/spec/lib/notification_callback_spec.rb
+++ b/modules/accredited_representative_portal/spec/lib/notification_callback_spec.rb
@@ -36,7 +36,13 @@ RSpec.describe AccreditedRepresentativePortal::NotificationCallback do
 
     # This removes: SHRINE WARNING: Error occurred when attempting to extract image dimensions:
     # #<FastImage::UnknownImageType: FastImage::UnknownImageType>
-    allow(FastImage).to receive(:size).with(a_string_ending_with('.pdf')).and_return(nil)
+    allow(FastImage).to receive(:size).and_wrap_original do |original, file|
+      if file.respond_to?(:path) && file.path.end_with?('.pdf')
+        nil
+      else
+        original.call(file)
+      end
+    end
   end
 
   it_behaves_like 'a SavedClaim Notification Callback',

--- a/modules/accredited_representative_portal/spec/lib/notification_email_spec.rb
+++ b/modules/accredited_representative_portal/spec/lib/notification_email_spec.rb
@@ -9,7 +9,13 @@ RSpec.describe AccreditedRepresentativePortal::NotificationEmail do
   before do
     # This removes: SHRINE WARNING: Error occurred when attempting to extract image dimensions:
     # #<FastImage::UnknownImageType: FastImage::UnknownImageType>
-    allow(FastImage).to receive(:size).with(a_string_ending_with('.pdf')).and_return(nil)
+    allow(FastImage).to receive(:size).and_wrap_original do |original, file|
+      if file.respond_to?(:path) && file.path.end_with?('.pdf')
+        nil
+      else
+        original.call(file)
+      end
+    end
   end
 
   describe '#deliver' do

--- a/modules/accredited_representative_portal/spec/lib/submission_handler_spec.rb
+++ b/modules/accredited_representative_portal/spec/lib/submission_handler_spec.rb
@@ -13,7 +13,13 @@ RSpec.describe AccreditedRepresentativePortal::SubmissionHandler do
   before do
     # This removes: SHRINE WARNING: Error occurred when attempting to extract image dimensions:
     # #<FastImage::UnknownImageType: FastImage::UnknownImageType>
-    allow(FastImage).to receive(:size).with(a_string_ending_with('.pdf')).and_return(nil)
+    allow(FastImage).to receive(:size).and_wrap_original do |original, file|
+      if file.respond_to?(:path) && file.path.end_with?('.pdf')
+        nil
+      else
+        original.call(file)
+      end
+    end
   end
 
   describe '.pending_attempts' do

--- a/modules/accredited_representative_portal/spec/models/accredited_representative_portal/saved_claim/benefits_intake_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representative_portal/saved_claim/benefits_intake_spec.rb
@@ -89,7 +89,13 @@ RSpec.describe AccreditedRepresentativePortal::SavedClaim::BenefitsIntake, type:
     before do
       # This removes: SHRINE WARNING: Error occurred when attempting to extract image dimensions:
       # #<FastImage::UnknownImageType: FastImage::UnknownImageType>
-      allow(FastImage).to receive(:size).with(a_string_ending_with('.pdf')).and_return(nil)
+      allow(FastImage).to receive(:size).and_wrap_original do |original, file|
+        if file.respond_to?(:path) && file.path.end_with?('.pdf')
+          nil
+        else
+          original.call(file)
+        end
+      end
     end
 
     context 'latest attempt was successful' do

--- a/modules/accredited_representative_portal/spec/models/accredited_representative_portal/saved_claim_claimant_representative_spec.rb
+++ b/modules/accredited_representative_portal/spec/models/accredited_representative_portal/saved_claim_claimant_representative_spec.rb
@@ -26,10 +26,16 @@ RSpec.describe AccreditedRepresentativePortal::SavedClaimClaimantRepresentative,
     described_class::ClaimantTypes
   end
 
-  # This removes: SHRINE WARNING: Error occurred when attempting to extract image dimensions:
-  # #<FastImage::UnknownImageType: FastImage::UnknownImageType>
   before do
-    allow(FastImage).to receive(:size).with(a_string_ending_with('.pdf')).and_return(nil)
+    # This removes: SHRINE WARNING: Error occurred when attempting to extract image dimensions:
+    # #<FastImage::UnknownImageType: FastImage::UnknownImageType>
+    allow(FastImage).to receive(:size).and_wrap_original do |original, file|
+      if file.respond_to?(:path) && file.path.end_with?('.pdf')
+        nil
+      else
+        original.call(file)
+      end
+    end
   end
 
   describe 'associations' do

--- a/modules/accredited_representative_portal/spec/policies/accredited_representative_portal/saved_claim_claimant_representative_policy_spec.rb
+++ b/modules/accredited_representative_portal/spec/policies/accredited_representative_portal/saved_claim_claimant_representative_policy_spec.rb
@@ -22,7 +22,13 @@ module AccreditedRepresentativePortal
 
       # This removes: SHRINE WARNING: Error occurred when attempting to extract image dimensions:
       # #<FastImage::UnknownImageType: FastImage::UnknownImageType>
-      allow(FastImage).to receive(:size).with(a_string_ending_with('.pdf')).and_return(nil)
+      allow(FastImage).to receive(:size).and_wrap_original do |original, file|
+        if file.respond_to?(:path) && file.path.end_with?('.pdf')
+          nil
+        else
+          original.call(file)
+        end
+      end
     end
 
     describe '#index?' do

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/claim_submissions_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/claim_submissions_spec.rb
@@ -9,7 +9,13 @@ RSpec.describe AccreditedRepresentativePortal::V0::ClaimSubmissionsController, t
 
     # This removes: SHRINE WARNING: Error occurred when attempting to extract image dimensions:
     # #<FastImage::UnknownImageType: FastImage::UnknownImageType>
-    allow(FastImage).to receive(:size).with(a_string_ending_with('.pdf')).and_return(nil)
+    allow(FastImage).to receive(:size).and_wrap_original do |original, file|
+      if file.respond_to?(:path) && file.path.end_with?('.pdf')
+        nil
+      else
+        original.call(file)
+      end
+    end
   end
 
   describe 'GET /accredited_representative_portal/v0/claim_submissions' do

--- a/modules/accredited_representative_portal/spec/serializers/accredited_representative_portal/claimant_serializer_spec.rb
+++ b/modules/accredited_representative_portal/spec/serializers/accredited_representative_portal/claimant_serializer_spec.rb
@@ -40,7 +40,13 @@ RSpec.describe AccreditedRepresentativePortal::ClaimantSerializer, type: :serial
   before do
     # This removes: SHRINE WARNING: Error occurred when attempting to extract image dimensions:
     # #<FastImage::UnknownImageType: FastImage::UnknownImageType>
-    allow(FastImage).to receive(:size).with(a_string_ending_with('.pdf')).and_return(nil)
+    allow(FastImage).to receive(:size).and_wrap_original do |original, file|
+      if file.respond_to?(:path) && file.path.end_with?('.pdf')
+        nil
+      else
+        original.call(file)
+      end
+    end
     allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_access_token')
   end
 

--- a/modules/accredited_representative_portal/spec/serializers/accredited_representative_portal/saved_claim_claimant_representative_serializer_spec.rb
+++ b/modules/accredited_representative_portal/spec/serializers/accredited_representative_portal/saved_claim_claimant_representative_serializer_spec.rb
@@ -10,7 +10,13 @@ RSpec.describe AccreditedRepresentativePortal::SavedClaimClaimantRepresentativeS
   before do
     # This removes: SHRINE WARNING: Error occurred when attempting to extract image dimensions:
     # #<FastImage::UnknownImageType: FastImage::UnknownImageType>
-    allow(FastImage).to receive(:size).with(a_string_ending_with('.pdf')).and_return(nil)
+    allow(FastImage).to receive(:size).and_wrap_original do |original, file|
+      if file.respond_to?(:path) && file.path.end_with?('.pdf')
+        nil
+      else
+        original.call(file)
+      end
+    end
   end
 
   describe '#first_name' do

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/saved_claim_service/attach_spec.rb
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/saved_claim_service/attach_spec.rb
@@ -14,7 +14,13 @@ RSpec.describe AccreditedRepresentativePortal::SavedClaimService::Attach do
   before do
     # This removes: SHRINE WARNING: Error occurred when attempting to extract image dimensions:
     # #<FastImage::UnknownImageType: FastImage::UnknownImageType>
-    allow(FastImage).to receive(:size).with(a_string_ending_with('.pdf')).and_return(nil)
+    allow(FastImage).to receive(:size).and_wrap_original do |original, file|
+      if file.respond_to?(:path) && file.path.end_with?('.pdf')
+        nil
+      else
+        original.call(file)
+      end
+    end
   end
 
   context 'when record invalid' do

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/saved_claim_service/create_spec.rb
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/saved_claim_service/create_spec.rb
@@ -19,7 +19,13 @@ RSpec.describe AccreditedRepresentativePortal::SavedClaimService::Create do
 
     # This removes: SHRINE WARNING: Error occurred when attempting to extract image dimensions:
     # #<FastImage::UnknownImageType: FastImage::UnknownImageType>
-    allow(FastImage).to receive(:size).with(a_string_ending_with('.pdf')).and_return(nil)
+    allow(FastImage).to receive(:size).and_wrap_original do |original, file|
+      if file.respond_to?(:path) && file.path.end_with?('.pdf')
+        nil
+      else
+        original.call(file)
+      end
+    end
   end
 
   let(:claimant_representative) do

--- a/spec/lib/lighthouse/benefits_intake/sidekiq/submission_status_job_spec.rb
+++ b/spec/lib/lighthouse/benefits_intake/sidekiq/submission_status_job_spec.rb
@@ -182,7 +182,13 @@ Rspec.describe BenefitsIntake::SubmissionStatusJob, type: :job do
         before do
           # This removes: SHRINE WARNING: Error occurred when attempting to extract image dimensions:
           # #<FastImage::UnknownImageType: FastImage::UnknownImageType>
-          allow(FastImage).to receive(:size).with(a_string_ending_with('.pdf')).and_return(nil)
+          allow(FastImage).to receive(:size).and_wrap_original do |original, file|
+            if file.respond_to?(:path) && file.path.end_with?('.pdf')
+              nil
+            else
+              original.call(file)
+            end
+          end
           job.instance_variable_set(:@pending_attempts, [attempt])
           job.instance_variable_set(:@pah, { 'uuid-1' => attempt })
           stub_const('BenefitsIntake::SubmissionStatusJob::FORM_HANDLERS', { 'Form23-42Fake' => handler_class })


### PR DESCRIPTION
## Summary

- The following warning was logged in CI spec:
- `SHRINE WARNING: Error occurred when attempting to extract image dimensions: #<FastImage::UnknownImageType: FastImage::UnknownImageType>`
- It's caused because `FastImage` can't tell the dimensions of a PDF.
- This PR stubs FastImage to return a value (`nil`) for a PDF. 
- `spec/lib/veteran_facing_services/notification_callback/shared/saved_claim.rb` is producing the warning but I can't determine why, so I'm allowing 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/121651

## Testing done

- [x] CI spec testing

## Acceptance criteria

- [x] the specs pass