### PR TITLE
Fix flaky time-dependent tests in VASS specs

### DIFF
--- a/modules/vass/spec/requests/vass/v0/appointments_spec.rb
+++ b/modules/vass/spec/requests/vass/v0/appointments_spec.rb
@@ -68,6 +68,12 @@ RSpec.describe 'Vass::V0::Appointments', type: :request do
     end
 
     context 'when user is authenticated' do
+      # Freeze time to be within the cassette cohort dates (2026-01-05 to 2026-01-20)
+      # and ensure slots (Jan 8, 9) are in the valid "tomorrow to 2 weeks" range
+      around do |example|
+        Timecop.freeze(DateTime.new(2026, 1, 7).utc) { example.run }
+      end
+
       context 'with available slots in current cohort' do
         it 'returns available slots status with appointment data' do
           VCR.use_cassette('vass/oauth_token_success', match_requests_on: %i[method uri]) do

--- a/modules/vass/spec/services/vass/appointments_service_spec.rb
+++ b/modules/vass/spec/services/vass/appointments_service_spec.rb
@@ -286,12 +286,10 @@ describe Vass::AppointmentsService do
 
   describe '#get_current_cohort_availability' do
     context 'with current cohort that is unbooked and has available slots' do
-      before do
-        Timecop.freeze(DateTime.new(2026, 1, 7).utc)
-      end
-
-      after do
-        Timecop.return
+      # Freeze time to be within the cassette cohort dates (2026-01-05 to 2026-01-20)
+      # and ensure slots (Jan 8, 9) are in the valid "tomorrow to 2 weeks" range
+      around do |example|
+        Timecop.freeze(DateTime.new(2026, 1, 7).utc) { example.run }
       end
 
       it 'returns available_slots status with appointment data and filtered slots' do
@@ -317,6 +315,11 @@ describe Vass::AppointmentsService do
     end
 
     context 'with current cohort that is already booked' do
+      # Freeze time to be within the cassette cohort dates (2026-01-05 to 2026-01-20)
+      around do |example|
+        Timecop.freeze(DateTime.new(2026, 1, 7).utc) { example.run }
+      end
+
       it 'returns already_booked status without calling availability API' do
         VCR.use_cassette('vass/oauth_token_success') do
           VCR.use_cassette('vass/appointments/get_appointments_booked_cohort') do
@@ -333,6 +336,11 @@ describe Vass::AppointmentsService do
     end
 
     context 'with current cohort but no available slots' do
+      # Freeze time to be within the cassette cohort dates (2026-01-05 to 2026-01-20)
+      around do |example|
+        Timecop.freeze(DateTime.new(2026, 1, 7).utc) { example.run }
+      end
+
       it 'returns no_slots_available status' do
         VCR.use_cassette('vass/oauth_token_success') do
           VCR.use_cassette('vass/appointments/get_appointments_unbooked_cohort') do
@@ -349,6 +357,11 @@ describe Vass::AppointmentsService do
     end
 
     context 'with no current cohort but future cohort exists' do
+      # Freeze time to be before the future cassette cohort (2026-02-15 to 2026-02-28)
+      around do |example|
+        Timecop.freeze(DateTime.new(2026, 1, 7).utc) { example.run }
+      end
+
       it 'returns next_cohort status with future cohort details' do
         VCR.use_cassette('vass/oauth_token_success') do
           VCR.use_cassette('vass/appointments/get_appointments_future_cohort_only') do


### PR DESCRIPTION
## Summary

Fixes flaky tests in VASS appointment specs caused by time-dependent logic with hardcoded VCR cassette dates.

## Root Cause

The service's `filter_available_slots` method filters slots based on `Time.current`, calculating "tomorrow" to "2 weeks out" range. When the real date moves past the cassette's hardcoded slot dates (Jan 7, 8, 9, 2026), no slots pass the filter, causing `:no_slots_available` instead of `:available_slots`.

## The Fix

Added `Timecop.freeze(DateTime.new(2026, 1, 7).utc)` around blocks to all time-dependent tests:
- `appointments_service_spec.rb`: 4 contexts
- `appointments_spec.rb` (request spec): 1 parent context covering all nested tests

## Verification

- All tests use consistent frozen time within cassette date ranges
- Using `around` blocks ensures proper cleanup
- Jan 7, 2026 places time within cohort (Jan 5-20) and keeps slots (Jan 8, 9) in valid "tomorrow to 2 weeks" range

## Related

- CI failures: 
  - https://github.com/department-of-veterans-affairs/vets-api/actions/runs/20854459655/job/59927445480
  - https://github.com/department-of-veterans-affairs/vets-api/actions/runs/20856488397/job/59928463346
  - https://github.com/department-of-veterans-affairs/vets-api/actions/runs/20859235791/job/59934452216