### PR TITLE
Update suppressed evidence request (aka. tracked items)

### DIFF
--- a/app/controllers/v0/benefits_claims_controller.rb
+++ b/app/controllers/v0/benefits_claims_controller.rb
@@ -305,7 +305,7 @@ module V0
       tracked_items = claim.dig('data', 'attributes', 'trackedItems')
       return unless tracked_items
 
-      tracked_items.reject! { |i| BenefitsClaims::Service::SUPPRESSED_EVIDENCE_REQUESTS.include?(i['displayName']) }
+      tracked_items.reject! { |i| BenefitsClaims::Constants::SUPPRESSED_EVIDENCE_REQUESTS.include?(i['displayName']) }
       claim
     end
 

--- a/app/controllers/v0/chatbot/claim_status_controller.rb
+++ b/app/controllers/v0/chatbot/claim_status_controller.rb
@@ -91,7 +91,7 @@ module V0
         tracked_items = claim.dig('data', 'attributes', 'trackedItems')
         return unless tracked_items
 
-        tracked_items.reject! { |i| BenefitsClaims::Service::SUPPRESSED_EVIDENCE_REQUESTS.include?(i['displayName']) }
+        tracked_items.reject! { |i| BenefitsClaims::Constants::SUPPRESSED_EVIDENCE_REQUESTS.include?(i['displayName']) }
         claim
       end
 

--- a/lib/lighthouse/benefits_claims/constants.rb
+++ b/lib/lighthouse/benefits_claims/constants.rb
@@ -176,6 +176,32 @@ module BenefitsClaims
       'ASB-medical evid of disease (biopsy) needed' => true,
       'NG1 - National Guard Records Request' => false
     }.freeze
+
+    # These are evidence requests that should not be displayed to the user when:
+    # - `cst_suppress_evidence_requests_website` feature flag is enabled
+    # - `cst_suppress_evidence_requests_mobile` feature flag is enabled
+    # See https://github.com/department-of-veterans-affairs/va.gov-team/issues/126870
+    SUPPRESSED_EVIDENCE_REQUESTS = [
+      'Admin Decision',
+      'ADMINCOD',
+      'Attorney Fee',
+      'Attorney Fee Release',
+      'Awaiting Upload of Hearing Transcript',
+      'Delayed BDD Exam Requests',
+      'Exam Request - Processing',
+      'Exam Review - Not Performed',
+      'Exam Review - Partially Complete',
+      'IT Ticket-Exam Control Issue',
+      'ND Additional Action Required',
+      'Pending Completion of Concurrent EP',
+      'Rating Extraschedular Memorandum',
+      'Records Research Task',
+      'Resolution of Pending Rating EP',
+      'RO Research Coordinator Review',
+      'Second Signature',
+      'Secondary Action Required',
+      'Stage 2 Development' # Not currently used by VBMS but will eventually replace `Secondary Action Required`
+    ].freeze
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/lib/lighthouse/benefits_claims/service.rb
+++ b/lib/lighthouse/benefits_claims/service.rb
@@ -23,8 +23,6 @@ module BenefitsClaims
     }.freeze
     # rubocop:enable Naming/VariableNumber
 
-    SUPPRESSED_EVIDENCE_REQUESTS = ['Attorney Fees', 'Secondary Action Required', 'Stage 2 Development'].freeze
-
     def initialize(icn)
       @icn = icn
       if icn.blank?

--- a/modules/mobile/app/services/mobile/v0/lighthouse_claims/proxy.rb
+++ b/modules/mobile/app/services/mobile/v0/lighthouse_claims/proxy.rb
@@ -78,7 +78,7 @@ module Mobile
           tracked_items = claim.dig('data', 'attributes', 'trackedItems')
           return unless tracked_items
 
-          tracked_items.reject! { |i| BenefitsClaims::Service::SUPPRESSED_EVIDENCE_REQUESTS.include?(i['displayName']) }
+          tracked_items.reject! { |i| BenefitsClaims::Constants::SUPPRESSED_EVIDENCE_REQUESTS.include?(i['displayName']) }
           claim
         end
 

--- a/modules/mobile/spec/requests/mobile/v0/lighthouse_claim_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/lighthouse_claim_spec.rb
@@ -4,6 +4,7 @@ require_relative '../../../support/helpers/rails_helper'
 require_relative '../../../support/helpers/committee_helper'
 
 require 'lighthouse/benefits_claims/configuration'
