### PR TITLE
DR 134686: Add feature toggle for new Contact Info pages for Decision Reviews

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -771,6 +771,9 @@ features:
   decision_review_add_user_account_id_to_rum:
     actor_type: user
     description: Adds the user account ID to Datadog RUM logs for SC, HLR and NOD apps
+  decision_review_use_new_contact_info_page:
+    actor_type: user
+    description: Enables the new prefilled contact info page in SC, HLR and NOD apps
   dependency_verification_browser_monitoring_enabled:
     actor_type: user
     description: Enable Datadog RUM/LOG monitoring for the form 21-0538


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary

In support of implementing the new prefill pattern Contact Info page for Decision Reviews apps, we are adding a feature toggle to control its display.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/134686