### PR TITLE
DR 127817: Datadog RUM feature flag removal for Decision Reviews

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2320,15 +2320,6 @@ features:
     actor_type: user
     description: Enable Notification Center
     enable_in_development: true
-  nod_browser_monitoring_enabled:
-    actor_type: user
-    description: NOD Datadog RUM monitoring
-  hlr_browser_monitoring_enabled:
-    actor_type: user
-    description: HLR Datadog RUM monitoring
-  sc_browser_monitoring_enabled:
-    actor_type: user
-    description: Supplemental Claim Datadog RUM monitoring
   burial_browser_monitoring_enabled:
     actor_type: user
     description: Burial Datadog RUM monitoring


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

Removal of Datadog RUM related feature flags for Decision Reviews apps. They are currently in use in upper envs, so there is a companion vets-website PR to remove them [here](https://github.com/department-of-veterans-affairs/vets-website/pull/41412).

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/127817

## Testing done

This cannot be tested in dev as the RUM feature is not enabled there. I can test that Datadog RUM is still logging for Decision Reviews as expected once the code makes it to staging.