### PR TITLE
Remove vre_use_new_vfs_notification_library feature flag

### DIFF
--- a/app/models/saved_claim/veteran_readiness_employment_claim.rb
+++ b/app/models/saved_claim/veteran_readiness_employment_claim.rb
@@ -15,15 +15,10 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
   VBMS_CONFIRMATION = :confirmation_vbms
   LIGHTHOUSE_CONFIRMATION = :confirmation_lighthouse
 
-  CONFIRMATION_EMAIL_TEMPLATES = {
-    VBMS_CONFIRMATION => Settings.vanotify.services.veteran_readiness_and_employment
-                                 .email.confirmation_vbms.template_id,
-    LIGHTHOUSE_CONFIRMATION => Settings.vanotify.services.veteran_readiness_and_employment
-                                       .email.confirmation_lighthouse.template_id
-  }.freeze
-
-  ERROR_EMAIL_TEMPLATE = Settings.vanotify.services.veteran_readiness_and_employment
-                                 .email.error.template_id
+  CONFIRMATION_EMAIL_TEMPLATES = [
+    VBMS_CONFIRMATION,
+    LIGHTHOUSE_CONFIRMATION
+  ].freeze
 
   REGIONAL_OFFICE_EMAILS = {
     '301' => 'VRC.VBABOS@va.gov',
@@ -134,8 +129,8 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
   # Common method for VRE form submission:
   # * Adds information from user to payload
   # * Submits to VBMS if participant ID is there, to Lighthouse if not.
-  # * Sends email if user is present
   # * Sends to RES service
+  # * Sends confirmation email
   # @param user [User] user account of submitting user
   # @return [Hash] Response payload of service that was used (RES)
   def send_to_vre(user)
@@ -156,12 +151,11 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
 
     send_to_res(user)
 
-    Flipper.enabled?(:vre_use_new_vfs_notification_library, self) &&
-      send_email(@sent_to_lighthouse ? LIGHTHOUSE_CONFIRMATION : VBMS_CONFIRMATION)
+    send_email(@sent_to_lighthouse ? LIGHTHOUSE_CONFIRMATION : VBMS_CONFIRMATION)
   end
 
   # Submit claim into VBMS service, uploading document directly to VBMS,
-  # adds document ID from VBMS to form info, and sends confirmation email to user
+  # adds document ID from VBMS to form info
   # Submits to Lighthouse on failure
   # @param user [User] user account of submitting user
   # @return None
@@ -184,9 +178,6 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
         update!(form: updated_form.to_json)
       end
     end
-
-    !Flipper.enabled?(:vre_use_new_vfs_notification_library, self) &&
-      send_vbms_lighthouse_confirmation_email('VBMS', CONFIRMATION_EMAIL_TEMPLATES[VBMS_CONFIRMATION])
   rescue => e
     Rails.logger.error('Error uploading VRE claim to VBMS.', { user_uuid: user&.uuid, messsage: e.message })
     send_to_lighthouse!(user)
@@ -196,8 +187,7 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
     PdfFill::Filler.fill_form(self, file_name, { created_at: })
   end
 
-  # Submit claim into lighthouse service, adds veteran info to top level of form,
-  # and sends confirmation email to user
+  # Submit claim into lighthouse service, adds veteran info to top level of form
   # @param user [User] user account of submitting user
   # @return None
   def send_to_lighthouse!(user)
@@ -219,9 +209,6 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
 
     process_attachments!
     @sent_to_lighthouse = true
-
-    !Flipper.enabled?(:vre_use_new_vfs_notification_library, self) &&
-      send_vbms_lighthouse_confirmation_email('Lighthouse', CONFIRMATION_EMAIL_TEMPLATES[LIGHTHOUSE_CONFIRMATION])
   rescue => e
     Rails.logger.error('Error uploading VRE claim to Benefits Intake API', { user_uuid: user&.uuid, e: })
     raise
@@ -280,23 +267,10 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
     []
   end
 
-  # Lighthouse::SubmitBenefitsIntakeClaim will call the function `send_confirmation_email` (if it exists).
-  # Do not name a function `send_confirmation_email`, unless it accepts 0 arguments.
-  def send_vbms_lighthouse_confirmation_email(service, email_template)
-    VANotify::EmailJob.perform_async(
-      email,
-      email_template,
-      {
-        'first_name' => parsed_form.dig('veteranInformation', 'fullName', 'first'),
-        'date' => Time.zone.today.strftime('%B %d, %Y')
-      }
-    )
-    Rails.logger.info("VRE #{service} upload successful. #{service} confirmation email sent.")
-  end
-
+  # Sends notification email via VeteranFacingServices::NotificationEmail library
   def send_email(email_type)
     VRE::NotificationEmail.new(id).deliver(email_type)
-    if CONFIRMATION_EMAIL_TEMPLATES.key?(email_type)
+    if CONFIRMATION_EMAIL_TEMPLATES.include?(email_type)
       Rails.logger.info("VRE Submit1900Job successful. #{email_type} confirmation email sent.")
     else
       Rails.logger.info('VRE Submit1900Job retries exhausted, failure email sent to veteran.')
@@ -309,9 +283,6 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
     files.find_each { |f| f.update(saved_claim_id: id) }
 
     Rails.logger.info('VRE claim submitting to Benefits Intake API')
-    # On success, this class will call claim.send_confirmation_email()
-    # if a function of that name exists.  If you need to implement
-    # function `send_confirmation_email()`, ensure it accepts 0 arguments
     Lighthouse::SubmitBenefitsIntakeClaim.new.perform(id)
   end
 
@@ -325,24 +296,6 @@ class SavedClaim::VeteranReadinessEmploymentClaim < SavedClaim
 
   def flipper_id
     email || guid
-  end
-
-  def send_failure_email(email_override = nil)
-    recipient_email = email_override || email
-    if recipient_email.present?
-      VANotify::EmailJob.perform_async(
-        recipient_email,
-        Settings.vanotify.services.va_gov.template_id.form1900_action_needed_email,
-        {
-          'first_name' => parsed_form.dig('veteranInformation', 'fullName', 'first'),
-          'date_submitted' => Time.zone.today.strftime('%B %d, %Y'),
-          'confirmation_number' => confirmation_number
-        }
-      )
-      Rails.logger.info('VRE Submit1900Job retries exhausted, failure email sent to veteran.')
-    else
-      Rails.logger.warn('VRE claim failure email not sent: email not present.')
-    end
   end
 
   private

--- a/config/features.yml
+++ b/config/features.yml
@@ -2171,9 +2171,6 @@ features:
   vre_prefill_name:
     actor_type: user
     description: Enables prefill transformation for veteran name fields in the Chapter 31 form
-  vre_use_new_vfs_notification_library:
-    actor_type: user
-    description: Whether or not to use the VFS library for interacting with VA Notify
   vre_modular_api:
     actor_type: user
     description: Enables calls to the modularized VRE API

--- a/modules/vre/app/jobs/vre/vre_submit1900_job.rb
+++ b/modules/vre/app/jobs/vre/vre_submit1900_job.rb
@@ -75,13 +75,7 @@ module VRE
     def self.trigger_failure_events(msg)
       claim_id = msg['args'][0]
       claim = ::SavedClaim.find(claim_id)
-
-      if Flipper.enabled?(:vre_use_new_vfs_notification_library, claim)
-        VRE::VREMonitor.new.track_submission_exhaustion(msg, claim)
-      else
-        VRE::Monitor.new.track_submission_exhaustion(msg, claim.email)
-        claim.send_failure_email
-      end
+      VRE::VREMonitor.new.track_submission_exhaustion(msg, claim)
     end
 
     private

--- a/modules/vre/lib/vre/notification_email.rb
+++ b/modules/vre/lib/vre/notification_email.rb
@@ -12,6 +12,9 @@ module VRE
     private
 
     def claim_class
+      # TODO(02/2026): Update to VRE::VREVeteranReadinessEmploymentClaim
+      # See: https://github.com/department-of-veterans-affairs/va-iir/issues/2011
+      # Currently points to monolith SavedClaim::VeteranReadinessEmploymentClaim
       SavedClaim::VeteranReadinessEmploymentClaim
     end
 

--- a/modules/vre/spec/jobs/vre_submit1900_job_spec.rb
+++ b/modules/vre/spec/jobs/vre_submit1900_job_spec.rb
@@ -54,9 +54,6 @@ describe VRE::VRESubmit1900Job do
   describe 'when queue is exhausted' do
     before do
       allow(SavedClaim::VeteranReadinessEmploymentClaim).to receive(:find).and_return(claim)
-      allow(Flipper).to receive(:enabled?)
-        .with(:vre_use_new_vfs_notification_library, claim)
-        .and_return(true)
     end
 
     it 'sends a failure email to user' do

--- a/modules/vre/spec/lib/vre/vre_monitor_spec.rb
+++ b/modules/vre/spec/lib/vre/vre_monitor_spec.rb
@@ -17,12 +17,6 @@ RSpec.describe VRE::VREMonitor do
   let(:message_prefix) { "#{described_class} #{VRE::FORM_ID}" }
   let(:current_user) { create(:user) }
 
-  before do
-    allow(Flipper).to receive(:enabled?)
-      .with(:vre_use_new_vfs_notification_library)
-      .and_return(true)
-  end
-
   shared_examples 'create operations tracking' do |status, log_level|
     let(:base_payload) do
       {

--- a/modules/vre/spec/models/vre/vre_veteran_readiness_employment_claim_spec.rb
+++ b/modules/vre/spec/models/vre/vre_veteran_readiness_employment_claim_spec.rb
@@ -77,6 +77,13 @@ RSpec.describe VRE::VREVeteranReadinessEmploymentClaim do
   describe '#send_to_vre' do
     subject { claim.send_to_vre(user_object) }
 
+    before do
+      # TODO(02/2026): Remove stub when VRE::NotificationEmail uses VRE::VREVeteranReadinessEmploymentClaim
+      # See: https://github.com/department-of-veterans-affairs/va-iir/issues/2011
+      allow_any_instance_of(VRE::NotificationEmail).to receive(:claim_class)
+        .and_return(VRE::VREVeteranReadinessEmploymentClaim)
+    end
+
     it 'propagates errors from send_to_lighthouse!' do
       allow(claim).to receive(:process_attachments!).and_raise(StandardError, 'Attachment error')
 
@@ -118,8 +125,7 @@ RSpec.describe VRE::VREVeteranReadinessEmploymentClaim do
         end
 
         it 'sends confirmation email' do
-          allow(Flipper).to receive(:enabled?).with(:vre_use_new_vfs_notification_library).and_return(false)
-          expect(claim).to receive(:send_vbms_lighthouse_confirmation_email)
+          expect(claim).to receive(:send_email).with(:confirmation_vbms)
 
           claim.send_to_vre(user_object)
         end
@@ -140,11 +146,9 @@ RSpec.describe VRE::VREVeteranReadinessEmploymentClaim do
       let(:user_object) { create(:unauthorized_evss_user) }
 
       it 'PDF is sent to Central Mail and not VBMS' do
-        allow(Flipper).to receive(:enabled?).with(:vre_use_new_vfs_notification_library).and_return(false)
-
         expect(claim).to receive(:process_attachments!)
         expect(claim).to receive(:send_to_lighthouse!).with(user_object).once.and_call_original
-        expect(claim).to receive(:send_vbms_lighthouse_confirmation_email)
+        expect(claim).to receive(:send_email).with(:confirmation_lighthouse)
         expect(claim).not_to receive(:upload_to_vbms)
         expect(VRE::VeteranReadinessEmploymentMailer).to receive(:build).with(
           user_object.participant_id, 'VRE.VBAPIT@va.gov', true
@@ -154,69 +158,9 @@ RSpec.describe VRE::VREVeteranReadinessEmploymentClaim do
     end
   end
 
-  describe '#send_failure_email' do
-    context 'when email is nil' do
-      it 'only logs a warning' do
-        expect(Rails.logger).to receive(:warn)
-        expect(VANotify::EmailJob).not_to receive(:perform_async)
-        claim.send_failure_email('')
-      end
-    end
-
-    context 'when email is present' do
-      it 'logs error and sends email' do
-        expect(VANotify::EmailJob).to receive(:perform_async)
-        claim.send_failure_email('test@example.com')
-      end
-    end
-  end
-
   describe '#regional_office' do
     it 'returns an empty array' do
       expect(claim.regional_office).to eq []
-    end
-  end
-
-  describe '#send_vbms_lighthouse_confirmation_email' do
-    context 'when sending to VBMS' do
-      it 'calls the VA notify email job' do
-        expect(VANotify::EmailJob).to receive(:perform_async).with(
-          claim.email,
-          'ch31_vbms_fake_template_id',
-          {
-            'date' => Time.zone.today.strftime('%B %d, %Y'),
-            'first_name' => claim.parsed_form['veteranInformation']['fullName']['first']
-          }
-        )
-
-        claim.send_vbms_lighthouse_confirmation_email('VBMS', 'ch31_vbms_fake_template_id', user_object)
-      end
-    end
-
-    context 'when sending to Lighthouse' do
-      it 'calls the VA notify email job' do
-        expect(VANotify::EmailJob).to receive(:perform_async).with(
-          claim.email,
-          'ch31_central_mail_fake_template_id',
-          {
-            'date' => Time.zone.today.strftime('%B %d, %Y'),
-            'first_name' => claim.parsed_form['veteranInformation']['fullName']['first']
-          }
-        )
-
-        claim.send_vbms_lighthouse_confirmation_email('Lighthouse', 'ch31_central_mail_fake_template_id', user_object)
-      end
-    end
-
-    context 'when email is missing' do
-      it 'logs a warning' do
-        claim.parsed_form['email'] = nil
-        expect(Rails.logger).to receive(:warn).with(
-          'VBMS confirmation email not sent: parsed form missing email.',
-          { user_uuid: user_object.uuid }
-        )
-        claim.send_vbms_lighthouse_confirmation_email('VBMS', 'ch31_vbms_fake_template_id', user_object)
-      end
     end
   end
 

--- a/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
+++ b/spec/models/saved_claim/veteran_readiness_employment_claim_spec.rb
@@ -142,11 +142,8 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
         end
 
         it 'sends confirmation email' do
-          allow(Flipper).to receive(:enabled?)
-            .with(:vre_use_new_vfs_notification_library, claim)
-            .and_return(false)
-          expect(claim).to receive(:send_vbms_lighthouse_confirmation_email)
-            .with('VBMS', 'confirmation_vbms_email_template_id')
+          expect(claim).to receive(:send_email)
+            .with(:confirmation_vbms)
 
           claim.send_to_vre(user_object)
         end
@@ -169,10 +166,9 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
       let(:user_object) { create(:unauthorized_evss_user) }
 
       it 'PDF is sent to Central Mail and not VBMS' do
-        Flipper.disable(:vre_use_new_vfs_notification_library)
         expect(claim).to receive(:process_attachments!)
         expect(claim).to receive(:send_to_lighthouse!).with(user_object).once.and_call_original
-        expect(claim).to receive(:send_vbms_lighthouse_confirmation_email)
+        expect(claim).to receive(:send_email).with(:confirmation_lighthouse)
         expect(claim).not_to receive(:upload_to_vbms)
         expect(VeteranReadinessEmploymentMailer).to receive(:build).with(
           user_object.participant_id, 'VRE.VBAPIT@va.gov', true
@@ -185,39 +181,6 @@ RSpec.describe SavedClaim::VeteranReadinessEmploymentClaim do
   describe '#regional_office' do
     it 'returns an empty array' do
       expect(claim.regional_office).to be_empty
-    end
-  end
-
-  describe '#send_vbms_lighthouse_confirmation_email' do
-    let(:user) do
-      OpenStruct.new(
-        edipi: '1007697216',
-        participant_id: '600061742',
-        first_name: 'WESLEY',
-        va_profile_email: 'test@example.com',
-        flipper_id: 'test-user-id'
-      )
-    end
-
-    context 'Legacy notification strategy' do
-      before do
-        allow(Flipper).to receive(:enabled?)
-          .with(:vre_use_new_vfs_notification_library, claim)
-          .and_return(false)
-      end
-
-      it 'calls the VA notify email job' do
-        expect(VANotify::EmailJob).to receive(:perform_async).with(
-          claim.email,
-          'ch31_vbms_fake_template_id',
-          {
-            'date' => Time.zone.today.strftime('%B %d, %Y'),
-            'first_name' => claim.parsed_form['veteranInformation']['fullName']['first']
-          }
-        )
-
-        claim.send_vbms_lighthouse_confirmation_email('VBMS', 'ch31_vbms_fake_template_id')
-      end
     end
   end
 


### PR DESCRIPTION
## Summary
We have been sending emails using the VFS Notification Library implementation, and have not run into any issues.  It's time to clean up the feature flag now.  This PR removes the `vre_use_new_vfs_notification_library` feature toggle, and any related code.

- Remove feature flag from `config/features.yml`
- Consolidate VRE notification email handling to always use `VRE::NotificationEmail` class
- Remove legacy `send_vbms_lighthouse_confirmation_email` and `send_failure_email` methods
- Update `CONFIRMATION_EMAIL_TEMPLATES` from hash to array of symbols (cleanup)
- Simplify `send_to_vre` flow to always call `send_email` at the end
- Update tests to remove Flipper stubs and use `send_email` expectations with email types
- Add TODO comments for future migration to `VRE::VREVeteranReadinessEmploymentClaim`

## Related issue(s)

[CVE Ticket# 2003](https://github.com/department-of-veterans-affairs/va-iir/issues/2003)


## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature


