### PR TITLE
Update cerner eligibility cookie

### DIFF
--- a/app/controllers/concerns/authentication_and_sso_concerns.rb
+++ b/app/controllers/concerns/authentication_and_sso_concerns.rb
@@ -107,11 +107,11 @@ module AuthenticationAndSSOConcerns # rubocop:disable Metrics/ModuleLength
 
   def set_cerner_eligibility_cookie
     cookie_name = V1::SessionsController::CERNER_ELIGIBLE_COOKIE_NAME
-    previous_value = cookies.signed[cookie_name]
+    previous_value = ActiveModel::Type::Boolean.new.cast(cookies.signed[cookie_name] || cookies[cookie_name])
 
     eligible = @current_user.cerner_eligible?
 
-    cookies.signed.permanent[cookie_name] = {
+    cookies.permanent[cookie_name] = {
       value: eligible,
       domain: IdentitySettings.sign_in.info_cookie_domain
     }

--- a/app/controllers/concerns/sign_in/authentication.rb
+++ b/app/controllers/concerns/sign_in/authentication.rb
@@ -70,7 +70,7 @@ module SignIn
     end
 
     def load_user_object
-      UserLoader.new(access_token:, request_ip: request.remote_ip).perform
+      UserLoader.new(access_token:, request_ip: request.remote_ip, cookies:).perform
     end
 
     def handle_authenticate_error(error, access_token_cookie_name: Constants::Auth::ACCESS_TOKEN_COOKIE_NAME)

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -300,7 +300,9 @@ module V1
     end
 
     def check_cerner_eligibility
-      value = ActiveModel::Type::Boolean.new.cast(cookies.signed[CERNER_ELIGIBLE_COOKIE_NAME])
+      cookie = cookies.signed[CERNER_ELIGIBLE_COOKIE_NAME] || cookies[CERNER_ELIGIBLE_COOKIE_NAME]
+
+      value = ActiveModel::Type::Boolean.new.cast(cookie)
 
       Rails.logger.info('[SessionsController] Cerner Eligibility',
                         eligible: value.nil? ? :unknown : value,

--- a/app/services/sign_in/user_loader.rb
+++ b/app/services/sign_in/user_loader.rb
@@ -2,11 +2,14 @@
 
 module SignIn
   class UserLoader
-    attr_reader :access_token, :request_ip
+    CERNER_ELIGIBLE_COOKIE_NAME = 'CERNER_ELIGIBLE'
 
-    def initialize(access_token:, request_ip:)
+    attr_reader :access_token, :request_ip, :cookies
+
+    def initialize(access_token:, request_ip:, cookies:)
       @access_token = access_token
       @request_ip = request_ip
+      @cookies = cookies
     end
 
     def perform
@@ -22,7 +25,7 @@ module SignIn
       user
     end
 
-    def reload_user
+    def reload_user # rubocop:disable Metrics/MethodLength
       validate_account_and_session
       user_identity.uuid = access_token.user_uuid
       current_user.uuid = access_token.user_uuid
@@ -35,6 +38,7 @@ module SignIn
       current_user.validate_mpi_profile
       current_user.create_mhv_account_async
       current_user.provision_cerner_async(source: :sis)
+      set_cerner_eligibility_cookie
 
       context = {
         user_uuid: current_user.uuid,
@@ -49,6 +53,13 @@ module SignIn
 
     def validate_account_and_session
       raise Errors::SessionNotFoundError.new message: 'Invalid Session Handle' unless session
+    end
+
+    def set_cerner_eligibility_cookie
+      cookies.permanent[CERNER_ELIGIBLE_COOKIE_NAME] = {
+        value: current_user.cerner_eligible?,
+        domain: IdentitySettings.sign_in.info_cookie_domain
+      }
     end
 
     def user_attributes

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -855,7 +855,7 @@ RSpec.describe V1::SessionsController, type: :controller do
               call_endpoint
 
               expect(response.headers['set-cookie']).to include('domain=some-domain')
-              expect(cookies.signed[cerner_eligible_cookie]).to eq(eligible)
+              expect(cookies[cerner_eligible_cookie]).to eq(eligible.to_s)
               expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
             end
           end
@@ -867,7 +867,7 @@ RSpec.describe V1::SessionsController, type: :controller do
             it 'sets the cookie and logs the cerner eligibility' do
               call_endpoint
 
-              expect(cookies.signed[cerner_eligible_cookie]).to eq(eligible)
+              expect(cookies[cerner_eligible_cookie]).to eq(eligible.to_s)
               expect(Rails.logger).to have_received(:info).with(expected_log_message, expected_log_payload)
             end
           end
@@ -878,7 +878,7 @@ RSpec.describe V1::SessionsController, type: :controller do
           let(:previous_value) { true }
 
           before do
-            cookies.signed[cerner_eligible_cookie] = true
+            cookies[cerner_eligible_cookie] = true
           end
 
           it 'logs the cerner eligibility with the previous value' do

--- a/spec/services/sign_in/user_loader_spec.rb
+++ b/spec/services/sign_in/user_loader_spec.rb
@@ -4,9 +4,15 @@ require 'rails_helper'
 
 RSpec.describe SignIn::UserLoader do
   describe '#perform' do
-    subject { SignIn::UserLoader.new(access_token:, request_ip:).perform }
+    subject { SignIn::UserLoader.new(access_token:, request_ip:, cookies:).perform }
 
     let(:access_token) { create(:access_token, user_uuid: user.uuid, session_handle:) }
+    let(:cookies) do
+      hash = {}
+      def hash.permanent = self
+      hash
+    end
+
     let!(:user) do
       create(:user, :loa3, uuid: user_uuid, loa: user_loa, icn: user_icn, session_handle: user_session_handle,
                            needs_accepted_terms_of_use:)
@@ -179,6 +185,13 @@ RSpec.describe SignIn::UserLoader do
             subject
             expect(Identity::CernerProvisionerJob).to have_received(:perform_async).with(user_icn, :sis)
           end
+        end
+
+        it 'sets the cerner eligibility cookie correctly' do
+          user = subject
+          expect(cookies['CERNER_ELIGIBLE']).to eq(
+            { value: user.cerner_eligible?, domain: IdentitySettings.sign_in.info_cookie_domain }
+          )
         end
       end
     end


### PR DESCRIPTION
⚠️ Merge after related `vets-website` PR is deployed ⚠️ 

## Summary

- Update `CERNER_ELIGIBLE` cookie to plain text
- add writing to sign in service auth to overwrite signed value and extend expiration since cookies aren't truly permanent 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/920
- https://github.com/department-of-veterans-affairs/vets-website/pull/40498

## Testing 
- enable this flipper - http://localhost:3000/flipper/features/cerner_non_eligible_sis_enabled
- Sign in with SSOe and check that `CERNER_ELIGIBLE` cookie is set
- Sign in with SiS and check that `CERNER_ELIGIBLE` cookie expiration date has changed 
- Clear cookies and sign in with SiS - cookie should be set 
- Test with [vets-website pr](https://github.com/department-of-veterans-affairs/vets-website/pull/40498)
  - set cookie to `false` - should default to SiS
  - set cookie to `true` - should default to SSOe
  - set cooke to no value - should default to SSOe
  - set cookie value to signed true - should default to SSOe
    ```
    eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaFUiLCJleHAiOm51bGwsInB1ciI6ImNvb2tpZS5teV9zaWduZWRfY29va2llX3RydWUifX0=--6aa10ad6de363182c3c933c01d1b7a8381051aa5
    ``` 
  - set cookie value to signed false - should default to SiS
    ```
    eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEciLCJleHAiOm51bGwsInB1ciI6ImNvb2tpZS5teV9zaWduZWRfY29va2llX2ZhbHNlIn19--dc7f2e226e669a44f8d2f3d18fa4a6980e46a872
    ``` 

## What areas of the site does it impact?
Authentication
## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

