### PR TITLE
[VACMS-23284] Refine PPMS error handling with catchall

### DIFF
--- a/modules/facilities_api/app/controllers/facilities_api/v2/facilities_error_handler.rb
+++ b/modules/facilities_api/app/controllers/facilities_api/v2/facilities_error_handler.rb
@@ -27,9 +27,11 @@ module FacilitiesApi::V2::FacilitiesErrorHandler
   rescue Common::Exceptions::BackendServiceException, Common::Client::Errors::ClientError,
          Common::Client::Errors::ParsingError => e
     json_error(method, e, 'Bad Gateway', '502', :bad_gateway)
+  rescue ActionController::ParameterMissing
+    raise # Let global ExceptionHandling format this properly
   rescue => e
     Datadog::Tracing.active_span&.set_error(e)
-    json_error("#{method}_unexpected", e, 'Internal Server Error', '500', :internal_server_error)
+    json_error("#{method}_unexpected", e, 'Internal server error', '500', :internal_server_error)
   end
 
   # Helper method to render JSON error responses

--- a/modules/facilities_api/spec/requests/facilities_api/v2/ccp_spec.rb
+++ b/modules/facilities_api/spec/requests/facilities_api/v2/ccp_spec.rb
@@ -604,13 +604,14 @@ RSpec.describe 'FacilitiesApi::V2::Ccp', team: :facilities, type: :request, vcr:
           mock_span = instance_double(Datadog::Tracing::Span)
           allow(Datadog::Tracing).to receive(:active_span).and_return(mock_span)
           allow(mock_span).to receive(:set_error)
+          allow(mock_span).to receive(:service=)
 
           get '/facilities_api/v2/ccp',
               params: { lat: 40.0, long: -74.0, type: 'provider', specialties: ['213E00000X'] }
 
           expect(response).to have_http_status(:internal_server_error)
           response_json = JSON.parse(response.body)
-          expect(response_json['errors'].first['title']).to eq('Internal Server Error')
+          expect(response_json['errors'].first['title']).to eq('Internal server error')
           expect(response_json['errors'].first['code']).to eq('500')
           expect(mock_span).to have_received(:set_error).with(instance_of(RuntimeError))
         end
@@ -626,7 +627,7 @@ RSpec.describe 'FacilitiesApi::V2::Ccp', team: :facilities, type: :request, vcr:
 
           expect(response).to have_http_status(:internal_server_error)
           response_json = JSON.parse(response.body)
-          expect(response_json['errors'].first['title']).to eq('Internal Server Error')
+          expect(response_json['errors'].first['title']).to eq('Internal server error')
         end
       end
     end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- Adds error handling for CCP endpoints for FacilitiesApi::V2::CcpController
- Followup from https://github.com/department-of-veterans-affairs/vets-api/pull/26104

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/23284

## Testing done

- [x] *New code is covered by unit tests* (the code currently testing errors seems to cover the tested error scenarios -- we can add more but I can't record cassettes locally due to lack of AWS creds for port forwarding to PPMS)
- Old behavior was to not handle errors
- Use RI to request `/facilities_api/v2/ccp/provider?specialties[]=111NI0900X&page=1&per_page=15&radius=68&address=Playhouse%20District,%20Pasadena,%20California,%20United%20States&bbox[]=-118.51976099999999&bbox[]=33.765853&bbox[]=-117.759761&bbox[]=34.525853000000005&latitude=34.145853&longitude=-118.139761`
- Then keep decreasing the radius to give no responses and a 404 that should be handled

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Facility Locator

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [NA]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [NA]  I added a screenshot of the developed feature

## Requested Feedback

Check that code is appropriate and that flipper doesn't add too much burden. We can remove that part if needed. Though, since it's new to capture errors for Facilities, I'd like to have that.