### PR TITLE
Fix Missing Directory Console1984 logs 

### DIFF
--- a/app/sidekiq/console1984_log_upload_job.rb
+++ b/app/sidekiq/console1984_log_upload_job.rb
@@ -30,6 +30,7 @@ class Console1984LogUploadJob
   end
 
   def create_log_file
+    FileUtils.mkdir_p(folder_path)
     File.write(file_path, JSON.pretty_generate(sessions_data))
   end
 
@@ -64,8 +65,12 @@ class Console1984LogUploadJob
     "console1984_logs_#{yesterday}.json"
   end
 
+  def folder_path
+    'tmp/console_access_logs'
+  end
+
   def file_path
-    Rails.root.join('tmp', 'console_access_logs', filename).to_s
+    Rails.root.join(folder_path + "/#{filename}").to_s
   end
 
   def sessions_data


### PR DESCRIPTION
## Summary

- Create directory `tmp/console_access_logs` if it doesn't exist

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127976

## Testing done

- [x] Manual testing locally

## Acceptance criteria

- [x] Directory is created
- [x] File is created