### PR TITLE
Remove 'use_v2' param

### DIFF
--- a/app/controllers/v0/dependents_applications_controller.rb
+++ b/app/controllers/v0/dependents_applications_controller.rb
@@ -17,8 +17,7 @@ module V0
 
     def create
       form = dependent_params.to_json
-      use_v2 = form.present? ? JSON.parse(form)&.dig('dependents_application', 'use_v2') : nil
-      claim = SavedClaim::DependencyClaim.new(form:, use_v2:)
+      claim = SavedClaim::DependencyClaim.new(form:)
 
       monitor.track_create_attempt(claim, current_user)
 
@@ -34,8 +33,7 @@ module V0
 
       claim.process_attachments!
 
-      # reinstantiate as v1 dependent service if use_v2 is blank
-      dependent_service = use_v2.blank? ? BGS::DependentService.new(current_user) : create_dependent_service
+      dependent_service = create_dependent_service
 
       dependent_service.submit_686c_form(claim)
 

--- a/app/models/saved_claim/dependency_claim.rb
+++ b/app/models/saved_claim/dependency_claim.rb
@@ -43,19 +43,13 @@ class SavedClaim::DependencyClaim < CentralMailClaim
   validate :validate_686_form_data, on: :run_686_form_jobs
   validate :address_exists
 
-  attr_accessor :use_v2
-
   after_initialize do
-    self.form_id = if use_v2 || form_id == '686C-674-V2'
-                     '686C-674-V2'
-                   else
-                     self.class::FORM.upcase
-                   end
+    self.form_id = '686C-674-V2'
   end
 
   def pdf_overflow_tracking
-    track_each_pdf_overflow(use_v2 ? '686C-674-V2' : '686C-674') if submittable_686?
-    track_each_pdf_overflow(use_v2 ? '21-674-V2' : '21-674') if submittable_674?
+    track_each_pdf_overflow('686C-674-V2') if submittable_686?
+    track_each_pdf_overflow('21-674-V2') if submittable_674?
   rescue => e
     monitor.track_pdf_overflow_tracking_failure(e)
   end

--- a/app/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job.rb
+++ b/app/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job.rb
@@ -252,8 +252,7 @@ module Lighthouse
         claim.send_failure_email(email)
       rescue => e
         # If we fail in the above failure events, this is a critical error and silent failure.
-        v2 = false
-        Rails.logger.error('Lighthouse::BenefitsIntake::SubmitCentralForm686cJob silent failure!', { e:, msg:, v2: })
+        Rails.logger.error('Lighthouse::BenefitsIntake::SubmitCentralForm686cJob silent failure!', { e:, msg: })
         StatsD.increment("#{Lighthouse::BenefitsIntake::SubmitCentralForm686cJob::STATSD_KEY_PREFIX}.silent_failure")
       end
 

--- a/app/sidekiq/lighthouse/benefits_intake/submit_central_form686c_v2_job.rb
+++ b/app/sidekiq/lighthouse/benefits_intake/submit_central_form686c_v2_job.rb
@@ -257,8 +257,7 @@ module Lighthouse
         claim.send_failure_email(email)
       rescue => e
         # If we fail in the above failure events, this is a critical error and silent failure.
-        v2 = true
-        Rails.logger.error('Lighthouse::BenefitsIntake::SubmitCentralForm686cJob silent failure!', { e:, msg:, v2: })
+        Rails.logger.error('Lighthouse::BenefitsIntake::SubmitCentralForm686cJob silent failure!', { e:, msg: })
         StatsD.increment("#{Lighthouse::BenefitsIntake::SubmitCentralForm686cV2Job::STATSD_KEY_PREFIX}}.silent_failure")
       end
 

--- a/lib/dependents/monitor.rb
+++ b/lib/dependents/monitor.rb
@@ -29,7 +29,6 @@ module Dependents
     # allowed logging params
     ALLOWLIST = %w[
       tags
-      use_v2
     ].freeze
 
     attr_writer :form_id
@@ -41,12 +40,11 @@ module Dependents
     def initialize(claim_id, form_id = nil)
       @claim_id = claim_id
       @claim = claim(claim_id)
-      @use_v2 = use_v2
       @form_id = form_id || @claim&.form_id
 
       super('dependents-application', allowlist: ALLOWLIST)
 
-      @tags += ["service:#{service}", "v2:#{@use_v2}"]
+      @tags += ["service:#{service}"]
     end
 
     def name
@@ -61,12 +59,6 @@ module Dependents
       SUBMISSION_STATS_KEY
     end
 
-    def use_v2
-      return nil unless @claim
-
-      @claim&.use_v2 || @claim&.form_id&.include?('-V2')
-    end
-
     def claim(claim_id)
       SavedClaim::DependencyClaim.find(claim_id) unless claim_id.nil?
     rescue => e
@@ -75,7 +67,7 @@ module Dependents
     end
 
     def default_payload
-      { service:, use_v2: @use_v2, claim: @claim, user_account_uuid: nil, tags: }
+      { service:, claim: @claim, user_account_uuid: nil, tags: }
     end
 
     def track_submission_exhaustion(msg, email = nil)
@@ -147,7 +139,6 @@ module Dependents
 
     def track_pdf_upload_error
       metric = "#{CLAIM_STATS_KEY}.upload_pdf.failure"
-      metric = "#{metric}.v2" if @use_v2
       payload = default_payload.merge({ statsd: metric })
 
       track_event('error', 'DependencyClaim error in upload_to_vbms method', metric, payload)
@@ -155,7 +146,6 @@ module Dependents
 
     def track_to_pdf_failure(e, form_id)
       metric = "#{CLAIM_STATS_KEY}.to_pdf.failure"
-      metric = "#{metric}.v2" if @use_v2
       payload = default_payload.merge({ statsd: metric, e:, form_id: })
 
       StatsD.increment(metric, tags:)
@@ -164,7 +154,6 @@ module Dependents
 
     def track_pdf_overflow_tracking_failure(e)
       metric = "#{CLAIM_STATS_KEY}.track_pdf_overflow.failure"
-      metric = "#{metric}.v2" if @use_v2
       payload = default_payload.merge({ statsd: metric, e: })
 
       StatsD.increment(metric, tags:)

--- a/modules/dependents_benefits/spec/fixtures/pdf_fill/21-686C/kitchen_sink.json
+++ b/modules/dependents_benefits/spec/fixtures/pdf_fill/21-686C/kitchen_sink.json
@@ -458,7 +458,6 @@
       "ssn": "987654321",
       "va_file_number": "987654321"
     },
-    "use_v2": true,
     "days_till_expires": 365,
     "privacy_agreement_accepted": true
   },

--- a/modules/dependents_benefits/spec/fixtures/pdf_fill/21-686C/overflow.json
+++ b/modules/dependents_benefits/spec/fixtures/pdf_fill/21-686C/overflow.json
@@ -441,7 +441,6 @@
       "report_marriage_of_child_under18": true,
       "report_child18_or_older_is_not_attending_school": true
     },
-    "use_v2": true,
     "days_till_expires": 365,
     "privacy_agreement_accepted": true
   },

--- a/modules/dependents_benefits/spec/fixtures/pdf_fill/21-686C/pension_overflow.json
+++ b/modules/dependents_benefits/spec/fixtures/pdf_fill/21-686C/pension_overflow.json
@@ -437,7 +437,6 @@
       "report_marriage_of_child_under18": true,
       "report_child18_or_older_is_not_attending_school": true
     },
-    "use_v2": true,
     "days_till_expires": 365,
     "privacy_agreement_accepted": true
   },

--- a/modules/dependents_benefits/spec/fixtures/pdf_fill/21-686C/simple.json
+++ b/modules/dependents_benefits/spec/fixtures/pdf_fill/21-686C/simple.json
@@ -44,7 +44,6 @@
       "spouse_income": "Y",
       "spouse_does_live_with_veteran": true
     },
-    "use_v2": true,
     "days_till_expires": 365,
     "privacy_agreement_accepted": true
   }

--- a/spec/controllers/v0/dependents_applications_controller_spec.rb
+++ b/spec/controllers/v0/dependents_applications_controller_spec.rb
@@ -9,10 +9,6 @@ RSpec.describe V0::DependentsApplicationsController do
     sign_in_as(user)
   end
 
-  let(:test_form) do
-    build(:dependency_claim).parsed_form
-  end
-
   let(:test_form_v2) do
     build(:dependency_claim_v2).parsed_form
   end
@@ -47,43 +43,7 @@ RSpec.describe V0::DependentsApplicationsController do
   end
 
   describe 'POST create' do
-    context 'with valid params v1' do
-      before do
-        allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_686?).and_return(true)
-        allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(true)
-        allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:confirmation_number).and_return('')
-        allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:pdf_overflow_tracking)
-        allow_any_instance_of(BGS::PersonWebService).to receive(:find_by_ssn).and_return({ file_nbr: '796043735' })
-      end
-
-      let(:vanotify) { double(send_email: true) }
-
-      it 'validates successfully' do
-        expect(VaNotify::Service).to receive(:new).and_return(vanotify)
-        expect(vanotify).to receive(:send_email).with(
-          {
-            email_address: user.va_profile_email,
-            template_id: 'fake_submitted686c674',
-            personalisation: hash_including('date_submitted', 'first_name', 'confirmation_number')
-          }.compact
-        )
-
-        expect(BGS::DependentService).to receive(:new)
-          .with(instance_of(User))
-          .and_return(service)
-
-        expect(service).to receive(:submit_686c_form)
-          .with(instance_of(SavedClaim::DependencyClaim))
-
-        VCR.use_cassette('bgs/dependent_service/submit_686c_form') do
-          post(:create, params: test_form)
-        end
-
-        expect(response).to have_http_status(:ok)
-      end
-    end
-
-    context 'with valid params v2' do
+    context 'with valid params' do
       before do
         allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_686?).and_return(true)
         allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(true)
@@ -140,29 +100,6 @@ RSpec.describe V0::DependentsApplicationsController do
             post(:create, params: test_form_v2, as: :json)
           end
         end
-      end
-    end
-
-    context 'with v1 submitting with a v2 user' do
-      before do
-        allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_686?).and_return(true)
-        allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:submittable_674?).and_return(true)
-        allow_any_instance_of(SavedClaim::DependencyClaim).to receive(:pdf_overflow_tracking)
-        allow_any_instance_of(BGS::PersonWebService).to receive(:find_by_ssn).and_return({ file_nbr: '796043735' })
-      end
-
-      it 'validates successfully' do
-        expect(BGS::DependentService).to receive(:new)
-          .with(instance_of(User))
-          .and_return(service)
-
-        expect(service).to receive(:submit_686c_form)
-          .with(instance_of(SavedClaim::DependencyClaim))
-
-        VCR.use_cassette('bgs/dependent_service/submit_686c_form') do
-          post(:create, params: test_form)
-        end
-        expect(response).to have_http_status(:ok)
       end
     end
 

--- a/spec/factories/686c/adopted_child_lives_with_veteran.rb
+++ b/spec/factories/686c/adopted_child_lives_with_veteran.rb
@@ -97,7 +97,6 @@ FactoryBot.define do
             'ssn' => '987654321',
             'va_file_number' => '987654321'
           },
-          'use_v2' => true,
           'days_till_expires' => 365,
           'privacy_agreement_accepted' => true
         },

--- a/spec/factories/686c/form_674_only.rb
+++ b/spec/factories/686c/form_674_only.rb
@@ -230,7 +230,6 @@ FactoryBot.define do
             'ssn' => '987654321',
             'va_file_number' => '987654321'
           },
-          'use_v2' => true,
           'days_till_expires' => 365,
           'privacy_agreement_accepted' => true
         },

--- a/spec/factories/686c/form_686c_674.rb
+++ b/spec/factories/686c/form_686c_674.rb
@@ -1140,7 +1140,6 @@ FactoryBot.define do
             'ssn' => '987654321',
             'va_file_number' => '987654321'
           },
-          'use_v2' => true,
           'days_till_expires' => 365,
           'privacy_agreement_accepted' => true
         },

--- a/spec/factories/686c/spouse.rb
+++ b/spec/factories/686c/spouse.rb
@@ -106,7 +106,6 @@ FactoryBot.define do
             'ssn' => '987654321',
             'va_file_number' => '987654321'
           },
-          'use_v2' => true,
           'days_till_expires' => 365,
           'privacy_agreement_accepted' => true
         },

--- a/spec/factories/686c/step_child_lives_with_veteran.rb
+++ b/spec/factories/686c/step_child_lives_with_veteran.rb
@@ -100,7 +100,6 @@ FactoryBot.define do
             'ssn' => '987654321',
             'va_file_number' => '987654321'
           },
-          'use_v2' => true,
           'days_till_expires' => 365,
           'privacy_agreement_accepted' => true
         },

--- a/spec/factories/dependency_claim.rb
+++ b/spec/factories/dependency_claim.rb
@@ -229,8 +229,6 @@ FactoryBot.define do
   factory :dependency_claim_v2, class: 'SavedClaim::DependencyClaim' do
     form_id { '686C-674-V2' }
 
-    use_v2 { true }
-
     form {
       {
         statement_of_truth_certified: true,
@@ -685,7 +683,6 @@ FactoryBot.define do
             report_marriage_of_child_under18: true,
             report_child18_or_older_is_not_attending_school: true
           },
-          use_v2: true,
           days_till_expires: 365,
           privacy_agreement_accepted: true
         },

--- a/spec/fixtures/pdf_fill/686C-674-V2/kitchen_sink.json
+++ b/spec/fixtures/pdf_fill/686C-674-V2/kitchen_sink.json
@@ -458,7 +458,6 @@
       "ssn": "987654321",
       "va_file_number": "987654321"
     },
-    "use_v2": true,
     "days_till_expires": 365,
     "privacy_agreement_accepted": true
   },

--- a/spec/fixtures/pdf_fill/686C-674-V2/overflow.json
+++ b/spec/fixtures/pdf_fill/686C-674-V2/overflow.json
@@ -441,7 +441,6 @@
       "report_marriage_of_child_under18": true,
       "report_child18_or_older_is_not_attending_school": true
     },
