### PR TITLE
Add RSpec profiling to CI test runs

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -216,7 +216,7 @@ jobs:
           TEST_ENV_NUMBER: ${{ matrix.test_group }}
         run: >
           ${{ env.COMPOSE_BASH_CMD }}
-          "TEST_ENV_NUMBER=${{ matrix.test_group }} TMPDIR=tmp/systmp bundle exec parallel_test spec modules --group-by filesize --type rspec --only-group ${{ matrix.test_group }} -n 24"
+          "TEST_ENV_NUMBER=${{ matrix.test_group }} TMPDIR=tmp/systmp bundle exec parallel_test spec modules --group-by filesize --type rspec --only-group ${{ matrix.test_group }} -n 24 -o '--profile 20'"
 
       - name: Prepare SimpleCov shard payload
         if: always()


### PR DESCRIPTION
## Summary

Adds `--profile 20` flag to the CI test command to show the 20 slowest examples in each test group.

## Why

This helps identify optimization targets for further CI speed improvements. The profiling output will appear in the CI logs for each test group, showing which specific examples are taking the longest.

## Change

```diff
- bundle exec parallel_test spec modules --group-by filesize --type rspec --only-group ${{ matrix.test_group }} -n 24
+ bundle exec parallel_test spec modules --group-by filesize --type rspec --only-group ${{ matrix.test_group }} -n 24 -o '--profile 20'
```

## Expected Output

Each test group's CI log will now include a section like:

```
Top 20 slowest examples:
  SomeSpec does something
    3.45 seconds ./spec/some_spec.rb:123
  AnotherSpec does another thing
    2.87 seconds ./spec/another_spec.rb:456
  ...
```

## Related

- [#114024](https://github.com/department-of-veterans-affairs/va.gov-team/issues/114024) (Benchmark vets-api test times)

## Testing

- [x] CI runs and shows profiling output in logs