### PR TITLE
Fix flaky medical copays show test

### DIFF
--- a/spec/requests/v1/medical_copays_spec.rb
+++ b/spec/requests/v1/medical_copays_spec.rb
@@ -62,8 +62,13 @@ RSpec.describe 'V1::MedicalCopays', type: :request do
   describe 'show' do
     let(:current_user) { build(:user, :loa3, icn: '32000551') }
 
+    # Service uses Concurrent::Promises for parallel API calls, so we need:
+    # - allow_playback_repeats: concurrent threads may replay same response
+    # - match_requests_on: [:method, :uri] to handle request ordering differences
+    let(:vcr_options) { { allow_playback_repeats: true, match_requests_on: %i[method uri] } }
+
     it 'returns copay detail for authenticated user' do
-      VCR.use_cassette('lighthouse/hcc/copay_detail_success') do
+      VCR.use_cassette('lighthouse/hcc/copay_detail_success', vcr_options) do
         allow(Auth::ClientCredentials::JWTGenerator).to receive(:generate_token).and_return('fake-jwt')
 
         get '/v1/medical_copays/4-1abZUKu7LnbcQc'
@@ -101,7 +106,7 @@ RSpec.describe 'V1::MedicalCopays', type: :request do
     end
 
     it 'handles auth error' do
-      VCR.use_cassette('lighthouse/hcc/auth_error') do
+      VCR.use_cassette('lighthouse/hcc/auth_error', vcr_options) do
         allow(Auth::ClientCredentials::JWTGenerator).to receive(:generate_token).and_return('fake-jwt')
 
         get '/v1/medical_copays/4-1abZUKu7LnbcQc'


### PR DESCRIPTION
## Summary

Fixes flaky test: `spec/requests/v1/medical_copays_spec.rb:65` - "returns copay detail for authenticated user"

## Problem

The `MedicalCopays::LighthouseIntegration::Service#get_detail` method uses `Concurrent::Promises.future` to make parallel API calls. VCR cassettes don't handle concurrent request playback reliably - request order can vary between runs, causing cassette matching failures and 500 errors on CI.

## Solution

Added VCR options to handle concurrent requests:
- `allow_playback_repeats: true` - allows the same cassette response to be replayed multiple times
- `match_requests_on: [:method, :uri]` - uses flexible matching that handles request ordering differences

This follows the established pattern used in other specs that deal with concurrent requests (e.g., `va_profile/veteran_status` tests).

## Testing

- [x] Ran test multiple times locally - passes consistently
- [x] Test previously failed intermittently on CI with 500 error