### PR TITLE
1833: delete 1095b env variables

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -514,12 +514,6 @@ form0781_remediation:
   aws:
     bucket: <%= ENV['evidence_remediation__aws__bucket'] %>
     region: us-gov-west-1
-form1095_b:
-  s3:
-    aws_access_key_id: <%= ENV['form1095_b__s3__aws_access_key_id'] %>
-    aws_secret_access_key: <%= ENV['form1095_b__s3__aws_secret_access_key'] %>
-    bucket: <%= ENV['form1095_b__s3__bucket'] %>
-    region: us-gov-west-1
 form526_backup:
   api_key: <%= ENV['form526_backup__api_key'] %>
   aws:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -513,12 +513,6 @@ form0781_remediation:
   aws:
     bucket: ~
     region: ~
-form1095_b:
-  s3:
-    aws_access_key_id: ~
-    aws_secret_access_key: ~
-    bucket: bucket
-    region: region
 form526_backup:
   api_key: ~
   aws:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -512,12 +512,6 @@ form0781_remediation:
   aws:
     bucket: ~
     region: ~
-form1095_b:
-  s3:
-    aws_access_key_id: ~
-    aws_secret_access_key: ~
-    bucket: bucket
-    region: region
 form526_backup:
   api_key: ~
   aws:


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO. 
- This PR deletes Settings variables that are no longer in use.
- I'm on the CVE team.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-iir/issues/1833

## Testing done

- [ ] *New code is covered by unit tests*
- This doesn't need testing because it's removing unused settings.

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
None because the settings are no longer used.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback


