### PR TITLE
added tweek to send_poa_request job, got rid of hardcoded vals

### DIFF
--- a/modules/accredited_representative_portal/app/services/accredited_representative_portal/send_poa_request_to_corp_db_service.rb
+++ b/modules/accredited_representative_portal/app/services/accredited_representative_portal/send_poa_request_to_corp_db_service.rb
@@ -27,7 +27,7 @@ module AccreditedRepresentativePortal
           attributes: {
             veteran: veteran_payload,
             representative: representative_payload,
-            recordConsent: true,
+            recordConsent: authorizations['recordDisclosureLimitations'].blank?,
             consentAddressChange: authorizations['addressChange'] == true,
             consentLimits: authorizations['recordDisclosureLimitations'] || []
           }

--- a/modules/accredited_representative_portal/spec/services/accredited_representative_portal/send_poa_request_to_corp_db_service_spec.rb
+++ b/modules/accredited_representative_portal/spec/services/accredited_representative_portal/send_poa_request_to_corp_db_service_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe AccreditedRepresentativePortal::SendPoaRequestToCorpDbService do
           expect(rep[:poaCode]).to eq(poa_request.power_of_attorney_holder_poa_code)
 
           # Authorizations
-          expect(attributes[:recordConsent]).to be(true)
+          expect(attributes[:recordConsent]).to be(false)
           expect(attributes[:consentAddressChange]).to be(true)
           consent_limits = parsed_data['authorizations']['recordDisclosureLimitations']
           expect(attributes[:consentLimits]).to match_array(consent_limits)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): YES/NO* 

Yes - send_poa_to_corpdb

- *(Summarize the changes that have been made to the platform)*

It was discovered that we were hardcoding RecordConsent as true in the payload for the lighthouse call to save poa data, it was reccomended to mimic the same logic as the api call in attempt.rb and replace the hardcoded value with checking recordDisclosureLimitations is blank or not.

- *(If bug, how to reproduce)*

It would have worked but opened the door for abuse, job works the same just using a different field, will need to test on staging.

- *(What is the solution, why is this the solution?)*

In the poa request payload replace the hardcoded value with checking recordDisclosureLimitations is blank or not

- *(Which team do you work for, does your team own the maintenance of this component?)*
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*

https://github.com/department-of-veterans-affairs/vets-api/issues/26313

- *Link to previous change of the code/bug (if applicable)*

https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/accredited_representative_portal/app/services/accredited_representative_portal/send_poa_request_to_corp_db_service.rb#L30

- *Link to epic if not included in ticket*

## Testing done

- [ x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*

Would have worked the same, just had true hardcoded

- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*

Need to accept or decline and make sure nothing fails in staging

- *If this work is behind a flipper:* - yes
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ x]  No error nor warning in the console.
- [ x]  Events are being sent to the appropriate logging solution
- [ x]  Documentation has been updated (link to documentation)
- [ x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

