### PR TITLE
VEBT-4564 add dollar sign to test cost in pdf

### DIFF
--- a/lib/pdf_fill/forms/va220803.rb
+++ b/lib/pdf_fill/forms/va220803.rb
@@ -81,6 +81,7 @@ module PdfFill
         format_previously_applied(form_data)
         format_organization_info(form_data)
         format_signature(form_data)
+        format_test_cost(form_data)
 
         form_data
       end
@@ -131,6 +132,10 @@ module PdfFill
           form_data['dateSigned']
         end
         form_data['dateSigned'] = date_signed
+      end
+
+      def format_test_cost(form_data)
+        form_data['testCost'] = "$#{form_data['testCost']}"
       end
     end
   end

--- a/spec/lib/pdf_fill/forms/va220803_spec.rb
+++ b/spec/lib/pdf_fill/forms/va220803_spec.rb
@@ -53,6 +53,12 @@ describe PdfFill::Forms::Va220803 do
       expect(merged_data['dateSigned']).to eq('01/01/2025')
     end
 
+    it 'formats the cost correctly' do
+      merged_data = subject.merge_fields
+
+      expect(merged_data['testCost']).to eq('$55')
+    end
+
     context 'with a chapter 35 form' do
       let(:form_data) do
         JSON.parse(Rails.root.join('spec', 'fixtures', 'education_benefits_claims', '0803', 'chapter35.json').read)


### PR DESCRIPTION
## Summary

The test cost in the the 0803 pdf needs a '$' in front of it.

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
