### PR TITLE
Accept logingov facial_match levels for current_ial

### DIFF
--- a/app/services/sign_in/credential_level_creator.rb
+++ b/app/services/sign_in/credential_level_creator.rb
@@ -111,7 +111,10 @@ module SignIn
     end
 
     def logingov_current_ial
-      verified_ial_level(logingov_ial2?)
+      translated_ial = verified_ial_level(logingov_ial2?)
+      Rails.logger.info('[SignIn][CredentialLevelCreator] logingov_current_ial',
+                        logingov_acr:, translated_ial:, credential_uuid:)
+      translated_ial
     end
 
     def mhv_current_ial
@@ -135,7 +138,7 @@ module SignIn
     end
 
     def logingov_ial2?
-      logingov_acr == Constants::Auth::LOGIN_GOV_IAL2
+      logingov_ial2_levels.include?(logingov_acr)
     end
 
     def idme_loa3_or_previously_verified?
@@ -169,6 +172,12 @@ module SignIn
     def previously_verified?(identifier_type)
       user_verification = UserVerification.find_by(identifier_type => credential_uuid)
       user_verification&.verified?
+    end
+
+    def logingov_ial2_levels
+      [Constants::Auth::LOGIN_GOV_IAL2,
+       Constants::Auth::LOGIN_GOV_IAL2_REQUIRED,
+       Constants::Auth::LOGIN_GOV_IAL2_PREFERRED]
     end
   end
 end

--- a/spec/services/sign_in/credential_level_creator_spec.rb
+++ b/spec/services/sign_in/credential_level_creator_spec.rb
@@ -100,12 +100,43 @@ RSpec.describe SignIn::CredentialLevelCreator do
       context 'and user info has verified_at trait' do
         let(:verified_at) { Time.zone.now }
         let(:expected_max_ial) { SignIn::Constants::Auth::IAL_TWO }
+        let(:expected_log_message) { '[SignIn][CredentialLevelCreator] logingov_current_ial' }
+        let(:expected_log_payload) { { logingov_acr:, translated_ial: expected_current_ial, credential_uuid: sub } }
 
         context 'and logingov acr is defined as IAL 2' do
           let(:logingov_acr) { SignIn::Constants::Auth::LOGIN_GOV_IAL2 }
           let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
 
           it_behaves_like 'a created credential level'
+
+          it 'logs the expected log' do
+            expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
+            subject
+          end
+        end
+
+        context 'and logingov acr is defined as IAL 2 required' do
+          let(:logingov_acr) { SignIn::Constants::Auth::LOGIN_GOV_IAL2_REQUIRED }
+          let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
+
+          it_behaves_like 'a created credential level'
+
+          it 'logs the expected log' do
+            expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
+            subject
+          end
+        end
+
+        context 'and logingov acr is defined as IAL 2 preferred' do
+          let(:logingov_acr) { SignIn::Constants::Auth::LOGIN_GOV_IAL2_PREFERRED }
+          let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
+
+          it_behaves_like 'a created credential level'
+
+          it 'logs the expected log' do
+            expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
+            subject
+          end
         end
 
         context 'and logingov acr is not defined as IAL 2' do


### PR DESCRIPTION
## Summary

- After verification, logingov sends back`urn:acr.login.gov:verified-facial-match-required` as the `current_ial`
- update current_ial to check for these values

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/1116

## Testing 

- Pull latest vets-website
- enable flipper - `:identity_logingov_ial2_enforcement`
- create a new login.gov account
- Verify with login.gov 
  - upload this yaml file instead of uploading photos - https://developers.login.gov/testing/#data-testing
- Check if you received a log like this:
   ```ruby
    [SignIn][CredentialLevelCreator] logingov_current_ial",
       {:credential_uuid=>"some-sub-uuid",
        :logingov_acr=>"urn:acr.login.gov:verified-facial-match-required",
        :translated_ial=>2}
   ```

## What areas of the site does it impact?
Sign-in Service

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected