### PR TITLE
Exclude overflow_only fields from PDF field validation

### DIFF
--- a/lib/pdf_fill/filler.rb
+++ b/lib/pdf_fill/filler.rb
@@ -286,7 +286,7 @@ module PdfFill
 
       # Validate that field names in data match the PDF template fields
       # Track mismatches via StatsD for monitoring blank/partial PDFs
-      validate_field_names(template_path, new_hash, form_id) if Flipper.enabled?(:pdf_fill_field_validation)
+      validate_field_names(template_path, new_hash, form_id, pdftk_keys) if Flipper.enabled?(:pdf_fill_field_validation)
 
       if fill_options.fetch(:use_hexapdf, false)
         fill_form_with_hexapdf(template_path, file_path, new_hash)
@@ -396,11 +396,12 @@ module PdfFill
     # @param data_hash [Hash] Hash of field names and values to fill.
     # @param form_id [String] The form ID for StatsD tagging.
     #
-    def validate_field_names(template_path, data_hash, form_id)
+    def validate_field_names(template_path, data_hash, form_id, pdftk_keys = {})
       template_fields = extract_template_field_names(template_path)
+      overflow_only_keys = extract_overflow_only_keys(pdftk_keys)
 
       data_field_names = data_hash.keys.map(&:to_s)
-      unmatched_fields = data_field_names - template_fields
+      unmatched_fields = data_field_names - template_fields - overflow_only_keys
 
       if unmatched_fields.any?
         StatsD.increment("#{STATSD_KEY_PREFIX}.field_validation.mismatch", tags: ["form_id:#{form_id}"])
@@ -414,6 +415,29 @@ module PdfFill
           }
         )
       end
+    end
+
+    ##
+    # Extracts field key names from pdftk_keys where overflow_only is true.
+    # These fields exist purely to route data to overflow pages and have no
+    # matching PDF template field, so they should be excluded from validation.
+    #
+    # @param hash [Hash] The pdftk KEY hash to walk.
+    #
+    # @return [Array<String>] Array of overflow-only field key names.
+    #
+    def extract_overflow_only_keys(hash)
+      keys = []
+      hash.each_value do |value|
+        next unless value.is_a?(Hash)
+
+        if value.key?(:key) && value[:overflow_only]
+          keys << value[:key]
+        else
+          keys.concat(extract_overflow_only_keys(value))
+        end
+      end
+      keys.map(&:to_s)
     end
 
     ##

--- a/spec/lib/pdf_fill/filler_spec.rb
+++ b/spec/lib/pdf_fill/filler_spec.rb
@@ -292,6 +292,82 @@ describe PdfFill::Filler, type: :model do
         described_class.validate_field_names(template_path, data_hash, form_id)
       end
     end
+
+    context 'when overflow_only fields are present in pdftk_keys' do
+      let(:data_hash) { { 'field1' => 'value1', 'overflow_field' => 'value2', 'wrong_field' => 'value3' } }
+      let(:pdftk_keys) do
+        {
+          normal: { key: 'field1' },
+          overflow: { key: 'overflow_field', overflow_only: true },
+          nested: { inner: { key: 'other_overflow', overflow_only: true } }
+        }
+      end
+
+      it 'excludes overflow_only fields from mismatch reporting' do
+        expect(StatsD).to receive(:increment).with('api.pdf_fill.field_validation.mismatch',
+                                                   tags: ["form_id:#{form_id}"])
+
+        described_class.validate_field_names(template_path, data_hash, form_id, pdftk_keys)
+      end
+
+      it 'does not report overflow_only fields as unmatched' do
+        allow(StatsD).to receive(:increment)
+
+        expect(Rails.logger).to receive(:warn).with(
+          "PDF field validation mismatch for form #{form_id}",
+          hash_including(unmatched_fields: ['wrong_field'])
+        )
+
+        described_class.validate_field_names(template_path, data_hash, form_id, pdftk_keys)
+      end
+    end
+
+    context 'when all mismatches are overflow_only fields' do
+      let(:data_hash) { { 'field1' => 'value1', 'overflow_field' => 'value2' } }
+      let(:pdftk_keys) do
+        { overflow: { key: 'overflow_field', overflow_only: true } }
+      end
+
+      it 'does not increment StatsD mismatch metric' do
+        expect(StatsD).not_to receive(:increment)
+
+        described_class.validate_field_names(template_path, data_hash, form_id, pdftk_keys)
+      end
+    end
+  end
+
+  describe '#extract_overflow_only_keys' do
+    it 'returns keys where overflow_only is true' do
+      hash = {
+        normal: { key: 'field1' },
+        overflow: { key: 'overflow_field', overflow_only: true }
+      }
+
+      expect(described_class.extract_overflow_only_keys(hash)).to eq(['overflow_field'])
+    end
+
+    it 'recursively finds nested overflow_only keys' do
+      hash = {
+        top: {
+          nested: { key: 'nested_overflow', overflow_only: true }
+        }
+      }
+
+      expect(described_class.extract_overflow_only_keys(hash)).to eq(['nested_overflow'])
+    end
+
+    it 'returns an empty array when no overflow_only keys exist' do
+      hash = {
+        normal: { key: 'field1' },
+        another: { key: 'field2' }
+      }
+
+      expect(described_class.extract_overflow_only_keys(hash)).to eq([])
+    end
+
+    it 'returns an empty array for an empty hash' do
+      expect(described_class.extract_overflow_only_keys({})).to eq([])
+    end
   end
 
   describe '#extract_template_field_names' do


### PR DESCRIPTION
## Summary

This PR is part of an effort to increase visibility into circumstances where a PDF might be improperly filled out.  In a [previous PR](https://github.com/department-of-veterans-affairs/vets-api/pull/26587), we added a validation check and incremented statsd metrics and emitted logs in order to identify code changes which might result in malformed PDFs.

After enabling the feature flag in production, we discovered that some forms were using a flag, `overflow_only`, to indicate that the field is not expected to be added to the PDF template.

This PR adds a step to the field validation process: check for `overflow_only` fields, and remove them from the list of fields used to compare against fields in the PDF template.  This change is behind the original feature flag.

- Excludes `overflow_only: true` fields from PDF field validation mismatch reporting
- These fields exist purely to route data to overflow pages and intentionally have no matching PDF template field, causing false positive mismatch alerts in StatsD
- Adds `extract_overflow_only_keys` helper that recursively walks the KEY hash to collect overflow-only field names
- Passes `pdftk_keys` into `validate_field_names` so overflow-only keys can be subtracted from the comparison

## Affected forms

| Form | Location | `overflow_only` fields |
|------|----------|----------------------|
| 21-0538 (Dependents Verification) | `modules/dependents_verification/.../section1.rb` | 12 |
| 21-674 (Dependents Benefits) | `modules/dependents_benefits/.../va21674.rb` | 13 |
| 21-674-V2 | `lib/pdf_fill/forms/va21674v2.rb` | 13 |

> Note: `va210781v2.rb` uses `overflow_only` as a method parameter for a different purpose (controlling whether to nil-out fields moved to overflow), not as a KEY hash attribute — unaffected by this change.

## Related issue(s)

- [Previous PR](https://github.com/department-of-veterans-affairs/vets-api/pull/26587)


## Testing done

- [x] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change* fields with `overflow_only` were reported as mismatched fields



## What areas of the site does it impact?
PDF Filler library

## Acceptance criteria

- [x]  I added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
