### PR TITLE
Update AttributeValidator to check mismatch when new user

### DIFF
--- a/app/services/sign_in/attribute_validator.rb
+++ b/app/services/sign_in/attribute_validator.rb
@@ -20,6 +20,7 @@ module SignIn
         update_mpi_correlation_record
       else
         add_mpi_user
+        user_attribute_mismatch_checks(new_record: true)
         validate_existing_mpi_attributes
       end
 
@@ -83,11 +84,11 @@ module SignIn
       end
     end
 
-    def user_attribute_mismatch_checks
-      attribute_mismatch_check(:first_name, first_name, mpi_response_profile.given_names.first)
-      attribute_mismatch_check(:last_name, last_name, mpi_response_profile.family_name)
-      attribute_mismatch_check(:birth_date, birth_date, mpi_response_profile.birth_date)
-      attribute_mismatch_check(:ssn, ssn, mpi_response_profile.ssn, prevent_auth: true)
+    def user_attribute_mismatch_checks(new_record: false)
+      attribute_mismatch_check(:first_name, first_name, mpi_response_profile.given_names.first, new_record:)
+      attribute_mismatch_check(:last_name, last_name, mpi_response_profile.family_name, new_record:)
+      attribute_mismatch_check(:birth_date, birth_date, mpi_response_profile.birth_date, new_record:)
+      attribute_mismatch_check(:ssn, ssn, mpi_response_profile.ssn, new_record:, prevent_auth: true)
     end
 
     def validate_credential_attributes
@@ -111,24 +112,18 @@ module SignIn
                    error: Errors::CredentialMissingAttributeError)
     end
 
-    def attribute_mismatch_check(type, credential_attribute, mpi_attribute, prevent_auth: false)
+    def attribute_mismatch_check(type, credential_attribute, mpi_attribute, new_record: false, prevent_auth: false)
       return unless mpi_attribute
 
       if scrub_attribute(credential_attribute) != scrub_attribute(mpi_attribute)
         error = prevent_auth ? Errors::AttributeMismatchError : nil
 
-        error_code =
-          if type.to_sym == :ssn
-            Constants::ErrorCode::SSN_ATTRIBUTE_MISMATCH
-          else
-            Constants::ErrorCode::GENERIC_EXTERNAL_ISSUE
-          end
+        error_code = type == :ssn ? Constants::ErrorCode::SSN_ATTRIBUTE_MISMATCH : Constants::ErrorCode::GENERIC_EXTERNAL_ISSUE
 
-        handle_error(
-          "Attribute mismatch, #{type} in credential does not match MPI attribute",
-          error_code,
-          error:
-        )
+        handle_error("Attribute mismatch, #{type} in credential does not match MPI attribute",
+                     error_code,
+                     error:,
+                     new_record:)
       end
     end
 
@@ -161,11 +156,12 @@ module SignIn
       user_verification&.credential_attributes_digest != credential_attributes_digest
     end
 
-    def handle_error(error_message, error_code, error: nil, raise_error: true)
+    def handle_error(error_message, error_code, error: nil, new_record: nil, raise_error: true)
       sign_in_logger.info('attribute validator error', { errors: error_message,
                                                          code: error_code,
                                                          credential_uuid:,
                                                          mhv_icn:,
+                                                         new_record:,
                                                          type: service_name }.compact)
       raise error.new message: error_message, code: error_code if error && raise_error
     end

--- a/spec/services/sign_in/attribute_validator_spec.rb
+++ b/spec/services/sign_in/attribute_validator_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe SignIn::AttributeValidator do
       let(:mpi_service) { instance_double(MPI::Service) }
       let(:sign_in_logger) { instance_double(SignIn::Logger) }
       let(:digest) { 'some-digest-value' }
+      let(:new_record) { nil }
 
       before do
         allow(MPI::Service).to receive(:new).and_return(mpi_service)
@@ -92,6 +93,7 @@ RSpec.describe SignIn::AttributeValidator do
             code: expected_error_code,
             credential_uuid: csp_id,
             mhv_icn:,
+            new_record:,
             type: service_name }.compact
         end
 
@@ -274,10 +276,9 @@ RSpec.describe SignIn::AttributeValidator do
                                                                 { errors: expected_error_message,
                                                                   code: expected_error_code,
                                                                   credential_uuid: csp_id,
+                                                                  new_record:,
                                                                   type: service_name })
           end
-
-          it_behaves_like 'mpi call to update correlation record'
         end
 
         context 'and attribute mismatch is first_name' do
@@ -403,6 +404,7 @@ RSpec.describe SignIn::AttributeValidator do
               create(:add_person_response, status: update_status, parsed_codes: { logingov_uuid: })
             end
             let(:update_status) { :ok }
+            let(:new_record) { false }
 
             it_behaves_like 'mpi versus credential mismatch'
             it_behaves_like 'mpi call to update correlation record'
@@ -453,6 +455,12 @@ RSpec.describe SignIn::AttributeValidator do
 
           context 'and mpi add person call is successful' do
             let(:status) { :ok }
+
+            context 'and mpi vs credential mismatch checks run' do
+              let(:new_record) { true }
+
+              it_behaves_like 'mpi versus credential mismatch'
+            end
 
             it_behaves_like 'mpi attribute validations'
           end
@@ -567,6 +575,7 @@ RSpec.describe SignIn::AttributeValidator do
                                                                       code: SignIn::Constants::ErrorCode::GENERIC_EXTERNAL_ISSUE,
                                                                       credential_uuid: csp_id,
                                                                       mhv_icn:,
+                                                                      new_record: false,
                                                                       type: service_name })
               end
             end


### PR DESCRIPTION
## Summary

- Run user_attribute_mismatch_checks after new user is created in mpi
- Add `new_record` attr to log payload to differentiate new or existing mpi_record

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/1050

## Testing 
- Add breakpoint after `add_user` in AttributeValidator
- in vets-api-mockdata find the `mvi/profile_idme_uuid/{user_idme_uuid}.yml` of the user you are signing in with
- add a prefix to the file name e.g. - `1234-{uuid}.yml`
- Change the ssn number in that file 
- Sign in wil SiS
- when you hit the breakpoint remove the prefix you added from the mockdata file and continue
- You should see a log like this with `new_record: true` - 
   ```ruby
   [SignInService] [SignIn::AttributeValidator] attribute validator error -- { :errors => "Attribute mismatch, ssn in credential does not match MPI attribute", :code => "113", :credential_uuid => "88f572d491af46efa393cba6c351e252", :new_record => true, :type => "idme" }
   ```
- It should prevent you from completing authentication

## What areas of the site does it impact?
Sign-in Service, authentication

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

