### PR TITLE
Add AU-2 structured audit logging to Common::VirusScan

### DIFF
--- a/lib/clamav/patch_client.rb
+++ b/lib/clamav/patch_client.rb
@@ -67,7 +67,7 @@ module ClamAV
       results = scan(file_path)
       safe = results.all? { |file| file.virus_name.nil? }
       virus_name = results.find { |file| file.virus_name.present? }&.virus_name
-      { safe: safe, virus_name: virus_name }
+      { safe:, virus_name: }
     end
 
     private

--- a/lib/common/virus_scan.rb
+++ b/lib/common/virus_scan.rb
@@ -10,33 +10,20 @@ module Common
     module_function
 
     def scan(file_path, upload_context: nil)
-      # `clamd` runs within service group, needs group read
       raise 'Failed to create temp file' unless File.exist?(file_path)
-
       return true if mock_enabled?
 
       file_metadata = collect_file_metadata(file_path)
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
       result = perform_scan(file_path)
 
       emit_scan_audit_log(
-        file_metadata: file_metadata,
-        scan_result: result[:safe] ? 'clean' : 'infected',
-        virus_name: result[:virus_name],
-        scan_duration_ms: duration_ms(start_time),
-        upload_context: upload_context
+        file_metadata:, scan_result: result[:safe] ? 'clean' : 'infected',
+        virus_name: result[:virus_name], scan_duration_ms: duration_ms(start_time), upload_context:
       )
-
       result[:safe]
-    rescue => e
-      emit_scan_audit_log(
-        file_metadata: file_metadata || {},
-        scan_result: 'error',
-        virus_name: nil,
-        scan_duration_ms: start_time ? duration_ms(start_time) : nil,
-        upload_context: upload_context
-      ) if start_time && !mock_enabled?
+    rescue
+      emit_error_audit_log(file_metadata, start_time, upload_context) if start_time
       raise
     end
 
@@ -57,20 +44,15 @@ module Common
     def scan_file_from_other_location(original_path)
       clamav_directory = Rails.root.join('clamav_tmp')
       FileUtils.mkdir_p(clamav_directory)
-
       File.chmod(0o640, original_path)
 
-      unique_id = "scan_#{Time.now.to_i}_#{SecureRandom.hex(8)}"
-      temp_filename = "#{unique_id}_#{File.basename(original_path)}"
-      temp_path = "clamav_tmp/#{temp_filename}"
+      temp_path = "clamav_tmp/scan_#{Time.now.to_i}_#{SecureRandom.hex(8)}_#{File.basename(original_path)}"
 
       begin
         FileUtils.cp(original_path, temp_path)
-
         raise "Failed to create temp file at #{original_path}" unless File.exist?(temp_path)
 
         Rails.logger.info("Created clamav tmp file: #{original_path}")
-
         File.chmod(0o640, temp_path)
         ClamAV::PatchClient.new.scan_with_result(temp_path)
       ensure
@@ -95,19 +77,18 @@ module Common
 
     def emit_scan_audit_log(file_metadata:, scan_result:, virus_name:, scan_duration_ms:, upload_context:)
       request_attributes = RequestStore.store['additional_request_attributes'] || {}
+      Rails.logger.info('ClamAV Virus Scan Audit',
+                        event: 'virus_scan', user_uuid: request_attributes['user_uuid'],
+                        ip_address: request_attributes['remote_ip'], file_name: file_metadata[:file_name_hashed],
+                        file_size: file_metadata[:file_size], content_type: file_metadata[:content_type],
+                        scan_result:, virus_name:, scan_duration_ms:, upload_context:)
+    end
 
-      Rails.logger.info('ClamAV Virus Scan Audit', {
-        event: 'virus_scan',
-        user_uuid: request_attributes['user_uuid'],
-        ip_address: request_attributes['remote_ip'],
-        file_name: file_metadata[:file_name_hashed],
-        file_size: file_metadata[:file_size],
-        content_type: file_metadata[:content_type],
-        scan_result: scan_result,
-        virus_name: virus_name,
-        scan_duration_ms: scan_duration_ms,
-        upload_context: upload_context
-      })
+    def emit_error_audit_log(file_metadata, start_time, upload_context)
+      emit_scan_audit_log(
+        file_metadata: file_metadata || {}, scan_result: 'error',
+        virus_name: nil, scan_duration_ms: duration_ms(start_time), upload_context:
+      )
     end
 
     def duration_ms(start_time)

--- a/spec/lib/common/virus_scan_spec.rb
+++ b/spec/lib/common/virus_scan_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe Common::VirusScan do
 
       it 'scans the file directly' do
         expect(Rails.logger).to receive(:info).with('Scanning file already in clamav_tmp')
-        expect(clamav_client).to receive(:scan_with_result).with(file_path).and_return({ safe: true, virus_name: nil })
+        expect(clamav_client).to receive(:scan_with_result).with(file_path)
+                                                           .and_return({ safe: true, virus_name: nil })
 
         result = described_class.scan(file_path)
         expect(result).to be true
@@ -294,24 +295,28 @@ RSpec.describe Common::VirusScan do
     end
 
     context 'when scan is clean' do
-      it 'emits audit log with scan_result clean' do
-        expect(Rails.logger).to receive(:info).with('Scanning file already in clamav_tmp')
-        expect(Rails.logger).to receive(:info).with('ClamAV Virus Scan Audit', hash_including(
+      let(:expected_audit_fields) do
+        {
           event: 'virus_scan',
           scan_result: 'clean',
           virus_name: nil,
           user_uuid: 'test-user-uuid-123',
           ip_address: '192.168.1.1'
-        ))
+        }
+      end
+
+      it 'emits audit log with scan_result clean' do
+        expect(Rails.logger).to receive(:info).with('Scanning file already in clamav_tmp')
+        expect(Rails.logger).to receive(:info)
+          .with('ClamAV Virus Scan Audit', hash_including(expected_audit_fields))
 
         described_class.scan(file_path)
       end
 
       it 'includes scan_duration_ms that is positive' do
         expect(Rails.logger).to receive(:info).with('Scanning file already in clamav_tmp')
-        expect(Rails.logger).to receive(:info).with('ClamAV Virus Scan Audit', hash_including(
-          scan_duration_ms: a_value > 0
-        ))
+        expect(Rails.logger).to receive(:info)
+          .with('ClamAV Virus Scan Audit', hash_including(scan_duration_ms: a_value > 0))
 
         described_class.scan(file_path)
       end
@@ -325,10 +330,9 @@ RSpec.describe Common::VirusScan do
 
       it 'emits audit log with virus_name populated' do
         expect(Rails.logger).to receive(:info).with('Scanning file already in clamav_tmp')
-        expect(Rails.logger).to receive(:info).with('ClamAV Virus Scan Audit', hash_including(
-          scan_result: 'infected',
-          virus_name: 'Eicar-Test-Signature'
-        ))
+        expect(Rails.logger).to receive(:info)
+          .with('ClamAV Virus Scan Audit',
+                hash_including(scan_result: 'infected', virus_name: 'Eicar-Test-Signature'))
 
         described_class.scan(file_path)
       end
@@ -339,9 +343,8 @@ RSpec.describe Common::VirusScan do
         expected_hash = Digest::SHA256.hexdigest('audit_test.pdf')
 
         expect(Rails.logger).to receive(:info).with('Scanning file already in clamav_tmp')
-        expect(Rails.logger).to receive(:info).with('ClamAV Virus Scan Audit', hash_including(
-          file_name: expected_hash
-        ))
+        expect(Rails.logger).to receive(:info)
+          .with('ClamAV Virus Scan Audit', hash_including(file_name: expected_hash))
 
         described_class.scan(file_path)
       end
@@ -350,9 +353,8 @@ RSpec.describe Common::VirusScan do
     context 'when upload_context is provided' do
       it 'passes upload_context through to audit log' do
         expect(Rails.logger).to receive(:info).with('Scanning file already in clamav_tmp')
-        expect(Rails.logger).to receive(:info).with('ClamAV Virus Scan Audit', hash_including(
-          upload_context: 'hca_attachment'
-        ))
+        expect(Rails.logger).to receive(:info)
+          .with('ClamAV Virus Scan Audit', hash_including(upload_context: 'hca_attachment'))
 
         described_class.scan(file_path, upload_context: 'hca_attachment')
       end
@@ -365,10 +367,8 @@ RSpec.describe Common::VirusScan do
 
       it 'emits audit log with scan_result error before re-raising' do
         expect(Rails.logger).to receive(:info).with('Scanning file already in clamav_tmp')
-        expect(Rails.logger).to receive(:info).with('ClamAV Virus Scan Audit', hash_including(
-          scan_result: 'error',
-          virus_name: nil
-        ))
+        expect(Rails.logger).to receive(:info)
+          .with('ClamAV Virus Scan Audit', hash_including(scan_result: 'error', virus_name: nil))
 
         expect { described_class.scan(file_path) }.to raise_error(StandardError, 'ClamAV timeout')
       end


### PR DESCRIPTION
## Summary

- Adds NIST AU-2/AU-3 compliant structured JSON audit logging to `Common::VirusScan` for Datadog observability (#133914)
- Introduces `scan_with_result` on `ClamAV::PatchClient` to capture virus name from scan results
- Emits a `ClamAV Virus Scan Audit` log entry on every scan with: `user_uuid`, `ip_address`, SHA-256 hashed file name, `file_size`, `content_type`, `scan_result` (clean/infected/error), `virus_name`, `scan_duration_ms`, and `upload_context`
- File names are SHA-256 hashed to avoid PII in logs; user context pulled from `RequestStore`
- Backward compatible: `scan` method signature adds optional `upload_context:` keyword arg, return value unchanged (boolean)

## Related issue(s)

- #133914

## Testing done

- All 41 unit tests pass (`bundle exec rspec spec/lib/common/virus_scan_spec.rb`)
- New test coverage for: clean scan audit log, infected scan with virus_name, SHA-256 hashed file name, positive scan_duration_ms, upload_context passthrough, error scan audit log, mock mode skips audit log, and `collect_file_metadata` correctness
- ClamAV is mocked in dev/test so audit logs cannot be verified locally — staging verification required post-deploy (see Acceptance Criteria)

## What areas of the site does it impact?

- All file upload flows that use `Common::VirusScan` (HCA attachments, claims evidence uploads, preneed attachments, etc.)
- No behavioral change to scan results — only adds structured logging alongside existing scan logic

## Acceptance criteria

- [x] `Common::VirusScan.scan` emits a structured `ClamAV Virus Scan Audit` log entry for every real (non-mock) scan
- [x] Log entry contains all required AU-2/AU-3 fields: `event`, `user_uuid`, `ip_address`, `file_name` (hashed), `file_size`, `content_type`, `scan_result`, `virus_name`, `scan_duration_ms`, `upload_context`
- [x] File names are SHA-256 hashed (no plaintext PII in logs)
- [x] Error scans emit audit log with `scan_result: "error"` before re-raising
- [ ] Mock mode does NOT emit audit logs
- [x] Existing scan behavior unchanged (boolean return, file cleanup, error handling)
- [ ] Staging verification: upload a file, confirm audit log appears in Datadog with query `service:vets-api @event:virus_scan`