### PR TITLE
Api 30782 v2 swagger cleanup

### DIFF
--- a/modules/claims_api/app/swagger/claims_api/v1/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v1/swagger.json
@@ -3191,7 +3191,7 @@
                           "poa_code": "074"
                         }
                       },
-                      "status": "submitted"
+                      "status": "pending"
                     }
                   }
                 },

--- a/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/dev/swagger.json
@@ -343,7 +343,7 @@
                   "202 without a transactionId": {
                     "value": {
                       "data": {
-                        "id": "00000000-0000-0000-0000-000000000012",
+                        "id": "00000000-0000-0000-0000-000000000001",
                         "type": "forms/526",
                         "attributes": {
                           "claimId": "600442191",
@@ -574,7 +574,7 @@
                   "202 with a transactionId": {
                     "value": {
                       "data": {
-                        "id": "00000000-0000-0000-0000-000000000013",
+                        "id": "00000000-0000-0000-0000-000000000002",
                         "type": "forms/526",
                         "attributes": {
                           "claimId": "600442191",
@@ -801,7 +801,7 @@
                         }
                       },
                       "meta": {
-                        "transactionId": "00000000-0000-0000-0000-000000000014"
+                        "transactionId": "00000000-0000-0000-0000-000000000003"
                       }
                     }
                   }
@@ -822,7 +822,7 @@
                       "properties": {
                         "id": {
                           "type": "string",
-                          "example": "00000000-0000-0000-0000-000000000015"
+                          "example": "00000000-0000-0000-0000-000000000004"
                         },
                         "type": {
                           "type": "string",
@@ -3921,7 +3921,7 @@
                 "Transaction ID": {
                   "value": {
                     "meta": {
-                      "transactionId": "00000000-0000-0000-0000-000000000016"
+                      "transactionId": "00000000-0000-0000-0000-000000000005"
                     },
                     "data": {
                       "type": "form/526",
@@ -7536,7 +7536,7 @@
                                 "type": "string",
                                 "nullable": true,
                                 "description": "Claim ID in Lighthouse",
-                                "example": "00000000-0000-0000-0000-000000000017"
+                                "example": "00000000-0000-0000-0000-000000000006"
                               },
                               "status": {
                                 "type": "string",
@@ -7818,7 +7818,7 @@
                             }
                           ],
                           "jurisdiction": null,
-                          "lighthouseId": "00000000-0000-0000-0000-000000000018",
+                          "lighthouseId": "00000000-0000-0000-0000-000000000007",
                           "maxEstClaimDate": null,
                           "minEstClaimDate": null,
                           "status": "ERRORED",
@@ -8055,7 +8055,7 @@
                               "type": "string",
                               "nullable": true,
                               "description": "Claim ID in Lighthouse",
-                              "example": "00000000-0000-0000-0000-000000000019"
+                              "example": "00000000-0000-0000-0000-000000000008"
                             },
                             "minEstClaimDate": {
                               "format": "date",
@@ -9717,7 +9717,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "00000000-0000-0000-0000-000000000020",
+                    "id": "00000000-0000-0000-0000-000000000009",
                     "type": "power-of-attorney-request",
                     "attributes": {
                       "veteran": {
@@ -11088,7 +11088,7 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "example": "00000000-0000-0000-0000-000000000021",
+            "example": "00000000-0000-0000-0000-000000000010",
             "description": "The ID of the Power of Attorney request",
             "schema": {
               "type": "string"
@@ -11102,7 +11102,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "00000000-0000-0000-0000-000000000022",
+                    "id": "00000000-0000-0000-0000-000000000011",
                     "type": "power-of-attorney-request",
                     "attributes": {
                       "veteran": {
@@ -11417,7 +11417,7 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "example": "00000000-0000-0000-0000-000000000023",
+            "example": "00000000-0000-0000-0000-000000000012",
             "description": "The ID of the request for representation",
             "schema": {
               "type": "string"
@@ -12571,7 +12571,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "00000000-0000-0000-0000-000000000024",
+                    "id": "00000000-0000-0000-0000-000000000013",
                     "type": "organization",
                     "attributes": {
                       "code": "083",
@@ -14068,7 +14068,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "00000000-0000-0000-0000-000000000025",
+                    "id": "00000000-0000-0000-0000-000000000014",
                     "type": "individual",
                     "attributes": {
                       "code": "067",
@@ -14902,7 +14902,7 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "example": "00000000-0000-0000-0000-000000000026",
+            "example": "00000000-0000-0000-0000-000000000015",
             "description": "The ID of the 21-22 submission",
             "schema": {
               "type": "string"
@@ -14916,7 +14916,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "00000000-0000-0000-0000-000000000027",
+                    "id": "00000000-0000-0000-0000-000000000016",
                     "type": "claimsApiPowerOfAttorneys",
                     "attributes": {
                       "createdAt": "2024-01-01 00:00:00 UTC",

--- a/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
+++ b/modules/claims_api/app/swagger/claims_api/v2/production/swagger.json
@@ -343,7 +343,7 @@
                   "202 without a transactionId": {
                     "value": {
                       "data": {
-                        "id": "00000000-0000-0000-0000-000000000028",
+                        "id": "00000000-0000-0000-0000-000000000001",
                         "type": "forms/526",
                         "attributes": {
                           "claimId": "600442191",
@@ -574,7 +574,7 @@
                   "202 with a transactionId": {
                     "value": {
                       "data": {
-                        "id": "00000000-0000-0000-0000-000000000029",
+                        "id": "00000000-0000-0000-0000-000000000002",
                         "type": "forms/526",
                         "attributes": {
                           "claimId": "600442191",
@@ -801,7 +801,7 @@
                         }
                       },
                       "meta": {
-                        "transactionId": "00000000-0000-0000-0000-000000000030"
+                        "transactionId": "00000000-0000-0000-0000-000000000003"
                       }
                     }
                   }
@@ -822,7 +822,7 @@
                       "properties": {
                         "id": {
                           "type": "string",
-                          "example": "00000000-0000-0000-0000-000000000031"
+                          "example": "00000000-0000-0000-0000-000000000004"
                         },
                         "type": {
                           "type": "string",
@@ -3921,7 +3921,7 @@
                 "Transaction ID": {
                   "value": {
                     "meta": {
-                      "transactionId": "00000000-0000-0000-0000-000000000032"
+                      "transactionId": "00000000-0000-0000-0000-000000000005"
                     },
                     "data": {
                       "type": "form/526",
@@ -7536,7 +7536,7 @@
                                 "type": "string",
                                 "nullable": true,
                                 "description": "Claim ID in Lighthouse",
-                                "example": "00000000-0000-0000-0000-000000000033"
+                                "example": "00000000-0000-0000-0000-000000000006"
                               },
                               "status": {
                                 "type": "string",
@@ -7818,7 +7818,7 @@
                             }
                           ],
                           "jurisdiction": null,
-                          "lighthouseId": "00000000-0000-0000-0000-000000000034",
+                          "lighthouseId": "00000000-0000-0000-0000-000000000007",
                           "maxEstClaimDate": null,
                           "minEstClaimDate": null,
                           "status": "ERRORED",
@@ -8055,7 +8055,7 @@
                               "type": "string",
                               "nullable": true,
                               "description": "Claim ID in Lighthouse",
-                              "example": "00000000-0000-0000-0000-000000000035"
+                              "example": "00000000-0000-0000-0000-000000000008"
                             },
                             "minEstClaimDate": {
                               "format": "date",
@@ -9717,7 +9717,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "00000000-0000-0000-0000-000000000036",
+                    "id": "00000000-0000-0000-0000-000000000009",
                     "type": "power-of-attorney-request",
                     "attributes": {
                       "veteran": {
@@ -11088,7 +11088,7 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "example": "00000000-0000-0000-0000-000000000037",
+            "example": "00000000-0000-0000-0000-000000000010",
             "description": "The ID of the Power of Attorney request",
             "schema": {
               "type": "string"
@@ -11102,7 +11102,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "00000000-0000-0000-0000-000000000038",
+                    "id": "00000000-0000-0000-0000-000000000011",
                     "type": "power-of-attorney-request",
                     "attributes": {
                       "veteran": {
@@ -11417,7 +11417,7 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "example": "00000000-0000-0000-0000-000000000039",
+            "example": "00000000-0000-0000-0000-000000000012",
             "description": "The ID of the request for representation",
             "schema": {
               "type": "string"
@@ -12571,7 +12571,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "00000000-0000-0000-0000-000000000040",
+                    "id": "00000000-0000-0000-0000-000000000013",
                     "type": "organization",
                     "attributes": {
                       "code": "083",
@@ -14068,7 +14068,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "00000000-0000-0000-0000-000000000041",
+                    "id": "00000000-0000-0000-0000-000000000014",
                     "type": "individual",
                     "attributes": {
                       "code": "067",
@@ -14902,7 +14902,7 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "example": "00000000-0000-0000-0000-000000000042",
+            "example": "00000000-0000-0000-0000-000000000015",
             "description": "The ID of the 21-22 submission",
             "schema": {
               "type": "string"
@@ -14916,7 +14916,7 @@
               "application/json": {
                 "example": {
                   "data": {
-                    "id": "00000000-0000-0000-0000-000000000043",
+                    "id": "00000000-0000-0000-0000-000000000016",
                     "type": "claimsApiPowerOfAttorneys",
                     "attributes": {
                       "createdAt": "2024-01-01 00:00:00 UTC",

--- a/rakelib/rswag.rake
+++ b/rakelib/rswag.rake
@@ -208,15 +208,15 @@ def sanitize_example_values!(data) # rubocop:disable Metrics/MethodLength
   date_regex = /^\d{4}-\d{2}-\d{2}$/
 
   # Counter to generate sequential UUIDs
-  @uuid_counter ||= 0
+  uuid_counter = 0
 
   transformer = lambda do |_k, v, _root|
     return v unless v.is_a?(String)
 
     # Sanitize UUIDs
     if v.match?(uuid_regex)
-      @uuid_counter += 1
-      format('00000000-0000-0000-0000-%012d', @uuid_counter)
+      uuid_counter += 1
+      format('00000000-0000-0000-0000-%012d', uuid_counter)
     # Sanitize ISO 8601 timestamps (e.g., "2026-02-06T17:04:14.037Z")
     elsif v.match?(iso_timestamp_regex)
       normalize_date_value(v, Date.parse(v.split('T').first)) { |d| "#{d}T00:00:00.000Z" }


### PR DESCRIPTION
## Summary

- *(Which team do you work for, does your team own the maintenance of this component?)*
dash

Summary: 
Adds post-processing for swagger docs generated for claims api via `bundle exec rake rswag:claims_api:build`.
Reduces the number of lines changed when generating swagger files.
Stubs ids and dates with constant values.


## Related issue(s)
[API-44648](https://jira.devops.va.gov/browse/API-44648)
<img width="1100" height="458" alt="Screenshot 2026-02-06 at 3 14 19 PM" src="https://github.com/user-attachments/assets/6c4235e8-d050-4260-bbee-9aa182c4d8b9" />


## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
  - when generating docs, IDs and dates would change, resulting in large git diffs
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
  - generate docs, observe few if any git diffs with `bundle exec rake rswag:claims_api:build`

## What areas of the site does it impact?
`rakelib/rswag.rake`

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
