### PR TITLE
[21-2680] Fix hospitalAddress schema to use structured address object

### DIFF
--- a/config/schemas/21-2680-PRIMARY.json
+++ b/config/schemas/21-2680-PRIMARY.json
@@ -284,10 +284,50 @@
           "example": "Springfield VA Medical Center"
         },
         "hospitalAddress": {
-          "type": "string",
-          "description": "Full address of hospital (required if currently hospitalized)",
-          "maxLength": 200,
-          "example": "789 Hospital Blvd, Springfield, IL 62701"
+          "type": "object",
+          "description": "Address of hospital (required if currently hospitalized)",
+          "additionalProperties": false,
+          "properties": {
+            "street": {
+              "type": "string",
+              "description": "Street address",
+              "maxLength": 30,
+              "example": "789 Hospital Blvd"
+            },
+            "street2": {
+              "type": "string",
+              "description": "Apartment or unit number",
+              "maxLength": 5,
+              "example": "ED"
+            },
+            "city": {
+              "type": "string",
+              "description": "City",
+              "maxLength": 18,
+              "example": "Albany"
+            },
+            "state": {
+              "type": "string",
+              "description": "State (two-letter abbreviation, required for US addresses)",
+              "maxLength": 2,
+              "pattern": "^[A-Z]{2}$",
+              "example": "NY"
+            },
+            "postalCode": {
+              "type": "string",
+              "description": "ZIP or postal code (5 or 9 digits for US addresses)",
+              "maxLength": 9,
+              "pattern": "^[0-9]{5}(-?[0-9]{4})?$",
+              "example": "12201"
+            },
+            "country": {
+              "type": "string",
+              "description": "Country (two or three-letter code)",
+              "maxLength": 3,
+              "pattern": "^[A-Z]{2,3}$",
+              "example": "USA"
+            }
+          }
         }
       },
       "allOf": [


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

- This work is behind a feature toggle (flipper): NO
- The `hospitalAddress` field in `config/schemas/21-2680-PRIMARY.json` was incorrectly defined as a flat string. It has been updated to a structured address object, matching the pattern already established by `claimantInformation.address` in the same schema (same fields, max lengths, and patterns). This aligns the schema with the existing PDF filler implementation (`va212680.rb`), which already expected `hospitalAddress` to be an object.
- Which team: Benefits Optimization (Aquia)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/134020

## Testing done

- [ ] New code is covered by unit tests
- Previously, `hospitalAddress` was defined as `type: string` with a `maxLength` of 200. The PDF filler (`va212680.rb`) was already treating it as an object — this schema change brings the schema into alignment with the existing implementation.
- To verify: validate a form payload against the updated `21-2680-PRIMARY.json` schema with `hospitalAddress` as a structured object (street, city, state, postalCode, country) — it should pass. A plain string value should now correctly fail validation.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
Form 21-2680 (Examination for Housebound Status or Permanent Need for Regular Aid and Attendance) — specifically the `additionalInformation.hospitalAddress` field used when a Veteran is currently hospitalized.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

No specific feedback requested — straightforward schema correction to align with existing implementation.