### PR TITLE
Add sec_id_history to user_info endpoint

### DIFF
--- a/app/models/sign_in/user_info.rb
+++ b/app/models/sign_in/user_info.rb
@@ -48,6 +48,7 @@ module SignIn
     attribute :person_types, :string
     attribute :icn, :string
     attribute :sec_id, :string
+    attribute :sec_id_history, :string
     attribute :edipi, :string
     attribute :mhv_ien, :string
     attribute :npi_id, :string

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -151,6 +151,10 @@ class User < Common::RedisStore
     identity&.sec_id || mpi_profile&.sec_id
   end
 
+  def sec_id_history
+    mpi_profile&.sec_id_history || []
+  end
+
   def ssn
     identity&.ssn || ssn_mpi
   end

--- a/app/services/sign_in/user_info_generator.rb
+++ b/app/services/sign_in/user_info_generator.rb
@@ -11,8 +11,8 @@ module SignIn
     def perform
       SignIn::UserInfo.new(sub:, ial:, aal:, csp_type:, csp_uuid:, email:, first_name:, last_name:, full_name:,
                            address_street1:, address_street2:, address_city:, address_state:, address_country:,
-                           address_postal_code:, phone_number:, person_types:, icn:, sec_id:, edipi:, mhv_ien:,
-                           npi_id:, cerner_id:, corp_id:, birls:, gcids:, birth_date:, ssn:, gender:)
+                           address_postal_code:, phone_number:, person_types:, icn:, sec_id:, sec_id_history:, edipi:,
+                           mhv_ien:, npi_id:, cerner_id:, corp_id:, birls:, gcids:, birth_date:, ssn:, gender:)
     end
 
     private
@@ -38,6 +38,7 @@ module SignIn
     def person_types        = user.person_types&.join('|') || ''
     def icn                 = user.icn
     def sec_id              = user.sec_id
+    def sec_id_history      = user.sec_id_history&.join('^') || ''
     def edipi               = user.edipi
     def mhv_ien             = user.mhv_ien
     def npi_id              = user.npi_id

--- a/lib/identity/parsers/gc_ids_constants.rb
+++ b/lib/identity/parsers/gc_ids_constants.rb
@@ -20,6 +20,9 @@ module Identity
       # SEC_ID_REGEX, ex. 1008830476^PN^200PROV^USDVA^A
       SEC_ID_REGEX = /^\w+\^PN\^200PROV\^USDVA\^A$/
 
+      # SEC_ID_HISTORY_REGEX, ex. 1008830476^PN^200PROV^USDVA^H
+      SEC_ID_HISTORY_REGEX = /^\w+\^PN\^200PROV\^USDVA\^H$/
+
       # MHV_IDS_REGEX, ex. 123456^PI^200MHV^USVHA^P
       MHV_IDS_REGEX = /^\w+\^PI\^200MH.{0,1}\^\w+\^\w+$/
 
@@ -70,6 +73,7 @@ module Identity
         icn: { regex: PERMANENT_ICN_REGEX, root_oid: VA_ROOT_OID, type: :single_id },
         sec_id: { regex: SEC_ID_REGEX, root_oid: VA_ROOT_OID, type: :single_id },
         sec_ids: { regex: SEC_ID_REGEX, root_oid: VA_ROOT_OID, type: :multiple_ids },
+        sec_id_history: { regex: SEC_ID_HISTORY_REGEX, root_oid: VA_ROOT_OID, type: :multiple_ids },
         edipi: { regex: EDIPI_REGEX, root_oid: DOD_ROOT_OID, type: :single_id },
         edipis: { regex: EDIPI_REGEX, root_oid: DOD_ROOT_OID, type: :multiple_ids },
         vba_corp_id: { regex: VBA_CORP_ID_REGEX, root_oid: VA_ROOT_OID, type: :single_id },

--- a/lib/mpi/models/mvi_profile_ids.rb
+++ b/lib/mpi/models/mvi_profile_ids.rb
@@ -24,6 +24,7 @@ module MPI
         attribute :participant_ids,     array: true, default: []
         attribute :sec_id,              :string
         attribute :sec_ids,             array: true, default: []
+        attribute :sec_id_history,      array: true, default: []
         attribute :vet360_id,           :string
         attribute :vha_facility_hash,   hash: true, default: {}
         attribute :vha_facility_ids,    array: true, default: []

