### PR TITLE
21P-8416 - accept claimantAddress or veteranAddress

### DIFF
--- a/modules/medical_expense_reports/lib/medical_expense_reports/benefits_intake/submit_claim_job.rb
+++ b/modules/medical_expense_reports/lib/medical_expense_reports/benefits_intake/submit_claim_job.rb
@@ -144,12 +144,14 @@ module MedicalExpenseReports
       # @param form [Hash]
       # @return [Hash]
       def generate_metadata(form)
+        address = form['claimantAddress'] || form['veteranAddress']
+
         # also validates/manipulates the metadata
         ::BenefitsIntake::Metadata.generate(
           form['veteranFullName']['first'],
           form['veteranFullName']['last'],
           form['vaFileNumber'] || form['veteranSocialSecurityNumber'],
-          form['veteranAddress']['postalCode'],
+          address['postalCode'],
           'va_gov_bio_huntridge',
           @claim.form_id,
           @claim.business_line


### PR DESCRIPTION
## Summary

Fixed 21P-8416 claim submissions not going to benefits intake API due to incorrect (missing) metadata.

## Testing done

In Staging, the front-end and back-end agree that claimantAddress is used for this part of the form. Because this form can be submitted by a Veteran or a dependent claimant, veteranAddress becomes claimantAddress when the claimant is the veteran. This will accept either.

## What areas of the site does it impact?

Just the 21P-8416 forms sending to Benefits Intake API