### PR TITLE
129194: Update burial question 18 to hit overflow

### DIFF
--- a/modules/burials/lib/burials/pdf_fill/sections/section_04.rb
+++ b/modules/burials/lib/burials/pdf_fill/sections/section_04.rb
@@ -67,6 +67,9 @@ module Burials
         },
         'stateCemeteryOrTribalTrustName' => {
           key: 'form1[0].#subform[37].StateCemeteryOrTribalTrustName[2]',
+          question_num: 18,
+          question_label: 'Name Of State Cemetery Or Tribal Trust Land',
+          question_text: 'NAME OF STATE CEMETERY OR TRIBAL TRUST LAND',
           limit: 33
         },
         'stateCemeteryOrTribalTrustZip' => {


### PR DESCRIPTION
While fixing the question 17 overflow for burial I noticed that question 18 didn't have the necessary metdata but had a `limit` set. This change is to add the metadata to get it to properly overflow

## Summary

- Update section 4 to have proper metadata for overflow

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129194

## Testing done

- [X] *Manual*

## Scre
<img width="491" height="198" alt="Screenshot 2026-01-07 at 1 29 24 PM" src="https://github.com/user-attachments/assets/87bfe2ae-8e6d-452c-9e65-8f41ee92ef57" />
enshots


## What areas of the site does it impact?
*Burials*