### PR TITLE
Enable authorize_sso and user_info in production

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   get '/v1/sessions/ssoe_logout', to: 'v1/sessions#ssoe_slo_callback'
 
   get '/v0/sign_in/authorize', to: 'v0/sign_in#authorize'
-  get '/v0/sign_in/authorize_sso', to: 'v0/sign_in#authorize_sso' unless Settings.vsp_environment == 'production'
+  get '/v0/sign_in/authorize_sso', to: 'v0/sign_in#authorize_sso'
   get '/v0/sign_in/callback', to: 'v0/sign_in#callback'
   post '/v0/sign_in/refresh', to: 'v0/sign_in#refresh'
   post '/v0/sign_in/revoke', to: 'v0/sign_in#revoke'
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
 
   namespace :sign_in do
     get '/openid_connect/certs', to: 'openid_connect_certificates#index'
+    get '/user_info', to: 'user_info#show'
 
     namespace :webhooks do
       post 'logingov/risc', to: 'logingov#risc'
@@ -33,7 +34,6 @@ Rails.application.routes.draw do
     unless Settings.vsp_environment == 'production'
       resources :client_configs, param: :client_id
       resources :service_account_configs, param: :service_account_id
-      get '/user_info', to: 'user_info#show'
     end
   end
 


### PR DESCRIPTION
## Summary

-  Enable `authorize_sso` and `user_info` endpoints in production

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/973

## What areas of the site does it impact?
Sign in service
## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
