### PR TITLE
API-51124 - Remove `extract_claimant_participant_id` from v1 FES mapper

### DIFF
--- a/modules/claims_api/lib/claims_api/v1/disability_compensation_fes_mapper.rb
+++ b/modules/claims_api/lib/claims_api/v1/disability_compensation_fes_mapper.rb
@@ -74,7 +74,7 @@ module ClaimsApi
           data: {
             serviceTransactionId: @auto_claim.auth_headers['va_eauth_service_transaction_id'],
             veteranParticipantId: extract_veteran_participant_id,
-            claimantParticipantId: extract_claimant_participant_id,
+            claimantParticipantId: extract_veteran_participant_id,
             form526: @fes_claim
           }
         }
@@ -247,14 +247,6 @@ module ClaimsApi
         # Try auth_headers first, then fall back to other sources
         @auto_claim.auth_headers&.dig('va_eauth_pid')&.to_i ||
           @auto_claim.auth_headers&.dig('participant_id')&.to_i
-      end
-
-      def extract_claimant_participant_id
-        if @auto_claim.auth_headers&.dig('dependent', 'participant_id').present?
-          @auto_claim.auth_headers.dig('dependent', 'participant_id')&.to_i
-        else
-          extract_veteran_participant_id
-        end
       end
     end
   end

--- a/modules/claims_api/spec/lib/claims_api/v1/disability_compensation_fes_mapper_spec.rb
+++ b/modules/claims_api/spec/lib/claims_api/v1/disability_compensation_fes_mapper_spec.rb
@@ -47,13 +47,6 @@ describe ClaimsApi::V1::DisabilityCompensationFesMapper do
           expect(fes_data[:data][:veteranParticipantId]).to eq(600_061_742)
           expect(fes_data[:data][:claimantParticipantId]).to eq(600_061_742)
         end
-
-        it 'finds the dependent participant_id as expected' do
-          auth_headers['dependent'] = {}
-          auth_headers['dependent']['participant_id'] = '8675309'
-
-          expect(fes_data[:data][:claimantParticipantId]).to eq(8_675_309)
-        end
       end
 
       describe 'claim meta' do


### PR DESCRIPTION
## Summary

This PR removes the `extract_claimant_participant_id` method from the V1 FES mapper because it was checking a header value that won't actually be present in request data.

## Related issue(s)

|[Jira ticket](https://jira.devops.va.gov/browse/API-51124)|
|-|
|<img width="745" height="647" alt="Screenshot 2025-11-05 at 14 02 55" src="https://github.com/user-attachments/assets/2162e870-f379-4530-8215-89f2f6060a2d" />|

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
