### PR TITLE
127003 support for new reason code modalities

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
@@ -15,8 +15,10 @@ module VAOS
       # Preferred modality text
       MODALITY_TEXT = {
         'FACE TO FACE' => 'In person',
+        'IN-PERSON' => 'In person',
         'VIDEO' => 'Video',
-        'TELEPHONE' => 'Phone'
+        'TELEPHONE' => 'Phone',
+        'PHONE' => 'Phone'
       }.freeze
 
       # Input format for preferred dates
@@ -100,9 +102,9 @@ module VAOS
       # @param reason_code_hash [Hash] the hash of reason code key value pairs
       # @return [Hash, nil] A hash containing the contact info, or nil if not possible.
       def extract_contact_fields(reason_code_hash)
-        if reason_code_hash.key?('phone number') || reason_code_hash.key?('email')
+        if reason_code_hash.key?('phone') || reason_code_hash.key?('phone number') || reason_code_hash.key?('email')
           contact_info = []
-          contact_info.push({ type: 'phone', value: reason_code_hash['phone number'] })
+          contact_info.push({ type: 'phone', value: reason_code_hash['phone'] || reason_code_hash['phone number'] })
           contact_info.push({ type: 'email', value: reason_code_hash['email'] })
           { telecom: contact_info }
         end
@@ -126,7 +128,9 @@ module VAOS
       # @param reason_code_hash [Hash] the hash of reason code key value pairs
       # @return [String, nil] The preferred modality for appointment as a string, or nil if not possible.
       def extract_preferred_modality(reason_code_hash)
-        if reason_code_hash.key?('preferred modality') && MODALITY_TEXT.key?(reason_code_hash['preferred modality'])
+        if reason_code_hash.key?('modality') && MODALITY_TEXT.key?(reason_code_hash['modality'])
+          MODALITY_TEXT[reason_code_hash['modality']]
+        elsif reason_code_hash.key?('preferred modality') && MODALITY_TEXT.key?(reason_code_hash['preferred modality'])
           MODALITY_TEXT[reason_code_hash['preferred modality']]
         end
       end

--- a/modules/vaos/spec/factories/v2/appointment_forms.rb
+++ b/modules/vaos/spec/factories/v2/appointment_forms.rb
@@ -251,6 +251,22 @@ FactoryBot.define do
       end
     end
 
+    trait :va_proposed_valid_reason_code_text_new_fields do
+      va_proposed_base
+      kind { 'clinic' }
+      reason_code do
+        { text: 'station: 983|modality: IN-PERSON|phone: 6195551234|email: myemail72585885@unattended.com|preferred dates:06/26/2024 AM,06/26/2024 PM|reason code:ROUTINEVISIT|comments:colon:in:comment' } # rubocop:disable Layout/LineLength
+      end
+    end
+
+    trait :va_proposed_valid_reason_code_text_old_and_new_fields do
+      va_proposed_base
+      kind { 'clinic' }
+      reason_code do
+        { text: 'station: 983|station id: 984|preferred modality: FACE TO FACE|modality: IN-PERSON|phone: 6195551234|phone number: 6195551235|email: myemail72585885@unattended.com|preferred dates:06/26/2024 AM,06/26/2024 PM|reason code:ROUTINEVISIT|comments:colon:in:comment' } # rubocop:disable Layout/LineLength
+      end
+    end
+
     trait :va_proposed_valid_and_invalid_reason_code_text do
       va_proposed_base
       kind { 'clinic' }

--- a/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
@@ -76,6 +76,32 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       expect(appt[:preferred_modality]).to eq('In person')
     end
 
+    it 'extract new valid reason code fields for va request' do
+      appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text_new_fields).attributes
+      subject.extract_reason_code_fields(appt)
+      expect(appt[:contact][:telecom][0]).to match({ type: 'phone', value: '6195551234' })
+      expect(appt[:contact][:telecom][1]).to match({ type: 'email', value: 'myemail72585885@unattended.com' })
+      expect(appt[:patient_comments]).to eq('colon:in:comment')
+      expect(appt[:reason_for_appointment]).to eq('Routine/Follow-up')
+      expect(appt[:preferred_dates]).to eq(['Wednesday, June 26, 2024 in the morning',
+                                            'Wednesday, June 26, 2024 in the afternoon'])
+      expect(appt[:preferred_modality]).to eq('In person')
+    end
+
+    context 'when there are old and new field names' do
+      it 'extract new valid reason code fields for va request' do
+        appt = build(:appointment_form_v2, :va_proposed_valid_reason_code_text_old_and_new_fields).attributes
+        subject.extract_reason_code_fields(appt)
+        expect(appt[:contact][:telecom][0]).to match({ type: 'phone', value: '6195551234' })
+        expect(appt[:contact][:telecom][1]).to match({ type: 'email', value: 'myemail72585885@unattended.com' })
+        expect(appt[:patient_comments]).to eq('colon:in:comment')
+        expect(appt[:reason_for_appointment]).to eq('Routine/Follow-up')
+        expect(appt[:preferred_dates]).to eq(['Wednesday, June 26, 2024 in the morning',
+                                              'Wednesday, June 26, 2024 in the afternoon'])
+        expect(appt[:preferred_modality]).to eq('In person')
+      end
+    end
+
     context 'when there are valid and invalid reason code fields' do
       it 'extract only valid reason code fields for va request' do
         appt = build(:appointment_form_v2, :va_proposed_valid_and_invalid_reason_code_text).attributes


### PR DESCRIPTION
## Summary

- This work is to update the vets-api appointments reason code service to support new field name mappings and modalities outlined in the linked ticket

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127003

## Testing done

- Updated unit tests to cover new modalities, ran regression tests
