### PR TITLE
Authorize user before populating CIV2 redis info

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -229,6 +229,7 @@ app/models/form_profiles/va_2122.rb @department-of-veterans-affairs/accredited-r
 app/models/form_profiles/va_2122a.rb @department-of-veterans-affairs/accredited-representative-crew @department-of-veterans-affairs/backend-review-group
 app/models/form_profiles/va_212680.rb @department-of-veterans-affairs/benefits-optimization-aquia @department-of-veterans-affairs/backend-review-group
 app/models/form_profiles/va_214140.rb @department-of-veterans-affairs/benefits-intake-pingwind @department-of-veterans-affairs/backend-review-group
+app/models/form_profiles/va_686c674.rb @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/backend-review-group
 app/models/form_profiles/va_686c674v2.rb @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/backend-review-group
 app/models/form_profiles/va_526ez.rb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 app/models/form_submission_attempt.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/disability-benefits @department-of-veterans-affairs/backend-review-group
@@ -472,6 +473,7 @@ app/services/user_visn_service.rb @department-of-veterans-affairs/vfs-authentica
 app/services/users @department-of-veterans-affairs/octo-identity
 app/sidekiq/lighthouse/benefits_intake/submit_central_form686c_job.rb @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/backend-review-group
 app/sidekiq/lighthouse/benefits_intake/submit_central_form686c_v2_job.rb @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/backend-review-group
+app/sidekiq/lighthouse/submit_career_counseling_job.rb @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group
 app/sidekiq/benefits_intake_remediation_status_job.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/backend-review-group
 app/sidekiq/benefits_intake_status_job.rb @department-of-veterans-affairs/platform-va-product-forms @department-of-veterans-affairs/disability-benefits @department-of-veterans-affairs/backend-review-group
 app/sidekiq/bgs @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/backend-review-group
@@ -1709,6 +1711,7 @@ spec/models/form_attachment_spec.rb @department-of-veterans-affairs/vfs-authenti
 spec/models/form_profile_spec.rb @department-of-veterans-affairs/vfs-authenticated-experience-backend @department-of-veterans-affairs/backend-review-group
 spec/models/form_profiles/mdot_spec.rb @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/backend-review-group
 spec/models/form_profiles/va0803_spec.rb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
+spec/models/form_profiles/va_686c674.rb @department-of-veterans-affairs/benefits-dependents-management @department-of-veterans-affairs/backend-review-group
 spec/models/form_profiles/va8794_spec.rb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 spec/models/form_profiles/va0976_spec.rb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 spec/models/form_profiles/va10272_spec.rb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group

--- a/app/models/form_profile.rb
+++ b/app/models/form_profile.rb
@@ -359,11 +359,7 @@ class FormProfile
     return @vet360_contact_info if @vet360_contact_info_retrieved
 
     @vet360_contact_info_retrieved = true
-    if user.icn.present? || user.vet360_id.present?
-      @vet360_contact_info = VAProfileRedis::V2::ContactInformation.for_user(user)
-    else
-      Rails.logger.info('Vet360 Contact Info Null')
-    end
+    @vet360_contact_info = VAProfileRedis::V2::ContactInformation.for_user(user)
     @vet360_contact_info
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -383,7 +383,7 @@ class User < Common::RedisStore
   delegate :show_onboarding_flow_on_login, to: :onboarding, allow_nil: true
 
   def vet360_contact_info
-    return nil unless vet360_id.present? || icn.present?
+    return nil if icn.blank?
 
     @vet360_contact_info ||= VAProfileRedis::V2::ContactInformation.for_user(self)
   end

--- a/app/models/va_profile_redis/v2/contact_information.rb
+++ b/app/models/va_profile_redis/v2/contact_information.rb
@@ -28,6 +28,8 @@ module VAProfileRedis
       attr_accessor :user
 
       def self.for_user(user)
+        return {} unless user.authorize :va_profile, :access_to_v2?
+
         contact_info      = new
         contact_info.user = user
         contact_info.populate_from_redis

