### PR TITLE
Add VA Profile config to UC

### DIFF
--- a/script/upstream-connect/README.md
+++ b/script/upstream-connect/README.md
@@ -120,6 +120,13 @@ Shows a menu of available services to connect to.
 - **Port**: `4492`
 - **Description**: Connect to Benefits Eligibility Platform for awards and payment history data
 
+### VA Profile
+- **Service Key**: `va_profile`
+- **Aliases**: `demographics`, `contact_info`, `military_personnel`, `military_service`, `phones`, `addresses`, `emails`, `preferred_name`
+- **Settings**: `va_profile`
+- **Port**: `4433`
+- **Description**: Connect to VA Profile for user profile, contact info, and military service history data
+
 ### Vet Service History and Eligibility API (Lighthouse)
 - **Service Key**: `vet_verification`
 - **Aliases**: `disability_rating`

--- a/script/upstream-connect/upstream_service_config.rb
+++ b/script/upstream-connect/upstream_service_config.rb
@@ -357,8 +357,8 @@ class UpstreamServiceConfig # rubocop:disable Metrics/ClassLength
     },
     'va_profile' => {
       name: 'VA Profile',
-      aliases: %w[demographics contact_info military_personnel military_service phones addresses emails preferred_name],
-      description: 'Connect to VA Profile for user profile and demographic data',
+      aliases: %w[contact_info demographics military_personnel military_service addresses emails phones preferred_name],
+      description: 'Connect to VA Profile for user profile, contact info, and military service history data',
       ports: [4433],
       settings_namespaces: ['va_profile'],
       skipped_settings: [%w[address_validation v3]],


### PR DESCRIPTION
## Summary

- Adds VA Profile config (tunnel to vet360/port 4433/`qa.vaprofile.va.gov`) to Upstream Connect

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-mobile-app/issues/11797

## Testing done

- Confirmed to work with the following:
  - GET /mobile/v0/user/contact-info
  - GET /mobile/v0/user/demographics
  - GET /mobile/v0/user/military-service-history
  - POST /mobile/v0/phones