### PR TITLE
Reduce reek `DuplicateMethodCall` noise

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -46,6 +46,9 @@ directories:
     InstanceVariableAssumption:
       enabled: false
 detectors:
+  DuplicateMethodCall:
+    enabled: true
+    max_calls: 3
   IrresponsibleModule:
     enabled: false
   UnusedParameters:


### PR DESCRIPTION
- Reconfigures .reek.yml with more lenient threshold for `DuplicateMethodCall`

## Summary

- *This work is behind a feature toggle (flipper): NO*
- *Adjust `reek.yml` to be more permissive with duplicate method calls`
-  This permits us to have slightly less reek noise on PRs
- Platform/SRE

## Related issue(s)

- *Link to ticket:* https://github.com/department-of-veterans-affairs/va.gov-team/issues/92940

## Testing done

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
