### PR TITLE
test: reduce sign_in_controller authorize idme spec runtime (6168 → 787 examples)

### DIFF
--- a/spec/controllers/v0/sign_in_controller_authorize_idme_spec.rb
+++ b/spec/controllers/v0/sign_in_controller_authorize_idme_spec.rb
@@ -16,13 +16,6 @@ RSpec.describe V0::SignInController, type: :controller do
         it_behaves_like 'an idme service interface with appropriate operation'
       end
 
-      context 'and operation param is authorize' do
-        let(:operation_value) { SignIn::Constants::Auth::AUTHORIZE }
-        let(:expected_op_value) { '' }
-
-        it_behaves_like 'an idme service interface with appropriate operation'
-      end
-
       context 'and operation param is arbitrary' do
         let(:operation_value) { 'some-operation-value' }
         let(:expected_error) { 'Operation is not valid' }
@@ -37,39 +30,32 @@ RSpec.describe V0::SignInController, type: :controller do
         it_behaves_like 'an idme service interface with appropriate operation'
       end
 
-      context 'and the operation param is interstitial_verify' do
-        let(:operation_value) { SignIn::Constants::Auth::INTERSTITIAL_VERIFY }
-        let(:expected_op_value) { '' }
+      # Other valid operations (authorize, interstitial_verify, interstitial_signup,
+      # verify_cta_authenticated, verify_page_authenticated, verify_page_unauthenticated)
+      # all produce identical behavior (no op= param). Their convert_operation output is
+      # verified in spec/lib/sign_in/idme/service_spec.rb ('when operation is a valid
+      # non-signup operation'). Here we just confirm they are accepted without error.
+      context 'and operation param is a valid non-signup operation' do
+        let(:acr_value) { 'loa1' }
+        let(:code_challenge) { { code_challenge: Base64.urlsafe_encode64('some-safe-code-challenge') } }
+        let(:code_challenge_method) { { code_challenge_method: 'S256' } }
 
-        it_behaves_like 'an idme service interface with appropriate operation'
-      end
+        [
+          SignIn::Constants::Auth::AUTHORIZE,
+          SignIn::Constants::Auth::INTERSTITIAL_VERIFY,
+          SignIn::Constants::Auth::INTERSTITIAL_SIGNUP,
+          SignIn::Constants::Auth::VERIFY_CTA_AUTHENTICATED,
+          SignIn::Constants::Auth::VERIFY_PAGE_AUTHENTICATED,
+          SignIn::Constants::Auth::VERIFY_PAGE_UNAUTHENTICATED
+        ].each do |op|
+          context "with operation=#{op}" do
+            let(:operation_value) { op }
 
-      context 'and the operation param is interstitial_signup' do
-        let(:operation_value) { SignIn::Constants::Auth::INTERSTITIAL_SIGNUP }
-        let(:expected_op_value) { '' }
-
-        it_behaves_like 'an idme service interface with appropriate operation'
-      end
-
-      context 'and the operation param is verify_cta_authenticated' do
-        let(:operation_value) { SignIn::Constants::Auth::VERIFY_CTA_AUTHENTICATED }
-        let(:expected_op_value) { '' }
-
-        it_behaves_like 'an idme service interface with appropriate operation'
-      end
-
-      context 'and the operation param is verify_page_authenticated' do
-        let(:operation_value) { SignIn::Constants::Auth::VERIFY_PAGE_AUTHENTICATED }
-        let(:expected_op_value) { '' }
-
-        it_behaves_like 'an idme service interface with appropriate operation'
-      end
-
-      context 'and the operation param is verify_page_unauthenticated' do
-        let(:operation_value) { SignIn::Constants::Auth::VERIFY_PAGE_UNAUTHENTICATED }
-        let(:expected_op_value) { '' }
-
-        it_behaves_like 'an idme service interface with appropriate operation'
+            it 'returns ok status' do
+              expect(subject).to have_http_status(:ok)
+            end
+          end
+        end
       end
     end
 
@@ -191,9 +177,19 @@ RSpec.describe V0::SignInController, type: :controller do
 
     context 'when type param is dslogon' do
       let(:type_value) { SignIn::Constants::Auth::DSLOGON }
-      let(:expected_type_value) { SignIn::Constants::Auth::DSLOGON }
+      let(:acr_value) { 'loa1' }
+      let(:code_challenge) { { code_challenge: Base64.urlsafe_encode64('some-safe-code-challenge') } }
+      let(:code_challenge_method) { { code_challenge_method: 'S256' } }
 
-      it_behaves_like 'an idme authentication service interface'
+      it 'routes through the same Idme::Service as idme' do
+        idme_service = instance_double(SignIn::Idme::Service)
+        allow(SignIn::Idme::Service).to receive(:new).and_return(idme_service)
+        allow(idme_service).to receive(:render_auth).and_return('<html></html>')
+
+        subject
+
+        expect(SignIn::Idme::Service).to have_received(:new).with(hash_including(type: SignIn::Constants::Auth::DSLOGON))
+      end
     end
   end
 end

