### PR TITLE
130877 vass token revoken endpoint

### DIFF
--- a/modules/vass/app/controllers/concerns/vass/jwt_authentication.rb
+++ b/modules/vass/app/controllers/concerns/vass/jwt_authentication.rb
@@ -142,6 +142,19 @@ module Vass
     end
 
     ##
+    # Decodes JWT without expiration verification.
+    # Used for token revocation - users should be able to logout even with expired tokens.
+    #
+    # @param token [String] JWT token
+    # @return [Hash, nil] Decoded payload or nil if invalid signature/format
+    #
+    def decode_jwt_for_revocation(token)
+      JWT.decode(token, jwt_secret, true, { algorithm: 'HS256', verify_expiration: false })[0]
+    rescue JWT::DecodeError
+      nil
+    end
+
+    ##
     # Returns JWT secret from VASS configuration.
     #
     # @return [String] JWT secret key

--- a/modules/vass/config/routes.rb
+++ b/modules/vass/config/routes.rb
@@ -18,6 +18,7 @@ Vass::Engine.routes.draw do
     # OTC (One-Time Code) authentication endpoints
     post 'request-otc', to: 'sessions#request_otc'
     post 'authenticate-otc', to: 'sessions#authenticate_otc'
+    post 'revoke-token', to: 'sessions#revoke_token'
 
     # Appointment management endpoints
     get 'appointment-availability', to: 'appointments#availability' # Get appointment availability for current cohort


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES - FE access is behind feature flipper that will not be turned on until feature rollout

This pull request adds a secure token revocation (logout) endpoint to the VASS authentication system, allowing users to log out even if their JWT token is expired. It introduces a new controller action, updates the JWT decoding logic to support revocation, adds routing for the new endpoint, and provides comprehensive request specs to ensure correct behavior and error handling.

**Authentication & Revocation Functionality:**

* Added a `revoke_token` action to `SessionsController`, enabling users to revoke (logout) their JWT token. This action deletes the session from Redis and works with both valid and expired tokens.
* Added a `decode_jwt_for_revocation` method to `Vass::JwtAuthentication` that decodes JWTs without verifying expiration, allowing expired tokens to be revoked.
* Included `Vass::JwtAuthentication` in `SessionsController` to provide JWT decoding and extraction methods for the new endpoint.

**Routing:**

* Registered a new POST route `/vass/v0/revoke-token` mapped to the `revoke_token` action in `SessionsController`.

**Testing:**

* Added comprehensive request specs for the `/vass/v0/revoke-token` endpoint, covering scenarios for valid, invalid, missing, already revoked, and expired tokens, ensuring correct status codes, error messages, and session deletion behavior.

## Related issue(s)

https://github.com/orgs/department-of-veterans-affairs/projects/1323/views/35?pane=issue&itemId=151699017&issue=department-of-veterans-affairs%7Cva.gov-team%7C130877

## Testing done

- [x] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated ([link to documentation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/va-online-scheduling/initiatives/solid-start-scheduling/engineering/api-specification.md#post-vassv0revoke-token))
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
