### PR TITLE
bump vets-json-schema - adds 21-0779 21-2680 21P-8416

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,10 +74,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 0a3ddc2b647869ba38d0dcae2886a729b7dde13d
+  revision: dec5c9d969c5afd6a8cc7a97d220727af6ff77db
   branch: master
   specs:
-    vets_json_schema (25.2.15)
+    vets_json_schema (25.2.20)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 


### PR DESCRIPTION
Brings in the changes form vets-json-schema:
* new schema 21-0779
* new schema 21-2680.
* new attributes in 21P-8416
https://github.com/department-of-veterans-affairs/vets-json-schema/pull/1073
https://github.com/department-of-veterans-affairs/vets-json-schema/pull/1071
https://github.com/department-of-veterans-affairs/vets-json-schema/pull/1070

New schemas will be used/tested in
https://github.com/department-of-veterans-affairs/vets-api/pull/24904
https://github.com/department-of-veterans-affairs/vets-api/pull/24917

There are no code changes in vets-api, so I expect that existing test will pass and be sufficient.

*(Describe what parts of the site are impacted and*if*code touched other areas)*

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
