### PR TITLE
Create new ial2 acr values

### DIFF
--- a/app/services/sign_in/constants/auth.rb
+++ b/app/services/sign_in/constants/auth.rb
@@ -5,7 +5,12 @@ module SignIn
     module Auth
       ACCESS_TOKEN_COOKIE_NAME = 'vagov_access_token'
       ACCESS_DENIED = 'access_denied'
-      ACR_VALUES = [LOA1 = 'loa1', LOA3 = 'loa3', IAL1 = 'ial1', IAL2 = 'ial2',
+      ACR_VALUES = [LOA1 = 'loa1',
+                    LOA3 = 'loa3',
+                    IAL1 = 'ial1',
+                    IAL2 = 'ial2',
+                    IAL2_REQUIRED  = 'urn:acr.va.gov:verified-facial-match-required',
+                    IAL2_PREFERRED = 'urn:acr.va.gov:verified-facial-match-preferred',
                     MIN = 'min'].freeze
       ACR_TRANSLATIONS = [IDME_LOA1 = 'http://idmanagement.gov/ns/assurance/loa/1/vets',
                           IDME_LOA3 = 'http://idmanagement.gov/ns/assurance/loa/3',
@@ -22,7 +27,9 @@ module SignIn
                                                       DSLOGON_ASSURANCE_THREE = '3'].freeze,
                           LOGIN_GOV_IAL0 = 'http://idmanagement.gov/ns/assurance/ial/0',
                           LOGIN_GOV_IAL1 = 'http://idmanagement.gov/ns/assurance/ial/1',
-                          LOGIN_GOV_IAL2 = 'http://idmanagement.gov/ns/assurance/ial/2'].freeze
+                          LOGIN_GOV_IAL2 = 'http://idmanagement.gov/ns/assurance/ial/2',
+                          LOGIN_GOV_IAL2_REQUIRED = 'urn:acr.login.gov:verified-facial-match-required',
+                          LOGIN_GOV_IAL2_PREFERRED = 'urn:acr.login.gov:verified-facial-match-preferred'].freeze
       ANTI_CSRF_COOKIE_NAME = 'vagov_anti_csrf_token'
       AUTHENTICATION_TYPES = [COOKIE = 'cookie', API = 'api', MOCK = 'mock'].freeze
       BROKER_CODE = 'sis'

--- a/app/services/sign_in/credential_level_creator.rb
+++ b/app/services/sign_in/credential_level_creator.rb
@@ -107,11 +107,7 @@ module SignIn
     end
 
     def idme_max_ial
-      if ial2_enabled?
-        verified_ial_level(idme_ial2? || idme_loa3_and_previously_verified?)
-      else
-        verified_ial_level(idme_loa3_or_previously_verified?)
-      end
+      verified_ial_level(idme_loa3_or_previously_verified?)
     end
 
     def logingov_current_ial
@@ -127,11 +123,7 @@ module SignIn
     end
 
     def idme_current_ial
-      if ial2_enabled?
-        verified_ial_level(idme_ial2? || idme_classic_loa3_and_previously_verified?)
-      else
-        verified_ial_level(idme_classic_loa3_or_ial2?)
-      end
+      verified_ial_level(idme_classic_loa3_or_ial2?)
     end
 
     def mhv_premium_verified?
@@ -148,14 +140,6 @@ module SignIn
 
     def idme_loa3_or_previously_verified?
       level_of_assurance == Constants::Auth::LOA_THREE || previously_verified?(:idme_uuid)
-    end
-
-    def idme_loa3_and_previously_verified?
-      level_of_assurance == Constants::Auth::LOA_THREE && previously_verified?(:idme_uuid)
-    end
-
-    def idme_classic_loa3_and_previously_verified?
-      credential_ial == Constants::Auth::IDME_CLASSIC_LOA3 && previously_verified?(:idme_uuid)
     end
 
     def idme_ial2?
@@ -185,10 +169,6 @@ module SignIn
     def previously_verified?(identifier_type)
       user_verification = UserVerification.find_by(identifier_type => credential_uuid)
       user_verification&.verified?
-    end
-
-    def ial2_enabled?
-      Flipper.enabled?(:identity_ial2_enforcement) && Settings.vsp_environment != 'production'
     end
   end
 end

