### PR TITLE
130877 vass token revoke endpoint

### DIFF
--- a/modules/vass/app/models/vass/v0/session.rb
+++ b/modules/vass/app/models/vass/v0/session.rb
@@ -107,27 +107,49 @@ module Vass
 
       ##
       # Saves the OTC to Redis with expiration.
+      # Stores identity data (last_name, dob) for verification during authentication.
       #
       # @param code [String] OTC code to save
       # @return [Boolean] true if saved successfully
       #
       def save_otc(code)
-        redis_client.save_otc(uuid:, code:)
+        redis_client.save_otc(uuid:, code:, last_name:, dob: date_of_birth)
       end
 
       ##
-      # Validates the provided OTC against the stored value.
+      # Validates the provided OTC and identity against stored values.
+      # Ensures the same last_name and dob used during OTC request are provided during authentication.
       #
-      # @return [Boolean] true if OTC matches, false otherwise
+      # @return [Boolean] true if OTC and identity match, false otherwise
       #
       def valid_otc?
         return false unless valid_for_validation?
 
-        stored_otc = redis_client.otc(uuid:)
-        return false if stored_otc.nil?
+        stored_data = redis_client.otc_data(uuid:)
+        return false if stored_data.nil?
 
-        # Constant-time comparison to prevent timing attacks
-        ActiveSupport::SecurityUtils.secure_compare(stored_otc, otp_code)
+        # Perform both checks without early returns to prevent timing attacks
+        otc_matches = ActiveSupport::SecurityUtils.secure_compare(stored_data[:code], otp_code)
+        identity_valid = identity_matches?(stored_data)
+
+        otc_matches && identity_valid
+      end
+
+      ##
+      # Checks if provided identity matches stored identity data.
+      # Uses case-insensitive comparison for last name.
+      #
+      # @param stored_data [Hash] Stored OTC data with :last_name and :dob
+      # @return [Boolean] true if identity matches
+      #
+      def identity_matches?(stored_data)
+        stored_last_name = stored_data[:last_name]&.downcase
+        stored_dob = stored_data[:dob]
+
+        provided_last_name = last_name&.downcase
+        provided_dob = date_of_birth
+
+        stored_last_name == provided_last_name && stored_dob == provided_dob
       end
 
       ##
@@ -136,8 +158,8 @@ module Vass
       # @return [Boolean] true if OTC is expired/not found
       #
       def otc_expired?
-        stored_otc = redis_client.otc(uuid:)
-        stored_otc.nil?
+        stored_data = redis_client.otc_data(uuid:)
+        stored_data.nil?
       end
 
       ##

--- a/modules/vass/spec/requests/vass/v0/sessions_spec.rb
+++ b/modules/vass/spec/requests/vass/v0/sessions_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe 'Vass::V0::Sessions', type: :request do
       before do
         # Store OTC and veteran metadata from create flow
         redis_client = Vass::RedisClient.build
-        redis_client.save_otc(uuid:, code: otp_code)
+        redis_client.save_otc(uuid:, code: otp_code, last_name:, dob: date_of_birth)
         redis_client.save_veteran_metadata(uuid:, edipi:, veteran_id: uuid)
       end
 
@@ -275,7 +275,7 @@ RSpec.describe 'Vass::V0::Sessions', type: :request do
     context 'with invalid OTC' do
       before do
         redis_client = Vass::RedisClient.build
-        redis_client.save_otc(uuid:, code: '000000')
+        redis_client.save_otc(uuid:, code: '000000', last_name:, dob: date_of_birth)
         redis_client.save_veteran_metadata(uuid:, edipi:, veteran_id: uuid)
       end
 
@@ -337,7 +337,7 @@ RSpec.describe 'Vass::V0::Sessions', type: :request do
     context 'when validation rate limit is exceeded' do
       before do
         redis_client = Vass::RedisClient.build
-        redis_client.save_otc(uuid:, code: otp_code)
+        redis_client.save_otc(uuid:, code: otp_code, last_name:, dob: date_of_birth)
         redis_client.save_veteran_metadata(uuid:, edipi:, veteran_id: uuid)
         # Exceed validation rate limit
         5.times { redis_client.increment_validation_rate_limit(identifier: uuid) }
@@ -363,7 +363,7 @@ RSpec.describe 'Vass::V0::Sessions', type: :request do
     context 'when an exception occurs during successful authentication flow' do
       before do
         redis_client = Vass::RedisClient.build
-        redis_client.save_otc(uuid:, code: otp_code)
+        redis_client.save_otc(uuid:, code: otp_code, last_name:, dob: date_of_birth)
         redis_client.save_veteran_metadata(uuid:, edipi:, veteran_id: uuid)
       end
 

