### PR TITLE
Adding first_name and last_name attributes to user_info endpoint

### DIFF
--- a/app/models/sign_in/user_info.rb
+++ b/app/models/sign_in/user_info.rb
@@ -32,6 +32,8 @@ module SignIn
     attribute :aal, :string
     attribute :csp_uuid, :string
     attribute :email, :string
+    attribute :first_name, :string
+    attribute :last_name, :string
     attribute :full_name, :string
     attribute :birth_date, :string
     attribute :ssn, :string

--- a/app/services/sign_in/user_info_generator.rb
+++ b/app/services/sign_in/user_info_generator.rb
@@ -9,10 +9,10 @@ module SignIn
     end
 
     def perform
-      SignIn::UserInfo.new(sub:, ial:, aal:, csp_type:, csp_uuid:, email:, full_name:, birth_date:, ssn:, gender:,
+      SignIn::UserInfo.new(sub:, ial:, aal:, csp_type:, csp_uuid:, email:, first_name:, last_name:, full_name:,
                            address_street1:, address_street2:, address_city:, address_state:, address_country:,
                            address_postal_code:, phone_number:, person_types:, icn:, sec_id:, edipi:, mhv_ien:,
-                           npi_id:, cerner_id:, corp_id:, birls:, gcids:)
+                           npi_id:, cerner_id:, corp_id:, birls:, gcids:, birth_date:, ssn:, gender:)
     end
 
     private
@@ -22,6 +22,8 @@ module SignIn
     def aal                 = AAL::LOGIN_GOV_AAL2
     def csp_uuid            = user_verification.credential_identifier
     def email               = user.user_verification&.user_credential_email&.credential_email
+    def last_name           = user.last_name
+    def first_name            = user.first_name
     def full_name           = user.full_name_normalized.values.compact.join(' ')
     def birth_date          = user.birth_date
     def ssn                 = user.ssn

--- a/spec/controllers/sign_in/user_info_controller_spec.rb
+++ b/spec/controllers/sign_in/user_info_controller_spec.rb
@@ -81,6 +81,8 @@ describe SignIn::UserInfoController do
           expect(body['csp_type']).to eq(MPI::Constants::IDME_IDENTIFIER)
           expect(body['csp_uuid']).to eq(credential_uuid)
           expect(body['email']).to eq(credential_email)
+          expect(body['first_name']).to eq(user.first_name)
+          expect(body['last_name']).to eq(user.last_name)
           expect(body['full_name']).to eq(user.full_name_normalized.values.compact.join(' '))
           expect(body['birth_date']).to eq(user.birth_date)
           expect(body['ssn']).to eq(user.ssn)

--- a/spec/models/sign_in/user_info_spec.rb
+++ b/spec/models/sign_in/user_info_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe SignIn::UserInfo do
         csp_type: 'some-csp-type',
         csp_uuid: 'some-csp-uuid',
         email: 'some-email',
+        first_name: 'some-first-name',
+        last_name: 'some-last-name',
         full_name: 'some-full-name',
         birth_date: 'some-birth-date',
         ssn: 'some-ssn',

--- a/spec/services/sign_in/user_info_generator_spec.rb
+++ b/spec/services/sign_in/user_info_generator_spec.rb
@@ -62,6 +62,8 @@ RSpec.describe SignIn::UserInfoGenerator do
         expect(user_info.csp_type).to eq(MPI::Constants::IDME_IDENTIFIER)
         expect(user_info.csp_uuid).to eq(credential_uuid)
         expect(user_info.email).to eq(credential_email)
+        expect(user_info.first_name).to eq(user.first_name)
+        expect(user_info.last_name).to eq(user.last_name)
         expect(user_info.full_name).to eq(user.full_name_normalized.values.compact.join(' '))
         expect(user_info.birth_date).to eq(user.birth_date)
         expect(user_info.ssn).to eq(user.ssn)


### PR DESCRIPTION
## Summary

- This PR adds the first_name and last_name field to the `user_info` response. 

## Testing done

- [ ] Authenticated with Sign in Service client_id=okta_test
- [ ] Navigated to localhost:3000/sign_in/user_info
- [ ] Confirmed that first_name/last_name attributes were returned in endpoint


## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [ ] Authenticate with Sign in Service client_id=okta_test
- [ ] Navigate to localhost:3000/sign_in/user_info
- [ ] Confirm that first_name/last_name attributes were returned in endpoint
