### PR TITLE
DR 103363 Remove unused Sentry logging code from DR services

### DIFF
--- a/lib/decision_review/utilities/pdf_validation/service.rb
+++ b/lib/decision_review/utilities/pdf_validation/service.rb
@@ -8,7 +8,6 @@ module DecisionReview
   #
   module PdfValidation
     class Service < Common::Client::Base
-      include SentryLogging
       include Common::Client::Concerns::Monitoring
 
       configuration DecisionReview::PdfValidation::Configuration

--- a/modules/decision_reviews/app/sidekiq/decision_reviews/submit_upload.rb
+++ b/modules/decision_reviews/app/sidekiq/decision_reviews/submit_upload.rb
@@ -116,7 +116,6 @@ module DecisionReviews
     # @param sanitized_file [CarrierWave::SanitizedFile] The sanitized file from S3
     # @return [Faraday::Env] The response from Lighthouse
     def handle_notice_of_disagreement(appeal_submission_upload, file_number_or_ssn, sanitized_file)
-      Sentry.set_tags(source: '10182-board-appeal')
       appeal_submission = appeal_submission_upload.appeal_submission
       upload_url_response = get_dr_svc.get_notice_of_disagreement_upload_url(
         nod_uuid: appeal_submission.submitted_appeal_uuid,
@@ -141,7 +140,6 @@ module DecisionReviews
     # @param sanitized_file [CarrierWave::SanitizedFile] The sanitized file from S3
     # @return [Faraday::Env] The response from Lighthouse
     def handle_supplemental_claim(appeal_submission_upload, file_number_or_ssn, sanitized_file)
-      Sentry.set_tags(source: '20-0995-supplemental-claim')
       appeal_submission = appeal_submission_upload.appeal_submission
       user_uuid = appeal_submission.user_uuid
       appeal_submission_upload_id = appeal_submission_upload.id

--- a/modules/decision_reviews/lib/decision_reviews/v1/service_exception.rb
+++ b/modules/decision_reviews/lib/decision_reviews/v1/service_exception.rb
@@ -7,8 +7,6 @@ module DecisionReviews
     # Custom exception that maps Decision Review errors to error details defined in config/locales/exceptions.en.yml
     #
     class ServiceException < Common::Exceptions::BackendServiceException
-      include SentryLogging
-
       UNMAPPED_KEY = 'unmapped_service_exception'
 
       def initialize(key: UNMAPPED_KEY, response_values: {}, original_status: nil, original_body: nil)


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

Removes unused Sentry logging from all Decision Reviews code.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/103363

## Testing done

Ran all unit tests in the `modules/decision_reviews` folder:
<img width="1367" height="282" alt="Screenshot 2025-10-28 at 9 52 03 AM" src="https://github.com/user-attachments/assets/6f4a6c11-f5a0-4754-b67d-757352553f8a" />

### Console testing by file

With help from AI, I ran through some testing steps for each file to ensure that logging was still working properly:

#### `modules/decision_reviews/lib/decision_reviews/v1/service.rb`

Test the `save_error_details` method:

1. Create a standard error and check output:

```
begin
  service = DecisionReviews::V1::Service.new
  test_error = StandardError.new('Test logging error')
  
  # Check count before
  count_before = PersonalInformationLog.count
  
  # Call the private method directly
  service.send(:save_error_details, test_error)
  
  # Verify log was created
  count_after = PersonalInformationLog.count
  puts "Logs created: #{count_after - count_before}"
  
  # Inspect the log entry
  log = PersonalInformationLog.last
  puts "Error class: #{log.error_class}"
  puts "Data keys: #{log.data.keys}"
  puts "Full data: #{log.data}"
rescue => e
  puts "Error occurred: #{e.message}"
end
```

2. Note that the `PersonalInformationLog` was created below and logs appropriately ✅ 

```
Logs created: 1
Error class: DecisionReviews::V1::Service#save_error_details exception StandardError (DECISION_REVIEW_V1)
Data keys: ["error"]
Full data: {"error"=>{"as_json"=>"Test logging error", "backtrace"=>nil, "inspect"=>"#<StandardError: Test logging error>", "instance_values"=>{}, "message"=>"Test logging error", "to_json"=>"\"Test logging error\"", "to_s"=>"Test logging error"}}
```

Test the `handle_error` method:

1. Create a standard error and check output:

```
# Enable logging to see output
Rails.logger.level = :info

service = DecisionReviews::V1::Service.new

# Test 1: Verify save_and_log_error is called (logs + saves to PersonalInformationLog)
count_before = PersonalInformationLog.count

begin
  error = StandardError.new('Test error for handle_error')
  service.send(:handle_error, error: error, message: 'Testing handle_error logging')
rescue => e
  puts "Caught re-raised error: #{e.class}"
end

# Verify logging occurred
count_after = PersonalInformationLog.count
puts "PersonalInformationLog entries created: #{count_after - count_before}"

# Check the log entry
log = PersonalInformationLog.last
puts "\n--- Log Entry ---"
puts "Error class: #{log.error_class}"
puts "Contains error data: #{log.data[:error].present?}"
```

2. Note that the `PersonalInformationLog` was created below and logs appropriately ✅ 

```
[45744:12000 service.rb:433] Rails -- Testing handle_error logging -- { :error_class => StandardError < Exception, :error => #<StandardError: Test error for handle_error> }
Caught re-raised error: StandardError
PersonalInformationLog entries created: 1

--- Log Entry ---
Error class: DecisionReviews::V1::Service#save_error_details exception StandardError (DECISION_REVIEW_V1)
Contains error data: false
```

#### `modules/decision_reviews/lib/decision_reviews/v1/service_exception.rb`

No specific logging in this file, but I did a simple console test to ensure that it still raises exceptions as expected:

```
begin
  raise DecisionReviews::V1::ServiceException.new(key: 'DR_TEST', response_values: {}, original_status: 500, original_body: 'test body')
rescue => e
  puts "Exception class: #{e.class}"
  puts "Status: #{e.status_code}"
  puts "Key: #{e.key}"
end
```

Logs:

```
Exception class: DecisionReviews::V1::ServiceException
Status: 400
Key: DR_TEST
```

#### `lib/decision_review/utilities/pdf_validation/service.rb`

Test the `validate_pdf_with_lighthouse` method:

1. Validate that the service is initialized properly:

```
service = DecisionReview::PdfValidation::Service.new
puts "Service initialized: #{service.class}"
```

Logs: `Service initialized: DecisionReview::PdfValidation::Service`

2. Test with a valid PDF:

```
valid_pdf_path = Rails.root.join('spec', 'fixtures', 'files', 'doctors-note.pdf')
file = File.open(valid_pdf_path)

begin
  response = service.validate_pdf_with_lighthouse(file)
  puts "\n--- Valid PDF Test ---"
  puts "Response status: #{response.status}"
  puts "Success - no error logs expected"
rescue => e
  puts "Unexpected error: #{e.class} - #{e.message}"
ensure
  file.close
end
```

Logs:
```
--- Valid PDF Test ---
Response status: 200
Success - no error logs expected
```

3. Test with an invalid PDF to trigger a ClientError

```
require 'tempfile'
corrupted_pdf = Tempfile.new(['corrupted', '.pdf'])
corrupted_pdf.write('This is not a valid PDF file content')
corrupted_pdf.rewind

begin
  service.validate_pdf_with_lighthouse(corrupted_pdf)
rescue Common::Exceptions::UnprocessableEntity => e
  puts "\n--- Invalid PDF Test (ClientError path) ---"
  puts "Caught expected UnprocessableEntity"
  puts "Error detail: #{e.errors.first[:detail]}"
  puts "Error source: #{e.errors.first[:source]}"
  puts "\nCheck log/development.log for entry containing:"
  puts "  - Message: 'Decision Review Upload failed PDF validation.'"
  puts "  - validation_failure_detail from Lighthouse"
rescue => e
  puts "Error: #{e.class} - #{e.message}"
ensure
  corrupted_pdf.close
  corrupted_pdf.unlink
end
```

Logs:

```
[45744:12000 service.rb:27] Rails -- Decision Review Upload failed PDF validation. -- { :message => "Decision Review Upload failed PDF validation.", :error => #<Common::Client::Errors::ClientError: the server responded with status 422 - method and url are not available due to include_request: false on Faraday::Response::RaiseError middleware>, :validation_failure_detail => "Document is not a valid PDF" }

--- Invalid PDF Test (ClientError path) ---
Caught expected UnprocessableEntity
Error detail: Document is not a valid PDF
Error source: FormAttachment.lighthouse_validation.invalid_pdf

Check log/development.log for entry containing:
  - Message: 'Decision Review Upload failed PDF validation.'
  - validation_failure_detail from Lighthouse
  ```
  
 4. Test with a generic error:
 
 ```
 puts "\n=== Test 3: Unexpected Error ==="
class BrokenFile
  def read; raise StandardError, 'Simulated error'; end
  def path; '/tmp/fake.pdf'; end
  def close; end
end

begin
  service.validate_pdf_with_lighthouse(BrokenFile.new)
rescue Common::Exceptions::UnprocessableEntity => e
  puts "✓ Caught generic error"
  puts "  Detail: #{e.errors.first[:detail]}"
  puts "  Source: #{e.errors.first[:source]}"
end
```
 
 ```
 [45744:12000 service.rb:35] Rails -- Decision Review Upload failed with an unexpected failure case. Investigation Required. -- { :message => "Decision Review Upload failed with an unexpected failure case. Investigation Required.", :error => #<StandardError: Simulated error> }
✓ Caught generic error
  Detail: Something went wrong...
  Source: FormAttachment.lighthouse_validation.unknown_error
  ```

### Smoke testing locally in all 3 apps

#### Supplemental Claims

I updated the `create` method in the `supplemental_claims_controller.rb` to force an error:

```
def create
        raise StandardError, 'Testing error logging in create method' if Rails.env.development?

        process_submission
      rescue => e
        ::Rails.logger.error(
          message: "Exception occurred while submitting Supplemental Claim: #{e.message}",
          backtrace: e.backtrace
        )
        handle_personal_info_error(e)
      end
      ```
      
This forced an error in the UI:

<img width="400" alt="Screenshot 2025-10-28 at 12 10 30 PM" src="https://github.com/user-attachments/assets/2a00f332-7503-4d4a-b5a0-63f50018dcdf" />

and also logged appropriately in the console:

<img width="1445" height="231" alt="Screenshot 2025-10-28 at 12 11 18 PM" src="https://github.com/user-attachments/assets/b06eec1a-48e6-436d-9982-682088fbdf78" />

#### Higher-Level Review

I did the same thing as Supplemental Claims in the `higher_level_reviews_controller.rb`:

```
def create
        raise StandardError, 'Testing error logging in create method' if Rails.env.development?

        req_body_obj = normalize_area_code_for_lighthouse_schema(request_body_hash)
        hlr_response_body = decision_review_service
                            .create_higher_level_review(request_body: req_body_obj, user: @current_user,
                                                        version: 'V2')
                            .body
        submitted_appeal_uuid = hlr_response_body.dig('data', 'id')
        ActiveRecord::Base.transaction do
          AppealSubmission.create!(user_account: @current_user.user_account,
                                   type_of_appeal: 'HLR', submitted_appeal_uuid:)

          store_saved_claim(claim_class: ::SavedClaim::HigherLevelReview, form: request_body_hash.to_json,
                            guid: submitted_appeal_uuid)

          # Clear in-progress form since submit was successful
          InProgressForm.form_for_user('20-0996', current_user)&.destroy!
        end
        render json: hlr_response_body
      rescue => e
        ::Rails.logger.error(
          message: "Exception occurred while submitting Higher Level Review: #{e.message}",
          backtrace: e.backtrace
        )

        handle_personal_info_error(e)
      end
      ```
      
  This raised an error in the UI:

<img width="400" alt="Screenshot 2025-10-28 at 12 12 35 PM" src="https://github.com/user-attachments/assets/b44c7e18-e316-4a61-ba31-544d72158f2e" />

as well as in the console:
<img width="1442" height="307" alt="Screenshot 2025-10-28 at 12 13 16 PM" src="https://github.com/user-attachments/assets/cc03c5fb-3d6f-4da0-bf93-c7fdd41f9a3f" />


#### Notice of Disagreement

I followed the same pattern for the `notice_of_disagreements_controller.rb`:

```
def create
        raise StandardError, 'Testing error logging in create method' if Rails.env.development?

        req_body_obj = normalize_area_code_for_lighthouse_schema(request_body_hash)
        nod_response_body = AppealSubmission.submit_nod(
          current_user: @current_user,
          request_body_hash: req_body_obj,
          decision_review_service:
        )

        render json: nod_response_body
      rescue => e
        ::Rails.logger.error(
          message: "Exception occurred while submitting Notice Of Disagreement: #{e.message}",
          backtrace: e.backtrace
        )
        handle_personal_info_error(e)
      end
```

Here's the UI error:

<img width="400" alt="Screenshot 2025-10-28 at 12 14 20 PM" src="https://github.com/user-attachments/assets/f76c1f70-1ac2-4199-9ac4-edf9b9ee1b56" />

and the error in the console:
<img width="1442" height="395" alt="Screenshot 2025-10-28 at 12 14 30 PM" src="https://github.com/user-attachments/assets/1e81f6d4-427f-4cce-97cc-41af07ceeaf9" />



