### PR TITLE
Updating logingov logic to check verified credential

### DIFF
--- a/app/services/sign_in/acr_translator.rb
+++ b/app/services/sign_in/acr_translator.rb
@@ -75,7 +75,7 @@ module SignIn
       when 'ial2'
         Constants::Auth::LOGIN_GOV_IAL2
       when 'min'
-        Constants::Auth::LOGIN_GOV_IAL0
+        uplevel ? Constants::Auth::LOGIN_GOV_IAL2 : Constants::Auth::LOGIN_GOV_IAL0
       else
         raise Errors::InvalidAcrError.new message: 'Invalid ACR for logingov'
       end

--- a/spec/services/sign_in/acr_translator_spec.rb
+++ b/spec/services/sign_in/acr_translator_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe SignIn::AcrTranslator do
 
         context 'and uplevel is true' do
           let(:uplevel) { true }
-          let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::LOGIN_GOV_IAL0 } }
+          let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::LOGIN_GOV_IAL2 } }
 
           it 'returns expected translated acr value' do
             expect(subject).to eq(expected_translated_acr)


### PR DESCRIPTION
## Summary

- This PR updates the login.gov functionality that checks whether a credential is verified or not. It uses last name to determine for now, until we can establish the set of acr values

## Testing done

- [ ] Created login.gov loa1 account
- [ ] Added an ICN to their UserAccount, and `verified_at` to UserVerification
- [ ] Authenticated with Sign in Service on va.gov, and confirmed user was forced to verify


## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [ ] Create Login.gov loa1 accounts
- [ ] Fake 'previous verifications' by adding ICN to UserAccount, and `verified_at` to UserVerification
- [ ] Authenticate with account, confirm that users are forced to verify
- [ ] Confirm that loa1 accounts that haven't previously verified are not affected
- [ ] Confirm that loa3/ial2 accounts are not affected
