### PR TITLE
Adding backup path queuing when PDF is not found

### DIFF
--- a/app/sidekiq/lighthouse/poll_form526_pdf.rb
+++ b/app/sidekiq/lighthouse/poll_form526_pdf.rb
@@ -65,19 +65,45 @@ module Lighthouse
     # This callback cannot be tested due to the limitations of `Sidekiq::Testing.fake!`
     # :nocov:
     sidekiq_retries_exhausted do |msg, _ex|
-      # log, mark Form526JobStatus for submission as "pdf_not_found"
       job_id = msg['jid']
       error_class = msg['error_class']
       error_message = msg['error_message']
+      submission_id = msg['args'].first
       form_job_status = Form526JobStatus.find_by(job_id:)
 
       PollForm526PdfStatus.update_job_status(
         form_job_status:,
-        message: 'Poll for Form 526 PDF: Retries exhausted',
+        message: 'Poll for Form 526 PDF: Retries exhausted - queueing backup submission',
         error_class:,
         error_message:,
         status: Form526JobStatus::STATUS[:pdf_not_found]
       )
+
+      # Queue backup submission to ensure 526 PDF reaches eFolder
+      submission = Form526Submission.find(submission_id)
+      if submission.backup_submitted_claim_id.nil?
+        backup_job_jid = Sidekiq::Form526BackupSubmissionProcess::Submit.perform_async(submission_id)
+
+        Rails.logger.warn(
+          'PollForm526Pdf exhausted - backup submission queued',
+          {
+            submission_id:,
+            backup_job_id: backup_job_jid,
+            reason: 'pdf_polling_exhausted'
+          }
+        )
+
+        StatsD.increment("#{STATSD_KEY_PREFIX}.backup_queued")
+      else
+        # Protection just incase somehow the job submits a backup but errors out later in the process
+        Rails.logger.warn(
+          'PollForm526Pdf exhausted - backup submission already exists, skipping',
+          {
+            submission_id:,
+            backup_submitted_claim_id: submission.backup_submitted_claim_id
+          }
+        )
+      end
     rescue => e
       log_exception_to_rails(e)
     end

--- a/spec/sidekiq/lighthouse/poll_form526_pdf_spec.rb
+++ b/spec/sidekiq/lighthouse/poll_form526_pdf_spec.rb
@@ -126,11 +126,57 @@ RSpec.describe Lighthouse::PollForm526Pdf, type: :job do
     context 'when all retries are exhausted' do
       let(:form526_job_status) { create(:form526_job_status, :poll_form526_pdf, form526_submission:, job_id: 1) }
 
-      it 'transitions to the pdf_not_found status' do
+      it 'transitions to the pdf_not_found status and queues a backup submission' do
         job_params = { 'jid' => form526_job_status.job_id, 'args' => [form526_submission.id] }
 
+        expect(Sidekiq::Form526BackupSubmissionProcess::Submit).to receive(:perform_async)
+          .with(form526_submission.id)
+          .and_return('backup_job_id_123')
+
+        expect(StatsD).to receive(:increment)
+          .with('worker.lighthouse.poll_form526_pdf.backup_queued')
+
+        expect(Rails.logger).to receive(:warn).with(
+          'Poll for Form 526 PDF: Retries exhausted - queueing backup submission',
+          hash_including(form526_submission_id: form526_submission.id)
+        )
+
+        expect(Rails.logger).to receive(:warn).with(
+          'PollForm526Pdf exhausted - backup submission queued',
+          {
+            submission_id: form526_submission.id,
+            backup_job_id: 'backup_job_id_123',
+            reason: 'pdf_polling_exhausted'
+          }
+        )
+
         subject.within_sidekiq_retries_exhausted_block(job_params) do
-          # block is required to use this functionality.
+          true
+        end
+        form526_job_status.reload
+        expect(form526_job_status.status).to eq 'pdf_not_found'
+      end
+
+      it 'skips backup submission if backup_submitted_claim_id already exists' do
+        form526_submission.update!(backup_submitted_claim_id: '999')
+        job_params = { 'jid' => form526_job_status.job_id, 'args' => [form526_submission.id] }
+
+        expect(Sidekiq::Form526BackupSubmissionProcess::Submit).not_to receive(:perform_async)
+
+        expect(Rails.logger).to receive(:warn).with(
+          'Poll for Form 526 PDF: Retries exhausted - queueing backup submission',
+          hash_including(form526_submission_id: form526_submission.id)
+        )
+
+        expect(Rails.logger).to receive(:warn).with(
+          'PollForm526Pdf exhausted - backup submission already exists, skipping',
+          {
+            submission_id: form526_submission.id,
+            backup_submitted_claim_id: '999'
+          }
+        )
+
+        subject.within_sidekiq_retries_exhausted_block(job_params) do
           true
         end
         form526_job_status.reload


