### PR TITLE
[Find a Rep v3] 133247: Add a New `org_name` Query Parameter to the VSO Representatives Endpoint

### DIFF
--- a/modules/veteran/app/controllers/veteran/v0/base_accredited_representatives_controller.rb
+++ b/modules/veteran/app/controllers/veteran/v0/base_accredited_representatives_controller.rb
@@ -44,7 +44,7 @@ module Veteran
 
       def search_params
         params.require(%i[lat long type])
-        params.permit(:distance, :lat, :long, :name, :page, :per_page, :sort, :type)
+        params.permit(:distance, :lat, :long, :name, :org_name, :page, :per_page, :sort, :type)
       end
 
       def pagination_params

--- a/modules/veteran/app/controllers/veteran/v0/vso_accredited_representatives_controller.rb
+++ b/modules/veteran/app/controllers/veteran/v0/vso_accredited_representatives_controller.rb
@@ -21,6 +21,10 @@ module Veteran
                 .where('? = ANY(veteran_representatives.user_types)', search_params[:type])
                 .group(Veteran::Service::Representative.column_names.map { |col| "veteran_representatives.#{col}" })
 
+        if search_params[:org_name] && Flipper.enabled?(:find_a_representative_enabled)
+          query = query.having('? = ANY(array_agg(veteran_organizations.name))', search_params[:org_name])
+        end
+
         search_params[:name] ? find_with_name_similar_to(query) : query
       end
 

--- a/modules/veteran/app/docs/veteran/v0/accreditation.yaml
+++ b/modules/veteran/app/docs/veteran/v0/accreditation.yaml
@@ -145,6 +145,11 @@ paths:
             type: string
           description: Name to search for.
         - in: query
+          name: org_name
+          schema:
+            type: string
+          description: Name of the Veteran Service Organization (VSO). Must be an exact match.
+        - in: query
           name: page
           schema:
             type: integer

--- a/modules/veteran/spec/requests/v0/vso_accredited_representatives_spec.rb
+++ b/modules/veteran/spec/requests/v0/vso_accredited_representatives_spec.rb
@@ -175,5 +175,53 @@ RSpec.describe 'Veteran::V0::VSOAccreditedRepresentatives', type: :request do
         expect(data['attributes']['organization_names']).to eq(expected_organization_names[index])
       end
     end
+
+    context 'when the :find_a_representative_enabled flag is enabled' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:find_a_representative_enabled).and_return(true)
+      end
+
+      context 'and an organization name with representative matches is provided' do
+        let(:org_name) { 'Alabama Department of Veterans Affairs' }
+
+        it 'returns the representatives belonging to that organization' do
+          get path, params: { type:, lat:, long:, distance:, org_name: }
+
+          parsed_response = JSON.parse(response.body)
+
+          expect(parsed_response['data'].pluck('id')).to eq(%w[111 113 114])
+        end
+      end
+
+      context 'and an organization name with no representative matches is provided' do
+        let(:org_name) { 'An Organization' }
+
+        it 'returns no representatives' do
+          get path, params: { type:, lat:, long:, distance:, org_name: }
+
+          parsed_response = JSON.parse(response.body)
+
+          expect(parsed_response['data']).to be_empty
+        end
+      end
+    end
+
+    context 'when the :find_a_representative_enabled flag is disabled' do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:find_a_representative_enabled).and_return(false)
+      end
+
+      context 'and an organization name is provided' do
+        let(:org_name) { 'An Organization' }
+
+        it 'ignores the org_name param and returns all matching representative results' do
+          get path, params: { type:, lat:, long:, distance:, org_name: }
+
+          parsed_response = JSON.parse(response.body)
+
+          expect(parsed_response['data'].pluck('id')).to eq(%w[111 113 114 115])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Keep your PR as a Draft until it's ready for Platform review. A PR is ready for Platform review when it has a teammate approval and tests, linting, and settings checks pass CI. See [these tips](https://depo-platform-documentation.scrollhelp.site/developer-docs/vets-api-pr-tips) on how to avoid common delays in getting your PR merged.

## Summary
This feature is behind a feature flag, `:find_a_representative_enabled`, which is being used to gate the overall "Find a Representative v3" release.

This PR adds a new, optional `org_name` query parameter to the `/services/veteran/v0/vso_accredited_representatives` endpoint. This new functionality will be used in the front end of the [Find a Representative](https://www.va.gov/get-help-from-accredited-representative/find-rep/) experience to support a new search field to allow users to filter their results by a specific Veteran Service Organization (VSO). 

The new search field uses a combo box with a pre-defined list of values, so the endpoint will look for an exact match for the organization name and return 0 results if a match is not found.

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#133247

## Testing done
- [x] *New code is covered by unit tests*

I tested the endpoint behavior locally with the feature flag enabled and disabled and using various query parameter combinations against local representative and organization data, to confirm the results.

Additionally, I confirmed the validity of the API docs changes against the OpenAPI spec.

## Screenshots
Updated Endpoint Docs:
<img width="756" height="683" alt="Updated Docs Screenshot" src="https://github.com/user-attachments/assets/85391257-112a-4217-b052-b8a14caa0ddd" />

## What areas of the site does it impact?
This PR impacts the `/services/veteran/v0/vso_accredited_representatives` endpoint and its associated API docs (`/services/veteran/v0/apidocs`).

## Acceptance criteria
- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [x]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [x]  I added a screenshot of the developed feature

## Requested Feedback
No specific feedback requested for this PR.
