### PR TITLE
Revert "Burials | HexaPDF compatibility updates (2 of 2)"

### DIFF
--- a/lib/pdf_fill/hash_converter.rb
+++ b/lib/pdf_fill/hash_converter.rb
@@ -14,7 +14,6 @@ module PdfFill
       @pdftk_form = {}
       @date_strftime = date_strftime
       @extras_generator = extras_generator
-      @use_hexapdf = extras_generator.use_hexapdf
     end
 
     def convert_value(v, key_data, is_overflow = false)
@@ -125,12 +124,8 @@ module PdfFill
 
       if k.present? && overflow?(key_data, new_value, from_array_overflow)
         add_to_extras(key_data, new_value, i)
-        # NOTE: Allows for accommodating fields that don't have enough space for the full placeholder text
-        # PDFtk doesn't care and truncates the text at the field limit, but HexaPDF will error out if the text
-        # exceeds the field limit
-        max_length = placeholder_text.length
-        limit = @use_hexapdf ? key_data.fetch(:limit, max_length) : max_length
-        new_value = placeholder_text[0...limit]
+
+        new_value = placeholder_text
       elsif !from_array_overflow
         add_to_extras(key_data, new_value, i, overflow: false)
       end

--- a/modules/burials/spec/lib/burials/pdf_fill/filler_spec.rb
+++ b/modules/burials/spec/lib/burials/pdf_fill/filler_spec.rb
@@ -25,10 +25,8 @@ describe PdfFill::Filler, type: :model do
                 end
               end
 
-              fill_options = { extras_redesign: true, omit_esign_stamp: true, use_hexapdf: true }
-
               file_path = described_class.fill_ancillary_form(form_data, 1, form_id,
-                                                              fill_options)
+                                                              { extras_redesign: true, omit_esign_stamp: true })
 
               if type == 'overflow'
                 extras_path = the_extras_generator.generate

--- a/spec/lib/pdf_fill/hash_converter_spec.rb
+++ b/spec/lib/pdf_fill/hash_converter_spec.rb
@@ -10,9 +10,7 @@ describe PdfFill::HashConverter do
   let(:extras_generator) { instance_double(PdfFill::ExtrasGenerator) }
   let(:placeholder_text) { 'special placeholder text' }
 
-  before do
-    allow(extras_generator).to receive_messages(placeholder_text:, use_hexapdf: false)
-  end
+  before { allow(extras_generator).to receive(:placeholder_text).and_return(placeholder_text) }
 
   def verify_extras_text(text, metadata)
     metadata[:overflow] = true unless metadata.key?(:overflow)
@@ -212,35 +210,6 @@ describe PdfFill::HashConverter do
           )
           verify_hash('key1' => placeholder_text, 'key2' => placeholder_text)
         end
-      end
-    end
-
-    context 'with use_hexapdf enabled and placeholder text truncation' do
-      before do
-        allow(extras_generator).to receive_messages(placeholder_text:, use_hexapdf: true)
-      end
-
-      it 'truncates placeholder text when field limit is less than placeholder length' do
-        verify_extras_text('bar', question_num: 1, question_text: 'foo', i: nil)
-
-        call_set_value(
-          { key: :foo, limit: 2, question_num: 1, question_text: 'foo' },
-          nil
-        )
-
-        verify_hash(foo: 'sp')
-      end
-
-      it 'uses full placeholder text when field limit is greater than placeholder length' do
-        verify_extras_text('super special valueable text', question_num: 1, question_text: 'foo', i: nil)
-
-        call_set_custom_value(
-          'super special valueable text',
-          { key: :foo, limit: 25, question_num: 1, question_text: 'foo' },
-          nil
-        )
-
-        verify_hash(foo: placeholder_text)
       end
     end
   end


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#25276

https://github.com/department-of-veterans-affairs/vets-api/actions/runs/20033399066/job/57448542173#step:12:3437

```
       +     name: "form1[0].#subform[82].OTHER_NAME_VETERAN_SERVED_UNDER[0]",
       +     value: "See"
       +   },
       -   {
       -     name: "form1[0].#subform[82].OTHER_NAME_VETERAN_SERVED_UNDER[0]",
       -     value: "See attachment"
       -   },
         ]
     # ./spec/support/matchers/pdf_fill_matchers.rb:10:in `block (2 levels) in <top (required)>'
     # ./modules/burials/spec/lib/burials/pdf_fill/filler_spec.rb:45:in `block (7 levels) in <top (required)>'

Finished in 2 minutes 1 second (files took 30.97 seconds to load)
1146 examples, 2 failures

Failed examples:

rspec './modules/burials/spec/lib/burials/pdf_fill/filler_spec.rb[1:1:1:3:1]' # PdfFill::Filler#fill_ancillary_form form 21P-530EZ with overflow test data fills the form correctly
rspec './modules/burials/spec/lib/burials/pdf_fill/filler_spec.rb[1:1:1:2:1]' # PdfFill::Filler#fill_ancillary_form form 21P-530EZ with kitchen_sink test data fills the form correctly
```