### PR TITLE
DR 127811: Feature flag removal

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2298,10 +2298,6 @@ features:
     actor_type: user
     description: Enable Notification Center
     enable_in_development: true
-  nod_part3_update:
-    actor_type: user
-    description: NOD update to latest form, part III box 11
-    enable_in_development: true
   nod_browser_monitoring_enabled:
     actor_type: user
     description: NOD Datadog RUM monitoring


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

Removing unused feature toggle: `nod_part3_update`.

Not used meaningfully in vets-website code, but related PR to remove from a test file there: https://github.com/department-of-veterans-affairs/vets-website/pull/41406

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/127811