### PR TITLE
Add form submission tracking to claims controller part 2

### DIFF
--- a/modules/vre/app/controllers/vre/v0/claims_controller.rb
+++ b/modules/vre/app/controllers/vre/v0/claims_controller.rb
@@ -9,7 +9,10 @@ module VRE
 
       def create
         if claim.save
-          submission_id = setup_form_submission_tracking(claim, user_account)
+          if Flipper.enabled?(:vre_form_submission_tracking)
+            submission_id = setup_form_submission_tracking(claim,
+                                                           user_account)
+          end
           VRE::VRESubmit1900Job.perform_async(claim.id, encrypted_user, submission_id)
           Rails.logger.info "ClaimID=#{claim.confirmation_number} Form=#{claim.class::FORM}"
           clear_saved_form(claim.form_id)

--- a/modules/vre/app/controllers/vre/v0/claims_controller.rb
+++ b/modules/vre/app/controllers/vre/v0/claims_controller.rb
@@ -9,7 +9,8 @@ module VRE
 
       def create
         if claim.save
-          VRE::VRESubmit1900Job.perform_async(claim.id, encrypted_user)
+          submission_id = setup_form_submission_tracking(claim, user_account)
+          VRE::VRESubmit1900Job.perform_async(claim.id, encrypted_user, submission_id)
           Rails.logger.info "ClaimID=#{claim.confirmation_number} Form=#{claim.class::FORM}"
           clear_saved_form(claim.form_id)
           render json: ::SavedClaimSerializer.new(claim)
@@ -31,6 +32,27 @@ module VRE
 
       def claim
         @claim ||= SavedClaim::VeteranReadinessEmploymentClaim.new(form: filtered_params[:form], user_account:)
+      end
+
+      def setup_form_submission_tracking(claim, user_account)
+        submission = claim.form_submissions.create(
+          form_type: claim.form_id,
+          user_account:
+        )
+
+        if submission.persisted?
+          Rails.logger.info('VR&E Form Submission created',
+                            claim_id: claim.id,
+                            form_type: claim.form_id,
+                            submission_id: submission.id)
+          submission.id
+        else
+          Rails.logger.warn('VR&E Form Submission creation failed - continuing without tracking',
+                            claim_id: claim.id,
+                            form_type: claim.form_id,
+                            errors: submission.errors.full_messages)
+          nil
+        end
       end
 
       def filtered_params

--- a/modules/vre/spec/controllers/claims_controller_spec.rb
+++ b/modules/vre/spec/controllers/claims_controller_spec.rb
@@ -87,4 +87,49 @@ RSpec.describe VRE::V0::ClaimsController, type: :controller do
       end
     end
   end
+
+  describe 'POST create with tracks form submissions' do
+    let(:form_params) { { veteran_readiness_employment_claim: { form: test_form.form } } }
+
+    before do
+      sign_in_as(loa3_user)
+    end
+
+    it 'creates a FormSubmission record' do
+      expect { post(:create, params: form_params) }
+        .to change(FormSubmission, :count).by(1)
+    end
+
+    it 'associates FormSubmission with user_account' do
+      post(:create, params: form_params)
+
+      submission = FormSubmission.last
+      expect(submission.user_account).to eq(loa3_user.user_account)
+    end
+
+    it 'sets correct form_type on FormSubmission' do
+      post(:create, params: form_params)
+
+      submission = FormSubmission.last
+      expect(submission.form_type).to eq('28-1900')
+    end
+
+    it 'passes FormSubmission ID to job as third argument' do
+      post(:create, params: form_params)
+
+      job_args = VRE::VRESubmit1900Job.jobs.last['args']
+      submission_id = FormSubmission.last.id
+      expect(job_args[2]).to eq(submission_id)
+    end
+
+    it 'handles missing user_account gracefully' do
+      UserAccount.find_by(icn: loa3_user.icn)&.destroy
+
+      expect { post(:create, params: form_params) }
+        .to change(FormSubmission, :count).by(1)
+
+      submission = FormSubmission.last
+      expect(submission.user_account).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): NO*
- Add form submission tracking functionality to the module claims controller

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-iir/issues/2344

## Testing done

- [x] *New code is covered by unit tests*
- Previous version was not tracking form submissions

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
VRE Claims

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

QA: Add feature flag around logic. Then use datadog to test 
