### PR TITLE
Add new content for herbicide exposure claims in override_content.json

### DIFF
--- a/lib/lighthouse/benefits_claims/tracked_item_content/override_content.json
+++ b/lib/lighthouse/benefits_claims/tracked_item_content/override_content.json
@@ -260,7 +260,7 @@
             {
               "type": "link",
               "text": "Get VA Form 21-4138 to download",
-              "href": "/forms/21-4138/",
+              "href": "/find-forms/about-form-21-4138/",
               "testId": "Get VA Form 21-4138 to download"
             }
           ]
@@ -349,19 +349,14 @@
             {
               "type": "link",
               "text": "Get VA Form 21-4138 to download",
-              "href": "/forms/21-4138/",
+              "href": "/find-forms/about-form-21-4138/",
               "testId": "Get VA Form 21-4138 to download"
             }
           ]
         },
         {
           "type": "paragraph",
-          "content": [
-            "Make sure your name and Social Security number are included on any document you upload or send.",
-            {
-              "type": "lineBreak"
-            }
-          ]
+          "content": "Make sure your name and Social Security number are included on any document you upload or send."
         }
       ]
     }
@@ -409,7 +404,7 @@
             {
               "type": "link",
               "text": "Get VA Form 21-4138 to download",
-              "href": "/forms/21-4138/",
+              "href": "/find-forms/about-form-21-4138/",
               "testId": "Get VA Form 21-4138 to download"
             }
           ]
@@ -424,7 +419,7 @@
             {
               "type": "link",
               "text": "Get VA Form 21-4142",
-              "href": "/forms/21-4142/",
+              "href": "/find-forms/about-form-21-4142/",
               "testId": "Get VA Form 21-4142"
             }
           ]
@@ -477,7 +472,7 @@
             {
               "type": "link",
               "text": "Get VA Form 21-4138 to download",
-              "href": "/forms/21-4138/",
+              "href": "/find-forms/about-form-21-4138/",
               "testId": "Get VA Form 21-4138 to download"
             }
           ]
@@ -492,7 +487,7 @@
             {
               "type": "link",
               "text": "Get VA Form 21-4142",
-              "href": "/forms/21-4142/",
+              "href": "/find-forms/about-form-21-4142/",
               "testId": "Get VA Form 21-4142"
             }
           ]


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- This work is behind a feature toggle (flipper): NO
- Adds 4 new Agent Orange / herbicide exposure tracked item content entries to `override_content.json` for the Document Status feature. These entries provide veteran-facing friendly names, descriptions, and next steps for herbicide-related evidence requests:
  - **AO - Blue Water Notice** — Service information related to herbicide exposure (blue water Vietnam veterans)
  - **AO - Explain how exposed to herbicides** — Herbicide exposure information
  - **AO - med evid of disab fm herbicide needed** — Medical documentation of herbicide exposure
  - **AO- Tell us specific disability fm herbicides** — Disease or disability related to herbicide exposure
- Team: Benefits Management Tools Team 2 (Bee's Knees)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/133135
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/133139
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/133147
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/133155

## Testing done

- [x] New code is covered by unit tests - covered dynamically by [tracked_item_content_spec.rb](https://github.com/department-of-veterans-affairs/vets-api/blob/e9ce9738b0b4def1156b60367d4045877fe018e1/spec/lib/lighthouse/benefits_claims/tracked_item_content_spec.rb)
- No behavioral code changes — this is a JSON content addition only
- Verified JSON structure matches the existing tracked item content schema (friendlyName, shortDescription, supportAliases, canUploadFile, isSensitive, longDescription, nextSteps)
- Each entry includes proper block types (paragraph, list, bold, link, lineBreak) consistent with existing entries

## Screenshots
_N/A — JSON content change only, no UI changes in this PR_

## What areas of the site does it impact?
The Claim Status Tool (CST) Document Status feature. When veterans view tracked items related to herbicide/Agent Orange exposure claims, they will now see improved, human-readable descriptions and actionable next steps instead of raw tracked item names.

## Acceptance criteria

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable). **covered dynamically by [tracked_item_content_spec.rb]**
- [ ] No error nor warning in the console.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Documentation has been updated (link to documentation)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Feature/bug has a monitor built into Datadog (if applicable)
- [ ] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ] I added a screenshot of the developed feature
