### PR TITLE
BIO disable notification emails for 21p-8416, 21p-534ez pending finalized Notify config

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1420,24 +1420,6 @@ vanotify:
         submitted:
           flipper_id: pension_submitted_email_notification
           template_id: <%= ENV['vanotify__services__21p_527ez__email__submitted__template_id'] %>
-    21p_534ez: &vanotify_services_survivors_benefits
-      api_key: <%= ENV['vanotify__services__21p_527ez__api_key'] %>
-      email:
-        confirmation:
-          flipper_id: false
-          template_id: <%= ENV['vanotify__services__21p_527ez__email__confirmation__template_id'] %>
-        error:
-          flipper_id: survivors_benefits_error_email_notification
-          template_id: <%= ENV['vanotify__services__21p_527ez__email__error__template_id'] %>
-        persistent_attachment_error:
-          flipper_id: survivors_benefits_persistent_attachment_error_email_notification
-          template_id: <%= ENV['vanotify__services__21p_527ez__email__persistent_attachment_error__template_id'] %>
-        received:
-          flipper_id: survivors_benefits_received_email_notification
-          template_id: <%= ENV['vanotify__services__21p_527ez__email__received__template_id'] %>
-        submitted:
-          flipper_id: survivors_benefits_submitted_email_notification
-          template_id: <%= ENV['vanotify__services__21p_527ez__email__submitted__template_id'] %>
     21p_530ez: &vanotify_services_burial
       api_key: <%= ENV['vanotify__services__21p_530ez__api_key'] %>
       email:
@@ -1571,7 +1553,6 @@ vanotify:
         claim_submission_success_text: <%= ENV['vanotify__services__oracle_health__template_id__claim_submission_success_text'] %>
         claim_submission_timeout_text: <%= ENV['vanotify__services__oracle_health__template_id__claim_submission_timeout_text'] %>
     pensions: *vanotify_services_pension
-    survivors_benefits: *vanotify_services_survivors_benefits
     va_gov:
       api_key: <%= ENV['vanotify__services__va_gov__api_key'] %>
       template_id:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1458,24 +1458,6 @@ vanotify:
           flipper_id: burial_submitted_email_notification
           template_id: burial_submitted_email_template_id
     21p_530: *vanotify_services_burial
-    21p_534ez: &vanotify_services_survivors_benefits
-      api_key: fake_secret
-      email:
-        confirmation:
-          flipper_id: false
-          template_id: form527ez_confirmation_email_template_id
-        error:
-          flipper_id: survivors_benefits_error_email_notification
-          template_id: form527ez_error_email_template_id
-        persistent_attachment_error:
-          flipper_id: survivors_benefits_persistent_attachment_error_email_notification
-          template_id: form527ez_persistent_attachment_error_email_template_id
-        received:
-          flipper_id: survivors_benefits_received_email_notification
-          template_id: form527ez_received_email_template_id
-        submitted:
-          flipper_id: survivors_benefits_submitted_email_notification
-          template_id: form527ez_submitted_email_template_id
     21p_530v2: *vanotify_services_burial
     accredited_representative_portal:
       api_key: fake_secret
@@ -1590,7 +1572,6 @@ vanotify:
         claim_submission_success_text: fake_template_id
         claim_submission_timeout_text: ~
     pensions: *vanotify_services_pension
-    survivors_benefits: *vanotify_services_survivors_benefits
     va_gov:
       api_key: fake_secret
       template_id:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1457,24 +1457,6 @@ vanotify:
           flipper_id: burial_submitted_email_notification
           template_id: burial_submitted_email_template_id
     21p_530: *vanotify_services_burial
-    21p_534ez: &vanotify_services_survivors_benefits
-      api_key: fake_secret
-      email:
-        confirmation:
-          flipper_id: false
-          template_id: form527ez_confirmation_email_template_id
-        error:
-          flipper_id: survivors_benefits_error_email_notification
-          template_id: form527ez_error_email_template_id
-        persistent_attachment_error:
-          flipper_id: survivors_benefits_persistent_attachment_error_email_notification
-          template_id: form527ez_persistent_attachment_error_email_template_id
-        received:
-          flipper_id: survivors_benefits_received_email_notification
-          template_id: form527ez_received_email_template_id
-        submitted:
-          flipper_id: survivors_benefits_submitted_email_notification
-          template_id: form534ez_submitted_email_template_id
     21p_530v2: *vanotify_services_burial
     accredited_representative_portal:
       api_key: fake_secret
@@ -1589,7 +1571,6 @@ vanotify:
         claim_submission_success_text: oh_fake_success_template_id
         claim_submission_timeout_text: oh_fake_timeout_template_id
     pensions: *vanotify_services_pension
-    survivors_benefits: *vanotify_services_survivors_benefits
     va_gov:
       api_key: fake_secret
       template_id:

--- a/modules/medical_expense_reports/app/models/medical_expense_reports/saved_claim.rb
+++ b/modules/medical_expense_reports/app/models/medical_expense_reports/saved_claim.rb
@@ -98,7 +98,7 @@ module MedicalExpenseReports
     # Class name for notification email
     # @return [Class]
     def send_email(email_type)
-      MedicalExpenseReports::NotificationEmail.new(id).deliver(email_type)
+      # MedicalExpenseReports::NotificationEmail.new(id).deliver(email_type)
     end
   end
 end

--- a/modules/medical_expense_reports/lib/medical_expense_reports/benefits_intake/submission_handler.rb
+++ b/modules/medical_expense_reports/lib/medical_expense_reports/benefits_intake/submission_handler.rb
@@ -38,13 +38,7 @@ module MedicalExpenseReports
       # handle a failure result
       # inheriting class must assign @avoided before calling `super`
       def on_failure
-        @avoided = notification_email.deliver(:error)
-        super
-      end
-
-      # handle a success result
-      def on_success
-        notification_email.deliver(:received)
+        @avoided = true
         super
       end
 

--- a/modules/medical_expense_reports/lib/medical_expense_reports/benefits_intake/submit_claim_job.rb
+++ b/modules/medical_expense_reports/lib/medical_expense_reports/benefits_intake/submit_claim_job.rb
@@ -163,7 +163,7 @@ module MedicalExpenseReports
 
       # VANotify job to send Submission in Progress email to veteran
       def send_submitted_email
-        MedicalExpenseReports::NotificationEmail.new(@claim.id).deliver(:submitted)
+        # MedicalExpenseReports::NotificationEmail.new(@claim.id).deliver(:submitted)
       rescue => e
         monitor.track_send_email_failure(@claim, @intake_service, @user_account_uuid, 'submitted', e)
       end

--- a/modules/survivors_benefits/app/models/survivors_benefits/saved_claim.rb
+++ b/modules/survivors_benefits/app/models/survivors_benefits/saved_claim.rb
@@ -93,12 +93,5 @@ module SurvivorsBenefits
     def to_pdf(file_name = nil, fill_options = {})
       ::PdfFill::Filler.fill_form(self, file_name, fill_options)
     end
-
-    ##
-    # Class name for notification email
-    # @return [Class]
-    def send_email(email_type)
-      SurvivorsBenefits::NotificationEmail.new(id).deliver(email_type)
-    end
   end
 end

--- a/modules/survivors_benefits/lib/survivors_benefits/benefits_intake/submission_handler.rb
+++ b/modules/survivors_benefits/lib/survivors_benefits/benefits_intake/submission_handler.rb
@@ -30,21 +30,15 @@ module SurvivorsBenefits
         @monitor ||= SurvivorsBenefits::Monitor.new
       end
 
-      # BenefitsIntake::SubmissionHandler::SavedClaim#notification_email
-      def notification_email
-        @notification_email ||= SurvivorsBenefits::NotificationEmail.new(claim.id)
-      end
-
       # handle a failure result
       # inheriting class must assign @avoided before calling `super`
       def on_failure
-        @avoided = notification_email.deliver(:error)
+        @avoided = true
         super
       end
 
       # handle a success result
       def on_success
-        notification_email.deliver(:received)
         super
       end
 

--- a/modules/survivors_benefits/lib/survivors_benefits/benefits_intake/submit_claim_job.rb
+++ b/modules/survivors_benefits/lib/survivors_benefits/benefits_intake/submit_claim_job.rb
@@ -162,7 +162,7 @@ module SurvivorsBenefits
 
       # VANotify job to send Submission in Progress email to veteran
       def send_submitted_email
-        SurvivorsBenefits::NotificationEmail.new(@claim.id).deliver(:submitted)
+        false
       rescue => e
         monitor.track_send_email_failure(@claim, @intake_service, @user_account_uuid, 'submitted', e)
       end


### PR DESCRIPTION
## Summary

We're waiting for Notify configuration to be setup. In the meanwhile, we do not want this form to accidentally send when pensions events happen.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/124576


## What areas of the site does it impact?

Disables notification e-mails for 21p-8416 and 21p-534ez claim endpoint and sidekiq job

## Requested Feedback

Are there any other ways that this could inadvertently trigger an e-mail attempt?
