### PR TITLE
ci: add SBOM generation workflow for ATO compliance

### DIFF
--- a/.github/workflows/datadog_sca.yml
+++ b/.github/workflows/datadog_sca.yml
@@ -2,14 +2,14 @@
 # Datadog GovCloud doesn't yet support Code Security SCA uploads
 # See: https://github.com/department-of-veterans-affairs/vets-api/pull/25424
 
+name: Datadog Software Composition Analysis
+
 on:
   push:
     branches: [master]
   pull_request:
     branches: [master]
   workflow_dispatch:
-
-name: Datadog Software Composition Analysis
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to generate SBOM (Software Bill of Materials) using Datadog's `sbom-generator`
- Uploads SBOM as GitHub artifact with 90-day retention for ATO compliance
- Triggers on pushes to master, PRs to master, and manual dispatch

## Why not upload to Datadog?
Datadog GovCloud (`ddog-gov.com`) doesn't yet support Code Security SCA uploads - see #25424 for details. This workflow generates the SBOM locally so we have it for compliance purposes, and can be extended to upload once GovCloud adds support.

## Test plan
- [x] Verify workflow runs on this PR
- [x] Verify SBOM artifact is generated and downloadable
- [x] Verify SBOM contains expected dependencies (ruby, node, python)