### PR TITLE
Log 403s with compliant error details

### DIFF
--- a/app/controllers/concerns/exception_handling.rb
+++ b/app/controllers/concerns/exception_handling.rb
@@ -110,7 +110,6 @@ module ExceptionHandling
   def log_forbidden(va_exception)
     Rails.logger.info(
       'Forbidden access (403)',
-      user_uuid: current_user&.uuid,
       request_id: request.uuid,
       remote_ip: request.remote_ip,
       detail: va_exception.errors.map(&:to_h)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -618,7 +618,6 @@ RSpec.describe ApplicationController, type: :controller do
           expect(Rails.logger).to have_received(:info).with(
             'Forbidden access (403)',
             hash_including(
-              user_uuid: nil,
               request_id: test_request_id,
               remote_ip: test_remote_ip,
               detail: expected_detail
@@ -627,29 +626,15 @@ RSpec.describe ApplicationController, type: :controller do
           expect(response).to have_http_status(:forbidden)
         end
 
-        context 'with a signed-in user' do
-          let(:user) { create(:user) }
+        it 'does not log user_uuid' do
+          allow(Rails.logger).to receive(:info)
 
-          before do
-            controller.instance_variable_set(:@current_user, user)
-          end
+          get :not_authorized
 
-          it 'logs the user_uuid of the current user' do
-            allow(Rails.logger).to receive(:info)
-
-            get :not_authorized
-
-            expect(Rails.logger).to have_received(:info).with(
-              'Forbidden access (403)',
-              hash_including(
-                user_uuid: user.uuid,
-                request_id: test_request_id,
-                remote_ip: test_remote_ip,
-                detail: expected_detail
-              )
-            )
-            expect(response).to have_http_status(:forbidden)
-          end
+          expect(Rails.logger).to have_received(:info).with(
+            'Forbidden access (403)',
+            hash_not_including(:user_uuid)
+          )
         end
       end
 
@@ -662,7 +647,6 @@ RSpec.describe ApplicationController, type: :controller do
           expect(Rails.logger).to have_received(:info).with(
             'Forbidden access (403)',
             hash_including(
-              user_uuid: nil,
               request_id: test_request_id,
               remote_ip: test_remote_ip,
               detail: [{ title: 'Forbidden', detail: 'Forbidden', code: '403', status: '403' }]


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- We have introduced a new dedicated log line for 403s
- The new log entry captures the required details for AU2 compliance
- This is targeted (only 403s), explicit (fields are guaranteed present), and doesn't change any other logging behavior. The current_user is generally available because Pundit/policy checks happen after authentication
- Platform/SRE

## Related issue(s)

- [*Link to ticket created in va.gov-team repo*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/133936)
- [*Link to epic*](https://github.com/department-of-veterans-affairs/va.gov-team/issues/133893)

## Testing done

- [x] *New code is covered by unit tests*
- Previously we did no direct logging of the unauthorized user uuid that triggered the 403.
- I tested locally by adding a temporary `/forbidden` route that triggers `Common::Exceptions::Forbidden`. 
- It's more awkward to setup but I would still like to test more directly in an authenticated context locally but we can also review in staging (and rollback if there are issues).

## Evidence

The new log lines will look like this (`user_uuid` should be filled in an authenticated context):

```
16:44:16 web.1  | 2026-02-24 16:44:16.323698 I [64855:puma srv tp 002] Rails -- Authorization failure (403) -- { :user_uuid => nil, :request_id => "3694573a-be73-4190-b7af-a395a8593ecd", :remote_ip => "127.0.0.1", :detail => [ { :title => "Forbidden", :detail => "User does not have access to the requested resource", :code => "403", :status => "403" } ] }
```

## What areas of the site does it impact?

Logs (for requests that fail pundit authorization)

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [~]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog: [Datadog search for 403s](https://vagov.ddog-gov.com/logs?query=env%3Aeks-prod%20service%3Avets-api%20%40http.status_code%3A403&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=flex_tier&stream_sort=desc&viz=stream&from_ts=1771966407231&to_ts=1771967307231&live=true)
- [x]  I added a screenshot of the developed feature (log example above)

## Resources

- See also [NIST SP 800-53 Rev. 5](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf) ("AU-2: Event Logging", p. 93)