### PR TITLE
Fix Committee validation error details missing from StatsD tags

### DIFF
--- a/lib/form214192/monitor.rb
+++ b/lib/form214192/monitor.rb
@@ -46,6 +46,12 @@ module Form214192
         "#{self.class.name} #{FORM_ID} Committee validation failed",
         "#{STATS_KEY}.validation_error",
         call_location:,
+        tags: [
+          "path:#{request.path}",
+          "error_type:#{validation_details[:error_type]}",
+          "data_pointer:#{validation_details[:data_pointer]}",
+          "source_app:#{extract_source_app(request)}"
+        ],
         form_id: FORM_ID,
         path: request.path,
         method: request.request_method,

--- a/lib/form21p530a/monitor.rb
+++ b/lib/form21p530a/monitor.rb
@@ -46,6 +46,12 @@ module Form21p530a
         "#{self.class.name} #{FORM_ID} Committee validation failed",
         "#{STATS_KEY}.validation_error",
         call_location:,
+        tags: [
+          "path:#{request.path}",
+          "error_type:#{validation_details[:error_type]}",
+          "data_pointer:#{validation_details[:data_pointer]}",
+          "source_app:#{extract_source_app(request)}"
+        ],
         form_id: FORM_ID,
         path: request.path,
         method: request.request_method,

--- a/spec/lib/form214192/monitor_spec.rb
+++ b/spec/lib/form214192/monitor_spec.rb
@@ -30,7 +30,23 @@ RSpec.describe Form214192::Monitor do
       it 'increments StatsD metric with correct tags' do
         expect(StatsD).to receive(:increment).with(
           "#{stats_key}.validation_error",
-          hash_including(tags: array_including('service:form214192'))
+          hash_including(tags: array_including(
+                           'service:form214192',
+                           'path:/v0/form214192',
+                           'error_type:pattern_mismatch',
+                           'source_app:21-4192-employment-information'
+                         ))
+        )
+
+        monitor.track_request_validation_error(error:, request:)
+      end
+
+      it 'includes data_pointer in StatsD tags' do
+        expect(StatsD).to receive(:increment).with(
+          "#{stats_key}.validation_error",
+          hash_including(tags: array_including(
+                           match(/^data_pointer:/)
+                         ))
         )
 
         monitor.track_request_validation_error(error:, request:)

--- a/spec/lib/form21p530a/monitor_spec.rb
+++ b/spec/lib/form21p530a/monitor_spec.rb
@@ -30,7 +30,23 @@ RSpec.describe Form21p530a::Monitor do
       it 'increments StatsD metric with correct tags' do
         expect(StatsD).to receive(:increment).with(
           "#{stats_key}.validation_error",
-          hash_including(tags: array_including('service:form21p530a'))
+          hash_including(tags: array_including(
+                           'service:form21p530a',
+                           'path:/v0/form21p530a',
+                           'error_type:pattern_mismatch',
+                           'source_app:21p-530a-interment-allowance'
+                         ))
+        )
+
+        monitor.track_request_validation_error(error:, request:)
+      end
+
+      it 'includes data_pointer in StatsD tags' do
+        expect(StatsD).to receive(:increment).with(
+          "#{stats_key}.validation_error",
+          hash_including(tags: array_including(
+                           match(/^data_pointer:/)
+                         ))
         )
 
         monitor.track_request_validation_error(error:, request:)


### PR DESCRIPTION
This work is behind a feature toggle (flipper): NO

## Summary

- Committee validation errors for Forms 21-4192 and 21P-530A were logging `path`, `error_type`, `data_pointer`, and `source_app` to Rails logger (visible in Datadog Logs) but **not** emitting them as StatsD metric tags. This meant Datadog Metrics Explorer, dashboards, and monitors could not filter or group by these fields.
- Root cause: the base `Logging::Monitor#track_request` only passes `context[:tags]` to `StatsD.increment`, but the form monitors were passing these fields as top-level keyword arguments instead of in the `tags` array.
- Fix adds an explicit `tags` array to both form monitors so the fields are emitted as StatsD tags alongside the existing `service` and `function` tags.
- Team: BIO-Aquia (Benefits Intake Operations)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/133036

## Testing done

- [x] New code is covered by unit tests
- Previously, the StatsD increment spec only verified the `service:form*` tag was present
- Updated specs now verify that `path:`, `error_type:`, `data_pointer:`, and `source_app:` tags are all included in the StatsD increment call
- All 26 monitor specs pass (13 for Form214192, 13 for Form21p530a)
- Verified by running `bundle exec rspec spec/lib/form214192/monitor_spec.rb spec/lib/form21p530a/monitor_spec.rb` in Docker

## What areas of the site does it impact?

- StatsD metrics for Committee validation errors on Form 21-4192 and Form 21P-530A endpoints
- No user-facing behavior changes — this only affects observability/monitoring data

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Feature/bug has a monitor built into Datadog (if applicable)

## Requested Feedback

After deployment, the `api.form214192.validation_error` and `api.form21p530a.validation_error` metrics will have new tags (`path`, `error_type`, `data_pointer`, `source_app`). Existing dashboards/monitors won't break since these are additive tags. Teams can then update dashboard queries to use e.g. `sum:vets_api.statsd.api.form214192.validation_error{path:/v0/form214192/download_pdf}` for per-endpoint filtering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)