### PR TITLE
ci: build Docker image once and share via GHA cache

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -229,39 +229,6 @@ jobs:
       - name: Determine shard grouping strategy
         id: grouping
         run: |
-          if [ -f tmp/parallel_runtime_rspec.log ]; then
-            echo "strategy=runtime" >> $GITHUB_OUTPUT
-            echo "Runtime log found, using runtime-based shard balancing"
-          else
-            echo "strategy=filesize" >> $GITHUB_OUTPUT
-            echo "No runtime log found, falling back to filesize grouping"
-          fi
-
-      # Shard balancing: if a runtime log exists (cached from a previous run),
-      # parallel_test uses --group-by runtime to distribute specs by actual
-      # measured execution time. Otherwise it falls back to --group-by filesize.
-      # The runtime log is generated in publish_results from JUnit XML timing
-      # data and cached for subsequent runs.
-      #
-      # Cache key priority:
-      #   1. This branch's most recent run
-      #   2. master branch (so new PRs get balanced shards immediately)
-      #   3. Any previous run (catch-all fallback)
-      # If no cache exists at all (e.g. first-ever run), parallel_test uses
-      # filesize grouping automatically.
-      - name: Restore runtime log from cache
-        uses: actions/cache/restore@v4
-        with:
-          path: tmp/parallel_runtime_rspec.log
-          key: parallel-runtime-log-${{ github.ref }}-${{ github.run_id }}
-          restore-keys: |
-            parallel-runtime-log-${{ github.ref }}-
-            parallel-runtime-log-refs/heads/master-
-            parallel-runtime-log-
-
-      - name: Determine shard grouping strategy
-        id: grouping
-        run: |
           if [ -s tmp/parallel_runtime_rspec.log ]; then
             echo "strategy=runtime" >> $GITHUB_OUTPUT
             echo "Runtime log found, using runtime-based shard balancing"


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Stacked on #26774 (test shard rebalancing).
- Instead of each of the 24 test shards rebuilding the Docker image from GHA layer cache, builds once in a dedicated `build` job and shares the image via GHA cache (`actions/cache`).
- Eliminates **Docker Buildx setup** and **Docker Build** per shard, replacing with a cache restore (~7s) + `docker load` (~28s).
- Docker image is exported with `docker save | zstd -T0` and saved to GHA cache. Shards restore and decompress via `zstd -d | docker load`.
- The `publish_results` job also reuses the cached image instead of rebuilding.
- Initially tried `actions/upload-artifact` / `actions/download-artifact` for image sharing, but artifact downloads showed high jitter (8-199s per shard). Switched to GHA cache which provides consistent ~7s restores with negligible variance.
- Platform team, CI infrastructure maintenance.

## Related issue(s)

- Stacked on #26774
- CI optimization effort — no associated ticket.

## Testing done

- [x] CI passes with the build-once + cache pattern
- [x] Per-shard overhead reduced and consistent
- [x] `publish_results` job successfully reuses the cached image

## What areas of the site does it impact?

CI pipeline only — no application code changes.

## Acceptance criteria

- [x] Build job exports and caches the Docker image
- [x] All 24 test shards successfully restore and load the image from cache
- [x] Test shards no longer run Docker Buildx setup or build-push-action
- [x] `publish_results` reuses the cached image (no rebuild)
- [x] Overall wall-clock time and per-shard overhead improved

## Measured Results

### Master baseline (per-shard Docker build)

| Metric | Value |
|--------|-------|
| Wall clock | 11.3m |
| Per-shard Buildx + Build | avg 62s (45-87s) |
| Per-shard overhead | avg 120s (105-132s, spread 27s) |

### Run 7 — Build-once with GHA cache

| Metric | Value |
|--------|-------|
| Wall clock | **9.6m** |
| Per-shard cache restore | avg 7s (4-10s, spread 6s) |
| Per-shard load | avg 28s (22-29s) |
| Per-shard overhead | **avg 94s (69-105s, spread 36s)** |

### Comparison

| Metric | Master (per-shard build) | Build-once (GHA cache) | Delta |
|--------|-------------------------|----------------------|-------|
| Wall clock | 11.3m | 9.6m | **-1.7m (-15%)** |
| Docker work avg | 62s (Buildx+Build) | 35s (cache+load) | **-27s (-44%)** |
| OH avg | 120s | 94s | **-26s (-22%)** |
| OH spread | 27s | 36s | +9s |

Combined with parent PR's shard rebalancing, **total improvement vs original master: ~3m+ (~25%).**

### Build job

| Step | Time |
|------|------|
| Docker Build (from GHA layer cache) | 89s |
| Export (`docker save \| zstd -T0`) | 12s |
| Cache save | 16s |
| **Build job total** | **147s** |

The build job runs in parallel with linting (~200s), so it adds **0s to the critical path**.

### Key observations

- **GHA cache restores are extremely consistent** — 4-10s across all 24 shards with sd=1.4s. No outliers in any run.
- **Per-shard overhead dropped 26s on average** — cache restore (7s) + load (28s) = 35s, vs Buildx (8s) + Build (54s) = 62s per shard on master.
- **Build job is free** — finishes before linting completes, so it doesn't extend the critical path.
- **zstd compression** keeps the cached image at ~840MB (vs ~2GB+ uncompressed).