### PR TITLE
Upgrade brakeman to 8.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,7 +296,7 @@ GEM
     blueprinter (1.2.1)
     bootsnap (1.20.1)
       msgpack (~> 1.2)
-    brakeman (7.1.2)
+    brakeman (8.0.0)
       racc
     breakers (1.0)
       base64 (~> 0.2)


### PR DESCRIPTION
## Summary

- Run `bundle update brakeman --conservative` and try to narrowly upgrade just brakeman to 8.0.0 without touching shared libs

## Related issue(s)

- Support [thread](https://dsva.slack.com/archives/CBU0KDSB1/p1769719980283269)

## Testing done

- [x] Basic local testing