### PR TITLE
Disable ial2_enforcement in development by default

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1220,7 +1220,7 @@ features:
   identity_ial2_enforcement:
     actor_type: user
     description: Enforces IAL2 for newly verified users
-    enable_in_development: true
+    enable_in_development: false
   kendra_enabled_for_resources_and_support_search:
     actor_type: user
     description: Enable/disable Amazon Kendra for Resources and Support search


### PR DESCRIPTION
## Summary

- Disable `identity_ial2_enforcement` flipper by default in `development` until verification button is updated on frontend.
- This is to avoid the possible issue where a developer authenticates with an `loa3` user that is not in their local database yet. With this flipper enabled they will need to verify their user with `ial2` to continue but the verify account button is not updated on the frontend yet to point to `ial2` acr

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## What areas of the site does it impact?
local development authentication

## Acceptance criteria

- [x]  No error nor warning in the console.
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

