### PR TITLE
Update SiS cookie delete on ssoe auth

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -115,9 +115,9 @@ module V1
 
     def delete_sign_in_service_cookies
       cookies.delete(SignIn::Constants::Auth::ACCESS_TOKEN_COOKIE_NAME)
-      cookies.delete(SignIn::Constants::Auth::REFRESH_TOKEN_COOKIE_NAME)
       cookies.delete(SignIn::Constants::Auth::ANTI_CSRF_COOKIE_NAME)
-      cookies.delete(SignIn::Constants::Auth::INFO_COOKIE_NAME)
+      cookies.delete(SignIn::Constants::Auth::INFO_COOKIE_NAME, domain: IdentitySettings.sign_in.info_cookie_domain)
+      cookies[SignIn::Constants::Auth::REFRESH_TOKEN_COOKIE_NAME] = { value: '', expires: Time.at(0).utc }
     end
 
     def set_sentry_context_for_callback


### PR DESCRIPTION
## Summary

- Rails doesn't delete cookies that are not present in the current request
- Since `vagov_refresh_token` has a path, it did not get deleted on new SSOe sessions
- This caused errors when users attempted to authenticate since it was trying to refresh a session that was already destroyed.
- To get around this we can set the refresh_token to nil and an expiry date in the past (this is what the Rails `cookie.delete` method does anyway)
- added `domain` to the `info_token` delete. From the [Rails docs](https://api.rubyonrails.org/v7.2.3/classes/ActionDispatch/Cookies.html):
  > Please note that if you specify a :domain when setting a cookie, you must also specify the domain when deleting the cookie

## Related issue(s)
-  https://github.com/department-of-veterans-affairs/identity-documentation/issues/1051

## Testing done

- Sign in with SiS
- Navigate to `http://localhost:3001/sign-in?oauth=false`
- Sign in, you should not see any errors and the SiS tokens should be deleted

## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
