### PR TITLE
Login.gov ial2 enforcement

### DIFF
--- a/app/services/sign_in/acr_translator.rb
+++ b/app/services/sign_in/acr_translator.rb
@@ -69,19 +69,25 @@ module SignIn
     end
 
     def translate_logingov_values
-      ial2_enabled = ial2_enabled?(type:)
-
       case acr
-      when 'ial1' then Constants::Auth::LOGIN_GOV_IAL1
-      when 'ial2' then Constants::Auth::LOGIN_GOV_IAL2
+      when 'ial1'
+        Constants::Auth::LOGIN_GOV_IAL1
+      when 'ial2', Constants::Auth::IAL2_PREFERRED
+        logingov_ial2_level
       when Constants::Auth::IAL2_REQUIRED
-        ial2_enabled ? Constants::Auth::LOGIN_GOV_IAL2_REQUIRED : invalid_acr!(type:)
-      when Constants::Auth::IAL2_PREFERRED
-        ial2_enabled ? Constants::Auth::LOGIN_GOV_IAL2_PREFERRED : invalid_acr!(type:)
+        ial2_enabled?(type:) ? Constants::Auth::LOGIN_GOV_IAL2_REQUIRED : invalid_acr!(type:)
       when 'min'
-        uplevel ? Constants::Auth::LOGIN_GOV_IAL2 : Constants::Auth::LOGIN_GOV_IAL0
+        uplevel ? logingov_ial2_level : Constants::Auth::LOGIN_GOV_IAL0
       else
         invalid_acr!(type:)
+      end
+    end
+
+    def logingov_ial2_level
+      if Flipper.enabled?('identity_logingov_ial2_full_enforcement')
+        Constants::Auth::LOGIN_GOV_IAL2_PREFERRED
+      else
+        Constants::Auth::LOGIN_GOV_IAL2
       end
     end
 

--- a/app/services/sign_in/constants/auth.rb
+++ b/app/services/sign_in/constants/auth.rb
@@ -28,6 +28,7 @@ module SignIn
                           LOGIN_GOV_IAL0 = 'http://idmanagement.gov/ns/assurance/ial/0',
                           LOGIN_GOV_IAL1 = 'http://idmanagement.gov/ns/assurance/ial/1',
                           LOGIN_GOV_IAL2 = 'http://idmanagement.gov/ns/assurance/ial/2',
+                          LOGIN_GOV_VERIFIED = 'urn:acr.login.gov:verified',
                           LOGIN_GOV_IAL2_REQUIRED = 'urn:acr.login.gov:verified-facial-match-required',
                           LOGIN_GOV_IAL2_PREFERRED = 'urn:acr.login.gov:verified-facial-match-preferred'].freeze
       ANTI_CSRF_COOKIE_NAME = 'vagov_anti_csrf_token'

--- a/app/services/sign_in/credential_level_creator.rb
+++ b/app/services/sign_in/credential_level_creator.rb
@@ -176,6 +176,7 @@ module SignIn
 
     def logingov_ial2_levels
       [Constants::Auth::LOGIN_GOV_IAL2,
+       Constants::Auth::LOGIN_GOV_VERIFIED,
        Constants::Auth::LOGIN_GOV_IAL2_REQUIRED,
        Constants::Auth::LOGIN_GOV_IAL2_PREFERRED]
     end

--- a/spec/services/sign_in/acr_translator_spec.rb
+++ b/spec/services/sign_in/acr_translator_spec.rb
@@ -100,11 +100,14 @@ RSpec.describe SignIn::AcrTranslator do
     context 'when type is logingov' do
       let(:type) { SignIn::Constants::Auth::LOGINGOV }
       let(:ial2_feature_flag_enabled) { false }
+      let(:ial2_full_enforcement_enabled) { false }
 
       before do
         allow(Flipper).to receive(:enabled?).and_call_original
         allow(Flipper).to receive(:enabled?).with('identity_logingov_ial2_enforcement')
                                             .and_return(ial2_feature_flag_enabled)
+        allow(Flipper).to receive(:enabled?).with('identity_logingov_ial2_full_enforcement')
+                                            .and_return(ial2_full_enforcement_enabled)
       end
 
       context 'and acr is ial1' do
@@ -118,10 +121,23 @@ RSpec.describe SignIn::AcrTranslator do
 
       context 'and acr is ial2' do
         let(:acr) { 'ial2' }
-        let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::LOGIN_GOV_IAL2 } }
 
-        it 'returns expected translated acr value' do
-          expect(subject).to eq(expected_translated_acr)
+        context 'when ial2 full enforcement is enabled' do
+          let(:ial2_full_enforcement_enabled) { true }
+          let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::LOGIN_GOV_IAL2_PREFERRED } }
+
+          it 'returns expected translated acr value' do
+            expect(subject).to eq(expected_translated_acr)
+          end
+        end
+
+        context 'when ial2 full enforcement is disabled' do
+          let(:ial2_full_enforcement_enabled) { false }
+          let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::LOGIN_GOV_IAL2 } }
+
+          it 'returns expected translated acr value' do
+            expect(subject).to eq(expected_translated_acr)
+          end
         end
       end
 
@@ -151,8 +167,8 @@ RSpec.describe SignIn::AcrTranslator do
       context 'and acr is IAL2_PREFERRED' do
         let(:acr) { SignIn::Constants::Auth::IAL2_PREFERRED }
 
-        context 'when ial2 is enabled' do
-          let(:ial2_feature_flag_enabled) { true }
+        context 'when ial2 full enforcement is enabled' do
+          let(:ial2_full_enforcement_enabled) { true }
           let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::LOGIN_GOV_IAL2_PREFERRED } }
 
           it 'returns expected translated acr value' do
