### PR TITLE
[BIO] 21-8940 Removes debugging logs

### DIFF
--- a/modules/increase_compensation/app/models/increase_compensation/saved_claim.rb
+++ b/modules/increase_compensation/app/models/increase_compensation/saved_claim.rb
@@ -93,16 +93,13 @@ module IncreaseCompensation
       # test fails because form is nil
       if form && pdf_path.present?
         signed_path = IncreaseCompensation::PdfStamper.stamp_signature(pdf_path, parsed_form)
-        Rails.logger.info('IncreaseCompensation::ToPdf Stamped', { signed_path:, pdf_path: })
 
         # stamp_signature will return the original file_path if signature is blank OR on failure
         if pdf_path != signed_path
-          Rails.logger.info('IncreaseCompensation::ToPdf moving files', { from_path: signed_path, to_path: pdf_path })
           # Pdf Stamper changes the file name so change it back here
           FileUtils.mv(signed_path, pdf_path, force: true)
         end
       end
-      Rails.logger.info('IncreaseCompensation::ToPdf final', { path: pdf_path })
       pdf_path
     end
 


### PR DESCRIPTION
Simply removes the `Rails.logger` calls that i inserted to debug a problem with signatures.

Fix for the bug was here: https://github.com/department-of-veterans-affairs/vets-api/pull/26416