### PR TITLE
Add veteranSsnLastFour to COE (26-1880) prefill

### DIFF
--- a/config/form_profile_mappings/26-1880.yml
+++ b/config/form_profile_mappings/26-1880.yml
@@ -6,3 +6,5 @@ contactEmail: [contact_information, email]
 periodsOfService: [military_information, tours_of_duty]
 currentlyActiveDuty: [military_information, currently_active_duty_hash]
 activeDuty: [military_information, currently_active_duty]
+nonPrefill:
+  veteranSsnLastFour: [identity_information, ssn_last_four]

--- a/spec/models/form_profile_spec.rb
+++ b/spec/models/form_profile_spec.rb
@@ -796,7 +796,10 @@ RSpec.describe FormProfile, type: :model do
       'currentlyActiveDuty' => {
         'yes' => false
       },
-      'activeDuty' => false
+      'activeDuty' => false,
+      'nonPrefill' => {
+        'veteranSsnLastFour' => '1863'
+      }
     }
   end
   let(:v28_8832_expected) do


### PR DESCRIPTION
## Summary

I'm Adam King, I work on the CVE team, and we own this component.

This PR (which is not behind a feature toggle) adds SSN last 4 digits to the in-progress form prefill for COE (Form 26-1880) via the nonPrefill mapping, enabling the front end to display the veteran's masked SSN without including it in the submission payload.


## Related issue(s)

[CVE Ticket 2325](https://github.com/department-of-veterans-affairs/va-iir/issues/2325)

## Testing done

Existing prefill tests updated to include new "last 4" field


## Acceptance criteria

- [x]  I updated unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