-    "use_v2": true,
     "days_till_expires": 365,
     "privacy_agreement_accepted": true
   },

--- a/spec/fixtures/pdf_fill/686C-674-V2/simple.json
+++ b/spec/fixtures/pdf_fill/686C-674-V2/simple.json
@@ -44,7 +44,6 @@
       "spouse_income": "Y",
       "spouse_does_live_with_veteran": true
     },
-    "use_v2": true,
     "days_till_expires": 365,
     "privacy_agreement_accepted": true
   }

--- a/spec/lib/dependents/monitor_spec.rb
+++ b/spec/lib/dependents/monitor_spec.rb
@@ -57,525 +57,359 @@ RSpec.describe Dependents::Monitor do
   end
   let(:encrypted_user) { KmsEncrypted::Box.new.encrypt(user_struct.to_h.to_json) }
 
-  context 'v1' do
-    describe '#track_submission_exhaustion' do
-      let(:tags) { ['form_id:686C-674', 'service:dependents-application', 'v2:false'] }
+  describe '#track_submission_exhaustion' do
+    let(:tags) { ['form_id:686C-674-V2', 'service:dependents-application'] }
 
-      it 'logs sidekiq job exhaustion' do
-        msg = { 'args' => [claim.id, encrypted_vet_info, encrypted_user], error_message: 'Error!' }
+    it 'logs sidekiq job exhaustion' do
+      msg = { 'args' => [claim_v2.id, encrypted_vet_info, encrypted_user], error_message: 'Error!' }
 
-        log = 'Failed all retries on Lighthouse::BenefitsIntake::SubmitCentralForm686cJob, ' \
-              "last error: #{msg['error_message']}"
-        payload = {
-          claim:,
-          error: msg,
-          service: 'dependents-application',
-          tags:,
-          use_v2: false,
-          user_account_uuid: nil
-        }
+      log = 'Failed all retries on Lighthouse::BenefitsIntake::SubmitCentralForm686cJob, ' \
+            "last error: #{msg['error_message']}"
+      payload = {
+        claim: claim_v2,
+        error: msg,
+        service: 'dependents-application',
+        tags:,
+        user_account_uuid: nil
+      }
 
-        expect(monitor_v1).to receive(:log_silent_failure).with(payload, anything)
-        expect(StatsD).to receive(:increment).with("#{submission_stats_key}.exhausted", tags:)
-        expect(Rails.logger).to receive(:error).with(log)
+      expect(monitor_v2).to receive(:log_silent_failure).with(payload, anything)
+      expect(StatsD).to receive(:increment).with("#{submission_stats_key}.exhausted", tags:)
+      expect(Rails.logger).to receive(:error).with(log)
 
-        monitor_v1.track_submission_exhaustion(msg)
-      end
-
-      it 'logs sidekiq job exhaustion with failure avoided' do
-        msg = { 'args' => [claim.id, encrypted_vet_info, encrypted_user], error_message: 'Error!' }
-
-        log = 'Failed all retries on Lighthouse::BenefitsIntake::SubmitCentralForm686cJob, ' \
-              "last error: #{msg['error_message']}"
-        payload = {
-          claim:,
-          error: msg,
-          service: 'dependents-application',
-          tags:,
-          use_v2: false,
-          user_account_uuid: nil
-        }
-
-        expect(monitor_v1).to receive(:log_silent_failure_avoided).with(payload, anything)
-        expect(StatsD).to receive(:increment).with("#{submission_stats_key}.exhausted", tags:)
-        expect(Rails.logger).to receive(:error).with(log)
-
-        monitor_v1.track_submission_exhaustion(msg, user_struct.va_profile_email)
-      end
+      monitor_v2.track_submission_exhaustion(msg)
     end
 
-    describe '#track_event' do
-      let(:tags) { ['service:dependents-application', 'function:track_event', 'form_id:686C-674', 'v2:false'] }
+    it 'logs sidekiq job exhaustion with failure avoided' do
+      msg = { 'args' => [claim_v2.id, encrypted_vet_info, encrypted_user], error_message: 'Error!' }
 
-      it 'handles an error' do
-        expect(StatsD).to receive(:increment).with('saved_claim.create', anything).once
-        expect(StatsD).to receive(:increment).with('saved_claim.pdf.overflow', anything).twice
-        expect(StatsD).to receive(:increment).with('test.monitor.exhaustion', tags:)
-        expect(Rails.logger).to receive(:error).with('Error!', {
-                                                       context: {
-                                                         claim_id: claim.id,
-                                                         confirmation_number: claim.confirmation_number,
-                                                         error: 'test',
-                                                         form_id: '686C-674',
-                                                         service: 'dependents-application',
-                                                         tags: ['form_id:686C-674', 'service:dependents-application',
-                                                                'v2:false'],
-                                                         use_v2: false,
-                                                         user_account_uuid: nil
-                                                       },
-                                                       file: a_kind_of(String),
-                                                       function: 'track_event',
-                                                       line: a_kind_of(Integer),
+      log = 'Failed all retries on Lighthouse::BenefitsIntake::SubmitCentralForm686cJob, ' \
+            "last error: #{msg['error_message']}"
+      payload = {
+        claim: claim_v2,
+        error: msg,
+        service: 'dependents-application',
+        tags: ['form_id:686C-674-V2', 'service:dependents-application'],
+        user_account_uuid: nil
+      }
+
+      expect(monitor_v2).to receive(:log_silent_failure_avoided).with(payload, anything)
+      expect(StatsD).to receive(:increment).with("#{submission_stats_key}.exhausted", tags:)
+      expect(Rails.logger).to receive(:error).with(log)
+
+      monitor_v2.track_submission_exhaustion(msg, user_struct.va_profile_email)
+    end
+  end
+
+  describe '#track_event' do
+    let(:tags) { ['service:dependents-application', 'function:track_event', 'form_id:686C-674-V2'] }
+
+    it 'handles an error' do
+      expect(StatsD).to receive(:increment).with('saved_claim.create', anything).at_least(:once)
+      expect(StatsD).to receive(:increment).with('saved_claim.pdf.overflow', anything).at_least(:once)
+      expect(StatsD).to receive(:increment).with('test.monitor.exhaustion', tags:)
+      expect(Rails.logger).to receive(:error).with('Error!', {
+                                                     context: {
+                                                       claim_id: claim_v2.id,
+                                                       confirmation_number: claim_v2.confirmation_number,
+                                                       error: 'test',
+                                                       form_id: '686C-674-V2',
                                                        service: 'dependents-application',
-                                                       statsd: 'test.monitor.exhaustion'
-                                                     })
+                                                       tags: ['form_id:686C-674-V2',
+                                                              'service:dependents-application'],
+                                                       user_account_uuid: nil
+                                                     },
+                                                     file: a_kind_of(String),
+                                                     function: 'track_event',
+                                                     line: a_kind_of(Integer),
+                                                     service: 'dependents-application',
+                                                     statsd: 'test.monitor.exhaustion'
+                                                   })
 
-        monitor_v1.track_event('error', 'Error!', 'test.monitor.exhaustion', error: 'test')
-      end
+      monitor_v2.track_event('error', 'Error!', 'test.monitor.exhaustion', error: 'test')
+    end
 
