### PR TITLE
Logging added to ensure 'RESIDENCE/CHOICE' has been replaced

### DIFF
--- a/app/controllers/concerns/vet360/writeable.rb
+++ b/app/controllers/concerns/vet360/writeable.rb
@@ -47,7 +47,10 @@ module Vet360
         params[:validation_key] ||= params[:override_validation_key]
 
         # Ensures the address_pou is valid
-        params[:address_pou] = 'RESIDENCE' if params[:address_pou] == 'RESIDENCE/CHOICE'
+        if params[:address_pou] == 'RESIDENCE/CHOICE'
+          params[:address_pou] = 'RESIDENCE'
+          Rails.logger.info('RESIDENCE/CHOICE POU conversion detected')
+        end
       else
         model = "VAProfile::Models::#{type.capitalize}"
       end


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

RESIDENCE/CHOICE was removed in the vets-website. RESIDENCE/CHOICE logs were added to ensure `RESIDENCE` addresses replaced `RESIDENCE/CHOICE` in the front end.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/109402
- department-of-veterans-affairs/vets-website/pull/40689
- department-of-veterans-affairs/vets-json-schema/pull/1088

## Testing done

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
