### PR TITLE
[Disability Benefits] rel: vets-json-schema latest version (25.2.43) bump

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,10 +74,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 1a1b735653b3687e6265093a2a66d4f37cf1b3e1
+  revision: 6f83c6cd8093b5fffe3463d2d3b794a8e91b6d4c
   branch: master
   specs:
-    vets_json_schema (25.2.42)
+    vets_json_schema (25.2.43)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): ~YES~/**NO***
- *(Summarize the changes that have been made to the platform)*
  - bumps `vets-json-schema` dependency to latest version (25.2.43)
- *(If bug, how to reproduce)*
  - The frontend is being updated to use `currentOrPastMonthYearDateUI` components which output `YYYY-MM` format, but vets-api validation rejects these payloads before they reach Lighthouse
- *(What is the solution, why is this the solution?)*
  - Updates `minimumYearDate` pattern to accept `YYYY`, `YYYY-MM`, and `YYYY-MM-DD` formats with optional `XX` placeholders for month and/or day
- *(Which team do you work for, does your team own the maintenance of this component?)*
  - Disability Benefits  🌊 Pathways team
- *(If introducing a flipper, what is the success criteria being targeted?)*
  - n/a

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/129871
- https://github.com/department-of-veterans-affairs/vets-json-schema/pull/1105
- https://github.com/department-of-veterans-affairs/vets-website/pull/41640
- https://github.com/department-of-veterans-affairs/vets-website/pull/41319

## Testing done

- *New code is covered by unit tests*
  - n/a
- *Describe what the old behavior was prior to the change*
  - The `minimumYearDate` pattern in vets-json-schema required a full `YYYY-MM-DD` format with optional `XX` placeholders for month and day. However, the Lighthouse API for 526EZ toxic exposure dates actually accepts and expects a simpler format: `YYYY` (year only) or `YYYY-MM` (year + month). The mismatch caused 422 validation errors when the frontend sent dates in the format that Lighthouse actually accepts. 
- *Describe the steps required to verify your changes are working as expected*
  - functionally tested in https://github.com/department-of-veterans-affairs/vets-json-schema/pull/1105/changes
- *If this work is behind a flipper:*
  - n/a

## What areas of the site does it impact?

- Affects validation of date field entries from the Toxic Exposure section submitted as part of form 526

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
