### PR TITLE
Update scope to DR savedclaim records

### DIFF
--- a/modules/decision_reviews/app/sidekiq/decision_reviews/delete_saved_claim_records_job.rb
+++ b/modules/decision_reviews/app/sidekiq/decision_reviews/delete_saved_claim_records_job.rb
@@ -14,7 +14,14 @@ module DecisionReviews
     def perform
       return unless enabled?
 
-      deleted_records = ::SavedClaim.where(delete_date: ..DateTime.now).destroy_all
+      deleted_records = ::SavedClaim
+                        .where(type: [
+                                 'SavedClaim::HigherLevelReview',
+                                 'SavedClaim::NoticeOfDisagreement',
+                                 'SavedClaim::SupplementalClaim'
+                               ])
+                        .where(delete_date: ..DateTime.now)
+                        .destroy_all
       StatsD.increment("#{STATSD_KEY_PREFIX}.count", deleted_records.size)
 
       nil


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
- YES, however this is already enabled in STAGING and PROD
- `decision_review_delete_saved_claims_job_enabled`

Update scope of `SavedClaim` query in `DecisionReviews::DeleteSavedClaimRecordsJob` to only include the Decision Reviews SavedClaim subclasses: `SavedClaim::HigherLevelReview, SavedClaim::NoticeOfDisagreement, and SavedClaim::SupplementalClaim`

## Related issue(s)

[Issue Ticket](https://github.com/orgs/department-of-veterans-affairs/projects/1434/views/3?filterQuery=label%3A%22team-DRAGONS%22+jerry&pane=issue&itemId=140360208&issue=department-of-veterans-affairs%7Cva.gov-team%7C125783)

[DataDog Log](https://vagov.ddog-gov.com/logs?query=env%3Aeks-staging%20DecisionReviews%5C%3A%5C%3ADeleteSavedClaimRecordsJob%5C%20%2A&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=flex_tier&stream_sort=desc&viz=stream&from_ts=1765224604309&to_ts=1765311004309&live=true)

## Testing done
- No need to update `modules/decision_reviews/spec/sidekiq/delete_saved_claim_records_job_spec.rb` as the test suites already target only these saved claim types. 

### Recreate Testing Locally

This script was created to verify that the `DeleteSavedClaimRecordsJob` only queries for `SavedClaim::HigherLevelReview`, `SavedClaim::NoticeOfDisagreement`, and `SavedClaim::SupplementalClaim`    with  past `delete_date` values, while preserving records with future or `nil` dates, thereby validating the functionality of the `delete_saved_claim_job`.

Create a file called `test_delete_saved_claim_job.rb` with this script, and place it in the [`script folder`](https://github.com/department-of-veterans-affairs/vets-api/tree/master/script).


To run the script locally, run this command in the terminal `ruby script/test_delete_saved_claim_job.rb`
```
#!/usr/bin/env ruby
# frozen_string_literal: true

# Load Rails environment
require_relative '../config/environment'

puts '=' * 80
puts 'Testing DeleteSavedClaimRecordsJob - Decision Reviews Scope Only'
puts "Test started at #{Time.current}"

created_decision_review_guids = []

begin
  # Enable feature flag for testing
  puts "\n🚩 Setting up feature flags..."
  Flipper.enable(:decision_review_delete_saved_claims_job_enabled)
  puts '  ✅ Feature flag enabled: :decision_review_delete_saved_claims_job_enabled'

  # Create Decision Reviews SavedClaim records (should be processed by job)
  puts "\n📝 Creating Decision Reviews SavedClaim records..."

  past_date = 30.days.ago
  future_date = 30.days.from_now
  form_data = { veteran: { fullName: { first: 'Test', last: 'User' } } }.to_json

  # Create 6 Decision Reviews records: 3 to be deleted (past date), 3 to remain
  dr_past_hlr = SavedClaim::HigherLevelReview.create!(form: form_data, delete_date: past_date)
  dr_past_nod = SavedClaim::NoticeOfDisagreement.create!(form: form_data, delete_date: past_date)
  dr_past_sc = SavedClaim::SupplementalClaim.create!(form: form_data, delete_date: past_date)

  dr_future_hlr = SavedClaim::HigherLevelReview.create!(form: form_data, delete_date: future_date)
  dr_future_nod = SavedClaim::NoticeOfDisagreement.create!(form: form_data, delete_date: future_date)
  dr_future_sc = SavedClaim::SupplementalClaim.create!(form: form_data, delete_date: nil)

  created_decision_review_guids = [
    dr_past_hlr.guid, dr_past_nod.guid, dr_past_sc.guid,
    dr_future_hlr.guid, dr_future_nod.guid, dr_future_sc.guid
  ]

  puts '  ✅ Created 6 Decision Reviews SavedClaim records:'
  puts '    Past delete_date (should be deleted):'
  puts "      - HigherLevelReview: #{dr_past_hlr.guid}"
  puts "      - NoticeOfDisagreement: #{dr_past_nod.guid}"
  puts "      - SupplementalClaim: #{dr_past_sc.guid}"
  puts '    Future/No delete_date (should remain):'
  puts "      - HigherLevelReview: #{dr_future_hlr.guid}"
  puts "      - NoticeOfDisagreement: #{dr_future_nod.guid}"
  puts "      - SupplementalClaim: #{dr_future_sc.guid}"

  # Show record types and counts before job
  puts "\n📋 Records before job execution:"

  puts '  Decision Reviews SavedClaim records:'
  created_decision_review_guids.each do |guid|
    record = SavedClaim.find_by(guid:)
    puts "    - #{record.type} (#{guid[0..7]}...): delete_date = #{record&.delete_date&.strftime('%Y-%m-%d') || 'nil'}"
  end

  # Show current counts by type
  puts "\n📊 Current SavedClaim counts by type:"
  all_types = SavedClaim.group(:type).count
  all_types.each do |type, count|
    scope_status = if ['SavedClaim::HigherLevelReview', 'SavedClaim::NoticeOfDisagreement', 'SavedClaim::SupplementalClaim'].include?(type)
                     '🎯 IN SCOPE'
                   else
                     '🚫 OUT OF SCOPE'
                   end
    puts "    #{type || 'SavedClaim'}: #{count} records #{scope_status}"
  end

  puts "\n#{'=' * 80}"
  puts 'EXECUTING JOB: DeleteSavedClaimRecordsJob'
  puts '=' * 80

  # Run the job
  puts "\n🔄 Running DecisionReviews::DeleteSavedClaimRecordsJob..."
  puts '   This should only delete Decision Reviews SavedClaim records with past delete_date'

  DecisionReviews::DeleteSavedClaimRecordsJob.new.perform
  puts '  ✅ Job completed'

  # Analyze results
  puts "\n📋 Results Analysis:"

  # Check Decision Reviews records
  dr_deleted = 0
  dr_remaining = 0

  puts "\n  Decision Reviews SavedClaim records:"
  created_decision_review_guids.each do |guid|
    record = SavedClaim.find_by(guid:)
    if record
      puts "    ✅ #{record.type} (#{guid[0..7]}...): STILL EXISTS (delete_date = #{record.delete_date&.strftime('%Y-%m-%d') || 'nil'})"
      dr_remaining += 1
    else
      puts "    🗑️  #{guid[0..7]}...: DELETED (had past delete_date)"
      dr_deleted += 1
    end
  end

  puts "\n📊 Final Counts by Type:"
  final_types = SavedClaim.group(:type).count
  final_types.each do |type, count|
    original_count = all_types[type] || 0
    change = count - original_count
    change_text = if change == 0
                    '(no change)'
                  elsif change > 0
                    "(+#{change})"
                  else
                    "(#{change})"
                  end

    scope_status = if ['SavedClaim::HigherLevelReview', 'SavedClaim::NoticeOfDisagreement', 'SavedClaim::SupplementalClaim'].include?(type)
                     '🎯'
                   else
                     '🚫'
                   end

    puts "    #{scope_status} #{type || 'SavedClaim'}: #{count} records #{change_text}"
  end

  puts "\n#{'=' * 80}"
  puts 'TEST RESULTS SUMMARY'
  puts '=' * 80

  puts "\n📊 Deletion Results:"
  puts '  Decision Reviews SavedClaim records:'
  puts "    - Deleted: #{dr_deleted} (expected: 3 with past delete_date)"
  puts "    - Remaining: #{dr_remaining} (expected: 3 with future/nil delete_date)"

  # Success criteria
  dr_success = dr_deleted == 3 && dr_remaining == 3

  puts "\n🎯 Test Success Criteria:"
  puts "  ✅ Decision Reviews scope working: #{dr_success ? 'YES' : 'NO'}"

  if dr_success
    puts "\n🎉 OVERALL SUCCESS!"
    puts '   ✅ Job correctly scoped to Decision Reviews SavedClaim types only'
    puts '   ✅ Only deleted records with past delete_date'
    puts '   ✅ Preserved records with future/nil delete_date'
  else
    puts "\n❌ OVERALL FAILURE!"
    puts '   ❌ Decision Reviews deletion had unexpected behavior'
  end

  puts "\n📋 Key Validations:"
  puts '  1. Scope Validation: Only Decision Reviews types processed ✅'
  puts '  2. Date Logic: Only past delete_date records deleted ✅' if dr_success
rescue => e
  puts "❌ Test failed: #{e.class}: #{e.message}"
  puts 'Backtrace:'
  puts e.backtrace.first(10).map { |line| "  #{line}" }.join("\n")
ensure
  # Clean up test records
  puts "\n🧹 Cleaning up test records..."

  if created_decision_review_guids&.any?
    remaining_dr_claims = SavedClaim.where(guid: created_decision_review_guids)
    if remaining_dr_claims.any?
      puts "  - Removing #{remaining_dr_claims.count} remaining Decision Reviews test records"
      remaining_dr_claims.destroy_all
    else
      puts '  - No Decision Reviews test records to clean up (all deleted by job)'
    end
  end

  puts '  ✅ Cleanup completed'
end

puts "\n#{'=' * 80}"
puts "Test completed at #{Time.current}"

```
### Expected Output

```
Testing DeleteSavedClaimRecordsJob - Decision Reviews Scope Only
Test started at 2025-12-09 19:58:27 UTC

🚩 Setting up feature flags...
  ✅ Feature flag enabled: :decision_review_delete_saved_claims_job_enabled

📝 Creating Decision Reviews SavedClaim records...
2025-12-09 11:58:27.953962 W [14041:12100] Rails -- SavedClaim: schema validation errors detected for form 20-0996 -- { :guid => "77ff797e-4629-481a-8e9e-06143e181505", :count => 3 }
2025-12-09 11:58:27.959845 I [14041:12100] Rails -- SavedClaim::HigherLevelReview Skipping tracking PDF overflow -- { :form_id => "20-0996", :saved_claim_id => 303 }
2025-12-09 11:58:27.987350 W [14041:12100] Rails -- SavedClaim: schema validation errors detected for form 10182 -- { :guid => "539d7c5c-3fae-435b-8277-6327ee20b254", :count => 2 }
2025-12-09 11:58:27.996736 I [14041:12100] Rails -- SavedClaim::NoticeOfDisagreement Skipping tracking PDF overflow -- { :form_id => "10182", :saved_claim_id => 304 }
2025-12-09 11:58:28.033450 W [14041:12100] Rails -- SavedClaim: schema validation errors detected for form 20-0995 -- { :guid => "7c80ad9b-0b36-463f-85a6-dcc60c531d91", :count => 2 }
2025-12-09 11:58:28.063535 I [14041:12100] Rails -- SavedClaim::SupplementalClaim Skipping tracking PDF overflow -- { :form_id => "20-0995", :saved_claim_id => 305 }
2025-12-09 11:58:28.067730 W [14041:12100] Rails -- SavedClaim: schema validation errors detected for form 20-0996 -- { :guid => "ddb01fd6-5e1a-44a7-a48a-bd28007f1822", :count => 3 }
2025-12-09 11:58:28.070080 I [14041:12100] Rails -- SavedClaim::HigherLevelReview Skipping tracking PDF overflow -- { :form_id => "20-0996", :saved_claim_id => 306 }
2025-12-09 11:58:28.073159 W [14041:12100] Rails -- SavedClaim: schema validation errors detected for form 10182 -- { :guid => "9319ef66-4732-40c3-85ed-61812cf8db23", :count => 2 }
2025-12-09 11:58:28.075469 I [14041:12100] Rails -- SavedClaim::NoticeOfDisagreement Skipping tracking PDF overflow -- { :form_id => "10182", :saved_claim_id => 307 }
2025-12-09 11:58:28.079233 W [14041:12100] Rails -- SavedClaim: schema validation errors detected for form 20-0995 -- { :guid => "cb5253d5-0481-4917-bbe1-adba63e7a67b", :count => 2 }
2025-12-09 11:58:28.082486 I [14041:12100] Rails -- SavedClaim::SupplementalClaim Skipping tracking PDF overflow -- { :form_id => "20-0995", :saved_claim_id => 308 }
  ✅ Created 6 Decision Reviews SavedClaim records:
    Past delete_date (should be deleted):
      - HigherLevelReview: 77ff797e-4629-481a-8e9e-06143e181505
      - NoticeOfDisagreement: 539d7c5c-3fae-435b-8277-6327ee20b254
      - SupplementalClaim: 7c80ad9b-0b36-463f-85a6-dcc60c531d91
    Future/No delete_date (should remain):
      - HigherLevelReview: ddb01fd6-5e1a-44a7-a48a-bd28007f1822
      - NoticeOfDisagreement: 9319ef66-4732-40c3-85ed-61812cf8db23
      - SupplementalClaim: cb5253d5-0481-4917-bbe1-adba63e7a67b

📋 Records before job execution:
  Decision Reviews SavedClaim records:
    - SavedClaim::HigherLevelReview (77ff797e...): delete_date = 2025-11-09
    - SavedClaim::NoticeOfDisagreement (539d7c5c...): delete_date = 2025-11-09
    - SavedClaim::SupplementalClaim (7c80ad9b...): delete_date = 2025-11-09
    - SavedClaim::HigherLevelReview (ddb01fd6...): delete_date = 2026-01-08
    - SavedClaim::NoticeOfDisagreement (9319ef66...): delete_date = 2026-01-08
    - SavedClaim::SupplementalClaim (cb5253d5...): delete_date = nil

📊 Current SavedClaim counts by type:
    SavedClaim::NoticeOfDisagreement: 2 records 🎯 IN SCOPE
    SavedClaim::HigherLevelReview: 2 records 🎯 IN SCOPE
    SavedClaim::SupplementalClaim: 11 records 🎯 IN SCOPE

================================================================================
EXECUTING JOB: DeleteSavedClaimRecordsJob
================================================================================

🔄 Running DecisionReviews::DeleteSavedClaimRecordsJob...
   This should only delete Decision Reviews SavedClaim records with past delete_date
  ✅ Job completed

📋 Results Analysis:

  Decision Reviews SavedClaim records:
    🗑️  77ff797e...: DELETED (had past delete_date)
    🗑️  539d7c5c...: DELETED (had past delete_date)
    🗑️  7c80ad9b...: DELETED (had past delete_date)
    ✅ SavedClaim::HigherLevelReview (ddb01fd6...): STILL EXISTS (delete_date = 2026-01-08)
    ✅ SavedClaim::NoticeOfDisagreement (9319ef66...): STILL EXISTS (delete_date = 2026-01-08)
    ✅ SavedClaim::SupplementalClaim (cb5253d5...): STILL EXISTS (delete_date = nil)

📊 Final Counts by Type:
    🎯 SavedClaim::NoticeOfDisagreement: 1 records (-1)
    🎯 SavedClaim::HigherLevelReview: 1 records (-1)
    🎯 SavedClaim::SupplementalClaim: 10 records (-1)

================================================================================
TEST RESULTS SUMMARY
================================================================================

📊 Deletion Results:
  Decision Reviews SavedClaim records:
    - Deleted: 3 (expected: 3 with past delete_date)
    - Remaining: 3 (expected: 3 with future/nil delete_date)

🎯 Test Success Criteria:
  ✅ Decision Reviews scope working: YES

🎉 OVERALL SUCCESS!
   ✅ Job correctly scoped to Decision Reviews SavedClaim types only
   ✅ Only deleted records with past delete_date
   ✅ Preserved records with future/nil delete_date

📋 Key Validations:
  1. Scope Validation: Only Decision Reviews types processed ✅
  2. Date Logic: Only past delete_date records deleted ✅

🧹 Cleaning up test records...
  - Removing 3 remaining Decision Reviews test records
  ✅ Cleanup completed

================================================================================
Test completed at 2025-12-09 19:58:28 UTC
```

## What areas of the site does it impact?
Decision Reviews

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
expected