### PR TITLE
Disable sign_in.auto_uplevel

### DIFF
--- a/config/identity_settings/settings.yml
+++ b/config/identity_settings/settings.yml
@@ -71,7 +71,7 @@ session_cookie:
 
 sign_in:
   arp_client_id: arp
-  auto_uplevel: true
+  auto_uplevel: false
   cookies_secure: false
   credential_attributes_digester:
     pepper: ~


### PR DESCRIPTION
## Summary

- Disable our `auto_uplevel` since it is handled by the CSPs now

## Testing 
- loa3 id.me user -> existing user
- loa1 id.me user -> existing user
- loa1 id.me user -> new user
- loa3 id.me user -> new user
- ial1 [login.gov](http://login.gov/) user -> existing user
- ial2 [login.gov](http://login.gov/) user -> existing user
- ial1 [login.gov](http://login.gov/) user -> new user
- ial2 [login.gov](http://login.gov/) user -> new user
- dslogon user -> existing user
- mhv user -> existing user

## What areas of the site does it impact?
Sign-in Service
