### PR TITLE
DR 128652: Fix evidence dates empty array issue

### DIFF
--- a/modules/decision_reviews/app/controllers/decision_reviews/v1/supplemental_claims_controller.rb
+++ b/modules/decision_reviews/app/controllers/decision_reviews/v1/supplemental_claims_controller.rb
@@ -191,7 +191,9 @@ module DecisionReviews
         # as we should only be collecting dates for pre-2005 treatment
         unique_evidence_dates = unique_evidence_dates.first(4)
 
-        merged_attributes['evidenceDates'] = unique_evidence_dates
+        # Only set evidenceDates if we have dates to include
+        # Lighthouse accepts missing evidenceDates key but rejects empty array
+        merged_attributes['evidenceDates'] = unique_evidence_dates unless unique_evidence_dates.empty?
         merged_entry
       end
     end

--- a/modules/decision_reviews/spec/controllers/supplemental_claims_controller_spec.rb
+++ b/modules/decision_reviews/spec/controllers/supplemental_claims_controller_spec.rb
@@ -292,5 +292,37 @@ RSpec.describe DecisionReviews::V1::SupplementalClaimsController, type: :control
         expect(merged_entry).to eq(expected_result)
       end
     end
+
+    context 'when entries have do not have evidenceDates' do
+      let(:entries) do
+        [
+          {
+            'attributes' => {
+              'locationAndName' => 'VA Medical Center - Boston',
+              'noTreatmentDates' => true
+            }
+          },
+          {
+            'attributes' => {
+              'locationAndName' => 'VA Medical Center - Boston',
+              'noTreatmentDates' => true
+            }
+          }
+        ]
+      end
+
+      let(:expected_result) do
+        {
+          'attributes' => {
+            'locationAndName' => 'VA Medical Center - Boston',
+            'noTreatmentDates' => true
+          }
+        }
+      end
+
+      it 'handles missing evidence dates gracefully' do
+        expect(merged_entry).to eq(expected_result)
+      end
+    end
   end
 end


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

We have continuing issues in where Veterans are unable to submit their Supplemental Claims due to our mishandling of their evidence dates. In this scenario, several Veterans filled out the VA treatment data similar to the below example:

<hr />

### First Provider 
<img width="400" alt="Screenshot 2025-12-30 at 8 58 46 AM" src="https://github.com/user-attachments/assets/0f7dac0f-02bc-4560-8ec0-b3a8278de583" />

<hr/>

### Second Provider
<img width="400" alt="Screenshot 2025-12-30 at 8 58 59 AM" src="https://github.com/user-attachments/assets/3b77112c-8e9c-436b-8be5-d332ab3f915a" />

<hr />

The way the front end handles duplicate location comparison is to JSON-stringify the entire entry and compare apples to apples. In this case, even though the location names are the same and both have the "no date" box checked, one has a treatment date added anyway, so the locations are not de-duped.

When the payload is then shaped to send to the back end, there is another part of the code that removes treatment dates from any providers where the "noDate" box was checked. Then the payload goes to the back end looking like this:

```
{
    "locationAndName": "Provider One",
    "noTreatmentDates": true
},
{
    "locationAndName": "Provider One",
    "noTreatmentDates": true
},
```

The back end runs the [`merge_evidence_entries` function](https://github.com/department-of-veterans-affairs/vets-api/blob/e6c6680835ed72cf54a5dfa696132e30f37fbab6/modules/decision_reviews/app/controllers/decision_reviews/v1/supplemental_claims_controller.rb#L176), which sees duplicate location names and tries to concatenate these entries together, but because neither one has `evidenceDates`, it adds an empty array and returns something like this:

```
{
    "locationAndName": "Provider One",
    "noTreatmentDates": true,
    "evidenceDates": []
}
```

Lighthouse will not accept an empty array for `evidenceDates`, but it is ok with the key not being included if the data is not there.

**The adjustment I made skips adding the `evidenceDates` key if there aren't any dates present in the first place.**

👉🏻 Note that this fix means we should not require any action by the stuck users in production in order for their submission to work.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/128652

## Testing done

- [x] *New code is covered by unit tests*

### Prior to the fix

<img width="400" alt="Screenshot 2025-12-30 at 9 08 59 AM" src="https://github.com/user-attachments/assets/e2d2aa25-5c36-42e1-9986-83a9cd1a72a5" />

<img width="400" alt="Screenshot 2025-12-30 at 9 09 14 AM" src="https://github.com/user-attachments/assets/35e15e0a-f890-4304-b308-f6f636b14aca" />

### After the fix

<img width="400" alt="Screenshot 2025-12-30 at 9 07 31 AM" src="https://github.com/user-attachments/assets/4ff29b47-5373-41ae-b60e-97d247568b3a" />

<img width="400" alt="Screenshot 2025-12-30 at 9 07 21 AM" src="https://github.com/user-attachments/assets/8a1001fa-c088-4bc2-8185-e62c3d3982da" />

## What areas of the site does it impact?
Supplemental Claims only

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  ~Events are being sent to the appropriate logging solution~
- [ ]  ~Documentation has been updated (link to documentation)~
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  ~I added a screenshot of the developed feature~