### PR TITLE
(BIO) Add Committee custom error handler

### DIFF
--- a/config/initializers/committee.rb
+++ b/config/initializers/committee.rb
@@ -3,19 +3,37 @@
 require 'committee'
 require 'committee/unprocessable_entity_error'
 
+schema_path = Rails.public_path.join('openapi.json').to_s
+
+ERROR_HANDLER = lambda do |ex, env|
+  req = Rack::Request.new(env)
+  Rails.logger.warn(
+    '[Committee] Request validation failed',
+    {
+      path: req.path,
+      method: req.request_method,
+      status: 422,
+      error_class: ex.class.name.demodulize,
+      error_type: ex.is_a?(Committee::InvalidRequest) ? 'request_validation' : 'response_validation'
+    }
+  )
+end
+
 Rails.application.config.middleware.use(
   Committee::Middleware::RequestValidation,
-  schema_path: Rails.public_path.join('openapi.json').to_s,
+  schema_path:,
   strict_reference_validation: true,
   raise: false,
-  error_class: Committee::UnprocessableEntityError
+  error_class: Committee::UnprocessableEntityError,
+  error_handler: ERROR_HANDLER
 )
 
 Rails.application.config.middleware.use(
   Committee::Middleware::ResponseValidation,
-  schema_path: Rails.public_path.join('openapi.json').to_s,
+  schema_path:,
   strict_reference_validation: true,
   validate_success_only: true,
   raise: false,
-  error_class: Committee::UnprocessableEntityError
+  error_class: Committee::UnprocessableEntityError,
+  error_handler: ERROR_HANDLER
 )

--- a/lib/committee/unprocessable_entity_error.rb
+++ b/lib/committee/unprocessable_entity_error.rb
@@ -13,7 +13,7 @@ module Committee
         errors: [
           {
             title: 'Unprocessable Entity',
-            detail: message,
+            detail: sanitize_detail,
             code: '422',
             status: '422',
             source: 'Committee::Middleware::RequestValidation'
@@ -28,6 +28,15 @@ module Committee
         { 'Content-Type' => 'application/json' },
         [JSON.generate(error_body)]
       ]
+    end
+
+    private
+
+    # Removes actual user input values from error messages to prevent PII exposure.
+    # We will make this more robust in the future, to give specific details about which
+    # fields and values are causing the schema validation to fail.
+    def sanitize_detail
+      'Request did not conform to API schema.'
     end
   end
 end

--- a/spec/lib/committee/unprocessable_entity_error_spec.rb
+++ b/spec/lib/committee/unprocessable_entity_error_spec.rb
@@ -25,7 +25,7 @@ describe Committee::UnprocessableEntityError do
   end
 
   describe '#error_body' do
-    it 'returns the correct error structure' do
+    it 'returns the correct error structure with sanitized message' do
       error = build_error('Validation failed')
       body = error.error_body
 
@@ -36,7 +36,7 @@ describe Committee::UnprocessableEntityError do
       error_obj = body[:errors].first
       expect(error_obj).to eq(
         title: 'Unprocessable Entity',
-        detail: 'Validation failed',
+        detail: 'Request did not conform to API schema.',
         code: '422',
         status: '422',
         source: 'Committee::Middleware::RequestValidation'
@@ -44,11 +44,11 @@ describe Committee::UnprocessableEntityError do
     end
 
     context 'with different error messages' do
-      it 'includes the message in the error detail' do
+      it 'returns generic message regardless of input to prevent PII exposure' do
         error = build_error('Invalid request parameters')
         body = error.error_body
 
-        expect(body[:errors].first[:detail]).to eq('Invalid request parameters')
+        expect(body[:errors].first[:detail]).to eq('Request did not conform to API schema.')
       end
     end
 
@@ -76,7 +76,7 @@ describe Committee::UnprocessableEntityError do
       expect(render_result[1]).to eq({ 'Content-Type' => 'application/json' })
     end
 
-    it 'includes the JSON-encoded error body' do
+    it 'includes the JSON-encoded error body with sanitized message' do
       error = build_error('Validation failed')
       render_result = error.render
 
@@ -86,7 +86,7 @@ describe Committee::UnprocessableEntityError do
       parsed_body = JSON.parse(render_result[2].first)
       expect(parsed_body).to have_key('errors')
       expect(parsed_body['errors']).to be_an(Array)
-      expect(parsed_body['errors'].first['detail']).to eq('Validation failed')
+      expect(parsed_body['errors'].first['detail']).to eq('Request did not conform to API schema.')
     end
 
     it 'returns valid JSON' do
@@ -112,7 +112,58 @@ describe Committee::UnprocessableEntityError do
 
       expect(error.message).to eq(message)
       expect(error.status).to eq(422)
-      expect(error.error_body[:errors].first[:detail]).to eq(message)
+      expect(error.error_body[:errors].first[:detail]).to eq('Request did not conform to API schema.')
+    end
+  end
+
+  describe '#sanitize_detail (PII protection)' do
+    it 'returns generic message for SSN pattern validation errors to prevent PII exposure' do
+      message = 'pattern ^\\d{9}$ does not match value: "123-45-6789", example: 123456789'
+      error = build_error(message)
+      body = error.error_body
+
+      expect(body[:errors].first[:detail]).to eq('Request did not conform to API schema.')
+      expect(body[:errors].first[:detail]).not_to include('123-45-6789')
+    end
+
+    it 'returns generic message for OpenAPI validation errors to prevent PII exposure' do
+      message = '#/paths/~1v0~1form21p530a~1download_pdf/post/requestBody/content/application~1json/schema/' \
+                'properties/veteranInformation/properties/ssn pattern ^\\d{9}$ does not match value: ' \
+                '"123-45x6789", example: 123456789'
+      error = build_error(message)
+      body = error.error_body
+
+      detail = body[:errors].first[:detail]
+      expect(detail).to eq('Request did not conform to API schema.')
+      expect(detail).not_to include('123-45x6789')
+      expect(detail).not_to include('pattern')
+      expect(detail).not_to include('#/paths')
+    end
+
+    it 'returns generic message for max length validation errors' do
+      message = '"USA" is longer than max length'
+      error = build_error(message)
+      body = error.error_body
+
+      expect(body[:errors].first[:detail]).to eq('Request did not conform to API schema.')
+      expect(body[:errors].first[:detail]).not_to include('USA')
+    end
+
+    it 'returns generic message for email validation errors' do
+      message = 'email address format does not match value: "test@example.com"'
+      error = build_error(message)
+      body = error.error_body
+
+      expect(body[:errors].first[:detail]).to eq('Request did not conform to API schema.')
+      expect(body[:errors].first[:detail]).not_to include('test@example.com')
+    end
+
+    it 'returns generic message for any non-blank error to maximize PII protection' do
+      message = 'Any validation error message with potential PII'
+      error = build_error(message)
+      body = error.error_body
+
+      expect(body[:errors].first[:detail]).to eq('Request did not conform to API schema.')
     end
   end
 end


### PR DESCRIPTION
## Summary

- **This work is behind a feature toggle (flipper): NO**

### Problem
Committee schema validation errors were returning user-submitted values (including PII such as SSNs, emails, and other sensitive data) in 422 error response bodies. This created a security vulnerability where:
- SSNs appeared in HTTP responses visible in browser DevTools
- User input was exposed to client-side error tracking tools
- PII could be logged by intermediate proxies or CDNs
- The error messages violated the principle of least exposure for sensitive data

**Example of problematic error:**
```json
{
  "detail": "pattern ^\\d{9}$ does not match value: \"123-45-6789\", example: 123456789"
}
```

### Solution
Modified `Committee::UnprocessableEntityError` to sanitize all error messages by returning a generic, PII-free error message to clients while maintaining detailed logging for observability.

**Key Changes:**
1. **Updated `lib/committee/unprocessable_entity_error.rb`:**
   - Added `sanitize_detail` method that returns generic message: `"Request did not conform to API schema."`
   - Prevents all user input from appearing in 422 response bodies

2. **Enhanced `config/initializers/committee.rb`:**
   - Added `ERROR_HANDLER` lambda for structured logging
   - Logs validation failures with request metadata (path, method, error class) WITHOUT including PII-laden error messages
   - Follows vets-api logging conventions with `[Committee]` prefix and hash context

3. **Updated test coverage:**
   - Modified `spec/lib/committee/unprocessable_entity_error_spec.rb` to verify PII sanitization
   - Tests cover SSN validation, email validation, max length errors, and generic validation failures

**Why this approach:**
- **Defense in depth:** Sanitizes at the error response layer, ensuring no PII leaks regardless of validation error type
- **Maintains observability:** Structured logging provides full context for monitoring/debugging without exposing sensitive data
- **Simple & maintainable:** Single generic message covers all validation scenarios, no complex regex patterns to maintain
- **Follows platform patterns:** Uses vets-api's `Rails.logger.warn` with structured hash context

**Team:** Benefits Intake Optimization (BIO-AQUIA)
**Ownership:** This team owns the maintenance of this security enhancement

## Related issue(s)

- _Link to ticket created in va.gov-team repo OR screenshot of Jira ticket_
- Discovered during 21P-530a form integration testing when frontend engineer noticed SSN appearing in 422 response

## Testing done

- [x] **New code is covered by unit tests**

### Old Behavior
Committee validation errors returned the actual user-submitted values in error response bodies:
```json
{
  "errors": [{
    "title": "Unprocessable Entity",
    "detail": "#/paths/.../ssn pattern ^\\d{9}$ does not match value: \"123-45-6789\", example: 123456789",
    "code": "422",
    "status": "422"
  }]
}
```

Server logs also included PII in error messages.

### New Behavior
Committee validation errors return a generic message:
```json
{
  "errors": [{
    "title": "Unprocessable Entity",
    "detail": "Request did not conform to API schema.",
    "code": "422",
    "status": "422"
  }]
}
```

Server logs capture validation failures with safe metadata:
```
[Committee] Request validation failed : {:path=>"/v0/form21p530a", :method=>"POST", :status=>422, :error_class=>"InvalidRequest", :error_type=>"request_validation"}
```

### Verification Steps

1. **Test SSN validation error:**
   ```bash
   curl -X POST http://localhost:3000/v0/form21p530a \
     -H "Content-Type: application/json" \
     -d '{"veteranInformation": {"ssn": "invalid-ssn", "fullName": {...}, "dateOfBirth": "1980-01-01", "dateOfDeath": "2024-01-01"}}'
   ```
   **Expected:** Response contains `"detail": "Request did not conform to API schema."` with NO trace of "invalid-ssn"

2. **Test max length validation:**
   ```bash
   curl -X POST http://localhost:3000/v0/form21p530a/download_pdf \
     -H "Content-Type: application/json" \
     -d '{"burialInformation": {"recipientOrganization": {"address": {"country": "USA"}}}}'
   ```
   **Expected:** Response contains generic message with NO trace of "USA"

3. **Verify logging:**
   ```bash
   docker-compose logs web | grep Committee
   ```
   **Expected:** See structured log entries like:
   ```
   [Committee] Request validation failed : {:path=>"/v0/form21p530a", :method=>"POST", :status=>422, :error_class=>"InvalidRequest", :error_type=>"request_validation"}
   ```
   With NO user input values present.

4. **Run test suite:**
   ```bash
   bundle exec rspec spec/lib/committee/unprocessable_entity_error_spec.rb
   ```
   **Expected:** All 15 specs pass, including new PII protection tests

## What areas of the site does it impact?

**Scope:** All Committee-validated API endpoints across vets-api

**Specific Impact:**
- Any endpoint using OpenAPI schema validation (via Committee middleware)
- All forms that submit to endpoints with Committee request validation enabled
- Currently affects 21P-530a form, but applies to ALL validated endpoints

**Areas NOT impacted:**
- Non-Committee validation errors (custom validations, ActiveRecord validations, etc.)
- Endpoints without OpenAPI schema definitions
- Client-side validation (frontend remains unchanged)

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution (Rails.logger.warn with structured context)
- [ ] Documentation has been updated (link to documentation) - *N/A: internal security fix, no user-facing docs needed*
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Feature/bug has a monitor built into Datadog (if applicable) - *Can monitor via Committee validation logs: `[Committee] Request validation failed`*
- [ ] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected - *21P-530a is unauthenticated*
- [x] I added a screenshot of the developed feature

## Screenshots

**Before (with PII exposure):**
```json
{
  "errors": [{
    "detail": "#/paths/~1v0~1form21p530a~1download_pdf/post/requestBody/content/application~1json/schema/properties/veteranInformation/properties/ssn pattern ^\\d{9}$ does not match value: \"123-45x6789\", example: 123456789"
  }]
}
```

**After (PII sanitized):**
```json
{
  "errors": [{
    "title": "Unprocessable Entity",
    "detail": "Request did not conform to API schema.",
    "code": "422",
    "status": "422",
    "source": "Committee::Middleware::RequestValidation"
  }]
}
```

**Logs (safe for Datadog/monitoring):**
```
[Committee] Request validation failed : {:path=>"/v0/form21p530a", :method=>"POST", :status=>422, :error_class=>"InvalidRequest", :error_type=>"request_validation"}
```

## Requested Feedback

**Security Review Requested:**
- Does this approach sufficiently mitigate PII exposure risks?
- Are there any edge cases where user input could still leak through?
- Should we consider adding additional sanitization layers at the middleware level?

**Observability Review:**
- Is the structured logging format sufficient for monitoring/alerting on validation failures?
- Should we add additional metadata (e.g., schema path, validation type)?
- Would it be valuable to add StatsD metrics for Committee validation failures?

**User Experience:**
- The generic error message provides no field-level detail to clients. Is this acceptable from a UX perspective?
- Should we consider a hybrid approach with field paths but no values (e.g., `"field /veteranInformation/ssn failed validation"`)?
