### PR TITLE
Additional logging for ARP ITF errors

### DIFF
--- a/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/intent_to_file_controller.rb
+++ b/modules/accredited_representative_portal/app/controllers/accredited_representative_portal/v0/intent_to_file_controller.rb
@@ -39,7 +39,7 @@ module AccreditedRepresentativePortal
         Rails.logger.info('ARP ITF: Created intent to file in Benefits Claims')
 
         if parsed_response['errors'].present?
-          Rails.logger.info("ARP ITF: Error response - error_count: #{parsed_response['errors']&.count}")
+          Rails.logger.warn("ARP ITF: Error response - error_count: #{parsed_response['errors']&.count}")
           raise ActionController::BadRequest.new(error: parsed_response['errors']&.first&.[]('detail'))
         else
           icn_temporary_identifier = IcnTemporaryIdentifier.save_icn(icn)
@@ -57,7 +57,7 @@ module AccreditedRepresentativePortal
           render json: parsed_response, status: :created
         end
       rescue ArgumentError => e
-        Rails.logger.info('ARP ITF: ArgumentError during ITF creation')
+        Rails.logger.warn('ARP ITF: ArgumentError during ITF creation')
         render json: { error: e.message }, status: :bad_request
       rescue => e
         Rails.logger.error("ARP ITF: ERROR - #{e.class}: #{e.message.truncate(100)}")


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
- *(Summarize the changes that have been made to the platform)*
Additional logging for ARP ITF submit since errors on staging (which can't be reproduced locally) are not showing up in Datadog

- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)* ARC
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

_This is a temporary measure until we can figure out why staging itf submits are failing_
