### PR TITLE
Update reason code service to handle comments with leading pipes

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_reason_code_service.rb
@@ -90,7 +90,7 @@ module VAOS
             reason_code_hash[segments[0].strip] = segments[1].strip
           # User comments may contain colons so valid comments may consist of >=2
           # segments. We take the string after the first colon as the comments value.
-          elsif segments[0].strip == 'comments' && segments.count > 1
+          elsif segments[0] && segments[0].strip == 'comments' && segments.count > 1
             reason_code_hash['comments'] = kvp.partition(':')[2].strip
           end
         end

--- a/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointments_reason_code_service_spec.rb
@@ -130,7 +130,9 @@ describe VAOS::V2::AppointmentsReasonCodeService do
       ['comments:text', { 'comments' => 'text' }],
       [' comments : text ', { 'comments' => 'text' }],
       ['comments:key:value', { 'comments' => 'key:value' }],
-      [' comments : key : value ', { 'comments' => 'key : value' }]
+      [' comments : key : value ', { 'comments' => 'key : value' }],
+      ['|comments:value ', { 'comments' => 'value' }],
+      ['key:value|comments:text ', { 'key' => 'value', 'comments' => 'text' }]
     ].each do |input, output|
       it "#{input} returns #{output}" do
         expect(subject.send(:parse_reason_code_text, input)).to eq(output)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- A [vets-website PR](https://github.com/department-of-veterans-affairs/vets-website/pull/40868) changed the reason code that was being passed to the backend and DS appointments now has the text "|comments:<input>". This is breaking vets-api reason code parsing
- To fix this issue, we are adding a safe-guard so parsing can continue correctly.
- United Appointments Experience

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127025

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
