### PR TITLE
Add comprehensive error handling for the upload_supporting_documents endpoint

### DIFF
--- a/modules/simple_forms_api/app/services/simple_forms_api/scanned_form_upload_service.rb
+++ b/modules/simple_forms_api/app/services/simple_forms_api/scanned_form_upload_service.rb
@@ -2,6 +2,18 @@
 
 module SimpleFormsApi
   class ScannedFormUploadService
+    class UploadError < StandardError
+      attr_reader :errors, :http_status
+
+      def initialize(message = 'Upload failed', errors: nil, http_status: :bad_gateway)
+        super(message)
+        normalized_errors = Array(errors)
+        normalized_errors = [{ title: 'Upload failed', detail: message }] if normalized_errors.empty?
+        @errors = normalized_errors
+        @http_status = http_status
+      end
+    end
+
     attr_reader :params, :current_user, :lighthouse_service
 
     def initialize(params:, current_user:, lighthouse_service:)
@@ -20,6 +32,16 @@ module SimpleFormsApi
       log_upload_result(main_file_path, status, confirmation_number)
 
       [status, confirmation_number]
+    rescue Common::Client::Errors::Error, Timeout::Error, Faraday::Error => e
+      Rails.logger.error('Simple forms api - supporting document upload failed', { error: e.message })
+      raise UploadError.new(
+        'Supporting document submission failed',
+        errors: [{
+          title: 'Submission failed',
+          detail: 'We could not submit your documents. Please try again later.'
+        }],
+        http_status: error_status(e)
+      )
     end
 
     private
@@ -114,6 +136,12 @@ module SimpleFormsApi
         { form_number: params[:form_number], status:, confirmation_number:,
           file_size: }
       )
+    end
+
+    def error_status(error)
+      return error.status if error.respond_to?(:status) && error.status
+
+      :bad_gateway
     end
   end
 end

--- a/modules/simple_forms_api/spec/requests/simple_forms_api/v1/scanned_form_uploads_spec.rb
+++ b/modules/simple_forms_api/spec/requests/simple_forms_api/v1/scanned_form_uploads_spec.rb
@@ -101,6 +101,33 @@ RSpec.describe 'SimpleFormsApi::V1::ScannedFormsUploader', type: :request do
 
       expect(response).to have_http_status(:ok)
     end
+
+    context 'when supporting document submission fails at Lighthouse' do
+      let(:upload_error) do
+        SimpleFormsApi::ScannedFormUploadService::UploadError.new(
+          'Supporting document submission failed',
+          errors: [{ title: 'Submission failed', detail: 'Try again later.' }],
+          http_status: :bad_gateway
+        )
+      end
+
+      before do
+        allow(Flipper).to receive(:enabled?).with(:simple_forms_upload_supporting_documents,
+                                                  an_instance_of(User)).and_return(true)
+        service_instance = instance_double(SimpleFormsApi::ScannedFormUploadService)
+        allow(SimpleFormsApi::ScannedFormUploadService).to receive(:new).and_return(service_instance)
+        allow(service_instance).to receive(:upload_with_supporting_documents).and_raise(upload_error)
+      end
+
+      it 'returns the error response from the service' do
+        post('/simple_forms_api/v1/submit_scanned_form', params:)
+
+        expect(response).to have_http_status(:bad_gateway)
+        resp = JSON.parse(response.body)
+        expect(resp['errors'].first['title']).to eq('Submission failed')
+        expect(resp['errors'].first['detail']).to eq('Try again later.')
+      end
+    end
   end
 
   describe '#upload_scanned_form' do
@@ -158,6 +185,69 @@ RSpec.describe 'SimpleFormsApi::V1::ScannedFormsUploader', type: :request do
 
         expect(response).to have_http_status(:ok)
         expect(PersistentAttachment.last).to be_a(PersistentAttachments::MilitaryRecords)
