### PR TITLE
Allow exempt-be-review PRs to pass when approvals are dismissed

### DIFF
--- a/.github/workflows/require_be_approval.yml
+++ b/.github/workflows/require_be_approval.yml
@@ -307,13 +307,13 @@ jobs:
           number: ${{ env.pr_number }}
           labels: exempt-be-review
 
+      - name: Exit for non backend approvals
+        if: steps.verify_approval.outputs.backend_approval_required == 'false' || steps.verify_approval.outputs.exempt_be_review == 'true'
+        run: exit 0
+
       - name: Fail if draft or failures
         if: steps.verify_approval.outputs.approval_status == 'required'
         run: exit 1
-
-      - name: Exit for non backend approvals
-        if: steps.verify_approval.outputs.backend_approval_required == 'false'
-        run: exit 0
 
       - name: Add ready-for-backend-review label
         if: |


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary
When a pull request’s branch is updated (such as after merging master, pushing new commits, or rebasing), GitHub automatically dismisses all existing approvals.

As a result, the backend review workflow may temporarily mark your PR as requiring backend approval again, even if it was previously exempt. This isn’t a bug — it’s GitHub’s default behavior.

An exemp-be-review team reached out asking for backend approval because the required backend approval workflow was failing for this [PR](https://github.com/department-of-veterans-affairs/vets-api/actions/runs/18757882115/job/53515704808#step:8:1). 

**Change:**

Reordered and updated the logic in the workflow to exit early for PRs that do not require backend review or are explicitly exempt:
```
- name: Exit for non backend approvals
  if: steps.verify_approval.outputs.backend_approval_required == 'false' || steps.verify_approval.outputs.exempt_be_review == 'true'
  run: exit 0
```


**Result**:
- PRs that are exempt or do not require backend approval will now cleanly exit before hitting failure conditions.
- Prevents false negatives in CI when approvals are dismissed automatically by GitHub branch updates.
- Maintains correct behavior for PRs that do require backend approval.


## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
