### PR TITLE
section 6 overflow remapping complete

### DIFF
--- a/modules/survivors_benefits/lib/survivors_benefits/pdf_fill/sections/section_06.rb
+++ b/modules/survivors_benefits/lib/survivors_benefits/pdf_fill/sections/section_06.rb
@@ -8,11 +8,6 @@ module SurvivorsBenefits
   module PdfFill
     # Section 6: Children of the Veteran Information
     class Section6 < Section
-      ITERATOR = ::PdfFill::HashConverter::ITERATOR
-      CHILD_ROW_INDEX = ->(iterator) { 2 - iterator }
-      CHILD_SSN_INDEX = ->(iterator) { (iterator + 1) % 3 }
-      CHILD_DOB_INDEX = ->(iterator) { 8 + ((iterator + 1) % 3) }
-
       KEY = {
         'p13HeaderVeteranSocialSecurityNumber' => {
           'first' => {
@@ -28,114 +23,261 @@ module SurvivorsBenefits
         'veteranChildrenCount' => {
           key: 'form1[0].#subform[210].Number_Of_Dependent_Children[0]'
         },
-        'veteransChildren' => {
-          limit: 3,
+        'veteransChildOne' => {
           first_key: 'childFullName',
           'childFullName' => {
             'first' => {
               limit: 12,
-              question_num: 1,
-              question_suffix: 'A',
+              question_num: 6,
+              question_suffix: 'B',
               question_label: "Child's First Name",
               question_text: 'CHILD\'S FIRST NAME',
-              iterator_offset: CHILD_ROW_INDEX,
-              key: "form1[0].#subform[210].Childs_FirstName[#{ITERATOR}]"
+              key: 'form1[0].#subform[210].Childs_FirstName[2]'
             },
             'middle' => {
               limit: 1,
-              question_num: 1,
-              question_suffix: 'A',
-              iterator_offset: CHILD_ROW_INDEX,
-              key: "form1[0].#subform[210].Childs_MiddleInitial1[#{ITERATOR}]"
+              question_num: 6,
+              question_suffix: 'B',
+              key: 'form1[0].#subform[210].Childs_MiddleInitial1[2]'
             },
             'last' => {
               limit: 18,
-              question_num: 1,
-              question_suffix: 'A',
+              question_num: 6,
+              question_suffix: 'B',
               question_label: "Child's Last Name",
               question_text: 'CHILD\'S LAST NAME',
-              iterator_offset: CHILD_ROW_INDEX,
-              key: "form1[0].#subform[210].Childs_LastName[#{ITERATOR}]"
+              key: 'form1[0].#subform[210].Childs_LastName[2]'
             }
           },
           'childDateOfBirth' => {
             'month' => {
-              iterator_offset: CHILD_DOB_INDEX,
-              key: "form1[0].#subform[210].Date_Month[#{ITERATOR}]"
+              key: 'form1[0].#subform[210].Date_Month[9]'
             },
             'day' => {
-              iterator_offset: CHILD_DOB_INDEX,
-              key: "form1[0].#subform[210].Date_Day[#{ITERATOR}]"
+              key: 'form1[0].#subform[210].Date_Day[9]'
             },
             'year' => {
-              iterator_offset: CHILD_DOB_INDEX,
-              key: "form1[0].#subform[210].Date_Year[#{ITERATOR}]"
+              key: 'form1[0].#subform[210].Date_Year[9]'
             }
           },
           'childSocialSecurityNumber' => {
             'first' => {
-              iterator_offset: CHILD_SSN_INDEX,
-              key: "form1[0].#subform[210].Childs_SocialSecurityNumber_FirstThreeNumbers[#{ITERATOR}]"
+              key: 'form1[0].#subform[210].Childs_SocialSecurityNumber_FirstThreeNumbers[1]'
             },
             'second' => {
-              iterator_offset: CHILD_SSN_INDEX,
-              key: "form1[0].#subform[210].Childs_SocialSecurityNumber_SecondTwoNumbers[#{ITERATOR}]"
+              key: 'form1[0].#subform[210].Childs_SocialSecurityNumber_SecondTwoNumbers[1]'
             },
             'third' => {
-              iterator_offset: CHILD_SSN_INDEX,
-              key: "form1[0].#subform[210].Childs_SocialSecurityNumber_LastFourNumbers[#{ITERATOR}]"
+              key: 'form1[0].#subform[210].Childs_SocialSecurityNumber_LastFourNumbers[1]'
             }
           },
           'childPlaceOfBirth' => {
-            iterator_offset: CHILD_ROW_INDEX,
-            key: "form1[0].#subform[210].Place_Of_Birth_City_State_Or_Country[#{ITERATOR}]"
+            limit: 28,
+            question_num: 6,
+            question_suffix: 'E',
+            question_label: 'Child\'s Place Of Birth (City/State or Country)',
+            question_text: 'CHILD\'S PLACE OF BIRTH (CITY/STATE OR COUNTRY)',
+            key: 'form1[0].#subform[210].Place_Of_Birth_City_State_Or_Country[2]'
           },
           'childStatusBiological' => {
-            iterator_offset: CHILD_ROW_INDEX,
-            key: "form1[0].#subform[210].JF06[#{ITERATOR}]"
+            key: 'form1[0].#subform[210].JF06[2]'
           },
           'childStatusAdopted' => {
-            iterator_offset: CHILD_ROW_INDEX,
-            key: "form1[0].#subform[210].JF14[#{ITERATOR}]"
+            key: 'form1[0].#subform[210].JF14[2]'
           },
           'childStatusStepchild' => {
-            iterator_offset: CHILD_ROW_INDEX,
-            key: "form1[0].#subform[210].JF08[#{ITERATOR}]"
+            key: 'form1[0].#subform[210].JF08[2]'
           },
           'childStatusMinor' => {
-            iterator_offset: CHILD_ROW_INDEX,
-            key: "form1[0].#subform[210].JF12[#{ITERATOR}]"
+            key: 'form1[0].#subform[210].JF12[2]'
           },
           'childStatusDisabled' => {
-            iterator_offset: CHILD_ROW_INDEX,
-            key: "form1[0].#subform[210].JF10[#{ITERATOR}]"
+            key: 'form1[0].#subform[210].JF10[2]'
           },
           'childStatusMarried' => {
-            iterator_offset: CHILD_ROW_INDEX,
-            key: "form1[0].#subform[210].JF18[#{ITERATOR}]"
+            key: 'form1[0].#subform[210].JF18[2]'
           },
           'childStatusSupported' => {
-            iterator_offset: CHILD_ROW_INDEX,
-            key: "form1[0].#subform[210].JF16[#{ITERATOR}]"
+            key: 'form1[0].#subform[210].JF16[2]'
           },
           'childSupport' => {
             'thousands' => {
-              iterator_offset: ->(iterator) { 3 - iterator },
-              key_from_iterator: lambda { |iterator|
-                case iterator
-                when 0 then 'form1[0].#subform[210].Monthly_Amount_Contribution[1]'
-                else "form1[0].#subform[210].Total_Annual_Earnings_Amount[#{ITERATOR}]"
-                end
-              }
+              key: 'form1[0].#subform[210].Monthly_Amount_Contribution[1]'
             },
             'dollars' => {
-              iterator_offset: ->(iterator) { 6 - (iterator * 3) },
-              key_from_iterator: lambda { |iterator|
-                case iterator
-                when 0 then 'form1[0].#subform[210].Monthly_Amount_Contribution[0]'
-                else "form1[0].#subform[210].Total_Annual_Earnings_Amount[#{ITERATOR}]"
-                end
-              }
+              key: 'form1[0].#subform[210].Monthly_Amount_Contribution[0]'
+            }
+          }
+        },
+        'veteransChildTwo' => {
+          first_key: 'childFullName',
+          'childFullName' => {
+            'first' => {
+              limit: 12,
+              question_num: 6,
+              question_suffix: 'G',
+              question_label: "Child's First Name",
+              question_text: 'CHILD\'S FIRST NAME',
+              key: 'form1[0].#subform[210].Childs_FirstName[1]'
+            },
+            'middle' => {
+              limit: 1,
+              question_num: 6,
+              question_suffix: 'G',
+              key: 'form1[0].#subform[210].Childs_MiddleInitial1[1]'
+            },
+            'last' => {
+              limit: 18,
+              question_num: 6,
+              question_suffix: 'G',
+              question_label: "Child's Last Name",
+              question_text: 'CHILD\'S LAST NAME',
+              key: 'form1[0].#subform[210].Childs_LastName[1]'
+            }
+          },
+          'childDateOfBirth' => {
+            'month' => {
+              key: 'form1[0].#subform[210].Date_Month[10]'
+            },
+            'day' => {
+              key: 'form1[0].#subform[210].Date_Day[10]'
+            },
+            'year' => {
+              key: 'form1[0].#subform[210].Date_Year[10]'
+            }
+          },
+          'childSocialSecurityNumber' => {
+            'first' => {
+              key: 'form1[0].#subform[210].Childs_SocialSecurityNumber_FirstThreeNumbers[2]'
+            },
+            'second' => {
+              key: 'form1[0].#subform[210].Childs_SocialSecurityNumber_SecondTwoNumbers[2]'
+            },
+            'third' => {
+              key: 'form1[0].#subform[210].Childs_SocialSecurityNumber_LastFourNumbers[2]'
+            }
+          },
+          'childPlaceOfBirth' => {
+            limit: 28,
+            question_num: 6,
+            question_suffix: 'J',
+            question_label: 'Child\'s Place Of Birth (City/State or Country)',
+            question_text: 'CHILD\'S PLACE OF BIRTH (CITY/STATE OR COUNTRY)',
+            key: 'form1[0].#subform[210].Place_Of_Birth_City_State_Or_Country[1]'
+          },
+          'childStatusBiological' => {
+            key: 'form1[0].#subform[210].JF06[1]'
+          },
+          'childStatusAdopted' => {
+            key: 'form1[0].#subform[210].JF14[1]'
+          },
+          'childStatusStepchild' => {
+            key: 'form1[0].#subform[210].JF08[1]'
+          },
+          'childStatusMinor' => {
+            key: 'form1[0].#subform[210].JF12[1]'
+          },
+          'childStatusDisabled' => {
+            key: 'form1[0].#subform[210].JF10[1]'
+          },
+          'childStatusMarried' => {
+            key: 'form1[0].#subform[210].JF18[1]'
+          },
+          'childStatusSupported' => {
+            key: 'form1[0].#subform[210].JF16[1]'
+          },
+          'childSupport' => {
+            'thousands' => {
+              key: 'form1[0].#subform[210].Total_Annual_Earnings_Amount[2]'
+            },
+            'dollars' => {
+              key: 'form1[0].#subform[210].Total_Annual_Earnings_Amount[3]'
+            }
+          }
+        },
+        'veteransChildThree' => {
+          first_key: 'childFullName',
+          'childFullName' => {
+            'first' => {
+              limit: 12,
+              question_num: 6,
+              question_suffix: 'L',
+              question_label: "Child's First Name",
+              question_text: 'CHILD\'S FIRST NAME',
+              key: 'form1[0].#subform[210].Childs_FirstName[0]'
+            },
+            'middle' => {
+              limit: 1,
+              question_num: 6,
+              question_suffix: 'L',
+              key: 'form1[0].#subform[210].Childs_MiddleInitial1[0]'
+            },
+            'last' => {
+              limit: 18,
+              question_num: 6,
+              question_suffix: 'L',
+              question_label: "Child's Last Name",
+              question_text: 'CHILD\'S LAST NAME',
+              key: 'form1[0].#subform[210].Childs_LastName[0]'
+            }
+          },
+          'childDateOfBirth' => {
+            'month' => {
+              key: 'form1[0].#subform[210].Date_Month[8]'
+            },
+            'day' => {
+              key: 'form1[0].#subform[210].Date_Day[8]'
+            },
+            'year' => {
+              key: 'form1[0].#subform[210].Date_Year[8]'
+            }
+          },
+          'childSocialSecurityNumber' => {
+            'first' => {
+              key: 'form1[0].#subform[210].Childs_SocialSecurityNumber_FirstThreeNumbers[0]'
+            },
+            'second' => {
+              key: 'form1[0].#subform[210].Childs_SocialSecurityNumber_SecondTwoNumbers[0]'
+            },
+            'third' => {
+              key: 'form1[0].#subform[210].Childs_SocialSecurityNumber_LastFourNumbers[0]'
+            }
+          },
+          'childPlaceOfBirth' => {
+            limit: 28,
+            question_num: 6,
+            question_suffix: 'O',
+            question_label: 'Child\'s Place Of Birth (City/State or Country)',
+            question_text: 'CHILD\'S PLACE OF BIRTH (CITY/STATE OR COUNTRY)',
+            key: 'form1[0].#subform[210].Place_Of_Birth_City_State_Or_Country[0]'
+          },
+          'childStatusBiological' => {
+            key: 'form1[0].#subform[210].JF06[0]'
+          },
+          'childStatusAdopted' => {
+            key: 'form1[0].#subform[210].JF14[0]'
+          },
+          'childStatusStepchild' => {
+            key: 'form1[0].#subform[210].JF08[0]'
+          },
+          'childStatusMinor' => {
+            key: 'form1[0].#subform[210].JF12[0]'
+          },
+          'childStatusDisabled' => {
+            key: 'form1[0].#subform[210].JF10[0]'
+          },
+          'childStatusMarried' => {
+            key: 'form1[0].#subform[210].JF18[0]'
+          },
+          'childStatusSupported' => {
+            key: 'form1[0].#subform[210].JF16[0]'
+          },
+          'childSupport' => {
+            'thousands' => {
+              key: 'form1[0].#subform[210].Total_Annual_Earnings_Amount[1]'
+            },
+            'dollars' => {
+              key: 'form1[0].#subform[210].Total_Annual_Earnings_Amount[0]'
             }
           }
         },
@@ -145,22 +287,22 @@ module SurvivorsBenefits
         'custodianFullName' => {
           'first' => {
             limit: 12,
-            question_num: 1,
-            question_suffix: 'A',
+            question_num: 6,
+            question_suffix: 'R',
             question_label: 'Custodian\'s First Name',
             question_text: 'CUSTODIAN\'S FIRST NAME',
             key: 'form1[0].#subform[210].Custodians_FirstName[0]'
           },
           'middle' => {
             limit: 1,
-            question_num: 1,
-            question_suffix: 'A',
+            question_num: 6,
+            question_suffix: 'R',
             key: 'form1[0].#subform[210].Custodians_MiddleInitial1[0]'
           },
           'last' => {
             limit: 18,
-            question_num: 1,
-            question_suffix: 'A',
+            question_num: 6,
+            question_suffix: 'R',
             question_label: "Custodian's Last Name",
             question_text: 'CUSTODIAN\'S LAST NAME',
             key: 'form1[0].#subform[210].Custodians_LastName[0]'
@@ -169,24 +311,24 @@ module SurvivorsBenefits
         'custodianAddress' => {
           'street' => {
             limit: 30,
-            question_num: 2,
-            question_suffix: 'A',
+            question_num: 6,
+            question_suffix: 'R',
             question_label: 'Mailing Address Number And Street',
             question_text: 'MAILING ADDRESS NUMBER AND STREET',
             key: 'form1[0].#subform[210].NumberStreet[2]'
           },
           'street2' => {
             limit: 5,
-            question_num: 2,
-            question_suffix: 'A',
+            question_num: 6,
+            question_suffix: 'R',
             question_label: 'Mailing Address Apt/Unit',
             question_text: 'MAILING ADDRESS APT/UNIT',
             key: 'form1[0].#subform[210].Apt_Or_Unit_Number[1]'
           },
           'city' => {
             limit: 18,
-            question_num: 2,
-            question_suffix: 'A',
+            question_num: 6,
+            question_suffix: 'R',
             question_label: 'Mailing Address City',
             question_text: 'MAILING ADDRESS CITY',
             key: 'form1[0].#subform[210].City[1]'
@@ -203,8 +345,8 @@ module SurvivorsBenefits
             },
             'lastFour' => {
               limit: 4,
-              question_num: 2,
-              question_suffix: 'A',
+              question_num: 6,
+              question_suffix: 'R',
               question_label: 'Postal Code - Last Four',
               question_text: 'POSTAL CODE - LAST FOUR',
               key: 'form1[0].#subform[210].Zip_Postal_Code[3]'
@@ -216,7 +358,10 @@ module SurvivorsBenefits
       def expand(form_data)
         form_data['p13HeaderVeteranSocialSecurityNumber'] = split_ssn(form_data['veteranSocialSecurityNumber'])
         form_data['veteransChildren'] ||= []
-        form_data['veteransChildren'] = form_data['veteransChildren'].map { |child| expand_child(child) }
+        veterans_children = form_data['veteransChildren'].map { |child| expand_child(child) }
+        form_data['veteransChildOne'] = veterans_children.first || {}
+        form_data['veteransChildTwo'] = veterans_children.second || {}
+        form_data['veteransChildThree'] = veterans_children.third || {}
         form_data['childrenLiveTogetherButNotWithSpouse'] =
           to_radio_yes_no_numeric(form_data['childrenLiveTogetherButNotWithSpouse'])
         form_data['custodianFullName'] ||= {}


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

Summary
- The 534EZ form's PDF generator now has overflow triggers updated for all fields in Section 6
- Section 6 was remapped to eliminate the use of the iterator

## Testing done

 New code is covered by unit tests
- Describe what the old behavior was prior to the change: Before, the 534EZ PDF generator was writing all fields in the form PDF in the same way. However, testing identified that the "text area" fields with built-in text wrapping were not covered by the existing overflow triggers, causing over-long submissions to wrap in an endless hidden overlap only visible when a user manually clicks within the field. This is not acceptable for processing of the claim, and overflow values need to write to the "Additional info" page like the typical "text fields" do.
- Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing: To test, through the backend we submitted a blob of extremely long entries for the free text fields within Section 6. We opened the generated PDF to determine if these fields wrote to the Additional Info page as expected. Upon this test, all fields' overflow entries now write to the Additional Info page alongside any typical text field overflow entry.
- If this work is behind a flipper: N/A
Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).

What is the testing plan for rolling out the feature? Testing in Staging to confirm functionality works as expected. Once successfully tested, feature will be part of 534EZ launch the week of 2/09.

What areas of the site does it impact?
(Describe what parts of the site are impacted and if code touched other areas): VETS-API code that generates PDFs for the 534EZ web form.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
