### PR TITLE
Temporarily disable rubocop in lib/unified_health_data/adapters/lab_or_test_adapter.rb

### DIFF
--- a/lib/unified_health_data/adapters/lab_or_test_adapter.rb
+++ b/lib/unified_health_data/adapters/lab_or_test_adapter.rb
@@ -16,6 +16,7 @@ module UnifiedHealthData
         parsed.compact
       end
 
+      # rubocop:disable Metrics/MethodLength
       def parse_single_record(record)
         return nil if record.nil? || record['resource'].nil?
 
@@ -42,6 +43,7 @@ module UnifiedHealthData
           status: record['resource']['status']
         )
       end
+      # rubocop:enable Metrics/MethodLength
 
       private
 


### PR DESCRIPTION
## Summary
Fix CI for vets-api to get code deploying again. Disable rubocop for method line length until a real fix can be implemented. 

## Related issue(s)
CI started failing after https://github.com/department-of-veterans-affairs/vets-api/pull/24722 merged 

## Testing done


## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
