### PR TITLE
Disabled global HTTPI Debugging logging

### DIFF
--- a/config/initializers/httpi.rb
+++ b/config/initializers/httpi.rb
@@ -2,3 +2,4 @@
 
 # since the httpclient gem uses its own certificate store, force HTTPI to use :net_http
 HTTPI.adapter = :net_http
+HTTPI.log = false


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

This pull request adds a centralized HTTPI initializer to standardize HTTP client behavior across the application. The configuration explicitly sets the adapter, disables global logging, and defines consistent timeout defaults.

These changes help prevent long-running or hanging HTTP requests, reduce unnecessary log volume, and minimize memory pressure caused by retained request objects.

Why This Change Is Needed
- HTTPI defaults can allow long-lived connections that increase memory usage
- Global logging significantly increases object allocation and retention
- Consistent timeouts protect Puma/Sidekiq threads from being blocked by external services
- Provides a single, predictable configuration point for all HTTPI-based service calls (including Facilities-related requests)

Backlogs are occurring during and these logs are adding to the vets-api memory usage.
Logs: `D, [2025-12-17T20:49:48.917904 #276] DEBUG -- : HTTPI /peer GET request to fwdproxy-prod.vfs.va.gov (net_http)`. [There are over 1.5M logs per day in prod.](https://vagov.ddog-gov.com/logs?query=%22HTTPI%20%2Fpeer%20GET%20request%20to%22%20service%3Avets-api%20env%3Aeks-prod&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=flex_tier&stream_sort=desc&viz=stream&from_ts=1765926049731&to_ts=1766012449731&live=true)
<img width="1089" height="494" alt="Screenshot 2025-12-17 at 4 54 36 PM" src="https://github.com/user-attachments/assets/3cfce93b-8dca-4aef-a3cb-253f296a8d9a" />
[Datadog logs
](https://vagov.ddog-gov.com/logs?query=autoscaling_group%3Adsva-vagov-prod-eks-node-group-main-dsva-vagov-prod-cluster%20AND%20kube_deployment%3Avets-api-mobile&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=flex_tier&stream_sort=desc&viz=stream&from_ts=1766004580000&to_ts=1766004590000&live=false)

This is a low-risk configuration change that standardizes HTTPI behavior and enforces reasonable timeouts. While it may cause very slow external requests to fail faster, it improves system stability and reduces memory pressure.


When HTTPI.log = true is enabled, HTTPI:
  - Logs entire HTTP requests and responses
  - Includes:
  - Full headers
  - Full request bodies
  - Full response bodies


## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