--- a/modules/dependents_benefits/spec/lib/dependents_benefits/user_data_spec.rb
+++ b/modules/dependents_benefits/spec/lib/dependents_benefits/user_data_spec.rb
@@ -88,6 +88,10 @@ RSpec.describe DependentsBenefits::UserData do
         )
       end
 
+      before do
+        allow(incomplete_user).to receive(:authorize).with(:va_profile, :access_to_v2?).and_return(true)
+      end
+
       it 'falls back to claim data' do
         user_data = described_class.new(incomplete_user, claim_data)
 
@@ -181,6 +185,8 @@ RSpec.describe DependentsBenefits::UserData do
         participant_id: 'participant-123',
         va_profile_email: 'john.doe@va.gov'
       )
+
+      allow(user_without_middle).to receive(:authorize).with(:va_profile, :access_to_v2?).and_return(true)
 
       claim_data_with_no_middle = claim_data.dup
       claim_data_with_no_middle['veteran_information']['full_name'].delete('middle')
@@ -335,6 +341,10 @@ RSpec.describe DependentsBenefits::UserData do
         )
       end
 
+      before do
+        allow(user_without_common_name).to receive(:authorize).with(:va_profile, :access_to_v2?).and_return(true)
+      end
+
       it 'falls back to email' do
         user_data = described_class.new(user_without_common_name, claim_data)
         expect(user_data.send(:external_key)).to eq('john.doe@example.com')
@@ -361,6 +371,7 @@ RSpec.describe DependentsBenefits::UserData do
 
       before do
         stub_const('BGS::Constants::EXTERNAL_KEY_MAX_LENGTH', 10)
+        allow(long_name_user).to receive(:authorize).with(:va_profile, :access_to_v2?).and_return(true)
       end
 
       it 'truncates to max length' do
@@ -396,6 +407,10 @@ RSpec.describe DependentsBenefits::UserData do
           )
         end
 
+        before do
+          allow(user_with_blank_email).to receive(:authorize).with(:va_profile, :access_to_v2?).and_return(true)
+        end
+
         it 'returns nil for blank email' do
           expect(user_data.send(:get_user_email, user_with_blank_email)).to be_nil
         end
@@ -421,6 +436,7 @@ RSpec.describe DependentsBenefits::UserData do
 
       before do
         allow(error_user).to receive(:va_profile_email).and_raise(StandardError, 'VAProfile service error')
+        allow(error_user).to receive(:authorize).with(:va_profile, :access_to_v2?).and_return(true)
       end
 
       it 'tracks warning and returns nil' do
@@ -463,6 +479,7 @@ RSpec.describe DependentsBenefits::UserData do
 
       before do
         allow(error_user).to receive(:va_profile_email).and_raise(StandardError, 'VAProfile service error')
+        allow(error_user).to receive(:authorize).with(:va_profile, :access_to_v2?).and_return(true)
       end
 
       it 'falls back to form email for notification_email' do

--- a/modules/dependents_benefits/spec/models/dependents_benefits/form_profiles/va_686c674_spec.rb
+++ b/modules/dependents_benefits/spec/models/dependents_benefits/form_profiles/va_686c674_spec.rb
@@ -182,7 +182,10 @@ RSpec.describe FormProfile, type: :model do
 
     context 'with military information data', :skip_va_profile do
       context 'with a user that can prefill VA Profile' do
-        before { can_prefill_vaprofile(true) }
+        before do
+          expect(user).to receive(:authorize).at_least(:once).with(:va_profile, :access_to_v2?).and_return(true)
+          can_prefill_vaprofile(true)
+        end
 
         context 'with a 686c-674 form v3 enabled' do
           let(:v686_c_674_v2_expected) do

--- a/modules/mobile/app/controllers/mobile/v0/community_care_providers_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/community_care_providers_controller.rb
@@ -48,6 +48,12 @@ module Mobile
       def coordinates
         return facility_coordinates if params[:facilityId]
 
