### PR TITLE
[880] Force verified authentication for credentials that were previously authenticated at verified levels

### DIFF
--- a/app/services/sign_in/acr_translator.rb
+++ b/app/services/sign_in/acr_translator.rb
@@ -32,7 +32,7 @@ module SignIn
     end
 
     def translate_acr_comparison
-      type == Constants::Auth::IDME && acr == 'min' ? Constants::Auth::IDME_COMPARISON_MINIMUM : nil
+      type == Constants::Auth::IDME && acr == 'min' && !uplevel ? Constants::Auth::IDME_COMPARISON_MINIMUM : nil
     end
 
     def translate_idme_values

--- a/lib/sign_in/idme/service.rb
+++ b/lib/sign_in/idme/service.rb
@@ -191,7 +191,7 @@ module SignIn
         ).first
         log_parsed_credential(decoded_jwt) if config.log_credential
 
-        OpenStruct.new(decoded_jwt)
+        parse_decoded_jwt(decoded_jwt)
       rescue JWT::JWKError
         raise Errors::PublicJWKError, '[SignIn][Idme][Service] Public JWK is malformed'
       rescue JWT::VerificationError
@@ -200,6 +200,13 @@ module SignIn
         raise Errors::JWTExpiredError, '[SignIn][Idme][Service] JWT has expired'
       rescue JWT::DecodeError
         raise Errors::JWTDecodeError, '[SignIn][Idme][Service] JWT is malformed'
+      end
+
+      def parse_decoded_jwt(decoded_jwt)
+        jwt_struct = OpenStruct.new(decoded_jwt)
+        jwt_struct.level_of_assurance ||= jwt_struct.lname ? Constants::Auth::LOA_THREE : Constants::Auth::LOA_ONE
+        jwt_struct.credential_ial ||= jwt_struct.lname ? Constants::Auth::IAL_TWO : Constants::Auth::IAL_ONE
+        jwt_struct
       end
 
       def log_parsed_credential(decoded_jwt)

--- a/spec/services/sign_in/acr_translator_spec.rb
+++ b/spec/services/sign_in/acr_translator_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe SignIn::AcrTranslator do
 
       context 'and acr is min' do
         let(:acr) { 'min' }
-        let(:acr_comparison) { SignIn::Constants::Auth::IDME_COMPARISON_MINIMUM }
 
         context 'and uplevel is false' do
           let(:uplevel) { false }
+          let(:acr_comparison) { SignIn::Constants::Auth::IDME_COMPARISON_MINIMUM }
           let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::IDME_LOA1, acr_comparison: } }
 
           it 'returns expected translated acr value' do
@@ -48,7 +48,7 @@ RSpec.describe SignIn::AcrTranslator do
 
         context 'and uplevel is true' do
           let(:uplevel) { true }
-          let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::IDME_LOA3, acr_comparison: } }
+          let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::IDME_LOA3 } }
 
           it 'returns expected translated acr value' do
             expect(subject).to eq(expected_translated_acr)

--- a/spec/services/sign_in/credential_level_creator_spec.rb
+++ b/spec/services/sign_in/credential_level_creator_spec.rb
@@ -29,10 +29,8 @@ RSpec.describe SignIn::CredentialLevelCreator do
                        dslogon_assurance:,
                        sub: })
     end
-    let(:auto_uplevel) { false }
 
     before do
-      allow(IdentitySettings.sign_in).to receive(:auto_uplevel).and_return(auto_uplevel)
       allow(Rails.logger).to receive(:info)
     end
 
@@ -48,7 +46,6 @@ RSpec.describe SignIn::CredentialLevelCreator do
                                                           requested_acr:,
                                                           current_ial: expected_current_ial,
                                                           max_ial: expected_max_ial,
-                                                          auto_uplevel:,
                                                           credential_uuid: sub)
       end
     end
@@ -113,33 +110,7 @@ RSpec.describe SignIn::CredentialLevelCreator do
 
         context 'and logingov acr is not defined as IAL 2' do
           let(:logingov_acr) { 'some-acr' }
-
-          shared_examples 'an auto-uplevel capable credential' do
-            context 'and user has previously authenticated as a verified user' do
-              let!(:user_verification) { create(:logingov_user_verification, logingov_uuid: sub) }
-
-              context 'and sign_in auto_uplevel settings is false' do
-                let(:auto_uplevel) { false }
-                let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
-                let(:expected_auto_uplevel) { false }
-
-                it_behaves_like 'a created credential level'
-              end
-
-              context 'and sign_in auto_uplevel settings is true' do
-                let(:auto_uplevel) { true }
-
-                it_behaves_like 'a created credential level'
-              end
-            end
-
-            context 'and user has not previously authenticated as a verified user' do
-              let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
-              let(:expected_auto_uplevel) { false }
-
-              it_behaves_like 'a created credential level'
-            end
-          end
+          let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
 
           context 'and requested_acr is set to ial2' do
             let(:requested_acr) { SignIn::Constants::Auth::IAL2 }
