### PR TITLE
Bump vets_json_schema to 25.2.32

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,10 +74,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: cd89087b891145844528a0e735be488ab6cba3a5
+  revision: 5071029d23c3e660f0a30c5f0a32e18db9122da9
   branch: master
   specs:
-    vets_json_schema (25.2.24)
+    vets_json_schema (25.2.32)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Bumps `vets_json_schema` gem from 25.2.24 to 25.2.32
- Updates the Gemfile.lock revision to `5071029d23c3e660f0a30c5f0a32e18db9122da9`

## Related issue(s)

- N/A - Dependency update

## Testing done

- [ ] *New code is covered by unit tests*
- This is a dependency version bump only, no new code introduced
- CI tests will verify compatibility with the updated schema

## Screenshots
_Note: Optional_

N/A

## What areas of the site does it impact?
Any forms or features that rely on the vets-json-schema for validation.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_