### PR TITLE
Gate blue info-nudge banner behind portal_notice_interstitial_enabled toggle

### DIFF
--- a/lib/mhv/oh_facilities_helper/service.rb
+++ b/lib/mhv/oh_facilities_helper/service.rb
@@ -36,6 +36,7 @@ module MHV
 
       def user_facility_ready_for_info_alert?
         return false if @current_user.va_treatment_facility_ids.blank?
+        return false unless Flipper.enabled?(:portal_notice_interstitial_enabled, @current_user)
 
         @current_user.va_treatment_facility_ids.any? do |facility|
           facilities_ready_for_info_alert.include?(facility.to_s)

--- a/spec/lib/mhv/oh_facilities_helper/service_spec.rb
+++ b/spec/lib/mhv/oh_facilities_helper/service_spec.rb
@@ -62,6 +62,10 @@ RSpec.describe MHV::OhFacilitiesHelper::Service do
   end
 
   describe '#user_facility_ready_for_info_alert?' do
+    before do
+      allow(Flipper).to receive(:enabled?).with(:portal_notice_interstitial_enabled, user).and_return(true)
+    end
+
     context 'when user has a facility in facilities ready for info alert list' do
       let(:va_treatment_facility_ids) { %w[553 999] }
 
@@ -99,6 +103,18 @@ RSpec.describe MHV::OhFacilitiesHelper::Service do
 
       it 'returns true' do
         expect(service.user_facility_ready_for_info_alert?).to be true
+      end
+    end
+
+    context 'when portal_notice_interstitial_enabled toggle is disabled' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:portal_notice_interstitial_enabled, user).and_return(false)
+      end
+
+      let(:va_treatment_facility_ids) { %w[553 999] }
+
+      it 'returns false regardless of facility match' do
+        expect(service.user_facility_ready_for_info_alert?).to be false
       end
     end
   end


### PR DESCRIPTION
## Summary

Gates the blue Oracle Health info-nudge banner (controlled by `user_facility_ready_for_info_alert?`) behind the **same Flipper toggle** (`portal_notice_interstitial_enabled`) that already gates the sign-in interstitial.

## Why

Previously, the blue info banner was controlled solely by the `facilities_ready_for_info_alert` Parameter Store setting — meaning it applied to 100% of users at listed facilities with no percentage-based rollout capability. The sign-in interstitial, however, is gated by `portal_notice_interstitial_enabled` which supports percentage-of-actors rollout via Flipper.

By adding the same Flipper gate to the info banner, both nudge tactics (interstitial at sign-in + blue banners at tool level) are now controlled by the same toggle. This ensures:
- **Consistent cohort**: The same deterministic hash is used, so the same users see both nudges
- **Percentage rollout**: We can roll out both nudges to X% of users at a facility simultaneously
- **Single control point**: One toggle controls the full nudge experience

## Changes

- **`lib/mhv/oh_facilities_helper/service.rb`**: Added `Flipper.enabled?(:portal_notice_interstitial_enabled, @current_user)` guard to `user_facility_ready_for_info_alert?`
- **`spec/lib/mhv/oh_facilities_helper/service_spec.rb`**: Added Flipper stubs to existing tests and a new test for when the toggle is disabled

## Testing

- All 98 specs pass
- Rubocop clean
