### PR TITLE
tell danger to ignore openapi spec docs

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -55,7 +55,7 @@ module VSPDanger
       *.csv *.json *.tsv *.txt *.md Gemfile.lock app/swagger modules/mobile/docs spec/fixtures/ spec/support/vcr_cassettes/
       modules/mobile/spec/support/vcr_cassettes/ db/seeds modules/vaos/app/docs modules/meb_api/app/docs
       modules/appeals_api/app/swagger/ *.bru *.pdf modules/*/spec/fixtures/* modules/*/spec/factories/*
-      modules/*/spec/**/*.rb spec/**/*.rb modules/*/docs/*.yaml modules/*/docs/*.yml modules/*/app/docs/**/*.yaml
+      modules/*/spec/**/*.rb spec/**/*.rb modules/*/docs/**/*.yaml modules/*/docs/**/*.yml modules/*/app/docs/**/*.yaml
       modules/*/app/docs/**/*.yml
     ].freeze
     PR_SIZE = { recommended: 200, maximum: 500 }.freeze


### PR DESCRIPTION
This pull request updates the file exclusion patterns in the `Dangerfile` to ensure documentation files in YAML format are ignored during PR size checks. This helps prevent documentation changes from affecting automated PR size warnings.

**Dangerfile exclusion pattern updates:**

* Added YAML and YML documentation files (`*.yaml`, `*.yml`) under `modules/*/docs/` and `modules/*/app/docs/` to the list of files ignored by PR size checks.Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.
