### PR TITLE
Revert "Bump sentry-ruby from 5.28.1 to 6.1.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1103,7 +1103,7 @@ GEM
       rake (>= 10.0)
     semantic_logger (4.17.0)
       concurrent-ruby (~> 1.0)
-    sentry-ruby (6.1.0)
+    sentry-ruby (5.28.1)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shellany (0.0.1)


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#25160

The original PR deployed on 11/19 (confirmed via Datadog using [these instructions](https://vfs.atlassian.net/wiki/spaces/BCP/pages/2183037084/Advanced+Backend+Support+Responsibilities#Which-PRs-were-included-in-a-deployment?)) and at deploy time on the 19th, the count of sentry events processed dropped 📉 from about 55k per day to ~1k/day. There were many breaking changes listed with that `sentry-ruby` bump. 
<img width="1109" height="323" alt="image" src="https://github.com/user-attachments/assets/2ae311b3-0690-4a8e-a0b9-31517a2e6189" />
