### PR TITLE
Remove released appointments feature toggles

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2336,10 +2336,6 @@ features:
     actor_type: user
     enable_in_development: true
     description: Toggle to remove the redundant call to facility configurations when determining patient eligibility.
-  va_online_scheduling_use_browser_timezone:
-    actor_type: user
-    enable_in_development: true
-    description: Toggle to default to browser timezone when facility timezone is unavailable.
   vaos_appointment_notification_callback:
     actor_type: user
     enable_in_development: true


### PR DESCRIPTION
## Summary

- Removing fully released appointments feature toggles
- Changes to vets-website have already been merged and will be deployed at 1 PM ET 3/11. 
- We will ask platform to remove the flags in the rails console in all environments after this change is merged and deployed.
- United Appointments Experience

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123628
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123627
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/123630
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114893

## Testing done

- N/A

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

Appointments

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
