### PR TITLE
Chore: Remove Already Initialized Constants

### DIFF
--- a/modules/decision_reviews/spec/support/vcr_helper.rb
+++ b/modules/decision_reviews/spec/support/vcr_helper.rb
@@ -3,8 +3,6 @@
 require 'support/vcr'
 require 'support/vcr_multipart_matcher_helper'
 
-VCR::MATCH_EVERYTHING = { match_requests_on: %i[method uri headers body] }.freeze
-
 module VCR
   def self.all_matches
     %i[method uri body]


### PR DESCRIPTION
## Summary

- Remove second VCR::MATCH_EVERYTHING constant
- UUID_REGEX could not be removed because it's different values 
- No other constants were found

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/121651

## Testing done

- [x] CI spec testing

## Acceptance criteria

- [x] the specs pass