--- a/modules/vass/spec/services/vass/redis_client_spec.rb
+++ b/modules/vass/spec/services/vass/redis_client_spec.rb
@@ -14,6 +14,8 @@ describe Vass::RedisClient do
   let(:uuid) { 'f5d4e6a1-b2c3-4d5e-6f7a-8b9c0d1e2f3a' }
   let(:oauth_token) { 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test.token' }
   let(:otc_code) { '123456' }
+  let(:last_name) { 'Smith' }
+  let(:dob) { '1980-01-15' }
   let(:session_token) { SecureRandom.uuid }
   let(:edipi) { '1234567890' }
   let(:veteran_id) { 'vet-uuid-123' }
@@ -123,27 +125,17 @@ describe Vass::RedisClient do
 
     context 'when OTC cache exists' do
       before do
-        Rails.cache.write(
-          "otc_#{uuid}",
-          otc_code,
-          namespace: 'vass-otc-cache',
-          expires_in: redis_otc_expiry
-        )
+        redis_client.save_otc(uuid:, code: otc_code, last_name:, dob:)
       end
 
-      it 'returns the cached OTC' do
+      it 'returns the cached OTC code' do
         expect(redis_client.otc(uuid:)).to eq(otc_code)
       end
     end
 
     context 'when OTC cache has expired' do
       before do
-        Rails.cache.write(
-          "otc_#{uuid}",
-          otc_code,
-          namespace: 'vass-otc-cache',
-          expires_in: redis_otc_expiry
-        )
+        redis_client.save_otc(uuid:, code: otc_code, last_name:, dob:)
       end
 
       it 'returns nil' do
@@ -154,19 +146,39 @@ describe Vass::RedisClient do
     end
   end
 
+  describe '#otc_data' do
+    context 'when OTC cache exists' do
+      before do
+        redis_client.save_otc(uuid:, code: otc_code, last_name:, dob:)
+      end
+
+      it 'returns hash with code, last_name, and dob' do
+        data = redis_client.otc_data(uuid:)
+        expect(data[:code]).to eq(otc_code)
+        expect(data[:last_name]).to eq(last_name)
+        expect(data[:dob]).to eq(dob)
+      end
+    end
+
+    context 'when OTC cache does not exist' do
+      it 'returns nil' do
+        expect(redis_client.otc_data(uuid:)).to be_nil
+      end
+    end
+  end
+
   describe '#save_otc' do
     it 'saves the OTC in cache with uuid key' do
-      expect(redis_client.save_otc(uuid:, code: otc_code)).to be(true)
+      expect(redis_client.save_otc(uuid:, code: otc_code, last_name:, dob:)).to be(true)
 
-      val = Rails.cache.read(
-        "otc_#{uuid}",
-        namespace: 'vass-otc-cache'
-      )
-      expect(val).to eq(otc_code)
+      data = redis_client.otc_data(uuid:)
+      expect(data[:code]).to eq(otc_code)
+      expect(data[:last_name]).to eq(last_name)
+      expect(data[:dob]).to eq(dob)
     end
 
     it 'uses shorter expiry than OAuth token' do
-      redis_client.save_otc(uuid:, code: otc_code)
+      redis_client.save_otc(uuid:, code: otc_code, last_name:, dob:)
 
       # Should still be present before OTC expiry
       Timecop.travel((redis_otc_expiry - 1.minute).from_now) do
@@ -182,7 +194,7 @@ describe Vass::RedisClient do
 
   describe '#delete_otc' do
     before do
-      redis_client.save_otc(uuid:, code: otc_code)
+      redis_client.save_otc(uuid:, code: otc_code, last_name:, dob:)
     end
 
     it 'removes the OTC from cache' do
@@ -206,16 +218,16 @@ describe Vass::RedisClient do
     let(:code2) { '222222' }
 
     it 'stores OTCs separately for different UUIDs' do
-      redis_client.save_otc(uuid: uuid1, code: code1)
-      redis_client.save_otc(uuid: uuid2, code: code2)
+      redis_client.save_otc(uuid: uuid1, code: code1, last_name:, dob:)
+      redis_client.save_otc(uuid: uuid2, code: code2, last_name:, dob:)
 
       expect(redis_client.otc(uuid: uuid1)).to eq(code1)
       expect(redis_client.otc(uuid: uuid2)).to eq(code2)
     end
 
     it 'deletes OTC for one UUID without affecting others' do
-      redis_client.save_otc(uuid: uuid1, code: code1)
-      redis_client.save_otc(uuid: uuid2, code: code2)
+      redis_client.save_otc(uuid: uuid1, code: code1, last_name:, dob:)
+      redis_client.save_otc(uuid: uuid2, code: code2, last_name:, dob:)
 
       redis_client.delete_otc(uuid: uuid1)
 


### PR DESCRIPTION
## Summary

Adds identity validation to the OTC authentication flow. The `authenticate-otc` endpoint now verifies that the `last_name` and `dob` provided during authentication match the values originally submitted when requesting the OTC.

## Changes

- **RedisClient**: `save_otc` now stores `last_name` and `dob` alongside the OTC code. Added `otc_data` method to retrieve the full stored data.
- **Session model**: `valid_otc?` validates both the OTC code and identity data (last_name, dob) against stored values. Uses case-insensitive comparison for last name.
- Constant-time comparison used to prevent timing attacks.

## Related issue(s)

https://github.com/orgs/department-of-veterans-affairs/projects/1323/views/35?pane=issue&itemId=151699017&issue=department-of-veterans-affairs%7Cva.gov-team%7C130877

## Testing done

- [ ] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