--- a/lib/mpi/responses/profile_parser.rb
+++ b/lib/mpi/responses/profile_parser.rb
@@ -193,6 +193,7 @@ module MPI
           participant_ids: sanitize_id_array(parsed_mvi_ids[:vba_corp_ids]),
           mhv_iens: sanitize_id_array(parsed_mvi_ids[:mhv_iens]),
           sec_ids: parsed_mvi_ids[:sec_ids] || [],
+          sec_id_history: parsed_mvi_ids[:sec_id_history] || [],
           vha_facility_ids: parsed_mvi_ids[:vha_facility_ids] || [],
           vha_facility_hash: parsed_mvi_ids[:vha_facility_hash] || {},
           birls_ids: sanitize_id_array(parsed_mvi_ids[:birls_ids]),

--- a/spec/factories/mvi_profile_relationships.rb
+++ b/spec/factories/mvi_profile_relationships.rb
@@ -37,6 +37,7 @@ FactoryBot.define do
     mhv_iens { [] }
     vha_facility_ids { %w[916 593 200HD 200IP 200MHV] }
     sec_id { '9901234567' }
+    sec_id_history { [] }
     birls_id { birls_ids.first }
     birls_ids { ['996122306'] }
     vet360_id { '993456789' }

--- a/spec/factories/mvi_profiles.rb
+++ b/spec/factories/mvi_profiles.rb
@@ -79,6 +79,7 @@ FactoryBot.define do
     vet360_id { '123456789' }
     sec_id { '0001234567' }
     sec_ids { [sec_id] }
+    sec_id_history { [] }
     search_token { 'WSDOC2002071538432741110027956' }
 
     factory :mpi_profile_response do
@@ -131,6 +132,7 @@ FactoryBot.define do
       vet360_id { '123456789' }
       sec_id { '0001234567' }
       sec_ids { [sec_id] }
+      sec_id_history { [] }
       search_token { 'WSDOC2002071538432741110027956' }
       person_types { ['PAT'] }
 

--- a/spec/lib/identity/parsers/gc_ids_spec.rb
+++ b/spec/lib/identity/parsers/gc_ids_spec.rb
@@ -17,6 +17,7 @@ describe Identity::Parsers::GCIds do
           icn: nil,
           sec_id: nil,
           sec_ids: nil,
+          sec_id_history: nil,
           mhv_ids: nil,
           mhv_ien: nil,
           mhv_iens: nil,
@@ -141,6 +142,22 @@ describe Identity::Parsers::GCIds do
           it 'returns parsed sec_ids from the input xml object' do
             expect(subject[:sec_ids]).to eq(expected_sec_ids)
           end
+        end
+      end
+
+      context 'and the format of the ids matches the sec id history regex' do
+        let(:id_object_one) { "#{id}^PN^200PROV^USDVA^H" }
+        let(:id_object_two) { '9988776655^PN^200PROV^USDVA^H' }
+        let(:ids) do
+          [
+            double(attributes: { extension: id_object_one, root: root_oid }),
+            double(attributes: { extension: id_object_two, root: root_oid })
+          ]
+        end
+        let(:expected_sec_id_history) { %w[123454321 9988776655] }
+
+        it 'returns parsed sec_id_history from the input xml object' do
+          expect(subject[:sec_id_history]).to eq(expected_sec_id_history)
         end
       end
 

--- a/spec/lib/mpi/responses/profile_parser_spec.rb
+++ b/spec/lib/mpi/responses/profile_parser_spec.rb
@@ -203,6 +203,7 @@ describe MPI::Responses::ProfileParser do
             mhv_iens: ['1100792239'],
             sec_id: '1008714701',
             sec_ids: ['1008714701'],
+            sec_id_history: ['0001234567'],
             edipi: nil,
             edipis: [],
             mhv_ids: ['1100792239'],
@@ -213,6 +214,7 @@ describe MPI::Responses::ProfileParser do
               '796122306^PI^200BRLS^USVBA^A',
               '9100792239^PI^200CORP^USVBA^A',
               '1008714701^PN^200PROV^USDVA^A',
+              '0001234567^PN^200PROV^USDVA^H',
               '1100792239^PI^200MHS^USVHA^A'
             ],
             search_token: 'WSDOC1908201553145951848240311',

--- a/spec/models/sign_in/user_info_spec.rb
+++ b/spec/models/sign_in/user_info_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe SignIn::UserInfo do
         person_types: 'some-person-types',
         icn: 'some-icn',
         sec_id: 'some-sec',
+        sec_id_history: 'some-sec-id-history',
         edipi: 'some-edipi',
         mhv_ien: 'some-mhv-ien',
         npi_id: 'some-npi-id',