--- a/spec/lib/sign_in/idme/service_spec.rb
+++ b/spec/lib/sign_in/idme/service_spec.rb
@@ -123,6 +123,27 @@ describe SignIn::Idme::Service do
       end
     end
 
+    context 'when operation is a valid non-signup operation' do
+      let(:expected_op_param) { 'op=' }
+
+      [
+        SignIn::Constants::Auth::AUTHORIZE,
+        SignIn::Constants::Auth::INTERSTITIAL_VERIFY,
+        SignIn::Constants::Auth::INTERSTITIAL_SIGNUP,
+        SignIn::Constants::Auth::VERIFY_CTA_AUTHENTICATED,
+        SignIn::Constants::Auth::VERIFY_PAGE_AUTHENTICATED,
+        SignIn::Constants::Auth::VERIFY_PAGE_UNAUTHENTICATED
+      ].each do |op|
+        context "with operation=#{op}" do
+          let(:operation) { op }
+
+          it 'does not include an op param in rendered form' do
+            expect(response).not_to include(expected_op_param)
+          end
+        end
+      end
+    end
+
     context 'when optional_scopes are provided' do
       context 'and the scopes are valid' do
         let(:optional_scopes) { ['all_emails'] }


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- Reduces `sign_in_controller_authorize_idme_spec.rb` from 6,168 to 787 test examples (~87% reduction) to improve CI test sharding efficiency.
- Changes are test-only — no production code modified.
- Platform Infrastructure / CI optimization.

### What changed

1. **Removed dslogon full test expansion** — DSLogon is no longer supported. Replaced 3,084 duplicated examples with a single routing test confirming dslogon still routes through `Idme::Service`.
2. **Collapsed 6 identical operation contexts** — `authorize`, `interstitial_verify`, `interstitial_signup`, `verify_cta_authenticated`, `verify_page_authenticated`, and `verify_page_unauthenticated` all produce identical behavior (no `op=` param via `convert_operation`). Replaced 6 full tree expansions (~385 examples each) with 6 lightweight acceptance tests.
3. **Added explicit `convert_operation` coverage** in `spec/lib/sign_in/idme/service_spec.rb` to verify all valid non-signup operations produce no `op=` param, providing a safety net for the collapsed contexts.

### Why this is safe

The spec had deeply nested shared contexts that multiplied every test path. The key insight is that `Idme::Service#convert_operation` only produces a value for `SIGN_UP` (returns `config.sign_up_operation` → `op=signup`). For every other valid operation, it returns `nil`, which is stripped by `.compact` in `auth_params`. This means all non-signup operations produce identical HTTP responses through the entire authorize flow.

**DSLogon removal justification:** In `AuthenticationServiceRetriever#auth_service`, both `idme` and `dslogon` fall through to the `else` branch and create the same `Idme::Service.new(type:, ...)`. The dslogon context was running all 3,084 idme examples a second time with only `type_value` changed. The new lightweight test confirms `Idme::Service` is instantiated with `type: dslogon`.

**Operation collapse justification:** The 6 collapsed operations all set `expected_op_value = ''` and ran the identical `'an idme service interface with appropriate operation'` shared context tree (~385 examples each). The only operation with distinct behavior is `sign_up` (sets `expected_op_value = 'op=signup'`), which retains its full expansion. The new parameterized test confirms each collapsed operation is accepted (returns 200), and the new unit test in `service_spec.rb` explicitly verifies `convert_operation` returns no `op=` param for each of them.

### CI impact (measured from JUnit XML)

| Metric | Master | This PR | Change |
|--------|--------|---------|--------|
| Examples | 6,168 | 787 | -87% |
| Spec runtime | 193.20s | 22.37s | **-170.83s (-88%)** |

test run: https://github.com/department-of-veterans-affairs/vets-api/actions/runs/22446509951/job/65006863354?pr=26788

## Related issue(s)

- CI test sharding optimization

## Testing done

- [x] *New code is covered by unit tests*
- Old behavior: 6,168 examples running identical assertions across duplicated operation/type contexts (193s on CI per JUnit XML)
- New behavior: 787 examples with equivalent coverage (22s on CI per JUnit XML)
- Verified `convert_operation` behavior is explicitly tested for all valid operations in `spec/lib/sign_in/idme/service_spec.rb`
- Ran `bundle exec rspec spec/controllers/v0/sign_in_controller_authorize_idme_spec.rb` — 787 examples, 0 failures
- Ran `bundle exec rspec spec/lib/sign_in/idme/service_spec.rb -e "render_auth"` — 14 examples, 0 failures

## What areas of the site does it impact?

Test suite only. No production code changes.

## Acceptance criteria

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

## Requested Feedback

This is a test optimization PR. The key question is whether the reduced test expansion still provides sufficient coverage. Would appreciate review of whether the lightweight acceptance tests + unit-level `convert_operation` coverage is an acceptable tradeoff for the ~88% runtime reduction.