### PR TITLE
BMT3/133151_skip_notification_warning - Convert error to warning

### DIFF
--- a/app/sidekiq/event_bus_gateway/letter_ready_notification_job.rb
+++ b/app/sidekiq/event_bus_gateway/letter_ready_notification_job.rb
@@ -132,7 +132,7 @@ module EventBusGateway
     end
 
     def log_notification_skipped(notification_type, reason, template_id)
-      ::Rails.logger.error(
+      ::Rails.logger.warn(
         "LetterReadyNotificationJob #{notification_type} skipped",
         {
           notification_type:,

--- a/spec/sidekiq/event_bus_gateway/letter_ready_notification_job_spec.rb
+++ b/spec/sidekiq/event_bus_gateway/letter_ready_notification_job_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe EventBusGateway::LetterReadyNotificationJob, type: :job do
         end
 
         it 'logs skipped notifications for both email and push' do
-          expect(Rails.logger).to receive(:error).with(
+          expect(Rails.logger).to receive(:warn).with(
             'LetterReadyNotificationJob email skipped',
             {
               notification_type: 'email',
@@ -229,7 +229,7 @@ RSpec.describe EventBusGateway::LetterReadyNotificationJob, type: :job do
               template_id: email_template_id
             }
           )
-          expect(Rails.logger).to receive(:error).with(
+          expect(Rails.logger).to receive(:warn).with(
             'LetterReadyNotificationJob push skipped',
             {
               notification_type: 'push',
@@ -281,7 +281,7 @@ RSpec.describe EventBusGateway::LetterReadyNotificationJob, type: :job do
         end
 
         it 'logs skipped email notification due to missing first_name' do
-          expect(Rails.logger).to receive(:error).with(
+          expect(Rails.logger).to receive(:warn).with(
             'LetterReadyNotificationJob email skipped',
             {
               notification_type: 'email',
@@ -475,7 +475,7 @@ RSpec.describe EventBusGateway::LetterReadyNotificationJob, type: :job do
         end
 
         it 'logs that push notification was skipped due to feature flag' do
-          expect(Rails.logger).to receive(:error).with(
+          expect(Rails.logger).to receive(:warn).with(
             'LetterReadyNotificationJob push skipped',
             {
               notification_type: 'push',


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO
- Converted an error logging to a warning since skipping one alert is expected due to feature flag
- Team: BMT3

## Related issue(s)

- Issue [#133151](https://github.com/department-of-veterans-affairs/va.gov-team/issues/133151)
- Epic [#121421](https://github.com/department-of-veterans-affairs/va.gov-team/issues/121421)

## Testing done

- [x] *New code is covered by unit tests*
- Previously an error would be logged if a push notification or email was skipped in the eventbus_gateway sidekiq jobs

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
vets-api eventbus gateway sidekiq job logging

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
