### PR TITLE
Upgrade vets-json-schema from 25.2.36 to 25.2.37

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,10 +74,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 08ac4c4679af2ea03824fe1029a17f89f6c5aa0a
+  revision: 531d9b1ef4f1738b825953b5e5a7e3d6fe1e1eec
   branch: master
   specs:
-    vets_json_schema (25.2.36)
+    vets_json_schema (25.2.37)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): NO*
- Changes 3 enums from DEPENDENT to CHILD in the schema for 21P-8416 to fix an error during form submission.
- To reproduce, fill out the 21P-8416 form and choose child during the expense's loops to see the 4xx error that is returned on the old schema. 

## Related issue(s)

- Address Issue 1 in https://github.com/department-of-veterans-affairs/va.gov-team/issues/127784
- Vets-json-schema PR: https://github.com/department-of-veterans-affairs/vets-json-schema/pull/1100

## Testing done

- Tested locally using vets-website connected to vets-api and submitted the form

## Screenshots
N/A

## What areas of the site does it impact?
The schema update is only for enum radio options on 3 questions. 

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

N/A
