### PR TITLE
2286 claims evidence tsa index

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2340,6 +2340,7 @@ spec/support/vcr_cassettes/sob @department-of-veterans-affairs/backend-review-gr
 spec/support/vcr_cassettes/staccato @department-of-veterans-affairs/health-apps-backend @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/token_validation @department-of-veterans-affairs/lighthouse-banana-peels @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/travel_pay @department-of-veterans-affairs/travel-pay-integration @department-of-veterans-affairs/backend-review-group
+spec/support/vcr_cassettes/tsa_letters @department-of-veterans-affairs/va-core-veteran-experiences @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/unified_health_data @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/uploads/validate_document.yml @department-of-veterans-affairs/backend-review-group
 spec/support/vcr_cassettes/user_eligibility_client @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/backend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -370,6 +370,7 @@ app/policies/mhv_user_account_policy.rb @department-of-veterans-affairs/octo-ide
 app/policies/mpi_policy.rb @department-of-veterans-affairs/octo-identity
 app/policies/power_of_attorney_policy.rb @department-of-veterans-affairs/accredited-representative-crew @department-of-veterans-affairs/backend-review-group
 app/policies/sign_in/ @department-of-veterans-affairs/octo-identity
+app/policies/tsa_letter_policy.rb @department-of-veterans-affairs/va-core-veteran-experiences @department-of-veterans-affairs/backend-review-group
 app/policies/va_profile_policy.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 app/policies/vet360_policy.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 app/policies/vye_policy.rb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/v0/tsa_letter_controller.rb
+++ b/app/controllers/v0/tsa_letter_controller.rb
@@ -12,14 +12,15 @@ module V0
       folder_identifier = "VETERAN:ICN:#{current_user.icn}"
       search_service.folder_identifier = folder_identifier
       response = search_service.find(filters:)
-      files = response[:files]
+      files = response.body['files']
       latest = files.max do |a, b|
-        a_time = DateTime.parse(a[:currentVersion][:systemData][:uploadedDateTime])
-        b_time = DateTime.parse(b[:currentVersion][:systemData][:uploadedDateTime])
+        # this needs to be more secure
+        a_time = DateTime.parse(a['currentVersion']['systemData']['uploadedDateTime'])
+        b_time = DateTime.parse(b['currentVersion']['systemData']['uploadedDateTime'])
         a_time <=> b_time
       end
-      latest_uuid = latest[:uuid]
-      latest_version = latest[:currentVersionUuid]
+      latest_uuid = latest['uuid']
+      latest_version = latest['currentVersionUuid']
       render(json: {uuid: latest_uuid, version: latest_version})
     end
 

--- a/app/controllers/v0/tsa_letter_controller.rb
+++ b/app/controllers/v0/tsa_letter_controller.rb
@@ -6,15 +6,6 @@ module V0
   class TsaLetterController < ApplicationController
     service_tag 'tsa_letter'
 
-    # x figure out routing
-    # "record" 404 vcr cassette
-    # serializer
-    # finish specs
-    # add spec for empty response
-    # make sorting safer
-    # x match on body
-    # turn off feature flag in staging
-
     def show
       search_service = ClaimsEvidenceApi::Service::Search.new
       filters = { subject: ['VETS Safe Travel Outreach Letter'] }
@@ -22,19 +13,10 @@ module V0
       search_service.folder_identifier = folder_identifier
       response = search_service.find(filters:)
       files = response.body['files']
-      latest = files.max do |a, b|
-        # this needs to be more secure
-        a_time = DateTime.parse(a['currentVersion']['systemData']['uploadedDateTime'])
-        b_time = DateTime.parse(b['currentVersion']['systemData']['uploadedDateTime'])
-        a_time <=> b_time
-      end
-      latest_uuid = latest['uuid']
-      latest_version = latest['currentVersionUuid']
-      upload_date = latest['currentVersion']['systemData']['uploadedDateTime']
-      render(json: {uuid: latest_uuid, version: latest_version, upload_date:})
+      serialized = most_recent_letter(files)
+      render(json: serialized)
     rescue => e
-      if e.respond_to?(:status) && e.status == 404
-        # should this return an empty instead?
+      if e.respond_to?(:status) && e.status == 403
         raise Common::Exceptions::RecordNotFound, current_user.user_account_uuid
       else
         raise e
@@ -53,6 +35,24 @@ module V0
 
     def service
       Efolder::Service.new(@current_user)
+    end
+
+    def most_recent_letter(files)
+      return { data: nil } if files.nil?
+
+      latest = files.max do |a, b|
+        # this needs to be more secure
+        a_time = DateTime.parse(a['currentVersion']['systemData']['uploadedDateTime'])
+        b_time = DateTime.parse(b['currentVersion']['systemData']['uploadedDateTime'])
+        a_time <=> b_time
+      end
+      document_id = latest['uuid']
+      document_version = latest['currentVersionUuid']
+      upload_datetime = latest['currentVersion']['systemData']['uploadedDateTime']
+      tsa_letter_metadata = OpenStruct.new(document_id:, document_version:, upload_datetime:)
+      TsaLetterSerializer.new(tsa_letter_metadata)
+      rescue Date::Error => e
+        Rails.logger.error()
     end
   end
 end

--- a/app/controllers/v0/tsa_letter_controller.rb
+++ b/app/controllers/v0/tsa_letter_controller.rb
@@ -12,8 +12,15 @@ module V0
       folder_identifier = "VETERAN:ICN:#{current_user.icn}"
       search_service.folder_identifier = folder_identifier
       response = search_service.find(filters:)
-      binding.pry
-      render(json: response)
+      files = response[:files]
+      latest = files.max do |a, b|
+        a_time = DateTime.parse(a[:currentVersion][:systemData][:uploadedDateTime])
+        b_time = DateTime.parse(b[:currentVersion][:systemData][:uploadedDateTime])
+        a_time <=> b_time
+      end
+      latest_uuid = latest[:uuid]
+      latest_version = latest[:currentVersionUuid]
+      render(json: {uuid: latest_uuid, version: latest_version})
     end
 
     # service = ClaimsEvidenceApi::Service::Search.new

--- a/app/controllers/v0/tsa_letter_controller.rb
+++ b/app/controllers/v0/tsa_letter_controller.rb
@@ -41,9 +41,8 @@ module V0
       return { data: nil } if files.nil?
 
       latest = files.max do |a, b|
-        # this needs to be more secure
-        a_time = DateTime.parse(a['currentVersion']['systemData']['uploadedDateTime'])
-        b_time = DateTime.parse(b['currentVersion']['systemData']['uploadedDateTime'])
+        a_time = DateTime.parse(a.dig('currentVersion', 'systemData', 'uploadedDateTime'))
+        b_time = DateTime.parse(b.dig('currentVersion', 'systemData', 'uploadedDateTime'))
         a_time <=> b_time
       end
       document_id = latest['uuid']
@@ -51,8 +50,10 @@ module V0
       upload_datetime = latest['currentVersion']['systemData']['uploadedDateTime']
       tsa_letter_metadata = OpenStruct.new(document_id:, document_version:, upload_datetime:)
       TsaLetterSerializer.new(tsa_letter_metadata)
