### PR TITLE
Bio/130419/gcio p1 001 create database migration for form intake submissions indexes

### DIFF
--- a/db/migrate/20260126173802_add_indexes_to_form_intake_submissions.rb
+++ b/db/migrate/20260126173802_add_indexes_to_form_intake_submissions.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class AddIndexesToFormIntakeSubmissions < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    # Indexes for common query patterns
+    # Using algorithm: :concurrently to avoid table locks in production
+    
+    add_index :form_intake_submissions, :aasm_state,
+              algorithm: :concurrently
+              
+    add_index :form_intake_submissions, :benefits_intake_uuid,
+              algorithm: :concurrently
+              
+    add_index :form_intake_submissions, %i[form_submission_id aasm_state],
+              name: 'idx_form_intake_sub_on_form_sub_id_and_state',
+              algorithm: :concurrently
+              
+    add_index :form_intake_submissions, %i[aasm_state created_at],
+              name: 'idx_form_intake_sub_on_state_and_created',
+              algorithm: :concurrently
+              
+    add_index :form_intake_submissions, :form_intake_submission_id,
+              unique: true,
+              name: 'idx_form_intake_sub_on_intake_id',
+              where: "form_intake_submission_id IS NOT NULL",
+              algorithm: :concurrently
+              
+    add_index :form_intake_submissions, :last_attempted_at,
+              name: 'idx_form_intake_sub_on_last_attempted',
+              where: "aasm_state = 'pending'",
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_23_162837) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_26_173802) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "fuzzystrmatch"
@@ -1185,7 +1185,13 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_23_162837) do
     t.datetime "last_attempted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["aasm_state", "created_at"], name: "idx_form_intake_sub_on_state_and_created"
+    t.index ["aasm_state"], name: "index_form_intake_submissions_on_aasm_state"
+    t.index ["benefits_intake_uuid"], name: "index_form_intake_submissions_on_benefits_intake_uuid"
+    t.index ["form_intake_submission_id"], name: "idx_form_intake_sub_on_intake_id", unique: true, where: "(form_intake_submission_id IS NOT NULL)"
+    t.index ["form_submission_id", "aasm_state"], name: "idx_form_intake_sub_on_form_sub_id_and_state"
     t.index ["form_submission_id"], name: "index_form_intake_submissions_on_form_submission_id"
+    t.index ["last_attempted_at"], name: "idx_form_intake_sub_on_last_attempted", where: "((aasm_state)::text = 'pending'::text)"
   end
 
   create_table "form_submission_attempts", force: :cascade do |t|


### PR DESCRIPTION
## What This Does

this is a follow on PR to add the indexes for PR #26113

Adds architecture documentation and foundation for sending structured form data to GCIO's digitization API after successful Lighthouse PDF uploads.

**Why**: IBM Mail Automation needs structured JSON data to process PDFs correctly into VBMS. This data must be available at GCIO before IBM queries for it.

## What's Included

### 🗄️ Database Migration (GCIO-001 Completed)
- New table: `form_intake_submissions`
- Tracks GCIO API submission attempts
- Encrypted PII fields (Lockbox + KMS)
- Links to existing `form_submissions` via foreign key
- Stores `benefits_intake_uuid` for correlation

## Key Architecture Decisions

**Security**: All PII encrypted using Lockbox + KMS
- Follows existing vets-api patterns
- Encrypted at rest in database

**Routing**: Through fwdproxy with mTLS authentication
- Secure egress to external GCIO API
- Certificates managed in AWS SSM Parameter Store

## Testing

- [x] Migration runs successfully
- [x] Migration is reversible (tested rollback)
- [x] Table structure verified
- [x] All indexes created (will be created in next PR) 


## Deployment Notes

- Migration safe to run in production (creates new table, no changes to existing)
- Feature flags not yet added (comes in GCIO-004)
- Zero impact to existing functionality


