### PR TITLE
DR 127818 Remove unused email confirmation flags

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -605,15 +605,6 @@ features:
   debts_sharepoint_error_logging:
     actor_type: user
     description: Logs Sharepoint error data
-  decision_review_hlr_email:
-    actor_type: user
-    description: Send email notification for successful HLR submission
-  decision_review_nod_email:
-    actor_type: user
-    description: Send email notification for successful NOD submission
-  decision_review_sc_email:
-    actor_type: user
-    description: Send email notification for successful SC submission
   decision_review_hlr_status_updater_enabled:
     actor_type: user
     description: Enables the Higher Level Review status update batch job

--- a/modules/appeals_api/config/flipper/enabled_features.yml
+++ b/modules/appeals_api/config/flipper/enabled_features.yml
@@ -1,8 +1,5 @@
 common:
   - benefits_require_gateway_origin
-  - decision_review_hlr_email
-  - decision_review_nod_email
-  - decision_review_sc_email
   - decision_review_delay_evidence
 development:
   - decision_review_icn_updater_enabled


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

Removing unused feature flippers:

- decision_review_hlr_email ([code search](https://github.com/search?q=org%3Adepartment-of-veterans-affairs+decision_review_hlr_email&type=code))
- decision_review_nod_email ([code search](https://github.com/search?q=org%3Adepartment-of-veterans-affairs+decision_review_nod_email&type=code))
- decision_review_sc_email  ([code search](https://github.com/search?q=org%3Adepartment-of-veterans-affairs+decision_review_sc_email&type=code))

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/127818