### PR TITLE
Clear both 28-1900 and 28-1900-V2 save in progress forms

### DIFF
--- a/app/controllers/v0/veteran_readiness_employment_claims_controller.rb
+++ b/app/controllers/v0/veteran_readiness_employment_claims_controller.rb
@@ -25,8 +25,7 @@ module V0
         render json: SavedClaimSerializer.new(claim)
       else
         StatsD.increment("#{stats_key}.failure")
-        Rails.logger.error('VR&E claim was not saved', { vre_modular_api_used: Flipper.enabled?(:vre_modular_api),
-                                                         error_messages: claim.errors,
+        Rails.logger.error('VR&E claim was not saved', { error_messages: claim.errors,
                                                          user_logged_in: current_user.present?,
                                                          current_user_uuid: current_user&.uuid })
         raise Common::Exceptions::ValidationErrors, claim

--- a/app/controllers/v0/veteran_readiness_employment_claims_controller.rb
+++ b/app/controllers/v0/veteran_readiness_employment_claims_controller.rb
@@ -18,7 +18,10 @@ module V0
           VRE::Submit1900Job.perform_async(claim.id, encrypted_user)
         end
         Rails.logger.info "ClaimID=#{claim.confirmation_number} Form=#{claim.class::FORM}"
-        clear_saved_form(claim.form_id)
+        # FIXME: revert to this with issue CVE-2253
+        # clear_saved_form(claim.form_id)
+        clear_saved_form('28-1900')
+        clear_saved_form('28-1900-V2')
         render json: SavedClaimSerializer.new(claim)
       else
         StatsD.increment("#{stats_key}.failure")


### PR DESCRIPTION
## Summary

I'm Adam King, I work for the Core Veteran Experiences team, we own this product.

Currently, the FE app for the VRE (28-1900) form has the form_id set at `28-1900` and the BE app is referencing `28-1900-V2`.  This is causing issues with the save-in-progress forms: when the form is submitted to the back end, we attempt to delete the wrong in-progress form.

This PR is a stopgap measure: attempt to delete any in-progress forms for the user matching both versions (`28-1900` or `28-1900-V2`).  Ticket [2253](https://github.com/department-of-veterans-affairs/va-iir/issues/2253) has been spun up to produce a lasting solution: delete the old PDF template, set the form name to `28-1900`, etc.

This code is not behind a feature toggle.

## Related issue(s)

- [2228](https://github.com/department-of-veterans-affairs/va-iir/issues/2228) ticket for this issue
- [2253](https://github.com/department-of-veterans-affairs/va-iir/issues/2253) cleanup ticket


## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