-      rescue Date::Error => e
-        Rails.logger.error()
+    rescue Date::Error => e
+      datetimes = files.map { |file| file.dig('currentVersion', 'systemData', 'uploadedDateTime') }
+      Rails.logger.error('Invalid datetime format found in TSA letters data', datetimes)
+      raise e
     end
   end
 end

--- a/app/controllers/v0/tsa_letter_controller.rb
+++ b/app/controllers/v0/tsa_letter_controller.rb
@@ -12,7 +12,7 @@ module V0
     # finish specs
     # add spec for empty response
     # make sorting safer
-    # match on body
+    # x match on body
     # turn off feature flag in staging
 
     def show
@@ -34,6 +34,7 @@ module V0
       render(json: {uuid: latest_uuid, version: latest_version, upload_date:})
     rescue => e
       if e.respond_to?(:status) && e.status == 404
+        # should this return an empty instead?
         raise Common::Exceptions::RecordNotFound, current_user.user_account_uuid
       else
         raise e

--- a/app/controllers/v0/tsa_letter_controller.rb
+++ b/app/controllers/v0/tsa_letter_controller.rb
@@ -1,15 +1,35 @@
 # frozen_string_literal: true
 
-require 'efolder/service'
+require 'claims_evidence_api/service/search'
 
 module V0
   class TsaLetterController < ApplicationController
     service_tag 'tsa_letter'
 
     def index
-      letters = service.list_tsa_letters
-      render(json: TsaLetterSerializer.new(letters))
+      search_service = ClaimsEvidenceApi::Service::Search.new
+      filters = { subject: ['VETS Safe Travel Outreach Letter'] }
+      folder_identifier = "VETERAN:ICN:#{current_user.icn}"
+      search_service.folder_identifier = folder_identifier
+      response = search_service.find(filters:)
+      binding.pry
+      render(json: response)
     end
+
+    # service = ClaimsEvidenceApi::Service::Search.new
+    # filters = { subject: ['VETS Safe Travel Outreach Letter'] }
+    # folder_identifier = "VETERAN:ICN:#{user icn}"
+    # service.folder_identifier = folder_identifier
+    # start_time = Time.now
+    # response = service.find(filters:)
+    # end_time = Time.now
+    # elapsed = end_time - start_time
+    # puts "Elapsed: #{elapsed}"
+
+    # require 'claims_evidence_api/service/files'
+    # service = ClaimsEvidenceApi::Service::Files.new
+    # uuid = 'c75438b4-47f8-44d3-9e35-798158591456' # pulled from search response
+    # version = '920debba-cc65-479c-ab47-db9b2a5cd95f' # from search response
 
     def show
       send_data(

--- a/app/controllers/v0/tsa_letter_controller.rb
+++ b/app/controllers/v0/tsa_letter_controller.rb
@@ -53,7 +53,6 @@ module V0
       TsaLetterSerializer.new(tsa_letter_metadata)
     rescue Date::Error
       datetimes = files.map { |file| file.dig('currentVersion', 'providerData', 'modifiedDateTime') }
-      # Rails.logger.error('Invalid datetime format found in TSA letters data', datetimes)
       raise Common::Exceptions::UnprocessableEntity,
             detail: "Invalid datetime format found in TSA letters data: #{datetimes.join(', ')}",
             source: self.class.name

--- a/app/controllers/v0/tsa_letter_controller.rb
+++ b/app/controllers/v0/tsa_letter_controller.rb
@@ -41,17 +41,17 @@ module V0
       return { data: nil } if files.nil?
 
       latest = files.max do |a, b|
-        a_time = DateTime.parse(a.dig('currentVersion', 'systemData', 'uploadedDateTime'))
-        b_time = DateTime.parse(b.dig('currentVersion', 'systemData', 'uploadedDateTime'))
+        a_time = DateTime.parse(a.dig('currentVersion', 'providerData', 'modifiedDateTime'))
+        b_time = DateTime.parse(b.dig('currentVersion', 'providerData', 'modifiedDateTime'))
         a_time <=> b_time
       end
       document_id = latest['uuid']
       document_version = latest['currentVersionUuid']
-      upload_datetime = latest['currentVersion']['systemData']['uploadedDateTime']
-      tsa_letter_metadata = OpenStruct.new(document_id:, document_version:, upload_datetime:)
+      modified_datetime = latest.dig('currentVersion', 'providerData', 'modifiedDateTime')
+      tsa_letter_metadata = OpenStruct.new(document_id:, document_version:, modified_datetime:)
       TsaLetterSerializer.new(tsa_letter_metadata)
     rescue Date::Error => e
-      datetimes = files.map { |file| file.dig('currentVersion', 'systemData', 'uploadedDateTime') }
+      datetimes = files.map { |file| file.dig('currentVersion', 'providerData', 'modifiedDateTime') }
       Rails.logger.error('Invalid datetime format found in TSA letters data', datetimes)
       raise e
     end

--- a/app/controllers/v0/tsa_letter_controller.rb
+++ b/app/controllers/v0/tsa_letter_controller.rb
@@ -24,21 +24,6 @@ module V0
       render(json: {uuid: latest_uuid, version: latest_version})
     end
 
-    # service = ClaimsEvidenceApi::Service::Search.new
-    # filters = { subject: ['VETS Safe Travel Outreach Letter'] }
-    # folder_identifier = "VETERAN:ICN:#{user icn}"
-    # service.folder_identifier = folder_identifier
-    # start_time = Time.now
-    # response = service.find(filters:)
-    # end_time = Time.now
-    # elapsed = end_time - start_time
-    # puts "Elapsed: #{elapsed}"
-
-    # require 'claims_evidence_api/service/files'
-    # service = ClaimsEvidenceApi::Service::Files.new
-    # uuid = 'c75438b4-47f8-44d3-9e35-798158591456' # pulled from search response
-    # version = '920debba-cc65-479c-ab47-db9b2a5cd95f' # from search response
-
     def show
       send_data(
         service.get_tsa_letter(params[:id]),

--- a/app/controllers/v0/tsa_letter_controller.rb
+++ b/app/controllers/v0/tsa_letter_controller.rb
@@ -5,6 +5,7 @@ require 'claims_evidence_api/service/search'
 module V0
   class TsaLetterController < ApplicationController
     service_tag 'tsa_letter'
+    before_action { authorize :tsa_letter, :access? }
 
     def show
       search_service = ClaimsEvidenceApi::Service::Search.new

--- a/app/policies/tsa_letter_policy.rb
+++ b/app/policies/tsa_letter_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+TsaLetterPolicy = Struct.new(:user, :tsa_letter) do
+  def access?
+    user.present? && user.icn.present?
+  end
+end

--- a/app/serializers/tsa_letter_serializer.rb
+++ b/app/serializers/tsa_letter_serializer.rb
@@ -4,5 +4,5 @@ class TsaLetterSerializer
   include JSONAPI::Serializer
 
   set_id { '' }
-  attribute :document_id, :doc_type, :type_description, :received_at
+  attribute :document_id, :document_version, :upload_datetime
 end

--- a/app/serializers/tsa_letter_serializer.rb
+++ b/app/serializers/tsa_letter_serializer.rb
@@ -4,5 +4,5 @@ class TsaLetterSerializer
   include JSONAPI::Serializer
 
   set_id { '' }
-  attribute :document_id, :document_version, :upload_datetime
+  attribute :document_id, :document_version, :modified_datetime
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -182,7 +182,8 @@ Rails.application.routes.draw do
 
     resources :efolder, only: %i[index show]
 
-    resources :tsa_letter, only: %i[index show]
+    get :tsa_letter, to: 'tsa_letter#show'
+    get 'tsa_letter/:id/version/:version_id/download', to: 'tsa_letter#download'
 
     resources :evss_claims, only: %i[index show] do
       post :request_decision, on: :member

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -12,80 +12,29 @@ RSpec.describe 'VO::TsaLetter', type: :request do
   end
 
   describe 'GET /v0/tsa_letter' do
-    let(:faraday_response) { Faraday::Response.new }
-    let(:tsa_letters) do
-      {
-        "page" => {
-          "totalPages" => 1,
-          "requestedResultsPerPage" => 10,
-          "currentPage" => 1,
-          "totalResults" => 1
-        },
-        "files" => [
-          {
-            "owner" => {
-              "type" => "VETERAN",
-              "id" => "796378881"
-            },
-            "uuid" => "c75438b4-47f8-44d3-9e35-798158591456",
-            "currentVersionUuid" => "920debba-cc65-479c-ab47-db9b2a5cd95f",
-            "currentVersion" => {
-              "systemData" => {
-                "uploadedDateTime" => "2025-09-09T14:18:53",
-                "contentSize" => 177200,
-                "contentName" => "VETS Safe Travel - Outreach Letter_TSA edits_08.29.25 DRAFT.pdf",
-                "mimeType" => "application/pdf",
-                "uploadSource" => "ClaimEvidenceUI"
-              },
-              "providerData" => {
-                "subject" => "VETS Safe Travel Outreach Letter",
-                "documentTypeId" => 34,
-                "ocrStatus" => "Not Searchable",
-                "newMail" => false,
-                "userSARL" => "7",
-                "bookmarks" => {
-                  "VBA" => {
-                    "isDefaultRealm" => true
-                  }
-                },
-                "systemSource" => "ClaimEvidenceUI",
-                "isAnnotated" => false,
-                "modifiedDateTime" => "2025-09-09T14:18:53",
-                "numberOfContentions" => 0,
-                "readByCurrentUser" => true,
-                "dateVaReceivedDocument" => "2025-09-09",
-                "hasContentionAnnotations" => false,
-                "contentSource" => "VA.gov",
-                "actionable" => false,
-                "lastOpenedDocument" => true
-              }
-            }
-          }
-        ]
-      }
-    end
-
-    before do
-      # allow_any_instance_of(ClaimsEvidenceApi::Service::Search).to receive(:find).and_return(tsa_letters)
+    it 'returns the most recent tsa letter metadata' do
+      VCR.use_cassette('tsa_letters/index_success', { match_requests_on: %i[method uri] }) do
+        get '/v0/tsa_letter'
+        expect(response.body).to eq({uuid: 'c75438b4-47f8-44d3-9e35-798158591456', version: '920debba-cc65-479c-ab47-db9b2a5cd95f'}.to_json)
+      end
     end
 
     it 'returns the tsa letter metadata' do
-      params = {:pageRequest=>{:resultsPerPage=>10, :page=>1},
-       :filters=>{"providerData.subject"=>{:evaluationType=>"CONTAINS", :value=>"[\"VETS Safe Travel Outreach Letter\"]"}},
-       :sort=>[]}
-      # faraday_double = double('response')
-      mocked_response = Faraday::Response.new(response_body: tsa_letters, status: 200)
-      mocked_env = Faraday::Env.new(response: mocked_response).tap do |e|
-        e.status = mocked_response.status
-        e.body = mocked_response.body
-      end
-      expect_any_instance_of(Faraday::Connection).to receive(:post).with("folders/files:search", params).and_return(mocked_response)
-      allow(mocked_response).to receive(:env).and_return(mocked_env)
-
-      # VCR.use_cassette('spec/support/vcr_cassettes/tsa_letters/index_success', { match_requests_on: %i[method uri] }) do
-      get '/v0/tsa_letter'
-      expect(response.body).to eq({uuid: 'c75438b4-47f8-44d3-9e35-798158591456', version: '920debba-cc65-479c-ab47-db9b2a5cd95f'}.to_json)
+      # params = {:pageRequest=>{:resultsPerPage=>10, :page=>1},
+      #  :filters=>{"providerData.subject"=>{:evaluationType=>"CONTAINS", :value=>"[\"VETS Safe Travel Outreach Letter\"]"}},
+      #  :sort=>[]}
+      # mocked_response = Faraday::Response.new(response_body: tsa_letters, status: 200)
+      # mocked_env = Faraday::Env.new(response: mocked_response).tap do |e|
+      #   e.status = mocked_response.status
+      #   e.body = mocked_response.body
       # end
+      # expect_any_instance_of(Faraday::Connection).to receive(:post).with("folders/files:search", params).and_return(mocked_response)
+      # allow(mocked_response).to receive(:env).and_return(mocked_env)
+
+      VCR.use_cassette('tsa_letters/index_success', { match_requests_on: %i[method uri] }) do
+        get '/v0/tsa_letter'
+        expect(response.body).to eq({uuid: 'c75438b4-47f8-44d3-9e35-798158591456', version: '920debba-cc65-479c-ab47-db9b2a5cd95f'}.to_json)
+      end
     end
   end
 

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'VO::TsaLetter', type: :request do
         }
       end
 
-      it 'logs error and renders 503' do
+      it 'logs error and renders 422' do
         VCR.use_cassette('tsa_letters/show_error', { match_requests_on: %i[method uri body] }) do
           # mocking this because I don't know if it's a real possibility
           mocked_response = Faraday::Response.new(response_body: bad_response, status: 200)
@@ -93,6 +93,15 @@ RSpec.describe 'VO::TsaLetter', type: :request do
           expect(response.parsed_body.dig('errors', 0, 'detail'))
             .to eq('Invalid datetime format found in TSA letters data: 2025-09-09T14:18:53, null')
         end
+      end
+    end
+
+    context 'when user does not have an ICN' do
+      let(:user) { build(:user, icn: nil) }
+
+      it 'renders 403' do
+        get '/v0/tsa_letter'
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -19,19 +19,8 @@ RSpec.describe 'VO::TsaLetter', type: :request do
       end
     end
 
-    it 'returns the tsa letter metadata' do
-      # params = {:pageRequest=>{:resultsPerPage=>10, :page=>1},
-      #  :filters=>{"providerData.subject"=>{:evaluationType=>"CONTAINS", :value=>"[\"VETS Safe Travel Outreach Letter\"]"}},
-      #  :sort=>[]}
-      # mocked_response = Faraday::Response.new(response_body: tsa_letters, status: 200)
-      # mocked_env = Faraday::Env.new(response: mocked_response).tap do |e|
-      #   e.status = mocked_response.status
-      #   e.body = mocked_response.body
-      # end
-      # expect_any_instance_of(Faraday::Connection).to receive(:post).with("folders/files:search", params).and_return(mocked_response)
-      # allow(mocked_response).to receive(:env).and_return(mocked_env)
-
-      VCR.use_cassette('tsa_letters/index_success', { match_requests_on: %i[method uri] }) do
+    it 'renders error message' do
+      VCR.use_cassette('tsa_letters/index_not_found', { match_requests_on: %i[method uri] }) do
         get '/v0/tsa_letter'
         expect(response.body).to eq({uuid: 'c75438b4-47f8-44d3-9e35-798158591456', version: '920debba-cc65-479c-ab47-db9b2a5cd95f'}.to_json)
       end

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'VO::TsaLetter', type: :request do
   end
 
   describe 'GET /v0/tsa_letter' do
-    it 'returns the most recent tsa letter metadata' do
+    it 'renders the most recent tsa letter metadata' do
       VCR.use_cassette('tsa_letters/show_success', { match_requests_on: %i[method uri body] }) do
         get '/v0/tsa_letter'
         expect(response).to have_http_status(:ok)
@@ -25,7 +25,7 @@ RSpec.describe 'VO::TsaLetter', type: :request do
     end
 
     context 'when user has no letter' do
-      it 'returns an empty response' do
+      it 'renders an empty response' do
         VCR.use_cassette('tsa_letters/show_success_empty', { match_requests_on: %i[method uri body] }) do
           get '/v0/tsa_letter'
           expect(response).to have_http_status(:ok)
@@ -35,7 +35,7 @@ RSpec.describe 'VO::TsaLetter', type: :request do
     end
 
     context 'when upstream returns 403' do
-      it 'returns 404' do
+      it 'renders 404' do
         VCR.use_cassette('tsa_letters/show_not_found', { match_requests_on: %i[method uri body] }) do
           get '/v0/tsa_letter'
           expect(response).to have_http_status(:not_found)
@@ -43,11 +43,57 @@ RSpec.describe 'VO::TsaLetter', type: :request do
       end
     end
 
-    context 'when upstream returns other error' do
-      it 'returns 503' do
+    context 'when upstream renders other error' do
+      it 'renders 503' do
         VCR.use_cassette('tsa_letters/show_error', { match_requests_on: %i[method uri body] }) do
           get '/v0/tsa_letter'
           expect(response).to have_http_status(:service_unavailable)
+        end
+      end
+    end
+
+    context 'when response contains invalid datetime' do
+      let(:bad_response) do
+        {
+          'files' => [
+            {
+              'uuid' => 'c75438b4-47f8-44d3-9e35-798158591456',
+              'currentVersionUuid' => '920debba-cc65-479c-ab47-db9b2a5cd95f',
+              'currentVersion' => {
+                'systemData' => {
+                  'uploadedDateTime' => '2025-09-09T14:18:53'
+                }
+              }
+            },
+            {
+              'uuid' => 'c75438b4-47f8-44d3-9e35-798158591456',
+              'currentVersionUuid' => 'cbb29e79-a10d-4757-b266-3db336fcffbe',
+              'currentVersion' => {
+                'systemData' => {
+                  'uploadedDateTime' => 'null'
+                }
+              }
+            }
+          ]
+        }
+      end
+
+      it 'logs error and renders 503' do
+        VCR.use_cassette('tsa_letters/show_error', { match_requests_on: %i[method uri body] }) do
+          # mocking this because I don't know if it's a real possibility
+          mocked_response = Faraday::Response.new(response_body: bad_response, status: 200)
+          mocked_env = Faraday::Env.new(response: mocked_response).tap do |e|
+            e.status = mocked_response.status
+            e.body = mocked_response.body
+          end
+          allow_any_instance_of(Faraday::Connection).to receive(:post).with('folders/files:search',
+                                                                            any_args).and_return(mocked_response)
+          allow(mocked_response).to receive(:env).and_return(mocked_env)
+          allow(Rails.logger).to receive(:error) # this is the initial parsing error
+          expect(Rails.logger).to receive(:error).with('Invalid datetime format found in TSA letters data',
+                                                       ['2025-09-09T14:18:53', 'null'])
+          get '/v0/tsa_letter'
+          expect(response).to have_http_status(:internal_server_error)
         end
       end
     end

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -14,7 +14,21 @@ RSpec.describe 'VO::TsaLetter', type: :request do
     it 'returns the most recent tsa letter metadata' do
       VCR.use_cassette('tsa_letters/show_success', { match_requests_on: %i[method uri body] }) do
         get '/v0/tsa_letter'
-        expect(response.body).to eq({uuid: 'c75438b4-47f8-44d3-9e35-798158591456', version: '920debba-cc65-479c-ab47-db9b2a5cd95f', "upload_date": '2025-09-09T14:18:53'}.to_json)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq({ data: { id: '', type: 'tsa_letter',
+                                              attributes: {
+                                                document_id: 'c75438b4-47f8-44d3-9e35-798158591456',
+                                                document_version: '920debba-cc65-479c-ab47-db9b2a5cd95f',
+                                                upload_datetime: '2025-09-09T14:18:53'
+                                              } } }.to_json)
+      end
+    end
+
+    it 'returns an empty response' do
+      VCR.use_cassette('tsa_letters/show_success_empty', { match_requests_on: %i[method uri body] }) do
+        get '/v0/tsa_letter'
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq({ data: nil }.to_json)
       end
     end
 
@@ -22,22 +36,22 @@ RSpec.describe 'VO::TsaLetter', type: :request do
       it 'returns 404' do
         VCR.use_cassette('tsa_letters/show_not_found', { match_requests_on: %i[method uri body] }) do
           get '/v0/tsa_letter'
-          expect(response.status).to eq(404)
+          expect(response).to have_http_status(:not_found)
         end
       end
     end
 
     context 'when upstream returns other error' do
-      it 'it returns 503' do
+      it 'returns 503' do
         VCR.use_cassette('tsa_letters/show_error', { match_requests_on: %i[method uri body] }) do
           get '/v0/tsa_letter'
-          expect(response.status).to eq(503)
+          expect(response).to have_http_status(:service_unavailable)
         end
       end
     end
   end
 
-  describe 'GET /v0/tsa_letter/:id', pending: 'route change' do
+  describe 'GET /v0/tsa_letter/:id' do
     let(:document_id) { '{93631483-E9F9-44AA-BB55-3552376400D8}' }
     let(:content) { File.read('spec/fixtures/files/error_message.txt') }
 
@@ -45,7 +59,7 @@ RSpec.describe 'VO::TsaLetter', type: :request do
       expect(efolder_service).to receive(:get_tsa_letter).with(document_id).and_return(content)
     end
 
-    it 'sends the doc pdf' do
+    it 'sends the doc pdf', pending: 'route change' do
       get "/v0/tsa_letter/#{CGI.escape(document_id)}"
       expect(response.body).to eq(content)
     end

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -24,15 +24,17 @@ RSpec.describe 'VO::TsaLetter', type: :request do
       end
     end
 
-    it 'returns an empty response' do
-      VCR.use_cassette('tsa_letters/show_success_empty', { match_requests_on: %i[method uri body] }) do
-        get '/v0/tsa_letter'
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to eq({ data: nil }.to_json)
+    context 'when user has no letter' do
+      it 'returns an empty response' do
+        VCR.use_cassette('tsa_letters/show_success_empty', { match_requests_on: %i[method uri body] }) do
+          get '/v0/tsa_letter'
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to eq({ data: nil }.to_json)
+        end
       end
     end
 
-    context 'when upstream returns 404' do
+    context 'when upstream returns 403' do
       it 'returns 404' do
         VCR.use_cassette('tsa_letters/show_not_found', { match_requests_on: %i[method uri body] }) do
           get '/v0/tsa_letter'
@@ -55,11 +57,8 @@ RSpec.describe 'VO::TsaLetter', type: :request do
     let(:document_id) { '{93631483-E9F9-44AA-BB55-3552376400D8}' }
     let(:content) { File.read('spec/fixtures/files/error_message.txt') }
 
-    before do
-      expect(efolder_service).to receive(:get_tsa_letter).with(document_id).and_return(content)
-    end
-
-    it 'sends the doc pdf', pending: 'route change' do
+    it 'sends the doc pdf' do
+      skip 'Pending migration to Claims Evidence API'
       get "/v0/tsa_letter/#{CGI.escape(document_id)}"
       expect(response.body).to eq(content)
     end

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'support/stub_efolder_documents'
+require 'claims_evidence_api/service/search'
+
 
 RSpec.describe 'VO::TsaLetter', type: :request do
   let(:user) { build(:user, :loa3) }
@@ -12,30 +13,66 @@ RSpec.describe 'VO::TsaLetter', type: :request do
 
   describe 'GET /v0/tsa_letter' do
     let(:tsa_letters) do
-      [
-        OpenStruct.new(
-          document_id: '{73CD7B28-F695-4337-BBC1-2443A913ACF6}',
-          doc_type: '34',
-          type_description: 'Correspondence',
-          received_at: Date.new(2024, 9, 13)
-        )
-      ]
+      {
+        "page": {
+          "totalPages": 1,
+          "requestedResultsPerPage": 10,
+          "currentPage": 1,
+          "totalResults": 1
+        },
+        "files": [
+          {
+            "owner": {
+              "type": "VETERAN",
+              "id": "796378881"
+            },
+            "uuid": "c75438b4-47f8-44d3-9e35-798158591456",
+            "currentVersionUuid": "920debba-cc65-479c-ab47-db9b2a5cd95f",
+            "currentVersion": {
+              "systemData": {
+                "uploadedDateTime": "2025-09-09T14:18:53",
+                "contentSize": 177200,
+                "contentName": "VETS Safe Travel - Outreach Letter_TSA edits_08.29.25 DRAFT.pdf",
+                "mimeType": "application/pdf",
+                "uploadSource": "ClaimEvidenceUI"
+              },
+              "providerData": {
+                "subject": "VETS Safe Travel Outreach Letter",
+                "documentTypeId": 34,
+                "ocrStatus": "Not Searchable",
+                "newMail": false,
+                "userSARL": "7",
+                "bookmarks": {
+                  "VBA": {
+                    "isDefaultRealm": true
+                  }
+                },
+                "systemSource": "ClaimEvidenceUI",
+                "isAnnotated": false,
+                "modifiedDateTime": "2025-09-09T14:18:53",
+                "numberOfContentions": 0,
+                "readByCurrentUser": true,
+                "dateVaReceivedDocument": "2025-09-09",
+                "hasContentionAnnotations": false,
+                "contentSource": "VA.gov",
+                "actionable": false,
+                "lastOpenedDocument": true
+              }
+            }
+          }
+        ]
+      }
     end
 
-    # before do
-    #   expect(efolder_service).to receive(:list_tsa_letters).and_return(tsa_letters)
-    # end
+    before do
+      allow_any_instance_of(ClaimsEvidenceApi::Service::Search).to receive(:find).and_return(tsa_letters)
+    end
 
     it 'returns the tsa letter metadata' do
-      VCR.use_cassette('spec/support/vcr_cassettes/tsa_letters/index_success.yml') do
-        expected_response = { 'data' =>
-          [{ 'id' => '',
-            'type' => 'tsa_letter',
-            'attributes' => { 'document_id' => '{73CD7B28-F695-4337-BBC1-2443A913ACF6}', 'doc_type' => '34',
-                              'type_description' => 'Correspondence', 'received_at' => '2024-09-13' } }] }
-        get '/v0/tsa_letter'
-        expect(response.body).to eq(expected_response.to_json)
-      end
+      # VCR.use_cassette('spec/support/vcr_cassettes/tsa_letters/index_success', { match_requests_on: %i[method uri] }) do
+      get '/v0/tsa_letter'
+      expect(response.body).to eq({uuid: 'c75438b4-47f8-44d3-9e35-798158591456', version: '920debba-cc65-479c-ab47-db9b2a5cd95f'}.to_json)
+      # end
     end
   end
 

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'claims_evidence_api/service/search'
 
 RSpec.describe 'VO::TsaLetter', type: :request do
   let(:user) { build(:user, :loa3) }
@@ -89,11 +88,10 @@ RSpec.describe 'VO::TsaLetter', type: :request do
           allow_any_instance_of(Faraday::Connection).to receive(:post).with('folders/files:search',
                                                                             any_args).and_return(mocked_response)
           allow(mocked_response).to receive(:env).and_return(mocked_env)
-          allow(Rails.logger).to receive(:error) # this is the initial parsing error
-          expect(Rails.logger).to receive(:error).with('Invalid datetime format found in TSA letters data',
-                                                       ['2025-09-09T14:18:53', 'null'])
           get '/v0/tsa_letter'
-          expect(response).to have_http_status(:internal_server_error)
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body.dig('errors', 0, 'detail'))
+            .to eq('Invalid datetime format found in TSA letters data: 2025-09-09T14:18:53, null')
         end
       end
     end

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -22,18 +22,20 @@ RSpec.describe 'VO::TsaLetter', type: :request do
       ]
     end
 
-    before do
-      expect(efolder_service).to receive(:list_tsa_letters).and_return(tsa_letters)
-    end
+    # before do
+    #   expect(efolder_service).to receive(:list_tsa_letters).and_return(tsa_letters)
+    # end
 
     it 'returns the tsa letter metadata' do
-      expected_response = { 'data' =>
-        [{ 'id' => '',
-           'type' => 'tsa_letter',
-           'attributes' => { 'document_id' => '{73CD7B28-F695-4337-BBC1-2443A913ACF6}', 'doc_type' => '34',
-                             'type_description' => 'Correspondence', 'received_at' => '2024-09-13' } }] }
-      get '/v0/tsa_letter'
-      expect(response.body).to eq(expected_response.to_json)
+      VCR.use_cassette('spec/support/vcr_cassettes/tsa_letters/index_success.yml') do
+        expected_response = { 'data' =>
+          [{ 'id' => '',
+            'type' => 'tsa_letter',
+            'attributes' => { 'document_id' => '{73CD7B28-F695-4337-BBC1-2443A913ACF6}', 'doc_type' => '34',
+                              'type_description' => 'Correspondence', 'received_at' => '2024-09-13' } }] }
+        get '/v0/tsa_letter'
+        expect(response.body).to eq(expected_response.to_json)
+      end
     end
   end
 

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -18,10 +18,21 @@ RSpec.describe 'VO::TsaLetter', type: :request do
       end
     end
 
-    it 'renders error message' do
-      VCR.use_cassette('tsa_letters/show_not_found', { match_requests_on: %i[method uri] }) do
-        get '/v0/tsa_letter'
-        expect(response.status).to eq(404)
+    context 'when upstream returns 404' do
+      it 'returns 404' do
+        VCR.use_cassette('tsa_letters/show_not_found', { match_requests_on: %i[method uri body] }) do
+          get '/v0/tsa_letter'
+          expect(response.status).to eq(404)
+        end
+      end
+    end
+
+    context 'when upstream returns other error' do
+      it 'it returns 503' do
+        VCR.use_cassette('tsa_letters/show_error', { match_requests_on: %i[method uri body] }) do
+          get '/v0/tsa_letter'
+          expect(response.status).to eq(503)
+        end
       end
     end
   end

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'VO::TsaLetter', type: :request do
                                               attributes: {
                                                 document_id: 'c75438b4-47f8-44d3-9e35-798158591456',
                                                 document_version: '920debba-cc65-479c-ab47-db9b2a5cd95f',
-                                                upload_datetime: '2025-09-09T14:18:53'
+                                                modified_datetime: '2025-09-09T14:18:53'
                                               } } }.to_json)
       end
     end
@@ -60,8 +60,8 @@ RSpec.describe 'VO::TsaLetter', type: :request do
               'uuid' => 'c75438b4-47f8-44d3-9e35-798158591456',
               'currentVersionUuid' => '920debba-cc65-479c-ab47-db9b2a5cd95f',
               'currentVersion' => {
-                'systemData' => {
-                  'uploadedDateTime' => '2025-09-09T14:18:53'
+                'providerData' => {
+                  'modifiedDateTime' => '2025-09-09T14:18:53'
                 }
               }
             },
