### PR TITLE
Handles separation code in v1

### DIFF
--- a/modules/claims_api/lib/claims_api/fes_mapper_base.rb
+++ b/modules/claims_api/lib/claims_api/fes_mapper_base.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ClaimsApi
+  module FesMapperBase
+    def map_separation_location_code
+      @fes_claim[:serviceInformation][:separationLocationCode] = return_separation_location_code
+    end
+
+    def return_separation_location_code
+      return_most_recent_service_period&.dig(:separationLocationCode)
+    end
+
+    def separation_location_code_present?
+      return_most_recent_service_period&.dig(:separationLocationCode).present?
+    end
+
+    def return_most_recent_service_period
+      @data[:serviceInformation][:servicePeriods]&.max_by do |period|
+        Date.parse(period[:activeDutyBeginDate])
+      end
+    end
+  end
+end

--- a/modules/claims_api/lib/claims_api/v1/disability_compensation_fes_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v1/disability_compensation_fes_mapper.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
+require_relative '../fes_mapper_base'
 require_relative '../lighthouse_military_address_validator'
 require 'claims_api/partial_date_parser'
 
 module ClaimsApi
   module V1
     class DisabilityCompensationFesMapper
+      include FesMapperBase
       include LighthouseMilitaryAddressValidator
 
       IGNORED_DISABILITY_FIELDS = %i[serviceRelevance secondaryDisabilities].freeze
@@ -193,6 +195,7 @@ module ClaimsApi
         info = @data[:serviceInformation]
 
         map_service_periods(info)
+        map_separation_location_code if separation_location_code_present?
         map_confinements(info) if info&.dig(:confinements).present?
         map_reserves(info) if info&.dig(:reservesNationalGuardService).present?
         map_title_10_activation(info) if info&.dig(:reservesNationalGuardService, :title10Activation).present?
@@ -201,7 +204,7 @@ module ClaimsApi
       # 'serviceBranch', 'activeDutyBeginDate' & 'activeDutyEndDate' are required via the schema
       def map_service_periods(info)
         @fes_claim[:serviceInformation] = {
-          servicePeriods: info[:servicePeriods].map(&:compact)
+          servicePeriods: info[:servicePeriods].map { |period| period.except(:separationLocationCode).compact }
         }
       end
 

--- a/modules/claims_api/spec/lib/claims_api/v1/disability_compensation_fes_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v1/disability_compensation_fes_mapper_spec.rb
@@ -290,7 +290,7 @@ describe ClaimsApi::V1::DisabilityCompensationFesMapper do
         end
 
         it 'maps the attributes' do
-          form_data['data']['attributes']['serviceInformation']['servicePeriods'][0]['separationLocationCode'] = '98282'
+          form_data['data']['attributes']['serviceInformation']['servicePeriods'][1]['separationLocationCode'] = '98282'
 
           service_info_object = fes_data[:data][:form526][:serviceInformation]
           first_service_period_info = service_info_object[:servicePeriods][0]
@@ -298,17 +298,27 @@ describe ClaimsApi::V1::DisabilityCompensationFesMapper do
           expect(first_service_period_info[:serviceBranch]).to eq('Air Force')
           expect(first_service_period_info[:activeDutyBeginDate]).to eq('1980-02-05')
           expect(first_service_period_info[:activeDutyEndDate]).to eq('1990-01-02')
-          expect(first_service_period_info[:separationLocationCode]).to eq('98282')
+          expect(service_info_object[:separationLocationCode]).to eq('98282')
           expect(service_info_object).not_to have_key(:confinements)
         end
 
         it 'removes nil values from the servicePeriods' do
           form_service_info_data = form_data['data']['attributes']['serviceInformation']
-          form_service_info_data['servicePeriods'][0]['separationLocationCode'] = nil
+          form_service_info_data['servicePeriods'][0]['activeDutyEndDate'] = nil
 
           service_info_object = fes_data[:data][:form526][:serviceInformation]
 
-          expect(service_info_object[:servicePeriods][0]).not_to have_key(:separationLocationCode)
+          expect(service_info_object[:servicePeriods][0]).not_to have_key(:activeDutyEndDate)
+        end
+
+        context 'separation location code' do
+          it 'does not include separation code if most recent period does not include it' do
+            form_data['data']['attributes']['serviceInformation']['servicePeriods'][0]['separationLocationCode'] =
+              '98282'
+            service_info_object = fes_data[:data][:form526][:serviceInformation]
+
+            expect(service_info_object).not_to have_key(:separationLocationCode)
+          end
         end
 
         it 'maps the confinements attribute correctly' do


### PR DESCRIPTION
## Summary
* Updates handling of the separation code in v1 FES mapper
* Adds/updates related tests
* Adds a shared base file for (what will be) shared methods for handling the separation code between the two version, which is the same.

## Related issue(s)


## Testing done

- [x] *New code is covered by unit tests*

#### Testing Notes
* With separation code
```
        "servicePeriods": [
          {
            "activeDutyBeginDate": "1989-06-08",
            "activeDutyEndDate": "1990-01-02",
            "serviceBranch": "Air Force"
          },
          {
            "activeDutyBeginDate": "1990-04-05",
            "activeDutyEndDate": "1999-01-01",
            "separationLocationCode": "98282",
            "serviceBranch": "Air Force Reserves"
          }
        ],
```
<img width="838" height="88" alt="Screenshot 2025-11-05 at 2 07 07 PM" src="https://github.com/user-attachments/assets/6a0ebfcd-aa7b-42e7-8b50-c9c4999abd79" />


* Without separation code (because ti is not on most recent)
```
        "servicePeriods": [
          {
            "activeDutyBeginDate": "1989-06-08",
            "activeDutyEndDate": "1990-01-02",
            "separationLocationCode": "98282",
            "serviceBranch": "Air Force"
          },
          {
            "activeDutyBeginDate": "1990-04-05",
            "activeDutyEndDate": "1999-01-01",
            "serviceBranch": "Air Force Reserves"
          }
        ],
```
![Uploading Screenshot 2025-11-05 at 2.10.08 PM.png…]()


## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	new file:   modules/claims_api/lib/claims_api/fes_mapper_base.rb
	modified:   modules/claims_api/lib/claims_api/v1/disability_compensation_fes_mapper.rb
	modified:   modules/claims_api/spec/lib/claims_api/v1/disability_compensation_fes_mapper_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
