### PR TITLE
feat(526): Update feature toggle name 

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -806,10 +806,10 @@ features:
     actor_type: user
     description: enables a job to run that will check DB records and report stats as metrics, into Datadog
     enable_in_development: true
-  disability_compensation_0781_supporting_documents_enhancement:
+  disability_526_supporting_evidence_enhancement:
     actor_type: user
     description: >
-      Enables content and design enhancements for Form 0781 supporting documents
+      Enables content and design enhancements for supporting evidence
       in the 526 disability compensation workflow.
     enable_in_development: false
   disability_compensation_new_conditions_workflow_metadata:


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): **YES**
- Renames feature toggle from `disability_compensation_0781_supporting_documents_enhancement` to `disability_526_supporting_evidence_enhancement`
- Updated per code review feedback to use a more concise name that follows the `disability_526_*` naming convention
- Team: Benefits Disability Experience (Team 1)

## Related issue(s)

- Frontend PR: https://github.com/department-of-veterans-affairs/vets-website/pull/41427

## Testing done

- [x] New code is covered by unit tests
- Verified no other references to the old toggle name exist in the codebase
- Feature toggle configuration only - no behavioral changes
- Toggle remains disabled (`enable_in_development: false`)

## Screenshots

N/A - Configuration change only

## What areas of the site does it impact?

526 Disability Compensation form - supporting evidence section (behind feature toggle, currently disabled)

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution
- [x] Documentation has been updated (link to documentation)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Feature/bug has a monitor built into Datadog (if applicable)
- [x] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x] I added a screenshot of the developed feature

## Requested Feedback

N/A - Straightforward rename per review feedback.