### PR TITLE
only add radius to facilities requests when lat and long are present

### DIFF
--- a/app/controllers/v0/caregivers_assistance_claims_controller.rb
+++ b/app/controllers/v0/caregivers_assistance_claims_controller.rb
@@ -64,6 +64,8 @@ module V0
         lighthouse_facilities_params.merge(per_page: RESULTS_PER_PAGE)
       )
       render(json: lighthouse_facilities)
+    rescue => e
+      Rails.logger.error("10-10CG - Error retrieving facilities: #{e.message}", params[:facility_ids])
     end
 
     private

--- a/spec/requests/v0/caregivers_assistance_claims_spec.rb
+++ b/spec/requests/v0/caregivers_assistance_claims_spec.rb
@@ -373,5 +373,13 @@ RSpec.describe 'V0::CaregiversAssistanceClaims', type: :request do
       )
       expect(lighthouse_service).to have_received(:get_paginated_facilities).with(expected_params)
     end
+
+    it 'logs an error when the facilities request fails' do
+      text = 'Lighthouse error message text'
+      expect(lighthouse_service).to receive(:get_paginated_facilities).and_raise(StandardError.new(text))
+      expect(Rails.logger).to receive(:error).with("10-10CG - Error retrieving facilities: #{text}", 'vha_123,vha_456')
+
+      post('/v0/caregivers_assistance_claims/facilities', params: params.to_json, headers:)
+    end
   end
 end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Only add the hardcoded `radius` parameter to Caregiver Facilities queries when `lat`+`long` are provided.
- This is required according to the Lighthouse API docs: https://developer.va.gov/explore/api/va-facilities/docs?version=current
- Health Applications 10-10 CG

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/130755
- https://github.com/department-of-veterans-affairs/vets-api/pull/26050

## Testing done

- [x] *New code is covered by unit tests*
- Before, we added `radius` to all queries, not realizing it would break the ones that only send `facilityIds` as a filtering param.
- To test, fill out a CG form, search for facilities, open the Network tab of the inspector, then click one that does not offer Caregiver Support services 
  - e.g., search for zip code 12345, then click on the Bennington VA Clinic, and note the 2 facilities calls that fire in response (without an error)

## What areas of the site does it impact?
10-10CG

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
