### PR TITLE
DR 133459: Add feature flag for Datadog RUM user_uuid toggling

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -740,6 +740,9 @@ features:
   decision_review_use_new_appealable_issues_service:
     actor_type: user
     description: Enables use of the new Appealable Issues service for fetching appealable issues.
+  decision_review_add_user_account_id_to_rum:
+    actor_type: user
+    description: Adds the user account ID to Datadog RUM logs for SC, HLR and NOD apps
   dependency_verification_browser_monitoring_enabled:
     actor_type: user
     description: Enable Datadog RUM/LOG monitoring for the form 21-0538


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

Creates a new feature flag for toggling whether `user_uuid` is available on Datadog RUM sessions for Supplemental Claim (form 20-0995), Higher-Level Review (form 20-0996) and Notice of Disagreement (form 10182)

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/133459