### PR TITLE
129069: Add changes to make question 17 appear properly in the overflow

### DIFF
--- a/modules/burials/lib/burials/pdf_fill/sections/section_04.rb
+++ b/modules/burials/lib/burials/pdf_fill/sections/section_04.rb
@@ -53,7 +53,7 @@ module Burials
           question_num: 17,
           question_label: 'Name Of National Or Federal Cemetery',
           question_text: 'NAME OF NATIONAL OR FEDERAL CEMETERY',
-          limit: 25
+          limit: 50
         },
         # 18
         'cemetaryLocationQuestionCemetery' => {


### PR DESCRIPTION
Question 17 wasn't appearing in the extras PDF when necessary

## Summary

- Update section 4 to include the metadata to output the value

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129069

## Testing done

- [X] *Manual*

## Screenshots
<img width="985" height="425" alt="Screenshot 2026-01-06 at 1 27 52 PM" src="https://github.com/user-attachments/assets/27d6e211-666d-4efb-902f-f0d66d8dbe25" />

## What areas of the site does it impact?
*Burials Only*