### PR TITLE
Updates appointments API documentation

### DIFF
--- a/modules/vaos/app/docs/vaos/v2/vaos_v2.yaml
+++ b/modules/vaos/app/docs/vaos/v2/vaos_v2.yaml
@@ -755,6 +755,12 @@ paths:
           schema:
             type: string
         - in: query
+          required: false
+          name: provider_id
+          description: The provider_id to find appointment slots for. Required if clinic_id not provided.
+          schema:
+            type: string
+        - in: query
           required: true
           name: start
           description: The start date for the query


### PR DESCRIPTION
## Summary

This updates the VAOS/appointments swagger documentation to include information around the optional `provider_id` parameter when searching for Oracle Health appointment slots.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/127862

## Testing done
N/A

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
VAOS documentation

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
