### PR TITLE
[BIO] 21-8940 fix added attachments

### DIFF
--- a/modules/increase_compensation/app/models/increase_compensation/saved_claim.rb
+++ b/modules/increase_compensation/app/models/increase_compensation/saved_claim.rb
@@ -66,7 +66,7 @@ module IncreaseCompensation
     # Only removed Sidekiq call from super
     def process_attachments!(docs = nil)
       refs = docs || parsed_form['files'] || []
-      files = PersistentAttachment.where(guid: refs.map { |f| f['confirmation_code'] })
+      files = PersistentAttachment.where(guid: refs.map { |f| f['confirmation_code'] || f['confirmationCode'] })
       files.find_each { |f| f.update(saved_claim_id: id, form_id: FORM_REAL_ID) }
 
       # Lighthouse::SubmitBenefitsIntakeClaim.perform_async(id)


### PR DESCRIPTION
## Summary

- *This work is behind a feature toggle (flipper): NO*
- handel snake case vs camel case reference
- *benefits-intake-pingwind*

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*
- *Link to previous change of the code/bug (if applicable)*
- *Link to epic if not included in ticket*

## Testing done

- [ ] *New code is covered by unit tests*
- *Describe what the old behavior was prior to the change*
- *Describe the steps required to verify your changes are working as expected. Exclusively stating 'Specs run' is NOT acceptable as appropriate testing*
- *If this work is behind a flipper:*
  - *Tests need to be written for both the flipper on and flipper off scenarios. [Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide#Featuretogglesguide-Backendexample).*
  - *What is the testing plan for rolling out the feature?*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

(OPTIONAL)_What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