--- a/config/features.yml
+++ b/config/features.yml
@@ -240,7 +240,7 @@ features:
   ezr_service_history_enabled:
     actor_type: user
     description: Enables Service History flow in the 10-10EZR form.
-    enable_in_development: false   
+    enable_in_development: false
   ezr_spouse_confirmation_flow_enabled:
     actor_type: user
     description: Enables the spouse (V2) confirmation flow in the 10-10EZR form.
@@ -1235,9 +1235,13 @@ features:
     actor_type: user
     description: Enable/disable 526ez in progress form reminders (sent via VaNotify)
     enable_in_development: true
-  identity_ial2_enforcement:
+  identity_idme_ial2_enforcement:
     actor_type: user
-    description: Enforces IAL2 for newly verified users
+    description: Enforces IAL2 for newly verified id.me users
+    enable_in_development: false
+  identity_logingov_ial2_enforcement:
+    actor_type: user
+    description: Enforces IAL2 facial recognition for newly verified login.gov users
     enable_in_development: false
   kendra_enabled_for_resources_and_support_search:
     actor_type: user
@@ -2807,7 +2811,6 @@ features:
   sob_claimant_service:
     actor_type: user
     description: If enabled, use the new claimant service for SOB
-    
   form_10203_claimant_service:
     actor_type: user
     description: If enabled, use the new claimant service for form 22-10203

--- a/db/seeds/development/identity/client_configs.rb
+++ b/db/seeds/development/identity/client_configs.rb
@@ -12,7 +12,8 @@ vaweb.update!(authentication: SignIn::Constants::Auth::COOKIE,
               enforced_terms: SignIn::Constants::Auth::VA_TERMS,
               terms_of_use_url: 'http://localhost:3001/terms-of-use',
               shared_sessions: true,
-              refresh_token_duration: SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES)
+              refresh_token_duration: SignIn::Constants::RefreshToken::VALIDITY_LENGTH_SHORT_MINUTES,
+              service_levels: SignIn::Constants::Auth::ACR_VALUES)
 
 # Create Config for VA flagship mobile Sign in Service client
 vamobile = SignIn::ClientConfig.find_or_initialize_by(client_id: 'vamobile')

--- a/spec/services/sign_in/acr_translator_spec.rb
+++ b/spec/services/sign_in/acr_translator_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe SignIn::AcrTranslator do
     context 'when type is idme' do
       let(:type) { SignIn::Constants::Auth::IDME }
       let(:ial2_feature_flag_enabled) { false }
-      let(:vsp_environment) { 'staging' }
 
       before do
-        allow(Flipper).to receive(:enabled?).with(:identity_ial2_enforcement).and_return(ial2_feature_flag_enabled)
-        allow(Settings).to receive(:vsp_environment).and_return(vsp_environment)
+        allow(Flipper).to receive(:enabled?).and_call_original
+        allow(Flipper).to receive(:enabled?).with('identity_idme_ial2_enforcement')
+                                            .and_return(ial2_feature_flag_enabled)
       end
 
       context 'and acr is loa1' do
@@ -40,12 +40,11 @@ RSpec.describe SignIn::AcrTranslator do
         end
       end
 
-      context 'and acr is ial2' do
-        let(:acr) { 'ial2' }
+      context 'and acr is IAL2_REQUIRED' do
+        let(:acr) { SignIn::Constants::Auth::IAL2_REQUIRED }
 
         context 'when ial2 is enabled' do
           let(:ial2_feature_flag_enabled) { true }
-          let(:vsp_environment) { 'staging' }
           let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::IDME_IAL2 } }
 
           it 'returns expected translated acr value' do
@@ -55,17 +54,6 @@ RSpec.describe SignIn::AcrTranslator do
 
         context 'when ial2 is disabled' do
           let(:ial2_feature_flag_enabled) { false }
-          let(:expected_error) { SignIn::Errors::InvalidAcrError }
-          let(:expected_error_message) { 'Invalid ACR for idme' }
-
-          it 'raises invalid acr error' do
-            expect { subject }.to raise_error(expected_error, expected_error_message)
-          end
-        end
-
-        context 'when ial2 is called in production' do
-          let(:ial2_feature_flag_enabled) { true }
-          let(:vsp_environment) { 'production' }
           let(:expected_error) { SignIn::Errors::InvalidAcrError }
           let(:expected_error_message) { 'Invalid ACR for idme' }
 
