### PR TITLE
Prevent InProgressForms #update race condition

### DIFF
--- a/app/controllers/v0/in_progress_forms_controller.rb
+++ b/app/controllers/v0/in_progress_forms_controller.rb
@@ -17,7 +17,7 @@ module V0
     end
 
     def update
-      if Flipper.enabled?(:in_progress_form_atomiticity, @current_user)
+      if Flipper.enabled?(:in_progress_form_atomicity, @current_user)
         atomic_update
       else
         original_update

--- a/app/models/in_progress_form.rb
+++ b/app/models/in_progress_form.rb
@@ -58,7 +58,7 @@ class InProgressForm < ApplicationRecord
   after_save :log_hca_email_diff
 
   def self.form_for_user(form_id, user, with_lock: false)
-    if Flipper.enabled?(:in_progress_form_atomiticity, user)
+    if Flipper.enabled?(:in_progress_form_atomicity, user)
       scope = with_lock ? lock : all
       user_uuid_form = scope.find_by(form_id:, user_uuid: user.uuid)
       user_account_form = scope.find_by(form_id:, user_account: user.user_account) if user.user_account

--- a/config/features.yml
+++ b/config/features.yml
@@ -1183,7 +1183,7 @@ features:
   ha_cpap_supplies_cta:
     actor_type: user
     description: Toggle CTA for reordering Hearing Aid and CPAP supplies form within static pages.
-  in_progress_form_atomiticity:
+  in_progress_form_atomicity:
     actor_type: user
     description: Prevents multiple form creations for in_progress_form updates
   in_progress_form_reminder:

--- a/spec/models/in_progress_form_spec.rb
+++ b/spec/models/in_progress_form_spec.rb
@@ -205,9 +205,9 @@ RSpec.describe InProgressForm, type: :model do
     context 'with with_lock parameter' do
       subject { InProgressForm.form_for_user(form_id, user, with_lock: true) }
 
-      context 'when in_progress_form_atomiticity flipper is enabled' do
+      context 'when in_progress_form_atomicity flipper is enabled' do
         before do
-          allow(Flipper).to receive(:enabled?).with(:in_progress_form_atomiticity, user).and_return(true)
+          allow(Flipper).to receive(:enabled?).with(:in_progress_form_atomicity, user).and_return(true)
         end
 
         context 'and in progress form exists' do
@@ -227,9 +227,9 @@ RSpec.describe InProgressForm, type: :model do
         end
       end
 
-      context 'when in_progress_form_atomiticity flipper is disabled' do
+      context 'when in_progress_form_atomicity flipper is disabled' do
         before do
-          allow(Flipper).to receive(:enabled?).with(:in_progress_form_atomiticity, user).and_return(false)
+          allow(Flipper).to receive(:enabled?).with(:in_progress_form_atomicity, user).and_return(false)
         end
 
         context 'and in progress form exists' do

--- a/spec/requests/v0/in_progress_forms_controller_spec.rb
+++ b/spec/requests/v0/in_progress_forms_controller_spec.rb
@@ -298,9 +298,9 @@ RSpec.describe V0::InProgressFormsController do
         let(:new_form) { create(:in_progress_form, user_uuid: user.uuid, user_account: user.user_account) }
 
         context 'when handling race condition' do
-          context 'with in_progress_form_atomiticity flipper on' do
+          context 'with in_progress_form_atomicity flipper on' do
             before do
-              allow(Flipper).to receive(:enabled?).with(:in_progress_form_atomiticity,
+              allow(Flipper).to receive(:enabled?).with(:in_progress_form_atomicity,
                                                         instance_of(User)).and_return(true)
             end
 
@@ -340,9 +340,9 @@ RSpec.describe V0::InProgressFormsController do
             end
           end
 
-          context 'with in_progress_form_atomiticity flipper off' do
+          context 'with in_progress_form_atomicity flipper off' do
             before do
-              allow(Flipper).to receive(:enabled?).with(:in_progress_form_atomiticity,
+              allow(Flipper).to receive(:enabled?).with(:in_progress_form_atomicity,
                                                         instance_of(User)).and_return(false)
             end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
- Handles cases where multiple updates being submitted to the in-progress-form controller quickly trigger a 500 error and prevent updates from saving. 
- Search `@exception.name:"ActiveRecord::RecordNotUnique" @named_tags.dd.env:eks-prod ` to see recent examples of error

Stages of race condition:
1. Request 1 controller finds no existing form_id+uuid IPF
2. Request 2 controller finds no existing form_id+uuid IPF
3. Request 1 creates a new form_id+uuid IPF
4. Request 2 tries to create a new form_id+uuid IPF and triggers error `ActiveRecord::RecordNotUnique`
5. User receives 500 error and updated data isn't saved

## Related issue(s)

- https://github.com/orgs/department-of-veterans-affairs/projects/1237/views/3?sliceBy%5Bvalue%5D=TaiWilkin&pane=issue&itemId=137480957&issue=department-of-veterans-affairs%7Cva.gov-team%7C124427

## Testing done

- [ ] *New code is covered by unit tests*

## What areas of the site does it impact?
InProgressForms

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
