### PR TITLE
1830: add new 1095b model

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -318,6 +318,7 @@ app/models/user_session_form.rb @department-of-veterans-affairs/octo-identity
 app/models/user_verification.rb @department-of-veterans-affairs/octo-identity
 app/models/user.rb @department-of-veterans-affairs/octo-identity
 app/models/va_profile_redis @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
+app/models/veteran_enrollment_system/form1095_b/form1095_b.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
 app/models/veteran_onboarding.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
 app/models/webhooks @department-of-veterans-affairs/backend-review-group
 app/models/webhooks/notification_attempt_assoc.rb @department-of-veterans-affairs/backend-review-group
@@ -1685,6 +1686,7 @@ spec/models/user_session_form_spec.rb @department-of-veterans-affairs/octo-ident
 spec/models/user_spec.rb @department-of-veterans-affairs/octo-identity
 spec/models/user_verification_spec.rb @department-of-veterans-affairs/octo-identity
 spec/models/va_profile_redis @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
+spec/models/veteran_enrollment_system/form1095_b/form1095_b_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
 spec/models/veteran_onboarding_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
 spec/models/webhooks @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/backend-review-group
 spec/policies/appeals_policy_spec.rb @department-of-veterans-affairs/backend-review-group

--- a/app/models/veteran_enrollment_system/form1095_b/form1095_b.rb
+++ b/app/models/veteran_enrollment_system/form1095_b/form1095_b.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require 'common/models/resource'
+
+module VeteranEnrollmentSystem
+  module Form1095B
+    class Form1095B
+      include Vets::Model
+
+      attribute :first_name, String
+      attribute :middle_name, String
+      attribute :last_name, String
+      attribute :last_4_ssn, String
+      attribute :birth_date, Date
+      attribute :address, String
+      attribute :city, String
+      attribute :state, String
+      attribute :province, String
+      attribute :country, String
+      attribute :zip_code, String
+      attribute :foreign_zip, String
+      attribute :is_corrected, Bool, default: false
+      attribute :coverage_months, Array
+      attribute :tax_year, String
+
+      def txt_file
+        template_path = self.class.txt_template_path(tax_year)
+        unless File.exist?(template_path)
+          Rails.logger.error "1095-B template for year #{tax_year} does not exist."
+          raise Common::Exceptions::UnprocessableEntity.new(
+            detail: "1095-B for tax year #{tax_year} not supported", source: self.class.name
+          )
+        end
+
+        template_file = File.open(template_path, 'r')
+        template_data = attributes.merge(txt_form_data)
+        prepared_text = template_file.read % template_data.symbolize_keys
+        template_file.close
+
+        prepared_text
+      end
+
+      def pdf_file
+        template_path = self.class.pdf_template_path(tax_year)
+        unless File.exist?(template_path)
+          Rails.logger.error "1095-B template for year #{tax_year} does not exist."
+          raise Common::Exceptions::UnprocessableEntity.new(
+            detail: "1095-B for tax year #{tax_year} not supported", source: self.class.name
+          )
+        end
+
+        pdftk = PdfForms.new(Settings.binaries.pdftk)
+        tmp_file = Tempfile.new("1095B-#{SecureRandom.hex}.pdf")
+        generate_pdf(pdftk, tmp_file, template_path)
+      end
+
+      class << self
+        # there is some overlap in the data provided by coveredIndividual and responsibleIndividual.
+        # in the VA enrollment system, they are always the same.
+        def parse(form_data)
+          prepared_data = {
+            first_name: form_data['data']['coveredIndividual']['name']['firstName'],
+            middle_name: form_data['data']['coveredIndividual']['name']['middleName'],
+            last_name: form_data['data']['coveredIndividual']['name']['lastName'],
+            last_4_ssn: form_data['data']['coveredIndividual']['ssn'],
+            birth_date: form_data['data']['coveredIndividual']['dateOfBirth'],
+            address: form_data['data']['responsibleIndividual']['address']['street1'],
+            city: form_data['data']['responsibleIndividual']['address']['city'],
+            state: form_data['data']['responsibleIndividual']['address']['stateOrProvince'],
+            province: form_data['data']['responsibleIndividual']['address']['stateOrProvince'],
+            country: form_data['data']['responsibleIndividual']['address']['country'],
+            zip_code: form_data['data']['responsibleIndividual']['address']['zipOrPostalCode'],
+            foreign_zip: form_data['data']['responsibleIndividual']['address']['zipOrPostalCode'],
+            is_corrected: false, # this will always be false at this time
+            coverage_months: coverage_months(form_data),
+            tax_year: form_data['data']['taxYear']
+          }
+          new(prepared_data)
+        end
+
+        def available_years(periods)
+          years = periods.each_with_object([]) do |period, array|
+            start_date = period['startDate'].to_date.year
+            # if no end date, the user is still enrolled
+            end_date = period['endDate']&.to_date&.year || Date.current.year
+            array << start_date
+            array << end_date
+            if (end_date - start_date) > 1
+              intervening_years = (start_date..end_date).to_a
+              array.concat(intervening_years)
+            end
+          end.uniq.sort
+          years.filter { |year| year.between?(*available_years_range) }
+        end
+
+        def available_years_range
+          current_year = Date.current.year
+          [current_year - 4, current_year - 1]
+        end
+
+        def pdf_template_path(year)
+          "lib/veteran_enrollment_system/form1095_b/templates/pdfs/1095b-#{year}.pdf"
+        end
+
+        def txt_template_path(year)
+          "lib/veteran_enrollment_system/form1095_b/templates/txts/1095b-#{year}.txt"
+        end
+
+        private
+
+        def coverage_months(form_data)
+          months = form_data['data']['coveredIndividual']['monthsCovered']
+          coverage_months = Date::MONTHNAMES.compact.map { |month| months&.include?(month.upcase) ? month.upcase : nil }
+          covered_all = form_data['data']['coveredIndividual']['coveredAll12Months']
+          [covered_all, *coverage_months]
+        end
+      end
+
+      private
+
+      def country_and_zip
+        "#{country} #{zip_code || foreign_zip}"
+      end
+
+      def middle_initial
+        middle_name ? middle_name[0] : ''
+      end
+
+      def birthdate_unless_ssn
+        last_4_ssn.present? ? '' : birth_date
+      end
+
+      def txt_form_data
+        text_data = {
+          birth_date_field: birthdate_unless_ssn,
+          state_or_province: state || province,
+          country_and_zip:,
+          middle_init: middle_initial,
+          corrected: is_corrected ? 'X' : '--'
+        }
+
+        coverage_months.each_with_index do |val, i|
+          field_name = "coverage_month_#{i}"
+          text_data[field_name.to_sym] = val ? 'X' : '--'
+        end
+
+        text_data
+      end
+
+      # rubocop:disable Metrics/MethodLength
+      def generate_pdf(pdftk, tmp_file, template_path)
+        pdftk.fill_form(
+          template_path,
+          tmp_file,
+          {
+            'topmostSubform[0].Page1[0].Pg1Header[0].cb_1[1]': is_corrected && 2,
+            'topmostSubform[0].Page1[0].Part1Contents[0].Line1[0].f1_01[0]': first_name,
+            'topmostSubform[0].Page1[0].Part1Contents[0].Line1[0].f1_02[0]': middle_name,
+            'topmostSubform[0].Page1[0].Part1Contents[0].Line1[0].f1_03[0]': last_name,
+            'topmostSubform[0].Page1[0].Part1Contents[0].f1_04[0]': last_4_ssn || '',
+            'topmostSubform[0].Page1[0].Part1Contents[0].f1_05[0]': birthdate_unless_ssn,
+            'topmostSubform[0].Page1[0].Part1Contents[0].f1_06[0]': address,
+            'topmostSubform[0].Page1[0].Part1Contents[0].f1_07[0]': city,
+            'topmostSubform[0].Page1[0].Part1Contents[0].f1_08[0]': state || province,
+            'topmostSubform[0].Page1[0].Part1Contents[0].f1_09[0]': country_and_zip,
+            'topmostSubform[0].Page1[0].Part1Contents[0].f1_10[0]': 'C',
+            'topmostSubform[0].Page1[0].f1_18[0]': 'US Department of Veterans Affairs',
+            'topmostSubform[0].Page1[0].f1_19[0]': '74-1612229',
+            'topmostSubform[0].Page1[0].f1_20[0]': '877-222-8387',
+            'topmostSubform[0].Page1[0].f1_21[0]': 'P.O. BOX 149975',
+            'topmostSubform[0].Page1[0].f1_22[0]': 'Austin',
+            'topmostSubform[0].Page1[0].f1_23[0]': 'TX',
+            'topmostSubform[0].Page1[0].f1_24[0]': '78714-8957',
+            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_25[0]': first_name,
+            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_26[0]': middle_initial,
+            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_27[0]': last_name,
+            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_28[0]': last_4_ssn || '',
+            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_29[0]': birthdate_unless_ssn,
+            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_01[0]': coverage_months[0] && 1,
+            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_02[0]': coverage_months[1] && 1,
+            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_03[0]': coverage_months[2] && 1,
+            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_04[0]': coverage_months[3] && 1,
+            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_05[0]': coverage_months[4] && 1,
+            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_06[0]': coverage_months[5] && 1,
+            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_07[0]': coverage_months[6] && 1,
+            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_08[0]': coverage_months[7] && 1,
+            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_09[0]': coverage_months[8] && 1,
+            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_10[0]': coverage_months[9] && 1,
+            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_11[0]': coverage_months[10] && 1,
+            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_12[0]': coverage_months[11] && 1,
+            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_13[0]': coverage_months[12] && 1
+          },
+          flatten: true
+        )
+        ret_pdf = tmp_file.read
+
+        tmp_file.close
+        tmp_file.unlink
+
+        ret_pdf
+      end
+      # rubocop:enable Metrics/MethodLength
+    end
+  end
+end

