### PR TITLE
Return Caseflow status with response to prevent silent errors

### DIFF
--- a/app/controllers/v0/appeals_controller.rb
+++ b/app/controllers/v0/appeals_controller.rb
@@ -6,7 +6,11 @@ module V0
 
     def index
       appeals_response = appeals_service.get_appeals(current_user)
-      render json: appeals_response.body
+      if Flipper.enabled?(:appeals_response_status)
+        render json: appeals_response.body, status: appeals_response.status
+      else
+        render json: appeals_response.body
+      end
     end
   end
 end

--- a/config/features.yml
+++ b/config/features.yml
@@ -52,6 +52,9 @@ features:
   appointments_consolidation:
     actor_type: user
     description: For features being tested while merging logic for appointments between web and mobile
+  appeals_response_status:
+    actor_type: user
+    description: Returns Caseflow status with Caseflow response
   arm_use_datadog_real_user_monitoring:
     actor_type: user
     description: Enables Datadog Real User Monitoring for ARM apps (Find a Rep, Appoint a Rep)
@@ -2793,7 +2796,7 @@ features:
   sob_claimant_service:
     actor_type: user
     description: If enabled, use the new claimant service for SOB
-    
+
   form_10203_claimant_service:
     actor_type: user
     description: If enabled, use the new claimant service for form 22-10203

--- a/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
+++ b/modules/appeals_api/app/controllers/appeals_api/v0/appeals_controller.rb
@@ -16,7 +16,11 @@ module AppealsApi
           'Consumer' => consumer,
           'VA-User' => requesting_va_user
         )
-        render(json: appeals_response.body)
+        if Flipper.enabled?(:appeals_response_status)
+          render(json: appeals_response.body, status: appeals_response.status)
+        else
+          render(json: appeals_response.body)
+        end
       end
 
       private


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

This PR updates the Appeals API controllers to return the HTTP status received from Caseflow instead of always returning a 200 OK. This prevents silent failures when Caseflow responds with errors (e.g., timeouts, 4xx, or 5xx responses).

This was fixed in [AppealsApi::V1::AppealsController](https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/appeals_api/app/controllers/appeals_api/v1/appeals_controller.rb)

A feature flag is used to safely roll out this behavior while preserving existing behavior when disabled.

[APM Traces](https://vagov.ddog-gov.com/apm/entity/service%3Avets-api-net-http?query=env%3Aeks-prod%20operation_name%3Ahttp.request%20service%3Avets-api-net-http%20%40http.url_details.path%3A%2Fapi%2Fv2%2Fappeals%20status%3Aerror&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code%2C%40http.url_details.path&dependencyMap.showNetworkMetrics=false&env=eks-prod&errors=qson%3A%28data%3A%28issueSort%3ATOTAL_COUNT%29%2Cversion%3A%210%29&fromUser=false&graphType=span_list&groupMapByOperation=null&historicalData=true&operationName=http.request&panels=qson%3A%28data%3A%28activePanelKey%3Atrace%2Ctrace%3A%28traceID%3A435470962274371258%2CspanID%3A2733628315500177777%2ChasSearchOrFacetActions%3A%21t%29%29%2Cversion%3A%210%29&shouldShowLegend=true&spanID=2733628315500177777&spanViewType=metadata&timeHint=1768436920547&trace=AwAAAZu_DfDjer5RkwAAABhBWnVfRGdQSUFBQU4ycmNVVXFCMVd3c0cAAAAkMDE5YmJmY2MtMDFjYS00M2U4LWFlY2UtYTFjZDFjZDlmY2MyAACI2Q&traceID=435470962274371258&traceQuery=&start=1768434491158&end=1768520891158&paused=false)

### Why is this change needed?

Previously, the Appeals API would return a successful `200` response even when Caseflow returned an error. This caused:

* Silent failures for consumers
* Incorrect success signaling
* Difficulty debugging upstream Caseflow issues
* Misleading monitoring and alerting signals

Returning the upstream status ensures that clients, logs, and monitoring accurately reflect Caseflow availability and failures.

### What changed?

* Controllers now render responses using `appeals_response.status` when the feature flag is enabled
* Existing behavior (always returning 200) is preserved when the flag is disabled
* Feature flag added to control rollout
* Minor cleanup and consistency updates

### How was this tested?
* Verified successful Caseflow responses continue to return `200`
* Verified non-200 Caseflow responses propagate the correct HTTP status when the feature flag is enabled
* Confirmed no behavior change when the feature flag is disabled

### Rollout / Risk
* Low risk
* Gated behind a feature flag for safe incremental rollout
* Improves correctness and observability without changing payload shape


## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
