### PR TITLE
1830: switch to using enrollment system upstream as source for 1095b

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1751,6 +1751,7 @@ spec/requests/v0/id_card/attributes_spec.rb @department-of-veterans-affairs/back
 spec/requests/v0/in_progress_forms_controller_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 spec/requests/v0/in_progress_forms/5655_spec.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 spec/requests/v0/intent_to_file_spec.rb @department-of-veterans-affairs/disability-benefits @department-of-veterans-affairs/benefits-lifestage @department-of-veterans-affairs/pensions @department-of-veterans-affairs/backend-review-group
+spec/requests/v0/legacy_form1095_bs_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-iir
 spec/requests/v0/maintenance_windows_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/requests/v0/map_services_spec.rb @department-of-veterans-affairs/octo-identity
 spec/requests/v0/medical_copays_spec.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/v0/form1095_bs_controller.rb
+++ b/app/controllers/v0/form1095_bs_controller.rb
@@ -16,8 +16,7 @@ module V0
         periods = VeteranEnrollmentSystem::EnrollmentPeriods::Service.new.get_enrollment_periods(icn: current_user.icn)
         years = model_class.available_years(periods)
         forms = years.map { |year| { year:, last_updated: nil } } # last_updated is not used on front end.
-        # the front end currently displays based on order and we want to show most recent first
-        forms.sort_by { |f| f[:year] }.reverse
+        forms.sort_by { |f| f[:year] }
       else
         current_form = Form1095B.find_by(veteran_icn: current_user.icn, tax_year: Form1095B.current_tax_year)
         forms = current_form.nil? ? [] : [{ year: current_form.tax_year, last_updated: current_form.updated_at }]

--- a/app/controllers/v0/form1095_bs_controller.rb
+++ b/app/controllers/v0/form1095_bs_controller.rb
@@ -1,41 +1,94 @@
 # frozen_string_literal: true
 
+require_relative '../../../lib/veteran_enrollment_system/form1095_b/service'
+require_relative '../../../lib/veteran_enrollment_system/enrollment_periods/service'
+
 module V0
   class Form1095BsController < ApplicationController
     service_tag 'form-1095b'
     before_action { authorize :form1095, :access? }
-    before_action :set_form, only: %i[download_pdf download_txt]
+    before_action :validate_year, only: %i[download_pdf download_txt], if: -> { fetch_from_enrollment_system? }
+    before_action :validate_pdf_template, only: %i[download_pdf], if: -> { fetch_from_enrollment_system? }
+    before_action :validate_txt_template, only: %i[download_txt], if: -> { fetch_from_enrollment_system? }
 
     def available_forms
-      form = Form1095B.find_by(veteran_icn: current_user.icn, tax_year: Form1095B.current_tax_year)
-      forms = form.nil? ? [] : [{ year: form.tax_year, last_updated: form.updated_at }]
-      StatsD.increment('api.user_has_no_1095b') if forms.empty?
+      if fetch_from_enrollment_system?
+        periods = VeteranEnrollmentSystem::EnrollmentPeriods::Service.new.get_enrollment_periods(icn: current_user.icn)
+        years = model_class.available_years(periods)
+        forms = years.map { |year| { year:, last_updated: nil } } # last_updated is not used on front end.
+        # the front end currently displays based on order and we want to show most recent first
+        forms.sort_by { |f| f[:year] }.reverse
+      else
+        current_form = Form1095B.find_by(veteran_icn: current_user.icn, tax_year: Form1095B.current_tax_year)
+        forms = current_form.nil? ? [] : [{ year: current_form.tax_year, last_updated: current_form.updated_at }]
+      end
       render json: { available_forms: forms }
     end
 
     def download_pdf
-      file_name = "1095B_#{download_params[:tax_year]}.pdf"
-      send_data @form.pdf_file, filename: file_name, type: 'application/pdf', disposition: 'inline'
+      file_name = "1095B_#{tax_year}.pdf"
+      send_data form.pdf_file, filename: file_name, type: 'application/pdf', disposition: 'inline'
     end
 
     def download_txt
-      file_name = "1095B_#{download_params[:tax_year]}.txt"
-      send_data @form.txt_file, filename: file_name, type: 'text/plain', disposition: 'inline'
+      file_name = "1095B_#{tax_year}.txt"
+      send_data form.txt_file, filename: file_name, type: 'text/plain', disposition: 'inline'
     end
 
     private
 
-    def set_form
-      @form = Form1095B.find_by(veteran_icn: @current_user[:icn], tax_year: download_params[:tax_year])
+    def form
+      if fetch_from_enrollment_system?
+        service = VeteranEnrollmentSystem::Form1095B::Service.new
+        form_data = service.get_form_by_icn(icn: current_user[:icn], tax_year:)
+        model_class.parse(form_data)
+      else
+        return current_form_record if current_form_record.present?
 
-      if @form.blank?
-        Rails.logger.error("Form 1095-B for #{download_params[:tax_year]} not found", user_uuid: @current_user&.uuid)
-        raise Common::Exceptions::RecordNotFound, download_params[:tax_year]
+        Rails.logger.error("Form 1095-B for #{tax_year} not found", user_uuid: current_user&.uuid)
+        raise Common::Exceptions::RecordNotFound, tax_year
       end
+    end
+
+    def current_form_record
+      @current_form_record ||= Form1095B.find_by(veteran_icn: current_user[:icn], tax_year:)
     end
 
     def download_params
       params.permit(:tax_year)
+    end
+
+    def tax_year
+      download_params[:tax_year]
+    end
+
+    def validate_year
+      unless Integer(tax_year).between?(*model_class.available_years_range)
+        raise Common::Exceptions::UnprocessableEntity, detail: "1095-B for tax year #{tax_year} not supported",
+                                                       source: self.class.name
+      end
+    end
+
+    def validate_txt_template
+      unless File.exist?(model_class.txt_template_path(tax_year))
+        raise Common::Exceptions::UnprocessableEntity, detail: "1095-B for tax year #{tax_year} not supported",
+                                                       source: self.class.name
+      end
+    end
+
+    def validate_pdf_template
+      unless File.exist?(model_class.pdf_template_path(tax_year))
+        raise Common::Exceptions::UnprocessableEntity, detail: "1095-B for tax year #{tax_year} not supported",
+                                                       source: self.class.name
+      end
+    end
+
+    def model_class
+      VeteranEnrollmentSystem::Form1095B::Form1095B
+    end
+
+    def fetch_from_enrollment_system?
+      Flipper.enabled?(:fetch_1095b_from_enrollment_system, current_user)
     end
   end
 end

--- a/app/controllers/v0/form1095_bs_controller.rb
+++ b/app/controllers/v0/form1095_bs_controller.rb
@@ -16,7 +16,7 @@ module V0
         periods = VeteranEnrollmentSystem::EnrollmentPeriods::Service.new.get_enrollment_periods(icn: current_user.icn)
         years = model_class.available_years(periods)
         forms = years.map { |year| { year:, last_updated: nil } } # last_updated is not used on front end.
-        forms.sort_by { |f| f[:year] }
+        forms.sort_by! { |f| f[:year] }
       else
         current_form = Form1095B.find_by(veteran_icn: current_user.icn, tax_year: Form1095B.current_tax_year)
         forms = current_form.nil? ? [] : [{ year: current_form.tax_year, last_updated: current_form.updated_at }]

--- a/app/models/veteran_enrollment_system/form1095_b/form1095_b.rb
+++ b/app/models/veteran_enrollment_system/form1095_b/form1095_b.rb
@@ -92,8 +92,9 @@ module VeteranEnrollmentSystem
         end
 
         def available_years_range
-          current_year = Date.current.year
-          [current_year - 4, current_year - 1]
+          current_tax_year = Date.current.year - 1
+          # using a range of years because more years of form data will be available in the future
+          [current_tax_year, current_tax_year]
         end
 
         def pdf_template_path(year)

--- a/app/swagger/swagger/requests/form1095_bs.rb
+++ b/app/swagger/swagger/requests/form1095_bs.rb
@@ -22,7 +22,7 @@ module Swagger
               property :available_forms, type: :array do
                 items do
                   property :year, type: :integer, example: 2021
-                  property :last_updated, type: :string, example: '2022-08-03T16:08:50.071Z'
+                  property :last_updated, type: %i[string null], example: '2022-08-03T16:08:50.071Z'
                 end
               end
             end

--- a/spec/lib/veteran_enrollment_system/enrollment_periods/service_spec.rb
+++ b/spec/lib/veteran_enrollment_system/enrollment_periods/service_spec.rb
@@ -14,10 +14,12 @@ RSpec.describe VeteranEnrollmentSystem::EnrollmentPeriods::Service do
           response = subject.get_enrollment_periods(icn:)
 
           expect(response).to eq([
-                                   {
-                                     'startDate' => '2024-03-05',
-                                     'endDate' => '2024-03-05'
-                                   }
+                                   { 'startDate' => '2024-03-05',
+                                     'endDate' => '2024-03-05' },
+                                   { 'startDate' => '2019-03-05',
+                                     'endDate' => '2022-03-05' },
+                                   { 'startDate' => '2010-03-05',
+                                     'endDate' => '2015-03-05' }
                                  ])
         end
       end

--- a/spec/models/veteran_enrollment_system/form1095_b/form1095_b_spec.rb
+++ b/spec/models/veteran_enrollment_system/form1095_b/form1095_b_spec.rb
@@ -97,29 +97,37 @@ RSpec.describe VeteranEnrollmentSystem::Form1095B::Form1095B, type: :model do
     after { Timecop.return }
 
     context 'with start and end dates' do
-      it 'returns previous four tax years for which the user had any coverage' do
+      it 'returns all currently available years during which the user had coverage' do
         periods = [{ 'startDate' => '2015-03-05', 'endDate' => '2025-03-05' }]
         result = described_class.available_years(periods)
-        expect(result).to eq([2021, 2022, 2023, 2024])
+        expect(result).to eq([2024])
       end
     end
 
     context 'when end date is nil' do
-      it 'returns previous four tax years for which the user had any coverage' do
+      it 'infers that the user is still covered and returns all currently available years' do
         periods = [{ 'startDate' => '2015-03-05', 'endDate' => nil }]
         result = described_class.available_years(periods)
-        expect(result).to eq([2021, 2022, 2023, 2024])
+        expect(result).to eq([2024])
       end
     end
 
     context 'with multiple periods' do
-      it 'includes previous four tax years for which user had any coverage' do
+      it 'returns all currently available years during which the user had coverage' do
         periods = [{ 'startDate' => '2015-03-05', 'endDate' => '2017-03-05' },
                    { 'startDate' => '2020-03-05', 'endDate' => '2021-03-05' },
                    { 'startDate' => '2022-03-05', 'endDate' => '2022-04-05' },
                    { 'startDate' => '2024-03-05', 'endDate' => nil }]
         result = described_class.available_years(periods)
-        expect(result).to eq([2021, 2022, 2024])
+        expect(result).to eq([2024])
+      end
+    end
+
+    context 'when user was not covered during available years' do
+      it 'returns an empty array' do
+        periods = [{ 'startDate' => '2015-03-05', 'endDate' => '2020-03-05' }]
+        result = described_class.available_years(periods)
+        expect(result).to eq([])
       end
     end
   end
@@ -128,9 +136,9 @@ RSpec.describe VeteranEnrollmentSystem::Form1095B::Form1095B, type: :model do
     before { Timecop.freeze(Time.zone.parse('2025-03-05T08:00:00Z')) }
     after { Timecop.return }
 
-    it 'returns an array containing last year and five years ago' do
+    it 'returns an array containing first and last years of accessible 1095-B data' do
       result = described_class.available_years_range
-      expect(result).to eq([2021, 2024])
+      expect(result).to eq([2024, 2024])
     end
   end
 

