### PR TITLE
Update brakeman

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,7 +291,7 @@ GEM
     blueprinter (1.2.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.1.0)
+    brakeman (7.1.1)
       racc
     breakers (1.0)
       base64 (~> 0.2)


### PR DESCRIPTION
## Summary

7.1.1 was release yesterday: https://brakemanscanner.org/blog/2025/11/03/brakeman-7-dot-1-dot-1-released
We'll all get the error `Brakeman 7.1.0 is not the latest version 7.1.1` during CI until we're on the latest. 

## Related issue(s)

Notified in the support channel: https://dsva.slack.com/archives/CBU0KDSB1/p1762219329819719

## Testing done

see CI.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Gemfile, brakeman, CI.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