@@ -160,13 +176,12 @@ RSpec.describe SignIn::AcrTranslator do
           end
         end
 
-        context 'when ial2 is disabled' do
-          let(:ial2_feature_flag_enabled) { false }
-          let(:expected_error) { SignIn::Errors::InvalidAcrError }
-          let(:expected_error_message) { 'Invalid ACR for logingov' }
+        context 'when ial2 full enforcement is disabled' do
+          let(:ial2_full_enforcement_enabled) { false }
+          let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::LOGIN_GOV_IAL2 } }
 
-          it 'raises invalid acr error' do
-            expect { subject }.to raise_error(expected_error, expected_error_message)
+          it 'returns expected translated acr value' do
+            expect(subject).to eq(expected_translated_acr)
           end
         end
       end
@@ -186,11 +201,22 @@ RSpec.describe SignIn::AcrTranslator do
         context 'and uplevel is true' do
           let(:uplevel) { true }
 
-          let(:ial2_feature_flag_enabled) { false }
-          let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::LOGIN_GOV_IAL2 } }
+          context 'when ial2 full enforcement is enabled' do
+            let(:ial2_full_enforcement_enabled) { true }
+            let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::LOGIN_GOV_IAL2_PREFERRED } }
 
-          it 'returns expected translated acr value' do
-            expect(subject).to eq(expected_translated_acr)
+            it 'returns expected translated acr value' do
+              expect(subject).to eq(expected_translated_acr)
+            end
+          end
+
+          context 'when ial2 full enforcement is disabled' do
+            let(:ial2_full_enforcement_enabled) { false }
+            let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::LOGIN_GOV_IAL2 } }
+
+            it 'returns expected translated acr value' do
+              expect(subject).to eq(expected_translated_acr)
+            end
           end
         end
       end

--- a/spec/services/sign_in/credential_level_creator_spec.rb
+++ b/spec/services/sign_in/credential_level_creator_spec.rb
@@ -139,6 +139,18 @@ RSpec.describe SignIn::CredentialLevelCreator do
           end
         end
 
+        context 'and logingov acr is defined as verified' do
+          let(:logingov_acr) { SignIn::Constants::Auth::LOGIN_GOV_VERIFIED }
+          let(:expected_current_ial) { SignIn::Constants::Auth::IAL_TWO }
+
+          it_behaves_like 'a created credential level'
+
+          it 'logs the expected log' do
+            expect(Rails.logger).to receive(:info).with(expected_log_message, expected_log_payload)
+            subject
+          end
+        end
+
         context 'and logingov acr is not defined as IAL 2' do
           let(:logingov_acr) { 'some-acr' }
           let(:expected_current_ial) { SignIn::Constants::Auth::IAL_ONE }


### PR DESCRIPTION
## Summary

- Add support for login.gov acr `urn:acr.login.gov:verified-facial-match-preferred` 
  - when this is called, it returns the new ial `urn:acr.login.gov:verified` for existing users that are not verified with facial match instead of `http://idmanagement.gov/ns/assurance/ial/2/aal/2` (which is deprecated).
- Add flipper that routes both `ial2` and `urn:acr.va.gov:verified-facial-match-preferred` to `urn:acr.login.gov:verified-facial-match-preferred`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/1071

## Testing done

- enable the `identity_logingov_ial2_full_enforcement` flipper
- Test authenticating with various login.gov accounts on web with acr `min` (normal web authentication)
   ```
   http://localhost:3000/v0/sign_in/authorize?type=logingov&client_id=vaweb&acr=min&response_type=code&s...
   ```
  - unverified `ial1` user
    - should allow the user to authenticate. they should be presented with the "Verify with Login.gov" CTA
  - user verified with `ial2` user (`http://idmanagement.gov/ns/assurance/ial/2`)
    -  if you don't have an existing `ial2` user, verify an `ial1` user with `identity_logingov_ial2_enforcement` flipper disabled
  - user verified with `ial2` facial_match_req (`urn:acr.login.gov:verified-facial-match-required`)
    - if you don't have an existing` ial2_facial_match_req` user, verify an `ial1` user with `identity_logingov_ial2_enforcement` flipper enabled
  - simulate a previously verified user (uplevel)
    - with an `ial1` user  
      - simulate previously verified by adding `icn` to `UserAccount`, and `verified_at` to their `UserVerification`
      - sign in
      - you should be redirected to login.gov verify page with acr `urn:acr.login.gov:verified-facial-match-prefferred`
- Test the same same scenarios with acr: `urn:acr.va.gov:verified-facial-match-prefferred` 
   ```
   http://localhost:3000/v0/sign_in/authorize?type=logingov&client_id=vaweb&acr=urn:acr.va.gov:verified-facial-match-prefferred....
   ```
  - With the flipper on this should redirect to login.gov with `urn:acr.login.gov:verified-facial-match-prefferred`
  - With the flipper off it should redirect to login.gov `http://idmanagement.gov/ns/assurance/ial/2`
- Test the same same scenarios with acr: `ial2`. 
   ```
   http://localhost:3000/v0/sign_in/authorize?type=logingov&client_id=vaweb&acr=ial2....
   ```
  - With the flipper on this should redirect to login.gov with `urn:acr.login.gov:verified-facial-match-prefferred`
  - With the flipper off it should redirect to login.gov `http://idmanagement.gov/ns/assurance/ial/2`

## What areas of the site does it impact?
Authentication, Sign-in Service

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected

