### PR TITLE
Added tracked item friendly name to evidence submissions in benefits claims response.

### DIFF
--- a/app/controllers/v0/benefits_claims_controller.rb
+++ b/app/controllers/v0/benefits_claims_controller.rb
@@ -247,6 +247,7 @@ module V0
         evidence_submission.tracked_item_id,
         tracked_items
       )
+      tracked_item_friendly_name = BenefitsClaims::Constants::FRIENDLY_DISPLAY_MAPPING[tracked_item_display_name]
 
       { acknowledgement_date: evidence_submission.acknowledgement_date,
         claim_id: evidence_submission.claim_id,
@@ -259,6 +260,7 @@ module V0
         lighthouse_upload: evidence_submission.job_class == 'Lighthouse::EvidenceSubmissions::DocumentUpload',
         tracked_item_id: evidence_submission.tracked_item_id,
         tracked_item_display_name:,
+        tracked_item_friendly_name:,
         upload_status: evidence_submission.upload_status,
         va_notify_status: evidence_submission.va_notify_status }
     end


### PR DESCRIPTION
## Summary

- **This work is behind a feature toggle (flipper): NO**
- This PR adds a new `tracked_item_friendly_name` field to evidence submission responses in the Benefits Claims API. This field provides a veteran-friendly display name for tracked items, mapped from the existing `tracked_item_display_name` using the `BenefitsClaims::Constants::FRIENDLY_DISPLAY_MAPPING` constant.
- Additionally, improves test coverage for the evidence submissions endpoints by adding comprehensive assertions to verify all response fields are properly populated and match expected values.
- **Team**: Benefits Management Tools Team 2 (Bee's Knees)
- **Maintenance**: This team owns the maintenance of the Benefits Claims controller and evidence submissions functionality.

**Changes Made**:
- Added `tracked_item_friendly_name` field to evidence submission response hash in `transform_evidence_submission` method
- Enhanced test coverage in `benefits_claims_controller_spec.rb` to verify all fields in evidence submission responses
- Tests now assert on all key fields including: `claim_id`, `document_type`, `file_name`, `upload_status`, `lighthouse_upload`, `tracked_item_id`, `tracked_item_display_name`, `tracked_item_friendly_name`, `acknowledgement_date`, `failed_date`, `created_at`, `delete_date`, and `id`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/126090

## Testing done

- [x] New code is covered by unit tests

**Test Coverage**:
The following test cases were enhanced with comprehensive field assertions:

1. **Claims Show Endpoint (`GET /v0/benefits_claims/:id`)**:
   - Test case: "when claim has an evidence_submission with no tracked_item"
     - Verifies evidence submission response includes all expected fields
     - Confirms `tracked_item_id`, `tracked_item_display_name`, and `tracked_item_friendly_name` are nil when no tracked item exists
   - Test case: "when claim has an evidence_submission with a tracked_item"
     - Verifies all evidence submission fields are populated correctly
     - Confirms `tracked_item_friendly_name` correctly maps from `tracked_item_display_name` using the `FRIENDLY_DISPLAY_MAPPING`
     - Example: "Submit buddy statement(s)" maps to "Witness or corroboration statements"

2. **Evidence Submissions Index Endpoint (`GET /v0/benefits_claims/evidence_submissions`)**:
   - Test case: "when evidence_submission records exist for the user"
     - Enhanced to verify all fields on each evidence submission in the response
     - Confirms proper handling of multiple evidence submissions with consistent field structure
   - Test case: "when multiple claims are returned for the evidence submission records"
     - Added assertions to verify all required fields are present for each submission
     - Confirms evidence submissions from different claims are properly distinguished by unique `claim_id` values

**Manual Testing**:
- Run the test suite: `bundle exec rspec spec/controllers/v0/benefits_claims_controller_spec.rb`
- All tests pass successfully with the new assertions
- The new `tracked_item_friendly_name` field is correctly populated in the response when a tracked item exists

**Behavior Verification**:

*Old Behavior*:
- Evidence submission responses only included `tracked_item_display_name` (technical/system name)
- Tests only verified the count of evidence submissions or a single field, not comprehensive field validation

*New Behavior*:
- Evidence submission responses now include both `tracked_item_display_name` (technical name) and `tracked_item_friendly_name` (veteran-friendly name)
- Tests verify all fields in evidence submission responses to ensure data integrity and prevent regressions
- The friendly name provides a more user-friendly display value for the frontend (e.g., "Witness or corroboration statements" instead of "Submit buddy statement(s)")

## Screenshots
_Not applicable - backend API change_

## What areas of the site does it impact?

**Primary Impact**:
- `V0::BenefitsClaimsController` - specifically the `show` action and evidence submissions endpoints
- Evidence submissions response structure (adds one new field)
- Benefits Claims API consumers (frontend applications displaying evidence submissions)

**Secondary Impact**:
- Any frontend code that displays tracked item information for evidence submissions will have access to the new `tracked_item_friendly_name` field for improved UX

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution
- [ ] Documentation has been updated (link to documentation) - _Not applicable, no user-facing documentation needed_
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Feature/bug has a monitor built into Datadog (if applicable) - _Not applicable, leverages existing monitoring_
- [ ] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected - _Not applicable, API change only_
- [x] I added a screenshot of the developed feature - _Not applicable, backend API change_
