### PR TITLE
Forbid flipper toggles in specs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2066,6 +2066,7 @@ spec/sidekiq/lighthouse/failure_notification_spec.rb @department-of-veterans-aff
 spec/sidekiq/lighthouse/form526_document_upload_polling_job_spec.rb @department-of-veterans-affairs/disability-benefits @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/lighthouse/poll_form526_pdf_spec.rb @department-of-veterans-affairs/disability-benefits @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/lighthouse/submit_benefits_intake_claim_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-management-tools-be
+spec/sidekiq/lighthouse/submit_career_counseling_job_spec.rb @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/benefits-management-tools-be
 spec/sidekiq/load_average_days_for_claim_completion_job_spec.rb @department-of-veterans-affairs/benefits-microservices @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/mhv @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/backend-review-group
 spec/sidekiq/mhv/account_creator_job_spec.rb @department-of-veterans-affairs/octo-identity

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1049,7 +1049,7 @@ lib/preneeds @department-of-veterans-affairs/bah-mbs-selfserv @department-of-vet
 lib/res @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group
 lib/reports/uploader.rb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 lib/rubocop/cops/ams_serializer.rb @department-of-veterans-affairs/backend-review-group
-./lib/rubocop/cops/forbid_flipper_toggle_in_specs.rb @department-of-veterans-affairs/backend-review-group
+lib/rubocop/cops/forbid_flipper_toggle_in_specs.rb @department-of-veterans-affairs/backend-review-group
 lib/rx @department-of-veterans-affairs/mobile-api-team @department-of-veterans-affairs/vfs-mhv-integration
 lib/salesforce @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 lib/saml @department-of-veterans-affairs/octo-identity

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1049,6 +1049,7 @@ lib/preneeds @department-of-veterans-affairs/bah-mbs-selfserv @department-of-vet
 lib/res @department-of-veterans-affairs/benefits-non-disability @department-of-veterans-affairs/backend-review-group
 lib/reports/uploader.rb @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 lib/rubocop/cops/ams_serializer.rb @department-of-veterans-affairs/backend-review-group
+./lib/rubocop/cops/forbid_flipper_toggle_in_specs.rb @department-of-veterans-affairs/backend-review-group
 lib/rx @department-of-veterans-affairs/mobile-api-team @department-of-veterans-affairs/vfs-mhv-integration
 lib/salesforce @department-of-veterans-affairs/govcio-vfep-codereviewers @department-of-veterans-affairs/backend-review-group
 lib/saml @department-of-veterans-affairs/octo-identity

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,8 @@ inherit_from:
   - .rubocop_todo.yml
 
 require:
-  - './lib/rubocop/cops/ams_serializer.rb'
+  - ./lib/rubocop/cops/ams_serializer.rb
+  - ./lib/rubocop/cops/forbid_flipper_toggle_in_specs.rb
 
 plugins:
   - rubocop-rails

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -822,7 +822,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_02_150423) do
     t.index ["key"], name: "index_devices_on_key", unique: true
   end
 
-  create_table "digital_dispute_submissions", id: :bigint, default: -> { "nextval('digital_dispute_submissions_new_id_seq'::regclass)" }, force: :cascade do |t|
+  create_table "digital_dispute_submissions", force: :cascade do |t|
     t.uuid "old_uuid_id", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "user_uuid", null: false
     t.uuid "user_account_id"
@@ -838,7 +838,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_02_150423) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "guid", default: -> { "gen_random_uuid()" }, null: false
-    t.bigint "new_id"
     t.index ["debt_identifiers"], name: "index_digital_dispute_submissions_on_debt_identifiers", using: :gin
     t.index ["guid"], name: "index_digital_dispute_submissions_on_guid", unique: true
     t.index ["needs_kms_rotation"], name: "index_digital_dispute_submissions_on_needs_kms_rotation"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -822,7 +822,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_02_150423) do
     t.index ["key"], name: "index_devices_on_key", unique: true
   end
 
-  create_table "digital_dispute_submissions", force: :cascade do |t|
+  create_table "digital_dispute_submissions", id: :bigint, default: -> { "nextval('digital_dispute_submissions_new_id_seq'::regclass)" }, force: :cascade do |t|
     t.uuid "old_uuid_id", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "user_uuid", null: false
     t.uuid "user_account_id"
@@ -838,6 +838,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_02_150423) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "guid", default: -> { "gen_random_uuid()" }, null: false
+    t.bigint "new_id"
     t.index ["debt_identifiers"], name: "index_digital_dispute_submissions_on_debt_identifiers", using: :gin
     t.index ["guid"], name: "index_digital_dispute_submissions_on_guid", unique: true
     t.index ["needs_kms_rotation"], name: "index_digital_dispute_submissions_on_needs_kms_rotation"

--- a/lib/rubocop/cops/forbid_flipper_toggle_in_specs.rb
+++ b/lib/rubocop/cops/forbid_flipper_toggle_in_specs.rb
@@ -13,7 +13,16 @@ module RuboCop
         MSG = 'Avoid using Flipper.enable/disable in specs. Use mocks or an isolated flipper instance instead.'
 
         # We may also want to catch `enable_actor` and similar methods in the future.
-        RESTRICT_ON_SEND = %i[enable disable].freeze
+        RESTRICT_ON_SEND = %i[
+          enable
+          disable
+          enable_actor
+          disable_actor
+          enable_percentage_of_actors
+          disable_percentage_of_actors
+          enable_percentage_of_time
+          disable_percentage_of_time
+        ].freeze
 
         def on_send(node)
           return unless in_spec_file?

--- a/lib/rubocop/cops/forbid_flipper_toggle_in_specs.rb
+++ b/lib/rubocop/cops/forbid_flipper_toggle_in_specs.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
 module RuboCop
-  module Cop
+  module Cops
+    # NOTE: Maybe should go into a Project namespace?
     module Project
       # Forbids using Flipper.enable/disable inside specs.
       #
       # Specs should use isolated feature managers or injected
       # flipper instances instead of mutating global state.
       #
-      class ForbidFlipperToggleInSpecs < Base
+      class ForbidFlipperToggleInSpecs < RuboCop::Cop::Base
         MSG = 'Avoid using Flipper.enable/disable in specs. Use mocks or an isolated flipper instance instead.'
 
+        # We may also want to catch `enable_actor` and similar methods in the future.
         RESTRICT_ON_SEND = %i[enable disable].freeze
 
         def on_send(node)

--- a/lib/rubocop/cops/forbid_flipper_toggle_in_specs.rb
+++ b/lib/rubocop/cops/forbid_flipper_toggle_in_specs.rb
@@ -9,7 +9,7 @@ module RuboCop
       # flipper instances instead of mutating global state.
       #
       class ForbidFlipperToggleInSpecs < Base
-        MSG = 'Avoid using Flipper.enable/disable in specs. Use an isolated flipper instance instead.'
+        MSG = 'Avoid using Flipper.enable/disable in specs. Use mocks or an isolated flipper instance instead.'
 
         RESTRICT_ON_SEND = %i[enable disable].freeze
 

--- a/lib/rubocop/cops/forbid_flipper_toggle_in_specs.rb
+++ b/lib/rubocop/cops/forbid_flipper_toggle_in_specs.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Project
+      # Forbids using Flipper.enable/disable inside specs.
+      #
+      # Specs should use isolated feature managers or injected
+      # flipper instances instead of mutating global state.
+      #
+      class ForbidFlipperToggleInSpecs < Base
+        MSG = 'Avoid using Flipper.enable/disable in specs. Use an isolated flipper instance instead.'
+
+        RESTRICT_ON_SEND = %i[enable disable].freeze
+
+        def on_send(node)
+          return unless in_spec_file?
+          return unless flipper_call?(node)
+
+          add_offense(node.loc.selector)
+        end
+
+        private
+
+        def flipper_call?(node)
+          receiver = node.receiver
+          return false unless receiver&.const_type?
+
+          receiver.const_name == 'Flipper'
+        end
+
+        def in_spec_file?
+          processed_source.file_path.include?('/spec/')
+        end
+      end
+    end
+  end
+end

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/intent_to_file_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/intent_to_file_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::IntentToFileController, type:
   end
 
   before do
-    Flipper.disable :accredited_representative_portal_skip_itf_check
+    Flipper.disable :accredited_representative_portal_skip_itf_check # rubocop:disable Project/ForbidFlipperToggleInSpecs
     VCR.configure do |c|
       c.debug_logger = File.open('record.log', 'w')
     end
@@ -70,7 +70,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::IntentToFileController, type:
 
       context 'itf check skipped' do
         it 'returns 404' do
-          Flipper.enable :accredited_representative_portal_skip_itf_check
+          Flipper.enable :accredited_representative_portal_skip_itf_check # rubocop:disable Project/ForbidFlipperToggleInSpecs
           get("/accredited_representative_portal/v0/intent_to_file/?benefitType=compensation&#{veteran_query_params}")
           expect(response).to have_http_status(:not_found)
         end

--- a/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_request_decisions_spec.rb
+++ b/modules/accredited_representative_portal/spec/requests/accredited_representative_portal/v0/power_of_attorney_request_decisions_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe AccreditedRepresentativePortal::V0::PowerOfAttorneyRequestDecisio
       end
 
       it 'does not enqueue SendPoaRequestToCorpDbJob if feature flag disabled' do
-        Flipper.disable(:send_poa_to_corpdb)
+        Flipper.disable(:send_poa_to_corpdb) # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
         accept_service = instance_double(
           AccreditedRepresentativePortal::PowerOfAttorneyRequestService::Accept

--- a/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
+++ b/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
@@ -97,7 +97,7 @@ describe AppealsApi::NoticeOfDisagreement, type: :model do
         let(:notice_of_disagreement) { create(:notice_of_disagreement, status: 'processing') }
 
         context 'and the delay evidence feature is enabled' do
-          before { Flipper.enable(:decision_review_delay_evidence) }
+          before { Flipper.enable(:decision_review_delay_evidence) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
           it 'calls "#submit_evidence_to_central_mail!"' do
             notice_of_disagreement.update(status: 'success')
@@ -107,7 +107,7 @@ describe AppealsApi::NoticeOfDisagreement, type: :model do
         end
 
         context 'and the delay evidence feature is disabled' do
-          before { Flipper.disable(:decision_review_delay_evidence) }
+          before { Flipper.disable(:decision_review_delay_evidence) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
           it 'does not call "#submit_evidence_to_central_mail!"' do
             notice_of_disagreement.update(status: 'success')
@@ -121,7 +121,7 @@ describe AppealsApi::NoticeOfDisagreement, type: :model do
         let(:notice_of_disagreement) { create(:notice_of_disagreement, status: 'success') }
 
         context 'and the delay evidence feature is enabled' do
-          before { Flipper.enable(:decision_review_delay_evidence) }
+          before { Flipper.enable(:decision_review_delay_evidence) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
           it 'does not call "#submit_evidence_to_central_mail!"' do
             notice_of_disagreement.update(source: 'VA.gov')

--- a/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
+++ b/modules/appeals_api/spec/models/notice_of_disagreement_spec.rb
@@ -135,7 +135,7 @@ describe AppealsApi::NoticeOfDisagreement, type: :model do
         let(:notice_of_disagreement) { create(:notice_of_disagreement, status: 'submitted') }
 
         context 'and the delay evidence feature is enabled' do
-          before { Flipper.enable(:decision_review_delay_evidence) }
+          before { Flipper.enable(:decision_review_delay_evidence) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
           it 'does not call "submit_evidence_to_central_mail!"' do
             notice_of_disagreement.update(status: 'processing')

--- a/modules/appeals_api/spec/models/supplemental_claim_spec.rb
+++ b/modules/appeals_api/spec/models/supplemental_claim_spec.rb
@@ -462,7 +462,7 @@ describe AppealsApi::SupplementalClaim, type: :model do
         let(:supplemental_claim) { create(:supplemental_claim, status: 'processing') }
 
         context 'and the delay evidence feature is enabled' do
-          before { Flipper.enable(:decision_review_delay_evidence) }
+          before { Flipper.enable(:decision_review_delay_evidence) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
           it 'calls "#submit_evidence_to_central_mail!"' do
             supplemental_claim.update(status: 'complete')
@@ -472,7 +472,7 @@ describe AppealsApi::SupplementalClaim, type: :model do
         end
 
         context 'and the delay evidence feature is disabled' do
-          before { Flipper.disable(:decision_review_delay_evidence) }
+          before { Flipper.disable(:decision_review_delay_evidence) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
           it 'does not call "#submit_evidence_to_central_mail!"' do
             supplemental_claim.update(status: 'complete')
@@ -486,7 +486,7 @@ describe AppealsApi::SupplementalClaim, type: :model do
         let(:supplemental_claim) { create(:supplemental_claim, status: 'success') }
 
         context 'and the delay evidence feature is enabled' do
-          before { Flipper.enable(:decision_review_delay_evidence) }
+          before { Flipper.enable(:decision_review_delay_evidence) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
           it 'does not call "#submit_evidence_to_central_mail!"' do
             supplemental_claim.update(source: 'VA.gov')
@@ -500,7 +500,7 @@ describe AppealsApi::SupplementalClaim, type: :model do
         let(:supplemental_claim) { create(:supplemental_claim, status: 'submitted') }
 
         context 'and the delay evidence feature is enabled' do
-          before { Flipper.enable(:decision_review_delay_evidence) }
+          before { Flipper.enable(:decision_review_delay_evidence) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
           it 'does not call "submit_evidence_to_central_mail!"' do
             supplemental_claim.update(status: 'processing')

--- a/modules/appeals_api/spec/requests/appeals_api/v2/decision_reviews/higher_level_reviews_spec.rb
+++ b/modules/appeals_api/spec/requests/appeals_api/v2/decision_reviews/higher_level_reviews_spec.rb
@@ -19,7 +19,7 @@ describe 'AppealsApi::V2::DecisionReviews::HigherLevelReviews', type: :request d
   let(:headers_invalid) { fixture_as_json 'decision_reviews/v2/invalid_200996_headers.json' }
   let(:parsed) { JSON.parse(response.body) }
 
-  before { Flipper.disable(:decision_review_hlr_form_v4_enabled) }
+  before { Flipper.disable(:decision_review_hlr_form_v4_enabled) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
   describe '#index' do
     let(:path) { base_path 'higher_level_reviews' }

--- a/modules/appeals_api/spec/sidekiq/appeals_api/add_icn_updater_spec.rb
+++ b/modules/appeals_api/spec/sidekiq/appeals_api/add_icn_updater_spec.rb
@@ -23,7 +23,7 @@ describe AppealsApi::AddIcnUpdater, type: :job do
     end
 
     it 'does not update ICN if flipper is disabled', skip: 'TODO' do
-      Flipper.disable(:decision_review_icn_updater_enabled)
+      Flipper.disable(:decision_review_icn_updater_enabled) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       # ...
     end
 

--- a/modules/appeals_api/spec/sidekiq/appeals_api/daily_error_report_spec.rb
+++ b/modules/appeals_api/spec/sidekiq/appeals_api/daily_error_report_spec.rb
@@ -15,7 +15,7 @@ describe AppealsApi::DailyErrorReport, type: :job do
          nathan.wright@oddball.io]
     end
 
-    before { Flipper.enable :decision_review_daily_error_report_enabled }
+    before { Flipper.enable :decision_review_daily_error_report_enabled } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
     it 'sends mail' do
       allow(YAML).to receive(:load_file).and_return({ 'common' => recipients })
@@ -29,7 +29,7 @@ describe AppealsApi::DailyErrorReport, type: :job do
     end
 
     it 'does not send email if flipper setting is disabled' do
-      Flipper.disable :decision_review_daily_error_report_enabled
+      Flipper.disable :decision_review_daily_error_report_enabled # rubocop:disable Project/ForbidFlipperToggleInSpecs
       allow(YAML).to receive(:load_file).and_return({ 'common' => recipients })
       expect(AppealsApi::DailyErrorReportMailer).not_to receive(:build)
       described_class.new.perform

--- a/modules/appeals_api/spec/sidekiq/appeals_api/daily_stuck_records_report_spec.rb
+++ b/modules/appeals_api/spec/sidekiq/appeals_api/daily_stuck_records_report_spec.rb
@@ -26,7 +26,7 @@ describe AppealsApi::DailyStuckRecordsReport, type: :job do
     end
 
     context 'when enabled' do
-      before { Flipper.enable :decision_review_daily_stuck_records_report_enabled }
+      before { Flipper.enable :decision_review_daily_stuck_records_report_enabled } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       it_behaves_like 'a monitored worker'
 
@@ -69,7 +69,7 @@ describe AppealsApi::DailyStuckRecordsReport, type: :job do
     end
 
     context 'when disabled' do
-      before { Flipper.disable :decision_review_daily_stuck_records_report_enabled }
+      before { Flipper.disable :decision_review_daily_stuck_records_report_enabled } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       it 'does nothing' do
         expect(AppealsApi::Slack::Messager).not_to receive(:new)

--- a/modules/appeals_api/spec/sidekiq/appeals_api/evidence_submission_backup_spec.rb
+++ b/modules/appeals_api/spec/sidekiq/appeals_api/evidence_submission_backup_spec.rb
@@ -48,7 +48,7 @@ describe AppealsApi::EvidenceSubmissionBackup, type: :job do
     end
 
     context 'when the delay evidence feature is enabled' do
-      before { Flipper.enable(:decision_review_delay_evidence) }
+      before { Flipper.enable(:decision_review_delay_evidence) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       it 'calls "#submits_to_central_mail!" for each evidence record returned from #evidence_to_submit' do
         subject.perform

--- a/modules/appeals_api/spec/sidekiq/appeals_api/evidence_submission_backup_spec.rb
+++ b/modules/appeals_api/spec/sidekiq/appeals_api/evidence_submission_backup_spec.rb
@@ -60,7 +60,7 @@ describe AppealsApi::EvidenceSubmissionBackup, type: :job do
     end
 
     context 'when the delay evidence feature is disabled' do
-      before { Flipper.disable(:decision_review_delay_evidence) }
+      before { Flipper.disable(:decision_review_delay_evidence) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       it 'does not take any action' do
         subject.perform

--- a/modules/appeals_api/spec/sidekiq/appeals_api/monthly_stats_report_spec.rb
+++ b/modules/appeals_api/spec/sidekiq/appeals_api/monthly_stats_report_spec.rb
@@ -46,7 +46,7 @@ describe AppealsApi::MonthlyStatsReport do
 
     describe 'disabled' do
       it 'is disabled unless the dedicated flipper setting is enabled' do
-        Flipper.disable(:decision_review_monthly_stats_report_enabled)
+        Flipper.disable(:decision_review_monthly_stats_report_enabled) # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
         expect(AppealsApi::StatsReportMailer).not_to receive(:build)
 

--- a/modules/appeals_api/spec/sidekiq/appeals_api/monthly_stats_report_spec.rb
+++ b/modules/appeals_api/spec/sidekiq/appeals_api/monthly_stats_report_spec.rb
@@ -16,7 +16,7 @@ describe AppealsApi::MonthlyStatsReport do
       let(:recipients) { %w[someone@somewhere.tld] }
 
       before do
-        Flipper.enable(:decision_review_monthly_stats_report_enabled)
+        Flipper.enable(:decision_review_monthly_stats_report_enabled) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       end
 
       it 'does not build a report without recipients' do
@@ -54,7 +54,7 @@ describe AppealsApi::MonthlyStatsReport do
       end
 
       it 'is disabled when emails are not configured to send' do
-        Flipper.enable(:decision_review_monthly_stats_report_enabled)
+        Flipper.enable(:decision_review_monthly_stats_report_enabled) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         allow(FeatureFlipper).to receive(:send_email?).and_return(false)
 
         expect(AppealsApi::StatsReportMailer).not_to receive(:build)

--- a/modules/appeals_api/spec/sidekiq/appeals_api/weeky_error_report_spec.rb
+++ b/modules/appeals_api/spec/sidekiq/appeals_api/weeky_error_report_spec.rb
@@ -8,7 +8,7 @@ describe AppealsApi::WeeklyErrorReport, type: :job do
 
   describe '#perform' do
     it 'sends mail' do
-      Flipper.enable(:decision_review_weekly_error_report_enabled)
+      Flipper.enable(:decision_review_weekly_error_report_enabled) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       expect(AppealsApi::WeeklyErrorReportMailer).to receive(:build)
         .once
         .and_return(double.tap do |mailer|
@@ -19,7 +19,7 @@ describe AppealsApi::WeeklyErrorReport, type: :job do
     end
 
     it 'does not send report email if flipper disabled' do
-      Flipper.disable(:decision_review_weekly_error_report_enabled)
+      Flipper.disable(:decision_review_weekly_error_report_enabled) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       expect(AppealsApi::WeeklyErrorReportMailer).not_to receive(:build)
 
       described_class.new.perform

--- a/modules/appeals_api/spec/sidekiq/higher_level_review_upload_status_batch_spec.rb
+++ b/modules/appeals_api/spec/sidekiq/higher_level_review_upload_status_batch_spec.rb
@@ -23,7 +23,7 @@ describe AppealsApi::HigherLevelReviewUploadStatusBatch, type: :job do
     end
 
     context 'when status updater is enabled' do
-      before { Flipper.enable :decision_review_hlr_status_updater_enabled }
+      before { Flipper.enable :decision_review_hlr_status_updater_enabled } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       it 'updates all the statuses' do
         Sidekiq::Testing.inline! { AppealsApi::HigherLevelReviewUploadStatusBatch.new.perform }
@@ -64,7 +64,7 @@ describe AppealsApi::HigherLevelReviewUploadStatusBatch, type: :job do
 
     context 'when status updater is disabled' do
       it 'does not update statuses' do
-        Flipper.disable :decision_review_hlr_status_updater_enabled
+        Flipper.disable :decision_review_hlr_status_updater_enabled # rubocop:disable Project/ForbidFlipperToggleInSpecs
         Sidekiq::Testing.inline! { AppealsApi::HigherLevelReviewUploadStatusBatch.new.perform }
         upload.reload
         expect(upload.status).to eq('submitted')

--- a/modules/appeals_api/spec/sidekiq/notice_of_disagreement_upload_status_batch_spec.rb
+++ b/modules/appeals_api/spec/sidekiq/notice_of_disagreement_upload_status_batch_spec.rb
@@ -29,7 +29,7 @@ describe AppealsApi::NoticeOfDisagreementUploadStatusBatch, type: :job do
     end
 
     context 'when status updater is enabled' do
-      before { Flipper.enable :decision_review_nod_status_updater_enabled }
+      before { Flipper.enable :decision_review_nod_status_updater_enabled } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       it 'updates all the statuses' do
         Sidekiq::Testing.inline! { AppealsApi::NoticeOfDisagreementUploadStatusBatch.new.perform }
@@ -53,7 +53,7 @@ describe AppealsApi::NoticeOfDisagreementUploadStatusBatch, type: :job do
 
     context 'when status updater is disabled' do
       it 'does not update statuses' do
-        Flipper.disable :decision_review_nod_status_updater_enabled
+        Flipper.disable :decision_review_nod_status_updater_enabled # rubocop:disable Project/ForbidFlipperToggleInSpecs
         Sidekiq::Testing.inline! { AppealsApi::NoticeOfDisagreementUploadStatusBatch.new.perform }
         upload.reload
         expect(upload.status).to eq('submitted')

--- a/modules/appeals_api/spec/sidekiq/supplemental_claim_upload_status_batch_spec.rb
+++ b/modules/appeals_api/spec/sidekiq/supplemental_claim_upload_status_batch_spec.rb
@@ -23,7 +23,7 @@ describe AppealsApi::SupplementalClaimUploadStatusBatch, type: :job do
     end
 
     context 'when status updater is enabled' do
-      before { Flipper.enable :decision_review_sc_status_updater_enabled }
+      before { Flipper.enable :decision_review_sc_status_updater_enabled } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       it 'updates all the statuses' do
         Sidekiq::Testing.inline! { AppealsApi::SupplementalClaimUploadStatusBatch.new.perform }
@@ -34,7 +34,7 @@ describe AppealsApi::SupplementalClaimUploadStatusBatch, type: :job do
 
     context 'when status updater is disabled' do
       it 'does not update statuses' do
-        Flipper.disable :decision_review_sc_status_updater_enabled
+        Flipper.disable :decision_review_sc_status_updater_enabled # rubocop:disable Project/ForbidFlipperToggleInSpecs
         Sidekiq::Testing.inline! { AppealsApi::SupplementalClaimUploadStatusBatch.new.perform }
         upload.reload
         expect(upload.status).to eq('submitted')

--- a/modules/appeals_api/spec/support/shared_examples_for_gateway_origin_check.rb
+++ b/modules/appeals_api/spec/support/shared_examples_for_gateway_origin_check.rb
@@ -8,7 +8,7 @@ shared_examples 'an endpoint requiring gateway origin headers' do |headers:|
 
   describe '#require_gateway_origin' do
     context 'with benefits_require_gateway_origin flag off' do
-      before { Flipper.disable(:benefits_require_gateway_origin) }
+      before { Flipper.disable(:benefits_require_gateway_origin) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       it 'does nothing' do
         make_request(headers)
@@ -18,7 +18,7 @@ shared_examples 'an endpoint requiring gateway origin headers' do |headers:|
     end
 
     context 'with benefits_require_gateway_origin flag on' do
-      before { Flipper.enable(:benefits_require_gateway_origin) }
+      before { Flipper.enable(:benefits_require_gateway_origin) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       it 'does nothing when rails is not running in production mode' do
         make_request(headers)

--- a/modules/dhp_connected_devices/spec/requests/dhp_connected_devices/fitbit_spec.rb
+++ b/modules/dhp_connected_devices/spec/requests/dhp_connected_devices/fitbit_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'DhpConnectedDevices::Fitbit', type: :request do
     end
 
     context 'fitbit feature enabled and un-authenticated user' do
-      before { Flipper.enable(:dhp_connected_devices_fitbit) }
+      before { Flipper.enable(:dhp_connected_devices_fitbit) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       it 'returns unauthenticated' do
         expect(fitbit_connect).to be 401
@@ -28,7 +28,7 @@ RSpec.describe 'DhpConnectedDevices::Fitbit', type: :request do
 
     context 'fitbit feature enabled and un-verified user' do
       before do
-        Flipper.enable(:dhp_connected_devices_fitbit)
+        Flipper.enable(:dhp_connected_devices_fitbit) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         sign_in_as(user_without_icn)
       end
 
@@ -40,7 +40,7 @@ RSpec.describe 'DhpConnectedDevices::Fitbit', type: :request do
     context 'fitbit feature disabled and authenticated user' do
       before do
         sign_in_as(current_user)
-        Flipper.disable(:dhp_connected_devices_fitbit)
+        Flipper.disable(:dhp_connected_devices_fitbit) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       end
 
       it 'returns not found' do
@@ -51,7 +51,7 @@ RSpec.describe 'DhpConnectedDevices::Fitbit', type: :request do
     context 'fitbit feature enabled and authenticated user' do
       before do
         sign_in_as(current_user)
-        Flipper.enable(:dhp_connected_devices_fitbit)
+        Flipper.enable(:dhp_connected_devices_fitbit) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       end
 
       let(:client) { DhpConnectedDevices::Fitbit::Client.new }
@@ -70,21 +70,21 @@ RSpec.describe 'DhpConnectedDevices::Fitbit', type: :request do
 
     context 'fitbit feature enabled and user unauthenticated' do
       it 'navigating to /fitbit-callback returns error' do
-        Flipper.enable(:dhp_connected_devices_fitbit)
+        Flipper.enable(:dhp_connected_devices_fitbit)  # rubocop:disable Project/ForbidFlipperToggleInSpecs
         expect(fitbit_callback).to be 401
       end
     end
 
     context 'fitbit feature not enabled and user unauthenticated' do
       it 'navigating to /fitbit-callback returns error' do
-        Flipper.disable(:dhp_connected_devices_fitbit)
+        Flipper.disable(:dhp_connected_devices_fitbit) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         expect(fitbit_callback).to be 401
       end
     end
 
     context 'fitbit feature enabled and user unverified' do
       before do
-        Flipper.enable(:dhp_connected_devices_fitbit)
+        Flipper.enable(:dhp_connected_devices_fitbit) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         sign_in_as(user_without_icn)
       end
 
@@ -96,7 +96,7 @@ RSpec.describe 'DhpConnectedDevices::Fitbit', type: :request do
     context 'fitbit feature not enabled and user authenticated' do
       before do
         sign_in_as(current_user)
-        Flipper.disable(:dhp_connected_devices_fitbit)
+        Flipper.disable(:dhp_connected_devices_fitbit) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       end
 
       it 'navigating to /fitbit-callback returns error' do
@@ -115,7 +115,7 @@ RSpec.describe 'DhpConnectedDevices::Fitbit', type: :request do
 
       before do
         sign_in_as(current_user)
-        Flipper.enable(:dhp_connected_devices_fitbit)
+        Flipper.enable(:dhp_connected_devices_fitbit) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         create(:device, :fitbit)
       end
 
@@ -253,14 +253,14 @@ RSpec.describe 'DhpConnectedDevices::Fitbit', type: :request do
 
     context 'fitbit feature enabled and user unauthenticated' do
       it 'navigating to /fitbit/disconnect returns error' do
-        Flipper.enable(:dhp_connected_devices_fitbit)
+        Flipper.enable(:dhp_connected_devices_fitbit) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         expect(fitbit_disconnect).to be 401
       end
     end
 
     context 'fitbit feature enabled and user unverified' do
       before do
-        Flipper.enable(:dhp_connected_devices_fitbit)
+        Flipper.enable(:dhp_connected_devices_fitbit) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         sign_in_as(user_without_icn)
       end
 

--- a/modules/dhp_connected_devices/spec/requests/dhp_connected_devices/veteran_device_records_spec.rb
+++ b/modules/dhp_connected_devices/spec/requests/dhp_connected_devices/veteran_device_records_spec.rb
@@ -8,7 +8,7 @@ Rspec.describe 'DhpConnectedDevices::VeteranDeviceRecords', type: :request do
 
   describe 'veteran_device_record#record' do
     context 'unauthenticated user' do
-      before { Flipper.enable(:dhp_connected_devices_fitbit) }
+      before { Flipper.enable(:dhp_connected_devices_fitbit) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       it 'returns unauthenticated error' do
         get '/dhp_connected_devices/veteran-device-records'

--- a/modules/employment_questionnaires/spec/controllers/employment_questionnaires/claims_controller_spec.rb
+++ b/modules/employment_questionnaires/spec/controllers/employment_questionnaires/claims_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe EmploymentQuestionnaires::V0::ClaimsController, type: :request do
 
   before do
     sign_in_as(user)
-    Flipper.enable(:employment_questionnaires_form_enabled)
+    Flipper.enable(:employment_questionnaires_form_enabled) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     allow(EmploymentQuestionnaires::Monitor).to receive(:new).and_return(monitor)
     allow(monitor).to receive_messages(track_show404: nil, track_show_error: nil, track_create_attempt: nil,
                                        track_create_error: nil, track_create_success: nil,

--- a/modules/mobile/spec/requests/mobile/v0/appeal_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/appeal_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe 'Mobile::V0::Appeal', type: :request do
       end
 
       context 'with appeals model used' do
-        before { Flipper.enable(:mobile_appeal_model) }
-        after { Flipper.disable(:mobile_appeal_model) }
+        before { Flipper.enable(:mobile_appeal_model) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
+        after { Flipper.disable(:mobile_appeal_model) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
         it 'and a result that matches our schema is successfully returned with the 200 status' do
           VCR.use_cassette('caseflow/appeals') do

--- a/modules/mobile/spec/requests/mobile/v0/appeal_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/appeal_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe 'Mobile::V0::Appeal', type: :request do
       end
 
       context 'with appeals model NOT used' do
-        before { Flipper.disable(:mobile_appeal_model) }
+        before { Flipper.disable(:mobile_appeal_model) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
         it 'and a result that matches our schema is successfully returned with the 200 status' do
           VCR.use_cassette('caseflow/appeals') do

--- a/modules/mobile/spec/requests/mobile/v0/appointments/vaos_v2_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/appointments/vaos_v2_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Mobile::V0::Appointments::VAOSV2', type: :request do
   let!(:user) { sis_user(icn: '1012846043V576341', vha_facility_ids: [402, 555]) }
 
   before do
-    Flipper.enable_actor(:appointments_consolidation, user)
+    Flipper.enable_actor(:appointments_consolidation, user) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     allow(Flipper).to receive(:enabled?).with(:va_online_scheduling_vaos_alternate_route).and_return(false)
     allow(Flipper).to receive(:enabled?).with('schema_contract_appointments_index').and_return(true)
     allow(Flipper).to receive(:enabled?).with(:travel_pay_view_claim_details, instance_of(User)).and_return(false)

--- a/modules/mobile/spec/requests/mobile/v0/health/allergy_intolerance_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/health/allergy_intolerance_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'Mobile::V0::Health::AllergyIntolerances', type: :request do
   end
 
   context 'when legacy is used' do
-    before { Flipper.disable(:mobile_allergy_intolerance_model) }
+    before { Flipper.disable(:mobile_allergy_intolerance_model) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
     it 'responds to GET #index' do
       VCR.use_cassette('rrd/lighthouse_allergy_intolerances') do
@@ -145,7 +145,7 @@ RSpec.describe 'Mobile::V0::Health::AllergyIntolerances', type: :request do
 
   context 'when non-legacy is used' do
     before { Flipper.enable_actor(:mobile_allergy_intolerance_model, user) }
-    after { Flipper.disable(:mobile_allergy_intolerance_model) }
+    after { Flipper.disable(:mobile_allergy_intolerance_model) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
     it 'responds to GET #index' do
       allow(UniqueUserEvents).to receive(:log_events)

--- a/modules/mobile/spec/requests/mobile/v0/health/allergy_intolerance_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/health/allergy_intolerance_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe 'Mobile::V0::Health::AllergyIntolerances', type: :request do
   end
 
   context 'when non-legacy is used' do
-    before { Flipper.enable_actor(:mobile_allergy_intolerance_model, user) }
+    before { Flipper.enable_actor(:mobile_allergy_intolerance_model, user) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
     after { Flipper.disable(:mobile_allergy_intolerance_model) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
     it 'responds to GET #index' do

--- a/modules/mobile/spec/requests/mobile/v0/health/rx/prescriptions_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/health/rx/prescriptions_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe 'health/rx/prescriptions', type: :request do
     describe 'feature mhv_medications_display_pending_meds' do
       context 'when mhv_medications_display_pending_meds is set to true"' do
         before do
-          Flipper.enable_actor(:mhv_medications_display_pending_meds, user)
+          Flipper.enable_actor(:mhv_medications_display_pending_meds, user) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         end
 
         it 'responds to GET #index with pending meds included in list' do

--- a/modules/mobile/spec/requests/mobile/v0/health/rx/prescriptions_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v0/health/rx/prescriptions_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe 'health/rx/prescriptions', type: :request do
 
       context 'when mhv_medications_display_pending_meds is set to false"' do
         before do
-          Flipper.disable(:mhv_medications_display_pending_meds)
+          Flipper.disable(:mhv_medications_display_pending_meds) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         end
 
         it 'responds to GET #index with pending meds not included in list' do

--- a/modules/mobile/spec/requests/mobile/v2/user_spec.rb
+++ b/modules/mobile/spec/requests/mobile/v2/user_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe 'Mobile::V2::User', type: :request do
       context 'with feature flag off and user\'s va_treatment_facility_ids contains the hardcoded facility id' do
         let!(:user) { sis_user(idme_uuid: 'b2fab2b5-6af0-45e1-a9e2-394347af91ef', vha_facility_ids: ['979']) }
 
-        before { Flipper.disable(:mobile_cerner_transition) }
-        after { Flipper.enable(:mobile_cerner_transition) }
+        before { Flipper.disable(:mobile_cerner_transition) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
+        after { Flipper.enable(:mobile_cerner_transition) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
         it 'sets hasFacilityTransitioningToCerner to false' do
           get_user
@@ -64,8 +64,8 @@ RSpec.describe 'Mobile::V2::User', type: :request do
       context 'with feature flag on and user\'s va_treatment_facility_ids contains the hardcoded facility id' do
         let!(:user) { sis_user(idme_uuid: 'b2fab2b5-6af0-45e1-a9e2-394347af91ef', vha_facility_ids: ['979']) }
 
-        before { Flipper.enable(:mobile_cerner_transition) }
-        after { Flipper.disable(:mobile_cerner_transition) }
+        before { Flipper.enable(:mobile_cerner_transition) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
+        after { Flipper.disable(:mobile_cerner_transition) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
         it 'sets hasFacilityTransitioningToCerner to true' do
           get_user
@@ -76,8 +76,8 @@ RSpec.describe 'Mobile::V2::User', type: :request do
       context "with feature flag on and user's va_treatment_facility_ids does not contain the hardcoded facility id" do
         let!(:user) { sis_user(idme_uuid: 'b2fab2b5-6af0-45e1-a9e2-394347af91ef', vha_facility_ids: ['555']) }
 
-        before { Flipper.enable(:mobile_cerner_transition) }
-        after { Flipper.disable(:mobile_cerner_transition) }
+        before { Flipper.enable(:mobile_cerner_transition) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
+        after { Flipper.disable(:mobile_cerner_transition) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
         it 'sets hasFacilityTransitioningToCerner to false' do
           get_user

--- a/modules/mobile/spec/requests/v0/feature_toggles_request_spec.rb
+++ b/modules/mobile/spec/requests/v0/feature_toggles_request_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Feature Toggles API endpoint', type: :request do
 
       it 'uses the current_user for feature toggle evaluation' do
         Flipper.disable(@feature_name) # rubocop:disable Project/ForbidFlipperToggleInSpecs
-        Flipper.enable_actor(@feature_name, user)
+        Flipper.enable_actor(@feature_name, user) # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
         # retrieve features anonymously
         get '/mobile/v0/feature-toggles'

--- a/modules/mobile/spec/requests/v0/feature_toggles_request_spec.rb
+++ b/modules/mobile/spec/requests/v0/feature_toggles_request_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Feature Toggles API endpoint', type: :request do
       end
 
       it 'uses the current_user for feature toggle evaluation' do
-        Flipper.disable(@feature_name)
+        Flipper.disable(@feature_name) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         Flipper.enable_actor(@feature_name, user)
 
         # retrieve features anonymously

--- a/modules/mobile/spec/requests/v0/feature_toggles_request_spec.rb
+++ b/modules/mobile/spec/requests/v0/feature_toggles_request_spec.rb
@@ -14,16 +14,16 @@ RSpec.describe 'Feature Toggles API endpoint', type: :request do
       @feature_name = 'this_is_only_a_test'
       @feature_name_camel = @feature_name.camelize(:lower)
       @cached_enabled_val = Flipper.enabled?(@feature_name)
-      Flipper.enable(@feature_name)
+      Flipper.enable(@feature_name) # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       @second_feature = 'this_is_only_a_test_two'
       @second_feature_camel = @second_feature.camelize(:lower)
-      Flipper.enable(@second_feature)
+      Flipper.enable(@second_feature) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     end
 
     after(:all) do
-      Flipper.disable(@feature_name)
-      Flipper.disable(@second_feature)
+      Flipper.disable(@feature_name) # rubocop:disable Project/ForbidFlipperToggleInSpecs
+      Flipper.disable(@second_feature) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     end
 
     context 'with authenticated user' do

--- a/modules/mobile/spec/support/helpers/iam_session_helper.rb
+++ b/modules/mobile/spec/support/helpers/iam_session_helper.rb
@@ -35,10 +35,10 @@ RSpec.configure do |config|
   config.include IAMSessionHelper
 
   config.before :each, type: :request do
-    Flipper.enable('va_online_scheduling')
+    Flipper.enable('va_online_scheduling') # rubocop:disable Project/ForbidFlipperToggleInSpecs
   end
 
   config.before :each, type: :controller do
-    Flipper.enable('va_online_scheduling')
+    Flipper.enable('va_online_scheduling') # rubocop:disable Project/ForbidFlipperToggleInSpecs
   end
 end

--- a/modules/mobile/spec/support/helpers/rails_helper.rb
+++ b/modules/mobile/spec/support/helpers/rails_helper.rb
@@ -14,7 +14,7 @@ RSpec.configure do |config|
   # Not every spec needs it but no specs need it disabled so to ensure we don't get flaky specs
   # this will just be enabled for all specs
   config.before :each, :mobile_spec, type: :request do
-    Flipper.enable('va_online_scheduling')
+    Flipper.enable('va_online_scheduling') # rubocop:disable Project/ForbidFlipperToggleInSpecs
   end
 
   config.after :each, :mobile_spec, skipped?: false, type: :request do |example|

--- a/modules/my_health/spec/requests/my_health/v1/prescriptions_spec.rb
+++ b/modules/my_health/spec/requests/my_health/v1/prescriptions_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe 'MyHealth::V1::Prescriptions', type: :request do
 
     context 'Feature mhv_medications_display_pending_meds=false"' do
       before do
-        Flipper.disable(:mhv_medications_display_pending_meds)
+        Flipper.disable(:mhv_medications_display_pending_meds) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       end
 
       it 'responds to GET #index with pending meds not included in list' do

--- a/modules/my_health/spec/requests/my_health/v1/prescriptions_spec.rb
+++ b/modules/my_health/spec/requests/my_health/v1/prescriptions_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe 'MyHealth::V1::Prescriptions', type: :request do
 
     context 'Feature mhv_medications_display_pending_meds=true"' do
       before do
-        Flipper.enable_actor(:mhv_medications_display_pending_meds, current_user)
+        Flipper.enable_actor(:mhv_medications_display_pending_meds, current_user) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       end
 
       it 'responds to GET #index with pending meds included in list' do

--- a/modules/representation_management/spec/requests/representation_management/v0/accredited_entities_for_appoint_spec.rb
+++ b/modules/representation_management/spec/requests/representation_management/v0/accredited_entities_for_appoint_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'RepresentationManagement::V0::AccreditedEntitiesForAppoint', typ
   let!(:bob_smith_firm) { create(:accredited_organization, :with_location, name: 'Bob Smith Firm') }
 
   before do
-    Flipper.enable(:appoint_a_representative_enable_pdf)
+    Flipper.enable(:appoint_a_representative_enable_pdf) # rubocop:disable Project/ForbidFlipperToggleInSpecs
   end
 
   context 'the response should be an empty array' do
@@ -54,11 +54,11 @@ RSpec.describe 'RepresentationManagement::V0::AccreditedEntitiesForAppoint', typ
 
   context "when the feature flag 'find_a_representative_use_accredited_models' is disabled" do
     before do
-      Flipper.disable(:find_a_representative_use_accredited_models)
+      Flipper.disable(:find_a_representative_use_accredited_models) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     end
 
     after do
-      Flipper.enable(:find_a_representative_use_accredited_models)
+      Flipper.enable(:find_a_representative_use_accredited_models) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     end
 
     it 'returns a 404' do

--- a/modules/representation_management/spec/requests/representation_management/v0/accredited_individuals_spec.rb
+++ b/modules/representation_management/spec/requests/representation_management/v0/accredited_individuals_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'RepresentationManagement::V0::AccreditedIndividuals', type: :req
 
   context 'when find_a_representative_use_accredited_models is disabled' do
     before do
-      Flipper.disable(:find_a_representative_use_accredited_models)
+      Flipper.disable(:find_a_representative_use_accredited_models) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     end
 
     it 'returns a not found routing error' do

--- a/modules/representation_management/spec/requests/representation_management/v0/accredited_individuals_spec.rb
+++ b/modules/representation_management/spec/requests/representation_management/v0/accredited_individuals_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'RepresentationManagement::V0::AccreditedIndividuals', type: :req
 
   context 'when find_a_representative_use_accredited_models is enabled' do
     before do
-      Flipper.enable(:find_a_representative_use_accredited_models)
+      Flipper.enable(:find_a_representative_use_accredited_models) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     end
 
     context 'when a required param is missing' do

--- a/modules/representation_management/spec/requests/representation_management/v0/original_entities_spec.rb
+++ b/modules/representation_management/spec/requests/representation_management/v0/original_entities_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'RepresentationManagement::V0::OriginalEntities', type: :request 
 
   context 'when use_veteran_models_for_appoint is disabled' do
     before do
-      Flipper.disable(:use_veteran_models_for_appoint)
+      Flipper.disable(:use_veteran_models_for_appoint) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     end
 
     it 'returns a not found routing error' do
@@ -27,7 +27,7 @@ RSpec.describe 'RepresentationManagement::V0::OriginalEntities', type: :request 
 
   context 'when use_veteran_models_for_appoint is enabled' do
     before do
-      Flipper.enable(:use_veteran_models_for_appoint)
+      Flipper.enable(:use_veteran_models_for_appoint) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     end
 
     context 'when no query param is provided' do

--- a/modules/representation_management/spec/requests/representation_management/v0/power_of_attorney_requests_swagger_spec.rb
+++ b/modules/representation_management/spec/requests/representation_management/v0/power_of_attorney_requests_swagger_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Power of Attorney Requests',
           end
           before do
             sign_in_as(user)
-            Flipper.enable(:appoint_a_representative_enable_v2_features)
+            Flipper.enable(:appoint_a_representative_enable_v2_features) # rubocop:disable Project/ForbidFlipperToggleInSpecs
             allow_any_instance_of(RepresentationManagement::PowerOfAttorneyRequestService::Orchestrate)
               .to receive(:call)
               .and_return({ request: poa_request_result })
@@ -59,7 +59,7 @@ RSpec.describe 'Power of Attorney Requests',
 
           before do
             sign_in_as(user)
-            Flipper.enable(:appoint_a_representative_enable_v2_features)
+            Flipper.enable(:appoint_a_representative_enable_v2_features) # rubocop:disable Project/ForbidFlipperToggleInSpecs
           end
 
           schema '$ref' => '#/components/schemas/errors'

--- a/modules/representation_management/spec/requests/v0/next_steps_email_spec.rb
+++ b/modules/representation_management/spec/requests/v0/next_steps_email_spec.rb
@@ -123,11 +123,11 @@ RSpec.describe 'NextStepsEmailController', type: :request do
 
     context "when the feature flag 'appoint_a_representative_enable_pdf' is disabled" do
       before do
-        Flipper.disable(:appoint_a_representative_enable_pdf)
+        Flipper.disable(:appoint_a_representative_enable_pdf) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       end
 
       after do
-        Flipper.enable(:appoint_a_representative_enable_pdf)
+        Flipper.enable(:appoint_a_representative_enable_pdf) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       end
 
       it 'returns a 404' do

--- a/modules/va_notify/spec/sidekiq/in_progress_form_reminder_spec.rb
+++ b/modules/va_notify/spec/sidekiq/in_progress_form_reminder_spec.rb
@@ -87,7 +87,7 @@ describe VANotify::InProgressFormReminder, type: :worker do
       end
 
       it 'delegates to VANotify::UserAccountJob if its the oldest in_progress_form' do
-        Flipper.disable(:in_progress_generic_multiple_template)
+        Flipper.disable(:in_progress_generic_multiple_template) # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
         user_with_uuid = double('VANotify::Veteran', icn: 'icn', first_name: 'first_name', uuid: 'uuid')
         allow(VANotify::Veteran).to receive(:new).and_return(user_with_uuid)

--- a/modules/vaos/spec/config/initializers/flipper_spec.rb
+++ b/modules/vaos/spec/config/initializers/flipper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Flipper::Instrumentation::AppointmentsEventSubscriber do
   context 'logs changes to toggle values' do
     it 'logs error for restricted operation of critical feature' do
       allow(Rails.logger).to receive(:error)
-      Flipper.disable(:va_online_scheduling_subscriber_unit_testing)
+      Flipper.disable(:va_online_scheduling_subscriber_unit_testing) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       expect(Rails.logger).to have_received(:error).with(
         'Restricted operation for critical appointments feature: disable va_online_scheduling_subscriber_unit_testing'
       )
@@ -14,7 +14,7 @@ RSpec.describe Flipper::Instrumentation::AppointmentsEventSubscriber do
 
     it 'logs warning for routine operation of critical feature' do
       allow(Rails.logger).to receive(:warn)
-      Flipper.enable(:va_online_scheduling_subscriber_unit_testing)
+      Flipper.enable(:va_online_scheduling_subscriber_unit_testing) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       expect(Rails.logger).to have_received(:warn).with(
         'Routine operation for critical appointments feature: enable va_online_scheduling_subscriber_unit_testing'
       )
@@ -22,7 +22,7 @@ RSpec.describe Flipper::Instrumentation::AppointmentsEventSubscriber do
 
     it 'logs info for restricted operation of non-critical feature' do
       allow(Rails.logger).to receive(:info)
-      Flipper.disable(:va_online_scheduling_this_is_only_a_test)
+      Flipper.disable(:va_online_scheduling_this_is_only_a_test) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       expect(Rails.logger).to have_received(:info).with(
         'Routine operation for appointments feature: disable va_online_scheduling_this_is_only_a_test'
       )
@@ -30,7 +30,7 @@ RSpec.describe Flipper::Instrumentation::AppointmentsEventSubscriber do
 
     it 'logs info for routine operation of non-critical feature' do
       allow(Rails.logger).to receive(:info)
-      Flipper.enable(:va_online_scheduling_this_is_only_a_test)
+      Flipper.enable(:va_online_scheduling_this_is_only_a_test)  # rubocop:disable Project/ForbidFlipperToggleInSpecs
       expect(Rails.logger).to have_received(:info).with(
         'Routine operation for appointments feature: enable va_online_scheduling_this_is_only_a_test'
       )

--- a/modules/vaos/spec/requests/vaos/v2/community_care/eligibility_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/community_care/eligibility_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'VAOS::V2::CommunityCare::Eligibility', type: :request do
   include SchemaMatchers
 
   before do
-    Flipper.enable('va_online_scheduling')
+    Flipper.enable('va_online_scheduling') # rubocop:disable Project/ForbidFlipperToggleInSpecs
     allow(Flipper).to receive(:enabled?).with(:va_online_scheduling_vaos_alternate_route).and_return(false)
     sign_in_as(current_user)
     allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token')

--- a/modules/vaos/spec/requests/vaos/v2/eligibility_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/eligibility_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'VAOS::V2::Patients', :skip_mvi, type: :request do
   include SchemaMatchers
 
   before do
-    Flipper.enable('va_online_scheduling')
+    Flipper.enable('va_online_scheduling') # rubocop:disable Project/ForbidFlipperToggleInSpecs
     allow(Flipper).to receive(:enabled?).with(:va_online_scheduling_vaos_alternate_route).and_return(false)
     sign_in_as(current_user)
     allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token')

--- a/modules/vaos/spec/requests/vaos/v2/facilities_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/facilities_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'VAOS::V2::Facilities', type: :request do
   include SchemaMatchers
 
   before do
-    Flipper.enable('va_online_scheduling')
+    Flipper.enable('va_online_scheduling') # rubocop:disable Project/ForbidFlipperToggleInSpecs
     allow(Flipper).to receive(:enabled?).with(:va_online_scheduling_vaos_alternate_route).and_return(false)
     sign_in_as(user)
     allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token')

--- a/modules/vaos/spec/requests/vaos/v2/locations/slots_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/locations/slots_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'VAOS::V2::Locations::Slots', type: :request do
   include SchemaMatchers
 
   before do
-    Flipper.enable('va_online_scheduling')
+    Flipper.enable('va_online_scheduling') # rubocop:disable Project/ForbidFlipperToggleInSpecs
     allow(Flipper).to receive(:enabled?).with(:va_online_scheduling_vaos_alternate_route).and_return(false)
     sign_in_as(user)
     allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token')

--- a/modules/vaos/spec/requests/vaos/v2/scheduling/configurations_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/scheduling/configurations_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'VAOS::V2::Scheduling::Configurations', :skip_mvi, type: :request
   let(:current_user) { build(:user, :vaos) }
 
   before do
-    Flipper.enable('va_online_scheduling')
+    Flipper.enable('va_online_scheduling') # rubocop:disable Project/ForbidFlipperToggleInSpecs
     allow(Flipper).to receive(:enabled?).with(:va_online_scheduling_vaos_alternate_route).and_return(false)
     sign_in_as(current_user)
     allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token')

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -61,7 +61,7 @@ describe VAOS::V2::AppointmentsService do
 
   before do
     allow_any_instance_of(VAOS::UserService).to receive(:session).and_return('stubbed_token')
-    Flipper.enable_actor(:appointments_consolidation, user)
+    Flipper.enable_actor(:appointments_consolidation, user) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     allow(Flipper).to receive(:enabled?).with(:va_online_scheduling_vaos_alternate_route).and_return(false)
   end
 

--- a/modules/vba_documents/spec/sidekiq/report_unsuccessful_submissions_spec.rb
+++ b/modules/vba_documents/spec/sidekiq/report_unsuccessful_submissions_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe VBADocuments::ReportUnsuccessfulSubmissions, type: :job do
     end
 
     context 'when the :decision_review_delay_evidence feature is enabled' do
-      before { Flipper.enable(:decision_review_delay_evidence) }
+      before { Flipper.enable(:decision_review_delay_evidence) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       it 'returns submissions in "uploaded" status' do
         expect(subject.stuck).to include(stuck_submission)

--- a/modules/vba_documents/spec/sidekiq/report_unsuccessful_submissions_spec.rb
+++ b/modules/vba_documents/spec/sidekiq/report_unsuccessful_submissions_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe VBADocuments::ReportUnsuccessfulSubmissions, type: :job do
     end
 
     context 'when the :decision_review_delay_evidence feature is disabled' do
-      before { Flipper.disable(:decision_review_delay_evidence) }
+      before { Flipper.disable(:decision_review_delay_evidence) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       it 'returns submissions in "uploaded" status' do
         expect(subject.stuck).to include(stuck_submission)

--- a/modules/vba_documents/spec/sidekiq/run_unsuccessful_submissions_spec.rb
+++ b/modules/vba_documents/spec/sidekiq/run_unsuccessful_submissions_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe VBADocuments::RunUnsuccessfulSubmissions, type: :job do
     end
 
     context 'when the decision_review_delay_evidence feature is disabled' do
-      before { Flipper.disable(:decision_review_delay_evidence) }
+      before { Flipper.disable(:decision_review_delay_evidence) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       it 'calls the UploadProcessor for the uploaded UploadSubmission' do
         expect(VBADocuments::UploadProcessor).to receive(:perform_async)

--- a/modules/vba_documents/spec/sidekiq/run_unsuccessful_submissions_spec.rb
+++ b/modules/vba_documents/spec/sidekiq/run_unsuccessful_submissions_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe VBADocuments::RunUnsuccessfulSubmissions, type: :job do
 
   describe '#perform' do
     context 'when the decision_review_delay_evidence feature is enabled' do
-      before { Flipper.enable(:decision_review_delay_evidence) }
+      before { Flipper.enable(:decision_review_delay_evidence) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       it 'calls the UploadProcessor for the uploaded UploadSubmission' do
         expect(VBADocuments::UploadProcessor).to receive(:perform_async)

--- a/modules/vba_documents/spec/sidekiq/slack_inflight_notifier_spec.rb
+++ b/modules/vba_documents/spec/sidekiq/slack_inflight_notifier_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'VBADocuments::SlackInflightNotifier', type: :job do
     end
 
     context 'when the :decision_review_delay_evidence feature is disabled' do
-      before { Flipper.disable(:decision_review_delay_evidence) }
+      before { Flipper.disable(:decision_review_delay_evidence) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       it 'includes evidence submissions in the "uploaded" status grouping' do
         @results = @job.perform

--- a/modules/vba_documents/spec/sidekiq/slack_inflight_notifier_spec.rb
+++ b/modules/vba_documents/spec/sidekiq/slack_inflight_notifier_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'VBADocuments::SlackInflightNotifier', type: :job do
     end
 
     context 'when the :decision_review_delay_evidence feature is enabled' do
-      before { Flipper.enable(:decision_review_delay_evidence) }
+      before { Flipper.enable(:decision_review_delay_evidence) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       it 'excludes evidence submissions from the "uploaded" status grouping' do
         @results = @job.perform

--- a/modules/vba_documents/spec/sidekiq/upload_scanner_spec.rb
+++ b/modules/vba_documents/spec/sidekiq/upload_scanner_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe VBADocuments::UploadScanner, type: :job do
       end
 
       context 'and the delay evidence feature flag is enabled' do
-        before { Flipper.enable(:decision_review_delay_evidence) }
+        before { Flipper.enable(:decision_review_delay_evidence) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
         it 'updates the submission status to "uploaded"' do
           with_settings(Settings.vba_documents.s3, enabled: true) do

--- a/modules/vba_documents/spec/sidekiq/upload_scanner_spec.rb
+++ b/modules/vba_documents/spec/sidekiq/upload_scanner_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe VBADocuments::UploadScanner, type: :job do
       end
 
       context 'and the delay evidence feature flag is disabled' do
-        before { Flipper.disable(:decision_review_delay_evidence) }
+        before { Flipper.disable(:decision_review_delay_evidence) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
         it 'updates the submission status to "uploaded"' do
           with_settings(Settings.vba_documents.s3, enabled: true) do

--- a/modules/veteran/spec/requests/v0/base_accredited_representatives_shared_spec.rb
+++ b/modules/veteran/spec/requests/v0/base_accredited_representatives_shared_spec.rb
@@ -22,7 +22,7 @@ RSpec.shared_examples 'base_accredited_representatives_controller_shared_example
 
   context 'when find a rep is enabled' do
     before do
-      Flipper.enable(:find_a_representative_enable_api)
+      Flipper.enable(:find_a_representative_enable_api) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     end
 
     context 'when a required param is missing' do

--- a/modules/veteran/spec/requests/v0/base_accredited_representatives_shared_spec.rb
+++ b/modules/veteran/spec/requests/v0/base_accredited_representatives_shared_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.shared_examples 'base_accredited_representatives_controller_shared_examples' do |path, type|
   context 'when find a rep is disabled' do
     before do
-      Flipper.disable(:find_a_representative_enable_api)
+      Flipper.disable(:find_a_representative_enable_api) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     end
 
     it 'returns a not found routing error' do

--- a/modules/veteran/spec/requests/v0/vso_accredited_representatives_spec.rb
+++ b/modules/veteran/spec/requests/v0/vso_accredited_representatives_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Veteran::V0::VSOAccreditedRepresentatives', type: :request do
     let(:long) { -77.0369 }
 
     before do
-      Flipper.enable(:find_a_representative_enable_api)
+      Flipper.enable(:find_a_representative_enable_api) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       # Create representatives
       create(:representative, representative_id: '111', poa_codes: %w[A12 A13], user_types: ['veteran_service_officer'],
                               long: -77.050552, lat: 38.820450, location: 'POINT(-77.050552 38.820450)',

--- a/spec/controllers/v0/feature_toggles_controller_spec.rb
+++ b/spec/controllers/v0/feature_toggles_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe V0::FeatureTogglesController, type: :controller do
 
       Flipper.enable_actor(@feature_name, actor)
       Flipper.enable_percentage_of_actors(@feature_name, 25)
-      Flipper.enable(@feature_name)
+      Flipper.enable(@feature_name) # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       get :index, params: { cookie_id: }
 
@@ -98,7 +98,7 @@ RSpec.describe V0::FeatureTogglesController, type: :controller do
       before do
         allow(ActiveRecord::Base.logger).to receive(:silence)
         allow(Settings.flipper).to receive(:mute_logs).and_return(true)
-        Flipper.disable(@feature_name)
+        Flipper.disable(@feature_name) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         Flipper.enable_percentage_of_actors(@feature_name, 100)
       end
 
@@ -156,7 +156,7 @@ RSpec.describe V0::FeatureTogglesController, type: :controller do
       @feature_name =  'find_a_representative_enabled'
       @cookie_id = 'abc_123'
       actor = Flipper::Actor.new(@cookie_id)
-      Flipper.disable(@feature_name)
+      Flipper.disable(@feature_name) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       Flipper.enable_actor(@feature_name, actor)
 
       get :index, params: { features: @feature_name, cookie_id: @cookie_id }

--- a/spec/controllers/v0/feature_toggles_controller_spec.rb
+++ b/spec/controllers/v0/feature_toggles_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe V0::FeatureTogglesController, type: :controller do
       @cookie_id = 'abc_123'
       actor = Flipper::Actor.new(@cookie_id)
       Flipper.disable(@feature_name) # rubocop:disable Project/ForbidFlipperToggleInSpecs
-      Flipper.enable_actor(@feature_name, actor)
+      Flipper.enable_actor(@feature_name, actor) # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       get :index, params: { cookie_id: @cookie_id }
 
@@ -55,7 +55,7 @@ RSpec.describe V0::FeatureTogglesController, type: :controller do
     end
 
     it 'returns percentage of actor consistently' do
-      Flipper.enable_percentage_of_actors(@feature_name, 25)
+      Flipper.enable_percentage_of_actors(@feature_name, 25) # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       5.times do |i|
         cookie_id = "cookie_#{31 + i}"
@@ -78,8 +78,8 @@ RSpec.describe V0::FeatureTogglesController, type: :controller do
       cookie_id = 'abc_123'
       actor = Flipper::Actor.new(cookie_id)
 
-      Flipper.enable_actor(@feature_name, actor)
-      Flipper.enable_percentage_of_actors(@feature_name, 25)
+      Flipper.enable_actor(@feature_name, actor) # rubocop:disable Project/ForbidFlipperToggleInSpecs
+      Flipper.enable_percentage_of_actors(@feature_name, 25) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       Flipper.enable(@feature_name) # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       get :index, params: { cookie_id: }
@@ -99,7 +99,7 @@ RSpec.describe V0::FeatureTogglesController, type: :controller do
         allow(ActiveRecord::Base.logger).to receive(:silence)
         allow(Settings.flipper).to receive(:mute_logs).and_return(true)
         Flipper.disable(@feature_name) # rubocop:disable Project/ForbidFlipperToggleInSpecs
-        Flipper.enable_percentage_of_actors(@feature_name, 100)
+        Flipper.enable_percentage_of_actors(@feature_name, 100) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       end
 
       it 'sets ActiveRecord logger to silence' do
@@ -157,7 +157,7 @@ RSpec.describe V0::FeatureTogglesController, type: :controller do
       @cookie_id = 'abc_123'
       actor = Flipper::Actor.new(@cookie_id)
       Flipper.disable(@feature_name) # rubocop:disable Project/ForbidFlipperToggleInSpecs
-      Flipper.enable_actor(@feature_name, actor)
+      Flipper.enable_actor(@feature_name, actor) # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       get :index, params: { features: @feature_name, cookie_id: @cookie_id }
 

--- a/spec/controllers/v0/feature_toggles_controller_spec.rb
+++ b/spec/controllers/v0/feature_toggles_controller_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe V0::FeatureTogglesController, type: :controller do
     @feature_name = 'this_is_only_a_test'
     @feature_name_camel = @feature_name.camelize(:lower)
     @cached_enabled_val = Flipper.enabled?(@feature_name)
-    Flipper.enable(@feature_name)
+    Flipper.enable(@feature_name) # rubocop:disable Project/ForbidFlipperToggleInSpecs
   end
 
   after(:all) do
-    Flipper.disable(@feature_name)
+    Flipper.disable(@feature_name) # rubocop:disable Project/ForbidFlipperToggleInSpecs
   end
 
   describe 'GET #index without params' do
     it 'returns all features (true or false)' do
-      Flipper.disable(@feature_name)
+      Flipper.disable(@feature_name) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       get :index
       expect(response).to have_http_status(:ok)
       json_data = JSON.parse(response.body)
@@ -31,7 +31,7 @@ RSpec.describe V0::FeatureTogglesController, type: :controller do
       @feature_name_camel = @feature_name.camelize(:lower)
       @cookie_id = 'abc_123'
       actor = Flipper::Actor.new(@cookie_id)
-      Flipper.disable(@feature_name)
+      Flipper.disable(@feature_name) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       Flipper.enable_actor(@feature_name, actor)
 
       get :index, params: { cookie_id: @cookie_id }

--- a/spec/controllers/v0/profile/payment_history_controller_spec.rb
+++ b/spec/controllers/v0/profile/payment_history_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe V0::Profile::PaymentHistoryController, type: :controller do
 
     context 'with mixed payments and flipper disabled' do
       it 'does not return both' do
-        Flipper.disable('payment_history')
+        Flipper.disable('payment_history') # rubocop:disable Project/ForbidFlipperToggleInSpecs
         VCR.use_cassette('bgs/person_web_service/find_person_by_participant_id') do
           VCR.use_cassette('bgs/payment_history/retrieve_payment_summary_with_bdn_returns') do
             sign_in_as(user)
@@ -55,7 +55,7 @@ RSpec.describe V0::Profile::PaymentHistoryController, type: :controller do
             expect(JSON.parse(response.body)['data']['attributes']['return_payments'].count).to eq(0)
           end
         end
-        Flipper.enable('payment_history')
+        Flipper.enable('payment_history') # rubocop:disable Project/ForbidFlipperToggleInSpecs
       end
     end
   end

--- a/spec/controllers/v0/users_controller_spec.rb
+++ b/spec/controllers/v0/users_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe V0::UsersController, type: :controller do
 
     context 'when profile claims enabled' do
       before do
-        Flipper.enable(:profile_user_claims)
+        Flipper.enable(:profile_user_claims) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       end
 
       it 'returns a JSON user profile with claims' do
@@ -55,7 +55,7 @@ RSpec.describe V0::UsersController, type: :controller do
 
     before do
       sign_in_as(user)
-      Flipper.disable(:profile_user_claims)
+      Flipper.disable(:profile_user_claims) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     end
 
     it 'returns a JSON user profile with a bad_address' do
@@ -79,7 +79,7 @@ RSpec.describe V0::UsersController, type: :controller do
 
     context 'onboarding' do
       it 'returns a JSON user with onboarding information when the feature toggle is enabled' do
-        Flipper.enable(:veteran_onboarding_beta_flow, user)
+        Flipper.enable(:veteran_onboarding_beta_flow, user) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         get :show
         json = json_body_for(response)
         expect(response).to be_successful
@@ -88,8 +88,8 @@ RSpec.describe V0::UsersController, type: :controller do
       end
 
       it 'returns a JSON user without onboarding information when the feature toggle is disabled' do
-        Flipper.disable(:veteran_onboarding_beta_flow)
-        Flipper.disable(:veteran_onboarding_show_to_newly_onboarded)
+        Flipper.disable(:veteran_onboarding_beta_flow) # rubocop:disable Project/ForbidFlipperToggleInSpecs
+        Flipper.disable(:veteran_onboarding_show_to_newly_onboarded) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         get :show
         json = json_body_for(response)
         expect(response).to be_successful
@@ -100,7 +100,7 @@ RSpec.describe V0::UsersController, type: :controller do
 
     context 'when profile claims enabled' do
       before do
-        Flipper.enable(:profile_user_claims)
+        Flipper.enable(:profile_user_claims) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       end
 
       it 'returns a JSON user profile with claims' do

--- a/spec/controllers/v0/veteran_onboardings_controller_spec.rb
+++ b/spec/controllers/v0/veteran_onboardings_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe V0::VeteranOnboardingsController, type: :controller do
   let(:veteran_onboarding) { create(:veteran_onboarding, user_account: user.user_account) }
 
   before do
-    Flipper.enable(:veteran_onboarding_beta_flow, user)
+    Flipper.enable(:veteran_onboarding_beta_flow, user) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     sign_in_as(user)
   end
 

--- a/spec/lib/disability_compensation/factories/api_provider_factory_spec.rb
+++ b/spec/lib/disability_compensation/factories/api_provider_factory_spec.rb
@@ -207,10 +207,10 @@ RSpec.describe ApiProviderFactory do
       end
 
       it 'provides a SupplementalDocumentUploadProvider based on a Flipper' do
-        Flipper.enable(ApiProviderFactory::FEATURE_TOGGLE_UPLOAD_0781)
+        Flipper.enable(ApiProviderFactory::FEATURE_TOGGLE_UPLOAD_0781) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         expect(provider.class).to equal(LighthouseSupplementalDocumentUploadProvider)
 
-        Flipper.disable(ApiProviderFactory::FEATURE_TOGGLE_UPLOAD_0781)
+        Flipper.disable(ApiProviderFactory::FEATURE_TOGGLE_UPLOAD_0781) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         expect(provider.class).to equal(EVSSSupplementalDocumentUploadProvider)
       end
     end

--- a/spec/lib/flipper/instrumentation/event_subscriber_spec.rb
+++ b/spec/lib/flipper/instrumentation/event_subscriber_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Flipper::Instrumentation::EventSubscriber do
 
   context 'logs changes to toggle values' do
     it 'logs feature calls with result after operation for disable' do
-      Flipper.disable(:this_is_only_a_test)
+      Flipper.disable(:this_is_only_a_test) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       last_event = FeatureToggleEvent.last
       expect(last_event.feature_name).to eq('this_is_only_a_test')
       expect(last_event.operation).to eq('disable')

--- a/spec/lib/flipper/instrumentation/event_subscriber_spec.rb
+++ b/spec/lib/flipper/instrumentation/event_subscriber_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Flipper::Instrumentation::EventSubscriber do
     end
 
     it 'logs feature calls with result after operation for disable_percentage_of_actors' do
-      Flipper.disable_percentage_of_actors(:this_is_only_a_test)
+      Flipper.disable_percentage_of_actors(:this_is_only_a_test) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       last_event = FeatureToggleEvent.last
       expect(last_event.feature_name).to eq('this_is_only_a_test')
       expect(last_event.operation).to eq('disable')
@@ -23,7 +23,7 @@ RSpec.describe Flipper::Instrumentation::EventSubscriber do
     end
 
     it 'logs feature calls with result after operation for disable_percentage_of_time' do
-      Flipper.disable_percentage_of_time(:this_is_only_a_test)
+      Flipper.disable_percentage_of_time(:this_is_only_a_test) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       last_event = FeatureToggleEvent.last
       expect(last_event.feature_name).to eq('this_is_only_a_test')
       expect(last_event.operation).to eq('disable')
@@ -31,7 +31,7 @@ RSpec.describe Flipper::Instrumentation::EventSubscriber do
     end
 
     it 'logs feature calls with result after operation for enable_percentage_of_actors' do
-      Flipper.enable_percentage_of_actors :this_is_only_a_test, 10
+      Flipper.enable_percentage_of_actors :this_is_only_a_test, 10 # rubocop:disable Project/ForbidFlipperToggleInSpecs
       last_event = FeatureToggleEvent.last
       expect(last_event.feature_name).to eq('this_is_only_a_test')
       expect(last_event.operation).to eq('enable')
@@ -39,7 +39,7 @@ RSpec.describe Flipper::Instrumentation::EventSubscriber do
     end
 
     it 'logs feature calls with result after operation for enable_percentage_of_time' do
-      Flipper.enable_percentage_of_time :this_is_only_a_test, 5
+      Flipper.enable_percentage_of_time :this_is_only_a_test, 5 # rubocop:disable Project/ForbidFlipperToggleInSpecs
       last_event = FeatureToggleEvent.last
       expect(last_event.feature_name).to eq('this_is_only_a_test')
       expect(last_event.operation).to eq('enable')
@@ -47,7 +47,7 @@ RSpec.describe Flipper::Instrumentation::EventSubscriber do
     end
 
     it 'logs feature calls with result after operation for enable_actor' do
-      Flipper.enable_actor :this_is_only_a_test, test_user
+      Flipper.enable_actor :this_is_only_a_test, test_user # rubocop:disable Project/ForbidFlipperToggleInSpecs
       last_event = FeatureToggleEvent.last
       expect(last_event.feature_name).to eq('this_is_only_a_test')
       expect(last_event.operation).to eq('enable')
@@ -55,7 +55,7 @@ RSpec.describe Flipper::Instrumentation::EventSubscriber do
     end
 
     it 'logs feature calls with result after operation for disable_actor' do
-      Flipper.disable_actor :this_is_only_a_test, test_user
+      Flipper.disable_actor :this_is_only_a_test, test_user # rubocop:disable Project/ForbidFlipperToggleInSpecs
       last_event = FeatureToggleEvent.last
       expect(last_event.feature_name).to eq('this_is_only_a_test')
       expect(last_event.operation).to eq('disable')

--- a/spec/lib/flipper/utilities/bulk_feature_checker_spec.rb
+++ b/spec/lib/flipper/utilities/bulk_feature_checker_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Flipper::Utilities::BulkFeatureChecker do
 
       before do
         features.each do |feature|
-          Flipper.enable(feature)
+          Flipper.enable(feature) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         end
       end
 
@@ -60,7 +60,7 @@ RSpec.describe Flipper::Utilities::BulkFeatureChecker do
 
       before do
         features.each do |feature|
-          Flipper.disable(feature)
+          Flipper.disable(feature) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         end
       end
 
@@ -82,11 +82,11 @@ RSpec.describe Flipper::Utilities::BulkFeatureChecker do
 
       before do
         enabled_features.each do |feature|
-          Flipper.enable(feature)
+          Flipper.enable(feature) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         end
 
         disabled_features.each do |feature|
-          Flipper.disable(feature)
+          Flipper.disable(feature) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         end
       end
 
@@ -108,11 +108,11 @@ RSpec.describe Flipper::Utilities::BulkFeatureChecker do
 
       before do
         enabled_features.each do |feature|
-          Flipper.enable(feature.to_s)
+          Flipper.enable(feature.to_s) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         end
 
         disabled_features.each do |feature|
-          Flipper.disable(feature.to_s)
+          Flipper.disable(feature.to_s) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         end
       end
 

--- a/spec/lib/lighthouse/benefits_documents/configuration_spec.rb
+++ b/spec/lib/lighthouse/benefits_documents/configuration_spec.rb
@@ -6,7 +6,7 @@ require 'lighthouse/benefits_documents/configuration'
 RSpec.describe BenefitsDocuments::Configuration do
   before do
     # Required to prevent inconsistent failure on CI pipeline
-    Flipper.enable('va_online_scheduling')
+    Flipper.enable('va_online_scheduling') # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
     token = 'abcd1234'
     allow_any_instance_of(BenefitsDocuments::Configuration).to receive(:access_token).and_return(token)

--- a/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
+++ b/spec/lib/sidekiq/form526_backup_submission_process/submit_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Sidekiq::Form526BackupSubmissionProcess::Submit, type: :job do
 
       context 'when form526_send_backup_submission_exhaustion_email_notice is disabled' do
         before do
-          Flipper.disable(:form526_send_backup_submission_exhaustion_email_notice)
+          Flipper.disable(:form526_send_backup_submission_exhaustion_email_notice) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         end
 
         it 'does not remediates the submission via an email notification' do

--- a/spec/lib/sidekiq/form526_job_status_tracker/job_tracker_spec.rb
+++ b/spec/lib/sidekiq/form526_job_status_tracker/job_tracker_spec.rb
@@ -12,7 +12,7 @@ describe Sidekiq::Form526JobStatusTracker::JobTracker do
   end
 
   before do
-    Flipper.disable(:disability_compensation_production_tester)
+    Flipper.disable(:disability_compensation_production_tester) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     allow_any_instance_of(BenefitsClaims::Configuration).to receive(:access_token)
       .and_return('access_token')
   end

--- a/spec/models/form526_submission_spec.rb
+++ b/spec/models/form526_submission_spec.rb
@@ -1058,7 +1058,7 @@ RSpec.describe Form526Submission do
       end
 
       context 'when feature enabled' do
-        before { Flipper.enable(:disability_compensation_flashes) }
+        before { Flipper.enable(:disability_compensation_flashes) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
         it 'queues flashes job' do
           expect do
@@ -1068,7 +1068,7 @@ RSpec.describe Form526Submission do
       end
 
       context 'when feature disabled' do
-        before { Flipper.disable(:disability_compensation_flashes) }
+        before { Flipper.disable(:disability_compensation_flashes) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
         it 'queues flashes job' do
           expect do
@@ -1351,14 +1351,14 @@ RSpec.describe Form526Submission do
         subject { create(:form526_submission, :with_multiple_succesful_jobs) }
 
         it 'does not trigger job when disability_526_call_received_email_from_polling enabled' do
-          Flipper.enable(:disability_526_call_received_email_from_polling)
+          Flipper.enable(:disability_526_call_received_email_from_polling) # rubocop:disable Project/ForbidFlipperToggleInSpecs
           expect do
             subject.workflow_complete_handler(nil, 'submission_id' => subject.id)
           end.not_to change(Form526ConfirmationEmailJob.jobs, :size)
         end
 
         it 'returns one job triggered when disability_526_call_received_email_from_polling disabled' do
-          Flipper.disable(:disability_526_call_received_email_from_polling)
+          Flipper.disable(:disability_526_call_received_email_from_polling) # rubocop:disable Project/ForbidFlipperToggleInSpecs
           expect do
             subject.workflow_complete_handler(nil, 'submission_id' => subject.id)
           end.to change(Form526ConfirmationEmailJob.jobs, :size).by(1)

--- a/spec/models/form_submission_attempt_spec.rb
+++ b/spec/models/form_submission_attempt_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe FormSubmissionAttempt, type: :model do
           end
 
           it 'sends an 4142 error email when it is not a SimpleFormsApi form and flippers are on' do
-            Flipper.enable(CentralMail::SubmitForm4142Job::POLLING_FLIPPER_KEY)
-            Flipper.enable(CentralMail::SubmitForm4142Job::POLLED_FAILURE_EMAIL)
+            Flipper.enable(CentralMail::SubmitForm4142Job::POLLING_FLIPPER_KEY) # rubocop:disable Project/ForbidFlipperToggleInSpecs
+            Flipper.enable(CentralMail::SubmitForm4142Job::POLLED_FAILURE_EMAIL) # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
             allow(VaNotify::Service).to receive(:new).and_return(vanotify_client)
             allow(vanotify_client).to receive(:send_email).and_return(OpenStruct.new(id: 'some_id'))
@@ -89,8 +89,8 @@ RSpec.describe FormSubmissionAttempt, type: :model do
           end
 
           it 'does not send an 4142 error email when it is not a SimpleFormsApi form and flippers are off' do
-            Flipper.disable(CentralMail::SubmitForm4142Job::POLLING_FLIPPER_KEY)
-            Flipper.disable(CentralMail::SubmitForm4142Job::POLLED_FAILURE_EMAIL)
+            Flipper.disable(CentralMail::SubmitForm4142Job::POLLING_FLIPPER_KEY) # rubocop:disable Project/ForbidFlipperToggleInSpecs
+            Flipper.disable(CentralMail::SubmitForm4142Job::POLLED_FAILURE_EMAIL) # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
             with_settings(Settings.vanotify.services.benefits_disability, { api_key: 'test_service_api_key' }) do
               expect do

--- a/spec/models/lighthouse526_document_upload_spec.rb
+++ b/spec/models/lighthouse526_document_upload_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Lighthouse526DocumentUpload do
 
           context 'when disability_compensation_email_veteran_on_polled_lighthouse_doc_failure flipper is enabled' do
             before do
-              Flipper.enable(:disability_compensation_email_veteran_on_polled_lighthouse_doc_failure)
+              Flipper.enable(:disability_compensation_email_veteran_on_polled_lighthouse_doc_failure)  # rubocop:disable Project/ForbidFlipperToggleInSpecs
             end
 
             context 'when the upload was a piece of veteran-supplied evidence' do
@@ -160,7 +160,7 @@ RSpec.describe Lighthouse526DocumentUpload do
 
           context 'when disability_compensation_email_veteran_on_polled_lighthouse_doc_failure flipper is disabled' do
             before do
-              Flipper.disable(:disability_compensation_email_veteran_on_polled_lighthouse_doc_failure)
+              Flipper.disable(:disability_compensation_email_veteran_on_polled_lighthouse_doc_failure) # rubocop:disable Project/ForbidFlipperToggleInSpecs
             end
 
             context 'when the upload was a piece of veteran-supplied evidence' do

--- a/spec/models/saved_claim/education_benefits/va0994_spec.rb
+++ b/spec/models/saved_claim/education_benefits/va0994_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe SavedClaim::EducationBenefits::VA0994 do
 
     describe 'confirmation email for 0994' do
       it 'is skipped when feature flag is turned off' do
-        Flipper.disable(:form0994_confirmation_email)
+        Flipper.disable(:form0994_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         allow(VANotify::EmailJob).to receive(:perform_async)
 
         subject = create(:va0994_full_form)
         subject.after_submit(user)
 
         expect(VANotify::EmailJob).not_to have_received(:perform_async)
-        Flipper.enable(:form0994_confirmation_email)
+        Flipper.enable(:form0994_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       end
 
       it 'sends v1 when they have applied for VA education benefits previously' do

--- a/spec/models/saved_claim/education_benefits/va10203_spec.rb
+++ b/spec/models/saved_claim/education_benefits/va10203_spec.rb
@@ -87,23 +87,23 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
         context 'sending the confirmation email' do
           context 'when the form21_10203_confirmation_email feature flag is disabled' do
             before do
-              Flipper.disable(:form21_10203_confirmation_email)
+              Flipper.disable(:form21_10203_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
               expect(FeatureFlipper).to receive(:send_email?).once.and_return(false)
             end
 
             it 'does not call SendSchoolCertifyingOfficialsEmail' do
               expect { instance.after_submit(user) }
                 .not_to change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size)
-              Flipper.enable(:form21_10203_confirmation_email)
+              Flipper.enable(:form21_10203_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
             end
           end
 
           context 'when the form21_10203_confirmation_email feature flag is enabled' do
-            before { Flipper.enable(:form21_10203_confirmation_email) }
+            before { Flipper.enable(:form21_10203_confirmation_email) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
             context 'when there is no form email' do
               it 'does not send a confirmation email' do
-                Flipper.enable(:form21_10203_confirmation_email)
+                Flipper.enable(:form21_10203_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
                 allow(VANotify::EmailJob).to receive(:perform_async)
 
                 subject = instance
@@ -118,7 +118,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
 
             context 'when there is a form email' do
               context 'when the form1995_confirmation_email_with_silent_failure_processing feature flag is disabled' do
-                before { Flipper.disable(:form1995_confirmation_email_with_silent_failure_processing) }
+                before { Flipper.disable(:form1995_confirmation_email_with_silent_failure_processing) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
                 it 'sends the confirmation email without the callback parameters' do
                   allow(VANotify::EmailJob).to receive(:perform_async)
@@ -135,7 +135,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
                       'regional_office_address' => "P.O. Box 4616\nBuffalo, NY 14240-4616"
                     }
                   )
-                  Flipper.enable(:form21_10203_confirmation_email)
+                  Flipper.enable(:form21_10203_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
                 end
               end
 
@@ -152,10 +152,10 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
                   }
                 end
 
-                before { Flipper.enable(:form1995_confirmation_email_with_silent_failure_processing) }
+                before { Flipper.enable(:form1995_confirmation_email_with_silent_failure_processing) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
                 it 'sends the confirmation email with the form email with the callback paarameters' do
-                  Flipper.enable(:form21_10203_confirmation_email)
+                  Flipper.enable(:form21_10203_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
                   allow(VANotify::EmailJob).to receive(:perform_async)
 
                   subject = instance
@@ -216,7 +216,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
                 mail = double('mail')
                 allow(mail).to receive(:deliver_now)
                 allow(StemApplicantConfirmationMailer).to receive(:build).with(instance, nil).and_return(mail)
-                Flipper.disable(:form21_10203_confirmation_email)
+                Flipper.disable(:form21_10203_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
               end
 
               it 'increments the SendSchoolCertifyingOfficialsEmail job queue (calls the job)' do
@@ -284,7 +284,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
 
         context 'when there is no form email' do
           it 'does not send a confirmation email' do
-            Flipper.enable(:form21_10203_confirmation_email)
+            Flipper.enable(:form21_10203_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
             allow(VANotify::EmailJob).to receive(:perform_async)
 
             subject = instance
@@ -299,7 +299,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
 
         context 'when there is a form email' do
           context 'when the form1995_confirmation_email_with_silent_failure_processing feature flag is disabled' do
-            before { Flipper.disable(:form1995_confirmation_email_with_silent_failure_processing) }
+            before { Flipper.disable(:form1995_confirmation_email_with_silent_failure_processing) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
             it 'sends the confirmation email without the callback parameters' do
               allow(VANotify::EmailJob).to receive(:perform_async)
@@ -316,7 +316,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
                   'regional_office_address' => "P.O. Box 4616\nBuffalo, NY 14240-4616"
                 }
               )
-              Flipper.enable(:form21_10203_confirmation_email)
+              Flipper.enable(:form21_10203_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
             end
           end
 
@@ -332,10 +332,10 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
               }
             end
 
-            before { Flipper.enable(:form1995_confirmation_email_with_silent_failure_processing) }
+            before { Flipper.enable(:form1995_confirmation_email_with_silent_failure_processing) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
             it 'sends the confirmation email with the form email with the callback paarameters' do
-              Flipper.enable(:form21_10203_confirmation_email)
+              Flipper.enable(:form21_10203_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
               allow(VANotify::EmailJob).to receive(:perform_async)
 
               subject = instance
@@ -437,23 +437,23 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
         context 'sending the confirmation email' do
           context 'when the form21_10203_confirmation_email feature flag is disabled' do
             before do
-              Flipper.disable(:form21_10203_confirmation_email)
+              Flipper.disable(:form21_10203_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
               expect(FeatureFlipper).to receive(:send_email?).once.and_return(false)
             end
 
             it 'does not call SendSchoolCertifyingOfficialsEmail' do
               expect { instance.after_submit(user) }
                 .not_to change(EducationForm::SendSchoolCertifyingOfficialsEmail.jobs, :size)
-              Flipper.enable(:form21_10203_confirmation_email)
+              Flipper.enable(:form21_10203_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
             end
           end
 
           context 'when the form21_10203_confirmation_email feature flag is enabled' do
-            before { Flipper.enable(:form21_10203_confirmation_email) }
+            before { Flipper.enable(:form21_10203_confirmation_email) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
             context 'when there is no form email' do
               it 'does not send a confirmation email' do
-                Flipper.enable(:form21_10203_confirmation_email)
+                Flipper.enable(:form21_10203_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
                 allow(VANotify::EmailJob).to receive(:perform_async)
 
                 subject = instance
@@ -468,7 +468,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
 
             context 'when there is a form email' do
               context 'when the form1995_confirmation_email_with_silent_failure_processing feature flag is disabled' do
-                before { Flipper.disable(:form1995_confirmation_email_with_silent_failure_processing) }
+                before { Flipper.disable(:form1995_confirmation_email_with_silent_failure_processing) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
                 it 'sends the confirmation email without the callback parameters' do
                   allow(VANotify::EmailJob).to receive(:perform_async)
@@ -485,7 +485,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
                       'regional_office_address' => "P.O. Box 4616\nBuffalo, NY 14240-4616"
                     }
                   )
-                  Flipper.enable(:form21_10203_confirmation_email)
+                  Flipper.enable(:form21_10203_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
                 end
               end
 
@@ -502,10 +502,10 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
                   }
                 end
 
-                before { Flipper.enable(:form1995_confirmation_email_with_silent_failure_processing) }
+                before { Flipper.enable(:form1995_confirmation_email_with_silent_failure_processing) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
                 it 'sends the confirmation email with the form email with the callback paarameters' do
-                  Flipper.enable(:form21_10203_confirmation_email)
+                  Flipper.enable(:form21_10203_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
                   allow(VANotify::EmailJob).to receive(:perform_async)
 
                   subject = instance
@@ -567,7 +567,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
                 mail = double('mail')
                 allow(mail).to receive(:deliver_now)
                 allow(StemApplicantConfirmationMailer).to receive(:build).with(instance, nil).and_return(mail)
-                Flipper.disable(:form21_10203_confirmation_email)
+                Flipper.disable(:form21_10203_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
               end
 
               it 'increments the SendSchoolCertifyingOfficialsEmail job queue (calls the job)' do
@@ -665,7 +665,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
 
         context 'when there is no form email' do
           it 'does not send a confirmation email' do
-            Flipper.enable(:form21_10203_confirmation_email)
+            Flipper.enable(:form21_10203_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
             allow(VANotify::EmailJob).to receive(:perform_async)
 
             subject = instance
@@ -680,7 +680,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
 
         context 'when there is a form email' do
           context 'when the form1995_confirmation_email_with_silent_failure_processing feature flag is disabled' do
-            before { Flipper.disable(:form1995_confirmation_email_with_silent_failure_processing) }
+            before { Flipper.disable(:form1995_confirmation_email_with_silent_failure_processing) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
             it 'sends the confirmation email without the callback parameters' do
               allow(VANotify::EmailJob).to receive(:perform_async)
@@ -697,7 +697,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
                   'regional_office_address' => "P.O. Box 4616\nBuffalo, NY 14240-4616"
                 }
               )
-              Flipper.enable(:form21_10203_confirmation_email)
+              Flipper.enable(:form21_10203_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
             end
           end
 
@@ -713,10 +713,10 @@ RSpec.describe SavedClaim::EducationBenefits::VA10203 do
               }
             end
 
-            before { Flipper.enable(:form1995_confirmation_email_with_silent_failure_processing) }
+            before { Flipper.enable(:form1995_confirmation_email_with_silent_failure_processing) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
             it 'sends the confirmation email with the form email with the callback paarameters' do
-              Flipper.enable(:form21_10203_confirmation_email)
+              Flipper.enable(:form21_10203_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
               allow(VANotify::EmailJob).to receive(:perform_async)
 
               subject = instance

--- a/spec/models/saved_claim/education_benefits/va10297_spec.rb
+++ b/spec/models/saved_claim/education_benefits/va10297_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe SavedClaim::EducationBenefits::VA10297 do
             }
           end
 
-          before { Flipper.enable(:form10297_confirmation_email_with_silent_failure_processing) }
+          before { Flipper.enable(:form10297_confirmation_email_with_silent_failure_processing) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
           it 'sends an email with the silent failure callback parameters' do
             subject = create(:va10297_simple_form)

--- a/spec/models/saved_claim/education_benefits/va1990_spec.rb
+++ b/spec/models/saved_claim/education_benefits/va1990_spec.rb
@@ -33,14 +33,14 @@ RSpec.describe SavedClaim::EducationBenefits::VA1990 do
       end
 
       it 'is skipped when feature flag is turned off' do
-        Flipper.disable(:form1990_confirmation_email)
+        Flipper.disable(:form1990_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         allow(VANotify::EmailJob).to receive(:perform_async)
 
         subject = create(:va1990_chapter33)
         subject.after_submit(user)
 
         expect(VANotify::EmailJob).not_to have_received(:perform_async)
-        Flipper.enable(:form1990_confirmation_email)
+        Flipper.enable(:form1990_confirmation_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       end
 
       it 'chapter 33' do

--- a/spec/models/schema_contract/validation_initiator_spec.rb
+++ b/spec/models/schema_contract/validation_initiator_spec.rb
@@ -13,7 +13,7 @@ describe SchemaContract::ValidationInitiator do
 
     before do
       Timecop.freeze
-      Flipper.enable(:schema_contract_test_index)
+      Flipper.enable(:schema_contract_test_index) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     end
 
     context 'response is successful, feature flag is on, and no record exists for the current day' do
@@ -45,7 +45,7 @@ describe SchemaContract::ValidationInitiator do
     end
 
     context 'when feature flag is off' do
-      before { Flipper.disable(:schema_contract_test_index) }
+      before { Flipper.disable(:schema_contract_test_index) } # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
       it 'does not create a record or enqueue a job' do
         expect(SchemaContract::ValidationJob).not_to receive(:perform_async)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1302,8 +1302,8 @@ RSpec.describe User, type: :model do
     let(:user) { create(:user) }
 
     before do
-      Flipper.enable(:veteran_onboarding_beta_flow, user)
-      Flipper.disable(:veteran_onboarding_show_to_newly_onboarded)
+      Flipper.enable(:veteran_onboarding_beta_flow, user) # rubocop:disable Project/ForbidFlipperToggleInSpecs
+      Flipper.disable(:veteran_onboarding_show_to_newly_onboarded) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     end
 
     context "when feature toggle is enabled, show onboarding flow depending on user's preferences" do
@@ -1319,8 +1319,8 @@ RSpec.describe User, type: :model do
 
     context 'when feature toggle is disabled, never show onboarding flow' do
       it 'show_onboarding_flow_on_login returns false when flag is disabled, even if display_onboarding_flow is true' do
-        Flipper.disable(:veteran_onboarding_beta_flow)
-        Flipper.disable(:veteran_onboarding_show_to_newly_onboarded)
+        Flipper.disable(:veteran_onboarding_beta_flow) # rubocop:disable Project/ForbidFlipperToggleInSpecs
+        Flipper.disable(:veteran_onboarding_show_to_newly_onboarded) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         expect(user.show_onboarding_flow_on_login).to be_falsey
       end
     end

--- a/spec/models/veteran_onboarding_spec.rb
+++ b/spec/models/veteran_onboarding_spec.rb
@@ -22,19 +22,19 @@ RSpec.describe VeteranOnboarding, type: :model do
   end
 
   it 'creates a VeteranOnboarding object if toggle is enabled' do
-    Flipper.enable(:veteran_onboarding_beta_flow, user)
+    Flipper.enable(:veteran_onboarding_beta_flow, user) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     expect { VeteranOnboarding.for_user(user) }.to change(VeteranOnboarding, :count).by(1)
   end
 
   describe '#show_onboarding_flow_on_login' do
     it 'returns the value of display_onboarding_flow' do
       subject = described_class.for_user(user)
-      Flipper.enable(:veteran_onboarding_beta_flow, user)
+      Flipper.enable(:veteran_onboarding_beta_flow, user) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       expect(subject.show_onboarding_flow_on_login).to be_truthy
     end
 
     it 'returns false and updates the database when verification is past the threshold' do
-      Flipper.enable(:veteran_onboarding_show_to_newly_onboarded, user)
+      Flipper.enable(:veteran_onboarding_show_to_newly_onboarded, user) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       Settings.veteran_onboarding = OpenStruct.new(onboarding_threshold_days: 10)
       verified_at_date = Time.zone.today - 11
       allow_any_instance_of(UserVerification).to receive(:verified_at).and_return(verified_at_date)
@@ -55,7 +55,7 @@ RSpec.describe VeteranOnboarding, type: :model do
       it "returns #{scenario[:expected]} when verified #{scenario[:days_ago]} days ago" do
         verified_at_date = Time.zone.today - scenario[:days_ago]
         allow_any_instance_of(UserVerification).to receive(:verified_at).and_return(verified_at_date)
-        Flipper.enable(:veteran_onboarding_show_to_newly_onboarded, user)
+        Flipper.enable(:veteran_onboarding_show_to_newly_onboarded, user) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         expect(user.onboarding&.show_onboarding_flow_on_login).to eq(scenario[:expected])
       end
     end

--- a/spec/requests/flipper_spec.rb
+++ b/spec/requests/flipper_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe 'flipper', type: :request do
         before do
           allow(user).to receive(:organization_member?).with(Settings.sidekiq.github_organization).and_return(true)
           allow(user).to receive(:team_member?).with(Settings.sidekiq.github_team).and_return(true)
-          Flipper.disable(:this_is_only_a_test)
+          Flipper.disable(:this_is_only_a_test) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         end
 
         it 'can see the feature name in title (h4) and button to enable/disable feature' do
@@ -341,7 +341,7 @@ RSpec.describe 'flipper', type: :request do
         it 'can toggle features' do
           allow(user).to receive(:organization_member?).with(Settings.flipper.github_organization).and_return(true)
           allow(user).to receive(:team_member?).with(Settings.flipper.github_team).and_return(true)
-          Flipper.enable(:this_is_only_a_test)
+          Flipper.enable(:this_is_only_a_test) # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
           bypass_flipper_authenticity_token do
             expect(Flipper.enabled?(:this_is_only_a_test)).to be true
@@ -355,7 +355,7 @@ RSpec.describe 'flipper', type: :request do
         it 'can add actors' do
           allow(user).to receive(:organization_member?).with(Settings.flipper.github_organization).and_return(true)
           allow(user).to receive(:team_member?).with(Settings.flipper.github_team).and_return(true)
-          Flipper.disable(:this_is_only_a_test)
+          Flipper.disable(:this_is_only_a_test) # rubocop:disable Project/ForbidFlipperToggleInSpecs
           test_user = create(:user)
 
           bypass_flipper_authenticity_token do
@@ -371,7 +371,7 @@ RSpec.describe 'flipper', type: :request do
         it 'can adjust percentage_of_actors' do
           allow(user).to receive(:organization_member?).with(Settings.flipper.github_organization).and_return(true)
           allow(user).to receive(:team_member?).with(Settings.flipper.github_team).and_return(true)
-          Flipper.disable(:this_is_only_a_test)
+          Flipper.disable(:this_is_only_a_test) # rubocop:disable Project/ForbidFlipperToggleInSpecs
           test_user1 = create(:user_account)
           test_user2 = create(:user_account)
 

--- a/spec/requests/swagger_spec.rb
+++ b/spec/requests/swagger_spec.rb
@@ -1165,8 +1165,8 @@ RSpec.describe 'the v0 API documentation', order: :defined, type: %i[apivore req
     describe 'disability compensation' do
       before do
         create(:in_progress_form, form_id: FormProfiles::VA526ez::FORM_ID, user_uuid: mhv_user.uuid)
-        Flipper.disable('disability_compensation_prevent_submission_job')
-        Flipper.disable('disability_compensation_production_tester')
+        Flipper.disable('disability_compensation_prevent_submission_job') # rubocop:disable Project/ForbidFlipperToggleInSpecs
+        Flipper.disable('disability_compensation_production_tester') # rubocop:disable Project/ForbidFlipperToggleInSpecs
         allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_token')
         allow_any_instance_of(User).to receive(:icn).and_return('123498767V234859')
       end
@@ -1317,7 +1317,7 @@ RSpec.describe 'the v0 API documentation', order: :defined, type: %i[apivore req
       let(:mhv_user) { create(:user, :loa3, :legacy_icn) }
 
       before do
-        Flipper.disable('disability_compensation_production_tester')
+        Flipper.disable('disability_compensation_production_tester') # rubocop:disable Project/ForbidFlipperToggleInSpecs
         allow_any_instance_of(Auth::ClientCredentials::Service).to receive(:get_token).and_return('fake_token')
       end
 
@@ -2341,7 +2341,7 @@ RSpec.describe 'the v0 API documentation', order: :defined, type: %i[apivore req
 
     describe 'search' do
       before do
-        Flipper.disable(:search_use_v2_gsa)
+        Flipper.disable(:search_use_v2_gsa) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       end
 
       context 'when successful' do

--- a/spec/requests/v0/disability_compensation_form/rating_info_spec.rb
+++ b/spec/requests/v0/disability_compensation_form/rating_info_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'V0::DisabilityCompensationForm::RatingInfo' do
 
   before do
     sign_in_as(user)
-    Flipper.disable('profile_lighthouse_rating_info')
+    Flipper.disable('profile_lighthouse_rating_info') # rubocop:disable Project/ForbidFlipperToggleInSpecs
   end
 
   describe 'GET /v0/disability_compensation_form/rating_info' do

--- a/spec/requests/v0/disability_compensation_form_spec.rb
+++ b/spec/requests/v0/disability_compensation_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'V0::DisabilityCompensationForm', type: :request do
   let(:headers_with_camel) { headers.merge('X-Key-Inflection' => 'camel') }
 
   before do
-    Flipper.disable('disability_compensation_prevent_submission_job')
+    Flipper.disable('disability_compensation_prevent_submission_job') # rubocop:disable Project/ForbidFlipperToggleInSpecs
     sign_in_as(user)
   end
 

--- a/spec/requests/v0/intent_to_file_spec.rb
+++ b/spec/requests/v0/intent_to_file_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'V0::IntentToFile', type: :request do
 
   before do
     sign_in_as(user)
-    Flipper.disable(:disability_compensation_production_tester)
+    Flipper.disable(:disability_compensation_production_tester) # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
     allow(BenefitsClaims::IntentToFile::Monitor).to receive(:new).and_return(monitor)
   end

--- a/spec/requests/v0/my_va/submission_pdf_urls_spec.rb
+++ b/spec/requests/v0/my_va/submission_pdf_urls_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'V0::MyVA::SubmissionPdfUrls', feature: :form_submission,
 
   before do
     sign_in_as(user)
-    Flipper.enable('my_va_form_submission_pdf_link')
+    Flipper.enable('my_va_form_submission_pdf_link') # rubocop:disable Project/ForbidFlipperToggleInSpecs
   end
 
   describe 'POST /v0/my_va/submission_pdf_urls' do
@@ -156,7 +156,7 @@ RSpec.describe 'V0::MyVA::SubmissionPdfUrls', feature: :form_submission,
 
     context 'when feature toggle is disabled' do
       before do
-        Flipper.disable('my_va_form_submission_pdf_link')
+        Flipper.disable('my_va_form_submission_pdf_link') # rubocop:disable Project/ForbidFlipperToggleInSpecs
       end
 
       it 'raises Forbidden error' do

--- a/spec/requests/v0/profile/service_history_spec.rb
+++ b/spec/requests/v0/profile/service_history_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'V0::Profile::ServiceHistory', type: :request do
 
       context 'when academy attendance flag is off' do
         before do
-          Flipper.disable(:profile_show_military_academy_attendance)
+          Flipper.disable(:profile_show_military_academy_attendance) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         end
 
         it 'returns military service episodes only' do
@@ -106,7 +106,7 @@ RSpec.describe 'V0::Profile::ServiceHistory', type: :request do
 
       context 'when academy attendance flag is on' do
         before do
-          Flipper.enable(:profile_show_military_academy_attendance)
+          Flipper.enable(:profile_show_military_academy_attendance) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         end
 
         it 'returns military service and academy attendance episodes' do

--- a/spec/requests/v0/search_spec.rb
+++ b/spec/requests/v0/search_spec.rb
@@ -10,7 +10,7 @@ Rspec.describe 'V0::Search', type: :request do
   let(:inflection_header) { { 'X-Key-Inflection' => 'camel' } }
 
   before do
-    Flipper.disable(:search_use_v2_gsa)
+    Flipper.disable(:search_use_v2_gsa) # rubocop:disable Project/ForbidFlipperToggleInSpecs
   end
 
   describe 'GET /v0/search' do

--- a/spec/services/users/profile_spec.rb
+++ b/spec/services/users/profile_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Users::Profile do
       describe 'form 526 required identifiers' do
         context 'when the user has the form_526_required_identifiers_in_user_object feature flag on' do
           before do
-            Flipper.enable(:form_526_required_identifiers_in_user_object)
+            Flipper.enable(:form_526_required_identifiers_in_user_object) # rubocop:disable Project/ForbidFlipperToggleInSpecs
           end
 
           context 'when a user is missing an identifier required by the 526 form' do
@@ -159,7 +159,7 @@ RSpec.describe Users::Profile do
 
         context 'when the user has the form_526_required_identifiers_in_user_object feature flag off' do
           before do
-            Flipper.disable(:form_526_required_identifiers_in_user_object)
+            Flipper.disable(:form_526_required_identifiers_in_user_object) # rubocop:disable Project/ForbidFlipperToggleInSpecs
           end
 
           it 'does not include the identifiers in the claims section of the user profile' do

--- a/spec/sidekiq/central_mail/submit_form4142_job_spec.rb
+++ b/spec/sidekiq/central_mail/submit_form4142_job_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
   describe 'Test old CentralMail route' do
     before do
       # Make Job use old CentralMail route for all tests
-      Flipper.disable(:disability_compensation_form4142_supplemental)
+      Flipper.disable(:disability_compensation_form4142_supplemental) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     end
 
     let(:user_account) { user.user_account }
@@ -184,7 +184,7 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
           let!(:failure_email) { EVSS::DisabilityCompensationForm::Form4142DocumentUploadFailureEmail }
 
           before do
-            Flipper.enable(:form526_send_4142_failure_notification)
+            Flipper.enable(:form526_send_4142_failure_notification) # rubocop:disable Project/ForbidFlipperToggleInSpecs
             allow(ZeroSilentFailures::Monitor).to receive(:new).with(zsf_tag).and_return(zsf_monitor)
           end
 
@@ -265,7 +265,7 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
         end
 
         it 'Creates a form 4142 submission polling record, when enabled' do
-          Flipper.enable(CentralMail::SubmitForm4142Job::POLLING_FLIPPER_KEY)
+          Flipper.enable(CentralMail::SubmitForm4142Job::POLLING_FLIPPER_KEY) # rubocop:disable Project/ForbidFlipperToggleInSpecs
           expect do
             VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
               VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
@@ -282,7 +282,7 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
         end
 
         it 'Returns successfully after creating polling record' do
-          Flipper.enable(CentralMail::SubmitForm4142Job::POLLING_FLIPPER_KEY)
+          Flipper.enable(CentralMail::SubmitForm4142Job::POLLING_FLIPPER_KEY) # rubocop:disable Project/ForbidFlipperToggleInSpecs
           Sidekiq::Testing.inline! do
             VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
               VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
@@ -300,7 +300,7 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
         end
 
         it 'Does not create a form 4142 submission polling record, when disabled' do
-          Flipper.disable(CentralMail::SubmitForm4142Job::POLLING_FLIPPER_KEY)
+          Flipper.disable(CentralMail::SubmitForm4142Job::POLLING_FLIPPER_KEY) # rubocop:disable Project/ForbidFlipperToggleInSpecs
           expect do
             VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload_location') do
               VCR.use_cassette('lighthouse/benefits_intake/200_lighthouse_intake_upload') do
@@ -413,7 +413,7 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
 
         context 'when the form526_send_4142_failure_notification Flipper is enabled' do
           before do
-            Flipper.enable(:form526_send_4142_failure_notification)
+            Flipper.enable(:form526_send_4142_failure_notification)  # rubocop:disable Project/ForbidFlipperToggleInSpecs
           end
 
           it 'enqueues a failure notification mailer to send to the veteran' do
@@ -431,7 +431,7 @@ RSpec.describe CentralMail::SubmitForm4142Job, type: :job do
 
         context 'when the form526_send_4142_failure_notification Flipper is disabled' do
           before do
-            Flipper.disable(:form526_send_4142_failure_notification)
+            Flipper.disable(:form526_send_4142_failure_notification) # rubocop:disable Project/ForbidFlipperToggleInSpecs
           end
 
           it 'does not enqueue a failure notification mailer to send to the veteran' do

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form526_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form526_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm526, type: :job do
 
   before do
     Sidekiq::Job.clear_all
-    Flipper.disable(:disability_compensation_fail_submission)
+    Flipper.disable(:disability_compensation_fail_submission) # rubocop:disable Project/ForbidFlipperToggleInSpecs
   end
 
   let(:user) { create(:user, :loa3) }

--- a/spec/sidekiq/evss/disability_compensation_form/submit_form8940_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/submit_form8940_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::SubmitForm8940, type: :job do
 
   before do
     Sidekiq::Job.clear_all
-    Flipper.disable(:disability_compensation_lighthouse_document_service_provider)
+    Flipper.disable(:disability_compensation_lighthouse_document_service_provider) # rubocop:disable Project/ForbidFlipperToggleInSpecs
   end
 
   let(:user) { create(:user, :loa3) }

--- a/spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb
+++ b/spec/sidekiq/evss/disability_compensation_form/upload_bdd_instructions_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::UploadBddInstructions, type: :j
 
   before do
     Sidekiq::Job.clear_all
-    Flipper.disable(:disability_compensation_use_api_provider_for_bdd_instructions)
+    Flipper.disable(:disability_compensation_use_api_provider_for_bdd_instructions) # rubocop:disable Project/ForbidFlipperToggleInSpecs
   end
 
   let(:user) { create(:user, :loa3) }
@@ -64,7 +64,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::UploadBddInstructions, type: :j
 
   describe 'When an ApiProvider is used for uploads' do
     before do
-      Flipper.enable(:disability_compensation_use_api_provider_for_bdd_instructions)
+      Flipper.enable(:disability_compensation_use_api_provider_for_bdd_instructions) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       # StatsD metrics are incremented in several callbacks we're not testing here so we need to allow them
       allow(StatsD).to receive(:increment)
     end
@@ -91,7 +91,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::UploadBddInstructions, type: :j
       end
 
       before do
-        Flipper.enable(:disability_compensation_upload_bdd_instructions_to_lighthouse)
+        Flipper.enable(:disability_compensation_upload_bdd_instructions_to_lighthouse) # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
         allow(BenefitsDocuments::Form526::UploadSupplementalDocumentService).to receive(:call)
           .and_return(faraday_response)
@@ -182,7 +182,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::UploadBddInstructions, type: :j
     # Upload to EVSS
     context 'when the disability_compensation_upload_bdd_instructions_to_lighthouse flipper is disabled' do
       before do
-        Flipper.disable(:disability_compensation_upload_bdd_instructions_to_lighthouse)
+        Flipper.disable(:disability_compensation_upload_bdd_instructions_to_lighthouse) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         allow_any_instance_of(EVSS::DocumentsService).to receive(:upload)
       end
 
@@ -251,7 +251,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::UploadBddInstructions, type: :j
 
       context 'when the API Provider uploads are enabled' do
         before do
-          Flipper.enable(:disability_compensation_use_api_provider_for_bdd_instructions)
+          Flipper.enable(:disability_compensation_use_api_provider_for_bdd_instructions) # rubocop:disable Project/ForbidFlipperToggleInSpecs
         end
 
         let(:sidekiq_job_exhaustion_errors) do
@@ -265,7 +265,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::UploadBddInstructions, type: :j
 
         context 'for a Lighthouse upload' do
           it 'logs the job failure' do
-            Flipper.enable(:disability_compensation_upload_bdd_instructions_to_lighthouse)
+            Flipper.enable(:disability_compensation_upload_bdd_instructions_to_lighthouse) # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
             subject.within_sidekiq_retries_exhausted_block(sidekiq_job_exhaustion_errors) do
               expect_any_instance_of(LighthouseSupplementalDocumentUploadProvider)
@@ -277,7 +277,7 @@ RSpec.describe EVSS::DisabilityCompensationForm::UploadBddInstructions, type: :j
 
         context 'for an EVSS Upload' do
           it 'logs the job failure' do
-            Flipper.disable(:disability_compensation_upload_bdd_instructions_to_lighthouse)
+            Flipper.disable(:disability_compensation_upload_bdd_instructions_to_lighthouse) # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
             subject.within_sidekiq_retries_exhausted_block(sidekiq_job_exhaustion_errors) do
               expect_any_instance_of(EVSSSupplementalDocumentUploadProvider).to receive(:log_uploading_job_failure)

--- a/spec/sidekiq/form526_status_polling_job_spec.rb
+++ b/spec/sidekiq/form526_status_polling_job_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe Form526StatusPollingJob, type: :job do
           let(:timestamp) { Time.now.utc }
 
           before do
-            Flipper.enable(:form526_send_backup_submission_polling_failure_email_notice)
+            Flipper.enable(:form526_send_backup_submission_polling_failure_email_notice) # rubocop:disable Project/ForbidFlipperToggleInSpecs
           end
 
           it 'enqueues a failure notification email job' do
@@ -247,7 +247,7 @@ RSpec.describe Form526StatusPollingJob, type: :job do
           let!(:pending_claim_ids) { Form526Submission.pending_backup.pluck(:backup_submitted_claim_id) }
 
           before do
-            Flipper.disable(:form526_send_backup_submission_polling_failure_email_notice)
+            Flipper.disable(:form526_send_backup_submission_polling_failure_email_notice) # rubocop:disable Project/ForbidFlipperToggleInSpecs
           end
 
           it 'does not enqueue a failure notification email job' do

--- a/spec/sidekiq/hca/ezr_submission_job_spec.rb
+++ b/spec/sidekiq/hca/ezr_submission_job_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe HCA::EzrSubmissionJob, type: :job do
 
   describe 'when retries are exhausted' do
     before do
-      Flipper.enable(:ezr_use_va_notify_on_submission_failure)  # rubocop:disable Project/ForbidFlipperToggleInSpecs
+      Flipper.enable(:ezr_use_va_notify_on_submission_failure) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     end
 
     after do

--- a/spec/sidekiq/hca/ezr_submission_job_spec.rb
+++ b/spec/sidekiq/hca/ezr_submission_job_spec.rb
@@ -47,11 +47,11 @@ RSpec.describe HCA::EzrSubmissionJob, type: :job do
 
   describe 'when retries are exhausted' do
     before do
-      Flipper.enable(:ezr_use_va_notify_on_submission_failure)
+      Flipper.enable(:ezr_use_va_notify_on_submission_failure)  # rubocop:disable Project/ForbidFlipperToggleInSpecs
     end
 
     after do
-      Flipper.disable(:ezr_use_va_notify_on_submission_failure)
+      Flipper.disable(:ezr_use_va_notify_on_submission_failure) # rubocop:disable Project/ForbidFlipperToggleInSpecs
     end
 
     context 'when the parsed form is not present' do
@@ -123,7 +123,7 @@ RSpec.describe HCA::EzrSubmissionJob, type: :job do
           msg = {
             'args' => [encrypted_form, nil]
           }
-          Flipper.disable(:ezr_use_va_notify_on_submission_failure)
+          Flipper.disable(:ezr_use_va_notify_on_submission_failure) # rubocop:disable Project/ForbidFlipperToggleInSpecs
 
           described_class.within_sidekiq_retries_exhausted_block(msg) do
             expect(VANotify::EmailJob).not_to receive(:perform_async).with(*failure_email_template_params)

--- a/spec/sidekiq/lighthouse/submit_career_counseling_job_spec.rb
+++ b/spec/sidekiq/lighthouse/submit_career_counseling_job_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Lighthouse::SubmitCareerCounselingJob do
 
   describe 'sidekiq_retries_exhausted block with flipper on' do
     before do
-      Flipper.enable(:form27_8832_action_needed_email)
+      Flipper.enable(:form27_8832_action_needed_email) # rubocop:disable Project/ForbidFlipperToggleInSpecs
       allow(PCPG::Monitor).to receive(:new).and_return(monitor)
       allow(monitor).to receive :track_submission_exhaustion
     end


### PR DESCRIPTION
## Summary

- Incorporate new cop for detection of direct `Flipper.enable/disable` in spec

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/132249
- see also https://github.com/department-of-veterans-affairs/va.gov-team/issues/131839

## Testing done

- Local verification

## What areas of the site does it impact?

- Linting
## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Screenshot

<img width="877" height="365" alt="Screenshot 2026-02-05 at 12 05 22 PM" src="https://github.com/user-attachments/assets/e3b92815-dbe1-43aa-89e7-971d172b8416" />

