### PR TITLE
MHV Email confirmation date can be after source date

### DIFF
--- a/lib/va_profile/models/email.rb
+++ b/lib/va_profile/models/email.rb
@@ -70,35 +70,25 @@ module VAProfile
 
       # Override the confirmation_date setter to correct it if it's after source_date.
       # This prevents issues where client-provided dates may be ahead due to time differences.
+      # Uses the framework's type casting to ensure consistency with Vets::Type::ISO8601Time.
       # @param value [Time, String, nil] the confirmation date to set
       # @return [Time] the corrected confirmation date
       def confirmation_date=(value)
-        @confirmation_date = parse_iso8601_time(value)
+        @confirmation_date = Vets::Attributes::Value.cast(:confirmation_date, Vets::Type::ISO8601Time, value)
         correct_confirmation_date_if_needed
       end
 
       # Override the source_date setter to correct confirmation_date when source_date is set.
       # This handles the case where confirmation_date is set before source_date during initialization.
+      # Uses the framework's type casting to ensure consistency with Vets::Type::ISO8601Time.
       # @param value [Time, String, nil] the source date to set
       # @return [Time] the source date
       def source_date=(value)
-        @source_date = parse_iso8601_time(value)
+        @source_date = Vets::Attributes::Value.cast(:source_date, Vets::Type::ISO8601Time, value)
         correct_confirmation_date_if_needed
       end
 
       private
-
-      # Parses an ISO8601 time value, handling both String and Time inputs.
-      # This ensures type consistency before comparisons.
-      # @param value [Time, String, nil] the value to parse
-      # @return [Time, nil] parsed Time object or nil
-      # @raise [ArgumentError] if value is not a valid ISO8601 string
-      def parse_iso8601_time(value)
-        return nil if value.nil?
-
-        value = value.iso8601 if value.is_a?(Time)
-        Time.iso8601(value)
-      end
 
       # Corrects confirmation_date if it's after source_date.
       # Both values are guaranteed to be Time objects (or nil) at this point.

--- a/spec/lib/va_profile/models/email_spec.rb
+++ b/spec/lib/va_profile/models/email_spec.rb
@@ -182,22 +182,22 @@ RSpec.describe VAProfile::Models::Email do
     end
 
     context 'when confirmation_date is not a valid ISO8601 string' do
-      it 'raises an ArgumentError' do
+      it 'raises a TypeError' do
         email = build(:email, email_address: 'test@example.com')
 
         expect do
           email.confirmation_date = 'invalid-date'
-        end.to raise_error(ArgumentError)
+        end.to raise_error(TypeError, 'confirmation_date is not iso8601')
       end
     end
 
     context 'when source_date is not a valid ISO8601 string' do
-      it 'raises an ArgumentError' do
+      it 'raises a TypeError' do
         email = build(:email, email_address: 'test@example.com')
 
         expect do
           email.source_date = 'invalid-date'
-        end.to raise_error(ArgumentError)
+        end.to raise_error(TypeError, 'source_date is not iso8601')
       end
     end
   end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Force the MHV Email confirmation date provided by in the client request to be the same as the source date set in `vets-api` if the confirmation date is after the source date. This can happen if the client and server times are off which is very likely to happen. Why still pass confirmation date? It is right now an indication that it is needed, plus we do want to set it to the time provided if we have other use cases to set this time to something in the past.
- Team: MHV Horizon

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/125320

## Testing done
- [x] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

