### PR TITLE
Reverts adding UTC date to supporting docs

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/v2/claims_requests/supporting_documents.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/v2/claims_requests/supporting_documents.rb
@@ -20,7 +20,17 @@ module ClaimsApi
 
           return [] if docs.nil? || docs&.dig(:documents).blank?
 
-          @supporting_documents = transform_documents(docs)
+          @supporting_documents = docs[:documents].map do |doc|
+            doc = doc.transform_keys { |key| key.to_s.underscore }
+            upload_date = upload_date(doc['upload_date']) || bd_upload_date(doc['uploaded_date_time'])
+            {
+              document_id: doc['document_id'],
+              document_type_label: doc['document_type_label'],
+              original_file_name: doc['original_file_name'],
+              tracked_item_id: doc['tracked_item_id'],
+              upload_date:
+            }
+          end
         end
 
         def get_file_number(ssn)
@@ -37,21 +47,6 @@ module ClaimsApi
             return nil
           end
           file_number
-        end
-
-        def transform_documents(docs)
-          docs[:documents].map do |doc|
-            doc = doc.transform_keys { |key| key.to_s.underscore }
-            upload_date = upload_date(doc['upload_date']) || bd_upload_date(doc['uploaded_date_time'])
-            {
-              document_id: doc['document_id'],
-              document_type_label: doc['document_type_label'],
-              original_file_name: doc['original_file_name'],
-              tracked_item_id: doc['tracked_item_id'],
-              upload_date:,
-              upload_date_time: doc['upload_date'] || doc['uploaded_date_time']
-            }
-          end
         end
 
         # duplicating temporarily to bd_upload_date. remove when EVSS call is gone

--- a/modules/claims_api/spec/concerns/claims_api/v2/claims_requests/supporting_documents_spec.rb
+++ b/modules/claims_api/spec/concerns/claims_api/v2/claims_requests/supporting_documents_spec.rb
@@ -129,7 +129,6 @@ describe ClaimsApi::V2::ClaimsRequests::SupportingDocuments do
       expect(result[0][:original_file_name]).to eq(supporting_doc_list[:data][:documents][0][:originalFileName])
       expect(result[0][:tracked_item_id]).to be_nil
       expect(result[0][:upload_date]).to eq('2024-07-16')
-      expect(result[0][:upload_date_time]).to eq('2024-07-16T18:59:08Z')
     end
   end
 

--- a/modules/claims_api/spec/requests/v2/veterans/claims_spec.rb
+++ b/modules/claims_api/spec/requests/v2/veterans/claims_spec.rb
@@ -1281,28 +1281,6 @@ RSpec.describe 'ClaimsApi::V2::Veterans::Claims', type: :request do
           end
         end
 
-        context 'date fields on supporting docs' do
-          it 'adds the uploadDateTime as UTC date format' do
-            mock_ccg(scopes) do |auth_header|
-              VCR.use_cassette('claims_api/v2/claims_show') do
-                allow_any_instance_of(ClaimsApi::V2::ClaimsRequests::SupportingDocuments).to receive(
-                  :get_file_number
-                ).and_return(file_number)
-                expect_any_instance_of(ClaimsApi::V2::BenefitsDocuments::Service)
-                  .to receive(:get_auth_token).and_return('some-value-here')
-                expect(ClaimsApi::AutoEstablishedClaim)
-                  .to receive(:get_by_id_and_icn).and_return(nil)
-
-                get claim_by_id_path, headers: auth_header
-
-                json_response = JSON.parse(response.body)
-                first_doc = json_response['data']['attributes'].dig('supportingDocuments', 0)
-                expect(first_doc['uploadDateTime']).to eq('2023-04-14T13:55:00Z')
-              end
-            end
-          end
-        end
-
         context 'it has no documents' do
           let(:bgs_claim) { build(:bgs_response_with_one_lc_status).to_h }
 


### PR DESCRIPTION
## Summary
* Reverts adding the UTC date to supporting docs ([API-50120](https://jira.devops.va.gov/browse/API-50120)) return because the need for a release note for the change was overlooked.

## Related issue(s)
* Reverts this PR: https://github.com/department-of-veterans-affairs/vets-api/pull/24519/changes

## Testing done

- [x] *No New code, reverts back to previous state*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
    modified:   modules/claims_api/app/controllers/concerns/claims_api/v2/claims_requests/supporting_documents.rb
    modified:   modules/claims_api/spec/concerns/claims_api/v2/claims_requests/supporting_documents_spec.rb
    modified:   modules/claims_api/spec/requests/v2/veterans/claims_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