@@ -111,6 +99,13 @@ RSpec.describe SignIn::AcrTranslator do
 
     context 'when type is logingov' do
       let(:type) { SignIn::Constants::Auth::LOGINGOV }
+      let(:ial2_feature_flag_enabled) { false }
+
+      before do
+        allow(Flipper).to receive(:enabled?).and_call_original
+        allow(Flipper).to receive(:enabled?).with('identity_logingov_ial2_enforcement')
+                                            .and_return(ial2_feature_flag_enabled)
+      end
 
       context 'and acr is ial1' do
         let(:acr) { 'ial1' }
@@ -130,6 +125,52 @@ RSpec.describe SignIn::AcrTranslator do
         end
       end
 
+      context 'and acr is IAL2_REQUIRED' do
+        let(:acr) { SignIn::Constants::Auth::IAL2_REQUIRED }
+
+        context 'when ial2 is enabled' do
+          let(:ial2_feature_flag_enabled) { true }
+          let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::LOGIN_GOV_IAL2_REQUIRED } }
+
+          it 'returns expected translated acr value' do
+            expect(subject).to eq(expected_translated_acr)
+          end
+        end
+
+        context 'when ial2 is disabled' do
+          let(:ial2_feature_flag_enabled) { false }
+          let(:expected_error) { SignIn::Errors::InvalidAcrError }
+          let(:expected_error_message) { 'Invalid ACR for logingov' }
+
+          it 'raises invalid acr error' do
+            expect { subject }.to raise_error(expected_error, expected_error_message)
+          end
+        end
+      end
+
+      context 'and acr is IAL2_PREFERRED' do
+        let(:acr) { SignIn::Constants::Auth::IAL2_PREFERRED }
+
+        context 'when ial2 is enabled' do
+          let(:ial2_feature_flag_enabled) { true }
+          let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::LOGIN_GOV_IAL2_PREFERRED } }
+
+          it 'returns expected translated acr value' do
+            expect(subject).to eq(expected_translated_acr)
+          end
+        end
+
+        context 'when ial2 is disabled' do
+          let(:ial2_feature_flag_enabled) { false }
+          let(:expected_error) { SignIn::Errors::InvalidAcrError }
+          let(:expected_error_message) { 'Invalid ACR for logingov' }
+
+          it 'raises invalid acr error' do
+            expect { subject }.to raise_error(expected_error, expected_error_message)
+          end
+        end
+      end
+
       context 'and acr is min' do
         let(:acr) { 'min' }
 
@@ -144,6 +185,8 @@ RSpec.describe SignIn::AcrTranslator do
 
         context 'and uplevel is true' do
           let(:uplevel) { true }
+
+          let(:ial2_feature_flag_enabled) { false }
           let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::LOGIN_GOV_IAL2 } }
 
           it 'returns expected translated acr value' do

--- a/spec/services/sign_in/credential_level_creator_spec.rb
+++ b/spec/services/sign_in/credential_level_creator_spec.rb
@@ -324,11 +324,6 @@ RSpec.describe SignIn::CredentialLevelCreator do
 
     context 'when type is some other supported value' do
       let(:type) { SignIn::Constants::Auth::IDME }
-      let(:flipper_enabled) { false }
-
-      before do
-        allow(Flipper).to receive(:enabled?).with(:identity_ial2_enforcement).and_return(flipper_enabled)
-      end
 
       context 'and user info level of assurance equals idme classic loa3' do
         let(:level_of_assurance) { SignIn::Constants::Auth::LOA_THREE }
@@ -466,67 +461,6 @@ RSpec.describe SignIn::CredentialLevelCreator do
               it_behaves_like 'a created credential level'
             end
           end
-        end
-      end
-
-      context 'when identity_ial2_enforcement flipper is enabled' do
-        let(:flipper_enabled) { true }
-
-        context 'and user has IAL2 credential' do
-          let(:credential_ial) { SignIn::Constants::Auth::IAL_TWO }
-          let(:level_of_assurance) { 'some-level-of-assurance' }
-          let(:expected_max_ial) { SignIn::Constants::Auth::IAL_TWO }
-          let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
-
-          it_behaves_like 'a created credential level'
-        end
-
-        context 'and user has LOA3 but is not previously verified' do
-          let(:level_of_assurance) { SignIn::Constants::Auth::LOA_THREE }
-          let(:credential_ial) { SignIn::Constants::Auth::IDME_CLASSIC_LOA3 }
-          let(:expected_max_ial) { SignIn::Constants::Auth::IAL_ONE }
-          let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
-
-          it_behaves_like 'a created credential level'
-        end
-
-        context 'and user has classic_loa3 credential with LOA3 level_of_assurance and is previously verified' do
-          let(:level_of_assurance) { SignIn::Constants::Auth::LOA_THREE }
-          let(:credential_ial) { SignIn::Constants::Auth::IDME_CLASSIC_LOA3 }
-          let(:expected_max_ial) { SignIn::Constants::Auth::IAL_TWO }
-          let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
-          let!(:user_verification) { create(:idme_user_verification, idme_uuid: sub) }
-
-          it_behaves_like 'a created credential level'
-        end
-
-        context 'and user has classic_loa3 credential and is previously verified but not loa3 level_of_assurance' do
-          let(:level_of_assurance) { 'some-level-of-assurance' }
-          let(:credential_ial) { SignIn::Constants::Auth::IDME_CLASSIC_LOA3 }
-          let(:expected_max_ial) { SignIn::Constants::Auth::IAL_ONE }
-          let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
-          let(:validation_error_message) { 'Validation failed: Max ial cannot be less than Current ial' }
-          let!(:user_verification) { create(:idme_user_verification, idme_uuid: sub) }
-
-          it_behaves_like 'invalid credential level error'
-        end
-
-        context 'and user has classic_loa3 credential but is not previously verified' do
-          let(:level_of_assurance) { 'some-level-of-assurance' }
-          let(:credential_ial) { SignIn::Constants::Auth::IDME_CLASSIC_LOA3 }
-          let(:expected_max_ial) { SignIn::Constants::Auth::IAL_ONE }
-          let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
-
-          it_behaves_like 'a created credential level'
-        end
-
-        context 'and user has neither IAL2 nor LOA3' do
-          let(:level_of_assurance) { 'some-level-of-assurance' }
-          let(:credential_ial) { 'some-credential-ial' }
-          let(:expected_max_ial) { SignIn::Constants::Auth::IAL_ONE }
-          let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }
-
-          it_behaves_like 'a created credential level'
         end
       end
     end


### PR DESCRIPTION
## Summary

- Created `identity_idme_ial2_enforcement` and `identity_logingov_ial2_enforcement` so we can enable each csp at different times
- Removed the previous ial2 id.me logic to determine a verified user. 
- Added new acr values
  - `urn:acr.va.gov:verified-facial-match-required`
    - Requires identity verification with facial match for all users. Even if a user has been previously verified without facial matching, they will be required to go through verification with facial match.
  - `urn:acr.va.gov:verified-facial-match-preferred`
    -   Requires identity verification. Users with no previous identity verification will be required to go through a facial match. Users with previous identity verification will use that data, even if it was done without facial match.

- These new acr values translate to the following:
  - Login.gov
    -  `urn:acr.va.gov:verified-facial-match-required` - `urn:acr.login.gov:verified-facial-match-required`
    -  `urn:acr.va.gov:verified-facial-match-preferred` - `urn:acr.login.gov:verified-facial-match-preferred`
  - ID.me 
    - `urn:acr.va.gov:verified-facial-match-required` - `http://idmanagement.gov/ns/assurance/ial/2/aal/2`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/1012

## Testing 
- Seed database - `rails db:seed`
- start `vets-api` and `vets-website`
- In the console - enable the flipper:
   ```ruby
   Flipper.enable(:identity_logingov_ial2_enforcement)
   ```
- Authenticate with login.gov with an ial1 user (you may have to create one)
- After you successfully authenticate, simulate the call on the verified page by calling `authorize` with `acr=urn:acr.va.gov:verified-facial-match-required`
   ```bash
   http://localhost:3000/v0/sign_in/authorize?type=logingov&client_id=vaweb&acr=urn:acr.va.gov:verified-facial-match-required&response_type=code&state=d30b0c56e41aea238a2fe44c4a61df72a9b2e23a2b1185bcf7d0163e&code_challenge=iqv1fQahQP8Ir5xSrgqUuhk0LFw8Dd3h4vrsTvHre6A&code_challenge_method=S256
   ```
- After you verify your user test signing in again
- Ensure the current implementation still works - disable the flipper and test authentication and verification

## What areas of the site does it impact?
Authentication, verification, Sign-in Service

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

