### PR TITLE
Adding authn_context to support SSOe ialmax

### DIFF
--- a/config/initializers/ial.rb
+++ b/config/initializers/ial.rb
@@ -13,4 +13,6 @@ module IAL
   LOGIN_GOV_IAL1_MFA = 'http://idmanagement.gov/ns/assurance/ial/1/mfa'
   LOGIN_GOV_IAL2_2FA = 'http://idmanagement.gov/ns/assurance/ial/2/2fa'
   LOGIN_GOV_IAL2_MFA = 'http://idmanagement.gov/ns/assurance/ial/2/mfa'
+
+  IDME_IAL2 = 'http://idmanagement.gov/ns/assurance/ial/2/aal/2'
 end

--- a/lib/saml/user.rb
+++ b/lib/saml/user.rb
@@ -18,6 +18,7 @@ module SAML
       LOA::IDME_LOA1_MFA => { loa_current: LOA::ONE, sign_in: { service_name: IDME_CSID } },
       LOA::IDME_LOA3_VETS => { loa_current: LOA::THREE, sign_in: { service_name: IDME_CSID } },
       LOA::IDME_LOA3 => { loa_current: LOA::THREE, sign_in: { service_name: IDME_CSID } },
+      IAL::IDME_IAL2 => { loa_current: LOA::THREE, sign_in: { service_name: IDME_CSID } },
       'multifactor' => { loa_current: nil, sign_in: { service_name: IDME_CSID } },
       'myhealthevet_multifactor' => { loa_current: nil, sign_in: { service_name: MHV_ORIGINAL_CSID } },
       'myhealthevet_loa3' => { loa_current: LOA::THREE, sign_in: { service_name: MHV_ORIGINAL_CSID } },


### PR DESCRIPTION
## Summary

- This PR adds authn_context to support SSOe IALMAX

## Testing done

- [ ] Created an ial2 test user, proved that I could log in on va.gov with sign in params `oauth=false`

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [ ]  Create ial2 id.me test user (not loa3 equivalent, needs to be ial2 equivalent)
- [ ] Attempt to log in with sign in params `oauth=false`
