### PR TITLE
Updates consentLimits logging

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/service_base.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/service_base.rb
@@ -42,7 +42,7 @@ module ClaimsApi
 
     def form_logger_consent_detail(poa, poa_code)
       "Updating Access. recordConsent: #{poa.form_data['recordConsent'] || false}" \
-        "#{poa.form_data['consentLimits'] ? ', consentLimits included' : nil}" \
+        "#{poa.form_data['consentLimits']&.any? ? ', consentLimits included' : nil}" \
         " for representative #{poa_code}"
     end
 

--- a/modules/claims_api/spec/sidekiq/service_base_spec.rb
+++ b/modules/claims_api/spec/sidekiq/service_base_spec.rb
@@ -203,4 +203,34 @@ RSpec.describe ClaimsApi::ServiceBase do
       service.send(:log_job_progress, claim.id, detail, transaction_id)
     end
   end
+
+  describe '#form_logger_consent_detail' do
+    let(:poa_code) { '065' }
+
+    it 'does not mention consentLimits in the log output if the array is empty' do
+      poa = OpenStruct.new(form_data: { 'recordConsent' => true, 'consentLimits' => [] })
+
+      detail = service.send(:form_logger_consent_detail, poa, poa_code)
+
+      expect(detail).to eq("Updating Access. recordConsent: true for representative #{poa_code}")
+    end
+
+    it 'does not mention consentLimits in the log output when no consentLimit key is sent' do
+      poa = OpenStruct.new(form_data: { 'recordConsent' => true })
+
+      detail = service.send(:form_logger_consent_detail, poa, poa_code)
+
+      expect(detail).to eq("Updating Access. recordConsent: true for representative #{poa_code}")
+    end
+
+    it 'mentions consentLimits in the log output if the array has any values' do
+      poa = OpenStruct.new(form_data: { 'recordConsent' => true, 'consentLimits' => ['DRUG_ABUSE'] })
+
+      detail = service.send(:form_logger_consent_detail, poa, poa_code)
+
+      expect(detail).to eq(
+        "Updating Access. recordConsent: true, consentLimits included for representative #{poa_code}"
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Summary
* Fixes the logout so it accounts for an empty array being sent in
    *  The initial implementation overlooked the fact it is common place to send in an empty array for this field in the form data.  This meant that `consentLimits`  would be mentioned in the logout even though they were not really included. 
* Adds test to verify behavior

## Related issue(s)
[API-53489](https://jira.devops.va.gov/browse/API-53489)

## Testing done

- [x] *New code is covered by unit tests*

#### Testing notes
* This addresses an empty array being sent in which the original check did not consider.  So the behavior should be
* consentLimits not mentioned when `consentLimits: []` is sent in the form data
* consentLimits not mentioned when no `consentLimits` object is on the form
* consentLimits mentioned in the logout when `consentLimist: ['DRUG_ABUSE']` or any other of the three values is in the from data

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
	modified:   modules/claims_api/app/sidekiq/claims_api/service_base.rb
	modified:   modules/claims_api/spec/sidekiq/service_base_spec.rb

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