-      it 'handles an info log' do
-        expect(StatsD).to receive(:increment).with('saved_claim.create', anything).once
-        expect(StatsD).to receive(:increment).with('saved_claim.pdf.overflow', anything).twice
-        expect(StatsD).to receive(:increment).with('test.monitor.success', tags:)
-        expect(Rails.logger).to receive(:info).with('Success!', {
-                                                      context: {
-                                                        claim_id: claim.id,
-                                                        confirmation_number: claim.confirmation_number,
-                                                        error: 'test',
-                                                        form_id: '686C-674',
-                                                        service: 'dependents-application',
-                                                        tags: ['form_id:686C-674', 'service:dependents-application',
-                                                               'v2:false'],
-                                                        use_v2: false,
-                                                        user_account_uuid: nil
-                                                      },
-                                                      file: a_kind_of(String),
-                                                      function: 'track_event',
-                                                      line: a_kind_of(Integer),
+    it 'handles an info log' do
+      expect(StatsD).to receive(:increment).with('saved_claim.create', anything).at_least(:once)
+      expect(StatsD).to receive(:increment).with('saved_claim.pdf.overflow', anything).at_least(:once)
+      expect(StatsD).to receive(:increment).with('test.monitor.success', tags:)
+      expect(Rails.logger).to receive(:info).with('Success!', {
+                                                    context: {
+                                                      claim_id: claim_v2.id,
+                                                      confirmation_number: claim_v2.confirmation_number,
+                                                      error: 'test',
+                                                      form_id: '686C-674-V2',
                                                       service: 'dependents-application',
-                                                      statsd: 'test.monitor.success'
-                                                    })
+                                                      tags: ['form_id:686C-674-V2', 'service:dependents-application'],
+                                                      user_account_uuid: nil
+                                                    },
+                                                    file: a_kind_of(String),
+                                                    function: 'track_event',
+                                                    line: a_kind_of(Integer),
+                                                    service: 'dependents-application',
+                                                    statsd: 'test.monitor.success'
+                                                  })
 
-        monitor_v1.track_event('info', 'Success!', 'test.monitor.success', error: 'test')
-      end
+      monitor_v2.track_event('info', 'Success!', 'test.monitor.success', error: 'test')
+    end
 
-      it 'handles a warning' do
-        expect(StatsD).to receive(:increment).with('saved_claim.create', anything).once
-        expect(StatsD).to receive(:increment).with('saved_claim.pdf.overflow', anything).twice
-        expect(StatsD).to receive(:increment).with('test.monitor.failure', tags:)
-        expect(Rails.logger).to receive(:warn).with('Oops!', {
-                                                      context: {
-                                                        claim_id: claim.id,
-                                                        confirmation_number: claim.confirmation_number,
-                                                        error: 'test',
-                                                        form_id: '686C-674',
-                                                        service: 'dependents-application',
-                                                        tags: ['form_id:686C-674', 'service:dependents-application',
-                                                               'v2:false'],
-                                                        use_v2: false,
-                                                        user_account_uuid: nil
-                                                      },
-                                                      file: a_kind_of(String),
-                                                      function: 'track_event',
-                                                      line: a_kind_of(Integer),
+    it 'handles a warning' do
+      expect(StatsD).to receive(:increment).with('saved_claim.create', anything).at_least(:once)
+      expect(StatsD).to receive(:increment).with('saved_claim.pdf.overflow', anything).at_least(:once)
+      expect(StatsD).to receive(:increment).with('test.monitor.failure', tags:)
+      expect(Rails.logger).to receive(:warn).with('Oops!', {
+                                                    context: {
+                                                      claim_id: claim_v2.id,
+                                                      confirmation_number: claim_v2.confirmation_number,
+                                                      error: 'test',
+                                                      form_id: '686C-674-V2',
                                                       service: 'dependents-application',
-                                                      statsd: 'test.monitor.failure'
-                                                    })
+                                                      tags: ['form_id:686C-674-V2', 'service:dependents-application'],
+                                                      user_account_uuid: nil
+                                                    },
+                                                    file: a_kind_of(String),
+                                                    function: 'track_event',
+                                                    line: a_kind_of(Integer),
+                                                    service: 'dependents-application',
+                                                    statsd: 'test.monitor.failure'
+                                                  })
 
-        monitor_v1.track_event('warn', 'Oops!', 'test.monitor.failure', error: 'test')
-      end
+      monitor_v2.track_event('warn', 'Oops!', 'test.monitor.failure', error: 'test')
+    end
+  end
 
-      it 'logs an error when it fails' do
-        allow(monitor_v1).to receive(:submit_event).and_raise(StandardError.new('test error'))
+  describe '#track_unknown_claim_type' do
+    it 'logs unknown claim type error' do
+      error = StandardError.new('Unknown type')
+      metric = "#{described_class::EMAIL_STATS_KEY}.unknown_type"
+      tags = ['form_id:686C-674-V2', 'service:dependents-application']
+      payload = {
+        claim:,
+        service: 'dependents-application',
+        tags:,
+        user_account_uuid: nil,
+        statsd: metric,
+        e: error
+      }
 
-        expect(Rails.logger)
-          .to receive(:error)
-          .with(
-            'Dependents::Monitor#track_event error',
-            {
-              level: 'info',
-              message: 'test error',
-              stats_key: 'test.monitor.error',
-              payload: hash_including(error: 'test error'),
-              error: 'test error'
-            }
-          )
+      expect(StatsD).to receive(:increment).with(metric, tags:)
+      expect(Rails.logger).to receive(:error).with("Unknown Dependents form type for claim #{claim.id}", payload)
 
