### PR TITLE
Update SSOe terms_of_use_url

### DIFF
--- a/lib/saml/post_url_service.rb
+++ b/lib/saml/post_url_service.rb
@@ -100,7 +100,7 @@ module SAML
       current_application = @tracker&.payload_attr(:application)
 
       base_url = if Settings.review_instance_slug.present?
-                   "http://#{Settings.review_instance_slug}.review.vetsgov-internal/terms-of-use"
+                   "http://#{Settings.review_instance_slug}.vfs.va.gov/terms-of-use"
                  else
                    "#{base_redirect_url}/terms-of-use"
                  end

--- a/spec/lib/saml/post_url_service_spec.rb
+++ b/spec/lib/saml/post_url_service_spec.rb
@@ -650,7 +650,7 @@ RSpec.describe SAML::PostURLService do
 
                 context 'and authentication is occuring on a review instance' do
                   let(:review_instance_slug) { 'some-review-instance-slug' }
-                  let(:base_url) { "http://#{review_instance_slug}.review.vetsgov-internal" }
+                  let(:base_url) { "http://#{review_instance_slug}.vfs.va.gov" }
 
                   before { allow(Settings).to receive(:review_instance_slug).and_return(review_instance_slug) }
 
@@ -686,7 +686,7 @@ RSpec.describe SAML::PostURLService do
 
                 context 'and authentication is occuring on a review instance' do
                   let(:review_instance_slug) { 'some-review-instance-slug' }
-                  let(:base_url) { "http://#{review_instance_slug}.review.vetsgov-internal" }
+                  let(:base_url) { "http://#{review_instance_slug}.vfs.va.gov" }
 
                   before { allow(Settings).to receive(:review_instance_slug).and_return(review_instance_slug) }
 
@@ -746,7 +746,7 @@ RSpec.describe SAML::PostURLService do
       Timecop.freeze('2018-04-09T17:52:03Z')
       RequestStore.store['request_id'] = request_id
       with_settings(IdentitySettings.saml_ssoe,
-                    relay: "http://#{slug_id}.review.vetsgov-internal/auth/login/callback") do
+                    relay: "http://#{slug_id}.vfs.va.gov/auth/login/callback") do
         with_settings(Settings, review_instance_slug: slug_id) do
           example.run
         end

--- a/spec/lib/saml/url_service_spec.rb
+++ b/spec/lib/saml/url_service_spec.rb
@@ -582,7 +582,7 @@ RSpec.describe SAML::URLService do
       Timecop.freeze('2018-04-09T17:52:03Z')
       RequestStore.store['request_id'] = '123'
       with_settings(IdentitySettings.saml_ssoe,
-                    relay: "http://#{slug_id}.review.vetsgov-internal/auth/login/callback") do
+                    relay: "http://#{slug_id}.vfs.va.gov/auth/login/callback") do
         with_settings(Settings, review_instance_slug: slug_id) do
           example.run
         end


### PR DESCRIPTION
## Summary

-  Platform changed review instances URLs from `review.vetsgov-internal` to `vfs.va.gov`.
- Update tou redirect url 

## Related issue(s)

-  https://github.com/department-of-veterans-affairs/identity-documentation/issues/901

## Testing 
- 

## What areas of the site does it impact?
Review instances authentication - SSOe

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

