### PR TITLE
Added guard and log warning if issue arises with appointments data

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -157,22 +157,16 @@ module VAOS
           vaos_request_failures = vaos_response[:meta][:failures]
           vaos_data = vaos_response[:data]
 
-          # Collect all failures (API errors and data format errors)
-          failures = Array(vaos_request_failures)
-
           unless vaos_data.is_a?(Array)
             Rails.logger.error(
               'VAOS::V2::AppointmentsService#referral_appointment_already_exists?: ' \
               "Unexpected VAOS response format: data is #{vaos_data.class.name}, expected Array"
             )
-            failures << {
-              code: 'VAOS_RESPONSE_FORMAT_ERROR',
-              source: 'VAOS',
-              detail: 'VAOS get_all_appointments returned data in unexpected format'
-            }
+            msg = 'Unexpected VAOS response in referral_appointment_already_exists? - data is not an Array'
+            vaos_request_failures = msg if vaos_request_failures.blank?
           end
 
-          return { error: true, failures: } if failures.present?
+          return { error: true, failures: vaos_request_failures } if vaos_request_failures.present?
 
           return { exists: true } if vaos_data.any? { |appt| appt[:referral_id] == referral_id }
         end

--- a/modules/vaos/spec/requests/vaos/v2/appointments_spec.rb
+++ b/modules/vaos/spec/requests/vaos/v2/appointments_spec.rb
@@ -1977,7 +1977,7 @@ RSpec.describe 'VAOS::V2::Appointments', :skip_mvi, type: :request do
           response_obj = JSON.parse(response.body)
           expect(response).to have_http_status(:bad_gateway)
           expect(response_obj['errors'].first['title']).to eq('Appointment creation failed')
-          expect(response_obj['errors'].first['detail']).to eq(
+          expect(response_obj['errors'].first['detail']).to start_with(
             'Error checking existing appointments: Missing ICN message'
           )
         end

--- a/modules/vaos/spec/services/v2/appointment_service_spec.rb
+++ b/modules/vaos/spec/services/v2/appointment_service_spec.rb
@@ -1851,9 +1851,8 @@ describe VAOS::V2::AppointmentsService do
             expect(Rails.logger)
               .to have_received(:warn)
               .with(expected_message)
-            expect(check[:failures]).to be_an(Array)
+            expect(check[:failures]).to be_a(String)
             expect(check[:failures]).to include('Missing ICN message')
-            expect(check[:failures].map { |f| f.is_a?(Hash) ? f[:code] : nil }).to include('VAOS_RESPONSE_FORMAT_ERROR')
           end
         end
       end
@@ -1868,11 +1867,8 @@ describe VAOS::V2::AppointmentsService do
           result = appointments_service.referral_appointment_already_exists?('ref-150')
 
           expect(result[:error]).to be(true)
-          expect(result[:failures]).to be_an(Array)
-          failure_codes = result[:failures]
-                          .select { |f| f.is_a?(Hash) }
-                          .map { |f| f[:code] }
-          expect(failure_codes).to include('VAOS_RESPONSE_FORMAT_ERROR')
+          expect(result[:failures]).to be_a(String)
+          expect(result[:failures]).to include('Unexpected VAOS response')
           expect(Rails.logger).to have_received(:error).with(
             'VAOS::V2::AppointmentsService#referral_appointment_already_exists?: ' \
             'Unexpected VAOS response format: data is Hash, expected Array'


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper): NO*
- *Adds a simple guard and log if we receive something that's not a hash because of an error in response from fwdproxy or the service it's connecting to*
- *UAE/Orion/Appointments*

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/132589

## Testing done

- [x] *New code is covered by unit tests*
- If an object was returned from the handling of the request it was attempted to be processed like an array but some methods were not available.
- "Check on Bearded IPO" on staging. See if the errors still appear in datadog.

## Screenshots
N/A

## What areas of the site does it impact?
Getting /vaos/v2/appointments and mobile that uses the vaos module to request the appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback

Check test operate on expected problems