### PR TITLE
Accept credential_ial 2 for idme verified

### DIFF
--- a/app/services/sign_in/credential_level_creator.rb
+++ b/app/services/sign_in/credential_level_creator.rb
@@ -80,21 +80,44 @@ module SignIn
     end
 
     def current_ial
-      case type
-      when Constants::Auth::LOGINGOV
-        verified_ial_level(logingov_acr == Constants::Auth::LOGIN_GOV_IAL2 || previously_verified?(:logingov_uuid))
-      when Constants::Auth::MHV
-        verified_ial_level(requested_verified_account? && Constants::Auth::MHV_PREMIUM_VERIFIED.include?(mhv_assurance))
-      when Constants::Auth::DSLOGON
-        verified_ial_level(requested_verified_account? &&
-                           Constants::Auth::DSLOGON_PREMIUM_VERIFIED.include?(dslogon_assurance))
-      else
-        verified_ial_level(credential_ial == Constants::Auth::IDME_CLASSIC_LOA3 || previously_verified?(:idme_uuid))
-      end
+      verified_ial_level(verified_for_current_type?)
     end
 
     def verified_ial_level(verified)
       verified ? Constants::Auth::IAL_TWO : Constants::Auth::IAL_ONE
+    end
+
+    def verified_for_current_type?
+      case type
+      when Constants::Auth::LOGINGOV
+        logingov_verified?
+      when Constants::Auth::MHV
+        mhv_verified?
+      when Constants::Auth::DSLOGON
+        dslogon_verified?
+      else
+        idme_verified?
+      end
+    end
+
+    def logingov_verified?
+      logingov_acr == Constants::Auth::LOGIN_GOV_IAL2 ||
+        previously_verified?(:logingov_uuid)
+    end
+
+    def mhv_verified?
+      requested_verified_account? &&
+        Constants::Auth::MHV_PREMIUM_VERIFIED.include?(mhv_assurance)
+    end
+
+    def dslogon_verified?
+      requested_verified_account? &&
+        Constants::Auth::DSLOGON_PREMIUM_VERIFIED.include?(dslogon_assurance)
+    end
+
+    def idme_verified?
+      [Constants::Auth::IDME_CLASSIC_LOA3, Constants::Auth::IAL_TWO].include?(credential_ial) ||
+        previously_verified?(:idme_uuid)
     end
 
     def requested_verified_account?

--- a/spec/services/sign_in/credential_level_creator_spec.rb
+++ b/spec/services/sign_in/credential_level_creator_spec.rb
@@ -346,7 +346,14 @@ RSpec.describe SignIn::CredentialLevelCreator do
           it_behaves_like 'a created credential level'
         end
 
-        context 'and user info credential ial does not equal idme classic loa3' do
+        context 'and user info credential ial equals ial2' do
+          let(:credential_ial) { SignIn::Constants::Auth::IAL_TWO }
+          let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
+
+          it_behaves_like 'a created credential level'
+        end
+
+        context 'and user info credential ial does not equal idme classic loa3 nor ial2' do
           let(:credential_ial) { 'some-credential-ial' }
 
           shared_examples 'an auto-uplevel capable credential' do


### PR DESCRIPTION
## Summary

- Accept `credential_ial` `2` for idme verified along side `classic_loa3`. ID.me will return `credential_ial` of `2` when authing with acr min 
```
scope=>"http://idmanagement.gov/ns/assurance/loa/1/vets
acr_values=>"comparison:minimum http://idmanagement.gov/ns/assurance/loa/1/vets.
```

## Related issue(s)
-https://github.com/department-of-veterans-affairs/identity-documentation/issues/883

## Testing 
- Locally test by updating som mock users to have the id.me credential return `2` for `credential_ial`. e.g. https://github.com/department-of-veterans-affairs/vets-api-mockdata/blob/master/credentials/idme/vetsgovuser0.json#L23
```ruby
{
  "iss": "https://api.idmelabs.com/oidc",
  ...
  "credential_aal": 2,
  "credential_ial": 2,
  "uuid": "some-uuid"
}
```
- Will need to create staging test users with ial2 status to test on staging


## What areas of the site does it impact?
Sign-in Service authentication

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
