### PR TITLE
Update tzinfo-data to 1.2025.2 (Gemfile)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -174,7 +174,7 @@ gem 'swagger-blocks'
 gem 'ttfunk', '~> 1.7.0'
 # Include the IANA Time Zone Database on Windows, where Windows doesn't ship with a timezone database.
 # POSIX systems should have this already, so we're not going to bring it in on other platforms
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'tzinfo-data', '~> 1.2025.2', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'utf8-cleaner'
 gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', branch: 'master'
 gem 'virtus'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1175,7 +1175,7 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2024.1)
+    tzinfo-data (1.2025.2)
       tzinfo (>= 1.0.0)
     uber (0.1.0)
     unicode-display_width (3.2.0)
@@ -1452,7 +1452,7 @@ DEPENDENCIES
   timecop
   travel_pay!
   ttfunk (~> 1.7.0)
-  tzinfo-data
+  tzinfo-data (~> 1.2025.2)
   utf8-cleaner
   va_notify!
   vaos!


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): NO*
- Specify `tzinfo-data` gem version as `~> 1.2025.2`
- This ensures we use current versions of tzinfo database (and potentially receive any security fixes since previous version)
- VA Platform SRE

## Related issue(s)

- *Link to ticket* https://github.com/department-of-veterans-affairs/va.gov-team/issues/123101

## Testing done

App starts and appears healthy with this Gemfile. If existing tests pass this upgrade is likely safe.

- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## What areas of the site does it impact?
- Anywhere we communicate or process timezone-aware datetimes

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature