### PR TITLE
[BIO] adds 21-8940 to the source app list

### DIFF
--- a/lib/source_app_middleware.rb
+++ b/lib/source_app_middleware.rb
@@ -47,6 +47,7 @@ class SourceAppMiddleware
     '21-2680-house-bound-status',
     '21-4142-medical-release',
     '21-4192-employment-information',
+    '21-8940',
     '21p-0537',
     '21P-0847-substitute-claimant',
     '21p-530a-interment-allowance',


### PR DESCRIPTION
This PR is to fix "vets-api source app monitor - un-mapped source app detected" alert firing in DataDog.

