### PR TITLE
Removes missed debug line in validator file for v2 526

### DIFF
--- a/modules/claims_api/app/controllers/concerns/claims_api/v2/alt_revised_disability_compensation_validation.rb
+++ b/modules/claims_api/app/controllers/concerns/claims_api/v2/alt_revised_disability_compensation_validation.rb
@@ -603,7 +603,6 @@ module ClaimsApi
       end
 
       def age_exception(idx)
-        Rails.logger.debug 'in the alt file?'
         collect_error_messages(
           source: "serviceInformation/servicePeriods/#{idx}/activeDutyBeginDate",
           detail: "Active Duty Begin Date (#{idx}) cannot be before Veteran's thirteenth birthday."


### PR DESCRIPTION
## Summary
* This debug line was missed in a  previous update so this is just a small clean up to remove it.

## Related issue(s)
[API-53927](https://jira.devops.va.gov/browse/API-53927)

## Testing done
* No tests required for this, just removing a missed debug line

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
    modified:   modules/claims_api/app/controllers/concerns/claims_api/v2/alt_revised_disability_compensation_validation.rb

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
