### PR TITLE
API-45672 - Intent to File V2 doc cleanup

### DIFF
--- a/lib/lighthouse/benefits_claims/service.rb
+++ b/lib/lighthouse/benefits_claims/service.rb
@@ -116,8 +116,6 @@ module BenefitsClaims
     end
 
     # For type "survivor", the request must include claimantSsn and be made by a valid Veteran Representative.
-    # If the Representative is not a Veteran or a VA employee, this method is currently not available to them,
-    # and they should use the Benefits Intake API as an alternative.
     def create_intent_to_file(type, claimant_ssn, lighthouse_client_id = nil, lighthouse_rsa_key_path = nil,
                               options = {})
       if claimant_ssn.blank? && type == 'survivor'


### PR DESCRIPTION
## Summary

This PR removes a note in the intent to file V2 schema that is no longer accurate. The note indicated that a particular method was not available for non-Veteran/non-VA employee users. However, since V2 uses CCG authentication this is no longer applicable.

## Related issue(s)

|[Jira ticket](https://jira.devops.va.gov/browse/API-45672)|
|-|
|<img width="762" height="776" alt="Screenshot 2025-11-05 at 15 47 32" src="https://github.com/user-attachments/assets/28aee07e-21eb-4e40-aeaf-353df71fcbbc" />|

## Testing done

NA, only change was to a comment

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

```
lib/lighthouse/benefits_claims/service.rb
```

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