+require 'lighthouse/benefits_claims/constants'
 require 'lighthouse/benefits_claims/service'
 
 RSpec.describe 'Mobile::V0::Claim', type: :request do
@@ -97,14 +98,14 @@ RSpec.describe 'Mobile::V0::Claim', type: :request do
           allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests_mobile).and_return(true)
         end
 
-        it 'excludes Attorney Fees, Secondary Action Required, and Stage 2 Development tracked items' do
+        it 'excludes suppressed evidence request tracked items' do
           VCR.use_cassette('mobile/lighthouse_claims/show/200_response') do
             get '/mobile/v0/claim/600117255', headers: sis_headers
           end
           parsed_body = JSON.parse(response.body)
           display_names = parsed_body.dig('data', 'attributes', 'eventsTimeline').map { |h| h['displayName'] }
           expect(display_names.size).to eq(19)
-          expect(display_names).not_to include('Attorney Fees')
+          expect(display_names & BenefitsClaims::Constants::SUPPRESSED_EVIDENCE_REQUESTS).to be_empty
         end
       end
 
@@ -114,14 +115,14 @@ RSpec.describe 'Mobile::V0::Claim', type: :request do
           allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests_mobile).and_return(false)
         end
 
-        it 'includes Attorney Fees, Secondary Action Required, and Stage 2 Development tracked items' do
+        it 'includes suppressed evidence request tracked items' do
           VCR.use_cassette('mobile/lighthouse_claims/show/200_response') do
             get '/mobile/v0/claim/600117255', headers: sis_headers
           end
           parsed_body = JSON.parse(response.body)
           display_names = parsed_body.dig('data', 'attributes', 'eventsTimeline').map { |h| h['displayName'] }
           expect(display_names.size).to eq(20)
-          expect(display_names).to include('Attorney Fees')
+          expect(display_names & BenefitsClaims::Constants::SUPPRESSED_EVIDENCE_REQUESTS).not_to be_empty
         end
       end
 

--- a/spec/controllers/v0/chatbot/claim_status_controller_spec.rb
+++ b/spec/controllers/v0/chatbot/claim_status_controller_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require 'chatbot/report_to_cxi'
+require 'lighthouse/benefits_claims/constants'
 require 'lighthouse/benefits_claims/service'
 require 'lighthouse/benefits_claims/configuration'
 
@@ -214,15 +215,13 @@ RSpec.describe 'V0::Chatbot::ClaimStatusController', type: :request do
           allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests_website).and_return(true)
         end
 
-        it 'excludes Attorney Fees, Secondary Action Required, and Stage 2 Development tracked items' do
+        it 'excludes suppressed evidence request tracked items' do
           VCR.use_cassette('lighthouse/benefits_claims/show/200_response') do
             get_single_claim
           end
           parsed_body = JSON.parse(response.body)
           names = parsed_body.dig('data', 'data', 'attributes', 'trackedItems').map { |i| i['displayName'] }
-          expect(names).not_to include('Attorney Fees')
-          expect(names).not_to include('Secondary Action Required')
-          expect(names).not_to include('Stage 2 Development')
+          expect(names & BenefitsClaims::Constants::SUPPRESSED_EVIDENCE_REQUESTS).to be_empty
         end
       end
 
@@ -231,15 +230,13 @@ RSpec.describe 'V0::Chatbot::ClaimStatusController', type: :request do
           allow(Flipper).to receive(:enabled?).with(:cst_suppress_evidence_requests_website).and_return(false)
         end
 
-        it 'includes Attorney Fees, Secondary Action Required, and Stage 2 Development tracked items' do
+        it 'includes suppressed evidence request tracked items' do
           VCR.use_cassette('lighthouse/benefits_claims/show/200_response') do
             get_single_claim
           end
           parsed_body = JSON.parse(response.body)
           names = parsed_body.dig('data', 'data', 'attributes', 'trackedItems').map { |i| i['displayName'] }
-          expect(names).to include('Attorney Fees')
-          expect(names).to include('Secondary Action Required')
-          expect(names).to include('Stage 2 Development')
+          expect(names & BenefitsClaims::Constants::SUPPRESSED_EVIDENCE_REQUESTS).not_to be_empty
         end
       end
     end

--- a/spec/support/vcr_cassettes/lighthouse/benefits_claims/show/200_response.yml
+++ b/spec/support/vcr_cassettes/lighthouse/benefits_claims/show/200_response.yml
@@ -268,7 +268,7 @@ http_interactions:
           {
           "closedDate": null,
           "description": "This evidence request should never be surfaced to the end user.",
-          "displayName": "Attorney Fees",
+          "displayName": "Attorney Fee",
           "overdue": false,
           "receivedDate": "2023-03-15",
           "requestedDate": "2023-04-14",

--- a/spec/support/vcr_cassettes/mobile/lighthouse_claims/show/200_response.yml
+++ b/spec/support/vcr_cassettes/mobile/lighthouse_claims/show/200_response.yml
@@ -109,7 +109,7 @@ http_interactions:
                        "endProductCode":"020",
                        "evidenceWaiverSubmitted5103":false,
                        "errors":[
-                          
+
                        ],
                        "jurisdiction":"National Work Queue",
                        "lighthouseId":null,
@@ -300,7 +300,7 @@ http_interactions:
                           {
                              "closedDate":"2022-10-30",
                              "description":null,
-                             "displayName":"Attorney Fees",
+                             "displayName":"Attorney Fee",
                              "overdue":false,
                              "receivedDate":null,
                              "requestedDate":"2022-09-30",


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES* (`cst_suppress_evidence_requests_website` and `cst_suppress_evidence_requests_mobile`)
- Moved the `SUPPRESSED_EVIDENCE_REQUESTS` constant from `BenefitsClaims::Service` to `BenefitsClaims::Constants` for better code organization
- Expanded the list of suppressed evidence requests from 3 items to 19 items to include additional internal-only tracked item types that should not be displayed to Veterans
- Updated all references across the codebase to use the new constant location
- Refactored tests to dynamically reference the constant instead of hardcoding specific item names
- *Team: BMT Team 2 (Bee's Knees)*
- *Success criteria: Internal-only evidence requests are filtered from claim details when the flipper is enabled*

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/126870

## Testing done

- [x] *New code is covered by unit tests*
- **Old behavior:** Only 3 evidence request types were suppressed: 'Attorney Fees', 'Secondary Action Required', and 'Stage 2 Development'. 'Attorney Fees' should be 'Attorney Fee'.
- **New behavior:** 19 evidence request types are now suppressed when the feature flag is enabled
- **Verification steps:**
  1. Run the related specs to verify the constant move didn't break functionality:
     ```bash
     bundle exec rspec spec/controllers/v0/benefits_claims_controller_spec.rb:673:700
     bundle exec rspec spec/controllers/v0/chatbot/claim_status_controller_spec.rb:213:240
     bundle exec rspec modules/mobile/spec/requests/mobile/v0/lighthouse_claim_spec.rb:94:126
     ```
  2. All tests verify that when `cst_suppress_evidence_requests_website` or `cst_suppress_evidence_requests_mobile` is enabled, none of the items in `SUPPRESSED_EVIDENCE_REQUESTS` appear in the response
  3. All tests verify that when the flipper is disabled, at least one suppressed item appears in the response
- *Flipper testing:* Tests cover both flipper on and flipper off scenarios using array intersection to validate filtering

## Screenshots
_N/A - Backend changes only_

## What areas of the site does it impact?

- **Benefits Claims Controller** (`app/controllers/v0/benefits_claims_controller.rb`) - filters tracked items in claim details
- **Chatbot Claim Status Controller** (`app/controllers/v0/chatbot/claim_status_controller.rb`) - filters tracked items for chatbot responses
- **Mobile Lighthouse Claims Proxy** (`modules/mobile/app/services/mobile/v0/lighthouse_claims/proxy.rb`) - filters tracked items for mobile app
- **Constants file** (`lib/lighthouse/benefits_claims/constants.rb`) - new home for the `SUPPRESSED_EVIDENCE_REQUESTS` constant

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Documentation has been updated (link to documentation)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Feature/bug has a monitor built into Datadog (if applicable)
- [ ] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ] I added a screenshot of the developed feature

## Requested Feedback

- Please verify the expanded list of 19 suppressed evidence requests is correct and complete
