### PR TITLE
feat(526): Add toggle for 0781 supporting documents enhancements

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -811,7 +811,7 @@ features:
     description: >
       Enables content and design enhancements for Form 0781 supporting documents
       in the 526 disability compensation workflow.
-    enable_in_development: true
+    enable_in_development: false
   disability_compensation_new_conditions_workflow_metadata:
     actor_type: user
     description: enables adding new conditions workflow indicator to in progress 526 forms


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- Adds a new feature toggle `disability_compensation_0781_supporting_documents_enhancement` to enable content and design enhancements for Form 0781 supporting documents in the 526 disability compensation workflow.
- Team: Benefits Disability Experience
- Success criteria: Feature toggle will be used to safely test and roll out content and design enhancements for form 0781, including a new list-and-loop data structure model and changes to the Review & Submit page functionality.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129443
- Epic: https://github.com/department-of-veterans-affairs/va.gov-team/issues/129439
- Frontend PR: https://github.com/department-of-veterans-affairs/vets-website/pull/41427

## Testing done

- [x] New code is covered by unit tests
- Feature toggle only - no behavioral changes until toggle is enabled
- Toggle defaults to disabled (`enable_in_development: false` for local testing)
- If this work is behind a flipper:
  - Toggle is added but not yet used in any code paths - tests will be added when feature implementation begins
  - Testing plan: Phased rollout, releasing to new forms first with testing across all identified scenarios before broader deployment

## Screenshots

N/A - Configuration change only

## What areas of the site does it impact?

- 526 Disability Compensation form, specifically the 0781 (Statement in Support of Claimed Mental Health Conditions) pathway
- No functional changes until toggle is enabled and feature code is implemented

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution
- [ ] Documentation has been updated (link to documentation)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Feature/bug has a monitor built into Datadog (if applicable)
- [x] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ] I added a screenshot of the developed feature

## Requested Feedback

This PR adds only the feature toggle configuration. The frontend toggle registration is in a separate PR for vets-website. Looking for confirmation that the toggle naming follows team conventions.