### PR TITLE
Change optimistic insertion operation for Unique User Metrics

### DIFF
--- a/app/models/mhv_metrics_unique_user_event.rb
+++ b/app/models/mhv_metrics_unique_user_event.rb
@@ -70,7 +70,11 @@ class MHVMetricsUniqueUserEvent < ApplicationRecord
     # This avoids raising exceptions and database error logs for duplicate records
     # rubocop:disable Rails/SkipsModelValidations
     # Validations are already enforced by validate_inputs above and database constraint
-    result = insert({ user_id:, event_name: }, unique_by: %i[user_id event_name])
+    result = insert(
+      { user_id:, event_name: },
+      unique_by: %i[user_id event_name],
+      returning: %i[user_id event_name]
+    )
     # rubocop:enable Rails/SkipsModelValidations
 
     # Cache that this event now exists (whether new or duplicate)

--- a/spec/models/mhv_metrics_unique_user_event_spec.rb
+++ b/spec/models/mhv_metrics_unique_user_event_spec.rb
@@ -161,7 +161,11 @@ RSpec.describe MHVMetricsUniqueUserEvent, type: :model do
 
         before do
           allow(described_class).to receive(:insert)
-            .with({ user_id:, event_name: }, unique_by: %i[user_id event_name])
+            .with(
+              { user_id:, event_name: },
+              unique_by: %i[user_id event_name],
+              returning: %i[user_id event_name]
+            )
             .and_return(insert_result)
         end
 
@@ -170,7 +174,11 @@ RSpec.describe MHVMetricsUniqueUserEvent, type: :model do
 
           expect(result).to be(true)
           expect(described_class).to have_received(:insert)
-            .with({ user_id:, event_name: }, unique_by: %i[user_id event_name])
+            .with(
+              { user_id:, event_name: },
+              unique_by: %i[user_id event_name],
+              returning: %i[user_id event_name]
+            )
           expect(described_class).to have_received(:mark_key_cached).with(cache_key)
           expect(Rails.logger).to have_received(:debug)
             .with('UUM: New unique event recorded', { user_id:, event_name: })
@@ -182,7 +190,11 @@ RSpec.describe MHVMetricsUniqueUserEvent, type: :model do
 
         before do
           allow(described_class).to receive(:insert)
-            .with({ user_id:, event_name: }, unique_by: %i[user_id event_name])
+            .with(
+              { user_id:, event_name: },
+              unique_by: %i[user_id event_name],
+              returning: %i[user_id event_name]
+            )
             .and_return(insert_result)
           allow(Rails.logger).to receive(:debug)
         end
@@ -195,6 +207,56 @@ RSpec.describe MHVMetricsUniqueUserEvent, type: :model do
           expect(Rails.logger).to have_received(:debug)
             .with('UUM: Duplicate event found in database', { user_id:, event_name: })
         end
+      end
+    end
+
+    context 'integration test with real database' do
+      let(:test_user_id) { SecureRandom.uuid }
+      let(:test_event_name) { 'integration_test_event' }
+
+      before do
+        # Ensure cache is clear for this specific key
+        Rails.cache.delete("#{test_user_id}:#{test_event_name}", namespace: 'unique_user_metrics')
+      end
+
+      after do
+        # Cleanup test data and cache
+        described_class.where(user_id: test_user_id).delete_all
+        Rails.cache.delete("#{test_user_id}:#{test_event_name}", namespace: 'unique_user_metrics')
+      end
+
+      it 'returns correct values for new vs duplicate inserts' do
+        # First insert with cache clear - should return true (new event)
+        Rails.cache.delete("#{test_user_id}:#{test_event_name}", namespace: 'unique_user_metrics')
+        result1 = described_class.record_event(user_id: test_user_id, event_name: test_event_name)
+        expect(result1).to be(true), 'First insert should return true for new event'
+
+        # Second insert with cache clear - should return false (duplicate)
+        Rails.cache.delete("#{test_user_id}:#{test_event_name}", namespace: 'unique_user_metrics')
+        result2 = described_class.record_event(user_id: test_user_id, event_name: test_event_name)
+        expect(result2).to be(false), 'Duplicate insert should return false'
+
+        # Subsequent inserts should also return false
+        3.times do
+          Rails.cache.delete("#{test_user_id}:#{test_event_name}", namespace: 'unique_user_metrics')
+          result = described_class.record_event(user_id: test_user_id, event_name: test_event_name)
+          expect(result).to be(false), 'Multiple duplicate inserts should all return false'
+        end
+
+        # Verify only one record exists (INSERT ON CONFLICT prevented duplicates)
+        records = described_class.where(user_id: test_user_id, event_name: test_event_name)
+        expect(records.count).to eq(1)
+        expect(records.first.created_at).to be_present
+      end
+
+      it 'does not raise exceptions on duplicate inserts' do
+        # Verify no ActiveRecord::RecordNotUnique exceptions are raised
+        expect do
+          5.times do
+            Rails.cache.delete("#{test_user_id}:#{test_event_name}", namespace: 'unique_user_metrics')
+            described_class.record_event(user_id: test_user_id, event_name: test_event_name)
+          end
+        end.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Change optimistic insertion operation for Unique User Metrics to use `INSERT ... ON CONFLICT` to make sure Postgres does not log an error.
- Team: MHV Horizon

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/124131

## Testing done
- [ ] *New code already covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
