### PR TITLE
Remove rubocop disable for perceived complexity

### DIFF
--- a/modules/vaos/app/services/vaos/v2/appointments_service.rb
+++ b/modules/vaos/app/services/vaos/v2/appointments_service.rb
@@ -73,7 +73,6 @@ module VAOS
       }.freeze
 
       # rubocop:disable Metrics/MethodLength
-      # rubocop:disable Metrics/PerceivedComplexity
       def get_appointments(start_date, # rubocop:disable Metrics/ParameterLists
                            end_date,
                            statuses = nil,
@@ -172,7 +171,6 @@ module VAOS
           meta: pagination(pagination_params).merge(partial_errors(response, __method__))
         }
       end
-      # rubocop:enable Metrics/PerceivedComplexity
 
       ##
       # Checks whether a referral has already been used in an existing appointment.


### PR DESCRIPTION
## Summary
Lint failure in `master`
https://github.com/department-of-veterans-affairs/vets-api/commits/master/

```
 Error: Lint/RedundantCopDisableDirective: Unnecessary disabling of `Metrics/PerceivedComplexity`.
```

## Related issue(s)
https://dsva.slack.com/archives/C0460N83Y9G/p1772469945851069

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*


## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

