### PR TITLE
126098 - Return a transaction response on update requests to the Person Settings service

### DIFF
--- a/lib/va_profile/person_settings/service.rb
+++ b/lib/va_profile/person_settings/service.rb
@@ -4,6 +4,7 @@
 # development and not fully integrated, gated behind the profile_scheduling_preferences
 # feature flag via the SchedulingPreferencesController.
 
+require 'va_profile/contact_information/v2/transaction_response'
 require 'va_profile/person_settings/configuration'
 require 'va_profile/person_settings/person_options_response'
 

--- a/spec/lib/va_profile/person_settings/service_spec.rb
+++ b/spec/lib/va_profile/person_settings/service_spec.rb
@@ -77,7 +77,18 @@ RSpec.describe VAProfile::PersonSettings::Service do
       let(:mock_response) do
         double('response',
                status: 200,
-               body: { bio: { personOptions: [] } })
+               body: {
+                 'tx_audit_id' => 'test-transaction-123',
+                 'status' => 'COMPLETED_SUCCESS',
+                 'tx_status' => 'COMPLETED_SUCCESS',
+                 'tx_type' => 'PUSH',
+                 'tx_interaction_type' => 'ATTENDED',
+                 'tx_push_input' => {
+                   'person_options' => []
+                 },
+                 'tx_output' =>
+                 [{ 'person_options' => [] }]
+               })
       end
 
       before do
@@ -94,6 +105,8 @@ RSpec.describe VAProfile::PersonSettings::Service do
       it 'returns a PersonOptionsTransactionResponse' do
         response = subject.update_person_options(person_options_data)
         expect(response).to be_a(VAProfile::ContactInformation::V2::PersonOptionsTransactionResponse)
+        expect(response.transaction).to be_a(VAProfile::Models::Transaction)
+        expect(response.transaction.id).to be_present
       end
     end
 


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary
This PR updates the `VAProfile::PersonSettings::Service#update_person_options` method to return a `PersonOptionsTransactionResponse` object. This fixes a bug in which this method incorrectly returned a `PersonOptionsResponse` object, which resulted in 500 errors. From the error trace in Datadog:
> "NoMethodError: undefined method `transaction` for an instance of VAProfile::PersonSettings::PersonOptionsResponse".

- *This work is behind a feature toggle (flipper): YES - `profile_scheduling_preferences`*
- Team: Authenticated Experience

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/126098

## Testing done

- [x] *New code is covered by unit tests*

Added tests to confirm the response type for both `get_person_options` and `update_person_options` methods

 I ran the following in rails console to verify that the `PersonOptionsTransactionResponse` object responds to the `transaction` method:
```ruby
require 'va_profile/contact_information/v2/transaction_response'

mock_response = OpenStruct.new(
  status: 200,
  body: {
    'tx_audit_id' => 'test-transaction-123',
    'status' => 'COMPLETED_SUCCESS',
    'tx_status' => 'COMPLETED_SUCCESS',
    'tx_type' => 'PUSH',
    'tx_interaction_type' => 'ATTENDED',
    'tx_push_input' => {
      'person_options' => []
    },
    'tx_output' =>
    [{ 'person_options' => [] }]
  }
)

response = VAProfile::ContactInformation::V2::PersonOptionsTransactionResponse.from(mock_response)
response.respond_to?(:transaction)
# => true
```

## What areas of the site does it impact?
VA.gov Profile > Health care settings > Scheduling preferences

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
