### PR TITLE
Add benefit type to claims_submission endpoint

### DIFF
--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/claim_submissions_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/claim_submissions_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::ClaimSubmissionsController, t
                 'submittedDate' => saved_claim_claimant_representative_a.created_at.to_date.iso8601,
                 'firstName' => 'John',
                 'lastName' => 'Doe',
+                'benefitType' => nil,
                 'formType' => '21-686c',
                 'packet' => false,
                 'confirmationNumber' =>
@@ -81,6 +82,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::ClaimSubmissionsController, t
                 'firstName' => 'John',
                 'lastName' => 'Doe',
                 'formType' => '21-686c',
+                'benefitType' => nil,
                 'packet' => false,
                 'confirmationNumber' =>
                   saved_claim_claimant_representative_b.saved_claim.latest_submission_attempt.benefits_intake_uuid,

--- a/modules/accredited_representative_portal/spec/serializers/accredited_representative_portal/saved_claim_claimant_representative_serializer_spec.rb
+++ b/modules/accredited_representative_portal/spec/serializers/accredited_representative_portal/saved_claim_claimant_representative_serializer_spec.rb
@@ -38,13 +38,6 @@ RSpec.describe AccreditedRepresentativePortal::SavedClaimClaimantRepresentativeS
     end
   end
 
-  describe '#benefit_type' do
-    it 'returns benefit type' do
-      benefit_type = saved_claim_claimant_rep.saved_claim.latest_submission_attempt.benefit_type
-      expect(subject[:benefitType]).to eq benefit_type
-    end
-  end
-
   describe 'vbms_status' do
     context 'submission attempt is pending and over 10 days ago' do
       it 'returns awaiting_receipt_warning' do


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

Add benefitType to claims_submission API endpoint

## Related issue(s)

Partial [Display ITF activity in the "Recent Submissions" section of the Submissions page #126380](https://github.com/department-of-veterans-affairs/va.gov-team/issues/126380)

## Testing done

- [ ] *New code is covered by unit tests*
- Tested locally

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
