### PR TITLE
Flaky Spec: Fix Rack::Attack multi-party forms spec failures

### DIFF
--- a/spec/middleware/rack/attack_multi_party_forms_spec.rb
+++ b/spec/middleware/rack/attack_multi_party_forms_spec.rb
@@ -3,18 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe 'Rack::Attack Multi-Party Forms Throttling', type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
   let(:user) { create(:user, :loa3) }
   let(:headers) { { 'REMOTE_ADDR' => '1.2.3.4' } }
 
   before do
-    # Enable Rack::Attack for these tests
+    @rack_attack_enabled_was = Rack::Attack.enabled
     Rack::Attack.enabled = true
     Rack::Attack.cache.store.flushdb
   end
 
   after do
     Rack::Attack.cache.store.flushdb
-    Rack::Attack.enabled = false
+    Rack::Attack.enabled = @rack_attack_enabled_was
   end
 
   describe 'multi_party_forms/ip throttle' do


### PR DESCRIPTION
## Summary

- Include `ActiveSupport::Testing::TimeHelpers` to fix `NoMethodError: undefined method 'travel'` in the rate limit reset test
- Save/restore `Rack::Attack.enabled` in before/after blocks instead of hard-coding `false`, preventing test order dependencies

## Related issue(s)

- Fixes flaky spec from #26471

## Test plan

- [ ] CI passes for `spec/middleware/rack/attack_multi_party_forms_spec.rb`
- [ ] The "resets the rate limit after the time period expires" test no longer raises `NoMethodError`