### PR TITLE
Chore: Update clamav to latest image and platform

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,11 +29,12 @@ x-app: &common
 
 services:
   clamav:
-    image: clamav/clamav:1.3.0
+    image: clamav/clamav
     ports:
       - 33100:3310
     volumes:
      - shared-vol:/vets-api
+    platform: linux/amd64
   redis:
     image: redis:6.2-alpine
     ports:


### PR DESCRIPTION
## Summary

ClamAV seemed to pulled 1.3.0 and impeding local development for some engineers using docker

- Updated clamav in docker-compose.yml to latest
- [clamav/clamav](https://hub.docker.com/r/clamav/clamav/tags) is only available for linux/amd64

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128080

## Testing done

- Ran `docker compose build --no-cache`
- Ran `docker compose up` 

<img width="584" height="417" alt="Screenshot 2025-12-17 at 1 42 59 PM" src="https://github.com/user-attachments/assets/a58fbfe6-217e-4e3b-9b43-934e02c490de" />

## Acceptance criteria

- [x] clamav is version latest in docker compose files
- [x] Both `build` and `up` commands complete successfully
