### PR TITLE
Replace Virtus with Vets::Model - EVSS::Letters

### DIFF
--- a/lib/evss/letters/benefit_information.rb
+++ b/lib/evss/letters/benefit_information.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
 
 module EVSS
   module Letters
@@ -16,11 +16,13 @@ module EVSS
     # @!attribute has_chapter35_eligiblity
     #   @return [Boolean] Returns true if the user is Chapter 35-eligible
     #
-    class BenefitInformation < Common::Base
+    class BenefitInformation
+      include Vets::Model
+
       attribute :monthly_award_amount, Float
       attribute :service_connected_percentage, Integer
       attribute :award_effective_date, DateTime
-      attribute :has_chapter35_eligibility, Boolean
+      attribute :has_chapter35_eligibility, Bool
     end
   end
 end

--- a/lib/evss/letters/benefit_information_dependent.rb
+++ b/lib/evss/letters/benefit_information_dependent.rb
@@ -1,23 +1,21 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
-
 module EVSS
   module Letters
     ##
     # Model for a dependent's benefit information
     #
     # @!attribute has_survivors_pension_award
-    #   @return [Boolean] Returns true if the user has a survivor's pension award
+    #   @return [Bool] Returns true if the user has a survivor's pension award
     # @!attribute has_survivors_indemnity_compensation_award
-    #   @return [Boolean] Returns true if the user has a survivor's indemnity compensation award
+    #   @return [Bool] Returns true if the user has a survivor's indemnity compensation award
     # @!attribute has_death_result_of_disability
-    #   @return [Boolean] Returns true of the veteran died as a result of their disability
+    #   @return [Bool] Returns true of the veteran died as a result of their disability
     #
     class BenefitInformationDependent < BenefitInformation
-      attribute :has_survivors_pension_award, Boolean
-      attribute :has_survivors_indemnity_compensation_award, Boolean
-      attribute :has_death_result_of_disability, Boolean
+      attribute :has_survivors_pension_award, Bool
+      attribute :has_survivors_indemnity_compensation_award, Bool
+      attribute :has_death_result_of_disability, Bool
     end
   end
 end

--- a/lib/evss/letters/benefit_information_veteran.rb
+++ b/lib/evss/letters/benefit_information_veteran.rb
@@ -1,29 +1,27 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
-
 module EVSS
   module Letters
     ##
     # Model for a veteran's benefit information
     #
     # @!attribute has_non_service_connected_pension
-    #   @return [Boolean] Returns true if the user has a pension unconnected to their service
+    #   @return [Bool] Returns true if the user has a pension unconnected to their service
     # @!attribute has_service_connected_disabilities
-    #   @return [Boolean] Returns true if the user has a disability connected to their service
+    #   @return [Bool] Returns true if the user has a disability connected to their service
     # @!attribute has_adapted_housing
-    #   @return [Boolean] Returns true if the user has adapted housing
+    #   @return [Bool] Returns true if the user has adapted housing
     # @!attribute has_individual_unemployability_granted
-    #   @return [Boolean] Returns true if the user has been granted individual unemployability
+    #   @return [Bool] Returns true if the user has been granted individual unemployability
     # @!attribute has_special_monthly_compensation
-    #   @return [Boolean] Returns true if the user has special monthly compensation
+    #   @return [Bool] Returns true if the user has special monthly compensation
     #
     class BenefitInformationVeteran < BenefitInformation
-      attribute :has_non_service_connected_pension, Boolean
-      attribute :has_service_connected_disabilities, Boolean
-      attribute :has_adapted_housing, Boolean
-      attribute :has_individual_unemployability_granted, Boolean
-      attribute :has_special_monthly_compensation, Boolean
+      attribute :has_non_service_connected_pension, Bool
+      attribute :has_service_connected_disabilities, Bool
+      attribute :has_adapted_housing, Bool
+      attribute :has_individual_unemployability_granted, Bool
+      attribute :has_special_monthly_compensation, Bool
     end
   end
 end

--- a/lib/evss/letters/letter.rb
+++ b/lib/evss/letters/letter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
 
 module EVSS
   module Letters
@@ -14,7 +14,9 @@ module EVSS
     # @!attribute letter_type
     #   @return [String] The letter type (must be one of LETTER_TYPES)
     #
-    class Letter < Common::Base
+    class Letter
+      include Vets::Model
+
       # if you update LETTER_TYPES, update LETTER_TYPES in vets-website src/applications/letters/utils/constants.js
       LETTER_TYPES = %w[
         benefit_summary

--- a/lib/evss/letters/military_service.rb
+++ b/lib/evss/letters/military_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'common/models/base'
+require 'vets/model'
 
 module EVSS
   module Letters
@@ -17,7 +17,9 @@ module EVSS
     # @!attribute released_date
     #   @return [DateTime] The date the veteran was released from service
     #
-    class MilitaryService < Common::Base
+    class MilitaryService
+      include Vets::Model
+
       attribute :branch, String
       attribute :character_of_service, String
       attribute :entered_date, DateTime


### PR DESCRIPTION
## Summary

EVSS::Letters has a group of models still using Common::Base. It's unclear if EVSS::Letters models are still being used

- Virtus is being replace with `Vets::Model`. Differences include:
    - There's no hash access for attributes `form[:attribute]` only dot notation `form.attribute`
    - Syntax change for Array attributes
    - Sorting uses a class method: `default_sort_by`
    - booleans are temporarily `Bool`, until Virtus is completely gone
- This PR replaces `Virtus` with `Vets::Model` and updates the _attributes_ and _implementation_ accordingly. 
- This change should not affect any functionality.

One change in the vets lib is to allow valid iso8601 to pass without casting

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119090

## Testing done

- [x] Manual testing for similar output

## Acceptance criteria

- [x] Virtus models are now Vets::Model
- [x] No functional change