### PR DESCRIPTION
## Summary

- **This work is behind a feature toggle (flipper): NO**
- When the `PollForm526Pdf` Sidekiq job exhausts after 4 days of polling without finding the 526 PDF in VBMS, we now queue a backup submission via `Sidekiq::Form526BackupSubmissionProcess::Submit` instead of simply marking the job as `pdf_not_found` and taking no further action. This ensures the veteran's claim has a 526 PDF and can be worked by claims processors.
- **Bug/Problem:** When `PollForm526Pdf` exhausts, the claim exists in VBMS but has no 526 PDF. Claims processors cannot work the claim, resulting in a silent failure requiring manual remediation. Veterans' claims sit unworked indefinitely.
- **Solution:** On exhaustion, the job still marks status as `pdf_not_found` for tracking, but additionally queues a backup submission (`Form526BackupSubmissionProcess::Submit`) to generate the 526 PDF locally and upload it via the Lighthouse Benefits Intake API. A guard clause prevents duplicate backup submissions by checking `backup_submitted_claim_id`. This is consistent with the existing pattern used when `SubmitForm526AllClaim` exhausts.
- **Team:** Disability Benefits (Core Forms Team). Yes, we own the maintenance of this component.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/115144
- Proposal: [proposal_backup_on_pdf_polling_failure.md](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/proposal_backup_on_pdf_polling_failure.md)

## Testing done

- [x] New code is covered by unit tests
- **Old behavior:** When `PollForm526Pdf` exhausted after 4 days, the job status was set to `pdf_not_found` and no further action was taken. The claim existed in VBMS without a 526 PDF, becoming a silent failure.
- **New behavior:** On exhaustion, the job still sets `pdf_not_found` status, but now also queues a backup submission to ensure the 526 PDF reaches the veteran's eFolder. If a backup submission already exists (`backup_submitted_claim_id` is present), the backup is skipped and a log message is emitted.
- **Verification steps:**
  1. Run `bundle exec rspec spec/sidekiq/lighthouse/poll_form526_pdf_spec.rb` — all specs pass
  2. The `'when all retries are exhausted'` context verifies:
     - Job status transitions to `pdf_not_found`
     - `Sidekiq::Form526BackupSubmissionProcess::Submit.perform_async` is called with the submission ID
     - `StatsD.increment('worker.lighthouse.poll_form526_pdf.backup_queued')` is called
     - Warning log `'PollForm526Pdf exhausted - backup submission queued'` is emitted with `submission_id`, `backup_job_id`, and `reason: 'pdf_polling_exhausted'`
  3. A separate spec verifies that when `backup_submitted_claim_id` already exists, the backup submission is **not** queued and a skip log is emitted instead

## Screenshots
N/A — backend-only change, no UI impact.

## What areas of the site does it impact?
This impacts the **Form 526 (Disability Compensation) submission pipeline**, specifically the PDF polling job (`Lighthouse::PollForm526Pdf`). No other areas of the site are impacted. The change is limited to the `sidekiq_retries_exhausted` callback in `app/sidekiq/lighthouse/poll_form526_pdf.rb`.

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution
  - `Rails.logger.warn('PollForm526Pdf exhausted - backup submission queued', ...)` when backup is queued
  - `Rails.logger.warn('PollForm526Pdf exhausted - backup submission already exists, skipping', ...)` when skipped
- [x] Documentation has been updated ([proposal](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/proposal_backup_on_pdf_polling_failure.md))
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Feature/bug has a monitor built into Datadog — `StatsD.increment('worker.lighthouse.poll_form526_pdf.backup_queued')` metric added for tracking
- [ ] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected — N/A, no route changes
- [ ] I added a screenshot of the developed feature — N/A, backend-only


