### PR TITLE
Add DB Team as codeowner for claims 526 schema

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1129,7 +1129,7 @@ modules/bpds @department-of-veterans-affairs/bpds @department-of-veterans-affair
 modules/burials @department-of-veterans-affairs/burials @department-of-veterans-affairs/backend-review-group
 modules/check_in @department-of-veterans-affairs/vsa-healthcare-health-quest-1-backend @department-of-veterans-affairs/patient-check-in @department-of-veterans-affairs/backend-review-group
 modules/claims_api @department-of-veterans-affairs/lighthouse-dash
-modules/claims_api/config/schemas/v2/526.json @department-of-veterans-affairs/disability-benefits
+modules/claims_api/config/schemas/v2/526.json @department-of-veterans-affairs/disability-benefits @department-of-veterans-affairs/backend-review-group
 modules/claims_evidence_api @department-of-veterans-affairs/benefits-lifestage @department-of-veterans-affairs/claims-evidence-api @department-of-veterans-affairs/backend-review-group
 modules/debts_api @department-of-veterans-affairs/vsa-debt-resolution @department-of-veterans-affairs/backend-review-group
 modules/decision_reviews @department-of-veterans-affairs/benefits-decision-reviews-be @department-of-veterans-affairs/backend-review-group


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- Update CODEOWNERS to assign claims 526 schema to DB Team

## Related issue(s)

- [131385](https://github.com/department-of-veterans-affairs/va.gov-team/issues/131385)