### PR TITLE
Revert "Revise automated email to Pega for missing status (#25067)"

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1575,7 +1575,6 @@ vanotify:
     ivc_champva:
       api_key: <%= ENV['vanotify__services__ivc_champva__api_key'] %>
       failure_email_threshold_days: 7
-      missing_pega_status_email_threshold_hours: 2
       pega_inbox_address: <%= ENV['vanotify__services__ivc_champva__pega_inbox_address'] %>
       template_id:
         form_10_10d_email: <%= ENV['vanotify__services__ivc_champva__template_id__form_10_10d_email'] %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1594,7 +1594,6 @@ vanotify:
     ivc_champva:
       api_key: fake_secret
       failure_email_threshold_days: 7
-      missing_pega_status_email_threshold_hours: 2
       pega_inbox_address: fake_email_address
       template_id:
         form_10_10d_email: form_10_10d_email

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1593,7 +1593,6 @@ vanotify:
     ivc_champva:
       api_key: fake_secret
       failure_email_threshold_days: 7
-      missing_pega_status_email_threshold_hours: 2
       pega_inbox_address: fake_email_address
       template_id:
         form_10_10d_email: form_10_10d_email

--- a/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
+++ b/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
@@ -26,28 +26,22 @@ module IvcChampva
 
       batches.each_value do |batch|
         form = batch[0] # get a representative form from this submission batch
-        next if form.nil? # Return early if form is nil
 
         # Check reporting API to see if this missing status is a false positive
         next if Flipper.enabled?(:champva_enable_pega_report_check, @current_user) && num_docs_match_reports?(batch)
 
-        # Check if we've been missing Pega status for > custom thresholds:
+        # Check if we've been missing Pega status for > custom threshold of days:
         elapsed_days = (current_time - form.created_at).to_i / 1.day
-        elapsed_minutes = (current_time - form.created_at).to_i / 1.minute
-        failure_email_threshold_days =
-          Settings.vanotify.services.ivc_champva.failure_email_threshold_days.presence&.to_i || 7
-        pega_email_threshold_hours =
-          Settings.vanotify.services.ivc_champva.missing_pega_status_email_threshold_hours.presence&.to_i || 2
-
-        if elapsed_days >= failure_email_threshold_days && !form.email_sent
+        threshold = Settings.vanotify.services.ivc_champva.failure_email_threshold_days.to_i || 7
+        if elapsed_days >= threshold && !form.email_sent
           template_id = "#{form[:form_number]}-FAILURE"
           additional_context = { form_id: form[:form_number], form_uuid: form[:form_uuid] }
 
           send_failure_email(form, template_id, additional_context)
           send_zsf_notification_to_pega(form, 'PEGA-TEAM-ZSF')
-        elsif elapsed_minutes >= (pega_email_threshold_hours * 60) && !form.email_sent
+        elsif elapsed_days >= (threshold - 2) && !form.email_sent
           # TODO: further limit this so we're not sending PEGA an email every time this job runs
-          # Alert Pega that there is a missing status
+          # Give pega 2-day notice if we intend to email a user.
           send_zsf_notification_to_pega(form, 'PEGA-TEAM_MISSING_STATUS')
         end
 
@@ -64,15 +58,6 @@ module IvcChampva
         first_name: form.first_name,
         last_name: form.last_name,
         form_number: form.form_number,
-        file_count: nil,
-        pega_status: form.pega_status,
-        date_submitted: form.created_at.strftime('%B %d, %Y'),
-        template_id:,
-        form_uuid: form.form_uuid }
-    end
-
-    def construct_email_payload_without_pii(form, template_id)
-      { form_number: form.form_number,
         file_count: nil,
         pega_status: form.pega_status,
         date_submitted: form.created_at.strftime('%B %d, %Y'),
@@ -121,7 +106,7 @@ module IvcChampva
     # @param form_data [hash] hash of form details (see `send_failure_email`)
     # @param form [IvcChampvaForm] form object in question
     def send_zsf_notification_to_pega(form, template_id)
-      form_data = construct_email_payload_without_pii(form, template_id)
+      form_data = construct_email_payload(form, template_id)
       form_data = form_data.merge({
                                     email: Settings.vanotify.services.ivc_champva.pega_inbox_address
                                   })


### PR DESCRIPTION
This reverts commit 6bec93446f48b1a5509196a9131e09fc18880808.

Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- This work is behind a feature toggle (flipper): YES/NO
- This reverts the changes made in the [previous PR](https://github.com/department-of-veterans-affairs/vets-api/pull/25067)
- This is the solution because the changes did not pass testing in staging and must not go to production
- I work for the Health Apps team and we own this module

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123908
- https://github.com/department-of-veterans-affairs/vets-api/pull/25067

## Testing done

- No testing performed, this is a revert

## Screenshots
None

## What areas of the site does it impact?
This impacts only the PEGA-TEAM_MISSING_STATUS emails sent by the IVC CHAMPVAMissingFormStatusJob`

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
None
