### PR TITLE
logging/StatsD for pension-related submissions

### DIFF
--- a/lib/dependents/monitor.rb
+++ b/lib/dependents/monitor.rb
@@ -174,7 +174,10 @@ module Dependents
     def track_pension_related_submission(form_id:, form_type:)
       tags = ["form_id:#{form_id}"]
       metric = "#{PENSION_SUBMISSION_STATS_KEY}.#{form_type}.submitted"
+      payload = default_payload.merge({ statsd: metric, form_id:, form_type: })
+
       StatsD.increment(metric, tags:)
+      Rails.logger.info("Pension-related claim submitted: #{form_type}", payload)
     end
 
     def track_event(level, message, stats_key, payload = {})

--- a/modules/dependents_benefits/lib/dependents_benefits/claim_processor.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits/claim_processor.rb
@@ -139,7 +139,8 @@ module DependentsBenefits
             if child_claims.any?(&:pension_related_submission?)
               form_type = parent_claim&.claim_form_type
               monitor.track_info_event('Submitted pension-related claim',
-                                       action: 'pension.submission', component:, parent_claim_id:, form_type:)
+                                       action: 'pension.submission',
+                                       component:, parent_claim_id:, form_type:, module_stats_key: DependentsBenefits::Monitor::PENSION_SUBMISSION_STATS_KEY)
             end
           end
         end

--- a/modules/dependents_benefits/lib/dependents_benefits/monitor.rb
+++ b/modules/dependents_benefits/lib/dependents_benefits/monitor.rb
@@ -20,6 +20,8 @@ module DependentsBenefits
     SUBMISSION_STATS_KEY = 'worker.lighthouse.dependents_benefits_intake_job'
     # statsd key for generic module events
     MODULE_STATS_KEY = 'module.dependents_benefits'
+    # statsd key for pension-related submissions
+    PENSION_SUBMISSION_STATS_KEY = 'dependents_benefits.pension_submission'
 
     # Allowed context keys for logging
     ALLOWLIST = %w[
@@ -71,7 +73,9 @@ module DependentsBenefits
       tags = { action: }
       tags[:component] = component if component
       context = append_tags(context, **tags)
-      submit_event(:info, message, module_stats_key, **context)
+      stats_key = context[:module_stats_key] || module_stats_key
+      context.delete(:module_stats_key)
+      submit_event(:info, message, stats_key, **context)
     end
 
     ##

--- a/modules/dependents_benefits/spec/lib/dependents_benefits/claim_processor_spec.rb
+++ b/modules/dependents_benefits/spec/lib/dependents_benefits/claim_processor_spec.rb
@@ -268,7 +268,8 @@ RSpec.describe DependentsBenefits::ClaimProcessor, type: :model do
               action: 'pension.submission',
               component:,
               parent_claim_id:,
-              form_type: '686c-674'
+              form_type: '686c-674',
+              module_stats_key: DependentsBenefits::Monitor::PENSION_SUBMISSION_STATS_KEY
             )
             processor.send(:handle_successful_submission)
           end

--- a/modules/dependents_benefits/spec/lib/dependents_benefits/monitor_spec.rb
+++ b/modules/dependents_benefits/spec/lib/dependents_benefits/monitor_spec.rb
@@ -248,10 +248,10 @@ RSpec.describe DependentsBenefits::Monitor do
     it 'calls submit_event with info level using action' do
       message = 'Test info message'
       action = 'test_action'
-      context = { test: 'context' }
+      context = { test: 'context', module_stats_key: described_class::PENSION_SUBMISSION_STATS_KEY }
       expected_context = { test: 'context', tags: ["action:#{action}"] }
 
-      expect(monitor).to receive(:submit_event).with(:info, message, described_class::MODULE_STATS_KEY,
+      expect(monitor).to receive(:submit_event).with(:info, message, described_class::PENSION_SUBMISSION_STATS_KEY,
                                                      **expected_context)
       monitor.track_info_event(message, action:, **context)
     end

--- a/spec/lib/dependents/monitor_spec.rb
+++ b/spec/lib/dependents/monitor_spec.rb
@@ -378,8 +378,18 @@ RSpec.describe Dependents::Monitor do
 
       # Allow any StatsD calls to happen for test setup or the test will fail
       allow(StatsD).to receive(:increment)
+      allow(Rails.logger).to receive(:info)
 
       expect(StatsD).to receive(:increment).with(metric, tags: ["form_id:#{form_id}"])
+      expect(Rails.logger).to receive(:info).with('Pension-related claim submitted: 686c-674', {
+                                                    service: 'dependents-application',
+                                                    claim: claim_v2,
+                                                    user_account_uuid: nil,
+                                                    tags: ["form_id:#{form_id}", 'service:dependents-application'],
+                                                    statsd: metric,
+                                                    form_id:,
+                                                    form_type: claim_v2.claim_form_type
+                                                  })
 
       monitor_v2.track_pension_related_submission(form_id:, form_type: '686c-674')
     end


### PR DESCRIPTION
- Add logging for pension-related submissions
- Add StatsD metric to dependents module pension-related submissions


## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
- *(Summarize the changes that have been made to the platform)*
   - We want to add logging to pension-related submissions on top of the current StatsD metric (non-module code) so that we can create a DD widget for those specific submission logs
   - While adding that, i also noticed the dependents module did not contain the StatsD metric for those pension-related submissions, so I added that as well
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)*
  - Lifestage Benefits - Dependents Management
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- *https://github.com/department-of-veterans-affairs/va.gov-team/issues/133380*

## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
