### PR TITLE
Add pilot VISNs and logging for testing in staging

### DIFF
--- a/app/services/user_visn_service.rb
+++ b/app/services/user_visn_service.rb
@@ -2,7 +2,7 @@
 
 class UserVisnService
   # Hardcoded pilot VISNs for MVP - easy to update as pilot expands
-  PILOT_VISNS = %w[2 15 21 983 200ESR].freeze
+  PILOT_VISNS = %w[2 15 21 20 10 19].freeze
   CACHE_KEY_PREFIX = 'va_profile:facility_visn'
 
   def initialize(user)
@@ -41,7 +41,9 @@ class UserVisnService
     facility = facilities.first
     return nil unless facility&.attributes
 
-    facility.attributes['visn']&.to_s
+    facility_visn = facility.attributes['visn']&.to_s
+    Rails.logger.info("Fetched VISN #{facility_visn} for facility #{facility_id} from Lighthouse API")
+    facility_visn
   rescue => e
     Rails.logger.warn("Failed to fetch VISN for facility #{facility_id}: #{e.message}")
     nil

--- a/spec/services/user_visn_service_spec.rb
+++ b/spec/services/user_visn_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe UserVisnService do
 
   describe 'PILOT_VISNS constant' do
     let(:pilot_visns) do
-      %w[2 15 21 983 200ESR]
+      %w[2 15 21 20 10 19]
     end
 
     it 'contains the expected pilot VISNs' do


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*

> Due to system testing constraints, we need to test the pilot VISN segmentation with any VISN association on a staging account. Kay Lawyer recommends we use an existing appointments staging user, and update our hard coding in order to test in staging.

- Authenticated Experience Team
- *(If introducing a flipper, what is the success criteria being targeted?)*
  - Uses an existing flipper 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/128116

## Testing done

The three values are being added for testing purposes in staging. These values will be removed once testing is complete.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature