### PR TITLE
fix: Filter encrypted_kms_key from logs and console output

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -3,6 +3,10 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
+  # Filter sensitive encryption keys from logs and console output
+  # This prevents encrypted_kms_key values from being exposed in plaintext
+  self.filter_attributes += [:encrypted_kms_key]
+
   def self.lockbox_options
     {
       previous_versions: [


### PR DESCRIPTION
Add encrypted_kms_key to filter_attributes in ApplicationRecord to prevent KMS encryption keys from being exposed in plaintext in logs, exception traces, and inspect output.

This addresses a security concern where encrypted_kms_key values were visible in console output and potentially in production logs, which could expose encryption keys used to protect PII/PHI data in models using has_kms_key.

Resolves security issue reported by Drew Fisher.