### PR TITLE
Fix flaky webhook scheduler test by adding event registration

### DIFF
--- a/spec/sidekiq/webhooks/scheduler_job_spec.rb
+++ b/spec/sidekiq/webhooks/scheduler_job_spec.rb
@@ -57,8 +57,13 @@ RSpec.describe Webhooks::SchedulerJob, type: :job do
   end
 
   it 'logs if sidekiq can not schedule the notification job' do
+    Webhooks::Utilities
+      .register_events('gov.va.developer.SchedulerJobTEST5',
+                       api_name: 'SchedulerJobTEST5', max_retries: 1) do
+      10.minutes.from_now
+    end
     allow(Webhooks::NotificationsJob).to receive(:perform_in).and_raise('busted')
     results = Webhooks::SchedulerJob.new.perform
-    expect(results.flatten.include?(nil)).to be true
+    expect(results).to include(nil)
   end
 end


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

The test was flaky because it didn't register any webhook events before calling perform, resulting in an empty iteration and no actual error path testing. This fix registers a test event and simplifies the expectation to use idiomatic RSpec syntax.


## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
