### PR TITLE
129438 add mhv_secure_messaging_can_reply_field feature toggle

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1378,6 +1378,9 @@ features:
   mhv_supply_reordering_enabled:
     actor_type: user
     description: Enables the launch of mhv supply reordering application at /my-health/order-medical-supplies
+  mhv_secure_messaging_can_reply_field:
+    actor_type: user
+    description: Enables/disables Secure Messaging use of canReply field from SM API
   mhv_secure_messaging_cerner_pilot:
     actor_type: user
     description: Enables/disables Secure Messaging Cerner Transition Pilot environment on VA.gov and VHAB


### PR DESCRIPTION
## Summary
Adding a feature toggle for [129438](https://github.com/department-of-veterans-affairs/va.gov-team/issues/129438)


## Related issue(s)
[129438](https://github.com/department-of-veterans-affairs/va.gov-team/issues/129438)
[Frontend feature toggle PR](https://github.com/department-of-veterans-affairs/vets-website/pull/41653)