### PR TITLE
DMT 109397 Remove dependents_claims_evidence_api_upload flipper

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -730,9 +730,6 @@ features:
     actor_type: user
     description: Manage dependent removal from view dependent page
     enable_in_development: true
-  dependents_claims_evidence_api_upload:
-    actor_type: user
-    description: Enable using the ClaimsEvidenceAPI module to upload 686/674 documents to VBMS
   dependents_bypass_schema_validation:
     actor_type: user
     description: Bypasses vets_json_schema validation for dependency claims

--- a/spec/services/bgs/dependent_service_spec.rb
+++ b/spec/services/bgs/dependent_service_spec.rb
@@ -299,8 +299,6 @@ RSpec.describe BGS::DependentService do
     let(:stats_key) { BGS::DependentService::STATS_KEY }
 
     before do
-      allow(Flipper).to receive(:enabled?).with(:dependents_claims_evidence_api_upload).and_return(true)
-
       allow(SavedClaim::DependencyClaim).to receive(:find).and_return(claim)
       allow(claim).to receive_messages(submittable_686?: true, submittable_674?: true, process_pdf: pdf_path)
 


### PR DESCRIPTION
## Summary

remove feature flipper `dependents_claims_evidence_api_upload`

## Related issue(s)

[Remove flipper to use the ClaimsEvidence in Dependents submission](https://github.com/department-of-veterans-affairs/va.gov-team/issues/109397)

## Testing done

- [x] *New code is covered by unit tests*
disabled flipper in staging and submitted a 686c/674 form, observed successfull events in datadog

## What areas of the site does it impact?

dependents

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
