### PR TITLE
[BIO] 21-8940 fix UUID mismatch

### DIFF
--- a/app/controllers/concerns/pdf_s3_operations.rb
+++ b/app/controllers/concerns/pdf_s3_operations.rb
@@ -8,8 +8,8 @@ module PdfS3Operations
   # Upload to S3 and return a download URL
   # @param claim [SavedClaim] the claim to upload
   # @param config [SimpleFormsApi::FormRemediation::Configuration::Base] S3 config
-  def upload_to_s3(claim, config:)
-    form_submission_attempt = create_submission_attempt(claim)
+  def upload_to_s3(claim, config:, benefits_intake_uuid: nil)
+    form_submission_attempt = create_submission_attempt(claim, benefits_intake_uuid)
     pdf_path = claim.to_pdf(claim.guid)
 
     begin
@@ -26,15 +26,16 @@ module PdfS3Operations
   end
 
   # Creates a submission record used for dating the PDF
-  def create_submission_attempt(claim)
-    form_submission = FormSubmission.create!(
+  def create_submission_attempt(claim, benefits_intake_uuid = nil)
+    upload_uuid = benefits_intake_uuid || claim.guid
+    form_submission = FormSubmission.create_with(
       form_type: claim.form_id,
       form_data: claim.to_json,
       saved_claim: claim,
       saved_claim_id: claim.id,
       user_account_id: claim.user_account_id
-    )
-    FormSubmissionAttempt.create!(form_submission:, benefits_intake_uuid: claim.guid)
+    ).find_or_create_by!(form_type: claim.form_id, saved_claim_id: claim.id)
+    FormSubmissionAttempt.create_with(form_submission:).find_or_create_by!(benefits_intake_uuid: upload_uuid)
   end
 
   ## Returns the URL of an already-created PDF

--- a/modules/increase_compensation/app/controllers/increase_compensation/v0/claims_controller.rb
+++ b/modules/increase_compensation/app/controllers/increase_compensation/v0/claims_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'lighthouse/benefits_intake/service'
 require 'increase_compensation/benefits_intake/submit_claim_job'
 require 'increase_compensation/monitor'
 require 'increase_compensation/zsf_config'
@@ -55,7 +56,6 @@ module IncreaseCompensation
 
         # Issue with 2 8940's in the api, frontend  calls to /in_progess_form/8940 but backend uses `8940V1`
         in_progress_form = current_user ? InProgressForm.form_for_user(claim.form_id[..6], current_user) : nil
-
         claim.form_start_date = in_progress_form.created_at if in_progress_form
 
         unless claim.save
@@ -65,16 +65,15 @@ module IncreaseCompensation
         end
 
         process_attachments(in_progress_form, claim)
+        benefits_intake = benefits_intake_service
+        start_submission_background_job(claim.id, current_user&.user_account_uuid, benefits_intake)
 
-        IncreaseCompensation::BenefitsIntake::SubmitClaimJob.perform_async(claim.id, current_user&.user_account_uuid)
         monitor.track_create_success(in_progress_form, claim, current_user)
 
-        clear_saved_form(claim.form_id[..6])
-
-        # submission attempt is created in the method
-        pdf_url = upload_to_s3(claim, config: IncreaseCompensation::ZsfConfig.new)
+        pdf_url = upload_to_s3(claim, config: s3_config, benefits_intake_uuid: benefits_intake.uuid)
         log_success(claim, current_user&.user_account_uuid)
-        render json: ArchivedClaimSerializer.new(claim, params: { pdf_url: })
+        clear_saved_form(claim.form_id[..6])
+        render json: build_response(benefits_intake.uuid, pdf_url, claim)
       rescue => e
         monitor.track_create_error(in_progress_form, claim, current_user, e)
         raise e
@@ -105,6 +104,42 @@ module IncreaseCompensation
       # Filters out the parameters to form access.
       def filtered_params
         params.require(short_name.to_sym).permit(:form)
+      end
+
+      def s3_config
+        IncreaseCompensation::ZsfConfig.new
+      end
+
+      def benefits_intake_service
+        service = ::BenefitsIntake::Service.new
+        service.request_upload
+        service
+      end
+
+      def start_submission_background_job(claim_id, user_account_uuid, benefits_intake_service)
+        IncreaseCompensation::BenefitsIntake::SubmitClaimJob.perform_async(
+          claim_id,
+          user_account_uuid,
+          benefits_intake_service
+        )
+      end
+
+      def build_response(confirmation_number, pdf_url, claim)
+        attributes = {
+          confirmation_number:,
+          expiration_date: 1.year.from_now,
+          form: '21-8940',
+          guid: claim.guid,
+          pdf_url: pdf_url || nil,
+          regional_office: claim_class.regional_office,
+          submitted_at: claim.submitted_at,
+          submission_api: 'benefitsIntake'
+        }
+
+        { data: {
+          id: claim.id,
+          attributes:
+        } }
       end
 
       ##

--- a/modules/increase_compensation/lib/increase_compensation/benefits_intake/submit_claim_job.rb
+++ b/modules/increase_compensation/lib/increase_compensation/benefits_intake/submit_claim_job.rb
@@ -27,6 +27,7 @@ module IncreaseCompensation
         rescue
           claim = nil
         end
+        IncreaseCompensation::NotificationEmail.new(claim.id, @intake_service&.uuid).deliver(:error) if claim
         ia_monitor.track_submission_exhaustion(msg, claim)
       end
 
@@ -38,7 +39,7 @@ module IncreaseCompensation
       #
       # @return [UUID] benefits intake upload uuid
       #
-      def perform(saved_claim_id, user_account_uuid = nil)
+      def perform(saved_claim_id, user_account_uuid = nil, benefits_intake_service = nil)
         return unless Flipper.enabled?(:increase_compensation_form_enabled)
 
         init(saved_claim_id, user_account_uuid)
@@ -49,6 +50,9 @@ module IncreaseCompensation
         form = @claim.parsed_form
         @metadata = generate_metadata(form)
         @ibm_payload = @claim.to_ibm
+        # benefits_intake_uuid come from here
+        @intake_service ||= benefits_intake_service
+        reset_intake_service if @intake_service.nil?
 
         # upload must be performed within 15 minutes of this request
         upload_document
@@ -60,6 +64,7 @@ module IncreaseCompensation
       rescue => e
         monitor.track_submission_retry(@claim, @intake_service, @user_account_uuid, e)
         @lighthouse_submission_attempt&.fail!
+        reset_intake_service
         raise e
       ensure
         cleanup_file_paths
@@ -78,8 +83,6 @@ module IncreaseCompensation
           raise IncreaseCompensationBenefitIntakeError,
                 "Unable to find IncreaseCompensation::SavedClaim #{saved_claim_id}"
         end
-
-        @intake_service = ::BenefitsIntake::Service.new
       end
 
       # Create a monitor to be used for _this_ job
@@ -129,7 +132,6 @@ module IncreaseCompensation
 
       # Upload generated pdf to Benefits Intake API
       def upload_document
-        @intake_service.request_upload # <- benefits_intake_uuid come from here
         monitor.track_submission_begun(@claim, @intake_service, @user_account_uuid)
         lighthouse_submission_polling
 
@@ -146,8 +148,36 @@ module IncreaseCompensation
 
         monitor.track_submission_attempted(@claim, @intake_service, @user_account_uuid, tracked_payload)
         response = @intake_service.perform_upload(**payload)
-        govcio_upload if response.success?
+        if response.success?
+          update_form_submission_attempt # these are created in the s3 upload so update if different or on retry
+          govcio_upload
+        end
         raise IncreaseCompensationBenefitIntakeError, response.to_s unless response.success?
+      end
+
+      def update_form_submission_attempt
+        # If its a retry we need the new intake uuid for the submission
+        form_submission = @claim.form_submissions.order(created_at: :asc).last || FormSubmission.create_with(
+          form_type: @claim.form_id,
+          form_data: @claim.to_json,
+          saved_claim: @claim,
+          saved_claim_id: @claim.id,
+          user_account_id: @claim.user_account_id
+        ).find_or_create_by!(form_type: @claim.form_id, saved_claim_id: @claim.id)
+
+        # update the submission attempt as well
+        latest_form_submission_attempt = form_submission.latest_attempt
+        if latest_form_submission_attempt
+          latest_form_submission_attempt.update!(benefits_intake_uuid: @intake_service.uuid)
+        else
+          FormSubmissionAttempt.create_with(
+            form_submission:
+          ).find_or_create_by!(benefits_intake_uuid: @intake_service.uuid)
+        end
+      end
+
+      def reset_intake_service
+        @intake_service = ::BenefitsIntake::Service.new
       end
 
       # Upload to IBM MMS if the govcio flipper is enabled