-        monitor_v1.track_event('info', 'test error', 'test.monitor.error', { error: 'test error' })
+      monitor_v1.track_unknown_claim_type(error)
+    end
+  end
+
+  describe '#track_send_email_success' do
+    it 'logs email success' do
+      message = 'Email sent successfully'
+      metric = 'test.email.success'
+      user_account_id = 'user123'
+      tags = ['form_id:686C-674-V2', 'service:dependents-application']
+      payload = {
+        claim:,
+        service: 'dependents-application',
+        tags:,
+        user_account_uuid: nil,
+        statsd: metric,
+        user_account_id:
+      }
+
+      expect(StatsD).to receive(:increment).with(metric, tags:)
+      expect(Rails.logger).to receive(:info).with(message, payload)
+
+      monitor_v1.track_send_email_success(message, metric, user_account_id)
+    end
+  end
+
+  describe '#track_send_email_error' do
+    it 'logs email error' do
+      message = 'Email failed to send'
+      metric = 'test.email.error'
+      error = StandardError.new('SMTP error')
+      user_account_uuid = 'uuid123'
+      tags = ['form_id:686C-674-V2', 'service:dependents-application']
+      payload = {
+        claim:,
+        service: 'dependents-application',
+        tags:,
+        user_account_uuid:,
+        statsd: metric,
+        e: error
+      }
+
+      expect(StatsD).to receive(:increment).with(metric, tags:)
+      expect(Rails.logger).to receive(:error).with(message, payload)
+
+      monitor_v1.track_send_email_error(message, metric, error, user_account_uuid)
+    end
+  end
+
+  describe '#track_send_submitted_email_success' do
+    it 'tracks submitted email success' do
+      user_account_uuid = 'uuid123'
+      message = "'Submitted' email success for claim #{claim.id}"
+      metric = "#{described_class::EMAIL_STATS_KEY}.submitted.success"
+
+      expect(monitor_v1).to receive(:track_send_email_success).with(message, metric, user_account_uuid)
+
+      monitor_v1.track_send_submitted_email_success(user_account_uuid)
+    end
+  end
+
+  describe '#track_send_submitted_email_failure' do
+    it 'tracks submitted email failure' do
+      error = StandardError.new('Email error')
+      user_account_uuid = 'uuid123'
+      message = "'Submitted' email failure for claim #{claim.id}"
+      metric = "#{described_class::EMAIL_STATS_KEY}.submitted.failure"
+
+      expect(monitor_v1).to receive(:track_send_email_error).with(message, metric, error, user_account_uuid)
+
+      monitor_v1.track_send_submitted_email_failure(error, user_account_uuid)
+    end
+  end
+
+  describe '#track_send_received_email_success' do
+    it 'tracks received email success' do
+      user_account_uuid = 'uuid123'
+      message = "'Received' email success for claim #{claim.id}"
+      metric = "#{described_class::EMAIL_STATS_KEY}.received.success"
+
+      expect(monitor_v1).to receive(:track_send_email_success).with(message, metric, user_account_uuid)
+
+      monitor_v1.track_send_received_email_success(user_account_uuid)
+    end
+  end
+
+  describe '#track_send_received_email_failure' do
+    it 'tracks received email failure' do
+      error = StandardError.new('Email error')
+      user_account_uuid = 'uuid123'
+
+      expect(monitor_v1)
+        .to receive(:track_send_email_failure)
+        .with(claim, nil, user_account_uuid, 'submitted', error)
+
+      monitor_v1.track_send_received_email_failure(error, user_account_uuid)
+    end
+  end
+
+  describe '#track_pdf_upload_error' do
+    it 'tracks PDF upload error' do
+      metric = "#{described_class::CLAIM_STATS_KEY}.upload_pdf.failure"
+      payload = {
+        claim:,
+        service: 'dependents-application',
+        tags: ['form_id:686C-674-V2', 'service:dependents-application'],
+        user_account_uuid: nil,
+        statsd: metric
+      }
+
+      expect(monitor_v1)
+        .to receive(:track_event)
+        .with('error', 'DependencyClaim error in upload_to_vbms method', metric, payload)
+
+      monitor_v1.track_pdf_upload_error
+    end
+  end
+
+  describe '#track_to_pdf_failure' do
+    it 'tracks PDF generation failure' do
+      error = StandardError.new('PDF error')
+      form_id = '686C-674'
+      metric = "#{described_class::CLAIM_STATS_KEY}.to_pdf.failure"
+      tags = ['form_id:686C-674-V2', 'service:dependents-application']
+      payload = {
+        claim:,
+        service: 'dependents-application',
+        tags:,
+        user_account_uuid: nil,
+        statsd: metric,
+        e: error,
+        form_id:
+      }
+
+      expect(StatsD).to receive(:increment).with(metric, tags:)
+      expect(Rails.logger).to receive(:error).with('SavedClaim::DependencyClaim#to_pdf error', payload)
+
+      monitor_v1.track_to_pdf_failure(error, form_id)
+    end
+  end
+
+  describe '#track_pdf_overflow_tracking_failure' do
+    it 'tracks PDF overflow tracking failure' do
+      error = StandardError.new('Overflow tracking error')
+      metric = "#{described_class::CLAIM_STATS_KEY}.track_pdf_overflow.failure"
+      tags = ['form_id:686C-674-V2', 'service:dependents-application']
+      payload = {
+        claim:,
+        service: 'dependents-application',
+        tags:,
+        user_account_uuid: nil,
+        statsd: metric,
+        e: error
+      }
+
+      expect(StatsD).to receive(:increment).with(metric, tags:)
+      expect(Rails.logger).to receive(:warn).with('Error tracking PDF overflow', payload)
+
+      monitor_v1.track_pdf_overflow_tracking_failure(error)
+    end
+  end
+
+  describe '#track_pdf_overflow' do
+    it 'tracks PDF overflow' do
+      form_id = '686C-674'
+      metric = 'saved_claim.pdf.overflow'
+
+      # Allow any StatsD calls to happen for test setup or the test will fail
+      allow(StatsD).to receive(:increment)
+
+      expect(StatsD).to receive(:increment).with(metric, tags: ["form_id:#{form_id}"])
+
+      monitor_v1.track_pdf_overflow(form_id)
+    end
+  end
+
+  describe '#track_pension_related_submission' do
+    it 'tracks pension related submission with correct tags' do
+      form_id = '686C-674-V2'
+      metric = "#{described_class::PENSION_SUBMISSION_STATS_KEY}.686c-674.submitted"
+
+      # Allow any StatsD calls to happen for test setup or the test will fail
+      allow(StatsD).to receive(:increment)
+
+      expect(StatsD).to receive(:increment).with(metric, tags: ["form_id:#{form_id}"])
+
+      monitor_v2.track_pension_related_submission(form_id:, form_type: '686c-674')
+    end
+  end
+
+  describe '#claim' do
+    context 'when claim is not found' do
+      it 'logs warning and returns nil' do
+        allow(SavedClaim::DependencyClaim).to receive(:find).and_raise(ActiveRecord::RecordNotFound)
+
+        expect(Rails.logger).to receive(:warn).with(
+          'Unable to find claim for Dependents::Monitor',
+          { claim_id: claim.id, e: ActiveRecord::RecordNotFound }
+        ).at_least(:once)
+
+        result = monitor_v1.send(:claim, claim.id)
+        expect(result).to be_nil
       end
     end
   end
 