@@ -150,38 +121,57 @@ RSpec.describe SignIn::CredentialLevelCreator do
 
           context 'and requested_acr is set to min' do
             let(:requested_acr) { SignIn::Constants::Auth::MIN }
-            let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
-            let(:expected_auto_uplevel) { true }
 
-            it_behaves_like 'an auto-uplevel capable credential'
+            it_behaves_like 'a created credential level'
           end
 
           context 'and requested_acr is set to ial1' do
             let(:requested_acr) { SignIn::Constants::Auth::IAL1 }
-            let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
 
-            it_behaves_like 'an auto-uplevel capable credential'
+            it_behaves_like 'a created credential level'
           end
         end
       end
 
       context 'and user info does not have verified_at trait' do
         let(:verified_at) { nil }
-        let(:expected_max_ial) { SignIn::Constants::Auth::IAL_ONE }
 
-        context 'and logingov acr is defined as IAL 2' do
-          let(:logingov_acr) { SignIn::Constants::Auth::LOGIN_GOV_IAL2 }
-          let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
-          let(:validation_error_message) { 'Validation failed: Max ial cannot be less than Current ial' }
+        context 'and user has previously verified' do
+          let!(:user_verification) { create(:logingov_user_verification, logingov_uuid: sub) }
+          let(:expected_max_ial) { SignIn::Constants::Auth::IAL_TWO }
 
-          it_behaves_like 'invalid credential level error'
+          context 'and logingov acr is defined as IAL 2' do
+            let(:logingov_acr) { SignIn::Constants::Auth::LOGIN_GOV_IAL2 }
+            let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
+
+            it_behaves_like 'a created credential level'
+          end
+
+          context 'and logingov acr is not defined as IAL 2' do
+            let(:logingov_acr) { 'some-id-token-payload' }
+            let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
+
+            it_behaves_like 'a created credential level'
+          end
         end
 
-        context 'and logingov acr is not defined as IAL 2' do
-          let(:logingov_acr) { 'some-id-token-payload' }
-          let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
+        context 'and user has not previously verified' do
+          let(:expected_max_ial) { SignIn::Constants::Auth::IAL_ONE }
 
-          it_behaves_like 'a created credential level'
+          context 'and logingov acr is defined as IAL 2' do
+            let(:logingov_acr) { SignIn::Constants::Auth::LOGIN_GOV_IAL2 }
+            let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
+            let(:validation_error_message) { 'Validation failed: Max ial cannot be less than Current ial' }
+
+            it_behaves_like 'invalid credential level error'
+          end
+
+          context 'and logingov acr is not defined as IAL 2' do
+            let(:logingov_acr) { 'some-id-token-payload' }
+            let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
+
+            it_behaves_like 'a created credential level'
+          end
         end
       end
     end
@@ -346,35 +336,16 @@ RSpec.describe SignIn::CredentialLevelCreator do
           it_behaves_like 'a created credential level'
         end
 
-        context 'and user info credential ial does not equal idme classic loa3' do
+        context 'and user info credential ial equals ial2' do
+          let(:credential_ial) { SignIn::Constants::Auth::IAL_TWO }
+          let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
+
+          it_behaves_like 'a created credential level'
+        end
+
+        context 'and user info credential ial is an arbitrary value' do
           let(:credential_ial) { 'some-credential-ial' }
-
-          shared_examples 'an auto-uplevel capable credential' do
-            context 'and user has previously authenticated as a verified user' do
-              let!(:user_verification) { create(:idme_user_verification, idme_uuid: sub) }
-
-              context 'and sign_in auto_uplevel settings is false' do
-                let(:auto_uplevel) { false }
-                let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
-                let(:expected_auto_uplevel) { false }
-
-                it_behaves_like 'a created credential level'
-              end
-
-              context 'and sign_in auto_uplevel settings is true' do
-                let(:auto_uplevel) { true }
-
-                it_behaves_like 'a created credential level'
-              end
-            end
-
-            context 'and user has not previously authenticated as a verified user' do
-              let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
-              let(:expected_auto_uplevel) { false }
-
-              it_behaves_like 'a created credential level'
-            end
-          end
+          let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
 
           context 'and requested_acr is set to loa3' do
             let(:requested_acr) { SignIn::Constants::Auth::LOA3 }
@@ -385,38 +356,111 @@ RSpec.describe SignIn::CredentialLevelCreator do
 
           context 'and requested_acr is set to min' do
             let(:requested_acr) { SignIn::Constants::Auth::MIN }
-            let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
-            let(:expected_auto_uplevel) { true }
+            let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
 
-            it_behaves_like 'an auto-uplevel capable credential'
+            it_behaves_like 'a created credential level'
           end
 
           context 'and requested_acr is set to ial1' do
             let(:requested_acr) { SignIn::Constants::Auth::LOA1 }
             let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
 
-            it_behaves_like 'an auto-uplevel capable credential'
+            it_behaves_like 'a created credential level'
           end
         end
       end
 
       context 'and user info level of assurance does not equal idme classic loa3' do
         let(:level_of_assurance) { 'some-level-of-assurance' }
-        let(:expected_max_ial) { SignIn::Constants::Auth::IAL_ONE }
         let(:validation_error_message) { 'Validation failed: Max ial cannot be less than Current ial' }
 
-        context 'and user info credential ial equals idme classic loa3' do
-          let(:credential_ial) { SignIn::Constants::Auth::IDME_CLASSIC_LOA3 }
-          let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
+        context 'and user has previously verified' do
+          let(:expected_max_ial) { SignIn::Constants::Auth::IAL_TWO }
+          let!(:user_verification) { create(:idme_user_verification, idme_uuid: sub) }
 
-          it_behaves_like 'invalid credential level error'
+          context 'and user info credential ial equals idme classic loa3' do
+            let(:credential_ial) { SignIn::Constants::Auth::IDME_CLASSIC_LOA3 }
+            let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
+
+            it_behaves_like 'a created credential level'
+          end
+
+          context 'and user info credential ial equals ial2' do
+            let(:credential_ial) { SignIn::Constants::Auth::IAL_TWO }
+            let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
+
+            it_behaves_like 'a created credential level'
+          end
+
+          context 'and user info credential ial is an arbitrary value' do
+            let(:credential_ial) { 'some-credential-ial' }
+            let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
+
+            context 'and requested_acr is set to loa3' do
+              let(:requested_acr) { SignIn::Constants::Auth::LOA3 }
+              let(:expected_error_code) { SignIn::Constants::ErrorCode::GENERIC_EXTERNAL_ISSUE }
+
+              it_behaves_like 'unverified credential blocked error'
+            end
+
+            context 'and requested_acr is set to min' do
+              let(:requested_acr) { SignIn::Constants::Auth::MIN }
+              let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
+
+              it_behaves_like 'a created credential level'
+            end
+
+            context 'and requested_acr is set to ial1' do
+              let(:requested_acr) { SignIn::Constants::Auth::LOA1 }
+              let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
+
+              it_behaves_like 'a created credential level'
+            end
+          end
         end
 
-        context 'and user info credential ial does not equal idme classic loa3' do
-          let(:credential_ial) { 'some-credential-ial' }
-          let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
+        context 'and user has not previously verified' do
+          let(:expected_max_ial) { SignIn::Constants::Auth::IAL_ONE }
 
-          it_behaves_like 'a created credential level'
+          context 'and user info credential ial equals idme classic loa3' do
+            let(:credential_ial) { SignIn::Constants::Auth::IDME_CLASSIC_LOA3 }
+            let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
+
+            it_behaves_like 'invalid credential level error'
+          end
+
+          context 'and user info credential ial equals ial2' do
+            let(:credential_ial) { SignIn::Constants::Auth::IAL_TWO }
+            let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
+
+            it_behaves_like 'invalid credential level error'
+          end
+
+          context 'and user info credential ial is an arbitrary value' do
+            let(:credential_ial) { 'some-credential-ial' }
+            let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
+
+            context 'and requested_acr is set to loa3' do
+              let(:requested_acr) { SignIn::Constants::Auth::LOA3 }
+              let(:expected_error_code) { SignIn::Constants::ErrorCode::GENERIC_EXTERNAL_ISSUE }
+
+              it_behaves_like 'unverified credential blocked error'
+            end
+
+            context 'and requested_acr is set to min' do
+              let(:requested_acr) { SignIn::Constants::Auth::MIN }
+              let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
+
+              it_behaves_like 'a created credential level'
+            end
+
+            context 'and requested_acr is set to ial1' do
+              let(:requested_acr) { SignIn::Constants::Auth::LOA1 }
+              let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
+
+              it_behaves_like 'a created credential level'
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
## Summary

- This PR forces accounts authenticating on va.gov to re-verify if they were previously authenticated at loa3/ial2 levels and are not authenticating at ial1/loa1

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/880

## Testing done

- [ ] Created id.me loa1 account
- [ ] Added an ICN to their UserAccount, and `verified_at` to UserVerification
- [ ] Authenticated with Sign in Service on va.gov, and confirmed user was forced to verify

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [ ] Create ID.me and Login.gov loa1 accounts
- [ ] Fake 'previous verifications' by adding ICN to UserAccount, and `verified_at` to UserVerification
- [ ] Authenticate with both accounts, confirm that users are forced to verify
- [ ] Confirm that loa1 accounts that haven't previously verified are not affected
- [ ] Confirm that loa3/ial2 accounts are not affected