+        unless @current_user.authorize(:va_profile, :access_to_v2?)
+          raise Common::Exceptions::UnprocessableEntity.new(
+            detail: 'User has no home latitude and longitude'
+          )
+        end
+
         Mobile::FacilitiesHelper.user_address_coordinates(@current_user)
       end
 

--- a/modules/vre/app/controllers/vre/v0/claims_controller.rb
+++ b/modules/vre/app/controllers/vre/v0/claims_controller.rb
@@ -36,6 +36,7 @@ module VRE
       end
 
       def encrypted_user
+        va_profile_email = current_user.icn.present? ? current_user&.va_profile_email : nil
         user_struct = OpenStruct.new(
           participant_id: current_user.participant_id,
           pid: current_user.participant_id,
@@ -47,7 +48,7 @@ module VRE
           uuid: current_user.uuid,
           icn: current_user.icn,
           first_name: current_user.first_name,
-          va_profile_email: current_user.va_profile_email
+          va_profile_email:
         )
         KmsEncrypted::Box.new.encrypt(user_struct.to_h.to_json)
       end

--- a/spec/models/form_profiles/va10297_spec.rb
+++ b/spec/models/form_profiles/va10297_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe FormProfiles::VA10297 do
   describe '#prefill' do
     before do
       allow(user).to receive(:authorize).with(:evss, :access?).and_return(true)
+      allow(user).to receive(:authorize).with(:va_profile, :access_to_v2?).and_return(true)
       allow(user).to receive(:authorize).with(:lighthouse, :direct_deposit_access?).and_return(true)
       allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_token')
     end


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

This PR adds authorization checks throughout the codebase to prevent unauthorized access to VA Profile V2 contact information stored in Redis. The changes ensure that only users with a valid Integration Control Number (ICN) can access their VA Profile contact information.

No behavior changes were added. More authorization was added.

### Key Changes
**Authorization Policy**
- Enforces that users must have an ICN present to access VA Profile V2 data via the `VAProfilePolicy#access_to_v2?` method

**Core Models Updated**
- `FormProfile` - Guards `initialize_contact_information` and `vet360_contact_info` methods
- `User` - Adds authorization check to `vet360_contact_info` and documents proper usage pattern for `va_profile_email`
- `VAProfileRedis::V2::ContactInformation` - Protects the `for_user` class method with authorization check

**Form Profiles Updated**
- `VA686c674` and `VA686c674v2` - Adds authorization checks before prefilling form addresses
- Dependents Benefits module form profile similarly updated

**Controllers & Services Updated**
- `VeteranReadinessEmploymentClaimsController` - Protects VA profile email access in encrypted user struct
- `VRE::V0::ClaimsController` - Same protection for encrypted user
- `DependentsVerification::V0::ClaimsController` - Guards email addition to claims
- `BGS::DependentV2Service` - Protects `get_user_email` method

**Background Jobs Updated**
- `HCA::LogEmailDiffJob` - Adds ICN check before accessing VA profile email
- `Lighthouse::SubmitCareerCounselingJob` - Conditional email access based on ICN presence

**Notification Email Classes**
- `Dependents::NotificationEmail` and `DependentsBenefits::NotificationEmail` - Check for ICN before accessing VA profile email

### Pattern Applied
The consistent pattern throughout:
```ruby
return {} unless user.authorize :va_profile, :access_to_v2?
# OR
va_profile_email = user.icn.present? ? user&.va_profile_email : nil
```

### Impact
- Prevents Redis lookup failures for users without ICN
- Provides clean fallback behavior (empty hash or nil) instead of errors
- Consolidates authorization logic in policy object
- Removes deprecated `vet360_id` checks in favor of ICN-only requirement

### Files Changed
7 files modified across 6 commits with authorization guards added to form profiles, models, controllers, services, and background jobs.
## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*



## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
