### PR TITLE
(BIO) Form helper: extract_country expanded options

### DIFF
--- a/lib/pdf_fill/forms/form_helper.rb
+++ b/lib/pdf_fill/forms/form_helper.rb
@@ -24,19 +24,20 @@ module PdfFill
         full_name
       end
 
-      def extract_country(address)
+      def extract_country(address, return_invalid: true)
         return if address.blank?
 
         country = address['country'] || address['country_name']
         return if country.blank?
 
-        if country.size == 3
+        if [3, 2].include?(country.size)
           IsoCountryCodes.find(country).alpha2
         else
           IsoCountryCodes.search_by_name(country)[0].alpha2
         end
       rescue IsoCountryCodes::UnknownCodeError
-        country
+        Rails.logger.warn("Unknown Country '#{country}' passed to to extract_country")
+        country if return_invalid
       end
 
       def split_postal_code(address)

--- a/spec/lib/pdf_fill/forms/form_helper_spec.rb
+++ b/spec/lib/pdf_fill/forms/form_helper_spec.rb
@@ -48,29 +48,39 @@ describe PdfFill::Forms::FormHelper do
   end
 
   describe '#extract_country' do
-    it 'returns the correct code for country' do
-      address = {
-        'country' => 'USA'
-      }
-      expect(including_class.new.extract_country(address)).to eq('US')
-    end
-  end
+    country_data = {
+      'when country is USA' => [
+        { description: 'length is 2', in: 'US', out: 'US' },
+        { description: 'length is 3', in: 'USA', out: 'US' },
+        { description: 'Full Country Name', in: 'United States', out: 'US' }
+      ],
+      'when country is non-us' => [
+        { description: 'length is 2', in: 'GH', out: 'GH' },
+        { description: 'length is 3', in: 'GHA', out: 'GH' },
+        { description: 'Full Country Name', in: 'Ghana', out: 'GH' }
+      ],
+      'when country is invalid' => [
+        { description: 'length is 2', in: 'ZZ', out: 'ZZ' },
+        { description: 'length is 3', in: 'ZZZ', out: 'ZZZ' },
+        { description: 'Full Country Name', in: 'Invalid Country', out: 'Invalid Country' }
+      ],
+      'when country is invalid and return_invalid: false' => [
+        { description: 'length is 2', in: 'ZZ', out: nil, options: { return_invalid: false } },
+        { description: 'length is 3', in: 'ZZZ', out: nil, options: { return_invalid: false } },
+        { description: 'Full Country Name', in: 'Invalid Country', out: nil, options: { return_invalid: false } }
+      ]
+    }
 
-  describe '#extract_country_if_not_usa' do
-    it 'returns the correct code for country' do
-      address = {
-        'country' => 'Ghana'
-      }
-      expect(including_class.new.extract_country(address)).to eq('GH')
-    end
-  end
-
-  describe '#extract_country_if_not_valid_code' do
-    it 'returns the passed value as country' do
-      address = {
-        'country' => 'InvalidCountry'
-      }
-      expect(including_class.new.extract_country(address)).to eq('InvalidCountry')
+    country_data.each do |desc, cases|
+      context desc do
+        cases.each do |c|
+          it "returns the correct code if #{c[:description]}" do
+            address = { 'country' => c[:in] }
+            options = c[:options] || {}
+            expect(including_class.new.extract_country(address, **options)).to eq(c[:out])
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
The `extract_country` method in `lib/pdf_fill/forms/form_helper.rb` has been expanded to accept both iso2 and iso3 country codes. 
Before: 
`extract_country({'country' => "US"})`  returns `"AU"` because `IsoCountryCodes.search_by_name("US")` returns a list of all countries that include "US" and we pick the first, Australia.
`extract_country({'country' => "INVALID"})`  returns `"INVALID"` an invalid country code

After:
`extract_country({'country' => "US"})`  returns `"US"`
`extract_country({'country' => "INVALID"})`  returns `"INVALID"` an invalid country code
`extract_country({'country' => "INVALID", return_invalid: false)`  returns nil
We also log invalid countries.
- BIO Aquia - no we don't own this component, but want to use it in all 4 forms

I'm also logging a warning for invalid country codes, I think we'd expect them to be valid by this point in the code.  I'm thinking country is to broad to e PII, correct me if I'm wrong.
## Testing done

- [x] *New code is covered by unit tests*
in addition to the unit test, existing `it_behaves_like 'a form filler' ` tests confirm no existing pdf generation is changed.


## What areas of the site does it impact?

Pdf Generation

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature