### PR TITLE
Fix test pollution using dependency injection and proper mocking

### DIFF
--- a/modules/ivc_champva/app/services/ivc_champva/mpi_service.rb
+++ b/modules/ivc_champva/app/services/ivc_champva/mpi_service.rb
@@ -4,9 +4,9 @@ require 'mpi/service'
 
 module IvcChampva
   class MPIService
-    def initialize
-      @mpi_service = MPI::Service.new
-      @monitor = IvcChampva::Monitor.new
+    def initialize(mpi_service: nil, monitor: nil)
+      @mpi_service = mpi_service || MPI::Service.new
+      @monitor = monitor || IvcChampva::Monitor.new
     end
 
     def validate_profiles(parsed_form_data)

--- a/modules/ivc_champva/spec/services/mpi_service_spec.rb
+++ b/modules/ivc_champva/spec/services/mpi_service_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 require_relative '../../lib/ivc_champva/monitor'
 
 RSpec.describe IvcChampva::MPIService do
-  let(:service) { described_class.new }
   let(:mock_mpi_service) { instance_double(MPI::Service) }
   let(:mock_monitor) { instance_double(IvcChampva::Monitor) }
+  let(:service) { described_class.new(mpi_service: mock_mpi_service, monitor: mock_monitor) }
 
   let(:form_data) do
     JSON.parse(Rails.root.join('modules', 'ivc_champva', 'spec', 'fixtures', 'form_json', 'vha_10_10d.json').read)
@@ -16,17 +16,6 @@ RSpec.describe IvcChampva::MPIService do
     instance_double(MPI::Responses::FindProfileResponse, ok?: true,
                                                          profile: instance_double(MPI::Models::MviProfile,
                                                                                   icn: '12345678901234567890'))
-  end
-
-  before do
-    allow(MPI::Service).to receive(:new).and_return(mock_mpi_service)
-    allow(IvcChampva::Monitor).to receive(:new).and_return(mock_monitor)
-  end
-
-  after do
-    # Clear RSpec mocks to prevent pollution of subsequent tests
-    RSpec::Mocks.space.proxy_for(MPI::Service).reset
-    RSpec::Mocks.space.proxy_for(IvcChampva::Monitor).reset
   end
 
   describe '#validate_profiles' do

--- a/modules/sob/spec/controllers/sob/v2/post911_gi_bill_statuses_controller_spec.rb
+++ b/modules/sob/spec/controllers/sob/v2/post911_gi_bill_statuses_controller_spec.rb
@@ -77,14 +77,11 @@ RSpec.describe SOB::V2::Post911GIBillStatusesController, type: :controller do
     end
 
     let(:mock_exception) { Breakers::OutageException.new(mock_outage, mock_service) }
+    let(:mock_benefits_service) { instance_double(BenefitsEducation::Service) }
 
     before do
-      allow_any_instance_of(BenefitsEducation::Configuration).to receive(:get).and_raise(mock_exception)
-    end
-
-    after do
-      # Clear RSpec mocks to prevent pollution of subsequent tests
-      RSpec::Mocks.space.proxy_for(BenefitsEducation::Configuration).reset
+      allow(controller).to receive(:service).and_return(mock_benefits_service)
+      allow(mock_benefits_service).to receive(:get_gi_bill_status).and_raise(mock_exception)
     end
 
     it 'returns a 503 status code' do


### PR DESCRIPTION
## Summary

Fixes CI test failures in Group 5 without using RSpec's private internal APIs (`RSpec::Mocks.space.proxy_for`). Two specs were causing cross-file test pollution when run together in parallel execution.

## Issues Fixed

### 1. IvcChampva::MPIService spec polluting AppealsApi specs
- **Root cause**: Stubbing `MPI::Service.new` at class level leaked to other specs
- **Solution**: Refactored production code to use dependency injection
- **Changes**:
  - Modified `IvcChampva::MPIService#initialize` to accept optional `mpi_service:` and `monitor:` keyword arguments
  - Updated spec to pass mock objects directly via constructor
  - Removed class-level `allow(Class).to receive(:new)` stubs entirely

### 2. SOB spec polluting VAProfile specs with Breakers::OutageException
- **Root cause**: Using `allow_any_instance_of(BenefitsEducation::Configuration)` leaked to other specs
- **Solution**: Stub at controller level instead of class level
- **Changes**:
  - Stub the controller's `service` method directly to return mock
  - Mock service raises the exception when called
  - Removed `allow_any_instance_of` entirely

## Why This Approach

The previous fix (#25395) used `RSpec::Mocks.space.proxy_for().reset` which:
- ❌ Uses RSpec's private internal API marked "do not use"
- ❌ Subject to breaking changes in future RSpec versions
- ❌ Not a pattern used anywhere else in the 400K+ line codebase

This fix uses standard patterns:
- ✅ Dependency injection (industry best practice)
- ✅ Controller method stubbing (standard RSpec approach)
- ✅ No private APIs
- ✅ Better code design

## Why This Started Failing

PR #25361 added 81 lines to a spec file, causing `parallel_test --group-by filesize` to rebalance files across groups. The problematic specs moved into Group 5 together, exposing these latent pollution bugs.

## Testing

Verified fixes resolve cross-file pollution:
```bash
# SOB + VAProfile specs
rspec modules/sob/spec/controllers/sob/v2/post911_gi_bill_statuses_controller_spec.rb spec/lib/va_profile/demographics/service_spec.rb
# Result: 10 examples, 0 failures

# IvcChampva + AppealsApi specs  
rspec modules/ivc_champva/spec/services/mpi_service_spec.rb modules/appeals_api/spec/docs/appeals_status/v1_spec.rb
# Result: 16 examples, 0 failures
```

## Files Changed

- `modules/ivc_champva/app/services/ivc_champva/mpi_service.rb` - Added dependency injection
- `modules/ivc_champva/spec/services/mpi_service_spec.rb` - Use dependency injection instead of class-level stubs
- `modules/sob/spec/controllers/sob/v2/post911_gi_bill_statuses_controller_spec.rb` - Stub controller method instead of class