### PR TITLE
Add a passthrough for state-code from AskVA payload

### DIFF
--- a/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/shared_helpers.rb
+++ b/modules/ask_va_api/app/lib/ask_va_api/inquiries/payload_builder/shared_helpers.rb
@@ -4,6 +4,18 @@ module AskVAApi
   module Inquiries
     module PayloadBuilder
       module SharedHelpers
+        # interim mapping for labels missing from locations.yml
+        # TODO: remove once frontend begins sending state codes (see AskVA #1825)
+        MISSING_STATE_CODES = {
+          'American Samoa' => 'AS',
+          'Armed Forces Americas (AA)' => 'AA',
+          'Armed Forces Europe (AE)' => 'AE',
+          'Armed Forces Pacific (AP)' => 'AP',
+          'Federated States Of Micronesia' => 'FM',
+          'Marshall Islands' => 'MH',
+          'Northern Mariana Islands' => 'MP'
+        }.freeze
+
         def fetch_country(country_code)
           return if country_code.blank?
 
@@ -26,6 +38,14 @@ module AskVAApi
         def fetch_state_code(state)
           return if state.blank?
 
+          state = state.to_s.strip
+
+          # pass through once frontend begins sending two-letter state codes
+          return state.upcase if state.length == 2
+
+          return MISSING_STATE_CODES[state] if MISSING_STATE_CODES[state]
+
+          # otherwise continue with existing behavior
           I18n.t('ask_va_api.states').invert[state]&.to_s
         end
 

--- a/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/shared_helpers_spec.rb
+++ b/modules/ask_va_api/spec/app/lib/ask_va_api/inquiries/payload_builder/shared_helpers_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AskVAApi::Inquiries::PayloadBuilder::SharedHelpers do
+  subject(:helper) do
+    Class.new do
+      include AskVAApi::Inquiries::PayloadBuilder::SharedHelpers
+    end.new
+  end
+
+  describe '#fetch_state_code' do
+    it 'returns nil when state is blank' do
+      expect(helper.fetch_state_code(nil)).to be_nil
+      expect(helper.fetch_state_code('')).to be_nil
+      expect(helper.fetch_state_code('   ')).to be_nil
+    end
+
+    it 'passes through two-letter codes (normalized to uppercase)' do
+      expect(helper.fetch_state_code('ca')).to eq('CA')
+      expect(helper.fetch_state_code('NY')).to eq('NY')
+      expect(helper.fetch_state_code('  fl ')).to eq('FL')
+    end
+
+    it 'maps known FE labels that are missing from locations.yml to codes' do
+      expect(helper.fetch_state_code('Armed Forces Americas (AA)')).to eq('AA')
+      expect(helper.fetch_state_code('American Samoa')).to eq('AS')
+    end
+
+    context 'when mapping state names via I18n' do
+      before do
+        # Keep this test independent of the real locations.yml contents/location.
+        allow(I18n).to receive(:t).with('ask_va_api.states').and_return(
+          {
+            'CA' => 'California',
+            'DC' => 'District of Columbia'
+          }
+        )
+      end
+
+      it 'maps state names to two-letter codes using the I18n state list' do
+        expect(helper.fetch_state_code('California')).to eq('CA')
+        expect(helper.fetch_state_code('District of Columbia')).to eq('DC')
+      end
+
+      it 'returns nil for unknown state names' do
+        expect(helper.fetch_state_code('Unknown State')).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **This work is behind a feature toggle (flipper):** No

- **Summary of changes**  
  Updated state code handling in AskVA API payload to support transition where the frontend continues to send state labels (e.g. `"Colorado"`) while preparing to send two-letter state codes (pending development).
  The API now:
  - Passes through valid two-letter state codes as-is (pending frontend development)
  - Maps a small set of known state/territory labels that are missing from `locations.yml`
  - Preserves existing name-to-code conversion behavior for other states

- **Bug description / reproduction**  
  When certain state labels (e.g. Armed Forces or territory values) are passed through to the CRM without being converted to a two-letter code, the CRM rejects the request due to state code length validation.

- **Solution & rationale**  
  This solution maintains backward compatibility with the current frontend behavior while enabling a smooth transition to future frontend changes.  
  It avoids expanding or re-introducing large state lists in `locations.yml`, and instead uses a minimal, clearly scoped interim mapping that will be removed once the frontend sends two-letter codes consistently.

- **Owning team / maintenance**  
  AskVA

---

## Related issue(s)

- AskVA Issue: https://github.com/department-of-veterans-affairs/ask-va/issues/1824
- Related context: CRM validation errors for non-2-letter state codes

---

## Testing done

- [x] **New code is covered by unit tests**

- **Previous behavior**  
  The API attempted to convert state labels to two-letter codes using `locations.yml`, falling back to the original label when no mapping was found. This caused certain state values to exceed CRM validation constraints. From the 

- **Verification steps**
  1. Added unit tests for `fetch_state_code`
  2. Verified:
     - Blank values return `nil`
     - Two-letter codes are passed through and normalized
     - Known missing state/territory labels are mapped correctly
     - Existing I18n-based state name conversion continues to work
     - Unknown values safely fall back without raising errors

---

## What areas of the site does it impact?

- AskVA API payload construction
- Downstream CRM integration for state code validation  
_No frontend or UI changes_

---

## Acceptance criteria

- [x] I fixed/updated/added unit tests for this change
- [x] No error nor warning in the console
- [x] No sensitive information (PII/credentials/internal URLs/etc.) is captured in logging or specs
- [x] Changes are limited in scope and backward-compatible

---