### PR TITLE
check for correct file suffix for merged fmp2 submissions

### DIFF
--- a/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
+++ b/modules/ivc_champva/app/controllers/ivc_champva/v1/pega_controller.rb
@@ -69,7 +69,9 @@ module IvcChampva
       end
 
       def get_ivc_forms(form_uuid, file_names)
-        forms = if file_names.any? { |name| name.end_with?('_merged.pdf') }
+        forms = if file_names.any? { |name| name.end_with?('_combined.pdf') }
+                  # For merged/combined PDFs, update all records for this submission
+                  # (Pega only sees the single combined file, but we have individual records)
                   fetch_forms_by_uuid(form_uuid)
                 else
                   forms_query(form_uuid, file_names)

--- a/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
+++ b/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb
@@ -210,12 +210,23 @@ module IvcChampva
     private
 
     ##
-    # Filters out VES JSON files from a batch since they're sent to VES, not Pega
+    # Filters batch to only include files that Pega actually processes.
+    # Excludes VES JSON files (sent to VES, not Pega) and for FMP combined submissions,
+    # only counts the combined PDF (not the individual files that were merged into it).
     #
     # @param batch [Array<IvcChampvaForm>] An array of IVC CHAMPVA form objects
-    # @return [Array<IvcChampvaForm>] Filtered array excluding VES JSON files
+    # @return [Array<IvcChampvaForm>] Filtered array of Pega-processable files
     def filter_pega_processable_files(batch)
-      batch.reject { |record| ves_json_file?(record.file_name) }
+      # Check if this is an FMP combined submission (has a _combined.pdf file)
+      has_combined_pdf = batch.any? { |record| combined_pdf_file?(record.file_name) }
+
+      if has_combined_pdf
+        # For FMP combined submissions, only the _combined.pdf was sent to Pega
+        batch.select { |record| combined_pdf_file?(record.file_name) }
+      else
+        # For regular submissions, exclude only VES JSON files
+        batch.reject { |record| ves_json_file?(record.file_name) }
+      end
     end
 
     ##
@@ -227,6 +238,17 @@ module IvcChampva
       return false if file_name.blank?
 
       file_name.include?('_ves.json')
+    end
+
+    ##
+    # Determines if a file is a combined PDF (FMP single-file upload) based on its filename
+    #
+    # @param file_name [String] The name of the file to check
+    # @return [Boolean] true if the file is a combined PDF, false otherwise
+    def combined_pdf_file?(file_name)
+      return false if file_name.blank?
+
+      file_name.end_with?('_combined.pdf')
     end
   end
 end

--- a/modules/ivc_champva/spec/jobs/missing_form_status_job_spec.rb
+++ b/modules/ivc_champva/spec/jobs/missing_form_status_job_spec.rb
@@ -278,6 +278,36 @@ RSpec.describe 'IvcChampva::MissingFormStatusJob', type: :job do
     batch.each(&:destroy)
   end
 
+  it 'reconciles all records when combined PDF submission matches single Pega report' do
+    # For combined submissions, multiple docs are merged into a single _combined.pdf
+    # Pega only sees the combined file, but we store individual records for each original doc
+    form_uuid = SecureRandom.uuid
+    batch = [
+      create(:ivc_champva_form, form_uuid:, file_name: "#{form_uuid}_vha_10_7959f_2_combined.pdf", pega_status: nil),
+      create(:ivc_champva_form, form_uuid:, file_name: "#{form_uuid}_vha_10_7959f_2.pdf", pega_status: nil),
+      create(:ivc_champva_form, form_uuid:, file_name: "#{form_uuid}_supporting_doc_0.pdf", pega_status: nil),
+      create(:ivc_champva_form, form_uuid:, file_name: "#{form_uuid}_supporting_doc_1.pdf", pega_status: nil)
+    ]
+
+    # Pega only reports the single combined PDF
+    pega_reports = [
+      { 'UUID' => form_uuid, 'Status' => 'Processed' }
+    ]
+
+    allow(job.pega_api_client).to receive(:record_has_matching_report).and_return(pega_reports)
+    allow(job.missing_status_cleanup).to receive(:manually_process_batch)
+
+    # Should return true: 1 combined PDF locally matches 1 Pega report
+    result = job.num_docs_match_reports?(batch)
+
+    expect(result).to be true
+    # All 4 records should be passed for status update
+    expect(job.missing_status_cleanup).to have_received(:manually_process_batch).with(batch)
+
+    # Clean up test data
+    batch.each(&:destroy)
+  end
+
   it 'catches PegaApiError and logs error without crashing the job' do
     form_uuid = SecureRandom.uuid
     batch = [

--- a/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/status_updates_spec.rb
+++ b/modules/ivc_champva/spec/requests/ivc_champva/v1/forms/status_updates_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe 'IvcChampva::V1::Forms::StatusUpdates', type: :request do
       let(:merged_pdf_payload) do
         {
           'form_uuid' => form_uuid,
-          'file_names' => ["#{form_uuid}_merged.pdf"],
+          'file_names' => ["#{form_uuid}_vha_10_7959f_2_combined.pdf"],
           'case_id' => 'ABC-1234',
           'status' => 'Processed'
         }
@@ -264,7 +264,7 @@ RSpec.describe 'IvcChampva::V1::Forms::StatusUpdates', type: :request do
           first_name: 'Veteran',
           last_name: 'Surname',
           form_number: '10-10D',
-          file_name: "#{form_uuid}_merged.pdf",
+          file_name: "#{form_uuid}_vha_10_7959f_2_combined.pdf",
           s3_status: 'Submitted',
           pega_status: nil,
           case_id: nil,
@@ -309,7 +309,7 @@ RSpec.describe 'IvcChampva::V1::Forms::StatusUpdates', type: :request do
           first_name: 'Veteran',
           last_name: 'Surname',
           form_number: '10-10D',
-          file_name: "#{form_uuid}_merged.pdf",
+          file_name: "#{form_uuid}_vha_10_7959f_2_combined.pdf",
           s3_status: 'Submitted',
           pega_status: nil,
           case_id: nil,
@@ -353,7 +353,7 @@ RSpec.describe 'IvcChampva::V1::Forms::StatusUpdates', type: :request do
           first_name: 'Veteran',
           last_name: 'Surname',
           form_number: '10-10D',
-          file_name: "#{form_uuid}_merged.pdf",
+          file_name: "#{form_uuid}_vha_10_7959f_2_combined.pdf",
           s3_status: 'Submitted',
           pega_status: nil,
           case_id: nil,


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- *This work is behind a feature toggle (flipper):NO*
- Fix check for fmp2 where we build a "*_combined.pdf" file but in the pega callback we're checking instead for "*_merged.pdf"
- Fix missing status job to correctly compare doc counts for combined files
- Update specs

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/133534

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