@@ -181,7 +211,7 @@ module IncreaseCompensation
 
       # VANotify job to send Submission in Progress email to veteran
       def send_submitted_email
-        IncreaseCompensation::NotificationEmail.new(@claim.id).deliver(:submitted)
+        IncreaseCompensation::NotificationEmail.new(@claim.id, @intake_service.uuid).deliver(:submitted)
       rescue => e
         monitor.track_send_email_failure(@claim, @intake_service, @user_account_uuid, 'submitted', e)
       end

--- a/modules/increase_compensation/lib/increase_compensation/notification_email.rb
+++ b/modules/increase_compensation/lib/increase_compensation/notification_email.rb
@@ -7,8 +7,9 @@ module IncreaseCompensation
   # @see VeteranFacingServices::NotificationEmail::SavedClaim
   class NotificationEmail < ::VeteranFacingServices::NotificationEmail::SavedClaim
     # @see VeteranFacingServices::NotificationEmail::SavedClaim#new
-    def initialize(saved_claim_id)
+    def initialize(saved_claim_id, confirmation_number = nil)
       super(saved_claim_id, service_name: 'increase_compensation')
+      @confirmation_number = confirmation_number
     end
 
     private
@@ -46,7 +47,9 @@ module IncreaseCompensation
         # confirmation, error
         'first_name' => first_name,
         # received
-        'date_received' => date_received
+        'date_received' => date_received,
+        # use benefits_intake_uuid if provided, otherwise use the claim.guid
+        'confirmation_number' => @confirmation_number || claim.confirmation_number
       }
 
       default.merge(template)

--- a/modules/increase_compensation/spec/lib/increase_compensation/benefits_intake/submit_claim_job_spec.rb
+++ b/modules/increase_compensation/spec/lib/increase_compensation/benefits_intake/submit_claim_job_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe IncreaseCompensation::BenefitsIntake::SubmitClaimJob, :uploader_h
         expect(service).to receive(:perform_upload)
         expect(job).to receive(:cleanup_file_paths)
 
-        result = job.perform(claim.id, user_account_uuid)
+        result = job.perform(claim.id, user_account_uuid, service)
         expect(result).to eq(service.uuid)
       end
 
@@ -65,7 +65,7 @@ RSpec.describe IncreaseCompensation::BenefitsIntake::SubmitClaimJob, :uploader_h
         expect(claim).not_to receive(:to_pdf)
         expect(service).not_to receive(:perform_upload)
 
-        result = job.perform(claim.id, user_account_uuid)
+        result = job.perform(claim.id, user_account_uuid, service)
         expect(result).to be_nil
       end
     end
@@ -77,6 +77,10 @@ RSpec.describe IncreaseCompensation::BenefitsIntake::SubmitClaimJob, :uploader_h
       expect(claim).to receive(:to_pdf).with(claim.guid, { omit_esign_stamp: }).and_return(pdf_path)
       expect(Lighthouse::Submission).to receive(:create)
       expect(Lighthouse::SubmissionAttempt).to receive(:create)
+      # expect(claim).to receive(:form_submissions).and_return(
+      #   [FromSubmission.new(form_type: claim.form_id, saved_claim_id: claim.id)]
+      # )
+      # expect(FormSubmissionAttempt).to receive(:create)
       expect(Datadog::Tracing).to receive(:active_trace)
       expect(UserAccount).to receive(:find)
 
@@ -85,12 +89,12 @@ RSpec.describe IncreaseCompensation::BenefitsIntake::SubmitClaimJob, :uploader_h
       )
       expect(job).to receive(:cleanup_file_paths)
 
-      job.perform(claim.id, :user_account_uuid)
+      job.perform(claim.id, :user_account_uuid, service)
     end
 
     it 'is unable to find user_account' do
       expect(IncreaseCompensation::SavedClaim).not_to receive(:find)
-      expect(BenefitsIntake::Service).not_to receive(:new)
+      expect(BenefitsIntake::Service).to receive(:new)
       expect(claim).not_to receive(:to_pdf)
 
       expect(job).to receive(:cleanup_file_paths)
@@ -107,7 +111,7 @@ RSpec.describe IncreaseCompensation::BenefitsIntake::SubmitClaimJob, :uploader_h
 
       expect(UserAccount).to receive(:find)
 
-      expect(BenefitsIntake::Service).not_to receive(:new)
+      expect(BenefitsIntake::Service).to receive(:new)
       expect(claim).not_to receive(:to_pdf)
 
       expect(job).to receive(:cleanup_file_paths)
@@ -205,8 +209,10 @@ RSpec.describe IncreaseCompensation::BenefitsIntake::SubmitClaimJob, :uploader_h
 
     before do
       job.instance_variable_set(:@claim, claim)
+      job.instance_variable_set(:@intake_service, service)
 
       allow(IncreaseCompensation::NotificationEmail).to receive(:new).and_return(notification)
+      allow(service).to receive(:uuid).and_return('test_guid')
       allow(notification).to receive(:deliver).and_raise(monitor_error)
 
       job.instance_variable_set(:@monitor, monitor)
@@ -214,10 +220,11 @@ RSpec.describe IncreaseCompensation::BenefitsIntake::SubmitClaimJob, :uploader_h
     end
 
     it 'errors and logs but does not reraise' do
-      expect(IncreaseCompensation::NotificationEmail).to receive(:new).with(claim.id)
+      expect(IncreaseCompensation::NotificationEmail).to receive(:new).with(claim.id, 'test_guid')
       expect(notification).to receive(:deliver).with(:submitted)
       expect(monitor).to receive(:track_send_email_failure)
       job.send(:send_submitted_email)
+      # IncreaseCompensation::NotificationEmail.new(@claim.id, @intake_service.uuid).deliver(:submitted)
     end
   end
 


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): **NO**

### Bug:
 21-8940 submissions would show up in MyVA after a successful submission. When a user would leave and return that same submission would now show "error" state. 
response from submission statuses:
```js
createdAt: "2026-02-20T20:14:48.490Z"
detail: "Invalid or unknown id"
formType:"21-8940V1"
id:"8fae7747-1200-430e-8ebb-986bb58df6ff"
message: null
pdfSupport: false
status: "error"
updatedAt: null
id:"8fae7747-1200-430e-8ebb-986bb58df6ff"
type: "submission_status"
```
When fetching submission statuses(SubmissionStatusesController) vet-api looks up a FormSubmissionAttempts `benefits_intake_uuid`. because of how the PdfS3Operations(`app/controllers/concerns/pdf_s3_operations.rb`) was set up it used the `claims.guid` instead of the uuid provided by `BenefitsIntake::Service#request_upload`

### Solution:
1. In the PdfS3Operations (`app/controllers/concerns/pdf_s3_operations.rb`) we run a find_or_create for FormSubmissions and FormSubmissionAttempts.
2. In the IncreaseCompensation controller we initailize a `BenefitsIntake::Service` so that the `uuid` and be passed to PdfS3Operations and the service gets passed to the SumbitClaimJob
3. In the SumbitClaimJob we look for FormSubmissions and Attempts(find_or_create/update) so the we can update them with the correct Benefits-Intake uuid
4.  If the ClaimJob fails we re-initialize a new BenefitsIntake::Service for retry

### teams
- **benefits-intake-pingwind** / **bio-huntridge**

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [x] *New code is covered by unit tests*
- Replication:
  1. On staging submit a [form 21-8940](https://staging.va.gov/disability/eligibility/special-claims/unemployability/apply-unemployability-compensation-form-21-8940)
  2.  Upon success go to MyVa, scroll down to view the status card
  5. log out and log back in
  6. go to MyVa and notice the same status card now shows error


## Screenshots
_Note: Optional_

## What areas of the site does it impact?
- app/controllers/concerns/pdf_s3_operations.rb
- modules/increase_compensation

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
