### PR TITLE
Add solution for SimpleCov coverage alerts to enforce 90% minimum

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -566,6 +566,7 @@ jobs:
           channel_id: "C039HRTHXDH"
 
       - name: Comment Coverage on PR
+        if: needs.tests.result == 'success' && github.event_name == 'pull_request' && fromJSON(steps.coverage.outputs.percent) < 90
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -579,6 +580,7 @@ jobs:
               **View detailed coverage:** [Open test run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) → Scroll to **Artifacts** → Download **Coverage Report** → Open **index.html**
 
       - name: Comment Coverage on PR
+        if: needs.tests.result == 'success' && github.event_name == 'pull_request' && fromJSON(steps.coverage.outputs.percent) >= 90 && fromJSON(steps.coverage.outputs.percent) < 93
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

There is no alert when Simplecov is reporting low coverage and there might be confusion on how to obtain the SimpleCov report. Automated test coverage tracking was added with Slack notifications and PR comments to improve visibility into code quality metrics.

**Key Changes**
1. Coverage Extraction & Reporting
- Modified SimpleCov output format to extract covered_percent metric
- Added coverage percentage output to GitHub Actions for reuse

2. Slack Notifications (Non-PR Events, PUSH to Master) - Screenshots below
- Critical Alert (< 90% coverage): Blocks deployment with rotating light emoji, shows coverage gap, includes run details
- Warning Alert (90-92% coverage): Allows deployment but encourages improvement
- Integrated with VSP GitHub Actions for Slack socket communication
- Both include links to download detailed coverage reports from artifacts
- Included deployment status for awareness

3. PR Comments -  Screenshots below
- Critical Comment (< 90%): Red warning with deployment blocked message
- Warning Comment (90-92%): Yellow warning recommending coverage improvement
- Both include links to download detailed coverage reports from artifacts


✅ Slack Notifications are sent to the [#platform-cop-be-notifications](https://dsva.slack.com/archives/C039HRTHXDH) slack channel when Master has low coverage.

✅ Pull request comments were added to clearly notify developers when their pull request test coverage is low.

SimpleCov support documentation was added to [these pending developer docs ](https://vfs.atlassian.net/wiki/spaces/PPT/pages/4529979393/Duplicate+of+Advanced+Backend+Support+Responsibilities#SimpleCov-Code-Coverage)(waiting for review).

## Related issue(s)

- department-of-veterans-affairs/va.gov-team/issues/118146

## Testing done
- Tested PR Comment for Low Coverage Warning
- Tested PR Comment for Critical Low Coverage Warning
- Tested slack notification for Low Coverage Warning
- Tested slack notification  for Critical Low Coverage Warning


## Screenshots

Low coverage ALERT
<img width="495" height="219" alt="Screenshot 2025-12-08 at 2 13 58 PM" src="https://github.com/user-attachments/assets/101e03a1-941d-4222-aeb7-bb2c2cf075c5" />

Low coverage warning
<img width="514" height="192" alt="Screenshot 2025-12-08 at 2 14 12 PM" src="https://github.com/user-attachments/assets/189359ad-ae3e-46ac-a242-f8e7820234c4" />

PR Comment
<img width="636" height="200" alt="Screenshot 2025-12-08 at 2 17 05 PM" src="https://github.com/user-attachments/assets/533c69fc-9698-48d6-8f67-ba997f74ec41" />

## What areas of the site does it impact?
Testing only

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
