### PR TITLE
Revert spec/factories/configurations.rb line in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1258,7 +1258,7 @@ spec/factories/caregivers_assistance_claim.rb @department-of-veterans-affairs/he
 spec/factories/central_mail_submissions.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 spec/factories/chatbot @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/backend-review-group
 spec/factories/coe_claim.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group
-spec/factories/configurations.rb https://github.com/department-of-veterans-affairs/vets-api/pull/24982
+spec/factories/configurations.rb @department-of-veterans-affairs/mobile-api-team @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/backend-review-group
 spec/factories/decision_review_evidence_attachment.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 spec/factories/decision_review_notification_audit_logs.rb @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group
 spec/factories/debt_transaction_logs.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group


### PR DESCRIPTION
Reverting back to [what it was](https://github.com/department-of-veterans-affairs/vets-api/blame/b8c793bafccaa86901a4e26e97797a4aa634f330/.github/CODEOWNERS). I reached out to Ryan M. and he said this change was an accident.

https://github.com/department-of-veterans-affairs/vets-api/commit/f2aa0f63f674faf34e9d2141eee514186250f049#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1261

Testing:
<img width="251" height="55" alt="image" src="https://github.com/user-attachments/assets/475f447e-3c36-48a6-804a-4c1bc6832119" />
