### PR TITLE
fix: Memory Leak - Save form attachments to DB before uploading to s3

### DIFF
--- a/app/controllers/concerns/form_attachment_create.rb
+++ b/app/controllers/concerns/form_attachment_create.rb
@@ -14,11 +14,12 @@ module FormAttachmentCreate
 
     validate_file_upload_class!
     ActiveRecord::Base.transaction do
-      # Save to get an ID
-      save_attachment_to_db!
 
       # Upload using the ID
       save_attachment_to_cloud!
+
+      # Save to get an ID
+      save_attachment_to_db!
 
       # Save the file_data JSON that was set by set_file_data!
       form_attachment.save!

--- a/app/models/form_attachment.rb
+++ b/app/models/form_attachment.rb
@@ -14,6 +14,7 @@ class FormAttachment < ApplicationRecord
   before_destroy { |record| record.get_file.delete }
 
   def set_file_data!(file, file_password = nil)
+    Rails.logger.info("Form Attachment file exist? #{File.exist?(file)}") if Flipper.enabled?(:form_attachment_logging)
     attachment_uploader = get_attachment_uploader
     file = unlock_pdf(file, file_password) if File.extname(file).downcase == '.pdf' && file_password.present?
     attachment_uploader.store!(file)


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

The Problem
CarrierWave generates file storage paths based on the model's attributes (typically including id). When you call store! on a new, unsaved record, CarrierWave may:
- Fail to generate a proper storage path
- Use temporary storage that gets lost
- Cause the errors we are seeing in prod

The form attachment should be saved to the database before uploading to s3 to ensure the form attachment can be saved and is valid. These errors are also resulting in puma backlog spikes as well.

[Datadog logs
](https://vagov.ddog-gov.com/logs?query=kube_namespace%3Avets-api%20kube_container_name%3Avets-api-web%20pod_name%3Avets-api-long-timeout-58df7b598f-9k2ql%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=flex_tier&stream_sort=time%2Casc&viz=stream&from_ts=1767305835946&to_ts=1767392235946&live=true)

<img width="997" height="640" alt="Screenshot 2026-01-02 at 4 29 32 PM" src="https://github.com/user-attachments/assets/edc01174-3e04-4fac-ac0f-852481040c08" />

There are more places where this will need to be resolved. 

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
