### PR TITLE
(BIO) Fix OliveBranch/Committee Validation Conflict for Forms 21-4192 and 21P-530A

### DIFF
--- a/app/controllers/v0/form214192_controller.rb
+++ b/app/controllers/v0/form214192_controller.rb
@@ -9,9 +9,9 @@ module V0
 
     def create
       # Body parsed by Rails; schema validated by committee before hitting here.
-      payload = request.request_parameters
+      payload = request.raw_post
 
-      claim = SavedClaim::Form214192.new(form: payload.to_json)
+      claim = SavedClaim::Form214192.new(form: payload)
 
       if claim.save
         claim.process_attachments!
@@ -36,7 +36,8 @@ module V0
     end
 
     def download_pdf
-      parsed_form = request.request_parameters
+      # Parse raw JSON to get camelCase keys (bypasses OliveBranch transformation)
+      parsed_form = JSON.parse(request.raw_post)
 
       source_file_path = with_retries('Generate 21-4192 PDF') do
         PdfFill::Filler.fill_ancillary_form(parsed_form, SecureRandom.uuid, '21-4192')

--- a/app/controllers/v0/form21p530a_controller.rb
+++ b/app/controllers/v0/form21p530a_controller.rb
@@ -9,9 +9,9 @@ module V0
 
     def create
       # Body parsed by Rails; schema validated by committee before hitting here.
-      payload = request.request_parameters
+      payload = request.raw_post
 
-      claim = SavedClaim::Form21p530a.new(form: payload.to_json)
+      claim = SavedClaim::Form21p530a.new(form: payload)
 
       if claim.save
         claim.process_attachments!
@@ -36,7 +36,8 @@ module V0
     end
 
     def download_pdf
-      parsed_form = request.request_parameters
+      # Parse raw JSON to get camelCase keys (bypasses OliveBranch transformation)
+      parsed_form = JSON.parse(request.raw_post)
 
       source_file_path = with_retries('Generate 21P-530A PDF') do
         PdfFill::Filler.fill_ancillary_form(parsed_form, SecureRandom.uuid, '21P-530a')


### PR DESCRIPTION
## Summary

- **This work is behind a feature toggle (flipper): NO**

### Problem
The frontend forms system sends requests with the `X-Key-Inflection: camel` header by default. This caused a conflict between OliveBranch middleware and Committee validation:

1. OliveBranch middleware runs first and transforms request parameters from camelCase → snake_case
2. Committee middleware then validates the request against OpenAPI schemas that expect camelCase keys
3. Validation fails with 422 "Unprocessable Entity" errors

This affected four endpoints:
- `POST /v0/form214192` (create)
- `POST /v0/form214192/download_pdf`
- `POST /v0/form21p530a` (create)
- `POST /v0/form21p530a/download_pdf`

### How to Reproduce
1. Send a POST request to `/v0/form214192` with:
   - `Content-Type: application/json`
   - `X-Key-Inflection: camel`
   - Valid camelCase form data matching the OpenAPI schema
2. Observe 422 validation error despite valid data

### Solution
Use `request.raw_post` instead of `request.request_parameters` to bypass OliveBranch transformation:

**For `create` actions (storing JSON string):**
```ruby
payload = request.raw_post  # Already a JSON string, untouched by OliveBranch
claim = SavedClaim::Form214192.new(form: payload)
```

**For `download_pdf` actions (need hash for PDF generation):**
```ruby
parsed_form = JSON.parse(request.raw_post)  # Manually parse to get camelCase hash
PdfFill::Filler.fill_ancillary_form(parsed_form, ...)
```

### Why This Solution?
1. **Committee validates raw body, not transformed params** - Committee reads the raw request body (still in camelCase) and validates it against the OpenAPI schema successfully
2. **OliveBranch only transforms params hash** - `request.raw_post` returns the original request body string, untouched by middleware transformations
3. **Low LOE** - Simple 1-2 line changes per endpoint vs. complex middleware bypass logic (like Accredited Representative Portal uses)
4. **Preserves original format** - Stores camelCase data in database, matching frontend expectations and OpenAPI schema

### Team Information
- **Team**: Benefits Intake Forms
- **Maintenance**: Yes, our team maintains Forms 21-4192 (Request for Employment Information) and 21P-530A (Application for Burial Benefits)

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/124293

## Testing done

- [x] New code is covered by unit tests (existing specs pass with changes)

### Old Behavior
- Endpoints would fail with 422 validation errors when receiving requests with `X-Key-Inflection: camel` header
- Controller used `request.request_parameters` which contained OliveBranch-transformed snake_case keys
- Committee validation would fail because it expected camelCase keys per OpenAPI schema

### New Behavior
- Endpoints successfully process requests with `X-Key-Inflection: camel` header
- Controller uses `request.raw_post` to get original camelCase JSON
- Committee validates successfully against OpenAPI schema
- Form data stored in database maintains original camelCase format

### Manual Testing Steps
1. Start vets-api locally
2. Run test script: `./scripts/4192.sh`
   - Verifies POST `/v0/form214192` creates claim successfully
   - Verifies POST `/v0/form214192/download_pdf` generates PDF (2MB)
3. Run test script: `./scripts/530a.sh`
   - Verifies POST `/v0/form21p530a/download_pdf` generates PDF (1.5MB)
4. Verify PDFs are generated in `scripts/output/` folder
5. Open PDFs and verify form fields are populated correctly

### Test Scripts Updated
- Created `scripts/4192.sh` - Tests Form 21-4192 endpoints
- Created `scripts/530a.sh` - Tests Form 21P-530A endpoints
- Both scripts send requests with `X-Key-Inflection: camel` header to simulate frontend behavior
- PDFs output to `scripts/output/` folder for inspection

## Screenshots


[21p530a_test_20251104_110253.pdf](https://github.com/user-attachments/files/23342265/21p530a_test_20251104_110253.pdf)
[form214192_test.pdf](https://github.com/user-attachments/files/23342266/form214192_test.pdf)

## What areas of the site does it impact?

**Directly Impacted:**
- Form 21-4192 (Request for Employment Information in Connection with Claim for Disability Benefits)
  - Create endpoint: `/v0/form214192`
  - PDF download endpoint: `/v0/form214192/download_pdf`
- Form 21P-530A (Application for Burial Benefits)
  - Create endpoint: `/v0/form21p530a`
  - PDF download endpoint: `/v0/form21p530a/download_pdf`

**No Impact to Other Areas:**
- Changes are isolated to these two controllers
- No shared code or utilities modified
- Other forms using `request.request_parameters` without the `X-Key-Inflection` header are unaffected

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution
- [ ] Documentation has been updated (link to documentation)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Feature/bug has a monitor built into Datadog (if applicable)
- [x] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected (both endpoints skip authentication for public form submission)
- [x] I added a screenshot of the developed feature

## Requested Feedback

### Middleware Order Context
The fix relies on understanding the middleware execution order:
```
27: OliveBranch::Middleware        (transforms params)
36: Committee::RequestValidation   (validates raw body)
```

Committee validates the **raw request body** before controllers execute, so using `request.raw_post` gives us the original camelCase JSON that Committee already validated.

### Alternative Approaches Considered
1. **Middleware bypass** (like ARP uses) - Higher complexity, requires prepending custom module to OliveBranch::Middleware
2. **Remove X-Key-Inflection header** - Frontend change required, affects other endpoints
3. **Update OpenAPI schema to snake_case** - Breaking change for frontend consumers

The `request.raw_post` approach was chosen for its simplicity and minimal code changes while maintaining proper validation.
