### PR TITLE
[882] updates SiS UserLoader to use current_loa for user current & max loa

### DIFF
--- a/app/services/sign_in/user_loader.rb
+++ b/app/services/sign_in/user_loader.rb
@@ -66,7 +66,7 @@ module SignIn
 
     def loa
       current_loa = user_is_verified? ? Constants::Auth::LOA_THREE : Constants::Auth::LOA_ONE
-      { current: current_loa, highest: Constants::Auth::LOA_THREE }
+      { current: current_loa, highest: current_loa }
     end
 
     def sign_in

--- a/spec/services/sign_in/user_loader_spec.rb
+++ b/spec/services/sign_in/user_loader_spec.rb
@@ -64,6 +64,17 @@ RSpec.describe SignIn::UserLoader do
           stub_mpi(build(:mpi_profile, edipi:, icn: user_icn, deceased_date:, id_theft_flag:, vha_facility_ids:))
         end
 
+        context 'and user is not verified' do
+          let(:user_icn) { nil }
+          let(:user_account) { create(:user_account, icn: user_icn) }
+          let(:user_verification) { create(:idme_user_verification, user_account:) }
+          let(:expected_loa) { { current: SignIn::Constants::Auth::LOA_ONE, highest: SignIn::Constants::Auth::LOA_ONE } }
+
+          it 'reloads user object with an loa of one' do
+            expect(subject.loa).to eq(expected_loa)
+          end
+        end
+
         context 'and user is authenticated with dslogon' do
           let(:user_verification) { create(:dslogon_user_verification, user_account:) }
 


### PR DESCRIPTION
## Summary

- Updates SiS `UserLoader` to always use the user's current LOA as determined by their `UserAccount` verification status.
- Previous behavior was to always set `max` loa to 3.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/882

## Testing done

- [x] *New code is covered by unit tests*
- Log in via SiS with a new or unverified user on the feature branch, then check your `max` loa - it should be `1`.
<img width="464" height="274" alt="image" src="https://github.com/user-attachments/assets/96e9994a-f87a-469c-a542-f27973c48e4d" />

- Perform an SiS authentication on `master` branch with the same user, your `max` loa should be `3`.
<img width="464" height="274" alt="image" src="https://github.com/user-attachments/assets/93fa314b-e206-42c7-81ae-b5eaaf438950" />


