### PR TITLE
Fix FeatureTogglesController Filter Chain Halting

### DIFF
--- a/app/controllers/v0/feature_toggles_controller.rb
+++ b/app/controllers/v0/feature_toggles_controller.rb
@@ -22,7 +22,7 @@ module V0
     private
 
     def load_user_if_session_exists
-      if Flipper.enabled?(:load_user_if_authenticated)
+      if Flipper.enabled?(:load_feature_toggle_user_if_authed)
         load_user_safely
       else
         load_user

--- a/config/features.yml
+++ b/config/features.yml
@@ -1269,7 +1269,7 @@ features:
     enable_in_development: true
   lighthouse_document_convert_to_unlocked_pdf_use_hexapdf:
     description: Enables the LighthouseDocument class's convert_to_unlocked_pdf method to use hexapdf to unlock encrypted pdfs
-  load_user_if_authenticated:
+  load_feature_toggle_user_if_authed:
     actor_type: user
     description: Prevents FeatureTogglesController Filter Chain Halting
   log_claims_request_origin:


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

**This is behind the flipper load_user_if_authenticated.** These changes strictly prevent redirects and do not modify any existing behavior or logic.

The `FeatureTogglesController` was experiencing a filter chain halt issue that caused repeating failed requests in the logs:

```
Filter chain halted as :load_user rendered or redirected
```

[In these logs](https://vagov.ddog-gov.com/logs?query=env%3Aeks-prod%20service%3Avets-api%20%40named_tags.remote_ip%3A67.219.8.57&agg_m=count&agg_m_source=base&agg_q=%40name&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40name%2C%40http.url_details.path%2C%40http.method&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=flex_tier&stream_sort=time%2Cdesc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1768954219336&to_ts=1768961419336&live=true), a single user continuously hit the FeatureToggles endpoint.

**Root Cause:**
- The endpoint had `skip_before_action :authenticate` but still ran `before_action :load_user`
- When unauthenticated users (or users with invalid/expired sessions) hit the endpoint, the `load_user` filter would fail and halt the request chain
- Since the frontend polls this endpoint frequently to check feature flags, this resulted in continuous failed requests and log spam

**Solution:**
Replace the standard `load_user` filter with a custom `load_user_if_session_exists` that gracefully handles missing or invalid sessions.

By calling `set_session_object` and `set_current_user` directly instead of the parent's `load_user`, we avoid the code path that calls `super()` → `SignIn::Authentication#load_user`, which can render/redirect and halt the request.

The `FeatureTogglesService` already handles both scenarios:
```ruby
FeatureTogglesService.new(
  current_user: @current_user,  # Can be nil
  cookie_id: params[:cookie_id]  # Fallback for anonymous users
)
```
By preventing filter chain halts, this eliminates the repeating error logs while maintaining appropriate warning-level logging for unexpected errors.

**Graceful Degradation**
- If a valid session exists → loads the user
- If no session exists → continues with `@current_user = nil`
- If an error occurs → logs warning and continues with `@current_user = nil`


**Changes Made:**
1. **Added** `skip_before_action :load_user` to prevent the parent's `load_user` from running
2. **Added** private method :load_user_if_session_exists` as a replacement
3. **Implemented** `load_user_if_session_exists` method that:
   - Only attempts user loading when a session token is present
   - Directly calls `set_session_object` and `set_current_user` (bypassing the parent's `load_user` which calls `super()` and can trigger renders/redirects)
   - Gracefully handles errors with proper exception handling
   - Sets `@current_user` and `@session_object` to `nil` when loading fails or no session exists