### PR TITLE
PBB 125198 0969 LH metadata missing zipcode

### DIFF
--- a/modules/income_and_assets/app/models/income_and_assets/saved_claim.rb
+++ b/modules/income_and_assets/app/models/income_and_assets/saved_claim.rb
@@ -42,6 +42,13 @@ module IncomeAndAssets
       parsed_form['email'] || 'test@example.com' # TODO: update this when we have a real email field
     end
 
+    # Utility function to retrieve veteran filenumber/ssn
+    #
+    # @return [String]
+    def veteran_filenumber
+      parsed_form['vaFileNumber'] || parsed_form['veteranSocialSecurityNumber']
+    end
+
     # Utility function to retrieve veteran first name from form
     #
     # @return [String]

--- a/modules/income_and_assets/lib/income_and_assets/benefits_intake/submit_claim_job.rb
+++ b/modules/income_and_assets/lib/income_and_assets/benefits_intake/submit_claim_job.rb
@@ -116,6 +116,7 @@ module IncomeAndAssets
           form['veteranFullName']['first'],
           form['veteranFullName']['last'],
           form['vaFileNumber'] || form['veteranSocialSecurityNumber'],
+          nil.to_s, # => '00000'; zipcode is not present on the 0969 form
           self.class.to_s,
           @claim.form_id,
           @claim.business_line

--- a/modules/income_and_assets/spec/lib/income_and_assets/benefits_intake/submit_claim_job_spec.rb
+++ b/modules/income_and_assets/spec/lib/income_and_assets/benefits_intake/submit_claim_job_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe IncomeAndAssets::BenefitsIntake::SubmitClaimJob, :uploader_helper
   let(:service) { double('service') }
   let(:monitor) { IncomeAndAssets::Monitor.new }
   let(:user_account_uuid) { 123 }
+  let(:generated_metadata) do
+    {
+      'veteranFirstName' => claim.veteran_first_name,
+      'veteranLastName' => claim.veteran_last_name,
+      'fileNumber' => claim.veteran_filenumber,
+      'zipCode' => '00000',
+      'source' => job.class.to_s,
+      'docType' => claim.form_id,
+      'businessLine' => claim.business_line
+    }
+  end
 
   describe '#perform' do
     let(:response) { double('response') }
@@ -47,7 +58,7 @@ RSpec.describe IncomeAndAssets::BenefitsIntake::SubmitClaimJob, :uploader_helper
       expect(UserAccount).to receive(:find)
 
       expect(service).to receive(:perform_upload).with(
-        upload_url: 'test_location', document: pdf_path, metadata: anything, attachments: []
+        upload_url: 'test_location', document: pdf_path, metadata: generated_metadata.to_json, attachments: []
       )
       expect(job).to receive(:cleanup_file_paths)
 


### PR DESCRIPTION
## Summary

add the default zipcode to the 0969 LH metadata

## Related issue(s)

[PBB | 0969 LH metadata is missing zipcode](https://github.com/department-of-veterans-affairs/va.gov-team/issues/125198)

## Testing done

- [x] *New code is covered by unit tests*
ran a form through the submission job locally checking the metadata value

## What areas of the site does it impact?

0969 income and assets

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
