### PR TITLE
add va_dependents_no_ssn

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2064,6 +2064,9 @@ features:
     actor_type: user
     description: Allows us to toggle duplicate modals for the 686C-674
     enable_in_development: true
+  va_dependents_no_ssn:
+    actor_type: user
+    description: Allows us to toggle the no SSN flow for adding dependents in 686C-674
   va_online_scheduling_enable_OH_cancellations:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
## Summary

- adds a new feature flipper - `va_dependents_no_ssn`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129868
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/125874

<img width="996" height="556" alt="Screenshot 2026-01-14 at 1 42 45 PM" src="https://github.com/user-attachments/assets/3a8869ae-344e-4877-9f01-1ee1c084d8dc" />


## What areas of the site does it impact?
686c-674 add flow

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature