### PR TITLE
Api 48984 fes schema updates

### DIFF
--- a/modules/claims_api/config/schemas/v1/526.json
+++ b/modules/claims_api/config/schemas/v1/526.json
@@ -82,7 +82,8 @@
             "country": {
               "description": "Country Veteran resides in.  Value must match the values returned by the \"/countries\" endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
               "type": "string",
-              "example": "USA"
+              "example": "USA",
+              "maxLength": 50
             },
             "zipFirstFive": {
               "description": "Zipcode (First 5 digits) Veteran resides in.",
@@ -218,7 +219,8 @@
             "country": {
               "description": "New country Veteran resides in. Value must match the values returned by the \"/countries\" endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
               "type": "string",
-              "example": "USA"
+              "example": "USA",
+              "maxLength": 50
             },
             "zipFirstFive": {
               "description": "New zipcode (First 5 digits) Veteran resides in.",

--- a/modules/claims_api/config/schemas/v2/526.json
+++ b/modules/claims_api/config/schemas/v2/526.json
@@ -97,7 +97,7 @@
             "country": {
               "description": "Country for the Veteran's current mailing address.  Must match the values returned by the /countries endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
               "type": "string",
-              "maxLength": 1000,
+              "maxLength": 50,
               "example": "USA"
             },
             "zipFirstFive": {
@@ -204,7 +204,7 @@
         "country": {
           "description": "Country for the Veteran's new address. Value must match the values returned by the /countries endpoint on the [Benefits Reference Data API](https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current).",
           "type": "string",
-          "maxLength": 1000,
+          "maxLength": 50,
           "example": "USA"
         },
         "zipFirstFive": {


### PR DESCRIPTION
## Summary

DRAFT-IGNORE FOR NOW
WILL NOT MERGE UNTIL FES RELEASE

Summary: adjusts 526 schema in v1 and v2 to align with [FES Rules](https://confluence.devops.va.gov/pages/viewpage.action?spaceKey=VAExternal&title=Form526+Establishment+Service+Validation+Rules).

## Related issue(s)
[API-48984](https://jira.devops.va.gov/browse/API-48984)
<img width="713" height="523" alt="Screenshot 2026-02-13 at 2 35 51 PM" src="https://github.com/user-attachments/assets/f3e3040e-6d3b-41a3-8292-14782d6e85a9" />

## Testing done

- [ ] *New code is covered by unit tests* (in progress)
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
Test 526 submission to v1 and v2 endpoints
Verify pdf in VMBS

## Screenshots

## What areas of the site does it impact?
```
modules/claims_api/config/schemas/v2/526.json
modules/claims_api/config/schemas/v1/526.json
```

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
