### PR TITLE
Add 'medical-expense-report' to middleware list

### DIFF
--- a/lib/source_app_middleware.rb
+++ b/lib/source_app_middleware.rb
@@ -104,6 +104,7 @@ class SourceAppMiddleware
     'letters',
     'login-page',
     'medical-copays',
+    'medical-expense-report',
     'medical-records',
     'medications',
     'messages',


### PR DESCRIPTION
This PR is to fix "vets-api source app monitor - un-mapped source app detected" alert firing in DSVA/on-call

https://vagov.ddog-gov.com/monitors/200229?event_id=AwAAAZueB3roM6rK2AAAABhBWnVlQ043SEFBQTRnUTlMRlVNWUluZk4AAAAkMDE5YjllMGYtOWNmMC00OWVlLTg4NjctY2M1ZmJhOThjODlmAAAK9Q&link_source=monitor_notif&from_ts=1767881949000&to_ts=1767883149000&live=false

<img width="1285" height="584" alt="Screenshot 2026-01-08 at 11 11 09 AM" src="https://github.com/user-attachments/assets/d6eea1d5-1486-4f88-8ecf-38d28a0f772c" />

<img width="1292" height="748" alt="Screenshot 2026-01-08 at 11 11 50 AM" src="https://github.com/user-attachments/assets/db90e030-7d3f-4e21-ba96-d486aac5aa4b" />

<img width="1210" height="845" alt="Screenshot 2026-01-08 at 11 12 07 AM" src="https://github.com/user-attachments/assets/801764b6-9b73-44db-b2ef-939c44b9ad6a" />
