### PR TITLE
Chore: Remove PII check logs from claims_api spec helper

### DIFF
--- a/modules/claims_api/spec/rails_helper.rb
+++ b/modules/claims_api/spec/rails_helper.rb
@@ -9,28 +9,5 @@ require 'bd/bd'
 require 'evss_service/base'
 
 RSpec.configure do |config|
-  config.before(:suite) do
-    `truncate -s 0 log/test.log`
-  end
   config.include FactoryBot::Syntax::Methods
-  config.after(:suite) do
-    @results ||= []
-    keywords ||= File.readlines('modules/claims_api/spec/support/pii_key_words.txt', chomp: true).map!(&:downcase)
-    File.readlines('log/test.log', chomp: true).each_with_index do |context, index|
-      keywords.each do |phrase|
-        @results << { line: index, phrase:, context: } if context.to_s.downcase.include?(phrase.downcase)
-      end
-    end
-
-    unless @results.empty?
-      puts ''
-      puts '======================================='
-      puts 'Start check for PII in test log'
-      puts '======================================='
-      puts @results.uniq!
-      puts '======================================='
-      puts 'End check for PII in test log'
-      puts '======================================='
-    end
-  end
 end


### PR DESCRIPTION
## Summary

- Remove logs related to PII checks 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/121651

## Testing done

- [x] CI spec testing

## Acceptance criteria

- [x] the specs pass