-  context 'v2' do
-    describe '#track_submission_exhaustion' do
-      let(:tags) { ['form_id:686C-674-V2', 'service:dependents-application', 'v2:true'] }
-
-      it 'logs sidekiq job exhaustion' do
-        msg = { 'args' => [claim_v2.id, encrypted_vet_info, encrypted_user], error_message: 'Error!' }
-
-        log = 'Failed all retries on Lighthouse::BenefitsIntake::SubmitCentralForm686cJob, ' \
-              "last error: #{msg['error_message']}"
-        payload = {
-          claim: claim_v2,
-          error: msg,
-          service: 'dependents-application',
-          tags:,
-          use_v2: true,
-          user_account_uuid: nil
-        }
-
-        expect(monitor_v2).to receive(:log_silent_failure).with(payload, anything)
-        expect(StatsD).to receive(:increment).with("#{submission_stats_key}.exhausted", tags:)
-        expect(Rails.logger).to receive(:error).with(log)
-
-        monitor_v2.track_submission_exhaustion(msg)
-      end
-
-      it 'logs sidekiq job exhaustion with failure avoided' do
-        msg = { 'args' => [claim_v2.id, encrypted_vet_info, encrypted_user], error_message: 'Error!' }
-
-        log = 'Failed all retries on Lighthouse::BenefitsIntake::SubmitCentralForm686cJob, ' \
-              "last error: #{msg['error_message']}"
-        payload = {
-          claim: claim_v2,
-          error: msg,
-          service: 'dependents-application',
-          tags: ['form_id:686C-674-V2', 'service:dependents-application', 'v2:true'],
-          use_v2: true,
-          user_account_uuid: nil
-        }
-
-        expect(monitor_v2).to receive(:log_silent_failure_avoided).with(payload, anything)
-        expect(StatsD).to receive(:increment).with("#{submission_stats_key}.exhausted", tags:)
-        expect(Rails.logger).to receive(:error).with(log)
-
-        monitor_v2.track_submission_exhaustion(msg, user_struct.va_profile_email)
-      end
-    end
-
-    describe '#track_event' do
-      let(:tags) { ['service:dependents-application', 'function:track_event', 'form_id:686C-674-V2', 'v2:true'] }
-
-      it 'handles an error' do
-        expect(StatsD).to receive(:increment).with('saved_claim.create', anything).at_least(:once)
-        expect(StatsD).to receive(:increment).with('saved_claim.pdf.overflow', anything).at_least(:once)
-        expect(StatsD).to receive(:increment).with('test.monitor.exhaustion', tags:)
-        expect(Rails.logger).to receive(:error).with('Error!', {
-                                                       context: {
-                                                         claim_id: claim_v2.id,
-                                                         confirmation_number: claim_v2.confirmation_number,
-                                                         error: 'test',
-                                                         form_id: '686C-674-V2',
-                                                         service: 'dependents-application',
-                                                         tags: ['form_id:686C-674-V2',
-                                                                'service:dependents-application', 'v2:true'],
-                                                         use_v2: true,
-                                                         user_account_uuid: nil
-                                                       },
-                                                       file: a_kind_of(String),
-                                                       function: 'track_event',
-                                                       line: a_kind_of(Integer),
-                                                       service: 'dependents-application',
-                                                       statsd: 'test.monitor.exhaustion'
-                                                     })
-
-        monitor_v2.track_event('error', 'Error!', 'test.monitor.exhaustion', error: 'test')
-      end
-
-      it 'handles an info log' do
-        expect(StatsD).to receive(:increment).with('saved_claim.create', anything).at_least(:once)
-        expect(StatsD).to receive(:increment).with('saved_claim.pdf.overflow', anything).at_least(:once)
-        expect(StatsD).to receive(:increment).with('test.monitor.success', tags:)
-        expect(Rails.logger).to receive(:info).with('Success!', {
-                                                      context: {
-                                                        claim_id: claim_v2.id,
-                                                        confirmation_number: claim_v2.confirmation_number,
-                                                        error: 'test',
-                                                        form_id: '686C-674-V2',
-                                                        service: 'dependents-application',
-                                                        tags: ['form_id:686C-674-V2', 'service:dependents-application',
-                                                               'v2:true'],
-                                                        use_v2: true,
-                                                        user_account_uuid: nil
-                                                      },
-                                                      file: a_kind_of(String),
-                                                      function: 'track_event',
-                                                      line: a_kind_of(Integer),
-                                                      service: 'dependents-application',
-                                                      statsd: 'test.monitor.success'
-                                                    })
-
-        monitor_v2.track_event('info', 'Success!', 'test.monitor.success', error: 'test')
-      end
-
-      it 'handles a warning' do
-        expect(StatsD).to receive(:increment).with('saved_claim.create', anything).at_least(:once)
-        expect(StatsD).to receive(:increment).with('saved_claim.pdf.overflow', anything).at_least(:once)
-        expect(StatsD).to receive(:increment).with('test.monitor.failure', tags:)
-        expect(Rails.logger).to receive(:warn).with('Oops!', {
-                                                      context: {
-                                                        claim_id: claim_v2.id,
-                                                        confirmation_number: claim_v2.confirmation_number,
-                                                        error: 'test',
-                                                        form_id: '686C-674-V2',
-                                                        service: 'dependents-application',
-                                                        tags: ['form_id:686C-674-V2', 'service:dependents-application',
-                                                               'v2:true'],
-                                                        use_v2: true,
-                                                        user_account_uuid: nil
-                                                      },
-                                                      file: a_kind_of(String),
-                                                      function: 'track_event',
-                                                      line: a_kind_of(Integer),
-                                                      service: 'dependents-application',
-                                                      statsd: 'test.monitor.failure'
-                                                    })
-
-        monitor_v2.track_event('warn', 'Oops!', 'test.monitor.failure', error: 'test')
-      end
+  describe '#form_id' do
+    it 'returns the form ID' do
+      expect(monitor_v1.send(:form_id)).to eq('686C-674-V2')
     end
   end
 
-  context 'version independent' do
-    describe '#track_unknown_claim_type' do
-      it 'logs unknown claim type error' do
-        error = StandardError.new('Unknown type')
-        metric = "#{described_class::EMAIL_STATS_KEY}.unknown_type"
-        tags = ['form_id:686C-674', 'service:dependents-application', 'v2:false']
-        payload = {
-          claim:,
-          service: 'dependents-application',
-          tags:,
-          use_v2: false,
-          user_account_uuid: nil,
-          statsd: metric,
-          e: error
-        }
-
-        expect(StatsD).to receive(:increment).with(metric, tags:)
-        expect(Rails.logger).to receive(:error).with("Unknown Dependents form type for claim #{claim.id}", payload)
-
-        monitor_v1.track_unknown_claim_type(error)
-      end
-    end
-
-    describe '#track_send_email_success' do
-      it 'logs email success' do
-        message = 'Email sent successfully'
-        metric = 'test.email.success'
-        user_account_id = 'user123'
-        tags = ['form_id:686C-674', 'service:dependents-application', 'v2:false']
-        payload = {
-          claim:,
-          service: 'dependents-application',
-          tags:,
-          use_v2: false,
-          user_account_uuid: nil,
-          statsd: metric,
-          user_account_id:
-        }
-
-        expect(StatsD).to receive(:increment).with(metric, tags:)
-        expect(Rails.logger).to receive(:info).with(message, payload)
-
-        monitor_v1.track_send_email_success(message, metric, user_account_id)
-      end
-    end
-
-    describe '#track_send_email_error' do
-      it 'logs email error' do
-        message = 'Email failed to send'
-        metric = 'test.email.error'
-        error = StandardError.new('SMTP error')
-        user_account_uuid = 'uuid123'
-        tags = ['form_id:686C-674', 'service:dependents-application', 'v2:false']
-        payload = {
-          claim:,
-          service: 'dependents-application',
-          tags:,
-          use_v2: false,
-          user_account_uuid:,
-          statsd: metric,
-          e: error
-        }
-
-        expect(StatsD).to receive(:increment).with(metric, tags:)
-        expect(Rails.logger).to receive(:error).with(message, payload)
-
-        monitor_v1.track_send_email_error(message, metric, error, user_account_uuid)
-      end
-    end
-
-    describe '#track_send_submitted_email_success' do
-      it 'tracks submitted email success' do
-        user_account_uuid = 'uuid123'
-        message = "'Submitted' email success for claim #{claim.id}"
-        metric = "#{described_class::EMAIL_STATS_KEY}.submitted.success"
-
-        expect(monitor_v1).to receive(:track_send_email_success).with(message, metric, user_account_uuid)
-
-        monitor_v1.track_send_submitted_email_success(user_account_uuid)
-      end
-    end
-
-    describe '#track_send_submitted_email_failure' do
-      it 'tracks submitted email failure' do
-        error = StandardError.new('Email error')
-        user_account_uuid = 'uuid123'
-        message = "'Submitted' email failure for claim #{claim.id}"
-        metric = "#{described_class::EMAIL_STATS_KEY}.submitted.failure"
-
-        expect(monitor_v1).to receive(:track_send_email_error).with(message, metric, error, user_account_uuid)
-
-        monitor_v1.track_send_submitted_email_failure(error, user_account_uuid)
-      end
-    end
-
-    describe '#track_send_received_email_success' do
-      it 'tracks received email success' do
-        user_account_uuid = 'uuid123'
-        message = "'Received' email success for claim #{claim.id}"
-        metric = "#{described_class::EMAIL_STATS_KEY}.received.success"
-
-        expect(monitor_v1).to receive(:track_send_email_success).with(message, metric, user_account_uuid)
-
-        monitor_v1.track_send_received_email_success(user_account_uuid)
-      end
-    end
-
-    describe '#track_send_received_email_failure' do
-      it 'tracks received email failure' do
-        error = StandardError.new('Email error')
-        user_account_uuid = 'uuid123'
-
-        expect(monitor_v1)
-          .to receive(:track_send_email_failure)
-          .with(claim, nil, user_account_uuid, 'submitted', error)
-
-        monitor_v1.track_send_received_email_failure(error, user_account_uuid)
-      end
-    end
-
-    describe '#track_pdf_upload_error' do
-      it 'tracks PDF upload error' do
-        metric = "#{described_class::CLAIM_STATS_KEY}.upload_pdf.failure"
-        payload = {
-          claim:,
-          service: 'dependents-application',
-          tags: ['form_id:686C-674', 'service:dependents-application', 'v2:false'],
-          use_v2: false,
-          user_account_uuid: nil,
-          statsd: metric
-        }
-
-        expect(monitor_v1)
-          .to receive(:track_event)
-          .with('error', 'DependencyClaim error in upload_to_vbms method', metric, payload)
-
-        monitor_v1.track_pdf_upload_error
-      end
-    end
-
-    describe '#track_to_pdf_failure' do
-      it 'tracks PDF generation failure' do
-        error = StandardError.new('PDF error')
-        form_id = '686C-674'
-        metric = "#{described_class::CLAIM_STATS_KEY}.to_pdf.failure"
-        tags = ['form_id:686C-674', 'service:dependents-application', 'v2:false']
-        payload = {
-          claim:,
-          service: 'dependents-application',
-          tags:,
-          use_v2: false,
-          user_account_uuid: nil,
-          statsd: metric,
-          e: error,
-          form_id:
-        }
-
-        expect(StatsD).to receive(:increment).with(metric, tags:)
-        expect(Rails.logger).to receive(:error).with('SavedClaim::DependencyClaim#to_pdf error', payload)
-
-        monitor_v1.track_to_pdf_failure(error, form_id)
-      end
-    end
-
-    describe '#track_pdf_overflow_tracking_failure' do
-      it 'tracks PDF overflow tracking failure' do
-        error = StandardError.new('Overflow tracking error')
-        metric = "#{described_class::CLAIM_STATS_KEY}.track_pdf_overflow.failure"
-        tags = ['form_id:686C-674', 'service:dependents-application', 'v2:false']
-        payload = {
-          claim:,
-          service: 'dependents-application',
-          tags:,
-          use_v2: false,
-          user_account_uuid: nil,
-          statsd: metric,
-          e: error
-        }
-
-        expect(StatsD).to receive(:increment).with(metric, tags:)
-        expect(Rails.logger).to receive(:warn).with('Error tracking PDF overflow', payload)
-
-        monitor_v1.track_pdf_overflow_tracking_failure(error)
-      end
-    end
-
-    describe '#track_pdf_overflow' do
-      it 'tracks PDF overflow' do
-        form_id = '686C-674'
-        metric = 'saved_claim.pdf.overflow'
-
-        # Allow any StatsD calls to happen for test setup or the test will fail
-        allow(StatsD).to receive(:increment)
-
-        expect(StatsD).to receive(:increment).with(metric, tags: ["form_id:#{form_id}"])
-
-        monitor_v1.track_pdf_overflow(form_id)
-      end
-    end
-
-    describe '#track_pension_related_submission' do
-      it 'tracks pension related submission with correct tags' do
-        form_id = '686C-674-V2'
-        metric = "#{described_class::PENSION_SUBMISSION_STATS_KEY}.686c-674.submitted"
-
-        # Allow any StatsD calls to happen for test setup or the test will fail
-        allow(StatsD).to receive(:increment)
-
-        expect(StatsD).to receive(:increment).with(metric, tags: ["form_id:#{form_id}"])
-
-        monitor_v2.track_pension_related_submission(form_id:, form_type: '686c-674')
-      end
-    end
-
-    describe '#claim' do
-      context 'when claim is not found' do
-        it 'logs warning and returns nil' do
-          allow(SavedClaim::DependencyClaim).to receive(:find).and_raise(ActiveRecord::RecordNotFound)
-
-          expect(Rails.logger).to receive(:warn).with(
-            'Unable to find claim for Dependents::Monitor',
-            { claim_id: claim.id, e: ActiveRecord::RecordNotFound }
-          ).at_least(:once)
-
-          result = monitor_v1.send(:claim, claim.id)
-          expect(result).to be_nil
-        end
-      end
-    end
-
-    describe '#form_id' do
-      it 'returns the form ID' do
-        expect(monitor_v1.send(:form_id)).to eq('686C-674')
-      end
-    end
-
-    describe '#submission_stats_key' do
-      it 'returns the submission stats key' do
-        expect(monitor_v1.send(:submission_stats_key)).to eq('worker.submit_686c_674_backup_submission')
-      end
+  describe '#submission_stats_key' do
+    it 'returns the submission stats key' do
+      expect(monitor_v1.send(:submission_stats_key)).to eq('worker.submit_686c_674_backup_submission')
     end
   end
 end

--- a/spec/models/saved_claim/dependency_claim_spec.rb
+++ b/spec/models/saved_claim/dependency_claim_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe SavedClaim::DependencyClaim do
     end
 
     context 'processing a v2 payload' do
-      subject { described_class.new(form: all_flows_payload_v2.to_json, use_v2: true) }
+      subject { described_class.new(form: all_flows_payload_v2.to_json) }
 
       describe '#formatted_686_data' do
         it 'returns all data for 686 submissions' do
@@ -141,7 +141,7 @@ RSpec.describe SavedClaim::DependencyClaim do
     end
 
     context 'processing a v2 payload' do
-      subject { described_class.new(form: form_674_only_v2.to_json, use_v2: true) }
+      subject { described_class.new(form: form_674_only_v2.to_json) }
 
       describe '#submittable_686?' do
         it 'returns false if there is no 686 to process' do
@@ -169,7 +169,7 @@ RSpec.describe SavedClaim::DependencyClaim do
     end
 
     context 'processing a v2 payload' do
-      subject { described_class.new(form: adopted_child_v2.to_json, use_v2: true) }
+      subject { described_class.new(form: adopted_child_v2.to_json) }
 
       describe '#submittable_674?' do
         it 'returns false if there is no 674 to process' do
@@ -186,7 +186,7 @@ RSpec.describe SavedClaim::DependencyClaim do
   end
 
   context 'v2 form on and vets json schema enabled' do
-    subject { described_class.new(form: all_flows_payload_v2.to_json, use_v2: true) }
+    subject { described_class.new(form: all_flows_payload_v2.to_json) }
 
     before do
       allow(Flipper).to receive(:enabled?).with(:saved_claim_pdf_overflow_tracking).and_return(true)
@@ -229,7 +229,7 @@ RSpec.describe SavedClaim::DependencyClaim do
   end
 
   context 'v2 form and vets json schema disabled' do
-    subject { described_class.new(form: all_flows_payload_v2.to_json, use_v2: true) }
+    subject { described_class.new(form: all_flows_payload_v2.to_json) }
 
     before do
       allow(Flipper).to receive(:enabled?).with(:saved_claim_pdf_overflow_tracking).and_return(true)

--- a/spec/services/bgs/dependent_service_spec.rb
+++ b/spec/services/bgs/dependent_service_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe BGS::DependentService do
 
   before do
     # TODO: Add back user_account_id once the DB migration is done
-    allow(claim).to receive_messages(id: '1234', use_v2: false,
+    allow(claim).to receive_messages(id: '1234',
                                      submittable_686?: false, submittable_674?: true, add_veteran_info: true,
                                      valid?: true, persistent_attachments: [], form_id: '686C-674', document_type: 148)
     allow_any_instance_of(KmsEncrypted::Box).to receive(:encrypt).and_return(encrypted_vet_info)

--- a/spec/services/bgs/dependent_v2_service_spec.rb
+++ b/spec/services/bgs/dependent_v2_service_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe BGS::DependentV2Service do
 
   before do
     # TODO: add user_account_id back once the DB migration is done
-    allow(claim).to receive_messages(id: '1234', use_v2: true, form_id: '686C-674-V2',
+    allow(claim).to receive_messages(id: '1234', form_id: '686C-674-V2',
                                      submittable_686?: false, submittable_674?: true, add_veteran_info: true,
                                      valid?: true, persistent_attachments: [], document_type: 148)
     allow_any_instance_of(KmsEncrypted::Box).to receive(:encrypt).and_return(encrypted_vet_info)

--- a/spec/sidekiq/bgs/submit_form674_job_spec.rb
+++ b/spec/sidekiq/bgs/submit_form674_job_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe BGS::SubmitForm674Job, type: :job do
         callback_klass: 'Dependents::NotificationCallback',
         callback_metadata: { email_template_id: 'fake_received686c674',
                              email_type: :received686c674,
-                             form_id: '686C-674',
+                             form_id: '686C-674-V2',
                              claim_id: dependency_claim.id,
                              saved_claim_id: dependency_claim.id,
                              service_name: 'dependents' }
@@ -151,7 +151,7 @@ RSpec.describe BGS::SubmitForm674Job, type: :job do
         callback_klass: 'Dependents::NotificationCallback',
         callback_metadata: { email_template_id: 'fake_received674',
                              email_type: :received674,
-                             form_id: '686C-674',
+                             form_id: '686C-674-V2',
                              claim_id: dependency_claim_674_only.id,
                              saved_claim_id: dependency_claim_674_only.id,
                              service_name: 'dependents' }

--- a/spec/sidekiq/bgs/submit_form674_v2_job_spec.rb
+++ b/spec/sidekiq/bgs/submit_form674_v2_job_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe BGS::SubmitForm674V2Job, type: :job do
         callback_klass: 'Dependents::NotificationCallback',
         callback_metadata: { email_template_id: 'fake_received686c674',
                              email_type: :received686c674,
-                             form_id: '686C-674',
+                             form_id: '686C-674-V2',
                              claim_id: dependency_claim.id,
                              saved_claim_id: dependency_claim.id,
                              service_name: 'dependents' }
@@ -149,7 +149,7 @@ RSpec.describe BGS::SubmitForm674V2Job, type: :job do
         callback_klass: 'Dependents::NotificationCallback',
         callback_metadata: { email_template_id: 'fake_received674',
                              email_type: :received674,
-                             form_id: '686C-674',
+                             form_id: '686C-674-V2',
                              claim_id: dependency_claim_674_only.id,
                              saved_claim_id: dependency_claim_674_only.id,
                              service_name: 'dependents' }

--- a/spec/sidekiq/bgs/submit_form686c_job_spec.rb
+++ b/spec/sidekiq/bgs/submit_form686c_job_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe BGS::SubmitForm686cJob, type: :job do
         callback_klass: 'Dependents::NotificationCallback',
         callback_metadata: { email_template_id: 'fake_received686',
                              email_type: :received686,
-                             form_id: '686C-674',
+                             form_id: '686C-674-V2',
                              claim_id: dependency_claim.id,
                              saved_claim_id: dependency_claim.id,
                              service_name: 'dependents' }

--- a/spec/sidekiq/bgs/submit_form686c_v2_job_spec.rb
+++ b/spec/sidekiq/bgs/submit_form686c_v2_job_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe BGS::SubmitForm686cV2Job, type: :job do
         callback_klass: 'Dependents::NotificationCallback',
         callback_metadata: { email_template_id: 'fake_received686',
                              email_type: :received686,
-                             form_id: '686C-674',
+                             form_id: '686C-674-V2',
                              claim_id: dependency_claim.id,
                              saved_claim_id: dependency_claim.id,
                              service_name: 'dependents' }

--- a/spec/sidekiq/dependents/form686c674_failure_email_job_spec.rb
+++ b/spec/sidekiq/dependents/form686c674_failure_email_job_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe Dependents::Form686c674FailureEmailJob, type: :job do
   let(:default_monitor_payload) do
     {
       service: 'dependent-change',
-      use_v2: @use_v2,
       claim: @claim,
       user_account_uuid: @claim&.user_account_id,
       tags: { function: described_class::ZSF_DD_TAG_FUNCTION }

--- a/spec/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job_spec.rb
+++ b/spec/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job_spec.rb
@@ -568,7 +568,7 @@ RSpec.describe Lighthouse::BenefitsIntake::SubmitCentralForm686cJob, :uploader_h
           .to receive(:error)
           .with(
             'Lighthouse::BenefitsIntake::SubmitCentralForm686cJob silent failure!',
-            { e: json_error, msg:, v2: false }
+            { e: json_error, msg: }
           )
 
         expect(StatsD)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Dependents only uses the V2 form version now, so we no longer need to use the `use_v2` flag on our claims. All claims are now considered V2.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111029

## Testing done

- [x] *New code is covered by unit tests*
- [x] Submit a Dependents claim (both in and out of the module)

## What areas of the site does it impact?
Dependents

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
