### PR TITLE
2239 enrollment periods 404

### DIFF
--- a/.solargraph.yml
+++ b/.solargraph.yml
@@ -1,0 +1,3 @@
+plugins:
+  - solargraph-rails
+max_files: 6000

--- a/.solargraph.yml
+++ b/.solargraph.yml
@@ -1,3 +1,0 @@
-plugins:
-  - solargraph-rails
-max_files: 6000

--- a/spec/requests/v0/form1095_bs_spec.rb
+++ b/spec/requests/v0/form1095_bs_spec.rb
@@ -173,6 +173,7 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
       context 'when user was not enrolled during allowed date range' do
         # per the vcr cassette, user was not enrolled in 2023
         before { Timecop.freeze(Time.zone.parse('2024-03-05T08:00:00Z')) }
+        after { Timecop.return }
 
         it 'returns an empty array' do
           VCR.use_cassette('veteran_enrollment_system/enrollment_periods/get_success',

--- a/spec/requests/v0/form1095_bs_spec.rb
+++ b/spec/requests/v0/form1095_bs_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
         sign_in_as(user)
       end
 
-      it 'returns success with list of available form years from the past four tax years' do
+      it 'returns success with list of available form years during allowed date range' do
         VCR.use_cassette('veteran_enrollment_system/enrollment_periods/get_success',
                          { match_requests_on: %i[method uri] }) do
           get '/v0/form1095_bs/available_forms'
@@ -155,6 +155,47 @@ RSpec.describe 'V0::Form1095Bs', type: :request do
               last_updated: nil }
           ] }
         )
+      end
+
+      context 'when user not found on enrollment system' do
+        it 'returns success with an empty list' do
+          VCR.use_cassette('veteran_enrollment_system/enrollment_periods/get_not_found',
+                           { match_requests_on: %i[method uri] }) do
+            get '/v0/form1095_bs/available_forms'
+          end
+          expect(response).to have_http_status(:success)
+          expect(response.parsed_body.deep_symbolize_keys).to eq(
+            { available_forms: [] }
+          )
+        end
+      end
+
+      context 'when user was not enrolled during allowed date range' do
+        # per the vcr cassette, user was not enrolled in 2023
+        before { Timecop.freeze(Time.zone.parse('2024-03-05T08:00:00Z')) }
+
+        it 'returns an empty array' do
+          VCR.use_cassette('veteran_enrollment_system/enrollment_periods/get_success',
+                           { match_requests_on: %i[method uri] }) do
+            get '/v0/form1095_bs/available_forms'
+          end
+          expect(response).to have_http_status(:success)
+          expect(response.parsed_body.deep_symbolize_keys).to eq(
+            { available_forms: [] }
+          )
+        end
+      end
+
+      context 'when an error is received from the enrollment system' do
+        it 'returns appropriate error status' do
+          # stubbing instead of using cassette because I haven't been able to produce errors other than 404 on
+          # enrollment system
+          upstream_response = OpenStruct.new(status: 400)
+          allow_any_instance_of(VeteranEnrollmentSystem::EnrollmentPeriods::Service).to \
+            receive(:perform).and_return(upstream_response)
+          get '/v0/form1095_bs/available_forms'
+          expect(response).to have_http_status(:bad_request)
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES
- This PR rescues 404 errors from the enrollment periods service and returns an empty array to indicate that the user was not enrolled in healthcare. This makes more sense than 404 because the vets-api knows the user even if the enrollment service does not. This is also more consistent with the old (pre feature flag) behavior.
- I'm on the CVE team.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-iir/issues/2239

## Testing done

- [x] *New code is covered by unit tests*
- The old behavior was to return 404 if the user doesn't have any enrollment period data.
- This can be tested on staging with a test user who was not enrolled in health care in the 2024 tax year. User vets.gov.user+7@gmail.com will work. I will also test this on staging. 
- *If this work is behind a flipper:*
  - Yes, this has tests both with and without flag on.
  - *What is the testing plan for rolling out the feature?* I will test on staging.

## Screenshots

## What areas of the site does it impact?
1095b only.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
