### PR TITLE
Chapter 31 - enrich duplicate submission logging

### DIFF
--- a/modules/vre/app/jobs/vre/vre_submit1900_job.rb
+++ b/modules/vre/app/jobs/vre/vre_submit1900_job.rb
@@ -34,9 +34,10 @@ module VRE
       submissions_count = submissions.count
       duplicates_detected = submissions_count > 1
       log_payload = { user_account_id: user_account.id,
-                      submission_count: submissions_count,
-                      duplicates_detected:,
-                      threshold_hours: }
+                      submissions_count:, duplicates_detected:, threshold_hours:,
+                      submissions_data: submissions.pluck(:id, :created_at).map do |id, created_at|
+                        { id:, created_at: }
+                      end }
 
       log_message = 'VRE::VRESubmit1900Job - Duplicate Submission Check'
 

--- a/modules/vre/app/jobs/vre/vre_submit1900_job.rb
+++ b/modules/vre/app/jobs/vre/vre_submit1900_job.rb
@@ -9,7 +9,7 @@ module VRE
 
     STATSD_KEY_PREFIX = 'worker.vre.vre_submit_1900_job'
     # retry for  2d 1h 47m 12s
-    # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
+    # https://github.com/sidekiq/sidekiq/wiki/Error-Han :dling
     RETRY = 16
 
     FORM_TYPE = '28-1900'
@@ -30,14 +30,12 @@ module VRE
       threshold_hours = 24 unless threshold_hours.positive?
       submissions = user_account.form_submissions.where(form_type: [FORM_TYPE, FORM_TYPE_V2],
                                                         created_at: threshold_hours.hours.ago..)
-
+      submissions_data = submissions.pluck(:id, :created_at).map { |id, created_at| { id:, created_at: } }
       submissions_count = submissions.count
       duplicates_detected = submissions_count > 1
-      log_payload = { user_account_id: user_account.id,
-                      submissions_count:, duplicates_detected:, threshold_hours:,
-                      submissions_data: submissions.pluck(:id, :created_at).map do |id, created_at|
-                        { id:, created_at: }
-                      end }
+
+      log_payload = { user_account_id: user_account.id, submissions_count:,
+                      duplicates_detected:, threshold_hours:, submissions_data: }
 
       log_message = 'VRE::VRESubmit1900Job - Duplicate Submission Check'
 

--- a/modules/vre/app/jobs/vre/vre_submit1900_job.rb
+++ b/modules/vre/app/jobs/vre/vre_submit1900_job.rb
@@ -9,7 +9,7 @@ module VRE
 
     STATSD_KEY_PREFIX = 'worker.vre.vre_submit_1900_job'
     # retry for  2d 1h 47m 12s
-    # https://github.com/sidekiq/sidekiq/wiki/Error-Han :dling
+    # https://github.com/sidekiq/sidekiq/wiki/Error-Handling
     RETRY = 16
 
     FORM_TYPE = '28-1900'


### PR DESCRIPTION
## Summary

I'm a part of the Core Veteran Experiences team, and we own this product.  This is a small PR to include database id and `created_at` timestamp, when logging duplicate Chapter 31 submission data

See [PR 25466](https://github.com/department-of-veterans-affairs/vets-api/pull/25466) for more information

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
