### PR TITLE
Ask-VA - Update inquiry DataDog logging to show scenario fields

### DIFF
--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/creator.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/creator.rb
@@ -26,7 +26,10 @@ module AskVAApi
       ENDPOINT = 'inquiries/new'
       SAFE_INQUIRY_FIELDS = %i[
         about_your_relationship_to_family_member
+        category_id
         contact_preference
+        family_members_location_of_residence
+        family_member_postal_code
         is_question_about_veteran_or_someone_else
         more_about_your_relationship_to_veteran
         relationship_to_veteran
@@ -34,8 +37,13 @@ module AskVAApi
         select_category
         select_subtopic
         select_topic
+        state_of_property
+        subtopic_id
         their_relationship_to_veteran
         they_have_relationship_not_listed
+        topic_id
+        veterans_postal_code
+        veterans_location_of_residence
         who_is_your_question_about
         your_location_of_residence
         your_role


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): NO
- *Added additional DataDog logging fields*
- *Standard scenario logging will support a standard, comprehensive approach to debugging front end scenarios that are unexpected*
- *AskVA*

## Related issue(s)

- *[Update Inquiry Logging 2033](https://github.com/department-of-veterans-affairs/ask-va/issues/2033)*
- *[Prevent Unauthenticated Education Inquiries 1872](https://github.com/department-of-veterans-affairs/ask-va/issues/1872)*

## Testing done

- Minor change to array - ran unit tests to confirm no break

## What areas of the site does it impact?
*VETS-API Ask VA module Inquiry service DataDog logging*

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)

