### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Vets API
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/department-of-veterans-affairs/vets-api)
 
 This project provides common APIs for applications that live on VA.gov (formerly vets.gov APIs).
 


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/department-of-veterans-affairs/vets-api) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.