### PR TITLE
Fix Flipper GitHub OAuth redirect_uri after Rack 3 upgrade

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,10 @@ require_relative '../lib/olive_branch_patch'
 
 module VetsAPI
   class Application < Rails::Application
+    # Prefer X-Forwarded-Scheme over X-Forwarded-Proto for scheme detection.
+    # Dev proxy sends X-Forwarded-Proto: http (incorrect) but X-Forwarded-Scheme: https (correct).
+    Rack::Request.x_forwarded_proto_priority = %i[scheme proto]
+
     # Initialize configuration defaults for originally generated Rails version.
     # https://guides.rubyonrails.org/configuring.html#default-values-for-target-version-7-0
     config.load_defaults 7.1


### PR DESCRIPTION
## Summary

After the Rack 3.2.4 upgrade (#26302), Flipper GitHub OAuth login on dev (`dev-api.va.gov`) fails with "The redirect_uri is not associated with this application."

The dev proxy sends `X-Forwarded-Proto: http` (incorrect) and `X-Forwarded-Scheme: https` (correct). Rack 3 defaults to reading `X-Forwarded-Proto` first for `request.scheme`, which causes the OAuth callback URL to be constructed as `http://dev-api.va.gov:443/flipper/auth/github/callback` instead of `https://dev-api.va.gov/flipper/auth/github/callback`.

This sets `Rack::Request.x_forwarded_proto_priority` to prefer `X-Forwarded-Scheme` over `X-Forwarded-Proto`, fixing scheme detection.

## Related issue(s)

Regression from Rack 3.2.4 upgrade (#26302).

## Testing done

- Verify `/v0/header_status` on dev returns `"Scheme": "https"`
- Test Flipper GitHub OAuth login at `dev-api.va.gov/flipper`

## What areas of the site does it impact?

- Flipper feature flag UI (`/flipper`)
- Sidekiq Web UI (`/sidekiq`)
- Coverband UI (`/coverband`)
- Any functionality relying on `request.scheme` behind the dev proxy

## Acceptance criteria

- [ ] `request.scheme` returns `https` on dev when `X-Forwarded-Scheme: https` is present
- [ ] Flipper GitHub OAuth login succeeds on dev without redirect_uri mismatch
- [ ] No regressions in existing specs