### PR TITLE
hotfix recursive network call

### DIFF
--- a/lib/vets/model.rb
+++ b/lib/vets/model.rb
@@ -34,6 +34,9 @@ module Vets
       self.class.attribute_set.each do |attr_name|
         instance_variable_set("@#{attr_name}", nil) unless instance_variable_defined?("@#{attr_name}")
       end
+
+      @vets_model_nested_array_enabled =
+        Flipper.enabled?(:vets_model_nested_array)
     end
 
     # Acts as ActiveRecord::Base#attributes which is needed for serialization
@@ -55,7 +58,7 @@ module Vets
     # @return [Hash] nested attributes
     def nested_attributes(values)
       values.transform_values do |value|
-        if Flipper.enabled?(:vets_model_nested_array) && value.is_a?(Array)
+        if @vets_model_nested_array_enabled && value.is_a?(Array)
           value.map do |item|
             if item.respond_to?(:attribute_values)
               nested_attributes(item.attribute_values)


### PR DESCRIPTION
Saw example of 1.5ms per call for hundreds of fields. This is happening in a core modeling library `lib/vets/model.rb`. Might account for a very noticeable percentage of increased compute in our API deployment--we should see if this is observable in DD infra observability.

### [Example trace](https://vagov.ddog-gov.com/apm/trace/699812c000000000150e942eec5ec338)

<img width="1651" height="209" alt="Screenshot 2026-02-20 at 6 38 44 PM" src="https://github.com/user-attachments/assets/ef424875-f133-47e2-9ef6-be94634b66ce" />

### [Metrics](https://vagov.ddog-gov.com/apm/traces?query=%40db.statement%3A%22GET%20flipper%2Fv1%2Ffeature%2Fvets_model_nested_array%22%20env%3Aeks-prod&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&historicalData=true&messageDisplay=inline&query_translation_version=v0&sort=desc&spanType=all&storage=hot&view=spans&start=1769043540440&end=1771721940440&paused=true)

<img width="1467" height="261" alt="Screenshot 2026-02-21 at 7 59 33 PM" src="https://github.com/user-attachments/assets/e68afae9-0aa5-4152-b85c-2fe2cb56ec10" />