### PR TITLE
[BIO] Adds Env Values for Email Templates

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1442,19 +1442,19 @@ vanotify:
       email:
         confirmation:
           flipper_id: false
-          template_id: <%= ENV['bio__increase_compensation__email__confirmation_template_id'] =>
+          template_id: <%= ENV['bio__increase_compensation__email__confirmation_template_id'] %>
         error:
           flipper_id: increase_compensation_error_email_notification
-          template_id: <%= ENV['bio__increase_compensation__email__action_needed_template_id'] =>
-        # persistent_attachment_error:
-        #   flipper_id: increase_compensation_persistent_attachment_error_email_notification
-        #   template_id: <%= ENV['bio__increase_compensation__email__action_needed_template_id'] =>
+          template_id: <%= ENV['bio__increase_compensation__email__action_needed_template_id'] %>
+        persistent_attachment_error:
+          flipper_id: increase_compensation_persistent_attachment_error_email_notification
+          template_id: <%= ENV['bio__increase_compensation__email__action_needed_template_id'] %>
         received:
           flipper_id: increase_compensation_received_email_notification
-          template_id: <%= ENV['bio__increase_compensation__email__received_template_id'] =>
+          template_id: <%= ENV['bio__increase_compensation__email__received_template_id'] %>
         submitted:
           flipper_id: increase_compensation_submitted_email_notification
-          template_id: <%= ENV['bio__increase_compensation__email__confirmation_template_id'] =>
+          template_id: <%= ENV['bio__increase_compensation__email__confirmation_template_id'] %>
     21p_0969: &vanotify_services_income_and_assets
       api_key: <%= ENV['vanotify__services__21p_0969__api_key'] %>
       email:


### PR DESCRIPTION

## Summary

- This work is behind a feature toggle (flipper): **YES** each email type has a flipper
  - increase_compensation_error_email_notification
  - increase_compensation_received_email_notification
  - increase_compensation_submitted_email_notification
- Adds in the env variable values for the email templates for the form 21-8940

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests* - **Previously existing tests, no functional changes in the PR**
- Verify in staging - submit a 8940 and check datadog for email jobs running


## What areas of the site does it impact?
only the form module `increase_compensation`

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable) - **Previously existing**
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
