### PR TITLE
Add StatsD metric for UHD prescription refills

### DIFF
--- a/lib/unified_health_data/service.rb
+++ b/lib/unified_health_data/service.rb
@@ -102,6 +102,7 @@ module UnifiedHealthData
         response = uhd_client.refill_prescription_orders(build_refill_request_body(normalized_orders))
         result = parse_refill_response(response)
         validate_refill_response_count(normalized_orders, result)
+        increment_refill(result[:success].size) if result[:success].present?
         result
       end
     rescue Common::Exceptions::BackendServiceException => e
@@ -413,6 +414,10 @@ module UnifiedHealthData
 
     def log_loinc_codes_enabled?
       Flipper.enabled?(:mhv_accelerated_delivery_uhd_loinc_logging_enabled, @user)
+    end
+
+    def increment_refill(count = 1)
+      StatsD.increment("#{STATSD_KEY_PREFIX}.refills.requested", count)
     end
 
     # Instantiate client, adapters, etc. once per service instance


### PR DESCRIPTION
## Summary

- **This work is behind a feature toggle (flipper): NO**
- Adds StatsD metric tracking for prescription refills submitted through the Unified Health Data (UHD) service
- Increments `api.uhd.refills.requested` with the count of successful refills, matching the existing pattern in `Rx::Client` (`api.mhv.rxrefill.refills.requested`)
- Team: MHV on VA.gov - Medical Records

## Related issue(s)

- N/A - metrics enhancement to track prescription refills via UHD service

## Testing done

- [x] New code is covered by unit tests
- Added test to verify StatsD metric is incremented for successful refills
- Added test to verify StatsD metric is NOT incremented when there are no successful refills
- All existing `refill_prescription` tests continue to pass

```
bundle exec rspec spec/lib/unified_health_data/service_spec.rb -e "refill_prescription"
# 24 examples, 0 failures
```

## What areas of the site does it impact?

- UHD prescription refill functionality (backend metrics only)
- No user-facing changes

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

## Requested Feedback

This change adds observability for prescription refills via UHD to match the existing Rx client metrics pattern.