### PR TITLE
Fix 400 error on Lighthouse access_token requests

### DIFF
--- a/modules/mobile/app/services/mobile/v0/lighthouse_health/configuration.rb
+++ b/modules/mobile/app/services/mobile/v0/lighthouse_health/configuration.rb
@@ -36,7 +36,7 @@ module Mobile
         # @return Faraday::Connection a Faraday connection instance with the correct middleware
         #
         def access_token_connection
-          Faraday.new(access_token_url) do |conn|
+          Faraday.new(access_token_url, headers: { 'Content-Type' => 'application/x-www-form-urlencoded' }) do |conn|
             conn.use(:breakers, service_name:)
             conn.use Faraday::Response::RaiseError
             conn.response :json, content_type: /\bjson$/

--- a/modules/mobile/spec/services/lighthouse_health_configuration_spec.rb
+++ b/modules/mobile/spec/services/lighthouse_health_configuration_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Mobile::V0::LighthouseHealth::Configuration do
+  subject(:config) { described_class.instance }
+
+  describe '#access_token_connection' do
+    it 'sets Content-Type header to application/x-www-form-urlencoded' do
+      # This header is required for OAuth token requests.
+      # net-http v0.7.0+ removed automatic Content-Type defaults for POST requests,
+      # so we must explicitly set this header to prevent 400 errors from the OAuth server.
+      connection = config.access_token_connection
+
+      expect(connection.headers['Content-Type']).to eq('application/x-www-form-urlencoded')
+    end
+
+    it 'includes RaiseError middleware for error handling' do
+      connection = config.access_token_connection
+
+      expect(connection.builder.handlers).to include(Faraday::Response::RaiseError)
+    end
+
+    it 'includes breakers middleware for circuit breaking' do
+      connection = config.access_token_connection
+
+      # Breakers middleware is registered as a symbol
+      handler_names = connection.builder.handlers.map do |h|
+        h.name
+      rescue
+        h.to_s
+      end
+      expect(handler_names.join).to include('breakers').or include('Breakers')
+    end
+
+    it 'includes JSON response middleware' do
+      connection = config.access_token_connection
+
+      expect(connection.builder.handlers).to include(Faraday::Response::Json)
+    end
+  end
+
+  describe '#connection' do
+    it 'does not require Content-Type header (used for GET requests with Bearer token)' do
+      connection = config.connection
+
+      # The main connection is used for API requests with Authorization header,
+      # not for token requests, so Content-Type is not required
+      expect(connection.headers['Content-Type']).to be_nil
+    end
+  end
+
+  describe '#service_name' do
+    it 'returns the correct service name for breakers' do
+      expect(config.service_name).to eq('MobileLighthouseHealth')
+    end
+  end
+end


### PR DESCRIPTION
The net-http gem v0.7.0 removed automatic Content-Type header defaults for POST requests. This caused access_token requests to the Lighthouse OAuth endpoint to fail with 400 Bad Request because the server couldn't parse the form-encoded body without the Content-Type header.

This fix explicitly sets Content-Type: application/x-www-form-urlencoded on the access_token_connection to ensure compatibility with net-http v0.7.0+ and proper OAuth token requests.

Root cause: googleauth gem update (298d685ddd) pulled in net-http 0.9.1 which includes the breaking change from v0.7.0.

Adds spec to prevent regression.

Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
- *(Summarize the changes that have been made to the platform)*
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)*
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
