### PR TITLE
ssoe cookie ssn mismatch logout

### DIFF
--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -37,6 +37,7 @@ module V1
                        VERIFY_PAGE_AUTHENTICATED = 'verify_page_authenticated',
                        VERIFY_PAGE_UNAUTHENTICATED = 'verify_page_unauthenticated'].freeze
     CERNER_ELIGIBLE_COOKIE_NAME = 'CERNER_ELIGIBLE'
+    LOGIN_EXCEPTION_COOKIE_NAME = 'exc'
 
     # Collection Action: auth is required for certain types of requests
     # @type is set automatically by the routes in config/routes.rb
@@ -82,6 +83,14 @@ module V1
 
       if ActiveModel::Type::Boolean.new.cast(params[:agreements_declined])
         redirect_to url_service.tou_declined_logout_redirect_url
+      elsif (exc_cookie = cookies.signed[LOGIN_EXCEPTION_COOKIE_NAME]).present?
+        code = exc_cookie[:code].presence
+        request_id = exc_cookie[:request_id].presence
+
+        Rails.logger.info('[V1][SessionsController] SLO Callback error cookie found', code:, request_id:)
+        cookies.delete(LOGIN_EXCEPTION_COOKIE_NAME)
+
+        redirect_to url_service.login_redirect_url(auth: 'fail', code:, request_id:)
       else
         redirect_to url_service.logout_redirect_url
       end
@@ -361,7 +370,7 @@ module V1
     end
 
     # rubocop:disable Metrics/ParameterLists
-    def handle_callback_error(exc, status, response, context = {},
+    def handle_callback_error(exc, status, response, context = {}, # rubocop:disable Metrics/MethodLength
                               code = SAML::Responses::Base::UNKNOWN_OR_BLANK_ERROR_CODE, tag = nil)
       # replaces bundled Sentry error message with specific XML messages
       message = if response && response.normalized_errors.count > 1 && response.status_detail
@@ -373,10 +382,23 @@ module V1
       Rails.logger.error('[V1][Sessions Controller] error', context:, message:)
       Rails.logger.info("SessionsController version:v1 saml_callback failure, user_uuid=#{@current_user&.uuid}")
 
-      unless performed?
-        redirect_to url_service.login_redirect_url(auth: 'fail', code:,
-                                                   request_id: request.request_id)
+      if exc.respond_to?(:force_logout) && exc.force_logout
+        cookies.signed[LOGIN_EXCEPTION_COOKIE_NAME] = {
+          value: { code:, request_id: request.request_id },
+          expires: 2.minutes.from_now,
+          secure: true,
+          httponly: true
+        }
+
+        url = URI.parse(url_service.ssoe_slo_url)
+        url.query = { appKey: CGI.escape(IdentitySettings.saml_ssoe.logout_app_key),
+                      clientId: params[:client_id] }.compact.to_query
+
+        redirect_to url.to_s
       end
+
+      redirect_to url_service.login_redirect_url(auth: 'fail', code:, request_id: request.request_id) unless performed?
+
       login_stats(:failure, exc) unless response.nil?
       callback_stats(status, response, tag)
       PersonalInformationLog.create(

--- a/app/models/user_session_form.rb
+++ b/app/models/user_session_form.rb
@@ -115,13 +115,15 @@ class UserSessionForm
                  end
 
     correlation_record = mpi_correlation_record(identifier:, identifier_type:)
+
     return if correlation_record.present? && correlation_record.ssn == saml_ssn
 
     raise SAML::UserAttributeError.new(
       message: SAML::UserAttributeError::ERRORS[:ssn_mismatch][:message],
       code: SAML::UserAttributeError::SSN_MISMATCH_CODE,
       tag: SAML::UserAttributeError::ERRORS[:ssn_mismatch][:tag],
-      context: { icn: saml_attributes[:mhv_icn], credential_uuid: identifier, type: identifier_type }
+      context: { icn: saml_attributes[:mhv_icn], credential_uuid: identifier, type: identifier_type },
+      force_logout: true
     )
   end
 

--- a/lib/saml/errors.rb
+++ b/lib/saml/errors.rb
@@ -2,7 +2,7 @@
 
 module SAML
   class SAMLError < StandardError
-    attr_reader :code, :tag, :level, :context
+    attr_reader :code, :tag, :level, :context, :force_logout
   end
 
   class UserAttributeError < SAMLError
@@ -40,12 +40,13 @@ module SAML
 
     attr_reader :identifier
 
-    def initialize(message:, code:, tag:, context: {}, identifier: nil)
+    def initialize(message:, code:, tag:, context: {}, identifier: nil, force_logout: false) # rubocop:disable Metrics/ParameterLists
       @code = code
       @tag = tag
       @level = :warning
       @context = context
       @identifier = identifier
+      @force_logout = force_logout
       super(message)
     end
   end

--- a/spec/controllers/v1/sessions_controller_spec.rb
+++ b/spec/controllers/v1/sessions_controller_spec.rb
@@ -769,6 +769,29 @@ RSpec.describe V1::SessionsController, type: :controller do
         expect(call_endpoint).to redirect_to(expected_redirect_url)
       end
     end
+
+    context 'when exception cookie is present' do
+      let(:cookie_value) do
+        { code: '113',
+          request_id: 'some_request_id' }
+      end
+
+      let(:expected_redirect_url) { "http://127.0.0.1:3001/auth/login/callback?auth=fail&#{cookie_value.to_query}" }
+      let(:signed_jar) { instance_double(ActionDispatch::Cookies::SignedKeyRotatingCookieJar) }
+      let(:cookie_jar) { instance_double(ActionDispatch::Cookies::CookieJar) }
+      let(:cookie_name) { V1::SessionsController::LOGIN_EXCEPTION_COOKIE_NAME }
+
+      before do
+        allow(controller).to receive(:cookies).and_return(cookie_jar)
+        allow(signed_jar).to receive(:[]).with(cookie_name).and_return(cookie_value)
+        allow(cookie_jar).to receive(:signed).and_return(signed_jar)
+        allow(cookie_jar).to receive(:delete)
+      end
+
+      it 'redirects to the login_url with expected error code' do
+        expect(call_endpoint).to redirect_to(expected_redirect_url)
+      end
+    end
   end
 
   describe 'POST #saml_callback' do
@@ -986,7 +1009,9 @@ RSpec.describe V1::SessionsController, type: :controller do
               }
             }
           end
-          let(:expected_redirect_params) { { auth: 'fail', code: '113', request_id: }.to_query }
+          let(:expected_redirect_url) { "https://int.eauth.va.gov/slo/globallogout?appKey=#{expected_app_key}" }
+          let(:expected_app_key) { 'https%253A%252F%252Fssoe-sp-dev.va.gov' }
+          let(:cookie_name) { V1::SessionsController::LOGIN_EXCEPTION_COOKIE_NAME }
 
           before do
             allow(Rails.logger).to receive(:error)
@@ -999,8 +1024,12 @@ RSpec.describe V1::SessionsController, type: :controller do
             expect(Rails.logger).to have_received(:error).with(expected_log_message, expected_log_payload)
           end
 
-          it 'responds with a correlation error message and code' do
-            expect(call_endpoint).to redirect_to(expected_redirect)
+          it 'sets an exc cookie with the expected error code and request id' do
+            expect(cookies.signed[:exc]).to eq({ code: '113', request_id: })
+          end
+
+          it 'redirects to ssoe global logout' do
+            expect(call_endpoint).to redirect_to(expected_redirect_url)
           end
         end
       end

--- a/spec/models/user_session_form_spec.rb
+++ b/spec/models/user_session_form_spec.rb
@@ -60,7 +60,16 @@ RSpec.describe UserSessionForm, type: :model do
         .and_return(find_profile_response)
 
       expect { UserSessionForm.new(saml_response) }
-        .to raise_error(SAML::UserAttributeError, expected_error_message)
+        .to raise_error(SAML::UserAttributeError, expected_error_message) do |error|
+          expect(error.code).to eq(SAML::UserAttributeError::SSN_MISMATCH_CODE)
+          expect(error.tag).to eq(:ssn_mismatch)
+          expect(error.context).to include(
+            icn: saml_attributes[:va_eauth_icn],
+            credential_uuid: identifier,
+            type: identifier_type
+          )
+          expect(error.force_logout).to be(true)
+        end
     end
   end
 


### PR DESCRIPTION
## Summary

- On SSOe SSN mismatch logout of SSOe
- Before redirecting to SSOe logout set a cookie with the error code and request_id
- In the logout callback we check if there is an exception cookie and redirect to the error page with the corresponding error code and request_id

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/1136

## Testing 
- Change your users ssn in their mpi response in `vets-api-mockdata`
- authenticate with ssoe - http://localhost:3001/sign-in?oauth=false
- you should be logged out of ssoe (it will redirect you to dev.va.gov but this is expected)
- manually go to http://localhost:3001/v1/sessions/ssoe_logout
- you should be redirected to the error page with error code 113 and a request_id in the params


## What areas of the site does it impact?
Authentication

## Acceptance criteria

- [x  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

