### PR TITLE
2287 claims evidence tsa download 2

### DIFF
--- a/app/controllers/v0/tsa_letter_controller.rb
+++ b/app/controllers/v0/tsa_letter_controller.rb
@@ -25,18 +25,15 @@ module V0
     end
 
     def download
+      download_service = ClaimsEvidenceApi::Service::Files.new
       send_data(
-        service.get_tsa_letter(params[:id]),
+        download_service.download(params[:id], params[:version_id]),
         type: 'application/pdf',
         filename: 'VETS Safe Travel Outreach Letter.pdf'
       )
     end
 
     private
-
-    def service
-      Efolder::Service.new(@current_user)
-    end
 
     def most_recent_letter(files)
       return { data: nil } if files.blank?

--- a/app/controllers/v0/tsa_letter_controller.rb
+++ b/app/controllers/v0/tsa_letter_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'claims_evidence_api/service/search'
+require 'claims_evidence_api/service/files'
 
 module V0
   class TsaLetterController < ApplicationController
@@ -26,8 +27,9 @@ module V0
 
     def download
       download_service = ClaimsEvidenceApi::Service::Files.new
+      letter_response = download_service.download(params[:id], params[:version_id])
       send_data(
-        download_service.download(params[:id], params[:version_id]),
+        letter_response.body,
         type: 'application/pdf',
         filename: 'VETS Safe Travel Outreach Letter.pdf'
       )

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -109,12 +109,16 @@ RSpec.describe 'VO::TsaLetter', type: :request do
   describe 'GET /v0/tsa_letter/:id/version/:version_id/download' do
     let(:document_id) { '93631483-E9F9-44AA-BB55-3552376400D8' }
     let(:version_id) { '920debba-cc65-479c-ab47-db9b2a5cd95f' }
-    let(:content) { File.read('spec/fixtures/files/error_message.txt') }
 
     it 'sends the doc pdf' do
-      skip 'Pending migration to Claims Evidence API'
-      get "/v0/tsa_letter/#{CGI.escape(document_id)}/version/#{CGI.escape(version_id)}/download"
-      expect(response.body).to eq(content)
+      VCR.use_cassette('tsa_letters/download_success', { match_requests_on: %i[method uri] }) do
+        get "/v0/tsa_letter/#{document_id}/version/#{version_id}/download"
+        expect(response).to have_http_status(:ok)
+        expect(response.headers['Content-Type']).to eq('application/pdf')
+        expect(response.headers['Content-Disposition']).to include('attachment')
+        expect(response.headers['Content-Disposition']).to include('filename="VETS Safe Travel Outreach Letter.pdf"')
+        expect(response.body).to be_present
+      end
     end
   end
 end

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -121,6 +121,19 @@ RSpec.describe 'VO::TsaLetter', type: :request do
       end
     end
 
+    context 'when document is not found' do
+      let(:document_id) { 'nonexistent-uuid' }
+      let(:version_id) { 'nonexistent-version' }
+
+      it 'renders 503' do
+        # probably better to catch and convert the response
+        VCR.use_cassette('tsa_letters/download_not_found', { match_requests_on: %i[method uri] }) do
+          get "/v0/tsa_letter/#{document_id}/version/#{version_id}/download"
+          expect(response).to have_http_status(:service_unavailable)
+        end
+      end
+    end
+
     context 'when user does not have an ICN' do
       let(:user) { build(:user, icn: nil) }
 

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe 'VO::TsaLetter', type: :request do
       end
     end
 
-    context 'when document is not found' do
+    context 'when upstream returns error status' do
       let(:document_id) { 'nonexistent-uuid' }
       let(:version_id) { 'nonexistent-version' }
 

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -126,7 +126,6 @@ RSpec.describe 'VO::TsaLetter', type: :request do
       let(:version_id) { 'nonexistent-version' }
 
       it 'renders 503' do
-        # probably better to catch and convert the response
         VCR.use_cassette('tsa_letters/download_not_found', { match_requests_on: %i[method uri] }) do
           get "/v0/tsa_letter/#{document_id}/version/#{version_id}/download"
           expect(response).to have_http_status(:service_unavailable)

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -110,14 +110,23 @@ RSpec.describe 'VO::TsaLetter', type: :request do
     let(:document_id) { '93631483-E9F9-44AA-BB55-3552376400D8' }
     let(:version_id) { '920debba-cc65-479c-ab47-db9b2a5cd95f' }
 
-    it 'sends the doc pdf' do
+    it 'renders 200 and sends the doc pdf' do
       VCR.use_cassette('tsa_letters/download_success', { match_requests_on: %i[method uri] }) do
         get "/v0/tsa_letter/#{document_id}/version/#{version_id}/download"
         expect(response).to have_http_status(:ok)
         expect(response.headers['Content-Type']).to eq('application/pdf')
         expect(response.headers['Content-Disposition']).to include('attachment')
         expect(response.headers['Content-Disposition']).to include('filename="VETS Safe Travel Outreach Letter.pdf"')
-        expect(response.body).to be_present
+        expect(response.body).to eq('%PDF-1.4 fake pdf content for testing purposes')
+      end
+    end
+
+    context 'when user does not have an ICN' do
+      let(:user) { build(:user, icn: nil) }
+
+      it 'renders 403' do
+        get "/v0/tsa_letter/#{document_id}/version/#{version_id}/download"
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -106,13 +106,14 @@ RSpec.describe 'VO::TsaLetter', type: :request do
     end
   end
 
-  describe 'GET /v0/tsa_letter/:id' do
-    let(:document_id) { '{93631483-E9F9-44AA-BB55-3552376400D8}' }
+  describe 'GET /v0/tsa_letter/:id/version/:version_id/download' do
+    let(:document_id) { '93631483-E9F9-44AA-BB55-3552376400D8' }
+    let(:version_id) { '920debba-cc65-479c-ab47-db9b2a5cd95f' }
     let(:content) { File.read('spec/fixtures/files/error_message.txt') }
 
     it 'sends the doc pdf' do
       skip 'Pending migration to Claims Evidence API'
-      get "/v0/tsa_letter/#{CGI.escape(document_id)}"
+      get "/v0/tsa_letter/#{CGI.escape(document_id)}/version/#{CGI.escape(version_id)}/download"
       expect(response.body).to eq(content)
     end
   end

--- a/spec/support/vcr_cassettes/tsa_letters/download_not_found.yml
+++ b/spec/support/vcr_cassettes/tsa_letters/download_not_found.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: <CLAIMS_EVIDENCE_API_URL>files/nonexistent-uuid/nonexistent-version/content
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/pdf
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Authorization:
+      - Bearer <TOKEN>
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 06 Oct 2025 17:03:17 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - envoy
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Security-Policy:
+      - 'default-src https: data: ''unsafe-inline'' ''unsafe-eval'''
+      X-Envoy-Upstream-Service-Time:
+      - '43'
+      Ssl-Env:
+      - 'On'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "uuid":"f5db9ad0-c27b-4517-90ee-a6526481af95",
+          "code":"VEFSERR40401",
+          "message":"Expected resource not found."
+        }
+  recorded_at: Mon, 06 Oct 2025 17:03:17 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/tsa_letters/download_not_found.yml
+++ b/spec/support/vcr_cassettes/tsa_letters/download_not_found.yml
@@ -19,11 +19,10 @@ http_interactions:
       - Bearer <TOKEN>
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 403
     headers:
       Date:
-      - Mon, 06 Oct 2025 17:03:17 GMT
+      - Mon, 19 Jan 2026 17:03:17 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -48,11 +47,6 @@ http_interactions:
       - max-age=16000000; includeSubDomains; preload;
     body:
       encoding: UTF-8
-      string: |-
-        {
-          "uuid":"f5db9ad0-c27b-4517-90ee-a6526481af95",
-          "code":"VEFSERR40401",
-          "message":"Expected resource not found."
-        }
+      string: ""
   recorded_at: Mon, 06 Oct 2025 17:03:17 GMT
 recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/tsa_letters/download_success.yml
+++ b/spec/support/vcr_cassettes/tsa_letters/download_success.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Oct 2025 17:03:17 GMT
+      - Mon, 19 Jan 2026 17:03:17 GMT
       Content-Type:
       - application/pdf
       Content-Disposition:

--- a/spec/support/vcr_cassettes/tsa_letters/download_success.yml
+++ b/spec/support/vcr_cassettes/tsa_letters/download_success.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://claimevidence-api-fake.fake.bip.va.gov/api/v1/rest/files/93631483-E9F9-44AA-BB55-3552376400D8/920debba-cc65-479c-ab47-db9b2a5cd95f/content
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/pdf
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Vets.gov Agent
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Authorization:
+      - Bearer <TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 06 Oct 2025 17:03:17 GMT
+      Content-Type:
+      - application/pdf
+      Content-Disposition:
+      - attachment; filename="VETS Safe Travel Outreach Letter.pdf"
+      Content-Length:
+      - '177200'
+      Connection:
+      - keep-alive
+      Server:
+      - envoy
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Security-Policy:
+      - 'default-src https: data: ''unsafe-inline'' ''unsafe-eval'''
+      X-Envoy-Upstream-Service-Time:
+      - '43'
+      Ssl-Env:
+      - 'On'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=16000000; includeSubDomains; preload;
+    body:
+      encoding: ASCII-8BIT
+      string: '%PDF-1.4 fake pdf content for testing purposes'
+  recorded_at: Mon, 06 Oct 2025 17:03:17 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr_cassettes/tsa_letters/download_success.yml
+++ b/spec/support/vcr_cassettes/tsa_letters/download_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://claimevidence-api-fake.fake.bip.va.gov/api/v1/rest/files/93631483-E9F9-44AA-BB55-3552376400D8/920debba-cc65-479c-ab47-db9b2a5cd95f/content
+    uri: <CLAIMS_EVIDENCE_API_URL>files/93631483-E9F9-44AA-BB55-3552376400D8/920debba-cc65-479c-ab47-db9b2a5cd95f/content
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES
- Changes the TSA letter download endpoint to use the new claims evidence api instead of the soon-to-be deprecated efolder api. 
- I work for the CVE team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-iir/issues/2286

## Testing done

- [x] *New code is covered by unit tests*
- Behavior does not change. Files come from another api.
- You can hit the `/v0/tsa_letter/:id/version/:version_id/download` endpoint. 
- *If this work is behind a flipper:*
  - This is feature flagged on the front end, not back end.
  - I will manually test it on staging.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
TSA letter download.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
