### PR TITLE
2164: disallow 1095b download of unsupported years

### DIFF
--- a/app/controllers/v0/form1095_bs_controller.rb
+++ b/app/controllers/v0/form1095_bs_controller.rb
@@ -7,8 +7,7 @@ module V0
   class Form1095BsController < ApplicationController
     service_tag 'form-1095b'
     before_action { authorize :form1095, :access? }
-    # temporarily disabling to allow testing
-    # before_action :validate_year, only: %i[download_pdf download_txt], if: -> { fetch_from_enrollment_system? }
+    before_action :validate_year, only: %i[download_pdf download_txt], if: -> { fetch_from_enrollment_system? }
     before_action :validate_pdf_template, only: %i[download_pdf], if: -> { fetch_from_enrollment_system? }
     before_action :validate_txt_template, only: %i[download_txt], if: -> { fetch_from_enrollment_system? }
 

--- a/spec/requests/v0/form1095_bs_spec.rb
+++ b/spec/requests/v0/form1095_bs_spec.rb
@@ -50,8 +50,9 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
-      it 'throws 422 when requested year is more than 5 years ago' do
-        get '/v0/form1095_bs/download_pdf/2018'
+      # 2021 is the one unsupported year for which we have a template
+      it 'throws 422 when requested year is not in supported range' do
+        get '/v0/form1095_bs/download_pdf/2021'
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
@@ -112,8 +113,9 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
-      it 'throws 422 when requested year is more than 5 years ago' do
-        get '/v0/form1095_bs/download_txt/2018'
+      # 2021 is the one unsupported year for which we have a template
+      it 'throws 422 when requested year is not in supported range' do
+        get '/v0/form1095_bs/download_txt/2021'
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES
- re-adds a controller restriction preventing download for any years other than the currently supported one. this was disabled to allow for testing for next year. this is also behind a feature flag that is not currently on in prod.
- I am on the CVE team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-iir/issues/2164

## Testing done

- [x] *New code is covered by unit tests*
- Will test on staging by confirming that request for 2025 1095b form results in 422

## Screenshots


## What areas of the site does it impact?
Only 1095b download, only with feature flag on

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

