### PR TITLE
IVC: Log supporting docs validation errors

### DIFF
--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/uploads_controller.rb
@@ -331,7 +331,11 @@ module IvcChampva
             "submit_supporting_documents attachment.file size: #{number_to_human_size(attachment.file&.size)}"
           )
 
-          raise Common::Exceptions::ValidationErrors, attachment unless attachment.valid?
+          unless attachment.valid?
+            error_msgs = attachment.errors.full_messages.join(', ')
+            Rails.logger.error "submit_supporting_documents attachment is invalid: #{error_msgs}"
+            raise Common::Exceptions::ValidationErrors, attachment
+          end
 
           attachment.save
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*

CHAMPVA Forms: Logs validation errors when uploading supporting documents

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/128842

## Testing done

Will monitor Datadog logs

## What areas of the site does it impact?
CHAMPVA forms

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
