### PR TITLE
Update CredentialAttributeDigester attrs

### DIFF
--- a/lib/sign_in/credential_attributes_digester.rb
+++ b/lib/sign_in/credential_attributes_digester.rb
@@ -13,11 +13,8 @@ module SignIn
     attribute :ssn, :string
     attribute :birth_date, :string
     attribute :email, :string
-    attribute :address
 
-    validates :credential_uuid, :last_name, :birth_date, presence: true
-
-    validate :address_is_a_hash?, if: -> { address.present? }
+    validates :credential_uuid, :last_name, :birth_date, :email, presence: true
     validate :pepper_present?
 
     def perform
@@ -25,8 +22,8 @@ module SignIn
 
       digest_credential_attributes
     rescue => e
-      Rails.logger.error('[SignIn][CredentialAttributesDigester] Failed to digest user attributes',
-                         message: e.message)
+      Rails.logger.info('[SignIn][CredentialAttributesDigester] Failed to digest user attributes',
+                        message: e.message)
       nil
     end
 
@@ -38,12 +35,6 @@ module SignIn
 
     def pepper
       @pepper ||= IdentitySettings.sign_in.credential_attributes_digester.pepper
-    end
-
-    def address_is_a_hash?
-      return if address.is_a?(Hash)
-
-      errors.add(:address, 'must be a Hash')
     end
 
     def pepper_present?

--- a/lib/sign_in/idme/service.rb
+++ b/lib/sign_in/idme/service.rb
@@ -243,8 +243,7 @@ module SignIn
                                                  last_name: attributes[:last_name],
                                                  ssn: attributes[:ssn],
                                                  birth_date: attributes[:birth_date],
-                                                 email: attributes[:csp_email],
-                                                 address: attributes[:address]).perform
+                                                 email: attributes[:csp_email]).perform
       end
     end
   end

--- a/lib/sign_in/logingov/service.rb
+++ b/lib/sign_in/logingov/service.rb
@@ -230,8 +230,7 @@ module SignIn
                                                  last_name: attributes[:last_name],
                                                  ssn: attributes[:ssn],
                                                  birth_date: attributes[:birth_date],
-                                                 email: attributes[:csp_email],
-                                                 address: attributes[:address]).perform
+                                                 email: attributes[:csp_email]).perform
       end
     end
   end

--- a/spec/lib/sign_in/credential_attributes_digester_spec.rb
+++ b/spec/lib/sign_in/credential_attributes_digester_spec.rb
@@ -5,7 +5,7 @@ require 'sign_in/credential_attributes_digester'
 
 RSpec.describe SignIn::CredentialAttributesDigester do
   subject(:digester) do
-    described_class.new(credential_uuid:, first_name:, last_name:, ssn:, birth_date:, email:, address:)
+    described_class.new(credential_uuid:, first_name:, last_name:, ssn:, birth_date:, email:)
   end
 
   let(:credential_uuid) { '5bfd88a0-e61d-4427-80e1-211b2b61ad6f' }
@@ -14,15 +14,6 @@ RSpec.describe SignIn::CredentialAttributesDigester do
   let(:ssn) { '796126859' }
   let(:birth_date) { '1932-02-05' }
   let(:email) { 'test@email.com' }
-  let(:address) do
-    {
-      street: 'Sesame Street',
-      postal_code: '60131',
-      state: 'IL',
-      city: 'Franklin Park',
-      country: 'USA'
-    }
-  end
 
   let(:pepper) { '5740e000be940493231f85324c413bd2' }
 
@@ -53,8 +44,8 @@ RSpec.describe SignIn::CredentialAttributesDigester do
       it { is_expected.not_to be_valid }
     end
 
-    context 'when address is not a hash' do
-      let(:address) { 'Not a hash' }
+    context 'when email is missing' do
+      let(:email) { nil }
 
       it { is_expected.not_to be_valid }
     end
@@ -68,7 +59,7 @@ RSpec.describe SignIn::CredentialAttributesDigester do
 
   describe '#perform' do
     context 'with valid attributes' do
-      let(:expected_digest) { 'e074ee2758fa5c27ee3a783aa7d2eabb9e16299aea63e79f485e1b896629e1e7' }
+      let(:expected_digest) { '626deaddbf14a3697aabcad66770ca0fd24638f7bca5d3380694c3e6c3f41e5b' }
 
       it 'returns the expected digest' do
         expect(digester.perform).to eq(expected_digest)
@@ -88,13 +79,13 @@ RSpec.describe SignIn::CredentialAttributesDigester do
       let(:expected_log_payload) { { message: 'error' } }
 
       before do
-        allow(Rails.logger).to receive(:error)
+        allow(Rails.logger).to receive(:info)
         allow(OpenSSL::HMAC).to receive(:hexdigest).and_raise(StandardError, 'error')
       end
 
       it 'logs and returns nil' do
         expect(digester.perform).to be_nil
-        expect(Rails.logger).to have_received(:error).with(expected_log_message, expected_log_payload)
+        expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
       end
     end
   end


### PR DESCRIPTION
## Summary

- Update CredentialAttributeDigester attrs
- remove `address`, require `email`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/893

## Testing 
- Authenticate with SiS and check that the credential_attributes_digest on UserVerification is updated the first time you login but on subsequent logins it stays the same.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Sign-in Service

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected


