### PR TITLE
Remove references to sentry logging

### DIFF
--- a/app/controllers/sign_in/application_controller.rb
+++ b/app/controllers/sign_in/application_controller.rb
@@ -9,7 +9,6 @@ module SignIn
     include ExceptionHandling
     include Headers
     include ControllerLoggingContext
-    include SentryLogging
     include SentryControllerLogging
     include Traceable
     service_tag 'identity'

--- a/app/controllers/sign_in/service_account_application_controller.rb
+++ b/app/controllers/sign_in/service_account_application_controller.rb
@@ -8,7 +8,6 @@ module SignIn
     include ExceptionHandling
     include Headers
     include ControllerLoggingContext
-    include SentryLogging
     include SentryControllerLogging
     include Traceable
 

--- a/app/models/mpi_data.rb
+++ b/app/models/mpi_data.rb
@@ -5,14 +5,12 @@ require 'mpi/service'
 require 'common/models/redis_store'
 require 'common/models/concerns/cache_aside'
 require 'mpi/constants'
-require 'sentry_logging'
 
 # Facade for MVI. User model delegates MVI correlation id and VA profile (golden record) methods to this class.
 # When a profile is requested from one of the delegates it is returned from either a cached response in Redis
 # or from the MVI SOAP service.
 class MPIData < Common::RedisStore
   include Common::CacheAside
-  include SentryLogging
 
   REDIS_CONFIG_KEY = :mpi_profile_response
   redis_config_key REDIS_CONFIG_KEY

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 require 'common/models/redis_store'
-require 'sentry_logging'
 
 class Session < Common::RedisStore
-  include SentryLogging
-
   redis_store REDIS_CONFIG[:session_store][:namespace]
   redis_ttl REDIS_CONFIG[:session_store][:each_ttl]
   redis_key :token

--- a/app/models/user_session_form.rb
+++ b/app/models/user_session_form.rb
@@ -2,7 +2,6 @@
 
 class UserSessionForm
   include ActiveModel::Validations
-  include SentryLogging
 
   VALIDATIONS_FAILED_ERROR_CODE = '004'
   SAML_REPLAY_VALID_SESSION_ERROR_CODE = '002'

--- a/lib/mpi/responses/add_parser.rb
+++ b/lib/mpi/responses/add_parser.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'sentry_logging'
 require_relative 'parser_base'
 require 'identity/parsers/gc_ids'
 
@@ -8,7 +7,6 @@ module MPI
   module Responses
     # Parses an MVI response and returns an MviProfile
     class AddParser < ParserBase
-      include SentryLogging
       include Identity::Parsers::GCIds
 
       ACKNOWLEDGEMENT_DETAIL_CODE_XPATH = 'acknowledgement/acknowledgementDetail/code'

--- a/lib/mpi/responses/profile_parser.rb
+++ b/lib/mpi/responses/profile_parser.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'sentry_logging'
 require 'identity/parsers/gc_ids'
 require_relative 'parser_base'
 require 'mpi/models/mvi_profile'
@@ -9,7 +8,6 @@ module MPI
   module Responses
     # Parses a MVI response and returns a MviProfile
     class ProfileParser < ParserBase
-      include SentryLogging
       include Identity::Parsers::GCIds
 
       BODY_XPATH = 'env:Envelope/env:Body/idm:PRPA_IN201306UV02'

--- a/lib/mpi/services/add_person_response_creator.rb
+++ b/lib/mpi/services/add_person_response_creator.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 require 'mpi/responses/add_parser'
-require 'sentry_logging'
 
 module MPI
   module Services
     class AddPersonResponseCreator
-      include SentryLogging
-
       attr_reader :type, :response, :error
 
       def initialize(type:, response: nil, error: nil)

--- a/lib/mpi/services/find_profile_response_creator.rb
+++ b/lib/mpi/services/find_profile_response_creator.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
 
 require 'mpi/responses/profile_parser'
-require 'sentry_logging'
 require 'mpi/errors/errors'
 
 module MPI
   module Services
     class FindProfileResponseCreator
-      include SentryLogging
-
       attr_reader :type, :response, :error
 
       def initialize(type:, response: nil, error: nil)

--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'common/exceptions/routing_error'
-require 'sentry_logging'
 require_relative 'url_service'
 
 module SAML
@@ -12,8 +11,6 @@ module SAML
   # @see SAML::URLService
   #
   class PostURLService < URLService
-    include SentryLogging
-
     def initialize(saml_settings, session: nil, user: nil, params: {}, loa3_context: LOA::IDME_LOA3_VETS)
       unless %w[new saml_callback saml_logout_callback ssoe_slo_callback].include?(params[:action])
         raise Common::Exceptions::RoutingError, params[:path]

--- a/lib/saml/user.rb
+++ b/lib/saml/user.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 require 'saml/user_attributes/ssoe'
-require 'sentry_logging'
 require 'base64'
 
 module SAML
   class User
-    include SentryLogging
-
     UNKNOWN_AUTHN_CONTEXT = 'unknown'
     MHV_ORIGINAL_CSID = 'mhv'
     MHV_MAPPED_CSID = 'myhealthevet'

--- a/lib/saml/user_attributes/ssoe.rb
+++ b/lib/saml/user_attributes/ssoe.rb
@@ -7,7 +7,6 @@ require 'identity/parsers/gc_ids'
 module SAML
   module UserAttributes
     class SSOe
-      include SentryLogging
       include Identity::Parsers::GCIds
       SERIALIZABLE_ATTRIBUTES = %i[email first_name middle_name last_name gender ssn birth_date
                                    idme_uuid logingov_uuid verified_at sec_id mhv_icn


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- Remove references to Sentry logging in identity files. These were previously updated to use Rails.logger

## Testing

- No code changes, just references 

## What areas of the site does it impact?
Identity logging

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
