### PR TITLE
134202a BIO - Update 21P-601 mapper boolean to use 1 or 0 rather than true or false

### DIFF
--- a/modules/bio_heart/lib/bio_heart_api/form_mappers/form_21p601_mapper.rb
+++ b/modules/bio_heart/lib/bio_heart_api/form_mappers/form_21p601_mapper.rb
@@ -286,8 +286,8 @@ module BioHeartApi
           payload["EXPENSE_PAID_TO_#{num}"] = expense['provider']
           payload["EXPENSE_PAID_FOR_#{num}"] = expense['expense_type']
           payload["EXPENSE_AMT_#{num}"] = format_currency(expense['amount'])
-          payload["PAID_#{num}"] = expense['is_paid'] == true
-          payload["UNPAID_#{num}"] = expense['is_paid'] == false
+          payload["PAID_#{num}"] = expense['is_paid'] == true ? 1 : 0
+          payload["UNPAID_#{num}"] = expense['is_paid'] == false ? 1 : 0
           payload["EXPENSE_PAID_BY_#{num}"] = expense['paid_by']
         end
 
@@ -296,8 +296,8 @@ module BioHeartApi
           payload["EXPENSE_PAID_TO_#{num}"] = nil
           payload["EXPENSE_PAID_FOR_#{num}"] = nil
           payload["EXPENSE_AMT_#{num}"] = nil
-          payload["PAID_#{num}"] = false
-          payload["UNPAID_#{num}"] = false
+          payload["PAID_#{num}"] = 0
+          payload["UNPAID_#{num}"] = 0
           payload["EXPENSE_PAID_BY_#{num}"] = nil
         end
       end

--- a/modules/bio_heart/spec/services/form_mappers/form_21p601_mapper_spec.rb
+++ b/modules/bio_heart/spec/services/form_mappers/form_21p601_mapper_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe BioHeartApi::FormMappers::Form21p601Mapper do
       it 'fills all expense slots with nil' do
         (1..4).each do |num|
           expect(result["EXPENSE_PAID_TO_#{num}"]).to be_nil
-          expect(result["PAID_#{num}"]).to be(false)
+          expect(result["PAID_#{num}"]).to be(0)
         end
       end
     end


### PR DESCRIPTION
## Summary

Per MMS data requirements, when we submit the form 21P-601 payload our boolean values need to be represented with the numbers 1 and 0 rather than the native `true` and `false`.

This PR makes that change in one place that was previously overlooked when putting this mapper together.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/134202

## Testing done

- [X] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

Form 21P-601 only (this change is behind a flipper and not enabled in production)

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [X]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA