### PR TITLE
Remove service type from covid appointments

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2666,10 +2666,6 @@ features:
     actor_type: user
     description: Enables PCMHI as care related to mental health appointments with new codes
     enable_in_development: true
-  va_online_scheduling_hide_service_type:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle to hide service type in the appointments API response.
   form10203_confirmation_email_with_silent_failure_processing:
     actor_type: user
     description: If enabled, confirmation email will be sent with silent failure processing

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -470,16 +470,16 @@ describe VAOS::V2::AppointmentsService do
       end
 
       context 'when requesting a list of appointments containing a non-Med non-CnP non-CC appointment' do
-        it 'removes the service type(s) from only the non-med non-cnp non-covid appointment' do
-          allow(Flipper).to receive(:enabled?).with(:va_online_scheduling_hide_service_type,
-                                                    instance_of(User)).and_return(false)
+        it 'removes the service type(s) from only the non-med non-cnp appointment and covid appointments' do
           VCR.use_cassette('vaos/v2/appointments/get_appointments_non_med',
                            allow_playback_repeats: true, match_requests_on: %i[method path query], tag: :force_utf8) do
             response = subject.get_appointments(start_date2, end_date2)
             expect(response[:data][0][:service_type]).to be_nil
             expect(response[:data][0][:service_types]).to be_nil
-            expect(response[:data][1][:service_type]).not_to be_nil
-            expect(response[:data][1][:service_types]).not_to be_nil
+            expect(response[:data][1][:service_type]).to be_nil
+            expect(response[:data][1][:service_types]).to be_nil
+            expect(response[:data][2][:service_type]).not_to be_nil
+            expect(response[:data][2][:service_types]).not_to be_nil
           end
         end
       end
@@ -2985,24 +2985,6 @@ describe VAOS::V2::AppointmentsService do
           expect(subject.send(:schedulable?, appt)).to be(false)
         end
       end
-    end
-  end
-
-  describe 'hide_service_type' do
-    it 'hides service type when va_online_scheduling_hide_service_type is true' do
-      allow(Flipper).to receive(:enabled?).with(:va_online_scheduling_hide_service_type,
-                                                instance_of(User)).and_return(true)
-      appt = build(:appointment_form_v2, :va_proposed_base).attributes
-      subject.send(:hide_service_type, appt)
-      expect(appt[:service_type]).to be_nil
-    end
-
-    it 'does not hide service type when va_online_scheduling_hide_service_type is false' do
-      allow(Flipper).to receive(:enabled?).with(:va_online_scheduling_hide_service_type,
-                                                instance_of(User)).and_return(false)
-      appt = build(:appointment_form_v2, :va_proposed_base).attributes
-      subject.send(:hide_service_type, appt)
-      expect(appt[:service_type]).to eq('audiology')
     end
   end
 end

