### PR TITLE
Record Unique User Metric events for Appointments based on facility ID

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2787,6 +2787,10 @@ features:
     actor_type: user
     description: Enables Oracle Health (OH) site-specific unique user metrics logging. When disabled, OH events will not be generated even if unique_user_metrics_logging is enabled.
     enable_in_development: true
+  mhv_oh_unique_user_metrics_logging_appt:
+    actor_type: user
+    description: Enables Oracle Health facility ID extraction for appointments controllers. When disabled, appointment_facility_ids returns nil, bypassing facility tracking overhead.
+    enable_in_development: true
   form_8794_release:
     actor_type: user
     description: If enabled, show link to digitized form instead of PDF download on SCO page

--- a/lib/unique_user_events/oracle_health.rb
+++ b/lib/unique_user_events/oracle_health.rb
@@ -18,7 +18,6 @@ module UniqueUserEvents
     # Uses EventRegistry constants to avoid string duplication
     TRACKED_EVENTS = [
       EventRegistry::SECURE_MESSAGING_MESSAGE_SENT,
-      EventRegistry::APPOINTMENTS_ACCESSED,
       EventRegistry::MEDICAL_RECORDS_ALLERGIES_ACCESSED,
       EventRegistry::MEDICAL_RECORDS_VACCINES_ACCESSED,
       EventRegistry::MEDICAL_RECORDS_LABS_ACCESSED,

--- a/modules/mobile/spec/controllers/mobile/v0/appointments_controller_spec.rb
+++ b/modules/mobile/spec/controllers/mobile/v0/appointments_controller_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mobile::V0::AppointmentsController, type: :controller do
+  describe '#appointment_facility_ids' do
+    let(:controller) { described_class.new }
+    let(:cancelled_status) { Mobile::V0::Adapters::VAOSV2Appointment::STATUSES[:cancelled] }
+    let(:booked_status) { Mobile::V0::Adapters::VAOSV2Appointment::STATUSES[:booked] }
+
+    before do
+      allow(Flipper).to receive(:enabled?).with(:mhv_oh_unique_user_metrics_logging_appt).and_return(true)
+    end
+
+    def mock_appointment(facility_id:, is_pending:, status:)
+      instance_double(
+        Mobile::V0::Appointment,
+        facility_id:,
+        is_pending:,
+        status:
+      )
+    end
+
+    context 'when mhv_oh_unique_user_metrics_logging_appt feature flag is disabled' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:mhv_oh_unique_user_metrics_logging_appt).and_return(false)
+      end
+
+      it 'returns nil regardless of appointments' do
+        appointments = [
+          mock_appointment(facility_id: '983', is_pending: false, status: booked_status),
+          mock_appointment(facility_id: '984', is_pending: false, status: booked_status)
+        ]
+
+        result = controller.send(:appointment_facility_ids, appointments)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when appointments are visible (pending or not cancelled)' do
+      it 'returns unique facility IDs from visible appointments' do
+        appointments = [
+          mock_appointment(facility_id: '983', is_pending: false, status: booked_status),
+          mock_appointment(facility_id: '984', is_pending: false, status: booked_status),
+          mock_appointment(facility_id: '757', is_pending: true, status: booked_status)
+        ]
+
+        result = controller.send(:appointment_facility_ids, appointments)
+        expect(result).to contain_exactly('983', '984', '757')
+      end
+
+      it 'extracts 3-character station ID from sta6aid format' do
+        appointments = [
+          mock_appointment(facility_id: '983GC', is_pending: false, status: booked_status),
+          mock_appointment(facility_id: '984HK', is_pending: false, status: booked_status)
+        ]
+
+        result = controller.send(:appointment_facility_ids, appointments)
+        expect(result).to contain_exactly('983', '984')
+      end
+
+      it 'returns unique facility IDs when duplicates exist' do
+        appointments = [
+          mock_appointment(facility_id: '983', is_pending: false, status: booked_status),
+          mock_appointment(facility_id: '983GC', is_pending: false, status: booked_status),
+          mock_appointment(facility_id: '983HK', is_pending: true, status: booked_status)
+        ]
+
+        result = controller.send(:appointment_facility_ids, appointments)
+        expect(result).to eq(['983'])
+      end
+    end
+
+    context 'when appointments include pending appointments' do
+      it 'includes pending appointments regardless of status' do
+        appointments = [
+          mock_appointment(facility_id: '983', is_pending: true, status: cancelled_status),
+          mock_appointment(facility_id: '984', is_pending: true, status: booked_status)
+        ]
+
+        result = controller.send(:appointment_facility_ids, appointments)
+        expect(result).to contain_exactly('983', '984')
+      end
+    end
+
+    context 'when all appointments are cancelled and not pending' do
+      it 'returns nil' do
+        appointments = [
+          mock_appointment(facility_id: '983', is_pending: false, status: cancelled_status),
+          mock_appointment(facility_id: '984', is_pending: false, status: cancelled_status)
+        ]
+
+        result = controller.send(:appointment_facility_ids, appointments)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when appointments list is empty' do
+      it 'returns nil' do
+        result = controller.send(:appointment_facility_ids, [])
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when appointments have nil facility_id' do
+      it 'filters out appointments with nil facility_id' do
+        appointments = [
+          mock_appointment(facility_id: nil, is_pending: false, status: booked_status),
+          mock_appointment(facility_id: '984', is_pending: false, status: booked_status)
+        ]
+
+        result = controller.send(:appointment_facility_ids, appointments)
+        expect(result).to eq(['984'])
+      end
+
+      it 'returns nil when all visible appointments have nil facility_id' do
+        appointments = [
+          mock_appointment(facility_id: nil, is_pending: false, status: booked_status),
+          mock_appointment(facility_id: nil, is_pending: true, status: booked_status)
+        ]
+
+        result = controller.send(:appointment_facility_ids, appointments)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'with mixed visible and cancelled appointments' do
+      it 'only includes facility IDs from visible appointments' do
+        appointments = [
+          mock_appointment(facility_id: '983', is_pending: false, status: booked_status), # visible (booked)
+          mock_appointment(facility_id: '984', is_pending: false, status: cancelled_status), # not visible (cancelled)
+          mock_appointment(facility_id: '757', is_pending: true, status: cancelled_status)   # visible (pending)
+        ]
+
+        result = controller.send(:appointment_facility_ids, appointments)
+        expect(result).to contain_exactly('983', '757')
+      end
+    end
+  end
+end

--- a/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
+++ b/modules/vaos/app/controllers/vaos/v2/appointments_controller.rb
@@ -40,10 +40,11 @@ module VAOS
         serializer = VAOS::V2::VAOSSerializer.new
         serialized = serializer.serialize(appointments[:data], 'appointments')
 
-        # Log unique user event for appointments accessed
+        # Log unique user event for appointments accessed (with facility tracking for OH events)
         UniqueUserEvents.log_event(
           user: current_user,
-          event_name: UniqueUserEvents::EventRegistry::APPOINTMENTS_ACCESSED
+          event_name: UniqueUserEvents::EventRegistry::APPOINTMENTS_ACCESSED,
+          event_facility_ids: appointment_facility_ids(appointments[:data])
         )
 
         if appointments[:meta][:failures] && appointments[:meta][:failures].empty?
@@ -142,6 +143,24 @@ module VAOS
       end
 
       private
+
+      # Extract unique facility IDs (3-character) from user-visible appointments for OH event tracking
+      # Only includes appointments that are future, past, or pending (shown to users in the UI)
+      # Note: location_id may be a sta6aid (5-6 characters like "983GC") - we extract only the
+      # 3-character facility ID prefix to match against TRACKED_FACILITY_IDS
+      # Returns nil if mhv_oh_unique_user_metrics_logging_appt feature flag is disabled
+      # @param appointments [Array] list of appointment hashes/objects
+      # @return [Array<String>, nil] unique 3-character facility IDs or nil if none/disabled
+      def appointment_facility_ids(appointments)
+        return nil unless Flipper.enabled?(:mhv_oh_unique_user_metrics_logging_appt)
+
+        visible_appointments = appointments.select do |appt|
+          # Pending appointments are always visible; non-cancelled appointments with date flags are visible
+          appt[:pending] || (appt[:status] != 'cancelled' && (appt[:future] || appt[:past]))
+        end
+        station_ids = visible_appointments.filter_map { |appt| appt[:location_id]&.[](0..2) }.uniq
+        station_ids.presence
+      end
 
       def set_facility_error_msg(appointment)
         appointment[:location] = FACILITY_ERROR_MSG if appointment[:location_id].present? && appointment[:location].nil?

--- a/modules/vaos/spec/requests/vaos/v2/appointments_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/appointments_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require 'unified_health_data/service'
+require 'unique_user_events'
 
 RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
   include SchemaMatchers
@@ -517,10 +518,13 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
               expect(data[0]['attributes']['location']).to eq(expected_facility)
               expect(response).to match_camelized_response_schema('vaos/v2/appointments', { strict: false })
 
-              # Verify event logging was called
+              # Verify event logging was called with facility IDs extracted from visible appointments
+              # Cassette has 16 appointments: 14 cancelled + 1 proposed (983) + 1 null status (983)
+              # Only non-cancelled appointments are tracked, so we expect ['983']
               expect(UniqueUserEvents).to have_received(:log_event).with(
                 user: anything,
-                event_name: UniqueUserEvents::EventRegistry::APPOINTMENTS_ACCESSED
+                event_name: UniqueUserEvents::EventRegistry::APPOINTMENTS_ACCESSED,
+                event_facility_ids: ['983']
               )
             end
           end


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES: `mhv_oh_unique_user_metrics_logging_appt`*
- Log a unique user event when a veteran fetches their appointments from specific OH sites. Note that we filter the appointments to what is shown to the user in the front end.
- Added flipper `mhv_oh_unique_user_metrics_logging_appt` to bypass the logic just in case something goes wrong.
- Team: MHV Horizon

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/131010

## Testing done
- [x] *New code is covered by unit tests*

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