@@ -69,8 +69,8 @@ RSpec.describe 'VO::TsaLetter', type: :request do
               'uuid' => 'c75438b4-47f8-44d3-9e35-798158591456',
               'currentVersionUuid' => 'cbb29e79-a10d-4757-b266-3db336fcffbe',
               'currentVersion' => {
-                'systemData' => {
-                  'uploadedDateTime' => 'null'
+                'providerData' => {
+                  'modifiedDateTime' => 'null'
                 }
               }
             }

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 require 'claims_evidence_api/service/search'
 
-
 RSpec.describe 'VO::TsaLetter', type: :request do
   let(:user) { build(:user, :loa3) }
 
@@ -13,21 +12,21 @@ RSpec.describe 'VO::TsaLetter', type: :request do
 
   describe 'GET /v0/tsa_letter' do
     it 'returns the most recent tsa letter metadata' do
-      VCR.use_cassette('tsa_letters/index_success', { match_requests_on: %i[method uri] }) do
+      VCR.use_cassette('tsa_letters/show_success', { match_requests_on: %i[method uri body] }) do
         get '/v0/tsa_letter'
-        expect(response.body).to eq({uuid: 'c75438b4-47f8-44d3-9e35-798158591456', version: '920debba-cc65-479c-ab47-db9b2a5cd95f'}.to_json)
+        expect(response.body).to eq({uuid: 'c75438b4-47f8-44d3-9e35-798158591456', version: '920debba-cc65-479c-ab47-db9b2a5cd95f', "upload_date": '2025-09-09T14:18:53'}.to_json)
       end
     end
 
     it 'renders error message' do
-      VCR.use_cassette('tsa_letters/index_not_found', { match_requests_on: %i[method uri] }) do
+      VCR.use_cassette('tsa_letters/show_not_found', { match_requests_on: %i[method uri] }) do
         get '/v0/tsa_letter'
-        expect(response.body).to eq({uuid: 'c75438b4-47f8-44d3-9e35-798158591456', version: '920debba-cc65-479c-ab47-db9b2a5cd95f'}.to_json)
+        expect(response.status).to eq(404)
       end
     end
   end
 
-  describe 'GET /v0/tsa_letter/:id' do
+  describe 'GET /v0/tsa_letter/:id', pending: 'route change' do
     let(:document_id) { '{93631483-E9F9-44AA-BB55-3552376400D8}' }
     let(:content) { File.read('spec/fixtures/files/error_message.txt') }
 

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -12,51 +12,52 @@ RSpec.describe 'VO::TsaLetter', type: :request do
   end
 
   describe 'GET /v0/tsa_letter' do
+    let(:faraday_response) { Faraday::Response.new }
     let(:tsa_letters) do
       {
-        "page": {
-          "totalPages": 1,
-          "requestedResultsPerPage": 10,
-          "currentPage": 1,
-          "totalResults": 1
+        "page" => {
+          "totalPages" => 1,
+          "requestedResultsPerPage" => 10,
+          "currentPage" => 1,
+          "totalResults" => 1
         },
-        "files": [
+        "files" => [
           {
-            "owner": {
-              "type": "VETERAN",
-              "id": "796378881"
+            "owner" => {
+              "type" => "VETERAN",
+              "id" => "796378881"
             },
-            "uuid": "c75438b4-47f8-44d3-9e35-798158591456",
-            "currentVersionUuid": "920debba-cc65-479c-ab47-db9b2a5cd95f",
-            "currentVersion": {
-              "systemData": {
-                "uploadedDateTime": "2025-09-09T14:18:53",
-                "contentSize": 177200,
-                "contentName": "VETS Safe Travel - Outreach Letter_TSA edits_08.29.25 DRAFT.pdf",
-                "mimeType": "application/pdf",
-                "uploadSource": "ClaimEvidenceUI"
+            "uuid" => "c75438b4-47f8-44d3-9e35-798158591456",
+            "currentVersionUuid" => "920debba-cc65-479c-ab47-db9b2a5cd95f",
+            "currentVersion" => {
+              "systemData" => {
+                "uploadedDateTime" => "2025-09-09T14:18:53",
+                "contentSize" => 177200,
+                "contentName" => "VETS Safe Travel - Outreach Letter_TSA edits_08.29.25 DRAFT.pdf",
+                "mimeType" => "application/pdf",
+                "uploadSource" => "ClaimEvidenceUI"
               },
-              "providerData": {
-                "subject": "VETS Safe Travel Outreach Letter",
-                "documentTypeId": 34,
-                "ocrStatus": "Not Searchable",
-                "newMail": false,
-                "userSARL": "7",
-                "bookmarks": {
-                  "VBA": {
-                    "isDefaultRealm": true
+              "providerData" => {
+                "subject" => "VETS Safe Travel Outreach Letter",
+                "documentTypeId" => 34,
+                "ocrStatus" => "Not Searchable",
+                "newMail" => false,
+                "userSARL" => "7",
+                "bookmarks" => {
+                  "VBA" => {
+                    "isDefaultRealm" => true
                   }
                 },
-                "systemSource": "ClaimEvidenceUI",
-                "isAnnotated": false,
-                "modifiedDateTime": "2025-09-09T14:18:53",
-                "numberOfContentions": 0,
-                "readByCurrentUser": true,
-                "dateVaReceivedDocument": "2025-09-09",
-                "hasContentionAnnotations": false,
-                "contentSource": "VA.gov",
-                "actionable": false,
-                "lastOpenedDocument": true
+                "systemSource" => "ClaimEvidenceUI",
+                "isAnnotated" => false,
+                "modifiedDateTime" => "2025-09-09T14:18:53",
+                "numberOfContentions" => 0,
+                "readByCurrentUser" => true,
+                "dateVaReceivedDocument" => "2025-09-09",
+                "hasContentionAnnotations" => false,
+                "contentSource" => "VA.gov",
+                "actionable" => false,
+                "lastOpenedDocument" => true
               }
             }
           }
@@ -65,10 +66,22 @@ RSpec.describe 'VO::TsaLetter', type: :request do
     end
 
     before do
-      allow_any_instance_of(ClaimsEvidenceApi::Service::Search).to receive(:find).and_return(tsa_letters)
+      # allow_any_instance_of(ClaimsEvidenceApi::Service::Search).to receive(:find).and_return(tsa_letters)
     end
 
     it 'returns the tsa letter metadata' do
+      params = {:pageRequest=>{:resultsPerPage=>10, :page=>1},
+       :filters=>{"providerData.subject"=>{:evaluationType=>"CONTAINS", :value=>"[\"VETS Safe Travel Outreach Letter\"]"}},
+       :sort=>[]}
+      # faraday_double = double('response')
+      mocked_response = Faraday::Response.new(response_body: tsa_letters, status: 200)
+      mocked_env = Faraday::Env.new(response: mocked_response).tap do |e|
+        e.status = mocked_response.status
+        e.body = mocked_response.body
+      end
+      expect_any_instance_of(Faraday::Connection).to receive(:post).with("folders/files:search", params).and_return(mocked_response)
+      allow(mocked_response).to receive(:env).and_return(mocked_env)
+
       # VCR.use_cassette('spec/support/vcr_cassettes/tsa_letters/index_success', { match_requests_on: %i[method uri] }) do
       get '/v0/tsa_letter'
       expect(response.body).to eq({uuid: 'c75438b4-47f8-44d3-9e35-798158591456', version: '920debba-cc65-479c-ab47-db9b2a5cd95f'}.to_json)

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -10,6 +10,7 @@ VCR.configure do |c|
   c.filter_sensitive_data('<AV_KEY>') { VAProfile::Configuration::SETTINGS.address_validation.api_key }
   c.filter_sensitive_data('<BENEFITS_INTAKE_SERVICE_API_KEY>') { Settings.benefits_intake_service.api_key }
   c.filter_sensitive_data('<CLAIMS_API_BD_URL>') { Settings.claims_api.benefits_documents.host }
+  c.filter_sensitive_data('<CLAIMS_EVIDENCE_API_URL>') { Settings.claims_evidence_api.base_url }
   c.filter_sensitive_data('<DMC_TOKEN>') { Settings.dmc.client_secret }
   c.filter_sensitive_data('<DMC_BASE_URL>') { Settings.dmc.url }
   c.filter_sensitive_data('<BGS_BASE_URL>') { Settings.bgs.url }

--- a/spec/support/vcr_cassettes/tsa_letters/index_success.yml
+++ b/spec/support/vcr_cassettes/tsa_letters/index_success.yml
@@ -1,0 +1,104 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://claimevidence-api-fake.fake.bip.va.gov/api/v1/rest/folders/files:search
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 06 Oct 2025 17:03:17 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - envoy
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Security-Policy:
+      - 'default-src https: data: ''unsafe-inline'' ''unsafe-eval'''
+      X-Oneagent-Js-Injection:
+      - 'true'
+      X-Envoy-Upstream-Service-Time:
+      - '43'
+      Ssl-Env:
+      - 'On'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Server-Timing:
+      - dtSInfo;desc="0", dtRpid;desc="-188950051"
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "page": {
+            "totalPages": 1,
+            "requestedResultsPerPage": 10,
+            "currentPage": 1,
+            "totalResults": 1
+          },
+          "files": [
+            {
+              "owner": {
+                "type": "VETERAN",
+                "id": "796378881"
+              },
+              "uuid": "c75438b4-47f8-44d3-9e35-798158591456",
+              "currentVersionUuid": "920debba-cc65-479c-ab47-db9b2a5cd95f",
+              "currentVersion": {
+                "systemData": {
+                  "uploadedDateTime": "2025-09-09T14:18:53",
+                  "contentSize": 177200,
+                  "contentName": "VETS Safe Travel - Outreach Letter_TSA edits_08.29.25 DRAFT.pdf",
+                  "mimeType": "application/pdf",
+                  "uploadSource": "ClaimEvidenceUI"
+                },
+                "providerData": {
+                  "subject": "VETS Safe Travel Outreach Letter",
+                  "documentTypeId": 34,
+                  "ocrStatus": "Not Searchable",
+                  "newMail": false,
+                  "userSARL": "7",
+                  "bookmarks": {
+                    "VBA": {
+                      "isDefaultRealm": true
+                    }
+                  },
+                  "systemSource": "ClaimEvidenceUI",
+                  "isAnnotated": false,
+                  "modifiedDateTime": "2025-09-09T14:18:53",
+                  "numberOfContentions": 0,
+                  "readByCurrentUser": true,
+                  "dateVaReceivedDocument": "2025-09-09",
+                  "hasContentionAnnotations": false,
+                  "contentSource": "VA.gov",
+                  "actionable": false,
+                  "lastOpenedDocument": true
+                }
+              }
+            }
+          ]
+        }
+  recorded_at: Mon, 06 Oct 2025 17:03:17 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/tsa_letters/index_success.yml
+++ b/spec/support/vcr_cassettes/tsa_letters/index_success.yml
@@ -97,6 +97,45 @@ http_interactions:
                   "lastOpenedDocument": true
                 }
               }
+            },
+            {
+              "owner": {
+                "type": "VETERAN",
+                "id": "796378881"
+              },
+              "uuid": "c75438b4-47f8-44d3-9e35-798158591456",
+              "currentVersionUuid": "cbb29e79-a10d-4757-b266-3db336fcffbe",
+              "currentVersion": {
+                "systemData": {
+                  "uploadedDateTime": "2025-08-09T14:18:53",
+                  "contentSize": 177200,
+                  "contentName": "VETS Safe Travel - Outreach Letter_TSA edits_08.29.25 DRAFT.pdf",
+                  "mimeType": "application/pdf",
+                  "uploadSource": "ClaimEvidenceUI"
+                },
+                "providerData": {
+                  "subject": "VETS Safe Travel Outreach Letter",
+                  "documentTypeId": 34,
+                  "ocrStatus": "Not Searchable",
+                  "newMail": false,
+                  "userSARL": "7",
+                  "bookmarks": {
+                    "VBA": {
+                      "isDefaultRealm": true
+                    }
+                  },
+                  "systemSource": "ClaimEvidenceUI",
+                  "isAnnotated": false,
+                  "modifiedDateTime": "2025-09-09T14:18:53",
+                  "numberOfContentions": 0,
+                  "readByCurrentUser": true,
+                  "dateVaReceivedDocument": "2025-09-09",
+                  "hasContentionAnnotations": false,
+                  "contentSource": "VA.gov",
+                  "actionable": false,
+                  "lastOpenedDocument": true
+                }
+              }
             }
           ]
         }

--- a/spec/support/vcr_cassettes/tsa_letters/show_error.yml
+++ b/spec/support/vcr_cassettes/tsa_letters/show_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://claimevidence-api-fake.fake.bip.va.gov/api/v1/rest/folders/files:search
+    uri: <CLAIMS_EVIDENCE_API_URL>folders/files:search
     body:
       encoding: US-ASCII
       string: '{"pageRequest":{"resultsPerPage":10,"page":1},"filters":{"providerData.subject":{"evaluationType":"CONTAINS","value":"[\"VETS Safe Travel Outreach Letter\"]"}},"sort":[]}'

--- a/spec/support/vcr_cassettes/tsa_letters/show_error.yml
+++ b/spec/support/vcr_cassettes/tsa_letters/show_error.yml
@@ -17,8 +17,8 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 404
-      message: Not found
+      code: 400
+      message: Bad Request
     headers:
       Date:
       - Mon, 06 Oct 2025 17:03:17 GMT
@@ -53,9 +53,9 @@ http_interactions:
       string: |-
         {
           "errors": [{
-            "status": "404",
-            "title": "Veteran not found",
-            "detail": "A veteran with that SSN was not found in our systems."
+            "status": "400",
+            "title": "Bad request",
+            "detail": "Bad request"
           }]
         }
   recorded_at: Mon, 06 Oct 2025 17:03:17 GMT

--- a/spec/support/vcr_cassettes/tsa_letters/show_not_found.yml
+++ b/spec/support/vcr_cassettes/tsa_letters/show_not_found.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://claimevidence-api-fake.fake.bip.va.gov/api/v1/rest/folders/files:search
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not found
+    headers:
+      Date:
+      - Mon, 06 Oct 2025 17:03:17 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - envoy
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Security-Policy:
+      - 'default-src https: data: ''unsafe-inline'' ''unsafe-eval'''
+      X-Oneagent-Js-Injection:
+      - 'true'
+      X-Envoy-Upstream-Service-Time:
+      - '43'
+      Ssl-Env:
+      - 'On'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Server-Timing:
+      - dtSInfo;desc="0", dtRpid;desc="-188950051"
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "errors": [{
+            "status": "404",
+            "title": "Veteran not found",
+            "detail": "A veteran with that SSN was not found in our systems."
+          }]
+        }
+  recorded_at: Mon, 06 Oct 2025 17:03:17 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/tsa_letters/show_not_found.yml
+++ b/spec/support/vcr_cassettes/tsa_letters/show_not_found.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://claimevidence-api-fake.fake.bip.va.gov/api/v1/rest/folders/files:search
+    uri: <CLAIMS_EVIDENCE_API_URL>folders/files:search
     body:
       encoding: US-ASCII
       string: '{"pageRequest":{"resultsPerPage":10,"page":1},"filters":{"providerData.subject":{"evaluationType":"CONTAINS","value":"[\"VETS Safe Travel Outreach Letter\"]"}},"sort":[]}'

--- a/spec/support/vcr_cassettes/tsa_letters/show_success.yml
+++ b/spec/support/vcr_cassettes/tsa_letters/show_success.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://claimevidence-api-fake.fake.bip.va.gov/api/v1/rest/folders/files:search
     body:
       encoding: US-ASCII
-      string: ''
+      string: '{"pageRequest":{"resultsPerPage":10,"page":1},"filters":{"providerData.subject":{"evaluationType":"CONTAINS","value":"[\"VETS Safe Travel Outreach Letter\"]"}},"sort":[]}'
     headers:
       Accept:
       - application/json

--- a/spec/support/vcr_cassettes/tsa_letters/show_success.yml
+++ b/spec/support/vcr_cassettes/tsa_letters/show_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://claimevidence-api-fake.fake.bip.va.gov/api/v1/rest/folders/files:search
+    uri: "<CLAIMS_EVIDENCE_API_URL>folders/files:search"
     body:
       encoding: US-ASCII
       string: '{"pageRequest":{"resultsPerPage":10,"page":1},"filters":{"providerData.subject":{"evaluationType":"CONTAINS","value":"[\"VETS Safe Travel Outreach Letter\"]"}},"sort":[]}'

--- a/spec/support/vcr_cassettes/tsa_letters/show_success.yml
+++ b/spec/support/vcr_cassettes/tsa_letters/show_success.yml
@@ -107,7 +107,7 @@ http_interactions:
               "currentVersionUuid": "cbb29e79-a10d-4757-b266-3db336fcffbe",
               "currentVersion": {
                 "systemData": {
-                  "uploadedDateTime": "2025-08-09T14:18:53",
+                  "uploadedDateTime": "2025-09-09T14:18:53",
                   "contentSize": 177200,
                   "contentName": "VETS Safe Travel - Outreach Letter_TSA edits_08.29.25 DRAFT.pdf",
                   "mimeType": "application/pdf",
@@ -126,7 +126,7 @@ http_interactions:
                   },
                   "systemSource": "ClaimEvidenceUI",
                   "isAnnotated": false,
-                  "modifiedDateTime": "2025-09-09T14:18:53",
+                  "modifiedDateTime": "2025-08-09T14:18:53",
                   "numberOfContentions": 0,
                   "readByCurrentUser": true,
                   "dateVaReceivedDocument": "2025-09-09",

--- a/spec/support/vcr_cassettes/tsa_letters/show_success_empty.yml
+++ b/spec/support/vcr_cassettes/tsa_letters/show_success_empty.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://claimevidence-api-fake.fake.bip.va.gov/api/v1/rest/folders/files:search
+    uri: <CLAIMS_EVIDENCE_API_URL>folders/files:search
     body:
       encoding: US-ASCII
       string: '{"pageRequest":{"resultsPerPage":10,"page":1},"filters":{"providerData.subject":{"evaluationType":"CONTAINS","value":"[\"VETS Safe Travel Outreach Letter\"]"}},"sort":[]}'

--- a/spec/support/vcr_cassettes/tsa_letters/show_success_empty.yml
+++ b/spec/support/vcr_cassettes/tsa_letters/show_success_empty.yml
@@ -17,7 +17,8 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 403
+      code: 200
+      message: OK
     headers:
       Date:
       - Mon, 06 Oct 2025 17:03:17 GMT
@@ -50,10 +51,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |-
-        {
-          "uuid":"f5db9ad0-c27b-4517-90ee-a6526481af95",
-          "code":"VEFSERR40302",
-          "message":"Unable to retrieve folder of Type: VETERAN using Identifier: ICN."
-        }
+        {"page":{"totalPages":0, "requestedResultsPerPage":10, "currentPage":1, "totalResults":0}}
   recorded_at: Mon, 06 Oct 2025 17:03:17 GMT
 recorded_with: VCR 6.3.1


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES
- This PR switches the tsa_letter endpoints from the efolder api, which is set for deprecation, to the new claims evidence api. It also restructures the endpoints in the process. That will not cause issues because we haven't yet released the feature. We will change the front end to use the new routes.
- I am on the CVE team

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-iir/issues/2286

## Testing done

- [x] *New code is covered by unit tests*
- This feature is behind a feature flag and has not yet shipped. It will be tested thoroughly prior to shipping. 

## Screenshots

## What areas of the site does it impact?
None at this time, but the feature will be a part of the benefits letters page.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
