### PR TITLE
create guard for bio forms so they are not included in simple forms e…

### DIFF
--- a/app/models/form_submission_attempt.rb
+++ b/app/models/form_submission_attempt.rb
@@ -153,6 +153,8 @@ class FormSubmissionAttempt < ApplicationRecord
   end
 
   def simple_forms_form_number
+    return nil if form_submission.saved_claim_id.present?
+
     @simple_forms_form_number ||=
       if (
         SimpleFormsApi::Notification::Email::TEMPLATE_IDS.keys +

--- a/spec/models/form_submission_attempt_spec.rb
+++ b/spec/models/form_submission_attempt_spec.rb
@@ -7,6 +7,22 @@ RSpec.describe FormSubmissionAttempt, type: :model do
     it { is_expected.to belong_to(:form_submission) }
   end
 
+  shared_examples 'does not send simple forms email' do |form_type|
+    context "is a bio form #{form_type} with a saved_claim_id" do
+      let(:saved_claim) { create(:fake_saved_claim) }
+      let(:form_submission) { build(:form_submission, form_type:, saved_claim_id: saved_claim.id) }
+      let(:form_submission_attempt) { create(:form_submission_attempt, form_submission:) }
+
+      it 'does not enqueue an email' do
+        allow(SimpleFormsApi::Notification::SendNotificationEmailJob).to receive(:perform_async)
+
+        subject_action.call(form_submission_attempt)
+
+        expect(SimpleFormsApi::Notification::SendNotificationEmailJob).not_to have_received(:perform_async)
+      end
+    end
+  end
+
   describe 'state machine' do
     before { allow_any_instance_of(SimpleFormsApi::Notification::Email).to receive(:send) }
 
@@ -102,6 +118,15 @@ RSpec.describe FormSubmissionAttempt, type: :model do
           end
         end
       end
+
+      context 'bio forms' do
+        let(:subject_action) { ->(fsa) { fsa.fail! } }
+
+        it_behaves_like 'does not send simple forms email', '21-4192'
+        it_behaves_like 'does not send simple forms email', '21-0779'
+        it_behaves_like 'does not send simple forms email', '21P-530a'
+        it_behaves_like 'does not send simple forms email', '21-2680'
+      end
     end
 
     it 'transitions to a success state' do
@@ -138,6 +163,15 @@ RSpec.describe FormSubmissionAttempt, type: :model do
           form_submission_attempt.benefits_intake_uuid,
           'vba_21_4142'
         )
+      end
+
+      context 'bio forms' do
+        let(:subject_action) { ->(fsa) { fsa.vbms! } }
+
+        it_behaves_like 'does not send simple forms email', '21-4192'
+        it_behaves_like 'does not send simple forms email', '21-0779'
+        it_behaves_like 'does not send simple forms email', '21P-530a'
+        it_behaves_like 'does not send simple forms email', '21-2680'
       end
     end
   end


### PR DESCRIPTION
This work is behind a feature toggle (flipper): NO
Fixes an issue where bio form submissions were being incorrectly routed into the Simple Forms notification email pipeline, causing error logs in Datadog.
Bug: Bio forms (21-4192, 21-0779, 21P-530a, 21-2680) share form numbers with Simple Forms API form upload forms. The simple_forms_form_number method in FormSubmissionAttempt routes based on form number alone, causing bio form submissions to enter the Simple Forms email pipeline. Since the two products have completely different form_data shapes, this causes check_missing_keys to raise an ArgumentError which made our logs pop with some error logs.
Solution: Bio form submissions always have a saved_claim_id present on the FormSubmission record, while Simple Forms submissions do not. Adding an early return when saved_claim_id is present prevents bio form submissions from ever entering the Simple Forms email pipeline. Since bio forms do not have email notifications built out yet, this bug was not impacting any email delivery — only producing noise in our logs. This fix cleans up that logging noise and also ensures we are correctly set up for when bio forms do eventually build out their email notifications. I'm not sure yet if this a band aid fix or if we need to talk about changing our form numbers to avoid this behavior in future.
This work is owned by the Simple Forms team.

Related issue(s)

N/A

Testing done

 New code is covered by unit tests
Old behavior: Bio form submissions with a saved_claim_id were being routed into the Simple Forms email pipeline, causing ArgumentError to be raised and logged as a failed form submission in Datadog on both failure and vbms state transitions.
New behavior: Bio form submissions with a saved_claim_id are excluded from the Simple Forms email pipeline entirely.
Added shared example tests across both transitioning to a failure state and transitioning to a vbms state contexts for all four affected forms (21-4192, 21-0779, 21P-530a, 21-2680) verifying that SendNotificationEmailJob is not enqueued.

What areas of the site does it impact?
Only impacts FormSubmissionAttempt email routing logic. No Simple Forms behavior changes — only the four bio forms are affected. Since bio forms do not have email notifications built out yet, there is no impact to email delivery.
