### PR TITLE
Update Brakeman to 7.1.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,7 +296,7 @@ GEM
     blueprinter (1.2.1)
     bootsnap (1.19.0)
       msgpack (~> 1.2)
-    brakeman (7.1.1)
+    brakeman (7.1.2)
       racc
     breakers (1.0)
       base64 (~> 0.2)


### PR DESCRIPTION
## Summary
Fixes error:
```
Run bundle exec brakeman --ensure-latest --confidence-level=2 --format github
Brakeman 7.1.1 is not the latest version 7.1.2
Error: Process completed with exit code 5.
```

## Related issue(s)

None. Saw while on support.

## Testing done

- [x] linting passes


## What areas of the site does it impact?
All PRs
