### PR TITLE
Adding Okta prod SiS client id to user info clients

### DIFF
--- a/config/identity_settings/environments/production.yml
+++ b/config/identity_settings/environments/production.yml
@@ -68,6 +68,8 @@ sign_in:
   sts_client:
     base_url: https://api.va.gov
     key_path: /srv/vets-api/secret/sign-in-service-sts-client.pem
+  user_info_clients:
+    - 861fbfbf1b4cd2594e0f7a4a367a9a87
   usip_uri: https://va.gov/sign-in
   web_origins:
     - https://identity.va.gov


### PR DESCRIPTION
## Summary

- This PR adds the okta production SiS client id to the list of production `user_info_clients`