+      end
+    end
+
+    context 'when file parameter is missing' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:simple_forms_upload_supporting_documents,
+                                                  an_instance_of(User)).and_return(true)
+      end
+
+      it 'returns a bad request error without processing the upload' do
+        expect do
+          post '/simple_forms_api/v1/supporting_documents_upload', params: { form_id: form_number }
+        end.not_to change(PersistentAttachment, :count)
+
+        expect(response).to have_http_status(:bad_request)
+        resp = JSON.parse(response.body)
+        expect(resp['errors'].first['title']).to eq('File missing')
+      end
+    end
+
+    context 'when file parameter is invalid' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:simple_forms_upload_supporting_documents,
+                                                  an_instance_of(User)).and_return(true)
+      end
+
+      it 'returns an unprocessable entity error' do
+        expect do
+          post '/simple_forms_api/v1/supporting_documents_upload', params: { form_id: form_number, file: 'invalid' }
+        end.not_to change(PersistentAttachment, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        resp = JSON.parse(response.body)
+        expect(resp['errors'].first['title']).to eq('Invalid file')
+      end
+    end
+
+    context 'when the processor cannot persist the attachment' do
+      let(:persistence_error) do
+        SimpleFormsApi::ScannedFormProcessor::PersistenceError.new(
+          'File upload failed',
+          [{ title: 'File upload failed', detail: 'Database unavailable' }]
+        )
+      end
+
+      before do
+        allow(Flipper).to receive(:enabled?).with(:simple_forms_upload_supporting_documents,
+                                                  an_instance_of(User)).and_return(true)
+        processor_instance = instance_double(SimpleFormsApi::ScannedFormProcessor)
+        allow(SimpleFormsApi::ScannedFormProcessor).to receive(:new).and_return(processor_instance)
+        allow(processor_instance).to receive(:process!).and_raise(persistence_error)
+      end
+
+      it 'renders a 500 error response' do
+        params = { form_id: form_number, file: valid_pdf_file }
+
+        expect do
+          post '/simple_forms_api/v1/supporting_documents_upload', params:
+        end.not_to change(PersistentAttachment, :count)
+
+        expect(response).to have_http_status(:internal_server_error)
+        resp = JSON.parse(response.body)
+        expect(resp['errors'].first['detail']).to eq('Database unavailable')
       end
     end
 

--- a/modules/simple_forms_api/spec/services/scanned_form_upload_service_spec.rb
+++ b/modules/simple_forms_api/spec/services/scanned_form_upload_service_spec.rb
@@ -211,5 +211,22 @@ RSpec.describe SimpleFormsApi::ScannedFormUploadService do
         )
       end
     end
+
+    context 'when Lighthouse upload raises a client error' do
+      before do
+        allow(lighthouse_service).to receive(:perform_upload)
+          .and_raise(Common::Client::Errors::ClientError.new('Boom', 502))
+      end
+
+      it 'raises an UploadError with a user-friendly message' do
+        expect do
+          service.upload_with_supporting_documents
+        rescue SimpleFormsApi::ScannedFormUploadService::UploadError => e
+          expect(e.errors.first[:title]).to eq('Submission failed')
+          expect(e.http_status).to eq(502)
+          raise
+        end.to raise_error(SimpleFormsApi::ScannedFormUploadService::UploadError)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Updated error handling across the Simple Forms scanned upload so backend validation failures surface actual cause instead of the generic upload message.
- Controller: now catches `ScannedFormProcessor::PersistenceError` and returns structured validation details in the HTTP response.
- Processor: preserves and formats validation messages before Shrine mutates the attachment, parsing the `RecordInvalid` exception text as a fallback so we never lose the specific error.
- Upload service: mirrors the new structure and raises richer `UploadErrors` for Lighthouse failures, ensuring downstream consumers receive consistent payloads.

## [Related issue(s)](https://github.com/department-of-veterans-affairs/va.gov-team/issues/118038)

## Testing done

- [x] *New code is covered by unit tests*
- Reproduced the previous behavior by forcing `PersistentAttachments::VAForm#save!` to raise `ActiveRecord::RecordInvalid`, confirming the old flow always responded with “We could not save your file.”
- Steps to Verify Changes:
  - Exercising `SimpleFormsApi::ScannedFormUploadService` specs to ensure the service bubbles up the structured errors.

## What areas of the site does it impact?
- Simple Forms upload API endpoints: controller response payloads, the processor’s persistence path,

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature.
