### PR TITLE
Add document_type guard clause

### DIFF
--- a/lib/lighthouse/benefits_documents/service.rb
+++ b/lib/lighthouse/benefits_documents/service.rb
@@ -117,11 +117,6 @@ module BenefitsDocuments
               ArgumentError.new('Claim id is required')
       end
 
-      Rails.logger.info('file_name present?', file&.original_filename.present?)
-      Rails.logger.info('file extension', file&.original_filename&.split('.')&.last)
-      Rails.logger.info('file content type', file&.content_type)
-      Rails.logger.info('participant_id present?', @user.participant_id.present?)
-
       if presumed_duplicate?(claim_id, file)
         raise Common::Exceptions::UnprocessableEntity.new(
           detail: 'DOC_UPLOAD_DUPLICATE',
@@ -192,6 +187,12 @@ module BenefitsDocuments
       tracked_item_ids = file_params[:trackedItemIds] || file_params[:tracked_item_ids]
       document_type = file_params[:documentType] || file_params[:document_type]
       password = file_params[:password]
+
+      unless document_type
+        raise Common::Exceptions::InternalServerError,
+              ArgumentError.new('document_type is required')
+      end
+
       LighthouseDocument.new(
         first_name: @user.first_name,
         participant_id: @user.participant_id,


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- Added guard clause for `document_type`, as it's a required field for validating claimant path. Active Record validation doesn't help because record isn't saved (and validated) before this call is made.
- cleaned up some logs I meant to delete 8 months ago :)
