### PR TITLE
Update callback log and metrics to include operation

### DIFF
--- a/app/controllers/concerns/sign_in/sso_authorizable.rb
+++ b/app/controllers/concerns/sign_in/sso_authorizable.rb
@@ -43,7 +43,8 @@ module SignIn
 
       state_payload_jwt = StatePayloadJwtEncoder.new(code_challenge:, code_challenge_method:, client_state:,
                                                      acr: user_attributes[:acr], type: user_attributes[:type],
-                                                     client_config: client_config(client_id)).perform
+                                                     client_config: client_config(client_id),
+                                                     operation: Constants::Auth::AUTHORIZE_SSO).perform
 
       state_payload = StatePayloadJwtDecoder.new(state_payload_jwt:).perform
 

--- a/app/models/sign_in/state_payload.rb
+++ b/app/models/sign_in/state_payload.rb
@@ -4,20 +4,12 @@ module SignIn
   class StatePayload
     include ActiveModel::Validations
 
-    attr_reader(
-      :acr,
-      :client_id,
-      :type,
-      :code_challenge,
-      :client_state,
-      :code,
-      :scope,
-      :created_at
-    )
+    attr_reader :acr, :client_id, :type, :code_challenge, :client_state, :code, :scope, :created_at, :operation
 
     validates :code, :created_at, presence: true
     validates :acr, inclusion: Constants::Auth::ACR_VALUES
     validates :type, inclusion: Constants::Auth::CSP_TYPES
+    validates :operation, inclusion: Constants::Auth::OPERATION_TYPES, allow_blank: true
     validates :client_state, length: { minimum: Constants::Auth::CLIENT_STATE_MINIMUM_LENGTH }, allow_blank: true
 
     validate :confirm_client_id
@@ -27,6 +19,7 @@ module SignIn
                    client_id:,
                    type:,
                    code:,
+                   operation:,
                    scope: nil,
                    code_challenge: nil,
                    client_state: nil,
@@ -39,6 +32,7 @@ module SignIn
       @code = code
       @scope = scope
       @created_at = created_at || Time.zone.now.to_i
+      @operation = operation
 
       validate!
     end

--- a/app/services/sign_in/constants/auth.rb
+++ b/app/services/sign_in/constants/auth.rb
@@ -38,6 +38,7 @@ module SignIn
       CSP_TYPES = [IDME = 'idme', LOGINGOV = 'logingov', DSLOGON = 'dslogon', MHV = 'mhv'].freeze
       OPERATION_TYPES = [SIGN_UP = 'sign_up',
                          AUTHORIZE = 'authorize',
+                         AUTHORIZE_SSO = 'authorize_sso',
                          INTERSTITIAL_VERIFY = 'interstitial_verify',
                          INTERSTITIAL_SIGNUP = 'interstitial_signup',
                          VERIFY_CTA_AUTHENTICATED = 'verify_cta_authenticated',

--- a/app/services/sign_in/state_payload_jwt_decoder.rb
+++ b/app/services/sign_in/state_payload_jwt_decoder.rb
@@ -23,7 +23,8 @@ module SignIn
         client_state: decoded_jwt.client_state,
         code: decoded_jwt.code,
         created_at: decoded_jwt.created_at,
-        scope: decoded_jwt.scope
+        scope: decoded_jwt.scope,
+        operation: decoded_jwt.operation
       )
     end
 

--- a/app/services/sign_in/state_payload_jwt_encoder.rb
+++ b/app/services/sign_in/state_payload_jwt_encoder.rb
@@ -2,10 +2,11 @@
 
 module SignIn
   class StatePayloadJwtEncoder
-    attr_reader :acr, :client_config, :type, :code_challenge, :code_challenge_method, :client_state, :scope
+    attr_reader :acr, :client_config, :type, :code_challenge, :code_challenge_method, :client_state, :scope, :operation
 
     # rubocop:disable Metrics/ParameterLists
-    def initialize(code_challenge:, code_challenge_method:, acr:, client_config:, type:, scope: nil, client_state: nil)
+    def initialize(code_challenge:, code_challenge_method:, acr:, client_config:, type:, operation:, scope: nil,
+                   client_state: nil)
       @acr = acr
       @client_config = client_config
       @type = type
@@ -13,6 +14,7 @@ module SignIn
       @code_challenge_method = code_challenge_method
       @client_state = client_state
       @scope = scope
+      @operation = operation
     end
     # rubocop:enable Metrics/ParameterLists
 
@@ -68,7 +70,8 @@ module SignIn
         client_state: state_payload.client_state,
         code: state_payload.code,
         created_at: state_payload.created_at,
-        scope: state_payload.scope
+        scope: state_payload.scope,
+        operation: state_payload.operation
       }
     end
 
@@ -79,7 +82,8 @@ module SignIn
                                           code_challenge: remove_base64_padding(code_challenge),
                                           code: state_code,
                                           client_state:,
-                                          scope:)
+                                          scope:,
+                                          operation:)
     end
 
     def state_code

--- a/spec/controllers/v0/sign_in_controller_callback_basic_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_callback_basic_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe V0::SignInController, type: :controller do
         let(:code) { {} }
         let(:expected_error) { 'Code is not defined' }
         let(:client_id) { nil }
+        let(:operation) { nil }
 
         it_behaves_like 'callback_api_error_response'
       end
@@ -21,6 +22,7 @@ RSpec.describe V0::SignInController, type: :controller do
         let(:state) { {} }
         let(:expected_error) { 'State is not defined' }
         let(:client_id) { nil }
+        let(:operation) { nil }
 
         it_behaves_like 'callback_api_error_response'
       end
@@ -29,6 +31,7 @@ RSpec.describe V0::SignInController, type: :controller do
         let(:state_value) { 'some-state' }
         let(:expected_error) { 'State JWT is malformed' }
         let(:client_id) { nil }
+        let(:operation) { nil }
 
         it_behaves_like 'callback_api_error_response'
       end
@@ -39,6 +42,7 @@ RSpec.describe V0::SignInController, type: :controller do
         let(:encode_algorithm) { SignIn::Constants::Auth::JWT_ENCODE_ALGORITHM }
         let(:expected_error) { 'State JWT body does not match signature' }
         let(:client_id) { nil }
+        let(:operation) { nil }
 
         it_behaves_like 'callback_api_error_response'
       end

--- a/spec/controllers/v0/sign_in_controller_callback_dslogon_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_callback_dslogon_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe V0::SignInController, type: :controller do
             let(:statsd_callback_success) { SignIn::Constants::Statsd::STATSD_SIS_CALLBACK_SUCCESS }
             let(:authentication_time) { 0 }
             let(:expected_icn) { nil }
+            let(:operation) { SignIn::Constants::Auth::AUTHORIZE }
             let(:expected_logger_context) do
               {
                 type:,
@@ -84,7 +85,8 @@ RSpec.describe V0::SignInController, type: :controller do
                 acr:,
                 icn: expected_icn,
                 credential_uuid: backing_idme_uuid,
-                authentication_time:
+                authentication_time:,
+                operation:
               }
             end
             let(:meta_refresh_tag) { '<meta http-equiv="refresh" content="0;' }

--- a/spec/controllers/v0/sign_in_controller_callback_idme_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_callback_idme_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe V0::SignInController, type: :controller do
                 let(:expected_log) { '[SignInService] [V0::SignInController] callback' }
                 let(:statsd_callback_success) { SignIn::Constants::Statsd::STATSD_SIS_CALLBACK_SUCCESS }
                 let(:authentication_time) { 0 }
+                let(:operation) { SignIn::Constants::Auth::AUTHORIZE }
                 let(:expected_logger_context) do
                   {
                     type:,
@@ -119,7 +120,8 @@ RSpec.describe V0::SignInController, type: :controller do
                     acr:,
                     icn: mpi_profile.icn,
                     credential_uuid: idme_uuid,
-                    authentication_time:
+                    authentication_time:,
+                    operation:
                   }
                 end
                 let(:meta_refresh_tag) { '<meta http-equiv="refresh" content="0;' }
@@ -171,6 +173,7 @@ RSpec.describe V0::SignInController, type: :controller do
               let(:expected_log) { '[SignInService] [V0::SignInController] callback' }
               let(:statsd_callback_success) { SignIn::Constants::Statsd::STATSD_SIS_CALLBACK_SUCCESS }
               let(:authentication_time) { 0 }
+              let(:operation) { SignIn::Constants::Auth::AUTHORIZE }
               let(:expected_logger_context) do
                 {
                   type:,
@@ -179,7 +182,8 @@ RSpec.describe V0::SignInController, type: :controller do
                   acr:,
                   icn: mpi_profile.icn,
                   credential_uuid: idme_uuid,
-                  authentication_time:
+                  authentication_time:,
+                  operation:
                 }
               end
               let(:meta_refresh_tag) { '<meta http-equiv="refresh" content="0;' }

--- a/spec/controllers/v0/sign_in_controller_callback_logingov_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_callback_logingov_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe V0::SignInController, type: :controller do
               let(:expected_log) { '[SignInService] [V0::SignInController] callback' }
               let(:statsd_callback_success) { SignIn::Constants::Statsd::STATSD_SIS_CALLBACK_SUCCESS }
               let(:authentication_time) { 0 }
+              let(:operation) { SignIn::Constants::Auth::AUTHORIZE }
               let(:expected_logger_context) do
                 {
                   type:,
@@ -109,7 +110,8 @@ RSpec.describe V0::SignInController, type: :controller do
                   acr:,
                   icn: mpi_profile.icn,
                   credential_uuid: logingov_uuid,
-                  authentication_time:
+                  authentication_time:,
+                  operation:
                 }
               end
               let(:meta_refresh_tag) { '<meta http-equiv="refresh" content="0;' }

--- a/spec/factories/sign_in/state_payloads.rb
+++ b/spec/factories/sign_in/state_payloads.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
     code { SecureRandom.hex }
     created_at { Time.zone.now.to_i }
     scope { SignIn::Constants::Auth::DEVICE_SSO }
+    operation { SignIn::Constants::Auth::VERIFY_CTA_AUTHENTICATED }
 
     initialize_with do
       new(acr:,
@@ -21,7 +22,8 @@ FactoryBot.define do
           type:,
           code:,
           created_at:,
-          scope:)
+          scope:,
+          operation:)
     end
   end
 end

--- a/spec/models/sign_in/state_payload_spec.rb
+++ b/spec/models/sign_in/state_payload_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe SignIn::StatePayload, type: :model do
            code:,
            client_state:,
            created_at:,
-           scope:)
+           scope:,
+           operation:)
   end
 
   let(:code_challenge) { Base64.urlsafe_encode64(SecureRandom.hex) }
@@ -24,6 +25,7 @@ RSpec.describe SignIn::StatePayload, type: :model do
   let(:client_state) { SecureRandom.hex }
   let(:created_at) { Time.zone.now.to_i }
   let(:scope) { SignIn::Constants::Auth::DEVICE_SSO }
+  let(:operation) { SignIn::Constants::Auth::VERIFY_CTA_AUTHENTICATED }
 
   describe 'validations' do
     describe '#code' do
@@ -140,6 +142,20 @@ RSpec.describe SignIn::StatePayload, type: :model do
 
       it 'sets created_at to current time' do
         expect(subject).to eq(expected_time)
+      end
+    end
+  end
+
+  describe '#operation' do
+    subject { state_payload.operation }
+
+    context 'when operation is not in the allowed list' do
+      let(:operation) { 'invalid-operation' }
+      let(:expected_error) { ActiveModel::ValidationError }
+      let(:expected_error_message) { 'Validation failed: Operation is not included in the list' }
+
+      it 'raises validation error' do
+        expect { subject }.to raise_error(expected_error, expected_error_message)
       end
     end
   end

--- a/spec/services/sign_in/state_payload_jwt_decoder_spec.rb
+++ b/spec/services/sign_in/state_payload_jwt_decoder_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe SignIn::StatePayloadJwtDecoder do
                                          type:,
                                          code_challenge:,
                                          client_state:,
-                                         scope:).perform
+                                         scope:,
+                                         operation:).perform
     end
     let(:code_challenge) { Base64.urlsafe_encode64('some-safe-code-challenge') }
     let(:code_challenge_method) { SignIn::Constants::Auth::CODE_CHALLENGE_METHOD }
@@ -27,6 +28,7 @@ RSpec.describe SignIn::StatePayloadJwtDecoder do
     let(:created_at) { Time.zone.now.to_i }
     let(:shared_sessions) { true }
     let(:scope) { SignIn::Constants::Auth::DEVICE_SSO }
