### PR TITLE
Updated inquiry logging for Ask-VA

### DIFF
--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/inquiry_payload.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/inquiry_payload.rb
@@ -28,6 +28,7 @@ module AskVAApi
         end
 
         def call
+          log_inquiry_context
           payload = {
             AreYouTheDependent: dependent_of_veteran?,
             AttachmentPresent: attachment_present?,
@@ -36,13 +37,6 @@ module AskVAApi
             DependentDOB: family_member_field(:date_of_birth), DependentFirstName: family_member_field(:first)
           }.merge(additional_payload_fields)
 
-          context = {
-            level_of_authentication: inquiry_details[:level_of_authentication],
-            user_loa: user&.loa&.fetch(:current, nil),
-            category: inquiry_details_obj.category, topic: inquiry_details_obj.topic,
-            user_is_authenticated: user.present?
-          }
-          Rails.logger.info('Education Inquiry Context', context)
           if user.nil? && inquiry_details_obj.inquiry_education_related?
             raise InquiryPayloadError, 'Unauthenticated Education inquiry submitted'
           end
@@ -52,6 +46,23 @@ module AskVAApi
         end
 
         private
+
+        def log_inquiry_context
+          context = {
+            level_of_authentication: inquiry_details[:level_of_authentication],
+            user_loa: user&.loa&.fetch(:current, nil),
+            user_is_authenticated: user.present?,
+            category: inquiry_params[:select_category],
+            topic: inquiry_params[:select_topic],
+            subtopic: inquiry_params[:select_subtopic],
+            who: inquiry_params[:who_is_your_question_about],
+            relationship_to_veteran: inquiry_params[:relationship_to_veteran],
+            is_question_about_veteran_or_someone_else: inquiry_params[:is_question_about_veteran_or_someone_else],
+            your_role: inquiry_params[:your_role],
+            attachments: attachment_present?
+          }
+          Rails.logger.info('Inquiry Context', context)
+        end
 
         def additional_payload_fields
           {


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): No
- *Added additional DataDog logging fields*
- *Standard scenario logging will support a standard, comprehensive approach to debugging front end scenarios that are unexpected*
- *AskVA*

## Related issue(s)

- *[Update Inquiry Logging 2033](https://github.com/department-of-veterans-affairs/ask-va/issues/2033)*
- *[Prevent Unauthenticated Education Inquiries 1872](https://github.com/department-of-veterans-affairs/ask-va/issues/1872)*

## Testing done

- Manual local testing with 7 scenarios

## What areas of the site does it impact?
*VETS-API Ask VA module Inquiry service DataDog logging*

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)