### PR TITLE
Add CCD endpoint to services config

### DIFF
--- a/config/betamocks/services_config.yml
+++ b/config/betamocks/services_config.yml
@@ -1080,6 +1080,12 @@
       :cache_multiple_responses:
         :uid_location: "query"
         :uid_locator: "patient-id"
+    - :method: :get
+      :path: "/v1/medicalrecords/ccd"
+      :file_path: "mhv/uhd/ccd"
+      :cache_multiple_responses:
+        :uid_location: "query"
+        :uid_locator: "patientId"
 
 # VRE
 - :name: "VRE"


### PR DESCRIPTION
## Summary

- **This work is behind a feature toggle (flipper): NO**

This PR adds the missing betamocks configuration for the CCD (Continuity of Care Document) endpoint. The backend implementation was merged in #24631, but the betamocks `services_config.yml` file was not updated at that time. This prevents local development and testing of the CCD v2 functionality.

**Changes:**
- Add `/v1/medicalrecords/ccd` route to `config/betamocks/services_config.yml`
- Route points to `mhv/uhd/ccd` mock data directory
- Includes patientId query parameter caching for user-specific responses

**Team:** MHV Medical Records team

## Related issue(s)
- Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/123774
- Backend implementation PR: https://github.com/department-of-veterans-affairs/vets-api/pull/24631 (merged)
- Related mockdata PR: https://github.com/department-of-veterans-affairs/vets-api-mockdata/pull/638

## Testing done

- [x] New code is covered by unit tests (N/A - configuration only)

## What areas of the site does it impact?

**Impacted areas:**
- Betamocks configuration for local development
- MHV Medical Records > Download page (when testing locally)

**Code touched:**
- `config/betamocks/services_config.yml` only

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (N/A - config file only)
- [x] No error nor warning in the console
- [x] Events are being sent to the appropriate logging solution (N/A - config file only)
- [x] Documentation has been updated (N/A - standard betamocks pattern)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Feature/bug has a monitor built into Datadog (N/A - existing monitoring from #24631)
- [x] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ] I added a screenshot of the developed feature (N/A - configuration only)

## Requested Feedback

This is a simple configuration addition that was missed in the original backend PR. No complex logic changes, just adding the route mapping to enable betamocks for local testing.