### PR TITLE
update default user_info_clients

### DIFF
--- a/config/identity_settings/settings.yml
+++ b/config/identity_settings/settings.yml
@@ -87,6 +87,7 @@ sign_in:
   user_info_clients:
     - okta_test
     - okta_stg
+    - occ_localhost
   usip_uri: http://localhost:3001/sign-in
   vaweb_client_id: vaweb
   vamobile_client_id: vamobile


### PR DESCRIPTION
## Summary

- Add `occ_localhost` to user_info_clients settings

## What areas of the site does it impact
Sign-in Service


