### PR TITLE
VEBT-3699/SOB certs

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -300,9 +300,6 @@ dgi:
     private_key_path: <%= ENV['dgi__jwt__private_key_path'] %>
     public_key_path: <%= ENV['dgi__jwt__public_key_path'] %>
   sob:
-    private_key_path: <%= ENV['dgi__sob__private_key_path'] %>
-    public_ica11_rca2_key_path: <%= ENV['dgi__sob__public_ica11_rca2_key_path'] %>
-    public_key_path: <%= ENV['dgi__sob__public_key_path'] %>
     mock: <%= ENV['dgi__sob__mock'] %>
     url: <%= ENV['dgi__sob__url'] %>
   vets:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -300,9 +300,6 @@ dgi:
     private_key_path: modules/meb_api/spec/fixtures/dgi_private_test.pem
     public_key_path: modules/meb_api/spec/fixtures/dgi_public_test.pem
   sob:
-    private_key_path: ~
-    public_ica11_rca2_key_path: ~
-    public_key_path: ~
     mock: ~
     url: ~
   vets:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -299,9 +299,6 @@ dgi:
     private_key_path: modules/meb_api/spec/fixtures/dgi_private_test.pem
     public_key_path: modules/meb_api/spec/fixtures/dgi_public_test.pem
   sob:
-    private_key_path: ~
-    public_ica11_rca2_key_path: ~
-    public_key_path: ~
     mock: ~
     url: ~
   vets:


### PR DESCRIPTION
**Note:** It's since been decided to register certs via the fwdproxy. So it's no longer to track cert and key in vets-api settings. Related vsp-infra-application prs will be updated to reflect this

## Summary

- *This work is behind a feature toggle (flipper): NO
- *(Summarize the changes that have been made to the platform)* New integration between SOB and DGIB claimants service to be built. New certs created. Connection is mTLS and does not require JWT
- *(Which team do you work for, does your team own the maintenance of this component?)* VEBT, yes

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/3890
- https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/3891
- https://jira.devops.va.gov/browse/VEBT-3699

## What areas of the site does it impact?
Statement of Benefits