### PR TITLE
[mobile] Add push notification event bus flipper

### DIFF
--- a/modules/mobile/app/controllers/mobile/v0/push_notifications_controller.rb
+++ b/modules/mobile/app/controllers/mobile/v0/push_notifications_controller.rb
@@ -5,7 +5,7 @@ require 'vetext/service'
 module Mobile
   module V0
     class PushNotificationsController < ApplicationController
-      BENEFITS_DOC_PUSH_NAME = 'benefits claims and decision reviews'
+      BENEFITS_DOC_PUSH_ID = 'claim_status_updates'
 
       def register
         begin
@@ -34,7 +34,7 @@ module Mobile
         response = service.get_preferences(params[:endpoint_sid]).body
         # Remove Benefits Documents push notification preference if the feature flag is disabled
         unless Flipper.enabled?(:event_bus_gateway_letter_ready_push_notifications, @current_user)
-          response.reject! { |pref| pref[:preference_name].downcase == BENEFITS_DOC_PUSH_NAME }
+          response.reject! { |pref| pref[:preference_id] == BENEFITS_DOC_PUSH_ID }
         end
         render json: Mobile::V0::PushGetPrefsSerializer.new(params[:endpoint_sid],
                                                             response)

--- a/modules/mobile/spec/requests/mobile/v0/push/prefs_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/push/prefs_spec.rb
@@ -20,13 +20,6 @@ RSpec.describe 'Mobile::V0::Push::Prefs', type: :request do
           {
             auto_opt_in: false,
             endpoint_sid: '8c258cbe573c462f912e7dd74585a5a9',
-            preference_name: 'Claim Status Updates',
-            preference_id: 'claim_status_updates',
-            value: true
-          },
-          {
-            auto_opt_in: false,
-            endpoint_sid: '8c258cbe573c462f912e7dd74585a5a9',
             preference_name: 'Benefits claims and decision reviews',
             preference_id: 'claim_status_updates',
             value: true
@@ -55,7 +48,7 @@ RSpec.describe 'Mobile::V0::Push::Prefs', type: :request do
           get '/mobile/v0/push/prefs/8c258cbe573c462f912e7dd74585a5a9', headers: sis_headers
           expect(response).to have_http_status(:ok)
           expect(response.body).to match_json_schema('get_prefs')
-          expect(response.body).to include('Benefits claims and decision reviews')
+          expect(response.body).to include('claim_status_updates')
         end
       end
 
@@ -69,7 +62,7 @@ RSpec.describe 'Mobile::V0::Push::Prefs', type: :request do
           get '/mobile/v0/push/prefs/8c258cbe573c462f912e7dd74585a5a9', headers: sis_headers
           expect(response).to have_http_status(:ok)
           expect(response.body).to match_json_schema('get_prefs')
-          expect(response.body).not_to include('Benefits claims and decision reviews')
+          expect(response.body).not_to include('claim_status_updates')
         end
       end
     end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/~~NO~~*
- *(Summarize the changes that have been made to the platform)*
In an effort to synchronize with the benefits decision letter availability, we want to place the letters push notification behind the same flipper flag that is already being used. This change will only allow the benefits decision letter push notification to show when the feature is fully released.
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*
Put the push notification for the benefits decision letter behind a feature flag.
- *(Which team do you work for, does your team own the maintenance of this component?)*
VA Mobile team
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
Ticket [#12410](https://github.com/department-of-veterans-affairs/va-mobile-app/issues/12410)
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
It would show the claims status updates id push notification if available
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots

## What areas of the site does it impact?
None

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

