### PR TITLE
2288: update tsa letter policy to match front end

### DIFF
--- a/app/policies/tsa_letter_policy.rb
+++ b/app/policies/tsa_letter_policy.rb
@@ -2,6 +2,6 @@
 
 TsaLetterPolicy = Struct.new(:user, :tsa_letter) do
   def access?
-    user.present? && user.icn.present?
+    user.present? && user.loa3?
   end
 end

--- a/app/policies/tsa_letter_policy.rb
+++ b/app/policies/tsa_letter_policy.rb
@@ -2,6 +2,6 @@
 
 TsaLetterPolicy = Struct.new(:user, :tsa_letter) do
   def access?
-    user.present? && user.loa3?
+    user.present? && user.loa3? && user.icn.present?
   end
 end

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -96,8 +96,8 @@ RSpec.describe 'VO::TsaLetter', type: :request do
       end
     end
 
-    context 'when user does not have an ICN' do
-      let(:user) { build(:user, icn: nil) }
+    context 'when user is not loa3' do
+      let(:user) { build(:user, :loa1) }
 
       it 'renders 403' do
         get '/v0/tsa_letter'
@@ -133,8 +133,8 @@ RSpec.describe 'VO::TsaLetter', type: :request do
       end
     end
 
-    context 'when user does not have an ICN' do
-      let(:user) { build(:user, icn: nil) }
+    context 'when user is not loa3' do
+      let(:user) { build(:user, :loa1) }
 
       it 'renders 403' do
         get "/v0/tsa_letter/#{document_id}/version/#{version_id}/download"

--- a/spec/requests/v0/tsa_letter_spec.rb
+++ b/spec/requests/v0/tsa_letter_spec.rb
@@ -96,8 +96,8 @@ RSpec.describe 'VO::TsaLetter', type: :request do
       end
     end
 
-    context 'when user is not loa3' do
-      let(:user) { build(:user, :loa1) }
+    context 'when user is not loa3 or does not have an icn' do
+      let(:user) { build(:user, :loa1, icn: nil) }
 
       it 'renders 403' do
         get '/v0/tsa_letter'
@@ -133,8 +133,8 @@ RSpec.describe 'VO::TsaLetter', type: :request do
       end
     end
 
-    context 'when user is not loa3' do
-      let(:user) { build(:user, :loa1) }
+    context 'when user is not loa3 or does not have an icn' do
+      let(:user) { build(:user, :loa1, icn: nil) }
 
       it 'renders 403' do
         get "/v0/tsa_letter/#{document_id}/version/#{version_id}/download"


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES
- This PR updates the tsa letter access policy to match the front end.
- I work for the CVE team.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-iir/issues/2288

## Testing done

- [x] *New code is covered by unit tests*
- Just updates access policy.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
TSA letter download.

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
