### PR TITLE
Revert "Bump oj from 3.16.14 to 3.16.15"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -824,9 +824,8 @@ GEM
     octokit (10.0.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    oj (3.16.15)
+    oj (3.16.14)
       bigdecimal (>= 3.0)
-      ostruct (>= 0.2)
     okcomputer (1.19.1)
       benchmark
     olive_branch (4.0.1)


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-api#26556. CI deployments stopped firing after merging this, so reverting for now to see if that fixes it.