### PR TITLE
Add deprecation warnings to EVSS Claims API endpoints

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,6 +50,7 @@ app/controllers/v0/chatbot @department-of-veterans-affairs/vfs-virtual-agent-cha
 app/controllers/v0/claim_documents_controller.rb @department-of-veterans-affairs/disability-benefits @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/claim_letters_controller.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/coe_controller.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group
+app/controllers/v0/concerns/evss_deprecation.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/contact_us @department-of-veterans-affairs/ask-va-team @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/contact_us/inquiries_controller.rb @department-of-veterans-affairs/ask-va-team @department-of-veterans-affairs/backend-review-group
 app/controllers/v0/csrf_token_controller.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/health-apps-backend
@@ -1209,6 +1210,7 @@ spec/controllers/v0/benefits_reference_data_controller_spec.rb @department-of-ve
 spec/controllers/v0/chatbot @department-of-veterans-affairs/vfs-virtual-agent-chatbot @department-of-veterans-affairs/backend-review-group
 spec/controllers/v0/claim_documents_controller_spec.rb @department-of-veterans-affairs/benefits-lifestage @department-of-veterans-affairs/backend-review-group
 spec/controllers/v0/claim_letters_controller_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/backend-review-group
+spec/controllers/v0/concerns/evss_deprecation_spec.rb @department-of-veterans-affairs/benefits-management-tools-be @department-of-veterans-affairs/backend-review-group
 spec/controllers/v0/contact_us @department-of-veterans-affairs/ask-va-team @department-of-veterans-affairs/backend-review-group
 spec/controllers/v0/datadog_action_controller_spec.rb @department-of-veterans-affairs/backend-review-group
 spec/controllers/v0/debt_letters_controller_spec.rb @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group

--- a/app/controllers/v0/concerns/evss_deprecation.rb
+++ b/app/controllers/v0/concerns/evss_deprecation.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Concern for adding deprecation warnings to EVSS endpoints
+
+module V0
+  module Concerns
+    module EVSSDeprecation
+      extend ActiveSupport::Concern
+
+      EVSS_SUNSET_DATE = '2026-01-28'
+      DEPRECATION_MESSAGE = 'The EVSS Claims API is deprecated and will be shut down on January 28, 2026. ' \
+                            'Please migrate to the /v0/benefits_claims endpoint which uses Lighthouse.'
+
+      included do
+        before_action :log_evss_deprecation_warning
+        after_action :add_deprecation_headers
+      end
+
+      private
+
+      def log_evss_deprecation_warning
+        Rails.logger.warn(
+          'EVSS endpoint accessed - service will be deprecated',
+          {
+            message_type: 'evss.deprecation_warning',
+            endpoint: request.path,
+            user_uuid: current_user&.uuid,
+            sunset_date: EVSS_SUNSET_DATE,
+            days_until_sunset: days_until_sunset
+          }
+        )
+
+        StatsD.increment(
+          'api.evss.deprecation_warning',
+          tags: [
+            "endpoint:#{controller_name}",
+            "action:#{action_name}",
+            'service:evss'
+          ]
+        )
+      end
+
+      def add_deprecation_headers
+        headers = response.headers
+        headers['Deprecation'] = "date=\"#{EVSS_SUNSET_DATE}\""
+        headers['Sunset'] = EVSS_SUNSET_DATE
+        headers['Link'] = '</v0/benefits_claims>; rel="alternate"; title="Replacement endpoint using Lighthouse"'
+        headers['Warning'] = "299 - \"#{DEPRECATION_MESSAGE}\""
+      end
+
+      def days_until_sunset
+        sunset = Date.parse(EVSS_SUNSET_DATE)
+        (sunset - Time.zone.today).to_i
+      end
+    end
+  end
+end

--- a/app/controllers/v0/evss_claims_controller.rb
+++ b/app/controllers/v0/evss_claims_controller.rb
@@ -4,6 +4,7 @@ module V0
   class EVSSClaimsController < ApplicationController
     include IgnoreNotFound
     include InboundRequestLogging
+    include V0::Concerns::EVSSDeprecation
     service_tag 'claim-status'
 
     before_action { authorize :evss, :access? }

--- a/spec/controllers/v0/concerns/evss_deprecation_spec.rb
+++ b/spec/controllers/v0/concerns/evss_deprecation_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/controller_spec_helper'
+
+RSpec.describe V0::Concerns::EVSSDeprecation, type: :controller do
+  controller(ApplicationController) do
+    include V0::Concerns::EVSSDeprecation
+
+    def index
+      render json: { 'data' => ['test'], 'meta' => { 'existing' => 'value' } }
+    end
+  end
+
+  let(:user) { build(:user) }
+
+  before do
+    sign_in_as(user)
+  end
+
+  describe 'deprecation warnings' do
+    it 'adds deprecation headers to response' do
+      get :index
+
+      expect(response.headers['Deprecation']).to eq('date="2026-01-28"')
+      expect(response.headers['Sunset']).to eq('2026-01-28')
+      expect(response.headers['Link']).to include('/v0/benefits_claims')
+      expect(response.headers['Warning']).to include('EVSS Claims API is deprecated')
+    end
+
+    it 'logs deprecation warning' do
+      expect(Rails.logger).to receive(:warn).with(
+        'EVSS endpoint accessed - service will be deprecated',
+        hash_including(
+          message_type: 'evss.deprecation_warning',
+          sunset_date: '2026-01-28',
+          days_until_sunset: be_an(Integer)
+        )
+      )
+
+      get :index
+    end
+
+    it 'increments StatsD metric' do
+      expect(StatsD).to receive(:increment).with(
+        'api.evss.deprecation_warning',
+        tags: array_including('service:evss')
+      )
+
+      get :index
+    end
+  end
+end

--- a/spec/requests/v0/evss_claims_spec.rb
+++ b/spec/requests/v0/evss_claims_spec.rb
@@ -27,6 +27,20 @@ RSpec.describe 'V0::EVSSClaims', type: :request do
     end
   end
 
+  context 'deprecation warnings' do
+    it 'includes deprecation headers on index endpoint' do
+      sign_in_as(evss_user)
+      VCR.use_cassette('evss/claims/claims', match_requests_on: %i[uri method body]) do
+        get '/v0/evss_claims'
+
+        expect(response.headers['Deprecation']).to eq('date="2026-01-28"')
+        expect(response.headers['Sunset']).to eq('2026-01-28')
+        expect(response.headers['Link']).to include('/v0/benefits_claims')
+        expect(response.headers['Warning']).to include('EVSS Claims API is deprecated')
+      end
+    end
+  end
+
   it 'lists all Claims when camel-inflected', run_at: 'Tue, 12 Dec 2017 03:09:06 GMT' do
     sign_in_as(evss_user)
     VCR.use_cassette('evss/claims/claims', match_requests_on: %i[uri method body]) do
@@ -48,6 +62,18 @@ RSpec.describe 'V0::EVSSClaims', type: :request do
       end.to change(EVSS::RequestDecision.jobs, :size).by(1)
       expect(response).to have_http_status(:accepted)
       expect(JSON.parse(response.body)['job_id']).to eq(EVSS::RequestDecision.jobs.first['jid'])
+    end
+
+    it 'includes deprecation headers on show endpoint' do
+      sign_in_as(evss_user)
+      VCR.use_cassette('evss/claims/claim', match_requests_on: %i[uri method body]) do
+        get '/v0/evss_claims/600118851'
+
+        expect(response.headers['Deprecation']).to eq('date="2026-01-28"')
+        expect(response.headers['Sunset']).to eq('2026-01-28')
+        expect(response.headers['Link']).to include('/v0/benefits_claims')
+        expect(response.headers['Warning']).to include('EVSS Claims API is deprecated')
+      end
     end
 
     it 'shows a single Claim', run_at: 'Wed, 13 Dec 2017 03:28:23 GMT' do


### PR DESCRIPTION
This PR adds deprecation warnings to EVSS Claims API endpoints in anticipation of the EVSS service being shut down on January 28, 2026. 

[REFERENCE TICKET](https://github.com/orgs/department-of-veterans-affairs/projects/1549/views/3?pane=issue&itemId=149409445&issue=department-of-veterans-affairs%7Cva.gov-team%7C129962)