### PR TITLE
Add white city to UUM tracked config

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1399,6 +1399,7 @@ unique_user_metrics:
   - '515'
   - '553'
   - '655'
+  - '692'
   processor_job:
     batch_size: <%= ENV['unique_user_metrics__processor_job__batch_size'] %>
     max_iterations: <%= ENV['unique_user_metrics__processor_job__max_iterations'] %>


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO* — this is a configuration change, no feature flag involved.
- Adds White City VA Medical Center (facility 692) to `oracle_health_tracked_facility_ids` in `config/settings.yml` so that unique user metrics are tracked for White City users as part of the OH transition nudge rollout pivot from Columbus (757) to White City (692).
- `oracle_health_tracked_facility_ids` is consumed by `UniqueUserEvents::OracleHealth` to generate facility-specific unique user metric events (e.g., tracking how many unique users at a given OH facility access medical records, medications, etc.).
- Team: MHV on VA.gov — My Health / MHV Horizon team owns this component.

## Related issue(s)

- *(Link to ticket)*

## Testing done

- [x] New code is covered by unit tests
- **Old behavior:** Unique user events were tracked for facilities 757, 506, 515, 553, and 655.
- **New behavior:** Facility 692 (White City) is now also tracked.
- **Verification steps:**
  1. Run `bundle exec rspec spec/lib/unique_user_events/oracle_health_spec.rb` — all specs pass.
  2. The `TRACKED_FACILITY_IDS` constant in `UniqueUserEvents::OracleHealth` is loaded from Settings at boot time. Adding `692` to the YAML array means it will be included automatically.
  3. Validated that `692` passes the 3-digit facility ID format validation in the module.

## Screenshots

_N/A — backend configuration change only._

## What areas of the site does it impact?

Unique user metrics tracking for Oracle Health facilities. No user-facing behavior changes. Adds facility 692 (White City) to the set of facilities that generate OH-specific unique user events.

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

## Requested Feedback

This is part of a coordinated effort to pivot the OH transition nudge from Columbus (757) to White City (692). Companion changes include a frontend PR updating `activeFacilities` in `src/applications/auth/helpers.js` and Parameter Store updates for `facilities_ready_for_info_alert`.