### PR TITLE
Fix race condition and add nil guard in SubmitFormJob

### DIFF
--- a/app/sidekiq/multi_party_forms/submit_form_job.rb
+++ b/app/sidekiq/multi_party_forms/submit_form_job.rb
@@ -8,6 +8,7 @@ module MultiPartyForms
     include Vets::SharedLogging
 
     class MergeServiceNotFoundError < StandardError; end
+    class MissingFormDataError < StandardError; end
 
     RETRY = 10
     STATSD_KEY_PREFIX = 'worker.multi_party_forms.submit_form'
@@ -65,6 +66,9 @@ module MultiPartyForms
       primary_data = @submission.primary_in_progress_form.form_data
       secondary_data = @submission.secondary_in_progress_form.form_data
 
+      raise MissingFormDataError, "Missing primary form data for submission #{@submission.id}" if primary_data.nil?
+      raise MissingFormDataError, "Missing secondary form data for submission #{@submission.id}" if secondary_data.nil?
+
       resolve_merge_service.new(primary_data, secondary_data).merge
     end
 
@@ -86,8 +90,11 @@ module MultiPartyForms
     def enqueue_lighthouse_submission
       return if @submission.submitted_at.present?
 
-      Lighthouse::SubmitBenefitsIntakeClaim.perform_async(@submission.saved_claim_id)
       @submission.update!(submitted_at: Time.zone.now)
+      Lighthouse::SubmitBenefitsIntakeClaim.perform_async(@submission.saved_claim_id)
+    rescue
+      @submission.update!(submitted_at: nil)
+      raise
     end
 
     def enqueue_confirmation_emails

--- a/spec/sidekiq/multi_party_forms/submit_form_job_spec.rb
+++ b/spec/sidekiq/multi_party_forms/submit_form_job_spec.rb
@@ -207,5 +207,53 @@ RSpec.describe MultiPartyForms::SubmitFormJob, type: :job do
         expect(StatsD).to have_received(:increment).with("#{described_class::STATSD_KEY_PREFIX}.failure")
       end
     end
+
+    context 'when primary form data is nil' do
+      before do
+        primary_in_progress_form.update_columns(form_data: nil)
+      end
+
+      it 'raises MissingFormDataError' do
+        expect { job.perform(submission.id) }
+          .to raise_error(described_class::MissingFormDataError, /Missing primary form data/)
+      end
+
+      it 'does not enqueue the Lighthouse submission job' do
+        expect(Lighthouse::SubmitBenefitsIntakeClaim).not_to receive(:perform_async)
+
+        expect { job.perform(submission.id) }.to raise_error(described_class::MissingFormDataError)
+      end
+    end
+
+    context 'when secondary form data is nil' do
+      before do
+        secondary_in_progress_form.update_columns(form_data: nil)
+      end
+
+      it 'raises MissingFormDataError' do
+        expect { job.perform(submission.id) }
+          .to raise_error(described_class::MissingFormDataError, /Missing secondary form data/)
+      end
+
+      it 'does not enqueue the Lighthouse submission job' do
+        expect(Lighthouse::SubmitBenefitsIntakeClaim).not_to receive(:perform_async)
+
+        expect { job.perform(submission.id) }.to raise_error(described_class::MissingFormDataError)
+      end
+    end
+
+    context 'when Lighthouse::SubmitBenefitsIntakeClaim.perform_async fails' do
+      before do
+        submission.update!(saved_claim:)
+        allow(Lighthouse::SubmitBenefitsIntakeClaim).to receive(:perform_async)
+          .and_raise(Redis::ConnectionError, 'connection refused')
+      end
+
+      it 'rolls back submitted_at so the job can be retried' do
+        expect { job.perform(submission.id) }.to raise_error(Redis::ConnectionError)
+
+        expect(submission.reload.submitted_at).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Reorder enqueue_lighthouse_submission to set submitted_at before calling perform_async, preventing duplicate Lighthouse submissions on retry. Roll back submitted_at if enqueuing fails.

Add MissingFormDataError guard in merge_form_data to fail fast if either in_progress_form has nil form_data, preventing silent bad submissions.

## Summary

- *This work is behind a feature toggle (flipper): YES/NO*
- *(Summarize the changes that have been made to the platform)*
- *(If bug, how to reproduce)*
- *(What is the solution, why is this the solution?)*
- *(Which team do you work for, does your team own the maintenance of this component?)*
- *(If introducing a flipper, what is the success criteria being targeted?)*

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
