### PR TITLE
Remove mhv_landing_page_show_share_my_health_data_link feature flag

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1449,9 +1449,6 @@ features:
     actor_type: user
     description: Shows Veterans their Priority Group on the MHV Landing Page
     enable_in_development: true
-  mhv_landing_page_show_share_my_health_data_link:
-    actor_type: user
-    description: Show Share My Health Data (SMHD) link on Medical Records card of the MHV landing page
   mhv_oh_migration_schedules:
     actor_type: user
     description: Enables fetching Oracle Health migration schedules for VAHB mobile users


### PR DESCRIPTION
## Summary

- **This work is behind a feature toggle (flipper):** NO, this PR removes one 
- Removed the `mhv_landing_page_show_share_my_health_data_link` feature flag from `features.yml`
- This flag was fully enabled in production and only controlled the visibility of the "Share My Health Data" link on the MHV landing page Medical Records card. No backend code (controllers, services, models) ever referenced it 
- **Team**: MHV Medical Records

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#132068

## Testing done

- [x] No new code introduced, this is a flag definition removal only
- Confirmed via codebase search that zero Ruby files reference `mhv_landing_page_show_share_my_health_data_link`
- The flag existed only in `config/features.yml` as a Flipper definition

## Screenshots

N/A

## What areas of the site does it impact?

None directly. This just removes an unused Flipper flag definition. The FE changes (separate PR) handle the actual UI behavior.

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable). — N/A, no backend logic to test
- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution — N/A
- [x] Documentation has been updated — N/A
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Feature/bug has a monitor built into Datadog (if applicable) — N/A
- [x] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected — N/A
- [x] I added a screenshot of the developed feature — N/A, config-only change