+    let(:operation) { SignIn::Constants::Auth::VERIFY_CTA_AUTHENTICATED }
 
     let(:client_state_minimum_length) { SignIn::Constants::Auth::CLIENT_STATE_MINIMUM_LENGTH }
 
@@ -47,7 +49,8 @@ RSpec.describe SignIn::StatePayloadJwtDecoder do
           type:,
           client_id:,
           created_at:,
-          scope:
+          scope:,
+          operation:
         }
       end
       let(:expected_error) { SignIn::Errors::StatePayloadSignatureMismatchError }
@@ -78,6 +81,7 @@ RSpec.describe SignIn::StatePayloadJwtDecoder do
         expect(decoded_state_payload.client_id).to eq(client_id)
         expect(decoded_state_payload.created_at).to eq(created_at)
         expect(decoded_state_payload.scope).to eq(scope)
+        expect(decoded_state_payload.operation).to eq(operation)
       end
     end
   end

--- a/spec/services/sign_in/state_payload_jwt_encoder_spec.rb
+++ b/spec/services/sign_in/state_payload_jwt_encoder_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe SignIn::StatePayloadJwtEncoder do
                                          type:,
                                          acr:,
                                          scope:,
-                                         client_config:).perform
+                                         client_config:,
+                                         operation:).perform
     end
 
     let(:code_challenge) { 'some-code-challenge' }
@@ -25,6 +26,7 @@ RSpec.describe SignIn::StatePayloadJwtEncoder do
     let(:shared_sessions) { false }
     let(:authentication) { SignIn::Constants::Auth::API }
     let(:client_state_minimum_length) { SignIn::Constants::Auth::CLIENT_STATE_MINIMUM_LENGTH }
+    let(:operation) { SignIn::Constants::Auth::VERIFY_CTA_AUTHENTICATED }
 
     shared_context 'validated code challenge state payload jwt' do
       let(:code) { 'some-state-code-value' }
@@ -51,6 +53,8 @@ RSpec.describe SignIn::StatePayloadJwtEncoder do
           expect(decoded_jwt.client_state).to eq(client_state)
           expect(decoded_jwt.code).to eq(code)
           expect(decoded_jwt.created_at).to eq(created_at)
+          expect(decoded_jwt.scope).to eq(scope)
+          expect(decoded_jwt.operation).to eq(operation)
         end
 
         it 'saves a StateCode in redis' do

--- a/spec/support/sign_in/shared_contexts/callback/setup.rb
+++ b/spec/support/sign_in/shared_contexts/callback/setup.rb
@@ -8,7 +8,7 @@ RSpec.shared_context 'callback_setup' do
   let(:error_params) { {} }
   let(:state_value) { 'some-state' }
   let(:code_value) { 'some-code' }
-  let(:statsd_tags) { ["type:#{type}", "client_id:#{client_id}", "ial:#{ial}", "acr:#{acr}"] }
+  let(:statsd_tags) { ["type:#{type}", "client_id:#{client_id}", "ial:#{ial}", "acr:#{acr}", "operation:#{operation}"] }
   let(:type) {}
   let(:acr) { nil }
   let(:ial) { nil }
@@ -29,6 +29,7 @@ RSpec.shared_context 'callback_setup' do
   end
   let(:enforced_terms) { nil }
   let(:terms_of_use_url) { 'some-terms-of-use-url' }
+  let(:operation) { SignIn::Constants::Auth::VERIFY_CTA_AUTHENTICATED }
 
   before do
     allow(Rails.logger).to receive(:info)

--- a/spec/support/sign_in/shared_contexts/callback/state_jwt_setup.rb
+++ b/spec/support/sign_in/shared_contexts/callback/state_jwt_setup.rb
@@ -6,6 +6,7 @@ RSpec.shared_context 'callback_state_jwt_setup' do
   let(:client_state) { SecureRandom.alphanumeric(SignIn::Constants::Auth::CLIENT_STATE_MINIMUM_LENGTH) }
   let(:acr) { SignIn::Constants::Auth::ACR_VALUES.first }
   let(:type) { SignIn::Constants::Auth::CSP_TYPES.first }
