### PR TITLE
2113 screen reader encoding changes

### DIFF
--- a/app/controllers/v0/form1095_bs_controller.rb
+++ b/app/controllers/v0/form1095_bs_controller.rb
@@ -7,7 +7,8 @@ module V0
   class Form1095BsController < ApplicationController
     service_tag 'form-1095b'
     before_action { authorize :form1095, :access? }
-    before_action :validate_year, only: %i[download_pdf download_txt], if: -> { fetch_from_enrollment_system? }
+    # temporarily disabling to allow testing
+    # before_action :validate_year, only: %i[download_pdf download_txt], if: -> { fetch_from_enrollment_system? }
     before_action :validate_pdf_template, only: %i[download_pdf], if: -> { fetch_from_enrollment_system? }
     before_action :validate_txt_template, only: %i[download_txt], if: -> { fetch_from_enrollment_system? }
 

--- a/app/models/veteran_enrollment_system/form1095_b/form1095_b.rb
+++ b/app/models/veteran_enrollment_system/form1095_b/form1095_b.rb
@@ -206,7 +206,7 @@ module VeteranEnrollmentSystem
           'topmostSubform[0].Page1[0].Part1Contents[0].f1_06[0]': address,
           'topmostSubform[0].Page1[0].Part1Contents[0].f1_07[0]': city,
           'topmostSubform[0].Page1[0].Part1Contents[0].f1_08[0]': state || province,
-          'topmostSubform[0].Page1[0].Part1Contents[0].f1_09[0]': country_and_zip,
+          'topmostSubform[0].Page1[0].Part1Contents[0].f1_09[0]': country_and_zip
         }
       end
 
@@ -220,7 +220,7 @@ module VeteranEnrollmentSystem
           'topmostSubform[0].Page1[0].Part1Contents[0].f1_6[0]': address,
           'topmostSubform[0].Page1[0].Part1Contents[0].f1_7[0]': city,
           'topmostSubform[0].Page1[0].Part1Contents[0].f1_8[0]': state || province,
-          'topmostSubform[0].Page1[0].Part1Contents[0].f1_9[0]': country_and_zip,
+          'topmostSubform[0].Page1[0].Part1Contents[0].f1_9[0]': country_and_zip
         }
       end
     end

--- a/app/models/veteran_enrollment_system/form1095_b/form1095_b.rb
+++ b/app/models/veteran_enrollment_system/form1095_b/form1095_b.rb
@@ -126,7 +126,7 @@ module VeteranEnrollmentSystem
       end
 
       def birthdate_unless_ssn
-        last_4_ssn.present? ? '' : birth_date
+        last_4_ssn.present? ? '' : birth_date.strftime('%m/%d/%Y')
       end
 
       def txt_form_data

--- a/app/models/veteran_enrollment_system/form1095_b/form1095_b.rb
+++ b/app/models/veteran_enrollment_system/form1095_b/form1095_b.rb
@@ -40,7 +40,7 @@ module VeteranEnrollmentSystem
 
       def pdf_file
         template_path = self.class.pdf_template_path(tax_year)
