### PR TITLE
chore: add cooldown period to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
       interval: "daily"
       time: "09:00"
       timezone: "UTC"
+    cooldown:
+      semver-major-days: 21
+      semver-minor-days: 14
+      semver-patch-days: 7
     ignore:
       - dependency-name: "vets_json_schema"
       - dependency-name: "active_model_serializers"


### PR DESCRIPTION
## Summary
- Adds cooldown periods to prevent Dependabot from immediately re-creating PRs after they are closed
- Cooldown periods by semver type:
  - Patch: 7 days
  - Minor: 14 days
  - Major: 21 days

## Test plan
- [ ] Verify Dependabot configuration is valid by checking GitHub Actions
- [ ] Monitor Dependabot behavior after merge