### PR TITLE
update log text so that it is unfiltered

### DIFF
--- a/app/models/saved_claim.rb
+++ b/app/models/saved_claim.rb
@@ -112,7 +112,9 @@ class SavedClaim < ApplicationRecord
     end
 
     unless validation_errors.empty?
-      Rails.logger.error('SavedClaim form did not pass validation', { form_id:, guid:, errors: validation_errors })
+
+      Rails.logger.error('SavedClaim form (safely filtered) did not pass validation',
+                         { form_id:, guid:, errors: validation_errors })
     end
 
     schema_errors.empty? && validation_errors.empty?

--- a/spec/models/saved_claim_spec.rb
+++ b/spec/models/saved_claim_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe TestSavedClaim, type: :model do # rubocop:disable RSpec/SpecFileP
 
         it 'adds validation errors to the form' do
           expect(Rails.logger).to receive(:error)
-            .with('SavedClaim form did not pass validation',
+            .with('SavedClaim form (safely filtered) did not pass validation',
                   { guid: saved_claim.guid, form_id: saved_claim.form_id, errors: filtered_schema_errors })
           saved_claim.validate
           expect(saved_claim.errors.full_messages).not_to be_empty


### PR DESCRIPTION
## Summary

Before https://github.com/department-of-veterans-affairs/vets-api/pull/22093 was merged, PII was being written to the logs for saved claims validation errors. As a result, data dog filters out prod logs With "SavedClaim form did not pass validation".  We still need that filter in place to exclude old logs from DD, but we can allow new logs to be written to DD. We can do that simply by changing the error message.

https://dsva.slack.com/archives/CBU0KDSB1/p1768919525713559

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/130435

## Testing done

- [ ] https://github.com/department-of-veterans-affairs/vets-api/pull/22093 does most of the testing. This PR just updates the log text for new logs so that DD won't filter it out in prod

## Screenshots
What we currently see in dd staging:
<img width="720" height="537" alt="image" src="https://github.com/user-attachments/assets/ce30121b-aef5-4763-be95-61ca008f55c6" />


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
