### PR TITLE
Fixing flaky lighthouse config spec

### DIFF
--- a/modules/vass/spec/services/vass/appointments_service_spec.rb
+++ b/modules/vass/spec/services/vass/appointments_service_spec.rb
@@ -286,6 +286,14 @@ describe Vass::AppointmentsService do
 
   describe '#get_current_cohort_availability' do
     context 'with current cohort that is unbooked and has available slots' do
+      before do
+        Timecop.freeze(DateTime.new(2026, 1, 7).utc)
+      end
+
+      after do
+        Timecop.return
+      end
+
       it 'returns available_slots status with appointment data and filtered slots' do
         VCR.use_cassette('vass/oauth_token_success') do
           VCR.use_cassette('vass/appointments/get_appointments_unbooked_cohort') do

--- a/spec/lib/lighthouse/healthcare_cost_and_coverage/configuration_spec.rb
+++ b/spec/lib/lighthouse/healthcare_cost_and_coverage/configuration_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe Lighthouse::HealthcareCostAndCoverage::Configuration do
       allow(Settings.betamocks).to receive(:recording).and_return(false)
 
       config.instance_variable_set(:@token_service, nil)
-      config.instance_variable_set(:@conn, nil)
     end
 
     describe '#get' do
@@ -68,11 +67,8 @@ RSpec.describe Lighthouse::HealthcareCostAndCoverage::Configuration do
         svc = double('Auth::ClientCredentials::Service', get_token: 'token')
         allow(Auth::ClientCredentials::Service).to receive(:new).and_return(svc)
 
-        # fresh Faraday connection per example
-        conn = double('Faraday::Connection')
-        config.instance_variable_set(:@conn, conn)
-
-        expect(conn).to receive(:get).with('/foo', nil, hash_including('Authorization' => 'Bearer token'))
+        expect_any_instance_of(Faraday::Connection).to receive(:get)
+          .with('/foo', nil, hash_including('Authorization' => 'Bearer token'))
         config.get('/foo', icn: '43000199')
       end
     end
@@ -82,10 +78,8 @@ RSpec.describe Lighthouse::HealthcareCostAndCoverage::Configuration do
         svc = double('Auth::ClientCredentials::Service', get_token: 'token')
         allow(Auth::ClientCredentials::Service).to receive(:new).and_return(svc)
 
-        conn = double('Faraday::Connection')
-        config.instance_variable_set(:@conn, conn)
-
-        expect(conn).to receive(:post).with('/foo', { bar: 1 }, hash_including('Authorization' => 'Bearer token'))
+        expect_any_instance_of(Faraday::Connection).to receive(:post)
+          .with('/foo', { bar: 1 }, hash_including('Authorization' => 'Bearer token'))
         config.post('/foo', { bar: 1 }, icn: '43000199')
       end
     end


### PR DESCRIPTION
## Summary
This PR fixes a flaky spec caused by lighthouse healthcare_cost_and_coverage configuration spec