### PR TITLE
2277: enrollment system errors with string bodies

### DIFF
--- a/lib/veteran_enrollment_system/enrollment_periods/service.rb
+++ b/lib/veteran_enrollment_system/enrollment_periods/service.rb
@@ -50,7 +50,11 @@ module VeteranEnrollmentSystem
       private
 
       def raise_error(response, icn)
-        message = response.body&.dig('messages')&.pluck('description')&.join(', ') || response.body
+        message = if response.body.is_a?(Hash)
+                    response.body['messages']&.pluck('description')&.join(', ') || response.body
+                  else
+                    response.body
+                  end
         sanitized_message = message.to_s.gsub(icn, '[REDACTED]')
         raise ERROR_MAP[response.status]&.new(detail: sanitized_message) ||
               Common::Exceptions::BackendServiceException.new(nil, detail: sanitized_message)

--- a/lib/veteran_enrollment_system/form1095_b/service.rb
+++ b/lib/veteran_enrollment_system/form1095_b/service.rb
@@ -52,7 +52,11 @@ module VeteranEnrollmentSystem
       private
 
       def raise_error(response, icn)
-        message = response.body&.dig('messages')&.pluck('description')&.join(', ') || response.body
+        message = if response.body.is_a?(Hash)
+                    response.body['messages']&.pluck('description')&.join(', ') || response.body
+                  else
+                    response.body
+                  end
         sanitized_message = message.to_s.gsub(icn, '[REDACTED]')
         raise ERROR_MAP[response.status]&.new(detail: sanitized_message) ||
               Common::Exceptions::BackendServiceException.new(nil, detail: sanitized_message)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- Fixes bug in which error response from upstream server is a string, not a hash. 
- I work for the CVE team.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-iir/issues/2277

## Testing done

- [x] *New code is covered by unit tests*
- This is a bug fix and can't really be tested. The error case has only happened on gateway timeouts from upstream. This should fix those errors. 

## Screenshots

## What areas of the site does it impact?
Just 1095b and enrollment periods error handling.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
