### PR TITLE
Fix extract_country helper method

### DIFF
--- a/lib/pdf_fill/forms/form_helper.rb
+++ b/lib/pdf_fill/forms/form_helper.rb
@@ -30,9 +30,15 @@ module PdfFill
         country = address['country'] || address['country_name']
         return if country.blank?
 
-        if country.size == 3
+        case country.size
+        when 3
+          # 3-character code (ISO 3166-1 alpha-3), convert to 2-character (alpha-2)
           IsoCountryCodes.find(country).alpha2
+        when 2
+          # Already a 2-character code (ISO 3166-1 alpha-2), return as-is
+          country
         else
+          # Country name or other format, search by name
           IsoCountryCodes.search_by_name(country)[0].alpha2
         end
       rescue IsoCountryCodes::UnknownCodeError


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*

Fixes an issue where the country code was not being returned correctly. If there was a 3 letter country code in the address, `extract_country` would successfully transform it into `US`. However, if a 2 letter country code was passed as part of the address into `extract_country` the method would mistakenly return `AU`. This ensures that regardless of the country code length, that the appropriate two letter code is returned.

## Related issue(s)


## Testing done

Tested locally

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
