### PR TITLE
DMT 133210 module model functions

### DIFF
--- a/app/models/saved_claim/dependency_claim.rb
+++ b/app/models/saved_claim/dependency_claim.rb
@@ -6,10 +6,11 @@ require 'dependents/monitor'
 require 'dependents/notification_email'
 
 # temporary for FDF
+require 'dependents_benefits/claim_behavior'
 require 'dependents_benefits/claim_behavior/vbms_information'
 
 class SavedClaim::DependencyClaim < CentralMailClaim
-  include DependentsBenefits::ClaimBehavior::FormTypeChecking
+  include DependentsBenefits::ClaimBehavior
   include DependentsBenefits::ClaimBehavior::VBMSInformation
 
   FORM = '686C-674'


### PR DESCRIPTION
## Summary

add backward compatible functions to legacy model

## Related issue(s)

[Module | Supporting Claim Evidence Documents Not Reaching LightHouse/VBMS Despite Successful Claim Submission](https://github.com/department-of-veterans-affairs/va.gov-team/issues/133210)

## Testing done

- [x] *New code is covered by unit tests*
functionality works when loading a claim via `SavedClaim` or the full specific class

## What areas of the site does it impact?

dependents

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Feature/bug has a monitor built into Datadog (if applicable)
