### PR TITLE
Enhancement: Use Custom RSpec Formatter for parallel_spec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,6 +1,7 @@
 --color
 --require spec_helper
---format progress
+--require ./spec/support/formatters/vets_rspec_formatter
+--format VetsRspecFormatter
 <% if ENV['CI'] %>
 --format RspecJunitFormatter
 --out log/rspec.xml

--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,6 +1,7 @@
 --color
 --require spec_helper
---format progress
+--require ./spec/support/formatters/vets_rspec_formatter
+--format VetsRspecFormatter
 <% if ENV['CI'] %>
 --format RspecJunitFormatter
 --out log/rspec<%= ENV['TEST_ENV_NUMBER'] %>.xml

--- a/spec/support/formatters/vets_rspec_formatter.rb
+++ b/spec/support/formatters/vets_rspec_formatter.rb
@@ -1,0 +1,53 @@
+
+require 'rspec/core/formatters'
+
+# Example output of formatter
+# ClaimsApi::CustomError
+# .
+# correctly sets the key as the string value from the error message (FAILED - 1)
+# ........
+
+
+class VetsRspecFormatter < RSpec::Core::Formatters::DocumentationFormatter
+  RSpec::Core::Formatters.register self,
+    :example_group_started,
+    :example_passed,
+    :example_failed,
+    :example_pending
+
+  # only output the top describe group
+  def example_group_started(notification)
+    @output.puts "\n#{notification.group.description.strip}\n" if @group_level == 0
+    @group_level += 1
+  end
+
+   # dots for passing like progress
+  def example_passed(passed)
+    @output.print '.'
+
+    flush_messages
+    @example_running = false
+  end
+
+  # failure message like documentation
+  def example_failed(failure)
+    failure_message = failure_output(failure.example)
+    output.puts "\n#{failure_message}\n"
+
+    flush_messages
+    @example_running = false
+  end
+
+  # asterisk for pending like progress
+  def example_pending(_notification)
+    @output.print '*'
+  end
+
+  private
+
+  def failure_output(example)
+    RSpec::Core::Formatters::ConsoleCodes.wrap("#{example.description.strip} " \
+                      "(FAILED - #{next_failure_index})",
+                      :failure)
+  end
+end


### PR DESCRIPTION
## Summary

- Use a custom formatter that:
    - shows the current top-level describe name (the file currently tested
    - a dot and asterisk for passing and pending (like progress format)
    - a failure message for failing examples (like documentation)

This is meant to be a _happy_ middle ground between the progress format and the documentation format in rspec
   
Example: 
```
IvcChampva::ProdSupportUtilities::Insights
......
AccreditedRepresentativePortal::V0::RepresentativeFormUploadController
..................
returns a 429 error (FAILED - 1)

SchemaCamelizer
...............
V0::Profile::Contacts
.....
PagerDuty::Models::Service
..........
```    

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/121651

## Testing done

- [ ] n/a

## Acceptance criteria

- [ ]  Passing, pending, failure are shown
- [ ]  Pending and failure summary are shown
- [ ]  The current file is shown