### PR TITLE
130349: change expense description to max 2000 chars

### DIFF
--- a/modules/travel_pay/app/models/travel_pay/base_expense.rb
+++ b/modules/travel_pay/app/models/travel_pay/base_expense.rb
@@ -15,7 +15,7 @@ module TravelPay
     attr_accessor :receipt
 
     validates :purchase_date, presence: true, unless: -> { is_a?(MileageExpense) }
-    validates :description, length: { maximum: 255 }, allow_nil: true, unless: -> { is_a?(MileageExpense) }
+    validates :description, length: { maximum: 2000 }, allow_nil: true, unless: -> { is_a?(MileageExpense) }
     validates :cost_requested, presence: true, numericality: { greater_than: 0 }, unless: -> { is_a?(MileageExpense) }
 
     # Returns the list of permitted parameters for this expense type

--- a/modules/travel_pay/spec/models/travel_pay/base_expense_spec.rb
+++ b/modules/travel_pay/spec/models/travel_pay/base_expense_spec.rb
@@ -83,14 +83,14 @@ RSpec.describe TravelPay::BaseExpense, type: :model do
         expect(subject.errors[:description]).to be_empty
       end
 
-      it 'requires description to be 255 characters or less when present' do
-        subject.description = 'a' * 256
+      it 'requires description to be 2000 characters or less when present' do
+        subject.description = 'a' * 2001
         expect(subject).not_to be_valid
-        expect(subject.errors[:description]).to include('is too long (maximum is 255 characters)')
+        expect(subject.errors[:description]).to include('is too long (maximum is 2000 characters)')
       end
 
-      it 'allows description of exactly 255 characters' do
-        subject.description = 'a' * 255
+      it 'allows description of exactly 2000 characters' do
+        subject.description = 'a' * 2000
         expect(subject).to be_valid
       end
     end


### PR DESCRIPTION
## Summary

This PR ups the max allowed characters for the expense's description field from 255 to 2000.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/130349

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
The expense validation previously allowed a max of 255 characters. Now it allows a max of 2000 characters, matching what the BTSSS API expects.

## Screenshots
N/A

## What areas of the site does it impact?
Travel pay complex claims

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
