### PR TITLE
Remove pessimistic version locks from gem bumps (tzinfo-data, fitbit_api)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ gem 'faraday-retry'
 gem 'faraday-typhoeus'
 gem 'fastimage'
 gem 'fhir_client', git: 'https://github.com/department-of-veterans-affairs/fhir_client.git', tag: 'v6.1.0'
-gem 'fitbit_api', '~> 1.1.0'
+gem 'fitbit_api'
 gem 'flipper'
 gem 'flipper-active_record'
 gem 'flipper-active_support_cache_store'
@@ -174,7 +174,7 @@ gem 'swagger-blocks'
 gem 'ttfunk', '~> 1.7.0'
 # Include the IANA Time Zone Database on Windows, where Windows doesn't ship with a timezone database.
 # POSIX systems should have this already, so we're not going to bring it in on other platforms
-gem 'tzinfo-data', '~> 1.2025.2', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'utf8-cleaner'
 gem 'vets_json_schema', git: 'https://github.com/department-of-veterans-affairs/vets-json-schema', branch: 'master'
 gem 'virtus'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1317,7 +1317,7 @@ DEPENDENCIES
   faraday_curl
   fastimage
   fhir_client!
-  fitbit_api (~> 1.1.0)
+  fitbit_api
   flipper
   flipper-active_record
   flipper-active_support_cache_store
@@ -1452,7 +1452,7 @@ DEPENDENCIES
   timecop
   travel_pay!
   ttfunk (~> 1.7.0)
-  tzinfo-data (~> 1.2025.2)
+  tzinfo-data
   utf8-cleaner
   va_notify!
   vaos!


### PR DESCRIPTION
Remove pessimistic version locks from tzinfo-data and fitbit_api so that dependabot can update if needed.

## Summary

- *This work is behind a feature toggle (flipper): NO*
- Remove pessimistic version locks for `fitbit_api` and `tzinfo-data` from Gemfile/Gemfile.lock
- This should permit dependabot to be able to update these gems if security fixes are urgent
- Platform SRE

## Related issue(s)

- *Link to ticket*: https://github.com/department-of-veterans-affairs/va.gov-team/issues/123101 / https://github.com/department-of-veterans-affairs/va.gov-team/issues/123102
- *Link to previous change of the code/bug (if applicable)*: https://github.com/department-of-veterans-affairs/vets-api/pull/25623 / https://github.com/department-of-veterans-affairs/vets-api/pull/25622

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
