### PR TITLE
Fix backend approval failure when the PR has a lot of comments

### DIFF
--- a/.github/workflows/require_be_approval.yml
+++ b/.github/workflows/require_be_approval.yml
@@ -212,14 +212,17 @@ jobs:
             echo "  Backend reviewers: ${BACKEND_REVIEWERS}"
 
             # Get most recent review state per user
+            REVIEWS_JSON=$(gh api /repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews --paginate --jq '
+              .[] | select(.state == "APPROVED") | {login: .user.login, submitted_at: .submitted_at}
+            ' 2>/dev/null || echo "[]")
+
             readarray -t APPROVALS < <(
-              gh api /repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews --jq '
-                [.[] | select(.state == "APPROVED")]
-                | sort_by(.submitted_at)
+              echo "$REVIEWS_JSON" | jq -s '
+                sort_by(.submitted_at)
                 | reverse
-                | unique_by(.user.login)
-                | .[].user.login
-              ' 2>/dev/null || true
+                | unique_by(.login)
+                | .[].login
+              ' -r 2>/dev/null || true
             )
 
             # Check if any approver is from backend-review-group


### PR DESCRIPTION
## Summary
When PRs accumulated more than 30 reviews (GitHub's default page size), the approval checks from backend-review-group members were on subsequent pages that weren't being fetched. This explained why sometimes PRs were failing on the Backend Approval check. It only failed on PRs with extensive review history.

This PR adds the `--paginate` flag to the gh api call to fetch all reviews across multiple pages. Because the output is different, I needed to refactor the approval detection logic. Also adds the `-r` flag to jq for proper raw string output.

I could have used `per_page` and set it to the max (100) ([docs here](https://docs.github.com/en/rest/pulls/reviews?apiVersion=2022-11-28)) but we would have hit the bug if there were more than 100 reviews/comments.

## Related issue(s)
None. Saw while on support. 
Slack thread: https://dsva.slack.com/archives/C0460N83Y9G/p1768259579086689

PRs where this failure was seen:
- https://github.com/department-of-veterans-affairs/vets-api/pull/25401
- https://github.com/department-of-veterans-affairs/vets-api/pull/25718

## Testing done
I tested with pr https://github.com/department-of-veterans-affairs/vets-api/pull/25740. This PR was having the issue where the Backend Approval check was failing saying `No approval from backend-review-group` even though two of us had reviewed. I pushed up the changes from this PR to that PR and approved and the check passed 🎉 
<img width="756" height="599" alt="Screenshot 2026-01-13 at 4 12 54 PM" src="https://github.com/user-attachments/assets/5815062b-3c63-48c9-8dbf-ec851dddd02b" />

```
 Determining approval requirements
----------------------------------------
Checking for backend-review-group approval...
  Backend reviewers: jweissman|LindseySaari|rmtolmach|stiehlrod|RachalCassity|CBonade|Crankums|rjohnson2011|stevenjcumming
[PASS] Backend approval confirmed by: rmtolmach
----------------------------------------
Final Status:
  Exempt: false
  Backend Approved: true
  Requires Approval: false
```

## What areas of the site does it impact?
None. `.github/workflows/require_be_approval.yml` only. 

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature
