### PR TITLE
Revert "Disabled global HTTPI Debugging logging"

### DIFF
--- a/config/initializers/httpi.rb
+++ b/config/initializers/httpi.rb
@@ -2,4 +2,3 @@
 
 # since the httpclient gem uses its own certificate store, force HTTPI to use :net_http
 HTTPI.adapter = :net_http
-HTTPI.log = false


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#25650

The HTTPI logs are being overrided by another gem, possibly caseflow and a few others. Making a ticket for backend cop