--- a/spec/services/sign_in/user_info_generator_spec.rb
+++ b/spec/services/sign_in/user_info_generator_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe SignIn::UserInfoGenerator do
   let(:user_verification) { create(:idme_user_verification, idme_uuid: credential_uuid, user_account:) }
 
   let(:mpi_profile) do
-    build(:mpi_profile, icn:, sec_id:, given_names: [first_name], family_name: last_name, edipi:, mhv_ien:, cerner_id:,
-                        participant_id: corp_id, birls_id: birls, full_mvi_ids: gcids)
+    build(:mpi_profile, icn:, sec_id:, sec_id_history:, given_names: [first_name], family_name: last_name, edipi:,
+                        mhv_ien:, cerner_id:, participant_id: corp_id, birls_id: birls, full_mvi_ids: gcids)
   end
   let(:user) do
     build(
@@ -26,6 +26,7 @@ RSpec.describe SignIn::UserInfoGenerator do
   let(:credential_uuid) { 'some-uuid' }
   let(:icn) { 'some-icn' }
   let(:sec_id) { 'some-sec-id' }
+  let(:sec_id_history) { %w[hist-sec-id-1 hist-sec-id-2] }
   let(:first_name) { 'some-first-name' }
   let(:last_name) { 'some-last-name' }
   let(:email) { 'some-email' }
@@ -78,6 +79,7 @@ RSpec.describe SignIn::UserInfoGenerator do
         expect(user_info.person_types).to eq(user.person_types&.join('|') || '')
         expect(user_info.icn).to eq(user.icn)
         expect(user_info.sec_id).to eq(user.sec_id)
+        expect(user_info.sec_id_history).to eq(user.sec_id_history.join('^'))
         expect(user_info.edipi).to eq(user.edipi)
         expect(user_info.mhv_ien).to eq(user.mhv_ien)
         expect(user_info.cerner_id).to eq(user.cerner_id)

--- a/spec/support/mpi/find_candidate_missing_attrs_response.xml
+++ b/spec/support/mpi/find_candidate_missing_attrs_response.xml
@@ -43,6 +43,7 @@
                 <id extension="796122306^PI^200BRLS^USVBA^A" root="2.16.840.1.113883.4.349"/>
                 <id extension="9100792239^PI^200CORP^USVBA^A" root="2.16.840.1.113883.4.349"/>
                 <id extension="1008714701^PN^200PROV^USDVA^A" root="2.16.840.1.113883.4.349"/>
+                <id extension="0001234567^PN^200PROV^USDVA^H" root="2.16.840.1.113883.4.349"/>
                 <id extension="1100792239^PI^200MHS^USVHA^A" root="2.16.840.1.113883.4.349"/>
                 <statusCode code="active"/>
                 <patientPerson>


### PR DESCRIPTION
## Summary

- Parse sec_id_history from MPI profile response.
  - `sec_id_history` contains  sec_ids that end with `^H` instead of `^A`.
- Return `sec_id_history` in user_info response delimited with `^`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/identity-documentation/issues/1155

## Testing 
- Add ` vaweb` to [user_info_clients](https://github.com/department-of-veterans-affairs/vets-api/blob/f8db0dc6505d6e6e5de9966942ac194eafa5e5cb/config/identity_settings/settings.yml#L87)
- Add sec_id_history to your users mpi_profile in vets-api-mockdata
   ```yml
   <patient classCode="PAT">
      ....
      <id extension="0000027766^PN^200PROV^USDVA^A" root="2.16.840.1.113883.4.349"/> # sec_id
      <id extension="0000027767^PN^200PROV^USDVA^H" root="2.16.840.1.113883.4.349"/> # sec_id_history
      <id extension="0000027768^PN^200PROV^USDVA^H" root="2.16.840.1.113883.4.349"/> # sec_id_history
      <id extension="0000027769^PN^200PROV^USDVA^H" root="2.16.840.1.113883.4.349"/> # sec_id_history
      <id extension="0000027770^PN^200PROV^USDVA^H" root="2.16.840.1.113883.4.349"/> # sec_id_history
      ....
    </patient>
   ```
- Authenticate with SiS
- navigate to http://localhost:3000/sign_in/user_info
- You should see sec_id_history attribute populated with the sec_id_history you added to your mpi_profile
   ```ruby
   {
     ...
     "sec_id_history": "0000027767^0000027768^0000027769^0000027770",
     ...
   }
   ```

## What areas of the site does it impact?
Sign-in Service

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
