### PR TITLE
Fixes missing ID in Decide endpoint response

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -343,7 +343,7 @@
                   "202 without a transactionId": {
                     "value": {
                       "data": {
-                        "id": "75f0f15b-49c4-4e4e-9add-a0e712e0bb15",
+                        "id": "de3512ff-f137-454c-a21d-ea9b14c64763",
                         "type": "forms/526",
                         "attributes": {
                           "claimId": "600442191",
@@ -528,7 +528,7 @@
                             },
                             "federalActivation": {
                               "activationDate": "2023-10-01",
-                              "anticipatedSeparationDate": "2025-10-25"
+                              "anticipatedSeparationDate": "2025-11-07"
                             },
                             "confinements": [
                               {
@@ -574,7 +574,7 @@
                   "202 with a transactionId": {
                     "value": {
                       "data": {
-                        "id": "7f5ecb84-0142-4fb0-995a-991f44147681",
+                        "id": "84b6d6d9-e6ff-4d1d-935a-9fc375643eb9",
                         "type": "forms/526",
                         "attributes": {
                           "claimId": "600442191",
@@ -738,7 +738,7 @@
                                 "serviceBranch": "Public Health Service",
                                 "serviceComponent": "Active",
                                 "activeDutyBeginDate": "2008-11-14",
-                                "activeDutyEndDate": "2025-10-25",
+                                "activeDutyEndDate": "2025-11-07",
                                 "separationLocationCode": "98282"
                               }
                             ],
@@ -759,7 +759,7 @@
                             },
                             "federalActivation": {
                               "activationDate": "2023-10-01",
-                              "anticipatedSeparationDate": "2025-10-25"
+                              "anticipatedSeparationDate": "2025-11-07"
                             },
                             "confinements": [
                               {
@@ -4086,7 +4086,7 @@
                               "serviceBranch": "Public Health Service",
                               "serviceComponent": "Active",
                               "activeDutyBeginDate": "2008-11-14",
-                              "activeDutyEndDate": "2025-10-25",
+                              "activeDutyEndDate": "2025-11-07",
                               "separationLocationCode": "98282"
                             }
                           ],
@@ -4107,7 +4107,7 @@
                           },
                           "federalActivation": {
                             "activationDate": "2023-10-01",
-                            "anticipatedSeparationDate": "2025-10-25"
+                            "anticipatedSeparationDate": "2025-11-07"
                           },
                           "confinements": [
                             {
@@ -9709,7 +9709,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "8df5c199-687c-4978-bce5-4ae40a446b46",
+                    "id": "57efa90f-7e36-404a-99f0-dc91fb16870b",
                     "type": "power-of-attorney-request",
                     "attributes": {
                       "veteran": {
@@ -11423,7 +11423,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": null,
+                    "id": "348fa995-5b29-4819-91af-13f1bb3c7d77",
                     "type": "power-of-attorney-request",
                     "attributes": {
                       "veteran": {
@@ -12563,7 +12563,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "eeab6f0b-9b9b-49d7-8d15-236f3083fbbe",
+                    "id": "d972b80c-a594-43c1-8298-8a9d2b4d5e51",
                     "type": "organization",
                     "attributes": {
                       "code": "083",
@@ -14060,7 +14060,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "69c82d27-93d5-415d-ad29-6c26136fb830",
+                    "id": "09c78b49-16f3-4226-a5af-4c86435744fa",
                     "type": "individual",
                     "attributes": {
                       "code": "067",
@@ -14908,10 +14908,10 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "91bcf079-c69b-4307-a00a-2c451feea8c0",
+                    "id": "600987f0-4942-411e-80de-3ea41650e733",
                     "type": "claimsApiPowerOfAttorneys",
                     "attributes": {
-                      "createdAt": "2025-10-23 13:50:22 UTC",
+                      "createdAt": "2025-11-05 18:05:14 UTC",
                       "representative": {
                         "poaCode": "074"
                       },

--- a/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
@@ -343,7 +343,7 @@
                   "202 without a transactionId": {
                     "value": {
                       "data": {
-                        "id": "23ae59e0-65fc-48c7-8333-816c247cd2ed",
+                        "id": "604e0325-56b6-41fe-a6cb-007c92a62a03",
                         "type": "forms/526",
                         "attributes": {
                           "claimId": "600442191",
@@ -528,7 +528,7 @@
                             },
                             "federalActivation": {
                               "activationDate": "2023-10-01",
-                              "anticipatedSeparationDate": "2025-10-25"
+                              "anticipatedSeparationDate": "2025-11-07"
                             },
                             "confinements": [
                               {
@@ -574,7 +574,7 @@
                   "202 with a transactionId": {
                     "value": {
                       "data": {
-                        "id": "a9f77cbf-724c-4cfe-8751-777c8981ed67",
+                        "id": "703e4fe8-38cb-4779-a6d8-e11ad366fa06",
                         "type": "forms/526",
                         "attributes": {
                           "claimId": "600442191",
@@ -738,7 +738,7 @@
                                 "serviceBranch": "Public Health Service",
                                 "serviceComponent": "Active",
                                 "activeDutyBeginDate": "2008-11-14",
-                                "activeDutyEndDate": "2025-10-25",
+                                "activeDutyEndDate": "2025-11-07",
                                 "separationLocationCode": "98282"
                               }
                             ],
@@ -759,7 +759,7 @@
                             },
                             "federalActivation": {
                               "activationDate": "2023-10-01",
-                              "anticipatedSeparationDate": "2025-10-25"
+                              "anticipatedSeparationDate": "2025-11-07"
                             },
                             "confinements": [
                               {
@@ -4086,7 +4086,7 @@
                               "serviceBranch": "Public Health Service",
                               "serviceComponent": "Active",
                               "activeDutyBeginDate": "2008-11-14",
-                              "activeDutyEndDate": "2025-10-25",
+                              "activeDutyEndDate": "2025-11-07",
                               "separationLocationCode": "98282"
                             }
                           ],
@@ -4107,7 +4107,7 @@
                           },
                           "federalActivation": {
                             "activationDate": "2023-10-01",
-                            "anticipatedSeparationDate": "2025-10-25"
+                            "anticipatedSeparationDate": "2025-11-07"
                           },
                           "confinements": [
                             {
@@ -9709,7 +9709,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "70b2ba46-fd9e-4d5c-b48b-3356872c0d1b",
+                    "id": "a2e97ae1-0a36-498f-a4f5-355c6bc6f697",
                     "type": "power-of-attorney-request",
                     "attributes": {
                       "veteran": {
@@ -11423,7 +11423,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": null,
+                    "id": "348fa995-5b29-4819-91af-13f1bb3c7d77",
                     "type": "power-of-attorney-request",
                     "attributes": {
                       "veteran": {
@@ -12563,7 +12563,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "b90962ff-c02a-471f-a192-3c3a20f48c39",
+                    "id": "d55d558c-d0a8-4db0-b260-42b7c6ddd391",
                     "type": "organization",
                     "attributes": {
                       "code": "083",
@@ -14060,7 +14060,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "5f56dce1-7412-49e2-986e-5f2a6e2653a0",
+                    "id": "27401182-addd-439f-b25b-150bba514689",
                     "type": "individual",
                     "attributes": {
                       "code": "067",
@@ -14908,10 +14908,10 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "955b4180-ca99-4e70-aa5e-3b2cf4615a6c",
+                    "id": "46c47ab4-e392-4730-835b-e2c30c901f03",
                     "type": "claimsApiPowerOfAttorneys",
                     "attributes": {
-                      "createdAt": "2025-10-23 13:51:35 UTC",
+                      "createdAt": "2025-11-05 18:06:35 UTC",
                       "representative": {
                         "poaCode": "074"
                       },

--- a/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb
@@ -673,7 +673,7 @@ describe 'PowerOfAttorney',
               'declinedReason' => nil, 'healthInfoAuth' => 'Y', 'poaCode' => '074',
               'procID' => '3857362', 'secondaryStatus' => 'Accepted',
               'vetFirstName' => 'ANDREA', 'vetLastName' => 'MITCHELL',
-              'vetMiddleName' => 'L', 'vetPtcpntID' => '600049322'
+              'vetMiddleName' => 'L', 'vetPtcpntID' => '600049322', 'id' => id
             }
           end
 


### PR DESCRIPTION
## Summary
* Updates test to include Id in the decide endpoint response

## Related issue(s)
This was broken in the PR: https://github.com/department-of-veterans-affairs/vets-api/commit/d683b56ee2c2d278e9e238f95c68cc5dda6db3f2

## Testing done

- [x] *Updated existing test*

#### Testing notes
* Looking at the `decide` endpoints response should include an ID

## Screenshots
<img width="511" height="330" alt="Screenshot 2025-11-05 at 12 07 11 PM" src="https://github.com/user-attachments/assets/dd329d2a-386a-4be9-a08b-f3fe174f0117" />


## What areas of the site does it impact?
	modified:   modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
	modified:   modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
	modified:   modules/claims_api/spec/requests/v2/veterans/rswag_power_of_attorney_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

I called out the fixes in the docs, nothing else should be `null`.  The IDs and dates do change so that change is expected but as long as nothing else is unexpectedly `null` the fix is in.
