### PR TITLE
Update user_info attributes

### DIFF
--- a/app/controllers/sign_in/user_info_controller.rb
+++ b/app/controllers/sign_in/user_info_controller.rb
@@ -6,9 +6,16 @@ module SignIn
 
     def show
       authorize access_token, policy_class: SignIn::UserInfoPolicy
-      user_info = SignIn::UserInfo.from_user(current_user)
+      user_info = SignIn::UserInfoGenerator.new(user: current_user).perform
 
-      render json: user_info.serializable_hash, status: :ok
+      if user_info.valid?
+        render json: user_info.serializable_hash, status: :ok
+      else
+        error = user_info.errors.full_messages.join(', ')
+
+        Rails.logger.error('[SignIn][UserInfoController] Invalid user_info', error:)
+        render json: { error: }, status: :bad_request
+      end
     end
 
     private

--- a/app/models/sign_in/user_info.rb
+++ b/app/models/sign_in/user_info.rb
@@ -6,21 +6,33 @@ module SignIn
     include ActiveModel::Attributes
     include ActiveModel::Serialization
 
-    ACCEPTED_GCID_TYPES = %w[
-      200ENPI 200VETS 200BRLS 200CORP 200VET360
-      200VIDM 200VLGN 200MHV 200CERNER
-    ].freeze
+    GCID_TYPE_CODES = {
+      icn: '200M',
+      sec_id: '200PROV',
+      edipi: '200DOD',
+      mhv_ien: '200MHV',
+      npi_id: '200ENPI',
+      vhic_id: '200VHIC',
+      nwhin_id: '200NWS',
+      cerner_id: '200CRNR',
+      corp_id: '200CORP',
+      birls_id: '200BRLS',
+      salesforce_id: '200DSLF',
+      usaccess_piv: '200PUSA',
+      piv_id: '200PIV',
+      va_active_directory_id: '200AD',
+      usa_staff_id: '200USAF'
+    }.freeze
+    ALLOWED_GCID_CODES = GCID_TYPE_CODES.values.index_with(&:itself).freeze
+    NUMERIC_GCID_CODE = /\A\d+\z/
 
     attribute :sub, :string
-    attribute :person_types, :string
-    attribute :email, :string
-    attribute :full_name, :string
-    attribute :first_name, :string
-    attribute :last_name, :string
     attribute :csp_type, :string
-    attribute :csp_uuid, :string
     attribute :ial, :string
     attribute :aal, :string
+    attribute :csp_uuid, :string
+    attribute :email, :string
+    attribute :full_name, :string
     attribute :birth_date, :string
     attribute :ssn, :string
     attribute :gender, :string
@@ -31,75 +43,39 @@ module SignIn
     attribute :address_country, :string
     attribute :address_postal_code, :string
     attribute :phone_number, :string
+    attribute :person_types, :string
     attribute :icn, :string
     attribute :sec_id, :string
     attribute :edipi, :string
     attribute :mhv_ien, :string
+    attribute :npi_id, :string
     attribute :cerner_id, :string
     attribute :corp_id, :string
     attribute :birls, :string
     attribute :gcids, :string
-    attribute :npi_id, :string
 
-    class << self
-      def from_user(user)
-        new(
-          sub: user.uuid, person_types: user.person_types.join('|'),
-          email: user.user_verification&.user_credential_email&.credential_email,
-          npi_id: user.npi_id, full_name: full_name(user),
-          first_name: user.first_name, last_name: user.last_name,
-          csp_type: csp_type_from_mpi(user), csp_uuid: user.user_verification.credential_identifier,
-          ial: ial_level(user), aal: AAL::LOGIN_GOV_AAL2,
-          birth_date: user.birth_date, ssn: user.ssn,
-          gender: user.gender,
-          address_street1: user.address[:street], address_street2: user.address[:street2],
-          address_city: user.address[:city], address_state: user.address[:state],
-          address_country: user.address[:country], address_postal_code: user.address[:postal_code],
-          phone_number: user.home_phone, icn: user.icn,
-          sec_id: user.sec_id, edipi: user.try(:edipi),
-          mhv_ien: user.try(:mhv_ien), cerner_id: user.try(:cerner_id),
-          corp_id: user.participant_id, birls: user.birls_id, gcids: validate_and_parse_gcids(user.mpi_gcids)
-        )
+    validate :gcids_have_approved_identifier
+
+    private
+
+    def gcids_have_approved_identifier
+      value = gcids
+      return if value.blank?
+
+      segments = value.split('|')
+
+      invalid = segments.reject do |segment|
+        next false if segment.blank?
+
+        code = segment.to_s.split('^', 4)[2]
+        next false if code.blank?
+
+        ALLOWED_GCID_CODES.key?(code) || code.match?(NUMERIC_GCID_CODE)
       end
 
-      private
+      return if invalid.empty?
 
-      def ial_level(user)
-        user.user_verification.verified? ? Constants::Auth::IAL_TWO : Constants::Auth::IAL_ONE
-      end
-
-      def csp_type_from_mpi(user)
-        case user.user_verification.credential_type
-        when 'idme'
-          MPI::Constants::IDME_IDENTIFIER
-        when 'logingov'
-          MPI::Constants::LOGINGOV_IDENTIFIER
-        end
-      end
-
-      def validate_and_parse_gcids(gcids)
-        return nil if gcids.blank?
-
-        gcid_list =
-          case gcids
-          when Array then gcids
-          when String then gcids.split('|')
-          else []
-          end
-
-        filtered = gcid_list.select do |gcid|
-          _identifier, _code, gcid_type, _agency, _status = gcid.split('^')
-          ACCEPTED_GCID_TYPES.include?(gcid_type)
-        end
-
-        return nil if filtered.empty?
-
-        filtered.join('|')
-      end
-
-      def full_name(user)
-        user.full_name_normalized.values.compact.join(' ')
-      end
+      errors.add(:gcids, 'contains non-approved gcids')
     end
   end
 end

--- a/app/services/sign_in/user_info_generator.rb
+++ b/app/services/sign_in/user_info_generator.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module SignIn
+  class UserInfoGenerator
+    attr_reader :user
+
+    def initialize(user:)
+      @user = user
+    end
+
+    def perform
+      SignIn::UserInfo.new(sub:, ial:, aal:, csp_type:, csp_uuid:, email:, full_name:, birth_date:, ssn:, gender:,
+                           address_street1:, address_street2:, address_city:, address_state:, address_country:,
+                           address_postal_code:, phone_number:, person_types:, icn:, sec_id:, edipi:, mhv_ien:,
+                           npi_id:, cerner_id:, corp_id:, birls:, gcids:)
+    end
+
+    private
+
+    def sub                 = user_verification.credential_identifier
+    def ial                 = user_verification.verified? ? Constants::Auth::IAL_TWO : Constants::Auth::IAL_ONE
+    def aal                 = AAL::LOGIN_GOV_AAL2
+    def csp_uuid            = user_verification.credential_identifier
+    def email               = user.user_verification&.user_credential_email&.credential_email
+    def full_name           = user.full_name_normalized.values.compact.join(' ')
+    def birth_date          = user.birth_date
+    def ssn                 = user.ssn
+    def gender              = user.gender
+    def address_street1     = user.address[:street]
+    def address_street2     = user.address[:street2]
+    def address_city        = user.address[:city]
+    def address_state       = user.address[:state]
+    def address_country     = user.address[:country]
+    def address_postal_code = user.address[:postal_code]
+    def phone_number        = user.home_phone
+    def person_types        = user.person_types&.join('|') || ''
+    def icn                 = user.icn
+    def sec_id              = user.sec_id
+    def edipi               = user.edipi
+    def mhv_ien             = user.mhv_ien
+    def npi_id              = user.npi_id
+    def cerner_id           = user.cerner_id
+    def corp_id             = user.participant_id
+    def birls               = user.birls_id
+    def gcids               = filter_gcids.join('|')
+
+    def user_verification
+      @user_verification ||= user.user_verification
+    end
+
+    def csp_type
+      case user_verification.credential_type
+      when 'idme'
+        MPI::Constants::IDME_IDENTIFIER
+      when 'logingov'
+        MPI::Constants::LOGINGOV_IDENTIFIER
+      end
+    end
+
+    def filter_gcids
+      return [] if user.mpi_gcids.blank?
+
+      user.mpi_gcids.filter do |gcid|
+        code = gcid.to_s.split('^', 4)[2]
+        next false if code.blank?
+
+        UserInfo::ALLOWED_GCID_CODES.key?(code) || code.match?(UserInfo::NUMERIC_GCID_CODE)
+      end
+    end
+  end
+end

--- a/spec/controllers/sign_in/user_info_controller_spec.rb
+++ b/spec/controllers/sign_in/user_info_controller_spec.rb
@@ -3,43 +3,60 @@
 require 'rails_helper'
 
 describe SignIn::UserInfoController do
+  let!(:client_config) { create(:client_config, client_id:) }
+  let(:client_id) { 'some-client-id' }
+  let(:user_info_clients) { [client_id] }
+  let!(:session) { create(:oauth_session, client_id:, user_account:, user_verification:) }
+
   let(:user_account) { create(:user_account, icn:) }
   let(:user_verification) { create(:idme_user_verification, idme_uuid: credential_uuid, user_account:) }
-  let!(:user) do
-    create(
+  let(:mpi_profile) do
+    build(:mpi_profile, icn:, address:, home_phone:, full_mvi_ids: gcids)
+  end
+
+  let(:user) do
+    build(
       :user,
+      :loa3,
       user_account:,
       user_verification:,
       icn:,
       idme_uuid: credential_uuid,
-      sec_id:,
-      first_name:,
-      last_name:,
+      first_name: mpi_profile.given_names.first,
+      last_name: mpi_profile.family_name,
+      birth_date: mpi_profile.birth_date,
+      ssn: mpi_profile.ssn,
+      gender: mpi_profile.gender,
+      edipi: mpi_profile.edipi,
+      sec_id: mpi_profile.sec_id,
       mpi_profile:
     )
   end
-  let!(:client_config) { create(:client_config, client_id:) }
-  let!(:session) { create(:oauth_session, client_id:, user_account:, user_verification:) }
-  let!(:user_credential_email) do
-    create(:user_credential_email, user_verification:, credential_email: email)
-  end
-
-  let(:mpi_profile) { build(:mpi_profile, icn:, sec_id:, given_names: [first_name], family_name: last_name) }
   let(:credential_uuid) { 'some-uuid' }
   let(:icn) { 'some-icn' }
-  let(:sec_id) { 'some-sec-id' }
-  let(:first_name) { 'some-first-name' }
-  let(:last_name) { 'some-last-name' }
-  let(:email) { 'some-email' }
-  let(:client_id) { 'some-client-id' }
-  let(:user_info_clients) { [client_id] }
-  let(:edipi) { 'some-edipi' }
-  let(:mhv_ien) { '111222333' }
-  let(:cerner_id) { 'CER12345' }
-  let(:corp_id) { 'CORP67890' }
-  let(:birls) { 'BIRL12345' }
-  let(:gcids) { '200ENPI^somecode^200ENPI^VA^active|200VETS^somecode^200VETS^VA^active' }
-  let(:npi_id) { 'NPI1234567' }
+
+  let(:home_phone) { '555-123-4567' }
+  let(:gcids) do
+    [
+      '1000123456V123456^NI^200M^USVHA^P',
+      '12345^PI^516^USVHA^PCE',
+      '2^PI^553^USVHA^PCE'
+    ]
+  end
+
+  let(:address) do
+    {
+      street: '123 Main St',
+      street2: 'Apt 4B',
+      city: 'Somecity',
+      state: 'CA',
+      country: 'USA',
+      postal_code: '90210'
+    }
+  end
+
+  let!(:user_credential_email) { create(:user_credential_email, user_verification:, credential_email:) }
+  let(:credential_email) { 'test@example.com' }
 
   let(:access_token) { create(:access_token, user_uuid: user.uuid, client_id:, session_handle: session.handle) }
   let(:encoded_access_token) { SignIn::AccessTokenJwtEncoder.new(access_token:).perform }
@@ -51,77 +68,61 @@ describe SignIn::UserInfoController do
 
   describe 'GET #show' do
     context 'when the client_id is in the list of valid clients' do
-      before do
-        allow(SignIn::UserInfo).to receive(:from_user).and_return(
-          SignIn::UserInfo.new(
-            sub: user.uuid,
-            person_types: 'PAT',
-            email:,
-            full_name: "#{first_name} #{last_name}",
-            first_name:,
-            last_name:,
-            csp_type: '200VIDM',
-            csp_uuid: credential_uuid,
-            ial: '2',
-            aal: '2',
-            birth_date: '1990-01-01',
-            ssn: '123456789',
-            gender: 'M',
-            address_street1: '123 Main St',
-            address_street2: 'Apt 4',
-            address_city: 'Anytown',
-            address_state: 'CA',
-            address_country: 'USA',
-            address_postal_code: '12345',
-            phone_number: mpi_profile.home_phone,
-            icn:,
-            sec_id:,
-            edipi:,
-            mhv_ien:,
-            cerner_id:,
-            corp_id:,
-            birls:,
-            gcids:,
-            npi_id:
-          )
-        )
+      context 'when the user has valid attributes' do
+        it 'returns the key user info fields' do
+          get :show
+
+          expect(response).to have_http_status(:ok)
+
+          body = JSON.parse(response.body)
+          expect(body['sub']).to eq(credential_uuid)
+          expect(body['ial']).to eq(SignIn::Constants::Auth::IAL_TWO.to_s)
+          expect(body['aal']).to eq('http://idmanagement.gov/ns/assurance/aal/2')
+          expect(body['csp_type']).to eq(MPI::Constants::IDME_IDENTIFIER)
+          expect(body['csp_uuid']).to eq(credential_uuid)
+          expect(body['email']).to eq(credential_email)
+          expect(body['full_name']).to eq(user.full_name_normalized.values.compact.join(' '))
+          expect(body['birth_date']).to eq(user.birth_date)
+          expect(body['ssn']).to eq(user.ssn)
+          expect(body['gender']).to eq(user.gender)
+          expect(body['address_street1']).to eq(user.address[:street])
+          expect(body['address_street2']).to eq(user.address[:street2])
+          expect(body['address_city']).to eq(user.address[:city])
+          expect(body['address_state']).to eq(user.address[:state])
+          expect(body['address_country']).to eq(user.address[:country])
+          expect(body['address_postal_code']).to eq(user.address[:postal_code])
+          expect(body['phone_number']).to eq(user.home_phone)
+          expect(body['person_types']).to eq(user.person_types.join('|'))
+          expect(body['icn']).to eq(user.icn)
+          expect(body['edipi']).to eq(user.edipi)
+          expect(body['mhv_ien']).to eq(user.mhv_ien)
+          expect(body['sec_id']).to eq(user.sec_id)
+          expect(body['cerner_id']).to eq(user.cerner_id)
+          expect(body['corp_id']).to eq(user.participant_id)
+          expect(body['birls']).to eq(user.birls_id)
+          expect(body['gcids']).to eq(gcids.join('|'))
+        end
       end
 
-      it 'returns the key user info fields' do
-        get :show
+      context 'when the user_info is invalid' do
+        before do
+          allow_any_instance_of(SignIn::UserInfo).to receive(:valid?).and_return(false)
+        end
 
-        expect(response).to have_http_status(:ok)
+        it 'returns a bad request' do
+          get :show
 
-        body = JSON.parse(response.body)
-
-        expect(body['sub']).to eq(user.uuid)
-        expect(body['email']).to eq(email)
-        expect(body['first_name']).to eq(first_name)
-        expect(body['last_name']).to eq(last_name)
-        expect(body['full_name'].downcase).to include(first_name.downcase, last_name.downcase)
-        expect(body['icn']).to eq(icn)
-        expect(body['sec_id']).to eq(sec_id)
-        expect(body['csp_type']).to eq('200VIDM')
-        expect(body['csp_uuid']).to eq(credential_uuid)
-        expect(body['ial']).to eq('2')
-        expect(body['phone_number']).to eq(mpi_profile.home_phone)
-        expect(body['person_types']).to eq('PAT')
-        expect(body['edipi']).to eq(edipi)
-        expect(body['mhv_ien']).to eq(mhv_ien)
-        expect(body['cerner_id']).to eq(cerner_id)
-        expect(body['corp_id']).to eq(corp_id)
-        expect(body['birls']).to eq(birls)
-        expect(body['gcids']).to eq('200ENPI^somecode^200ENPI^VA^active|200VETS^somecode^200VETS^VA^active')
-        expect(body['npi_id']).to eq(npi_id)
+          expect(response).to have_http_status(:bad_request)
+        end
       end
-    end
 
-    context 'when the client_id is not in the list of valid clients' do
-      let(:user_info_clients) { ['some-other-client-id'] }
+      context 'when the client_id is not in the list of valid clients' do
+        let(:user_info_clients) { ['some-other-client-id'] }
 
-      it 'returns a forbidden response' do
-        get :show
-        expect(response).to have_http_status(:forbidden)
+        it 'returns a forbidden response' do
+          get :show
+          expect(response).to have_http_status(:forbidden)
+        end
       end
     end
   end

--- a/spec/models/sign_in/user_info_spec.rb
+++ b/spec/models/sign_in/user_info_spec.rb
@@ -1,0 +1,258 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SignIn::UserInfo do
+  shared_examples 'valid GCID code' do
+    let(:gcids) { example_gcid }
+
+    it 'is valid' do
+      expect(user_info).to be_valid
+    end
+  end
+
+  describe 'attributes' do
+    subject(:user_info) { described_class.new(attributes) }
+
+    let(:attributes) do
+      {
+        sub: 'some-sub',
+        ial: 'some-ial',
+        aal: 'some-aal',
+        csp_type: 'some-csp-type',
+        csp_uuid: 'some-csp-uuid',
+        email: 'some-email',
+        full_name: 'some-full-name',
+        birth_date: 'some-birth-date',
+        ssn: 'some-ssn',
+        gender: 'some-gender',
+        address_street1: 'some-street1',
+        address_street2: 'some-street2',
+        address_city: 'some-city',
+        address_state: 'some-state',
+        address_country: 'some-country',
+        address_postal_code: 'some-postal-code',
+        phone_number: 'some-phone-number',
+        person_types: 'some-person-types',
+        icn: 'some-icn',
+        sec_id: 'some-sec',
+        edipi: 'some-edipi',
+        mhv_ien: 'some-mhv-ien',
+        npi_id: 'some-npi-id',
+        cerner_id: 'some-cerner-id',
+        corp_id: 'some-corp-id',
+        birls: 'some-birls',
+        gcids:
+      }
+    end
+
+    context 'validations' do
+      subject(:user_info) { described_class.new(attributes) }
+
+      let(:attributes) do
+        {
+          gcids:
+        }
+      end
+
+      context 'when gcids are valid' do
+        let(:gcids) do
+          '1000123456V123456^NI^200M^USVHA^P|12345^PI^516^USVHA^PCE|2^PI^553^USVHA^PCE'
+        end
+
+        it 'is valid' do
+          expect(user_info).to be_valid
+        end
+      end
+
+      context 'when gcids contain each valid GCID type code' do
+        context 'ICN code' do
+          let(:example_gcid) { '1000123456V123456^NI^200M^USVHA^P' }
+
+          it_behaves_like 'valid GCID code'
+        end
+
+        context 'SEC ID code' do
+          let(:example_gcid) { '12345^PI^200PROV^USVHA^P' }
+
+          it_behaves_like 'valid GCID code'
+        end
+
+        context 'EDIPI code' do
+          let(:example_gcid) { '1234567890^NI^200DOD^USDOD^P' }
+
+          it_behaves_like 'valid GCID code'
+        end
+
+        context 'MHV IEN code' do
+          let(:example_gcid) { '12345^PI^200MHV^USVHA^P' }
+
+          it_behaves_like 'valid GCID code'
+        end
+
+        context 'NPI ID code' do
+          let(:example_gcid) { '1234567890^NI^200ENPI^USVHA^P' }
+
+          it_behaves_like 'valid GCID code'
+        end
+
+        context 'VHIC ID code' do
+          let(:example_gcid) { '12345^PI^200VHIC^USVHA^P' }
+
+          it_behaves_like 'valid GCID code'
+        end
+
+        context 'NWHIN ID code' do
+          let(:example_gcid) { '12345^PI^200NWS^USVHA^P' }
+
+          it_behaves_like 'valid GCID code'
+        end
+
+        context 'Cerner ID code' do
+          let(:example_gcid) { '12345^PI^200CRNR^USVHA^P' }
+
+          it_behaves_like 'valid GCID code'
+        end
+
+        context 'Corp ID code' do
+          let(:example_gcid) { '12345^PI^200CORP^USVHA^P' }
+
+          it_behaves_like 'valid GCID code'
+        end
+
+        context 'BIRLS ID code' do
+          let(:example_gcid) { '12345^PI^200BRLS^USVHA^P' }
+
+          it_behaves_like 'valid GCID code'
+        end
+
+        context 'Salesforce ID code' do
+          let(:example_gcid) { '12345^PI^200DSLF^USVHA^P' }
+
+          it_behaves_like 'valid GCID code'
+        end
+
+        context 'USAccess PIV code' do
+          let(:example_gcid) { '12345^PI^200PUSA^USVHA^P' }
+
+          it_behaves_like 'valid GCID code'
+        end
+
+        context 'PIV ID code' do
+          let(:example_gcid) { '12345^PI^200PIV^USVHA^P' }
+
+          it_behaves_like 'valid GCID code'
+        end
+
+        context 'VA Active Directory ID code' do
+          let(:example_gcid) { '12345^PI^200AD^USVHA^P' }
+
+          it_behaves_like 'valid GCID code'
+        end
+
+        context 'USA Staff ID code' do
+          let(:example_gcid) { '12345^PI^200USAF^USVHA^P' }
+
+          it_behaves_like 'valid GCID code'
+        end
+
+        describe 'numeric GCID codes' do
+          let(:gcids) { '12345^PI^516^USVHA^PCE' }
+
+          it 'is valid' do
+            expect(user_info).to be_valid
+          end
+        end
+
+        describe 'multiple valid GCID codes' do
+          let(:gcids) do
+            '1000123456V123456^NI^200M^USVHA^P|12345^PI^200PROV^USVHA^P|1234567890^NI^200DOD^USDOD^P'
+          end
+
+          it 'is valid' do
+            expect(user_info).to be_valid
+          end
+        end
+
+        describe 'mixed named and numeric GCID codes' do
+          let(:gcids) do
+            '1000123456V123456^NI^200M^USVHA^P|12345^PI^516^USVHA^PCE|2^PI^553^USVHA^PCE'
+          end
+
+          it 'is valid' do
+            expect(user_info).to be_valid
+          end
+        end
+      end
+
+      context 'when gcids are invalid' do
+        let(:expected_error_message) { 'contains non-approved gcids' }
+
+        context 'when gcids contain an invalid code' do
+          let(:gcids) do
+            '1000123456V123456^NI^200BAD^USVHA^P|1000123456V123456^NI^200INVALID^USVHA^P'
+          end
+
+          it 'is not valid' do
+            expect(user_info).not_to be_valid
+            expect(user_info.errors[:gcids]).to include(expected_error_message)
+          end
+        end
+
+        context 'when gcids contain mixed valid and invalid codes' do
+          let(:gcids) do
+            '1000123456V123456^NI^200M^USVHA^P|12345^PI^INVALID^USVHA^P|2^PI^553^USVHA^PCE'
+          end
+
+          it 'is not valid' do
+            expect(user_info).not_to be_valid
+            expect(user_info.errors[:gcids]).to include(expected_error_message)
+          end
+        end
+
+        context 'when gcids is blank' do
+          let(:gcids) { '' }
+
+          it 'is valid (allows blank gcids)' do
+            expect(user_info).to be_valid
+          end
+        end
+
+        context 'when gcids is nil' do
+          let(:gcids) { nil }
+
+          it 'is valid (allows nil gcids)' do
+            expect(user_info).to be_valid
+          end
+        end
+
+        context 'when gcids is not a string' do
+          let(:gcids) { %w[200M 200PROV] }
+
+          it 'is not valid' do
+            expect(user_info).not_to be_valid
+            expect(user_info.errors[:gcids]).to include(expected_error_message)
+          end
+        end
+
+        context 'when gcids contains segments with missing code' do
+          let(:gcids) { '1000123456V123456^NI^^USVHA^P' }
+
+          it 'is not valid' do
+            expect(user_info).not_to be_valid
+            expect(user_info.errors[:gcids]).to include(expected_error_message)
+          end
+        end
+
+        context 'when gcids contains malformed segments' do
+          let(:gcids) { '1000123456V123456' }
+
+          it 'is not valid' do
+            expect(user_info).not_to be_valid
+            expect(user_info.errors[:gcids]).to include(expected_error_message)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/sign_in/user_info_generator_spec.rb
+++ b/spec/services/sign_in/user_info_generator_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SignIn::UserInfoGenerator do
+  subject(:generator) { described_class.new(user:) }
+
+  let(:user_account) { create(:user_account, icn:) }
+  let(:user_verification) { create(:idme_user_verification, idme_uuid: credential_uuid, user_account:) }
+
+  let(:mpi_profile) do
+    build(:mpi_profile, icn:, sec_id:, given_names: [first_name], family_name: last_name, edipi:, mhv_ien:, cerner_id:,
+                        participant_id: corp_id, birls_id: birls, full_mvi_ids: gcids)
+  end
+  let(:user) do
+    build(
+      :user,
+      user_account:,
+      user_verification:,
+      icn:,
+      idme_uuid: credential_uuid,
+      first_name:,
+      last_name:
+    )
+  end
+  let(:credential_uuid) { 'some-uuid' }
+  let(:icn) { 'some-icn' }
+  let(:sec_id) { 'some-sec-id' }
+  let(:first_name) { 'some-first-name' }
+  let(:last_name) { 'some-last-name' }
+  let(:email) { 'some-email' }
+  let(:client_id) { 'some-client-id' }
+  let(:edipi) { 'some-edipi' }
+  let(:mhv_ien) { '111222333' }
+  let(:cerner_id) { 'CER12345' }
+  let(:corp_id) { 'CORP67890' }
+  let(:birls) { 'BIRL12345' }
+  let(:gcids) do
+    [
+      '1000123456V123456^NI^200M^USVHA^P',
+      '12345^PI^516^USVHA^PCE',
+      '2^PI^553^USVHA^PCE'
+    ]
+  end
+  let(:npi_id) { 'NPI1234567' }
+
+  let!(:user_credential_email) { create(:user_credential_email, user_verification:, credential_email:) }
+  let(:credential_email) { 'test@example.com' }
+
+  before do
+    allow(user).to receive(:mpi_profile).and_return(mpi_profile)
+  end
+
+  describe '#perform' do
+    context 'when user has valid attributes' do
+      it 'generates user info with expected values' do
+        user_info = generator.perform
+
+        expect(user_info.sub).to eq(credential_uuid)
+        expect(user_info.ial).to eq(SignIn::Constants::Auth::IAL_TWO.to_s)
+        expect(user_info.aal).to eq('http://idmanagement.gov/ns/assurance/aal/2')
+        expect(user_info.csp_type).to eq(MPI::Constants::IDME_IDENTIFIER)
+        expect(user_info.csp_uuid).to eq(credential_uuid)
+        expect(user_info.email).to eq(credential_email)
+        expect(user_info.full_name).to eq(user.full_name_normalized.values.compact.join(' '))
+        expect(user_info.birth_date).to eq(user.birth_date)
+        expect(user_info.ssn).to eq(user.ssn)
+        expect(user_info.gender).to eq(user.gender)
+        expect(user_info.address_street1).to eq(user.address[:street])
+        expect(user_info.address_street2).to eq(user.address[:street2])
+        expect(user_info.address_city).to eq(user.address[:city])
+        expect(user_info.address_state).to eq(user.address[:state])
+        expect(user_info.address_country).to eq(user.address[:country])
+        expect(user_info.address_postal_code).to eq(user.address[:postal_code])
+        expect(user_info.phone_number).to eq(user.home_phone)
+        expect(user_info.person_types).to eq(user.person_types&.join('|') || '')
+        expect(user_info.icn).to eq(user.icn)
+        expect(user_info.sec_id).to eq(user.sec_id)
+        expect(user_info.edipi).to eq(user.edipi)
+        expect(user_info.mhv_ien).to eq(user.mhv_ien)
+        expect(user_info.cerner_id).to eq(user.cerner_id)
+        expect(user_info.corp_id).to eq(user.participant_id)
+        expect(user_info.birls).to eq(user.birls_id)
+        expect(user_info.npi_id).to eq(user.npi_id)
+      end
+
+      context 'when the gcids are valid' do
+        let(:expected_gcids) do
+          '1000123456V123456^NI^200M^USVHA^P|12345^PI^516^USVHA^PCE|2^PI^553^USVHA^PCE'
+        end
+
+        it 'includes them in the user info' do
+          user_info = generator.perform
+          expect(user_info.gcids).to eq(expected_gcids)
+        end
+      end
+
+      context 'when the gcids are not authorized' do
+        let(:gcids) do
+          [
+            '1000123456V123456^NI^200BAD^USVHA^P',
+            '1000123456V123456^NI^200INVALID^USVHA^P'
+          ]
+        end
+
+        it 'excludes them from the user info' do
+          user_info = generator.perform
+          expect(user_info.gcids).to eq('')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Update UserInfo to only return all approved GCIDS
- move business logic to service class
- Update specs

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/973

## Testing done

- Start vets-api
- Start vets-website
- navigate to http://localhost:3000/v0/sign_in/authorize_sso?client_id=okta_test&code_challenge_method=S256&code_challenge=1BUpxy37SoIPmKw96wbd6MDcvayOYm3ptT-zbe6L_zM=
- sign in
- grab the code from the redirect url
- make token request, fill in with your code
   ```bash
   curl -X POST localhost:3000/v0/sign_in/token -H 'Content-Type: application/json' -d '{"grant_type": "authorization_code", "code_verifier": "5787d673fb784c90f0e309883241803d", "code": "<code>"}'
   ```
- gab the access token from the response
- make a request to the `user_info` endpoint with that access_token
   ```bash
   curl -X GET localhost:3000/sign_in/user_info -H 'Authorization: Bearer <access token>'
   ```


## What areas of the site does it impact?
SignIn UserInfo endpoint

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

