### PR TITLE
arc/fix_arc_seeds

### DIFF
--- a/modules/accredited_representative_portal/lib/tasks/seed.rake
+++ b/modules/accredited_representative_portal/lib/tasks/seed.rake
@@ -78,11 +78,6 @@ module AccreditedRepresentativePortal
           insert_poa_requests(
             accreditations
           )
-
-          insert_all(
-            Records::USER_ACCOUNT_ACCREDITED_INDIVIDUALS,
-            factory: %i[user_account_accredited_individual]
-          )
         end
       end
 
@@ -157,9 +152,6 @@ module AccreditedRepresentativePortal
               :power_of_attorney_request
             ]
           )
-
-        insert_all(Records::USER_ACCOUNT_ACCREDITED_INDIVIDUALS,
-                   factory: %i[user_account_accredited_individual])
 
         ##
         # Forms and resolutions can't happen in bulk because encryption happens

--- a/modules/accredited_representative_portal/lib/tasks/seed/records.rb
+++ b/modules/accredited_representative_portal/lib/tasks/seed/records.rb
@@ -177,44 +177,6 @@ module AccreditedRepresentativePortal
         }
       ].freeze
 
-      USER_ACCOUNT_ACCREDITED_INDIVIDUALS = [
-        {
-          accredited_individual_registration_number: '10000',
-          user_account_email: 'vets.gov.user+0@gmail.com',
-          user_account_icn: '1012667122V019349'
-        },
-        {
-          accredited_individual_registration_number: '10001',
-          user_account_email: 'vets.gov.user+1@gmail.com',
-          user_account_icn: '1012666182V203559'
-        },
-        {
-          accredited_individual_registration_number: '10002',
-          user_account_email: 'vets.gov.user+2@gmail.com',
-          user_account_icn: '1012829932V238054'
-        },
-        {
-          accredited_individual_registration_number: '10003',
-          user_account_email: 'vets.gov.user+4@gmail.com',
-          user_account_icn: '1012659372V317896'
-        },
-        {
-          accredited_individual_registration_number: '10004',
-          user_account_email: 'vets.gov.user+5@gmail.com',
-          user_account_icn: '1012667179V787205'
-        },
-        {
-          accredited_individual_registration_number: '10005',
-          user_account_email: 'vets.gov.user+6@gmail.com',
-          user_account_icn: '1012830899V368969'
-        },
-        {
-          accredited_individual_registration_number: '10006',
-          user_account_email: 'vets.gov.user+7@gmail.com',
-          user_account_icn: '1012643432V477452'
-        }
-      ].freeze
-
       CLAIMANTS = [
         {
           id: '7de8ce1e-af1c-4c5d-8caf-4002593dac69'


### PR DESCRIPTION
## Summary

- We removed the `user_account_accredited_individual` factory. Was breaking our local seeds

## Related issue(s)

- Slack conversation [here](https://dsva.slack.com/archives/C06ABHUNBRS/p1772809795162919)
- [Ticket](https://github.com/orgs/department-of-veterans-affairs/projects/1809/views/13?sliceBy%5Bvalue%5D=patrick-brown-oddball&pane=issue&itemId=162921854&issue=department-of-veterans-affairs%7Cva.gov-team%7C135366) 

## Testing done

- Ran locally

## What areas of the site does it impact?
Accredited Representative Portal

## Acceptance criteria

- [ ]  No error nor warning in the console.
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs