### PR TITLE
Add PostGIS patch to Console1984

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -763,6 +763,7 @@ config/initializers/combine_pdf_log_patch.rb @department-of-veterans-affairs/bac
 config/initializers/config.rb @department-of-veterans-affairs/backend-review-group
 config/initializers/console_filter_toggles.rb @department-of-veterans-affairs/backend-review-group
 config/initializers/console1984_supervisor_patch.rb @department-of-veterans-affairs/backend-review-group
+config/initializers/console1984_postgis_patch.rb @department-of-veterans-affairs/backend-review-group
 config/initializers/cookie_rotation.rb @department-of-veterans-affairs/backend-review-group
 config/initializers/core_extensions.rb @department-of-veterans-affairs/backend-review-group
 config/initializers/datadog.rb @department-of-veterans-affairs/backend-review-group

--- a/config/initializers/console1984_postgis_patch.rb
+++ b/config/initializers/console1984_postgis_patch.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+######## Why does this patch exist? ########
+#
+# Console1984 blocks all `instance_variable_get` and `instance_variable_set` to prevent
+# adding new methods to classes, changing class-state or accessing/overridden instance variables via reflection.
+# This is meant to prevent manipulating certain Console1984 classes during a console session.
+#
+# The `datadog` gem wants to access the DB connection configuration hash from the current connection.
+#
+# The result of this incompatibility is an error when accessing Rails console in live environments
+#
+# You can't invoke instance_variable_get on #<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter>
+#
+# This will likely be the case for many versions in the future, so a patch is required. Instead of patching
+# the `datadog` gem, it would less risky to patch the `console1984` gem and allow
+#
+############################################
+
+module Console1984
+  module Freezeable
+    module ClassMethods
+      private
+
+      def prevent_sensitive_method(method_name)
+        define_method(method_name) do |*arguments|
+          if instance_of?(ActiveRecord::ConnectionAdapters::PostGISAdapter)
+            super(*arguments)
+          else
+            raise Console1984::Errors::ForbiddenCommandAttempted, "You can't invoke #{method_name} on #{self}"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add patch to remove error during console access

```
ERROR -- datadog: [datadog] (.../sql.rb:72:in `rescue in on_start') You can't invoke instance_variable_get on #<ActiveRecord::ConnectionAdapters::PostGISAdapter:...>
```

## Additional Context

Console1984 blocks all `instance_variable_get` and `instance_variable_set` to prevent
adding new methods to classes, changing class-state or accessing/overridden instance variables via reflection.
This is meant to prevent manipulating certain Console1984 classes during a console session.

The `datadog` gem wants to access the DB connection configuration hash from the current connection.

The result of this incompatibility is an error when accessing Rails console in live environments

You can't invoke instance_variable_get on #<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter>

This will likely be the case for many versions in the future, so a patch is required. Instead of patching
the `datadog` gem, it would less risky to patch the `console1984` gem and allow

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131585

## Testing done

- [x] manual testing to ensure Console1984 works, but need to validate in staging. 

## Acceptance criteria

- [x] Error goes away
- [x] Console1984 continues to work as intended
- [x] Datadog logs in console 

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
