### PR TITLE
Fix security vulnerability: Add ownership verification to submission PDF URLs

### DIFF
--- a/app/controllers/v0/my_va/submission_pdf_urls_controller.rb
+++ b/app/controllers/v0/my_va/submission_pdf_urls_controller.rb
@@ -42,8 +42,10 @@ module V0
       def verify_submission_ownership!
         submission = FormSubmissionAttempt.find_by(benefits_intake_uuid: request_params[:submission_guid])
                                           &.form_submission
+        user_account = current_user.user_account
 
-        unless submission&.user_account_id == current_user.user_account&.id
+        # Explicitly check both exist and match - prevents nil == nil from passing
+        unless submission && user_account && submission.user_account_id == user_account.id
           raise Common::Exceptions::Forbidden, detail: 'You do not have access to this submission'
         end
       end

--- a/spec/requests/v0/my_va/submission_pdf_urls_spec.rb
+++ b/spec/requests/v0/my_va/submission_pdf_urls_spec.rb
@@ -68,6 +68,23 @@ RSpec.describe 'V0::MyVA::SubmissionPdfUrls', feature: :form_submission,
       end
     end
 
+    context 'when both submission.user_account_id and current_user.user_account are nil' do
+      let(:form_submission) { create(:form_submission, user_account: nil) }
+      let(:form_submission_attempt) do
+        create(:form_submission_attempt, form_submission:, benefits_intake_uuid: MOCK_GUID)
+      end
+
+      before do
+        form_submission_attempt
+        allow_any_instance_of(User).to receive(:user_account).and_return(nil)
+      end
+
+      it 'raises Forbidden error (prevents nil == nil from passing)' do
+        post('/v0/my_va/submission_pdf_urls', params: { form_id: VALID_FORM_ID, submission_guid: MOCK_GUID })
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
     context 'when user owns submission but pdf does not exist in S3' do
       let(:form_submission) { create(:form_submission, user_account:) }
       let(:form_submission_attempt) do


### PR DESCRIPTION
## Summary
- Fixes critical security vulnerability where any authenticated user could download any submission PDF by guessing/obtaining submission_guid
- Adds `verify_submission_ownership!` method to verify user owns the submission before returning PDF URL
- Returns 403 Forbidden if user doesn't own the submission or it doesn't exist

## Security Issue
The `/v0/my_va/submission_pdf_urls` endpoint was not verifying that the requesting user owned the submission. This allowed any authenticated user to access other users' submitted PDFs containing PII/PHI.

## Test plan
- [x] Added test case for unauthorized access (user doesn't own submission)
- [x] Added test case for non-existent submission
- [x] Updated existing tests to properly create form_submission records linked to user
- [x] All 10 tests pass locally