### PR TITLE
Add ARP claimant details feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -18,7 +18,7 @@ features:
   this_is_only_a_test_two:
     actor_type: user
     description: Used in feature toggle specs.
-  accredited_representative_portal_claimaint_details:
+  accredited_representative_portal_claimant_details:
     actor_type: user
     description: Enables the claimant details page on the frontend
     enable_in_development: true


### PR DESCRIPTION
## Summary

Add feature flag to do claimant details work on vets-website behind.

## Related issue(s)

[Create feature flag for Claimant Details MVP #132590](https://github.com/department-of-veterans-affairs/va.gov-team/issues/132590)

## Testing done

Verified feature flag existence

## Screenshots
<img width="553" height="192" alt="Screenshot 2026-02-17 at 11 45 52" src="https://github.com/user-attachments/assets/069f014f-66f3-4686-aa85-591b0519ef46" />

## What areas of the site does it impact?
n/a

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
