### PR TITLE
Fix time-dependent prescription filtering test

### DIFF
--- a/spec/lib/unified_health_data/service_spec.rb
+++ b/spec/lib/unified_health_data/service_spec.rb
@@ -1053,9 +1053,14 @@ describe UnifiedHealthData::Service, type: :service do
 
       context 'with current_only: true' do
         it 'applies filtering to exclude old discontinued/expired prescriptions' do
-          VCR.use_cassette('unified_health_data/get_prescriptions_success') do
-            filtered_prescriptions = service.get_prescriptions(current_only: true)
-            expect(filtered_prescriptions.size).to eq(54)
+          # Freeze time to prevent test from failing as prescriptions age
+          # The cassette has prescriptions with various expiration dates
+          # Using a fixed date ensures the 180-day filtering logic is consistent
+          Timecop.freeze(Time.zone.parse('2025-11-27')) do
+            VCR.use_cassette('unified_health_data/get_prescriptions_success') do
+              filtered_prescriptions = service.get_prescriptions(current_only: true)
+              expect(filtered_prescriptions.size).to eq(54)
+            end
           end
         end
       end


### PR DESCRIPTION
## Summary

- **This work is behind a feature toggle (flipper): NO**

- **Summary of changes:** Fixed a time-dependent test failure in the Unified Health Data service spec. The test for prescription filtering was using a dynamic 180-day sliding window (`180.days.ago`) that caused the expected count to change daily as prescriptions aged past the threshold.

- **Bug reproduction:** Run `bundle exec rspec spec/lib/unified_health_data/service_spec.rb:1102` on different dates and observe the count changing (54 on Nov 27 → 53 on Nov 28 → 52 on Dec 1).

- **Solution:** Wrapped the test in `Timecop.freeze(Time.zone.parse('2025-11-27'))` to freeze time, ensuring the 180-day calculation remains consistent regardless of when the test runs. This is a standard practice for tests with time-based logic.

- **Team:** MHV-Medical Records team. This is a test-only fix and doesn't impact production code functionality.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/126414

- Reported by Rebecca Tolmach, Rachal Cassity, and Adrian Rollett in Slack thread: https://dsva.slack.com/archives/C0460N83Y9G/p1764601233663759

## Testing done

- [x] **New code is covered by unit tests** (modified existing test to use Timecop)

- **Before:** Test would fail intermittently as prescriptions in the VCR cassette aged past the 180-day discontinued/expired threshold. The test expected 54 prescriptions but would get 53, then 52, etc. as days passed.

- **After:** Test consistently passes with 54 prescriptions regardless of the current date, because time is frozen to 2025-11-27.

- **Verification steps:**
  1. Run the specific test: `bundle exec rspec spec/lib/unified_health_data/service_spec.rb:1102`
  2. Verify it passes with expected count of 54
  3. Run the full service spec: `bundle exec rspec spec/lib/unified_health_data/service_spec.rb`
  4. Verify all 94 examples pass with 0 failures

- **Test:** The fix ensures the test that validates prescription filtering logic (excluding discontinued/expired prescriptions older than 180 days) continues to work correctly over time.

## Screenshots

N/A - This is a test-only change with no user-facing impact.

## What areas of the site does it impact?

**Impact:** Test suite only. No production code or user-facing functionality is affected.

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution (N/A - test only)
- [x] Documentation has been updated (N/A - self-documenting test code with inline comments)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Feature/bug has a monitor built into Datadog (N/A - test stability fix)
- [x] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected (N/A - test only)
- [ ] I added a screenshot of the developed feature (N/A - test only)

## Requested Feedback

This is a straightforward test stability fix using Timecop, which is already used extensively in the test suite for similar time-based scenarios. The fix prevents future CI failures as prescriptions in the VCR cassette continue to age.