### PR TITLE
Fix unnecessary filtering of Kafka event tags in Datadog logs

### DIFF
--- a/lib/kafka/monitor.rb
+++ b/lib/kafka/monitor.rb
@@ -10,18 +10,9 @@ module Kafka
     # metric prefix
     STATSD_KEY_PREFIX = 'api.kafka_service'
 
-    # override default allowed logging params to include `tags`
-    ALLOWLIST = %w[
-      statsd
-      service
-      function
-      line
-      context
-      tags
-    ].freeze
-
     def initialize
-      super('kafka-service', allowlist: ALLOWLIST)
+      # the allowlist includes 'tags' so that tags are not filtered out in logs.
+      super('kafka-service', allowlist: ['tags'])
     end
 
     # Track submission successful


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Changes to the shared logging/monitoring tools in vets-api have caused some of our logging data from our Kafka event producer to be filtered out unnecessarily in Datadog. This PR updates our logging code so that we don't filter out non-sensitive data that we use for tracking in our Datadog dashboard.
- I'm part of the VES Submission Traceability team, which owns and maintaines this code.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/VES/issues/6023

## Testing done

- [N/A] *New code is covered by unit tests*
- Old behavior: `tags` were showing up as `[FILTERED]` in Datadog logs. New behavior: `tags` are not filtered out in logs.
-  After deploying, the fix can be verified by searching for the relevant Datadog event logs and checking that the `tags` parameter is not filtered out,

## Screenshots
N/A

## What areas of the site does it impact?
None; this code is not Veteran-facing.

## Acceptance criteria

- [N/A]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [TBD]  Events are being sent to the appropriate logging solution
- [N/A]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [N/A]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [N/A]  I added a screenshot of the developed feature

## Requested Feedback

Verification that this is the correct way to use `#track_request` without filtering the `tags` parameter.
