### PR TITLE
RES-19017/add is interrupted field to ch31 case details

### DIFF
--- a/modules/vre/app/serializers/vre/ch31_case_details_serializer.rb
+++ b/modules/vre/app/serializers/vre/ch31_case_details_serializer.rb
@@ -8,6 +8,7 @@ module VRE
 
     attributes :res_case_id,
                :is_transferred_to_cwnrs,
+               :is_interrupted,
                :external_status
   end
 end

--- a/modules/vre/app/services/vre/ch31_case_details/response.rb
+++ b/modules/vre/app/services/vre/ch31_case_details/response.rb
@@ -11,10 +11,7 @@ module VRE
       attribute :external_status, Hash
 
       def initialize(_status, response = nil)
-        return unless response
-
-        body = response.body
-        super(body)
+        super(response.body) if response
       end
     end
   end

--- a/modules/vre/app/services/vre/ch31_case_details/response.rb
+++ b/modules/vre/app/services/vre/ch31_case_details/response.rb
@@ -7,10 +7,14 @@ module VRE
 
       attribute :res_case_id, Integer
       attribute :is_transferred_to_cwnrs, Bool
+      attribute :is_interrupted, Bool
       attribute :external_status, Hash
 
       def initialize(_status, response = nil)
-        super(response.body) if response
+        return unless response
+
+        body = response.body
+        super(body)
       end
     end
   end

--- a/modules/vre/spec/fixtures/ch31_case_details.json
+++ b/modules/vre/spec/fixtures/ch31_case_details.json
@@ -1,41 +1,35 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object",
-  "required": ["data"],
-  "properties": {
-    "data": {
-      "type": ["object", "null"],
-      "required": ["id", "type", "attributes"],
-      "properties": {
-        "id": { "type": "string" },
-        "type": { "type": "string" },
-        "attributes": {
-          "type": "object",
-          "required": ["res_case_id", "is_transferred_to_cwnrs", "is_interrupted", "external_status"],
-          "properties": {
-            "res_case_id": { "type": ["integer", "null"] },
-            "is_transferred_to_cwnrs": { "type": ["boolean", "null"] },
-            "is_interrupted": { "type": ["boolean", "null"] },
-            "external_status": {
-              "type": ["object", "null"],
-              "properties": {
-                "is_discontinued": { "type": ["boolean", "null"] },
-                "discontinued_reason": { "type": ["string", "null"] },
-                "state_list": {
-                  "type": ["array", "null"],
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "step_code": { "type": ["string", "null"] },
-                      "status": { "type": ["string", "null"] }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+  "resCaseId": 123456,
+  "isTransferredToCWNRS": true,
+  "isInterrupted": false,
+  "externalStatus": {
+    "isDiscontinued": false,
+    "discontinuedReason": null,
+    "stateList": [
+      {
+        "stepCode": "APPL",
+        "status": "COMPLETED"
+      },
+      {
+        "stepCode": "ELGLDET",
+        "status": "COMPLETED"
+      },
+      {
+        "stepCode": "INTAKE",
+        "status": "ACTIVE"
+      },
+      {
+        "stepCode": "ENTLDET",
+        "status": "PENDING"
+      },
+      {
+        "stepCode": "PLANSELECT",
+        "status": "PENDING"
+      },
+      {
+        "stepCode": "PLANSELECT",
+        "status": "PENDING"
       }
-    }
+    ]
   }
 }

--- a/modules/vre/spec/fixtures/ch31_case_details.json
+++ b/modules/vre/spec/fixtures/ch31_case_details.json
@@ -1,34 +1,41 @@
 {
-  "resCaseId": 123456,
-  "isTransferredToCWNRS": true,
-  "externalStatus": {
-    "isDiscontinued": false,
-    "discontinuedReason": null,
-    "stateList": [
-      {
-        "stepCode": "APPL",
-        "status": "COMPLETED"
-      },
-      {
-        "stepCode": "ELGLDET",
-        "status": "COMPLETED"
-      },
-      {
-        "stepCode": "INTAKE",
-        "status": "ACTIVE"
-      },
-      {
-        "stepCode": "ENTLDET",
-        "status": "PENDING"
-      },
-      {
-        "stepCode": "PLANSELECT",
-        "status": "PENDING"
-      },
-      {
-        "stepCode": "PLANSELECT",
-        "status": "PENDING"
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": ["data"],
+  "properties": {
+    "data": {
+      "type": ["object", "null"],
+      "required": ["id", "type", "attributes"],
+      "properties": {
+        "id": { "type": "string" },
+        "type": { "type": "string" },
+        "attributes": {
+          "type": "object",
+          "required": ["res_case_id", "is_transferred_to_cwnrs", "is_interrupted", "external_status"],
+          "properties": {
+            "res_case_id": { "type": ["integer", "null"] },
+            "is_transferred_to_cwnrs": { "type": ["boolean", "null"] },
+            "is_interrupted": { "type": ["boolean", "null"] },
+            "external_status": {
+              "type": ["object", "null"],
+              "properties": {
+                "is_discontinued": { "type": ["boolean", "null"] },
+                "discontinued_reason": { "type": ["string", "null"] },
+                "state_list": {
+                  "type": ["array", "null"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "step_code": { "type": ["string", "null"] },
+                      "status": { "type": ["string", "null"] }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
-    ]
+    }
   }
 }

--- a/modules/vre/spec/serializers/ch31_case_details_serializer_spec.rb
+++ b/modules/vre/spec/serializers/ch31_case_details_serializer_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe VRE::Ch31CaseDetailsSerializer, type: :serializer do
     expect(attributes['is_transferred_to_cwnrs']).to eq(body['is_transferred_to_cwnrs'])
   end
 
+  it 'includes :is_interrupted' do
+    expect(attributes['is_interrupted']).to eq(body['is_interrupted'])
+  end
+
   it 'includes :external_status' do
     expect(attributes['external_status']).to eq(body['external_status'])
   end

--- a/spec/support/schemas/vre/ch31_case_details.json
+++ b/spec/support/schemas/vre/ch31_case_details.json
@@ -11,10 +11,11 @@
         "type": { "type": "string" },
         "attributes": {
           "type": "object",
-          "required": ["res_case_id", "is_transferred_to_cwnrs", "external_status"],
+          "required": ["res_case_id", "is_transferred_to_cwnrs", "is_interrupted", "external_status"],
           "properties": {
             "res_case_id": { "type": ["integer", "null"] },
             "is_transferred_to_cwnrs": { "type": ["boolean", "null"] },
+            "is_interrupted": { "type": ["boolean", "null"] },
             "external_status": {
               "type": ["object", "null"],
               "properties": {

--- a/spec/support/vcr_cassettes/vre/ch31_case_details/200.yml
+++ b/spec/support/vcr_cassettes/vre/ch31_case_details/200.yml
@@ -63,6 +63,6 @@ http_interactions:
       - max-age=16000000; includeSubDomains; preload;
     body:
       encoding: UTF-8
-      string: '{"resCaseId":123456,"isTransferredToCWNRS":true,"externalStatus":{"isDiscontinued":false,"discontinuedReason":null,"stateList":[{"stepCode":"APPL","status":"COMPLETED"},{"stepCode":"ELGLDET","status":"COMPLETED"},{"stepCode":"INTAKE","status":"ACTIVE"},{"stepCode":"ENTLDET","status":"PENDING"},{"stepCode":"PLANSELECT","status":"PENDING"},{"stepCode":"PLANSELECT","status":"PENDING"}]}}'
+      string: '{"resCaseId":123456,"isTransferredToCWNRS":true,"isInterrupted":false,"externalStatus":{"isDiscontinued":false,"discontinuedReason":null,"stateList":[{"stepCode":"APPL","status":"COMPLETED"},{"stepCode":"ELGLDET","status":"COMPLETED"},{"stepCode":"INTAKE","status":"ACTIVE"},{"stepCode":"ENTLDET","status":"PENDING"},{"stepCode":"PLANSELECT","status":"PENDING"},{"stepCode":"PLANSELECT","status":"PENDING"}]}}'
   recorded_at: Mon, 06 Oct 2025 15:51:09 GMT
 recorded_with: VCR 6.3.1


### PR DESCRIPTION
**Submitting on behalf of @ealvaro until he completes onboarding**

## Summary

- *This work is behind a feature toggle (flipper): NO
- *(Summarize the changes that have been made to the platform)* New page for VRE Ch 31 case details has yet to be released. While in development, new field was added, `is_interrupted`
- *(What is the solution, why is this the solution?)* Update serializer and response object with new field
- *(Which team do you work for, does your team own the maintenance of this component?)* RES, yes

## Related issue(s)

- https://jira.devops.va.gov/browse/RES-19017