### PR TITLE
DR 103986 Add flipper for Supplemental Claims redesign

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -678,6 +678,9 @@ features:
   decision_review_stuck_records_monitoring:
     actor_type: user
     description: Enables monitoring for stuck records in decision review applications
+  decision_review_sc_redesign_nov2025:
+    actor_type: user
+    description: Enables the Nov 2025 Supplemental Claims redesign
   dependency_verification:
     actor_type: user
     description: Feature gates the dependency verification modal for updating the diaries service.


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

Adding a feature flipper (`decision_review_sc_redesign_nov2025`) for the Supplemental Claims redesign work.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/103986