### PR TITLE
VEBT/revert flipper in vets model

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -3020,9 +3020,6 @@ features:
     actor_type: user
     description: Enable debug logging for Facilities API for errors
     enable_in_development: false
-  vets_model_nested_array:
-    actor_type: user
-    description: If enabled, allows Vets::Model to serialize nested array of objects
   vre_form_submission_tracking:
     actor_type: user
     description: If enabled, track form submissions for VR&E application Form 28-1900

--- a/lib/vets/model.rb
+++ b/lib/vets/model.rb
@@ -34,9 +34,6 @@ module Vets
       self.class.attribute_set.each do |attr_name|
         instance_variable_set("@#{attr_name}", nil) unless instance_variable_defined?("@#{attr_name}")
       end
-
-      @vets_model_nested_array_enabled =
-        Flipper.enabled?(:vets_model_nested_array)
     end
 
     # Acts as ActiveRecord::Base#attributes which is needed for serialization
@@ -58,15 +55,7 @@ module Vets
     # @return [Hash] nested attributes
     def nested_attributes(values)
       values.transform_values do |value|
-        if @vets_model_nested_array_enabled && value.is_a?(Array)
-          value.map do |item|
-            if item.respond_to?(:attribute_values)
-              nested_attributes(item.attribute_values)
-            else
-              item
-            end
-          end
-        elsif value.respond_to?(:attribute_values)
+        if value.respond_to?(:attribute_values)
           nested_attributes(value.attribute_values)
         else
           value


### PR DESCRIPTION
Change was made to account for deeply nested arrays in Vets::Model but was deemed unnecessary and not effective:  https://dsva.slack.com/archives/CBU0KDSB1/p1772122346312739