### PR TITLE
Form 21-2680 remap prefill

### DIFF
--- a/config/form_profile_mappings/21-2680.yml
+++ b/config/form_profile_mappings/21-2680.yml
@@ -1,7 +1,7 @@
-veteranInformation:
-  veteranFullName: [identity_information, full_name]
-  veteranDob: [identity_information, date_of_birth]
+userInformation:
+  fullName: [identity_information, full_name]
+  dob: [identity_information, date_of_birth]
   phoneNumber: [contact_information, us_phone]
   email: [contact_information, email]
-  veteranAddress: [contact_information, address]
-  veteranSsn: [identity_information, ssn]
+  address: [contact_information, address]
+

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -760,23 +760,22 @@ RSpec.describe FormProfile, type: :model do
   end
 
   let(:v21_2680_expected) do
-    { veteranInformation: {
-      veteranFullName: {
+    { userInformation: {
+      fullName: {
         first: 'Abraham',
         last: 'Lincoln',
         suffix: 'Jr.'
       },
-      veteranDob: '1809-02-12',
+      dob: '1809-02-12',
       phoneNumber: '3035551234',
       email: user.va_profile_email,
-      veteranAddress: {
+      address: {
         street: '140 Rock Creek Rd',
         city: 'Washington',
         state: 'DC',
         country: 'USA',
         postalCode: '20011'
-      },
-      veteranSsn: '796111863'
+      }
     } }
   end
 


### PR DESCRIPTION
## Summary
Our stakeholders have asked that we remove prefill until we can properly prefill for the correct user type (veteran, dependent, etc).  

By changing `veteranInformation` to `userInformation` we've effectively done that because userInformation isn't referenced by the front end (yet). Later, we can make updates on the front end to map userInformation to veteranInformation or claimantInformation as necessary.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/129352

## Testing done

- [x] New code is covered by unit tests
- [x] tested FE as a logged in user userInformation is prefilled, but not yet used in the form and no prefill data will be passed on submit. Veteran data is no longer prefilled.

## Screenshots
<img width="1904" height="1678" alt="image" src="https://github.com/user-attachments/assets/84fcf0eb-7100-4b20-b130-973de147b2c5" />

## What areas of the site does it impact?
form 21-2680 prefill
## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
