### PR TITLE
bmt1/125013: Claim Title Mappings for "Request for substitution of claimant on record"

### DIFF
--- a/lib/benefits_claims/title_generator.rb
+++ b/lib/benefits_claims/title_generator.rb
@@ -38,13 +38,14 @@ module BenefitsClaims
     VETERANS_PENSION_CODES = %w[180AILP 180ORGPENPMC 180ORGPEN].freeze
     SURVIVORS_PENSION_CODES = %w[190ORGDPN 190ORGDPNPMC 190AID 140ISD 687NRPMC].freeze
     DIC_CODES = %w[290DICEDPMC 020SMDICPMC 020IRDICPMC].freeze
-    SUBSTITUTION_CODES = %w[290SCNR 290SCPMC 290SCR].freeze
 
     GENERIC_PENSION_CODES = %w[
       150ELECPMC 150INCNWPMC 150INCPMC 120INCPMC 150NWTHPMC
       120SUPHCDPMC 120ILCP7PMC 120SMPPMC 150MERPMC 120ASMP
       120ARP 150AIA 600APCDP 600PCDPPM 696MROCPMC
     ].freeze
+
+    CLAIMANT_SUBSTITUTION_CODES = %w[290SCNR 290SCPMC 290SCR].freeze
 
     DISABILITY_COMPENSATION_CODES = %w[
       010INITMORE8 010LCOMP 010LCOMPBDD 020CLMINC 020NEW 020NI 020SUPP 110INITLESS8 110LCOMP7
@@ -79,19 +80,19 @@ module BenefitsClaims
         )
       end
 
-      # Add substitution codes
-      SUBSTITUTION_CODES.each do |code|
-        mapping[code] = Title.new(
-          display_title: 'Request for substitution of claimant on record',
-          claim_type_base: 'request for substitution of claimant on record'
-        )
-      end
-
       # Add generic pension codes (remaining from pensionClaimTypeCodes)
       GENERIC_PENSION_CODES.each do |code|
         mapping[code] = Title.new(
           display_title: 'Claim for pension',
           claim_type_base: 'pension claim'
+        )
+      end
+
+      # Add claimant substitution codes
+      CLAIMANT_SUBSTITUTION_CODES.each do |code|
+        mapping[code] = Title.new(
+          display_title: 'Request for substitution of claimant on record',
+          claim_type_base: 'request for substitution of claimant on record'
         )
       end
 

--- a/spec/lib/benefits_claims/title_generator_spec.rb
+++ b/spec/lib/benefits_claims/title_generator_spec.rb
@@ -59,19 +59,6 @@ RSpec.describe BenefitsClaims::TitleGenerator do
         end
       end
 
-      context 'with substitution codes' do
-        BenefitsClaims::TitleGenerator::SUBSTITUTION_CODES.each do |code|
-          it "returns substitution title for code #{code}" do
-            result = described_class.generate_titles('Some Type', code)
-
-            expect(result).to eq({
-                                   display_title: 'Request for substitution of claimant on record',
-                                   claim_type_base: 'request for substitution of claimant on record'
-                                 })
-          end
-        end
-      end
-
       context 'with generic pension codes' do
         BenefitsClaims::TitleGenerator::GENERIC_PENSION_CODES.each do |code|
           it "returns generic pension title for code #{code}" do
@@ -80,6 +67,19 @@ RSpec.describe BenefitsClaims::TitleGenerator do
             expect(result).to eq({
                                    display_title: 'Claim for pension',
                                    claim_type_base: 'pension claim'
+                                 })
+          end
+        end
+      end
+
+      context 'with claimant substitution codes' do
+        BenefitsClaims::TitleGenerator::CLAIMANT_SUBSTITUTION_CODES.each do |code|
+          it "returns substitution title for code #{code}" do
+            result = described_class.generate_titles('Some Type', code)
+
+            expect(result).to eq({
+                                   display_title: 'Request for substitution of claimant on record',
+                                   claim_type_base: 'request for substitution of claimant on record'
                                  })
           end
         end
@@ -357,10 +357,20 @@ RSpec.describe BenefitsClaims::TitleGenerator do
       end
     end
 
-    describe 'SUBSTITUTION_CODES' do
+    describe 'CLAIMANT_SUBSTITUTION_CODES' do
       it 'contains the expected codes' do
         expected = %w[290SCNR 290SCPMC 290SCR]
-        expect(BenefitsClaims::TitleGenerator::SUBSTITUTION_CODES).to eq(expected)
+        expect(BenefitsClaims::TitleGenerator::CLAIMANT_SUBSTITUTION_CODES).to eq(expected)
+      end
+
+      it 'contains unique codes' do
+        codes = BenefitsClaims::TitleGenerator::CLAIMANT_SUBSTITUTION_CODES
+        expect(codes.uniq.length).to eq(codes.length)
+      end
+
+      it 'contains only string values' do
+        codes = BenefitsClaims::TitleGenerator::CLAIMANT_SUBSTITUTION_CODES
+        expect(codes.all? { |code| code.is_a?(String) }).to be true
       end
     end
 
@@ -410,6 +420,15 @@ RSpec.describe BenefitsClaims::TitleGenerator do
 
         all_pension_codes.each do |code|
           expect(mapping).to have_key(code)
+        end
+      end
+
+      it 'includes all claimant substitution codes' do
+        mapping = BenefitsClaims::TitleGenerator::CLAIM_TYPE_CODE_MAPPING
+        BenefitsClaims::TitleGenerator::CLAIMANT_SUBSTITUTION_CODES.each do |code|
+          expect(mapping).to have_key(code)
+          expect(mapping[code].display_title).to eq('Request for substitution of claimant on record')
+          expect(mapping[code].claim_type_base).to eq('request for substitution of claimant on record')
         end
       end
 


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES*
- Map EP Codes 290SCNR, 290SCPMC, and 290SCR Claim Titles to "Request for substitution of claimant on record"

## Related issue(s)

- [CST] Implement next set of claim title improvements #125013
## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
n/a

## What areas of the site does it impact?
Claim list in the Claim Status Tool 

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

