### PR TITLE
Update sign_in/application_controller_spec and ssoe_user_spec to chec…

### DIFF
--- a/spec/controllers/sign_in/application_controller_spec.rb
+++ b/spec/controllers/sign_in/application_controller_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
       get 'access_token_auth' => 'sign_in/application#access_token_auth'
       get 'test_logging' => 'sign_in/application#test_logging'
     end
+
+    allow(Rails.logger).to receive(:warn)
   end
 
   describe '#authentication' do
@@ -94,18 +96,20 @@ RSpec.describe SignIn::ApplicationController, type: :controller do
     end
 
     shared_context 'user fingerprint validation' do
+      let(:expected_error) { '[SignIn][Authentication] fingerprint mismatch' }
+
       context 'user.fingerprint matches request IP' do
-        it 'passes fingerprint validation and does not create a log' do
-          expect_any_instance_of(SentryLogging).not_to receive(:log_message_to_sentry).with(:warn)
+        it 'passes fingerprint validation and does not warn' do
           expect(subject.request.remote_ip).to eq(user.fingerprint)
+          expect(Rails.logger).not_to have_received(:warn).with(expected_error, anything)
         end
       end
 
       context 'user.fingerprint does not match request IP' do
         let!(:user) do
-          create(:user, :loa3, uuid: access_token_object.user_uuid, session_handle: access_token_object.session_handle)
+          create(:user, :loa3, uuid: access_token_object.user_uuid,
+                               session_handle: access_token_object.session_handle)
         end
-        let(:expected_error) { '[SignIn][Authentication] fingerprint mismatch' }
         let(:log_context) { { request_ip: request.remote_ip, fingerprint: user.fingerprint } }
 
         it 'fails fingerprint validation and creates a log' do

--- a/spec/lib/saml/ssoe_user_spec.rb
+++ b/spec/lib/saml/ssoe_user_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe SAML::User do
           application: client_id
         }
       )
+
+      allow(Rails.logger).to receive(:warn)
     end
 
     context 'mapped attributes' do
@@ -714,13 +716,11 @@ RSpec.describe SAML::User do
       context 'with one id string' do
         let(:sec_id) { '1234567890' }
 
-        it 'does not log a warning to sentry' do
-          expect_any_instance_of(SentryLogging).not_to receive(:log_message_to_sentry).with(
-            'User attributes contains multiple sec_id values',
-            'warn',
-            { sec_id: }
-          )
+        it 'does not log a warning' do
           subject.validate!
+          expect(Rails.logger).not_to have_received(:warn).with(
+            '[SAML][UserAttributes][SSOe] User attributes contains multiple sec_id values', anything
+          )
         end
       end
 


### PR DESCRIPTION
## Summary

-  Update `sign_in/application_controller_spec` and `ssoe_user_spec` to check Rails.logger
- Code changes were made in other PRs, these specs were missed when updating 


## What areas of the site does it impact?
Sign-In Service specs, SSOe specs

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
