### PR TITLE
Add validation error message to InvalidCredentialLevelError

### DIFF
--- a/app/services/sign_in/credential_level_creator.rb
+++ b/app/services/sign_in/credential_level_creator.rb
@@ -54,7 +54,13 @@ module SignIn
                           current_ial:,
                           max_ial:,
                           auto_uplevel:)
-    rescue ActiveModel::ValidationError
+    rescue ActiveModel::ValidationError => e
+      Rails.logger.info("[SignIn][CredentialLevelCreator] error: #{e.message}", credential_type: type,
+                                                                                requested_acr:,
+                                                                                current_ial:,
+                                                                                max_ial:,
+                                                                                auto_uplevel:,
+                                                                                credential_uuid:)
       raise Errors::InvalidCredentialLevelError.new message: 'Unsupported credential authorization levels'
     end
 


### PR DESCRIPTION
## Summary

- Add validation error message to InvalidCredentialLevelError to better pinpoint where failures are occurring.

## Testing 
- Verify SiS authentication works with id.me and login.gov.
- Modify SignIn::CredentialLevel to raise a validation error and verify that the logged error message looks something like:
   ```ruby
   [SignIn][CredentialLevelCreator] error  => { "message": "Validation failed: Requested acr is not included in the list", "auto_uplevel": false, "credential_type": "logingov", "credential_uuid": "some-sub-uuid", "current_ial": 2, "max_ial": 1, "requested_acr": "bad"}
   ```

## What areas of the site does it impact?
Sign-in service, authentication

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