+  let(:operation) { SignIn::Constants::Auth::AUTHORIZE }
 
   let(:state_value) do
     SignIn::StatePayloadJwtEncoder.new(code_challenge:,
@@ -13,7 +14,8 @@ RSpec.shared_context 'callback_state_jwt_setup' do
                                        acr:,
                                        client_config:,
                                        type:,
-                                       client_state:).perform
+                                       client_state:,
+                                       operation:).perform
   end
 
   let(:uplevel_state_value) do
@@ -22,6 +24,7 @@ RSpec.shared_context 'callback_state_jwt_setup' do
                                        acr:,
                                        client_config:,
                                        type:,
-                                       client_state:).perform
+                                       client_state:,
+                                       operation:).perform
   end
 end

--- a/spec/support/sign_in/shared_examples/callback/api_error_response.rb
+++ b/spec/support/sign_in/shared_examples/callback/api_error_response.rb
@@ -6,10 +6,10 @@ RSpec.shared_examples 'callback_api_error_response' do
   let(:statsd_callback_failure) { SignIn::Constants::Statsd::STATSD_SIS_CALLBACK_FAILURE }
   let(:expected_error_log) { '[SignInService] [V0::SignInController] callback error' }
   let(:expected_error_message) do
-    { errors: expected_error, client_id:, type:, acr: }
+    { errors: expected_error, client_id:, type:, acr:, operation: }
   end
   let(:expected_statsd_tags) do
-    ["type:#{type || ''}", "client_id:#{client_id || ''}", "acr:#{acr || ''}"]
+    ["type:#{type || ''}", "client_id:#{client_id || ''}", "acr:#{acr || ''}", "operation:#{operation || ''}"]
   end
 
   it 'renders expected error' do

--- a/spec/support/sign_in/shared_examples/callback/error_response.rb
+++ b/spec/support/sign_in/shared_examples/callback/error_response.rb
@@ -5,7 +5,7 @@ RSpec.shared_examples 'callback_error_response' do
   let(:expected_error_status) { :bad_request }
   let(:statsd_callback_failure) { SignIn::Constants::Statsd::STATSD_SIS_CALLBACK_FAILURE }
   let(:expected_statsd_tags) do
-    ["type:#{type || ''}", "client_id:#{client_id || ''}", "acr:#{acr || ''}"]
+    ["type:#{type || ''}", "client_id:#{client_id || ''}", "acr:#{acr || ''}", "operation:#{operation || ''}"]
   end
 
   context 'and client_id maps to a web based configuration' do
@@ -13,7 +13,7 @@ RSpec.shared_examples 'callback_error_response' do
     let(:expected_error_status) { :ok }
     let(:auth_param) { 'fail' }
     let(:expected_error_log) { '[SignInService] [V0::SignInController] callback error' }
-    let(:expected_error_message) { { errors: expected_error, client_id:, type:, acr: } }
+    let(:expected_error_message) { { errors: expected_error, client_id:, type:, acr:, operation: } }
     let(:request_id) { SecureRandom.uuid }
     let(:meta_refresh_tag) { '<meta http-equiv="refresh" content="0;' }
 


### PR DESCRIPTION
## Summary

- Update the callback logs and metrics to include the operation to better track return rate
- Add operation to the state payload

## Related issue(s)
- https://github.com/department-of-veterans-affairs/identity-documentation/issues/1063

## Testing 
- Authenticate with SiS
- You should see operation the callback log and metrics (log/statsd.log)
   ```ruby
   [SignInService] [V0::SignInController] callback -- { :type => "idme", :client_id => "vaweb", :ial => 2, :acr => "min", :icn => "1008704012V552302", :credential_uuid => "88f572d491af46efa393cba6c351e252", :authentication_time => 16, :operation => "authorize" }
   ```
   ```
   [StatsD] api_sis_callback_success:1|c|#type:idme,client_id:vaweb,ial:2,acr:min,operation:authorize
   ```
- Go to localhost:3001/verify and click on idme or logingov. 
- You should see a log and metric like:
   ```ruby
   Rails -- [SignInService] [V0::SignInController] authorize -- { :type => "idme", :client_id => "vaweb", :acr => "loa3", :operation => "verify_page_unauthenticated" }
   ```
   ```
   [StatsD] api_sis_auth_success:1|c|#type:idme,client_id:vaweb,acr:loa3,operation:verify_page_unauthenticated
   ```

## What areas of the site does it impact?
Sign-in service, authentication

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

