### PR TITLE
Add '10-10d-extended' to middleware list

### DIFF
--- a/lib/source_app_middleware.rb
+++ b/lib/source_app_middleware.rb
@@ -26,7 +26,7 @@ class SourceAppMiddleware
     '0994-edu-benefits',
     '0996-higher-level-review',
     '10-10D',
-    '10-10d-extended'
+    '10-10d-extended',
     '1010cg-application-caregiver-assistance',
     '10182-board-appeal',
     '10203-edu-benefits',


### PR DESCRIPTION
Fixing vets-api source monitor

DD Alert [here](https://vagov.ddog-gov.com/monitors/200229?event_id=AwAAAZqd163ImttAhgAAABhBWnFkMlJOb0FBQjBVQXRzdHRlaGtGTmcAAAAkMDE5YTlkZGUtNjBhMC00ZjNlLThkOGMtM2FkODcxOTlhNmFkAAAJUA&link_source=monitor_notif&from_ts=1763583849000&to_ts=1763585049000&live=false)

DD Log [here](https://vagov.ddog-gov.com/logs?query=%22Unrecognized%20value%20for%20HTTP_SOURCE_APP_NAME%20request%20header%22%20service%3Avets-api%20env%3Aeks-prod&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZqd4LqliDDuvgAAABhBWnFkNE1fMUFBQU9jeXoxdFRrYndBQkoAAAAkMDE5YTlkZTYtMmQ3OC00NTc5LTgyMzYtNjgxMDNkMzJhZjJjABBpXQ&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1740494857565&to_ts=1740509257565&live=true)

<img width="1299" height="692" alt="Screenshot 2025-11-19 at 4 49 51 PM" src="https://github.com/user-attachments/assets/45937fc2-6292-4a93-9a83-bc82b5b10a65" />

