### PR TITLE
Fix flaky form1010cg attachments spec

### DIFF
--- a/spec/requests/v0/form1010cg/attachments_spec.rb
+++ b/spec/requests/v0/form1010cg/attachments_spec.rb
@@ -40,8 +40,12 @@ RSpec.describe 'V0::Form1010CG::Attachments', type: :request do
 
     context 'with JPG' do
       let(:form_attachment_guid) { 'cdbaedd7-e268-49ed-b714-ec543fbb1fb8' }
+      # Cache ID from VCR cassette - must match for S3 URL consistency
+      let(:carrierwave_cache_id) { '1619206365-340201329057824-0002-6154' }
 
       before do
+        # Stub CarrierWave cache_id to match VCR cassette URLs
+        allow(CarrierWave).to receive(:generate_cache_id).and_return(carrierwave_cache_id)
         expect(SecureRandom).to receive(:uuid).and_call_original
         expect(SecureRandom).to receive(:uuid).and_return(form_attachment_guid) # when FormAttachment is initalized
         allow(SecureRandom).to receive(:uuid).and_call_original # Allow method to be called later in the req stack
@@ -65,8 +69,12 @@ RSpec.describe 'V0::Form1010CG::Attachments', type: :request do
 
     context 'with PDF' do
       let(:form_attachment_guid) { '834d9f51-d0c7-4dc2-9f2e-9b722db98069' }
+      # Cache ID from VCR cassette - must match for S3 URL consistency
+      let(:carrierwave_cache_id) { '1619206361-354509863784495-0001-7383' }
 
       before do
+        # Stub CarrierWave cache_id to match VCR cassette URLs
+        allow(CarrierWave).to receive(:generate_cache_id).and_return(carrierwave_cache_id)
         expect(SecureRandom).to receive(:uuid).and_call_original
         expect(SecureRandom).to receive(:uuid).and_return(form_attachment_guid) # when FormAttachment is initalized
         allow(SecureRandom).to receive(:uuid).and_call_original # Allow method to be called later in the req stack


### PR DESCRIPTION
## Summary

Fixes flaky test in `spec/requests/v0/form1010cg/attachments_spec.rb` caused by CarrierWave generating dynamic cache_ids that don't match VCR cassette URLs.

## Root Cause

The VCR cassettes contain S3 URLs with hardcoded CarrierWave cache_ids:
- `uploads/tmp/1619206365-340201329057824-0002-6154/doctors-note.jpg`
- `uploads/tmp/1619206361-354509863784495-0001-7383/doctors-note.pdf`

CarrierWave generates new cache_ids (with timestamps) on each test run. When the generated cache_id doesn't match the cassette, VCR throws `UnusedHTTPInteractionError`.

The test was already stubbing `SecureRandom.uuid` for the form attachment GUID, but wasn't stubbing the CarrierWave cache_id generation.

## The Fix

Added stubs for `CarrierWave.generate_cache_id` in each context block to return the cache_ids that match the VCR cassettes.

## Verification

- Ran spec with original failing seeds (1827, 18424) - all passing
- Ran spec 10 times with random seeds - all passing

## Related

- CI failures: 
  - https://github.com/department-of-veterans-affairs/vets-api/actions/runs/20931325057
  - https://github.com/department-of-veterans-affairs/vets-api/actions/runs/20932094793
- Seeds from failures: 1827, 18424
- Error: `VCR::Errors::UnusedHTTPInteractionError`