### PR TITLE
122654: Remove Sentry reference in FormProfile for Pensions

### DIFF
--- a/modules/pensions/app/models/pensions/form_profiles/va_21p527ez.rb
+++ b/modules/pensions/app/models/pensions/form_profiles/va_21p527ez.rb
@@ -58,7 +58,7 @@ module Pensions
     rescue => e
       monitor.track_request(
         :error,
-        "VA Profile military information prefill failed",
+        'VA Profile military information prefill failed',
         'api.pensions.form_profile.military_prefill_error',
         call_location: caller_locations.first,
         exception: { message: e.message, backtrace: e.backtrace }

--- a/modules/pensions/spec/lib/pensions/form_profiles/va_21p527ez_spec.rb
+++ b/modules/pensions/spec/lib/pensions/form_profiles/va_21p527ez_spec.rb
@@ -71,9 +71,13 @@ RSpec.describe Pensions::FormProfiles::VA21p527ez, type: :model do
       it 'logs the exception and returns an empty hash' do
         expect(monitor).to receive(:track_request).with(
           :error,
-          'VA Profile military information prefill failed due to test error',
+          'VA Profile military information prefill failed',
           'api.pensions.form_profile.military_prefill_error',
-          call_location: instance_of(Thread::Backtrace::Location)
+          call_location: instance_of(Thread::Backtrace::Location),
+          exception: {
+            message: 'test error',
+            backtrace: instance_of(Array)
+          }
         )
 
         expect(form.send(:initialize_va_profile_prefill_military_information)).to eq({})


### PR DESCRIPTION
Remove Sentry reference from Pension's FormProfile logic

## Summary

- Update form profile file
- Update spec

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/122654

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