--- a/spec/support/vcr_cassettes/vaos/v2/appointments/get_appointments_non_med.yml
+++ b/spec/support/vcr_cassettes/vaos/v2/appointments/get_appointments_non_med.yml
@@ -54,11 +54,15 @@ http_interactions:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"159472","identifier":[{"system":"http://vista-scheduling-provider-v1.sqa/vistasp/v1/Appointment/","value":"523938333130383130"}],"kind":"phone","status":"proposed","created":"2021-09-01T00:00:00Z","serviceType":"socialWork","serviceTypes":[{"coding":[{"system":"http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type","code":"socialWork"}]}],"serviceCategory":[{"coding":[{"system":"http://www.va.gov/Terminology/VistADefinedTerms/409_1","code":"RESEARCH",
-        "display":"RESEARCH"}],"text":"RESEARCH"}],
-        "patientIcn":"1012845331V153043","locationId":"983","start":"2023-02-04T00:00:00Z","created":"2021-09-01T00:00:00Z","requestedPeriods":[{"start":"2023-02-04T00:00:00Z","end":"2023-02-04T00:00:00Z"}],"cancellable":true},{"id":"159473","identifier":[{"system":"http://vista-scheduling-provider-v1.sqa/vistasp/v1/Appointment/","value":"523938333130383130"}],"kind":"clinic","status":"proposed","created":"2021-09-01T00:00:00Z","serviceType":"covid","serviceTypes":[{"coding":[{"system":"http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type","code":"primaryCare"}]}],"serviceCategory":[{"coding":[{"system":"http://www.va.gov/Terminology/VistADefinedTerms/409_1","code":"REGULAR",
-        "display":"REGULAR"}],"text":"REGULAR"}],
-        "patientIcn":"1012845331V153043","locationId":"983","start":"2023-02-04T00:00:00Z","created":"2021-09-01T00:00:00Z","requestedPeriods":[{"start":"2023-02-04T00:00:00Z","end":"2023-02-04T00:00:00Z"}],"cancellable":true}]}'
+      string: |-
+        {"data":[
+          {"id":"159472","identifier":[{"system":"http://vista-scheduling-provider-v1.sqa/vistasp/v1/Appointment/","value":"523938333130383130"}],"kind":"phone","status":"proposed","created":"2021-09-01T00:00:00Z","serviceType":"socialWork","serviceTypes":[{"coding":[{"system":"http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type","code":"socialWork"}]}],
+            "serviceCategory":[{"coding":[{"system":"http://www.va.gov/Terminology/VistADefinedTerms/409_1","code":"RESEARCH","display":"RESEARCH"}],"text":"RESEARCH"}],"patientIcn":"1012845331V153043","locationId":"983","start":"2023-02-04T00:00:00Z","created":"2021-09-01T00:00:00Z","requestedPeriods":[{"start":"2023-02-04T00:00:00Z","end":"2023-02-04T00:00:00Z"}],"cancellable":true},
+          {"id":"159473","identifier":[{"system":"http://vista-scheduling-provider-v1.sqa/vistasp/v1/Appointment/","value":"523938333130383130"}],"kind":"clinic","status":"proposed","created":"2021-09-01T00:00:00Z","serviceType":"covid","serviceTypes":[{"coding":[{"system":"http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type","code":"covid"}]}],
+            "serviceCategory":[{"coding":[{"system":"http://www.va.gov/Terminology/VistADefinedTerms/409_1","code":"REGULAR","display":"REGULAR"}],"text":"REGULAR"}],"patientIcn":"1012845331V153043","locationId":"983","start":"2023-02-04T00:00:00Z","created":"2021-09-01T00:00:00Z","requestedPeriods":[{"start":"2023-02-04T00:00:00Z","end":"2023-02-04T00:00:00Z"}],"cancellable":true},
+          {"id":"159473","identifier":[{"system":"http://vista-scheduling-provider-v1.sqa/vistasp/v1/Appointment/","value":"523938333130383130"}],"kind":"clinic","status":"proposed","created":"2021-09-01T00:00:00Z","serviceType":"primaryCare","serviceTypes":[{"coding":[{"system":"http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type","code":"primaryCare"}]}],
+            "serviceCategory":[{"coding":[{"system":"http://www.va.gov/Terminology/VistADefinedTerms/409_1","code":"REGULAR","display":"REGULAR"}],"text":"REGULAR"}],"patientIcn":"1012845331V153043","locationId":"983","start":"2023-02-04T00:00:00Z","created":"2021-09-01T00:00:00Z","requestedPeriods":[{"start":"2023-02-04T00:00:00Z","end":"2023-02-04T00:00:00Z"}],"cancellable":true}
+        ]}
   recorded_at: Thu, 04 Nov 2021 20:02:42 GMT
 - request:
     method: get


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- We are removing the service type (`serviceType` and `serviceTypes`) from covid appointments to avoid confusion.
- United Appointments Experience

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128004

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots

N/A

## What areas of the site does it impact?
Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
