### PR TITLE
[HOTFIX] Flaky `BGSV2` spec

### DIFF
--- a/lib/bgsv2/service.rb
+++ b/lib/bgsv2/service.rb
@@ -219,6 +219,7 @@ module BGSV2
       service.share_data.find_regional_offices[:return]
     rescue => e
       notify_of_service_exception(e, __method__, 1, :warn)
+      []
     end
 
     def create_note(claim_id, note_text)


### PR DESCRIPTION
### Important
This change could fix a bug that is somehow relied upon in production. Or it could fix a bug that would strictly improve production behavior. One option that should be considered here is dealing with the test flakiness without changing any app code.

### Flaky test failure
Recent example CI test failure [here](https://github.com/department-of-veterans-affairs/vets-api/actions/runs/21522153291/job/62016432514)

<img width="948" height="523" alt="Screenshot 2026-01-30 at 1 54 23 PM" src="https://github.com/user-attachments/assets/297a30e9-4f54-456a-b600-1d8cbd140647" />

### Evidence of an indirect fix
I suspect that this doesn't address the actual underlying flakiness of this spec. But it does resolve another piece of deterministically differing behavior that depends on running the spec with `RAILS_ENABLE_TEST_LOG` turned on or off. With it turned on, I reproduce the exact test failure reason that is observed in CI!
```
# fails every time in a way that exactly matches what is seen in CI 👇 
RAILS_ENABLE_TEST_LOG=1 bundle exec rspec ./spec/lib/bgsv2/form674_spec.rb:56
```

```
# succeeds every time 👇 
bundle exec rspec ./spec/lib/bgsv2/form674_spec.rb:56
```

The differing behavior is due to a `rescue` returning the result of a logger call, which depends on how `RAILS_ENABLE_TEST_LOG` is set!

Returning an empty array from the rescue in `find_regional_offices` instead makes more sense and seems to match the semantics expected at the call site [here](https://github.com/department-of-veterans-affairs/vets-api/blob/93f7f0fa1c96fbef58fe39db72db9ee86e49af67/lib/bgsv2/vnp_veteran.rb#L108-L109).
```ruby
regional_offices = bgs_service.find_regional_offices
return '347' if regional_offices.blank? # return default value 347 if regional office is not found
```

### Hypothesis on fixing flakiness _provisionally_
My theory is that this same change to the code will also end up causing this test to pass deterministically, even in the face of whatever the actual underlying nondeterminism is.

### Later improvement
I think that the test could be corrected to not have that underlying nondeterminism, but that we should clear out the flakiness in our CI somehow for now.