### PR TITLE
133996: Make sure account number overflows

### DIFF
--- a/modules/burials/lib/burials/pdf_fill/sections/section_07_v2.rb
+++ b/modules/burials/lib/burials/pdf_fill/sections/section_07_v2.rb
@@ -27,7 +27,11 @@ module Burials
         },
         # 31D
         'bankAccountNumber' => {
-          key: 'form1[0].#subform[95].Routing_Or_Transit_Number[1]'
+          key: 'form1[0].#subform[95].Routing_Or_Transit_Number[1]',
+          limit: 15,
+          question_num: 31,
+          question_label: 'Account Number',
+          question_text: 'ACCOUNT NUMBER'
         }
       }.freeze
 


### PR DESCRIPTION
When bank account number exceeded 15 characters it truncated the rest of the number. 

## Summary

- Update account number metadata to overflow after 15chars

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/133996

## Screenshots
_Note: Optional_
<img width="1003" height="274" alt="Screenshot 2026-02-23 at 11 34 59 AM" src="https://github.com/user-attachments/assets/13d9e699-6924-440f-8c7d-acc13f004566" />

<img width="482" height="229" alt="Screenshot 2026-02-23 at 11 35 04 AM" src="https://github.com/user-attachments/assets/17316071-bafc-414f-8131-074b64ebf4b9" />

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