--- a/app/models/veteran_enrollment_system/form1095_b/form1095_b.rb
+++ b/app/models/veteran_enrollment_system/form1095_b/form1095_b.rb
@@ -32,12 +32,10 @@ module VeteranEnrollmentSystem
           )
         end
 
-        template_file = File.open(template_path, 'r')
         template_data = attributes.merge(txt_form_data)
-        prepared_text = template_file.read % template_data.symbolize_keys
-        template_file.close
-
-        prepared_text
+        File.open(template_path, 'r') do |template_file|
+          template_file.read % template_data.symbolize_keys
+        end
       end
 
       def pdf_file
@@ -62,7 +60,7 @@ module VeteranEnrollmentSystem
             first_name: form_data['data']['coveredIndividual']['name']['firstName'],
             middle_name: form_data['data']['coveredIndividual']['name']['middleName'],
             last_name: form_data['data']['coveredIndividual']['name']['lastName'],
-            last_4_ssn: form_data['data']['coveredIndividual']['ssn'],
+            last_4_ssn: form_data['data']['coveredIndividual']['ssn']&.last(4).presence,
             birth_date: form_data['data']['coveredIndividual']['dateOfBirth'],
             address: form_data['data']['responsibleIndividual']['address']['street1'],
             city: form_data['data']['responsibleIndividual']['address']['city'],
@@ -110,7 +108,7 @@ module VeteranEnrollmentSystem
 
         def coverage_months(form_data)
           months = form_data['data']['coveredIndividual']['monthsCovered']
-          coverage_months = Date::MONTHNAMES.compact.map { |month| months&.include?(month.upcase) ? month.upcase : nil }
+          coverage_months = Date::MONTHNAMES.compact.map { |month| months&.include?(month.upcase) ? month.upcase : false }
           covered_all = form_data['data']['coveredIndividual']['coveredAll12Months']
           [covered_all, *coverage_months]
         end

--- a/spec/factories/form1095_bs.rb
+++ b/spec/factories/form1095_bs.rb
@@ -21,4 +21,22 @@ FactoryBot.define do
       }.to_json
     }
   end
+
+  factory :enrollment_system_form1095_b, class: 'VeteranEnrollmentSystem::Form1095B::Form1095B' do
+    tax_year { 2024 }
+    first_name { 'First' }
+    middle_name { 'Middle' }
+    last_name { 'Last' }
+    last_4_ssn { '1234' }
+    birth_date { '1932-02-05'.to_date }
+    address { '123 Test st' }
+    city { 'Hollywood' }
+    state { 'CA' }
+    province { nil }
+    zip_code { '12345' }
+    foreign_zip { '12345' }
+    country { 'USA' }
+    is_corrected { false }
+    coverage_months { Array.new(13, true) }
+  end
 end

--- a/spec/models/veteran_enrollment_system/form1095_b/form1095_b_spec.rb
+++ b/spec/models/veteran_enrollment_system/form1095_b/form1095_b_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe VeteranEnrollmentSystem::Form1095B::Form1095B, type: :model do
                                     'first_name' => 'HECTOR',
                                     'middle_name' => nil,
                                     'last_name' => 'ALLEN',
-                                    'last_4_ssn' => '796126859',
+                                    'last_4_ssn' => '6859',
                                     'birth_date' => '1932-02-05'.to_date,
                                     'address' => 'PO BOX 494',
                                     'city' => 'MOCA',
@@ -45,18 +45,18 @@ RSpec.describe VeteranEnrollmentSystem::Form1095B::Form1095B, type: :model do
                                     'is_corrected' => false,
                                     'coverage_months' => [
                                       false,
-                                      nil,
-                                      nil,
+                                      false,
+                                      false,
                                       'MARCH',
-                                      nil,
-                                      nil,
-                                      nil,
-                                      nil,
-                                      nil,
-                                      nil,
-                                      nil,
-                                      nil,
-                                      nil
+                                      false,
+                                      false,
+                                      false,
+                                      false,
+                                      false,
+                                      false,
+                                      false,
+                                      false,
+                                      false
                                     ],
                                     'tax_year' => '2024'
                                   })
@@ -75,8 +75,20 @@ RSpec.describe VeteranEnrollmentSystem::Form1095B::Form1095B, type: :model do
       form_data['data']['coveredIndividual']['monthsCovered'] = %w[MARCH SEPTEMBER]
       instance = described_class.parse(form_data)
       expect(instance.coverage_months[1..12]).to eq(
-        [nil, nil, 'MARCH', nil, nil, nil, nil, nil, 'SEPTEMBER', nil, nil, nil]
+        [false, false, 'MARCH', false, false, false, false, false, 'SEPTEMBER', false, false, false]
       )
+    end
+
+    it 'handles empty ssn' do
+      form_data['data']['coveredIndividual']['ssn'] = ''
+      instance = described_class.parse(form_data)
+      expect(instance.last_4_ssn).to be_nil
+    end
+
+    it 'handles nil ssn' do
+      form_data['data']['coveredIndividual']['ssn'] = nil
+      instance = described_class.parse(form_data)
+      expect(instance.last_4_ssn).to be_nil
     end
   end
 

--- a/spec/models/veteran_enrollment_system/form1095_b/form1095_b_spec.rb
+++ b/spec/models/veteran_enrollment_system/form1095_b/form1095_b_spec.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe VeteranEnrollmentSystem::Form1095B::Form1095B, type: :model do
+  let(:form_data) do
+    { 'data' =>
+      { 'issuer' =>
+        { 'issuerName' => 'US Department of Veterans Affairs',
+          'ein' => '54-2002017',
+          'contactPhoneNumber' => '877-222-8387',
+          'address' => { 'street1' => 'PO Box 149975', 'city' => 'Austin', 'stateOrProvince' => 'TX',
+                         'zipOrPostalCode' => '78714-8975', 'country' => 'USA' } },
+        'responsibleIndividual' =>
+        { 'name' => { 'firstName' => 'HECTOR', 'lastName' => 'ALLEN' },
+          'address' => { 'street1' => 'PO BOX 494', 'city' => 'MOCA', 'stateOrProvince' => 'PR',
+                         'zipOrPostalCode' => '00676-0494', 'country' => 'USA' },
+          'ssn' => '796126859',
+          'dateOfBirth' => '19320205' },
+        'coveredIndividual' =>
+        { 'name' => { 'firstName' => 'HECTOR', 'lastName' => 'ALLEN' }, 'ssn' => '796126859',
+          'dateOfBirth' => '19320205', 'coveredAll12Months' => false, 'monthsCovered' => ['MARCH'] },
+        'taxYear' => '2024' },
+      'messages' => [] }
+  end
+  let(:form1095b) { build(:enrollment_system_form1095_b) }
+
+  describe '.parse' do
+    it 'returns an instance of model with expected attributes' do
+      rv = described_class.parse(form_data)
+      expect(rv).to be_instance_of(described_class)
+      expect(rv.attributes).to eq({
+                                    'first_name' => 'HECTOR',
+                                    'middle_name' => nil,
+                                    'last_name' => 'ALLEN',
+                                    'last_4_ssn' => '796126859',
+                                    'birth_date' => '1932-02-05'.to_date,
+                                    'address' => 'PO BOX 494',
+                                    'city' => 'MOCA',
+                                    'state' => 'PR',
+                                    'province' => 'PR',
+                                    'country' => 'USA',
+                                    'zip_code' => '00676-0494',
+                                    'foreign_zip' => '00676-0494',
+                                    'is_corrected' => false,
+                                    'coverage_months' => [
+                                      false,
+                                      nil,
+                                      nil,
+                                      'MARCH',
+                                      nil,
+                                      nil,
+                                      nil,
+                                      nil,
+                                      nil,
+                                      nil,
+                                      nil,
+                                      nil,
+                                      nil
+                                    ],
+                                    'tax_year' => '2024'
+                                  })
+    end
+
+    it 'sets coveredAll12Months correctly' do
+      form_data['data']['coveredIndividual']['coveredAll12Months'] = false
+      instance = described_class.parse(form_data)
+      expect(instance.coverage_months[0]).to be(false)
+      form_data['data']['coveredIndividual']['coveredAll12Months'] = true
+      instance = described_class.parse(form_data)
+      expect(instance.coverage_months[0]).to be(true)
+    end
+
+    it 'sets covered months as expected' do
+      form_data['data']['coveredIndividual']['monthsCovered'] = %w[MARCH SEPTEMBER]
+      instance = described_class.parse(form_data)
+      expect(instance.coverage_months[1..12]).to eq(
+        [nil, nil, 'MARCH', nil, nil, nil, nil, nil, 'SEPTEMBER', nil, nil, nil]
+      )
+    end
+  end
+
+  describe '.available_years' do
+    before { Timecop.freeze(Time.zone.parse('2025-03-05T08:00:00Z')) }
+    after { Timecop.return }
+
+    context 'with start and end dates' do
+      it 'returns previous four tax years for which the user had any coverage' do
+        periods = [{ 'startDate' => '2015-03-05', 'endDate' => '2025-03-05' }]
+        result = described_class.available_years(periods)
+        expect(result).to eq([2021, 2022, 2023, 2024])
+      end
+    end
+
+    context 'when end date is nil' do
+      it 'returns previous four tax years for which the user had any coverage' do
+        periods = [{ 'startDate' => '2015-03-05', 'endDate' => nil }]
+        result = described_class.available_years(periods)
+        expect(result).to eq([2021, 2022, 2023, 2024])
+      end
+    end
+
+    context 'with multiple periods' do
+      it 'includes previous four tax years for which user had any coverage' do
+        periods = [{ 'startDate' => '2015-03-05', 'endDate' => '2017-03-05' },
+                   { 'startDate' => '2020-03-05', 'endDate' => '2021-03-05' },
+                   { 'startDate' => '2022-03-05', 'endDate' => '2022-04-05' },
+                   { 'startDate' => '2024-03-05', 'endDate' => nil }]
+        result = described_class.available_years(periods)
+        expect(result).to eq([2021, 2022, 2024])
+      end
+    end
+  end
+
+  describe '.available_years_range' do
+    before { Timecop.freeze(Time.zone.parse('2025-03-05T08:00:00Z')) }
+    after { Timecop.return }
+
+    it 'returns an array containing last year and five years ago' do
+      result = described_class.available_years_range
+      expect(result).to eq([2021, 2024])
+    end
+  end
+
+  describe '.pdf_template_path' do
+    it 'returns the path to the pdf template' do
+      expect(described_class.pdf_template_path(2023)).to eq(
+        'lib/veteran_enrollment_system/form1095_b/templates/pdfs/1095b-2023.pdf'
+      )
+    end
+  end
+
+  describe '.txt_template_path' do
+    it 'returns the path to the txt template' do
+      expect(described_class.txt_template_path(2023)).to eq(
+        'lib/veteran_enrollment_system/form1095_b/templates/txts/1095b-2023.txt'
+      )
+    end
+  end
+
+  describe '#pdf_file' do
+    context 'when template is present' do
+      it 'generates pdf string for valid 1095_b' do
+        expect(form1095b.pdf_file.class).to eq(String)
+      end
+    end
+
+    context 'when template is not present' do
+      let(:inv_year_form) { build(:enrollment_system_form1095_b, tax_year: 2008) }
+
+      it 'raises error' do
+        expect { inv_year_form.pdf_file }.to raise_error(Common::Exceptions::UnprocessableEntity)
+      end
+    end
+  end
+
+  describe '#txt_file' do
+    context 'when template is present' do
+      it 'generates text string for valid 1095_b' do
+        expect(form1095b.txt_file.class).to eq(String)
+      end
+    end
+
+    context 'when template is not present' do
+      let(:inv_year_form) { build(:enrollment_system_form1095_b, tax_year: 2008) }
+
+      it 'raises error' do
+        expect { inv_year_form.txt_file }.to raise_error(Common::Exceptions::UnprocessableEntity)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO. This code is not yet in use. A subsequent PR will feature flag the use of this code. 
- This adds a new form 1095b model. The old model is being deprecated because it's a database backed model that's created by background job syncing. This model will be hydrated by the new enrollment system API.
- I work for the core veteran experiences team (formerly IIR)
- For more context, see [the full diff of work](https://github.com/department-of-veterans-affairs/vets-api/pull/24941/files)

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-iir/issues/1830

## Testing done

- [x] *New code is covered by unit tests*
- This code will be feature flagged and tested on staging before being turned on. We intend to turn on the feature flag on production for a small % of users initially and will increase from there. 

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
None at this time because the code is not being used. 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

