### PR TITLE
2111: add enrollment periods api keys

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1805,6 +1805,8 @@ veteran_enrollment_system:
     api_key: ~
   form1095b:
     api_key: <%= ENV['veteran_enrollment_system__form1095b__api_key'] %>
+  enrollment_periods:
+    api_key: <%= ENV['veteran_enrollment_system__enrollment_periods__api_key'] %>
   host: <%= ENV['veteran_enrollment_system__host'] %>
   open_timeout: 10
   port: <%= ENV['veteran_enrollment_system__port'] %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1803,10 +1803,10 @@ veteran_enrollment_system:
     api_key: <%= ENV['veteran_enrollment_system__associations__api_key'] %>
   ee_summary:
     api_key: ~
-  form1095b:
-    api_key: <%= ENV['veteran_enrollment_system__form1095b__api_key'] %>
   enrollment_periods:
     api_key: <%= ENV['veteran_enrollment_system__enrollment_periods__api_key'] %>
+  form1095b:
+    api_key: <%= ENV['veteran_enrollment_system__form1095b__api_key'] %>
   host: <%= ENV['veteran_enrollment_system__host'] %>
   open_timeout: 10
   port: <%= ENV['veteran_enrollment_system__port'] %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1826,6 +1826,8 @@ veteran_enrollment_system:
     api_key: ~
   form1095b:
     api_key: ~
+  enrollment_periods:
+    api_key: ~
   host: https://localhost
   open_timeout: 10
   port: 4430

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1824,9 +1824,9 @@ veteran_enrollment_system:
     api_key: ~
   ee_summary:
     api_key: ~
-  form1095b:
-    api_key: ~
   enrollment_periods:
+    api_key: ~
+  form1095b:
     api_key: ~
   host: https://localhost
   open_timeout: 10

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1823,9 +1823,9 @@ veteran_enrollment_system:
     api_key: ~
   ee_summary:
     api_key: ~
-  form1095b:
-    api_key: ~
   enrollment_periods:
+    api_key: ~
+  form1095b:
     api_key: ~
   host: https://localhost
   open_timeout: 10

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1825,6 +1825,8 @@ veteran_enrollment_system:
     api_key: ~
   form1095b:
     api_key: ~
+  enrollment_periods:
+    api_key: ~
   host: https://localhost
   open_timeout: 10
   port: 4430

--- a/lib/veteran_enrollment_system/enrollment_periods/configuration.rb
+++ b/lib/veteran_enrollment_system/enrollment_periods/configuration.rb
@@ -6,7 +6,7 @@ module VeteranEnrollmentSystem
   module EnrollmentPeriods
     class Configuration < VeteranEnrollmentSystem::BaseConfiguration
       def self.api_key_path
-        :form1095b
+        :enrollment_periods
       end
 
       def service_name

--- a/spec/lib/veteran_enrollment_system/enrollment_periods/configuration_spec.rb
+++ b/spec/lib/veteran_enrollment_system/enrollment_periods/configuration_spec.rb
@@ -8,7 +8,7 @@ describe 'VeteranEnrollmentSystem::EnrollmentPeriods::Configuration' do
 
   describe '.api_key_path' do
     it 'returns the api key path' do
-      expect(VeteranEnrollmentSystem::EnrollmentPeriods::Configuration.api_key_path).to eq(:form1095b)
+      expect(VeteranEnrollmentSystem::EnrollmentPeriods::Configuration.api_key_path).to eq(:enrollment_periods)
     end
   end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- Adds handling for new api keys that have been created on aws
- I am on the CVE team

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-iir/issues/2111

## Testing done

I will test on staging to ensure that the service continues working as normal.

## Screenshots


## What areas of the site does it impact?

It changes which api keys are used by the enrollment periods service.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
