### PR TITLE
VEBT-3662/SOB lower env certs

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1180,8 +1180,6 @@ res:
   ch_31_eligibility:
     mock: <%= ENV['res__ch_31_eligibility__mock']%>
   mock_ch_31: <%= ENV['res__mock_ch31'] %>
-  ch_31_eligibility:
-    mock: <%= ENV['res__ch_31_eligibility__mock']%>
 review_instance_slug: <%= ENV['review_instance_slug'] %>
 rrd:
   alerts:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1196,8 +1196,6 @@ res:
   ch_31_eligibility:
     mock: ~
   mock_ch_31: ~
-  ch_31_eligibility:
-    mock: ~
 review_instance_slug: ~
 rrd:
   alerts:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1195,8 +1195,6 @@ res:
   ch_31_eligibility:
     mock: ~
   mock_ch_31: ~
-  ch_31_eligibility:
-    mock: ~
 review_instance_slug: ~
 rrd:
   alerts:


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- *(Summarize the changes that have been made to the platform)* @department-of-veterans-affairs/octo-identity is creating new prod certs for Statement of Benefits application to connect to DGI claimant service. Per slack thread [here](https://dsva.slack.com/archives/CSFV4QTKN/p1761149268882329), we can re-use existing dgi cert public and private keys for lower envs while they create new certs for production. In preparation, creating new settings and corresponding params in param store. **For prod params, because cert hasn't been created yet, I entered '/' as value -- will that break anything? **
- *(Which team do you work for, does your team own the maintenance of this component?)* VEBT, yes

## Related issue(s)

- https://jira.devops.va.gov/browse/VEBT-3662
