### PR TITLE
Add database indexes for multi_party_form_submissions

### DIFF
--- a/db/migrate/20260218120000_add_multi_party_form_indexes.rb
+++ b/db/migrate/20260218120000_add_multi_party_form_indexes.rb
@@ -28,12 +28,6 @@ class AddMultiPartyFormIndexes < ActiveRecord::Migration[7.1]
               name: 'index_mpf_submissions_on_secondary_user_status',
               algorithm: :concurrently
 
-    # Token verification (physician clicks magic link)
-    add_index :multi_party_form_submissions,
-              %i[id secondary_access_token_expires_at],
-              name: 'index_mpf_submissions_on_id_token_expiry',
-              algorithm: :concurrently
-
     # Cleanup queries (find expired/stale submissions by status and age)
     add_index :multi_party_form_submissions,
               %i[status created_at],

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1447,7 +1447,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_18_120000) do
     t.datetime "submitted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["id", "secondary_access_token_expires_at"], name: "index_mpf_submissions_on_id_token_expiry"
     t.index ["primary_in_progress_form_id"], name: "index_mpf_submissions_on_primary_form"
     t.index ["primary_user_uuid", "status", "form_type"], name: "index_mpf_submissions_on_primary_user_status_form"
     t.index ["saved_claim_id"], name: "index_mpf_submissions_on_saved_claim"


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES (`form_2680_multi_party_forms_enabled`)
- Adds 8 database indexes to the `multi_party_form_submissions` table to support efficient query patterns for the multi-party forms feature
- All indexes use `algorithm: :concurrently` with `disable_ddl_transaction!` to avoid blocking writes during deployment
- Team: Benefits Intake Optimization (BIO) - Aquia

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/131513

## Testing done

- [x] New code is covered by unit tests
- Migration runs successfully against test database — all 8 indexes created without error
- `strong_migrations` safety check passes (concurrent index creation used throughout)
- Indexes added:
  - `[primary_user_uuid, status, form_type]` — Veteran submission lookups
  - `[secondary_email, status]` — physician pending form lookups
  - `[secondary_user_uuid, status]` — Secondary Party UUID lookups
  - `[id, secondary_access_token_expires_at]` — magic link token verification
  - `[status, created_at]` — cleanup queries for expired/stale submissions
  - `primary_in_progress_form_id` — InProgressForm association
  - `secondary_in_progress_form_id` — InProgressForm association
  - `saved_claim_id` — SavedClaim association

## What areas of the site does it impact?

`multi_party_form_submissions` table only. No application logic changed.

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs