### PR TITLE
do not override PdfS3Operations s3_signed_url

### DIFF
--- a/modules/medical_expense_reports/app/controllers/medical_expense_reports/v0/claims_controller.rb
+++ b/modules/medical_expense_reports/app/controllers/medical_expense_reports/v0/claims_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'simple_forms_api/form_remediation/uploader'
 require 'medical_expense_reports/benefits_intake/submit_claim_job'
 require 'medical_expense_reports/monitor'
 require 'medical_expense_reports/zsf_config'
@@ -15,6 +14,7 @@ module MedicalExpenseReports
       include PdfS3Operations
 
       before_action :check_flipper_flag
+      skip_after_action :set_csrf_header, only: [:create]
       service_tag 'medical-expense-reports-application'
 
       # an identifier that matches the parameter that the form will be set as in the JSON submission.

--- a/modules/survivors_benefits/app/controllers/survivors_benefits/v0/claims_controller.rb
+++ b/modules/survivors_benefits/app/controllers/survivors_benefits/v0/claims_controller.rb
@@ -12,7 +12,9 @@ module SurvivorsBenefits
     #
     class ClaimsController < ClaimsBaseController
       include PdfS3Operations
+
       before_action :check_flipper_flag
+      skip_after_action :set_csrf_header, only: [:create]
       service_tag 'survivors-benefits'
 
       # an identifier that matches the parameter that the form will be set as in the JSON submission.
@@ -120,14 +122,6 @@ module SurvivorsBenefits
       #
       def monitor
         @monitor ||= SurvivorsBenefits::Monitor.new
-      end
-
-      def config
-        Settings.bio.survivors_benefits
-      end
-
-      def pdf_url(guid)
-        SimpleFormsApi::FormRemediation::S3Client.fetch_presigned_url(guid, config:)
       end
     end
   end


### PR DESCRIPTION
## Summary

PdfS3Operations s3_signed_url is being overridden by the claims controller, which may be causing a different configuration object to be passed

- [x]  No error nor warning in the console.