--- a/spec/requests/swagger_spec.rb
+++ b/spec/requests/swagger_spec.rb
@@ -2439,22 +2439,29 @@ RSpec.describe 'the v0 API documentation', order: :defined, type: %i[apivore req
     end
 
     describe '1095-B' do
-      let(:user) { build(:user, :loa3, icn: '3456787654324567') }
+      let(:user) { build(:user, :loa3, icn: '1012667145V762142') }
       let(:headers) { { '_headers' => { 'Cookie' => sign_in(user, nil, true) } } }
       let(:bad_headers) { { '_headers' => { 'Cookie' => sign_in(mhv_user, nil, true) } } }
 
       before do
         create(:form1095_b, tax_year: Form1095B.current_tax_year)
+        allow(Flipper).to receive(:enabled?).with(:fetch_1095b_from_enrollment_system, any_args).and_return(true)
+        Timecop.freeze(Time.zone.parse('2025-03-05T08:00:00Z'))
       end
+
+      after { Timecop.return }
 
       context 'available forms' do
         it 'supports getting available forms' do
-          expect(subject).to validate(
-            :get,
-            '/v0/form1095_bs/available_forms',
-            200,
-            headers
-          )
+          VCR.use_cassette('veteran_enrollment_system/enrollment_periods/get_success',
+                           { match_requests_on: %i[method uri] }) do
+            expect(subject).to validate(
+              :get,
+              '/v0/form1095_bs/available_forms',
+              200,
+              headers
+            )
+          end
         end
 
         it 'requires authorization' do

--- a/spec/requests/swagger_spec.rb
+++ b/spec/requests/swagger_spec.rb
@@ -2444,7 +2444,6 @@ RSpec.describe 'the v0 API documentation', order: :defined, type: %i[apivore req
       let(:bad_headers) { { '_headers' => { 'Cookie' => sign_in(mhv_user, nil, true) } } }
 
       before do
-        create(:form1095_b, tax_year: Form1095B.current_tax_year)
         allow(Flipper).to receive(:enabled?).with(:fetch_1095b_from_enrollment_system, any_args).and_return(true)
         Timecop.freeze(Time.zone.parse('2025-03-05T08:00:00Z'))
       end

--- a/spec/requests/v0/enrollment_periods_spec.rb
+++ b/spec/requests/v0/enrollment_periods_spec.rb
@@ -17,8 +17,14 @@ RSpec.describe 'V0::EnrollmentPeriods', type: :request do
                          match_requests_on: %i[uri method body]) do
           get '/v0/enrollment_periods'
           expect(response).to have_http_status(:success)
-          expect(response.parsed_body).to eq({ 'enrollment_periods' => [{ 'startDate' => '2024-03-05',
-                                                                          'endDate' => '2024-03-05' }] })
+          expect(response.parsed_body).to eq({ 'enrollment_periods' => [
+                                               { 'startDate' => '2024-03-05',
+                                                 'endDate' => '2024-03-05' },
+                                               { 'startDate' => '2019-03-05',
+                                                 'endDate' => '2022-03-05' },
+                                               { 'startDate' => '2010-03-05',
+                                                 'endDate' => '2015-03-05' }
+                                             ] })
         end
       end
 

--- a/spec/requests/v0/form1095_bs_spec.rb
+++ b/spec/requests/v0/form1095_bs_spec.rb
@@ -3,136 +3,175 @@
 require 'rails_helper'
 
 RSpec.describe 'V0::Form1095Bs', type: :request do
-  subject { create(:form1095_b) }
+  let(:user) { build(:user, :loa3, icn: '1012667145V762142') }
+  let(:invalid_user) { build(:user, :loa1) }
 
-  let(:user) { build(:user, :loa3, icn: subject.veteran_icn) }
-  let(:invalid_user) { build(:user, :loa1, icn: subject.veteran_icn) }
-
-  describe 'GET /download_pdf for valid user' do
-    before do
-      sign_in_as(user)
-    end
-
-    it 'returns http success' do
-      get '/v0/form1095_bs/download_pdf/2021'
-      expect(response).to have_http_status(:success)
-    end
-
-    it 'returns a PDF form' do
-      get '/v0/form1095_bs/download_pdf/2021'
-      expect(response.content_type).to eq('application/pdf')
-    end
-
-    it 'throws 404 when form not found' do
-      get '/v0/form1095_bs/download_pdf/2018'
-      expect(response).to have_http_status(:not_found)
-    end
-
-    it 'throws 422 when no template exists for requested year' do
-      create(:form1095_b, tax_year: 2018)
-      get '/v0/form1095_bs/download_pdf/2018'
-      expect(response).to have_http_status(:unprocessable_entity)
-    end
+  before do
+    allow(Flipper).to receive(:enabled?).with(:fetch_1095b_from_enrollment_system, any_args).and_return(true)
+    Timecop.freeze(Time.zone.parse('2025-03-05T08:00:00Z'))
   end
 
-  describe 'GET /download_pdf for invalid user' do
-    before do
-      sign_in_as(invalid_user)
+  after { Timecop.return }
+
+  describe 'GET /download_pdf' do
+    context 'with valid user' do
+      before do
+        sign_in_as(user)
+      end
+
+      it 'returns http success' do
+        VCR.use_cassette('veteran_enrollment_system/form1095_b/get_form_success',
+                         { match_requests_on: %i[method uri] }) do
+          get '/v0/form1095_bs/download_pdf/2024'
+          expect(response).to have_http_status(:success)
+        end
+      end
+
+      it 'returns a PDF form' do
+        VCR.use_cassette('veteran_enrollment_system/form1095_b/get_form_success',
+                         { match_requests_on: %i[method uri] }) do
+          get '/v0/form1095_bs/download_pdf/2024'
+          expect(response.content_type).to eq('application/pdf')
+        end
+      end
+
+      # disabled pending work on https://github.com/department-of-veterans-affairs/va-iir/issues/2133
+      it 'throws 404 when form not found', pending: 'upcoming changes' do
+        VCR.use_cassette('veteran_enrollment_system/form1095_b/get_form_not_found',
+                         { match_requests_on: %i[method uri] }) do
+          get '/v0/form1095_bs/download_pdf/2024'
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      # this will be irrelevant after we add the template
+      it 'throws 422 when no template exists for requested year' do
+        create(:form1095_b, tax_year: 2018)
+        get '/v0/form1095_bs/download_pdf/2018'
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
     end
 
-    it 'returns http 403' do
-      get '/v0/form1095_bs/download_pdf/2021'
-      expect(response).to have_http_status(:forbidden)
+    context 'with invalid user' do
+      before do
+        sign_in_as(invalid_user)
+      end
+
+      it 'returns http 403' do
+        get '/v0/form1095_bs/download_pdf/2021'
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when user is not logged in' do
+      it 'returns http 401' do
+        get '/v0/form1095_bs/download_pdf/2021'
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 
   describe 'GET /download_txt for valid user' do
-    before do
-      sign_in_as(user)
+    context 'with valid user' do
+      before do
+        sign_in_as(user)
+      end
+
+      it 'returns http success' do
+        VCR.use_cassette('veteran_enrollment_system/form1095_b/get_form_success',
+                         { match_requests_on: %i[method uri] }) do
+                           get '/v0/form1095_bs/download_txt/2024'
+                           expect(response).to have_http_status(:success)
+                         end
+      end
+
+      it 'returns a txt form' do
+        VCR.use_cassette('veteran_enrollment_system/form1095_b/get_form_success',
+                         { match_requests_on: %i[method uri] }) do
+                           get '/v0/form1095_bs/download_txt/2024'
+                           expect(response.content_type).to eq('text/plain')
+                         end
+      end
+
+      # disabled pending work on https://github.com/department-of-veterans-affairs/va-iir/issues/2133
+      it 'throws 404 when form not found', pending: 'upcoming changes' do
+        get '/v0/form1095_bs/download_txt/2018'
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'throws 422 when requested year is outside of available years range' do
+        create(:form1095_b, tax_year: 2018)
+        get '/v0/form1095_bs/download_txt/2018'
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      # this will be irrelevant after we add the template
+      it 'throws 422 when no template exists for requested year' do
+        create(:form1095_b, tax_year: 2023)
+        get '/v0/form1095_bs/download_txt/2023'
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
     end
 
-    it 'returns http success' do
-      get '/v0/form1095_bs/download_txt/2021'
-      expect(response).to have_http_status(:success)
+    context 'with invalid user' do
+      before do
+        sign_in_as(invalid_user)
+      end
+
+      it 'returns http 403' do
+        get '/v0/form1095_bs/download_txt/2021'
+        expect(response).to have_http_status(:forbidden)
+      end
     end
 
-    it 'returns a txt form' do
-      get '/v0/form1095_bs/download_txt/2021'
-      expect(response.content_type).to eq('text/plain')
-    end
-
-    it 'throws 404 when form not found' do
-      get '/v0/form1095_bs/download_txt/2018'
-      expect(response).to have_http_status(:not_found)
-    end
-
-    it 'throws 422 when no template exists for requested year' do
-      create(:form1095_b, tax_year: 2018)
-      get '/v0/form1095_bs/download_txt/2018'
-      expect(response).to have_http_status(:unprocessable_entity)
-    end
-  end
-
-  describe 'GET /download_txt for invalid user' do
-    before do
-      sign_in_as(invalid_user)
-    end
-
-    it 'returns http 403' do
-      get '/v0/form1095_bs/download_txt/2021'
-      expect(response).to have_http_status(:forbidden)
+    context 'when user is not logged in' do
+      it 'returns http 401' do
+        get '/v0/form1095_bs/download_txt/2021'
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 
   describe 'GET /available_forms' do
-    before do
-      sign_in_as(user)
-      # allow endpoint increment in order to test user_has_no_1095b increment
-      allow(StatsD).to receive(:increment).with('api.rack.request',
-                                                { tags: ['controller:v0/form1095_bs', 'action:available_forms',
-                                                         'source_app:not_provided', 'status:200'] })
+    context 'with valid user' do
+      before do
+        sign_in_as(user)
+      end
+
+      it 'returns success with only the most recent tax year form data' do
+        this_year = Date.current.year
+        create(:form1095_b, tax_year: this_year - 1)
+        create(:form1095_b, tax_year: this_year)
+        create(:form1095_b, tax_year: this_year - 2)
+
+        VCR.use_cassette('veteran_enrollment_system/enrollment_periods/get_success',
+                         { match_requests_on: %i[method uri] }) do
+          get '/v0/form1095_bs/available_forms'
+        end
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body.deep_symbolize_keys).to eq(
+          { available_forms: [{ year: 2024,
+                                last_updated: nil }] }
+        )
+      end
     end
 
