### PR TITLE
Add case sensitivity warning to Flipper UI actor input

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -41,7 +41,7 @@ Rails.application.reloader.to_prepare do
     config.show_feature_description_in_list = true
     config.confirm_disable = true
     config.confirm_fully_enable = true
-    config.add_actor_placeholder = 'actor ID (or comma-separated list)'
+    config.add_actor_placeholder = 'CASE SENSITIVE: lowercase email or UUID (comma-separated for multiple)'
     config.descriptions_source = lambda do |_keys|
       FLIPPER_FEATURE_CONFIG['features'].transform_values { |value| value['description'] }
     end

--- a/spec/requests/flipper_spec.rb
+++ b/spec/requests/flipper_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe 'flipper', type: :request do
       allow(user).to receive(:team_member?).with(Settings.flipper.github_team).and_return(true)
     end
 
-    it 'displays placeholder text indicating comma-separated values are supported' do
+    it 'displays placeholder text indicating case sensitivity and comma-separated values are supported' do
       feature = Flipper[:this_is_only_a_test]
       allow(feature).to receive_messages(boolean_value: false, actors_value: [])
 
@@ -409,9 +409,11 @@ RSpec.describe 'flipper', type: :request do
       assert_response :success
 
       body = Nokogiri::HTML(response.body)
-      actor_input = body.at_css('input[name="value"][placeholder*="comma"]')
+      actor_input = body.at_css('input[name="value"][placeholder*="CASE SENSITIVE"]')
       expect(actor_input).not_to be_nil
-      expect(actor_input['placeholder']).to include('comma')
+      expect(actor_input['placeholder']).to include('CASE SENSITIVE')
+      expect(actor_input['placeholder']).to include('lowercase email')
+      expect(actor_input['placeholder']).to include('comma-separated')
     end
   end
 end


### PR DESCRIPTION
## Summary

This PR adds a case sensitivity warning to the Flipper UI actor input placeholder to help users avoid issues when adding actors.

## Background

Flipper actor IDs are **case sensitive**. The `User` model's `flipper_id` method returns:
- **Lowercase email address** (e.g., `user@example.com`)
- **User account UUID** (if email is not present)

If a user enters an actor ID with different casing (e.g., `User@Example.com` instead of `user@example.com`), the feature will not be enabled for that user because the string comparison is exact.

## Changes

- Updated `config.add_actor_placeholder` in `config/initializers/flipper.rb` from:
  - Old: `actor ID (or comma-separated list)`
  - New: `CASE SENSITIVE: lowercase email or UUID (comma-separated for multiple)`
- Updated test in `spec/requests/flipper_spec.rb` to verify the new placeholder text

## Screenshot

<img width="1030" height="601" alt="Screenshot 2025-12-15 at 1 51 02 PM" src="https://github.com/user-attachments/assets/a4d58bd4-7d16-491b-880c-270127cbd363" />


*Screenshot shows the new placeholder text in the actor input field*

## Testing

- [x] Unit test passes: `bundle exec rspec spec/requests/flipper_spec.rb:404`
- [x] Manually verified the change in local development environment
