### PR TITLE
BMT3/121452 - add push api key

### DIFF
--- a/app/sidekiq/event_bus_gateway/letter_ready_notification_job.rb
+++ b/app/sidekiq/event_bus_gateway/letter_ready_notification_job.rb
@@ -142,7 +142,7 @@ module EventBusGateway
       ]
       StatsD.increment("#{STATSD_METRIC_PREFIX}.skipped", tags:)
     end
-
+    
     def log_completion(email_template_id, push_template_id, errors)
       successful_notifications = []
       successful_notifications << 'email' if email_template_id.present? && errors.none? { |e| e[:type] == 'email' }

--- a/app/sidekiq/event_bus_gateway/letter_ready_push_job.rb
+++ b/app/sidekiq/event_bus_gateway/letter_ready_push_job.rb
@@ -68,7 +68,8 @@ module EventBusGateway
     end
 
     def notify_client
-      @notify_client ||= VaNotify::Service.new(Constants::NOTIFY_SETTINGS.api_key)
+      # Push notifications require a separate API key from email and sms
+      @notify_client ||= VaNotify::Service.new(Constants::NOTIFY_SETTINGS.push_api_key)
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1515,6 +1515,7 @@ vanotify:
         form526_submission_failure_notification_template_id: <%= ENV['vanotify__services__benefits_disability__template_id__form526_submission_failure_notification_template_id'] %>
     benefits_management_tools:
       api_key: <%= ENV['vanotify__services__benefits_management_tools__api_key'] %>
+      push_api_key: <%= ENV['vanotify__services__benefits_management_tools__push_api_key'] %>
       template_id:
         decision_letter_ready_email: <%= ENV['vanotify__services__benefits_management_tools__template_id__decision_letter_ready_email'] %>
         evidence_submission_failure_email: <%= ENV['vanotify__services__benefits_management_tools__template_id__evidence_submission_failure_email'] %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1534,6 +1534,7 @@ vanotify:
         form526_submission_failure_notification_template_id: form526_submission_failure_notification_template_id
     benefits_management_tools:
       api_key: fake_secret
+      push_api_key: fake_secret
       template_id:
         decision_letter_ready_email: fake_template_id
         evidence_submission_failure_email: fake_template_id

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1533,6 +1533,7 @@ vanotify:
         form526_submission_failure_notification_template_id: form526_submission_failure_notification_template_id
     benefits_management_tools:
       api_key: fake_secret
+      push_api_key: fake_secret
       template_id:
         decision_letter_ready_email: fake_template_id
         evidence_submission_failure_email: fake_template_id

--- a/modules/va_notify/lib/va_notify/service.rb
+++ b/modules/va_notify/lib/va_notify/service.rb
@@ -21,6 +21,9 @@ module VaNotify
 
     attr_reader :notify_client, :callback_options, :template_id
 
+    # API keys for email/SMS often differ from keys for push notifications.
+    # Initialize separate service instances with the appropriate API key for each channel type.
+    # Each instance only supports the channels its API key is authorized for.
     def initialize(api_key, callback_options = {})
       overwrite_client_networking
       @api_key = api_key

--- a/modules/va_notify/spec/lib/service_spec.rb
+++ b/modules/va_notify/spec/lib/service_spec.rb
@@ -149,6 +149,31 @@ describe VaNotify::Service do
         expect(service_object.callback_options).to eq(callback_options)
       end
     end
+
+    it 'supports separate service instances for email and push channels' do
+      email_api_key = 'email-aaaa-bbbb-cccc-dddd-eeeeeeeeeeee-ffffffff-gggg-hhhh-iiii-jjjjjjjjjjjj'
+      push_api_key = 'push-1111-2222-3333-4444-555555555555-66666666-7777-8888-9999-000000000000'
+      test_base_url = 'https://fakishapi.com'
+
+      with_settings(Settings.vanotify, client_url: test_base_url) do
+        # Email service uses email API key
+        email_notification_client = instance_double(Notifications::Client)
+        allow(Notifications::Client).to receive(:new).with(email_api_key, test_base_url)
+                                                     .and_return(email_notification_client)
+        email_service = VaNotify::Service.new(email_api_key)
+        expect(email_service.notify_client).to eq(email_notification_client)
+
+        # Push service uses push API key
+        push_notification_client = instance_double(Notifications::Client)
+        push_va_notify_client = instance_double(VaNotify::Client)
+        allow(Notifications::Client).to receive(:new).with(push_api_key, test_base_url)
+                                                     .and_return(push_notification_client)
+        allow(VaNotify::Client).to receive(:new).with(push_api_key, {})
+                                                .and_return(push_va_notify_client)
+        push_service = VaNotify::Service.new(push_api_key)
+        expect(push_service.push_client).to eq(push_va_notify_client)
+      end
+    end
   end
 
   describe '#send_email', test_service: false do

--- a/spec/sidekiq/event_bus_gateway/letter_ready_push_job_spec.rb
+++ b/spec/sidekiq/event_bus_gateway/letter_ready_push_job_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe EventBusGateway::LetterReadyPushJob, type: :job do
   # Shared setup for most test scenarios
   before do
     allow(VaNotify::Service).to receive(:new)
-      .with(EventBusGateway::Constants::NOTIFY_SETTINGS.api_key)
+      .with(EventBusGateway::Constants::NOTIFY_SETTINGS.push_api_key)
       .and_return(va_notify_service)
     allow_any_instance_of(MPI::Service).to receive(:find_profile_by_attributes)
       .and_return(mpi_profile_response)
@@ -84,7 +84,7 @@ RSpec.describe EventBusGateway::LetterReadyPushJob, type: :job do
 
     it 'configures VaNotify::Service with correct API key' do
       expect(VaNotify::Service).to receive(:new)
-        .with(EventBusGateway::Constants::NOTIFY_SETTINGS.api_key)
+        .with(EventBusGateway::Constants::NOTIFY_SETTINGS.push_api_key)
         .and_return(va_notify_service)
       subject.new.perform(participant_id, template_id)
     end
@@ -187,7 +187,7 @@ RSpec.describe EventBusGateway::LetterReadyPushJob, type: :job do
     context 'when VA Notify service initialization fails' do
       before do
         allow(VaNotify::Service).to receive(:new)
-          .with(EventBusGateway::Constants::NOTIFY_SETTINGS.api_key)
+          .with(EventBusGateway::Constants::NOTIFY_SETTINGS.push_api_key)
           .and_raise(StandardError, 'Service initialization failed')
       end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- We were informed by VANotify that our existing BMT api key will not have access to send push notifications.  This code adds a second BMT push api key specifically for push notifications
- BMT3, working with VaNotify team

## Related issue(s)

- [Issue 121452](https://github.com/department-of-veterans-affairs/va.gov-team/issues/121452)
- Epic: [In App Push Notification Enablement](https://github.com/department-of-veterans-affairs/va.gov-team/issues/121421)


## Testing done

- [x] *New code is covered by unit tests*
- Prior code used the same api key for both email and push notifications
- Testing involved running specs as well as testing locally that the SendNotification job sucessfully worked, as well as the sendEmail and SendPush jobs
## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Affects the ability to send push notifications to veterans

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
