### PR TITLE
Fix Common Carrier `reasonNotUsingPOV` casing in Travel Pay expense responses

### DIFF
--- a/modules/travel_pay/app/services/travel_pay/expense_normalizer.rb
+++ b/modules/travel_pay/app/services/travel_pay/expense_normalizer.rb
@@ -4,13 +4,19 @@ module TravelPay
   module ExpenseNormalizer
     # Normalizes expense data by overwriting expenseType with name for Parking expenses
     # This corrects the TP API response where the Parking expenseType is returned as "Other"
+    # Preserves acronym casing for POV fields
     #
     # @param expense [Hash] Single expense hash
     # @return [Hash] The normalized expense
     def normalize_expense(expense)
       return expense unless expense.is_a?(Hash)
 
+      # Fix incorrect Parking expenseType
       expense['expenseType'] = expense['name'] if expense['name']&.downcase == 'parking'
+
+      # Preserve POV acronym casing
+      expense['reasonNotUsingPOV'] = expense.delete('reasonNotUsingPov') if expense.key?('reasonNotUsingPov')
+
       expense
     end
 

--- a/modules/travel_pay/spec/services/expense_normalizer_spec.rb
+++ b/modules/travel_pay/spec/services/expense_normalizer_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TravelPay::ExpenseNormalizer do
+  # Create a dummy class to include the module
+  let(:normalizer) do
+    Class.new do
+      include TravelPay::ExpenseNormalizer
+    end.new
+  end
+
+  describe '#normalize_expense' do
+    it 'returns non-hash inputs unchanged' do
+      expect(normalizer.normalize_expense(nil)).to be_nil
+      expect(normalizer.normalize_expense('string')).to eq('string')
+      expect(normalizer.normalize_expense(123)).to eq(123)
+    end
+
+    it 'normalizes Parking expenseType using name' do
+      expense = {
+        'expenseType' => 'Other',
+        'name' => 'Parking'
+      }
+
+      normalizer.normalize_expense(expense)
+
+      expect(expense['expenseType']).to eq('Parking')
+    end
+
+    it 'preserves POV acronym casing' do
+      expense = {
+        'reasonNotUsingPov' => 'Other'
+      }
+
+      normalizer.normalize_expense(expense)
+
+      expect(expense['reasonNotUsingPOV']).to eq('Other')
+      expect(expense).not_to have_key('reasonNotUsingPov')
+    end
+
+    it 'does not override correctly cased reasonNotUsingPOV' do
+      expense = {
+        'reasonNotUsingPOV' => 'Other'
+      }
+
+      normalizer.normalize_expense(expense)
+
+      expect(expense['reasonNotUsingPOV']).to eq('Other')
+      expect(expense.keys).to contain_exactly('reasonNotUsingPOV')
+    end
+  end
+
+  describe '#normalize_expenses' do
+    it 'normalizes each expense in the array' do
+      expenses = [
+        { 'reasonNotUsingPov' => 'Other' },
+        { 'name' => 'Parking', 'expenseType' => 'Other' }
+      ]
+
+      normalizer.normalize_expenses(expenses)
+
+      expect(expenses[0]['reasonNotUsingPOV']).to eq('Other')
+      expect(expenses[0]).not_to have_key('reasonNotUsingPov')
+
+      expect(expenses[1]['expenseType']).to eq('Parking')
+    end
+
+    it 'returns non-array inputs unchanged' do
+      expect(normalizer.normalize_expenses(nil)).to be_nil
+      expect(normalizer.normalize_expenses({})).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Normalizes Common Carrier expense responses to return `reasonNotUsingPOV` instead of `reasonNotUsingPov`. Also adds unit coverage to prevent regressions.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/130327

## Testing done

- [ x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
None

## What areas of the site does it impact?
Travel Pay
## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
