### PR TITLE
chore: remove active_model_serializers from Dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
       timezone: "UTC"
     ignore:
       - dependency-name: "vets_json_schema"
-      - dependency-name: "active_model_serializers"
       - dependency-name: "sidekiq"
       - dependency-name: "sidekiq-pro"
       - dependency-name: "sidekiq-ent"


### PR DESCRIPTION
## Summary
- Removes `active_model_serializers` from the Dependabot ignore list per [this comment](https://github.com/department-of-veterans-affairs/vets-api/pull/25583#issuecomment-3656826854)
- Allows Dependabot to create PRs for active_model_serializers updates

## Test plan
- [ ] Verify Dependabot configuration is valid
- [ ] Monitor for active_model_serializers update PRs after merge