### PR TITLE
Fix for flakey meb_api service spec

### DIFF
--- a/modules/meb_api/spec/lib/dgi/letters/configuration_spec.rb
+++ b/modules/meb_api/spec/lib/dgi/letters/configuration_spec.rb
@@ -15,6 +15,11 @@ describe MebApi::DGI::Letters::Configuration do
     )
   end
 
+  after do
+    # Clear the memoized connection to prevent state leakage to other tests
+    config.instance_variable_set(:@conn, nil)
+  end
+
   context 'when mock is disabled' do
     let(:mock_enabled) { false }
 


### PR DESCRIPTION
## Summary
I tried fixing this in https://github.com/department-of-veterans-affairs/vets-api/pull/24786 but just saw it fail again today while doing some other work. Worked with Joseph (and Claude 🤖) and we were able to figure it out. It was failing because:
- Configuration class is being created as a singleton instance (line 6)
- The connection is memoized (`@conn | |=` in modules/meb_api/lib/dgi/letters/configuration.rb)
- `Settings.dgi.vets.url` is set to `'https://example.com'` (line 13) _but wasn't cleaned up because `@conn` still points to `https://example.com` b/c it was memoized._
- So then `service_spec.rb` would run later and get the same singleton with the `example.com` connection when it was supposed to be a jenkins url.

### Error
https://github.com/department-of-veterans-affairs/vets-api/actions/runs/19581026130/job/56078803658?pr=25277
It was a large VCR error. This is part of it. Check out the last two lines I pasted:
```
  2) MebApi::DGI::Letters::Service#get_claim_letter when successful returns a status of 200
     Failure/Error: 
       connection.send(method.to_sym, path, params) do |request|
         request.headers.update(headers)
         options.each { |option, value| request.options.send("#{option}=", value) }
       end.env

     VCR::Errors::UnhandledHTTPRequestError:


       ================================================================================
       An HTTP request has been made that VCR does not know how to handle:
         GET https://example.com/claimant/600000001/claimType/Chapter33/letter
```
The URL should be `<DGI_VETS_URL>claimant/600000001/claimType...` where `DGI_VETS_URL` is NOT `example.com`, but a jenkins URL. 

## Related issue(s)
This will resolve one test listed here: https://vfs.atlassian.net/wiki/spaces/BCP/pages/3797057551/Vets-API+Flakey+Specs

## Testing done
We were able to get this to fail locally by running two two tests together: `bundle exec rspec modules/meb_api/spec/lib/dgi/letters/configuration_spec.rb modules/meb_api/spec/dgi/letters/service_spec.rb`. I ran them 10 times and they failed 60% of the time. 

With this fix, I ran the tests 20 times in a loop and there were zero failures 😎 🎉 ✅ 
```
for i in {1..20}; do be rspec modules/meb_api/spec/lib/dgi/letters/configuration_spec.rb modules/meb_api/spec/dgi/letters/service_spec.rb; done
```

## What areas of the site does it impact?
specs only. 

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
