### PR TITLE
Add EKS Env to S3 Directory for Console1984LogUploadJob

### DIFF
--- a/app/sidekiq/console1984_log_upload_job.rb
+++ b/app/sidekiq/console1984_log_upload_job.rb
@@ -38,7 +38,7 @@ class Console1984LogUploadJob
     transfer_manager.upload_file(
       file_path,
       bucket: CONSOLE_LOGS_S3_BUCKET,
-      key: "console1984/#{Settings.vsp_environmen}/#{filename}",
+      key: "console1984/#{Settings.vsp_environment}/#{filename}",
       content_type: 'application/json',
       server_side_encryption: 'AES256'
     )

--- a/spec/sidekiq/console1984_log_upload_job_spec.rb
+++ b/spec/sidekiq/console1984_log_upload_job_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Console1984LogUploadJob, type: :job do
           expect(mock_transfer_manager).to receive(:upload_file).with(
             expected_file_path.to_s,
             bucket: 'vets-api-console-access-logs',
-            key: "console1984/#{expected_filename}",
+            key: "console1984/test/#{expected_filename}",
             content_type: 'application/json',
             server_side_encryption: 'AES256'
           )
@@ -140,7 +140,7 @@ RSpec.describe Console1984LogUploadJob, type: :job do
           expect(mock_transfer_manager).to receive(:upload_file).with(
             expected_file_path.to_s,
             bucket: 'vets-api-console-access-logs',
-            key: "console1984/#{expected_filename}",
+            key: "console1984/test/#{expected_filename}",
             content_type: 'application/json',
             server_side_encryption: 'AES256'
           )


### PR DESCRIPTION
## Summary

- Add EKS environment to Console1984LogUploadJob 
- This is likely causing the failed s3 upload 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/127976

## Testing done

- [x] n/a

## Acceptance criteria

- [x]  Bucket name and path match [terraform](https://github.com/department-of-veterans-affairs/devops/blob/master/terraform/applications/vets-api/s3.tf#L32) 