### PR TITLE
remove id.me feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -966,10 +966,6 @@ features:
     actor_type: user
     description: Enables Representative Status widget 2.0 features for frontend and backend
     enable_in_development: true
-  accredited_representative_portal_id_me:
-    actor_type: user
-    description: Enables ID.me authentication feature for frontend and backend
-    enable_in_development: true
   form526_legacy:
     actor_type: user
     description: If true, points controllers to the legacy EVSS Form 526 instance. If false, the controllers will use the Dockerized instance running in DVP.


### PR DESCRIPTION
Removing id.me feature flag as the rollout was successful and we no longer need the option to hide id.me login for ARP. There is a follow-on task to remove the feature flags in the staging and prod DB once this is merged.