-        unless File.exist?(template_path)
+        unless File.exist?(template_path) && respond_to?("pdf_#{tax_year}_attributes", true)
           Rails.logger.error "1095-B template for year #{tax_year} does not exist."
           raise Common::Exceptions::UnprocessableEntity.new(
             detail: "1095-B for tax year #{tax_year} not supported", source: self.class.name

--- a/app/models/veteran_enrollment_system/form1095_b/form1095_b.rb
+++ b/app/models/veteran_enrollment_system/form1095_b/form1095_b.rb
@@ -146,49 +146,11 @@ module VeteranEnrollmentSystem
         text_data
       end
 
-      # rubocop:disable Metrics/MethodLength
       def generate_pdf(pdftk, tmp_file, template_path)
         pdftk.fill_form(
           template_path,
           tmp_file,
-          {
-            'topmostSubform[0].Page1[0].Pg1Header[0].cb_1[1]': is_corrected && 2,
-            'topmostSubform[0].Page1[0].Part1Contents[0].Line1[0].f1_01[0]': first_name,
-            'topmostSubform[0].Page1[0].Part1Contents[0].Line1[0].f1_02[0]': middle_name,
-            'topmostSubform[0].Page1[0].Part1Contents[0].Line1[0].f1_03[0]': last_name,
-            'topmostSubform[0].Page1[0].Part1Contents[0].f1_04[0]': last_4_ssn || '',
-            'topmostSubform[0].Page1[0].Part1Contents[0].f1_05[0]': birthdate_unless_ssn,
-            'topmostSubform[0].Page1[0].Part1Contents[0].f1_06[0]': address,
-            'topmostSubform[0].Page1[0].Part1Contents[0].f1_07[0]': city,
-            'topmostSubform[0].Page1[0].Part1Contents[0].f1_08[0]': state || province,
-            'topmostSubform[0].Page1[0].Part1Contents[0].f1_09[0]': country_and_zip,
-            'topmostSubform[0].Page1[0].Part1Contents[0].f1_10[0]': 'C',
-            'topmostSubform[0].Page1[0].f1_18[0]': 'US Department of Veterans Affairs',
-            'topmostSubform[0].Page1[0].f1_19[0]': '74-1612229',
-            'topmostSubform[0].Page1[0].f1_20[0]': '877-222-8387',
-            'topmostSubform[0].Page1[0].f1_21[0]': 'P.O. BOX 149975',
-            'topmostSubform[0].Page1[0].f1_22[0]': 'Austin',
-            'topmostSubform[0].Page1[0].f1_23[0]': 'TX',
-            'topmostSubform[0].Page1[0].f1_24[0]': '78714-8957',
-            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_25[0]': first_name,
-            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_26[0]': middle_initial,
-            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_27[0]': last_name,
-            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_28[0]': last_4_ssn || '',
-            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_29[0]': birthdate_unless_ssn,
-            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_01[0]': coverage_months[0] && 1,
-            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_02[0]': coverage_months[1] && 1,
-            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_03[0]': coverage_months[2] && 1,
-            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_04[0]': coverage_months[3] && 1,
-            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_05[0]': coverage_months[4] && 1,
-            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_06[0]': coverage_months[5] && 1,
-            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_07[0]': coverage_months[6] && 1,
-            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_08[0]': coverage_months[7] && 1,
-            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_09[0]': coverage_months[8] && 1,
-            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_10[0]': coverage_months[9] && 1,
-            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_11[0]': coverage_months[10] && 1,
-            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_12[0]': coverage_months[11] && 1,
-            'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_13[0]': coverage_months[12] && 1
-          },
+          pdf_data,
           flatten: true
         )
         ret_pdf = tmp_file.read
@@ -198,7 +160,69 @@ module VeteranEnrollmentSystem
 
         ret_pdf
       end
+
+      # rubocop:disable Metrics/MethodLength
+      def pdf_data
+        year_specific_attributes = send("pdf_#{tax_year}_attributes")
+        {
+          'topmostSubform[0].Page1[0].Pg1Header[0].cb_1[1]': is_corrected && 2,
+          'topmostSubform[0].Page1[0].Part1Contents[0].f1_10[0]': 'C',
+          'topmostSubform[0].Page1[0].f1_18[0]': 'US Department of Veterans Affairs',
+          'topmostSubform[0].Page1[0].f1_19[0]': '74-1612229',
+          'topmostSubform[0].Page1[0].f1_20[0]': '877-222-8387',
+          'topmostSubform[0].Page1[0].f1_21[0]': 'P.O. BOX 149975',
+          'topmostSubform[0].Page1[0].f1_22[0]': 'Austin',
+          'topmostSubform[0].Page1[0].f1_23[0]': 'TX',
+          'topmostSubform[0].Page1[0].f1_24[0]': '78714-8957',
+          'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_25[0]': first_name,
+          'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_26[0]': middle_initial,
+          'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_27[0]': last_name,
+          'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_28[0]': last_4_ssn || '',
+          'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].f1_29[0]': birthdate_unless_ssn,
+          'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_01[0]': coverage_months[0] && 1,
+          'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_02[0]': coverage_months[1] && 1,
+          'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_03[0]': coverage_months[2] && 1,
+          'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_04[0]': coverage_months[3] && 1,
+          'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_05[0]': coverage_months[4] && 1,
+          'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_06[0]': coverage_months[5] && 1,
+          'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_07[0]': coverage_months[6] && 1,
+          'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_08[0]': coverage_months[7] && 1,
+          'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_09[0]': coverage_months[8] && 1,
+          'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_10[0]': coverage_months[9] && 1,
+          'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_11[0]': coverage_months[10] && 1,
+          'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_12[0]': coverage_months[11] && 1,
+          'topmostSubform[0].Page1[0].Table1_Part4[0].Row23[0].c1_13[0]': coverage_months[12] && 1
+        }.merge(year_specific_attributes)
+      end
       # rubocop:enable Metrics/MethodLength
+
+      def pdf_2024_attributes
+        {
+          'topmostSubform[0].Page1[0].Part1Contents[0].Line1[0].f1_01[0]': first_name,
+          'topmostSubform[0].Page1[0].Part1Contents[0].Line1[0].f1_02[0]': middle_name,
+          'topmostSubform[0].Page1[0].Part1Contents[0].Line1[0].f1_03[0]': last_name,
+          'topmostSubform[0].Page1[0].Part1Contents[0].f1_04[0]': last_4_ssn || '',
+          'topmostSubform[0].Page1[0].Part1Contents[0].f1_05[0]': birthdate_unless_ssn,
+          'topmostSubform[0].Page1[0].Part1Contents[0].f1_06[0]': address,
+          'topmostSubform[0].Page1[0].Part1Contents[0].f1_07[0]': city,
+          'topmostSubform[0].Page1[0].Part1Contents[0].f1_08[0]': state || province,
+          'topmostSubform[0].Page1[0].Part1Contents[0].f1_09[0]': country_and_zip,
+        }
+      end
+
+      def pdf_2025_attributes
+        {
+          'topmostSubform[0].Page1[0].Part1Contents[0].Line1[0].f1_1[0]': first_name,
+          'topmostSubform[0].Page1[0].Part1Contents[0].Line1[0].f1_2[0]': middle_name,
+          'topmostSubform[0].Page1[0].Part1Contents[0].Line1[0].f1_3[0]': last_name,
+          'topmostSubform[0].Page1[0].Part1Contents[0].f1_4[0]': last_4_ssn || '',
+          'topmostSubform[0].Page1[0].Part1Contents[0].f1_5[0]': birthdate_unless_ssn,
+          'topmostSubform[0].Page1[0].Part1Contents[0].f1_6[0]': address,
+          'topmostSubform[0].Page1[0].Part1Contents[0].f1_7[0]': city,
+          'topmostSubform[0].Page1[0].Part1Contents[0].f1_8[0]': state || province,
+          'topmostSubform[0].Page1[0].Part1Contents[0].f1_9[0]': country_and_zip,
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES
- The 2025 1095B PDF has some small modifications from the 2024 version. This updates handling of writing to the form to reflect those changes. It also removes a validation from the controller to enable testing (we will re-add it when testing is done).  
- I work for the CVE team.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-iir/issues/2113

## Testing done

- [x] *New code is covered by unit tests*
- Code is covered by unit tests as well as they can be, but there are limitations to testing PDF files.
- I have also tested this locally by creating PDF files and visually comparing them.
- I will also test this on staging. The feature is flagged and should not impact production.


## Screenshots


## What areas of the site does it impact?
Only 1095b download.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback