### PR TITLE
2376: add feature flag for enabling access to multiple years of 1095b

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2868,6 +2868,9 @@ features:
   fetch_1095b_from_enrollment_system:
     actor_type: user
     description: Enables fetching of form 1095b from enrollment system instead of from local database
+  form1095b_multiple_years:
+    actor_type: user
+    description: Enables access to multiple years of form 1095b
   meb_1995_instruction_page_update_v3:
     actor_type: user
     description: Updated verbiage for instruction page for 5490


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): No. It is a feature flag.
- This PR adds a new feature flag for allowing users to download multiple years of 1095b forms 
- I'm on the CVE team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-iir/issues/2376

## Testing done

Can't really test a feature flag.

## Screenshots


## What areas of the site does it impact?
None.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback
