### PR TITLE
Add BIO form IDs to My VA submission status restricted list

### DIFF
--- a/app/controllers/v0/my_va/submission_statuses_controller.rb
+++ b/app/controllers/v0/my_va/submission_statuses_controller.rb
@@ -44,6 +44,10 @@ module V0
           21P-530EZ
           21P-0969
           21P-535
+          21-2680
+          21-0779
+          21-4192
+          21P-530a
         ] + uploadable_forms
       end
 

--- a/spec/controllers/v0/my_va/submission_statuses_controller_spec.rb
+++ b/spec/controllers/v0/my_va/submission_statuses_controller_spec.rb
@@ -155,6 +155,14 @@ RSpec.describe V0::MyVA::SubmissionStatusesController, type: :controller do
       end
     end
 
+    context 'when feature flag is disabled (restricted list)' do
+      it 'includes multi-party form IDs in the restricted benefits intake forms' do
+        forms = controller.send(:restricted_benefits_intake_forms)
+
+        expect(forms).to include('21-2680', '21-0779', '21-4192', '21P-530a')
+      end
+    end
+
     context 'serialization' do
       let(:mock_submission_status) do
         OpenStruct.new(


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- This work is behind a feature toggle (flipper): NO (the restricted list is the default when `my_va_display_all_lighthouse_benefits_intake_forms` is disabled)
- Adds `21-2680`, `21-0779`, `21-4192`, and `21P-530a` to `restricted_benefits_intake_forms` in `V0::MyVA::SubmissionStatusesController`.
- Previously, only the `-UPLOAD` variants of these forms were in the restricted list. The multi-party form submissions go through the standard Lighthouse Benefits Intake pathway with the base form IDs, so they were not appearing on the My VA page at all — showing "Application for benefits" as a fallback title.
- Team: Benefits Intake Optimization (BIO) - Aquia

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/126671

## Testing done

- [x] New code is covered by unit tests
- **Old behavior**: Submissions for `21-2680`, `21-0779`, `21-4192`, `21P-530a` were filtered out of My VA form statuses when `my_va_display_all_lighthouse_benefits_intake_forms` was disabled (the default). Only the `-UPLOAD` variants were included.
- **New behavior**: Submissions for all four multi-party form IDs now appear on the My VA page alongside their `-UPLOAD` counterparts.
- Added a spec to `submission_statuses_controller_spec.rb` verifying the four form IDs are included in `restricted_benefits_intake_forms`.

## Next steps for full title support

The backend now surfaces these forms, but the frontend (vets-website) shows "Application for benefits" as a fallback when it doesn't recognize the form ID. A follow-up vets-website ticket is needed to add `21-2680`, `21-0779`, `21-4192`, and `21P-530a` to the `VA_FORM_IDS` lookup so proper titles are displayed (e.g., "Examination for Housebound Status or Permanent Need for Regular Aid and Attendance" for 21-2680).

## What areas of the site does it impact?

My VA page — "Form submission statuses" section (`/my-va/`).

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs