### PR TITLE
Update build.yml to run on master only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   workflow_run:
     workflows: ["Code Checks"]
-    branches: ["*"]
+    branches: [master]
     types: [completed]
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary
This used to be `master` until it was switched to `*` in https://github.com/department-of-veterans-affairs/vets-api/pull/21574 for the Preview Environment effort. Since that's not moving forward, we can go back to `master`. The benefit to this change is that the [Build, Push & Deploy](https://github.com/department-of-veterans-affairs/vets-api/actions/workflows/build.yml) action won't run as much. It's getting kicked off for all pushes to PRs which isn't necessary and can be confusing. 

## Related issue(s)
None. Saw this while on support. 

## Testing done

- [x] Watch after merge to make sure this is run
- [x] Doesn't run on push to PR. 

## Screenshots
What's happening now on a push to a PR:
<img width="530" height="59" alt="image" src="https://github.com/user-attachments/assets/6cdf235e-c5db-44b1-a68d-5b17a123cd20" />
The workflow starts and builds a docker image and then gets to the logic where it says to only run on `master` pushes. 

This is ideal:
<img width="533" height="41" alt="image" src="https://github.com/user-attachments/assets/c326f786-1b1d-4905-a688-27555ced16af" />
Doesn't even start.

But then, of course, it will run all the steps on merge to master. 

## What areas of the site does it impact?
Build, Push, & Deploy GitHub action. 
