### PR TITLE
Optimize Flipper initializer to avoid N+1 queries on boot

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -57,9 +57,10 @@ Rails.application.reloader.to_prepare do
 
     # Make sure that each feature we reference in code is present in the UI, as long as we have a Database already
     added_flippers = []
+    existing_features = Flipper.features.to_set(&:name)
     begin
       FLIPPER_FEATURE_CONFIG['features'].each do |feature, feature_config|
-        unless Flipper.exist?(feature)
+        unless feature.in?(existing_features)
           Flipper.add(feature)
           added_flippers.push(feature)
 


### PR DESCRIPTION
Previously, the initializer called Flipper.exist?(feature) for each of the 772 features in config/features.yml, resulting in 772 identical database queries during every Rails boot.

This change fetches all existing feature names once upfront into a Set, then checks against that in-memory set instead. This makes for a slightly faster experience running the test suite.

Performance improvement when running a single test(NOCOVERAGE=1):
- Before: 7.8s to load files
- After: 5.16s to load files
- Improvement: ~2.6s faster (34%)