-    it 'returns success with only the most recent tax year form data' do
-      this_year = Date.current.year
-      last_year_form = create(:form1095_b, tax_year: this_year - 1)
-      create(:form1095_b, tax_year: this_year)
-      create(:form1095_b, tax_year: this_year - 2)
+    context 'with invalid user' do
+      before do
+        sign_in_as(invalid_user)
+      end
 
-      expect(StatsD).not_to receive(:increment).with('api.user_has_no_1095b')
-      get '/v0/form1095_bs/available_forms'
-      expect(response).to have_http_status(:success)
-      expect(response.parsed_body.deep_symbolize_keys).to eq(
-        { available_forms: [{ year: last_year_form.tax_year,
-                              last_updated: last_year_form.updated_at.strftime('%Y-%m-%dT%H:%M:%S.%LZ') }] }
-      )
+      it 'returns http 403' do
+        get '/v0/form1095_bs/available_forms'
+        expect(response).to have_http_status(:forbidden)
+      end
     end
 
-    it 'returns success with no available forms and increments statsd when user has no form data' do
-      expect(StatsD).to receive(:increment).with('api.user_has_no_1095b')
-      get '/v0/form1095_bs/available_forms'
-      expect(response).to have_http_status(:success)
-      expect(response.parsed_body.symbolize_keys).to eq(
-        { available_forms: [] }
-      )
-    end
-  end
-
-  describe 'GET /available_forms for invalid user' do
-    before do
-      sign_in_as(invalid_user)
-    end
-
-    it 'returns http 403' do
-      get '/v0/form1095_bs/available_forms'
-      expect(response).to have_http_status(:forbidden)
-    end
-  end
-
-  describe 'GET /available_forms when not logged in' do
-    it 'returns http 401' do
-      get '/v0/form1095_bs/available_forms'
-      expect(response).to have_http_status(:unauthorized)
+    context 'when user is not logged in' do
+      it 'returns http 401' do
+        get '/v0/form1095_bs/available_forms'
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 end

--- a/spec/requests/v0/form1095_bs_spec.rb
+++ b/spec/requests/v0/form1095_bs_spec.rb
@@ -151,10 +151,6 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
         expect(response).to have_http_status(:success)
         expect(response.parsed_body.deep_symbolize_keys).to eq(
           { available_forms: [
-            { year: 2021,
-              last_updated: nil },
-            { year: 2022,
-              last_updated: nil },
             { year: 2024,
               last_updated: nil }
           ] }

--- a/spec/requests/v0/form1095_bs_spec.rb
+++ b/spec/requests/v0/form1095_bs_spec.rb
@@ -35,12 +35,12 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
         end
       end
 
-      # disabled pending work on https://github.com/department-of-veterans-affairs/va-iir/issues/2133
-      it 'throws 404 when form not found', pending: 'upcoming changes' do
+      # this will change to 404 with ticket: https://github.com/department-of-veterans-affairs/va-iir/issues/2133
+      it 'throws 503 when form data not found' do
         VCR.use_cassette('veteran_enrollment_system/form1095_b/get_form_not_found',
                          { match_requests_on: %i[method uri] }) do
           get '/v0/form1095_bs/download_pdf/2024'
-          expect(response).to have_http_status(:not_found)
+          expect(response).to have_http_status(:service_unavailable)
         end
       end
 
@@ -97,15 +97,13 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
                          end
       end
 
-      # disabled pending work on https://github.com/department-of-veterans-affairs/va-iir/issues/2133
-      it 'throws 404 when form not found', pending: 'upcoming changes' do
-        get '/v0/form1095_bs/download_txt/2018'
-        expect(response).to have_http_status(:not_found)
-      end
-
-      it 'throws 422 when requested year is outside of available years range' do
-        get '/v0/form1095_bs/download_txt/2018'
-        expect(response).to have_http_status(:unprocessable_entity)
+      # this will change to 404 with ticket: https://github.com/department-of-veterans-affairs/va-iir/issues/2133
+      it 'throws 503 when form data not found' do
+        VCR.use_cassette('veteran_enrollment_system/form1095_b/get_form_not_found',
+                         { match_requests_on: %i[method uri] }) do
+          get '/v0/form1095_bs/download_txt/2024'
+          expect(response).to have_http_status(:service_unavailable)
+        end
       end
 
       # this will be irrelevant after we add the template

--- a/spec/requests/v0/form1095_bs_spec.rb
+++ b/spec/requests/v0/form1095_bs_spec.rb
@@ -45,7 +45,12 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
       end
 
       # this will be irrelevant after we add the template
-      it 'throws 422 when no template exists for requested year' do
+      it 'throws 422 when template is not available' do
+        get '/v0/form1095_bs/download_pdf/2023'
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'throws 422 when requested year is more than 5 years ago' do
         get '/v0/form1095_bs/download_pdf/2018'
         expect(response).to have_http_status(:unprocessable_entity)
       end
@@ -104,8 +109,13 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
       end
 
       # this will be irrelevant after we add the template
-      it 'throws 422 when no template exists for requested year' do
+      it 'throws 422 when template is not available' do
         get '/v0/form1095_bs/download_txt/2023'
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'throws 422 when requested year is more than 5 years ago' do
+        get '/v0/form1095_bs/download_txt/2018'
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end

--- a/spec/requests/v0/form1095_bs_spec.rb
+++ b/spec/requests/v0/form1095_bs_spec.rb
@@ -84,17 +84,17 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
       it 'returns http success' do
         VCR.use_cassette('veteran_enrollment_system/form1095_b/get_form_success',
                          { match_requests_on: %i[method uri] }) do
-                           get '/v0/form1095_bs/download_txt/2024'
-                           expect(response).to have_http_status(:success)
-                         end
+          get '/v0/form1095_bs/download_txt/2024'
+          expect(response).to have_http_status(:success)
+        end
       end
 
       it 'returns a txt form' do
         VCR.use_cassette('veteran_enrollment_system/form1095_b/get_form_success',
                          { match_requests_on: %i[method uri] }) do
-                           get '/v0/form1095_bs/download_txt/2024'
-                           expect(response.content_type).to eq('text/plain')
-                         end
+          get '/v0/form1095_bs/download_txt/2024'
+          expect(response.content_type).to eq('text/plain')
+        end
       end
 
       # this will change to 404 with ticket: https://github.com/department-of-veterans-affairs/va-iir/issues/2133

--- a/spec/requests/v0/legacy_form1095_bs_spec.rb
+++ b/spec/requests/v0/legacy_form1095_bs_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'V0::Form1095Bs', type: :request do
+  subject { create(:form1095_b) }
+
+  let(:user) { build(:user, :loa3, icn: subject.veteran_icn) }
+  let(:invalid_user) { build(:user, :loa1, icn: subject.veteran_icn) }
+
+  before do
+    allow(Flipper).to receive(:enabled?).with(:fetch_1095b_from_enrollment_system, any_args).and_return(false)
+  end
+
+  describe 'GET /download_pdf for valid user' do
+    before do
+      sign_in_as(user)
+    end
+
+    it 'returns http success' do
+      get '/v0/form1095_bs/download_pdf/2021'
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'returns a PDF form' do
+      get '/v0/form1095_bs/download_pdf/2021'
+      expect(response.content_type).to eq('application/pdf')
+    end
+
+    it 'throws 404 when form not found' do
+      get '/v0/form1095_bs/download_pdf/2018'
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'throws 422 when no template exists for requested year' do
+      create(:form1095_b, tax_year: 2018)
+      get '/v0/form1095_bs/download_pdf/2018'
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe 'GET /download_pdf for invalid user' do
+    before do
+      sign_in_as(invalid_user)
+    end
+
+    it 'returns http 403' do
+      get '/v0/form1095_bs/download_pdf/2021'
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /download_txt for valid user' do
+    before do
+      sign_in_as(user)
+    end
+
+    it 'returns http success' do
+      get '/v0/form1095_bs/download_txt/2021'
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'returns a txt form' do
+      get '/v0/form1095_bs/download_txt/2021'
+      expect(response.content_type).to eq('text/plain')
+    end
+
+    it 'throws 404 when form not found' do
+      get '/v0/form1095_bs/download_txt/2018'
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'throws 422 when no template exists for requested year' do
+      create(:form1095_b, tax_year: 2018)
+      get '/v0/form1095_bs/download_txt/2018'
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe 'GET /download_txt for invalid user' do
+    before do
+      sign_in_as(invalid_user)
+    end
+
+    it 'returns http 403' do
+      get '/v0/form1095_bs/download_txt/2021'
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /available_forms' do
+    before do
+      sign_in_as(user)
+    end
+
+    it 'returns success with only the most recent tax year form data' do
+      this_year = Date.current.year
+      last_year_form = create(:form1095_b, tax_year: this_year - 1)
+      create(:form1095_b, tax_year: this_year)
+      create(:form1095_b, tax_year: this_year - 2)
+
+      get '/v0/form1095_bs/available_forms'
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body.deep_symbolize_keys).to eq(
+        { available_forms: [{ year: last_year_form.tax_year,
+                              last_updated: last_year_form.updated_at.strftime('%Y-%m-%dT%H:%M:%S.%LZ') }] }
+      )
+    end
+
+    it 'returns success with no available forms' do
+      get '/v0/form1095_bs/available_forms'
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body.symbolize_keys).to eq(
+        { available_forms: [] }
+      )
+    end
+  end
+
+  describe 'GET /available_forms for invalid user' do
+    before do
+      sign_in_as(invalid_user)
+    end
+
+    it 'returns http 403' do
+      get '/v0/form1095_bs/available_forms'
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /available_forms when not logged in' do
+    it 'returns http 401' do
+      get '/v0/form1095_bs/available_forms'
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/support/vcr_cassettes/veteran_enrollment_system/enrollment_periods/get_success.yml
+++ b/spec/support/vcr_cassettes/veteran_enrollment_system/enrollment_periods/get_success.yml
@@ -54,7 +54,11 @@ http_interactions:
         {
           "data": {
             "icn": "1012667122V019349",
-            "mecPeriods": [{"startDate": "2024-03-05", "endDate": "2024-03-05"}]
+            "mecPeriods": [
+              {"startDate": "2024-03-05", "endDate": "2024-03-05"},
+              {"startDate": "2019-03-05", "endDate": "2022-03-05"},
+              {"startDate": "2010-03-05", "endDate": "2015-03-05"}
+            ]
           },
           "messages": []
         }


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES
- This changes the 1095b available_years and download endpoints to fetch data from the enrollment system rather than relying on database records that are synced from the enrollment system via a background job.
- I am on the CVE team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-iir/issues/1830

## Testing done

- [ ] Will be tested thoroughly on staging.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
It adds new feature flagged behavior to the 1095b controller. The behavior is the same while the feature flag is off. With the feature flag on, it will fetch data from the enrollment system rather than from the local database.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
