### PR TITLE
Api 48893 remove evss documentsservice and flipper 2

### DIFF
--- a/modules/claims_api/app/sidekiq/claims_api/claim_uploader.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/claim_uploader.rb
@@ -27,7 +27,6 @@ module ClaimsApi
           self.class.perform_in(30.minutes, uuid, record_type)
         end
       else
-        auth_headers = auto_claim.auth_headers
         uploader = claim_object.uploader
         original_filename = claim_object.file_data['filename']
         uploader.retrieve_from_store!(original_filename)

--- a/modules/claims_api/app/sidekiq/claims_api/claim_uploader.rb
+++ b/modules/claims_api/app/sidekiq/claims_api/claim_uploader.rb
@@ -33,11 +33,7 @@ module ClaimsApi
         uploader.retrieve_from_store!(original_filename)
         file_body = uploader.read
         ClaimsApi::Logger.log('lighthouse_claim_uploader', claim_id: auto_claim.id, attachment_id: uuid)
-        if Flipper.enabled? :claims_claim_uploader_use_bd
-          bd_upload_body(auto_claim:, file_body:, doc_type:, original_filename:)
-        else
-          EVSS::DocumentsService.new(auth_headers).upload(file_body, claim_upload_document(claim_object))
-        end
+        bd_upload_body(auto_claim:, file_body:, doc_type:, original_filename:)
       end
     end
 


### PR DESCRIPTION
This PR removes usage of the EVSS DocumentService in the claims_api module. The existing usage was gated by a feature toggle and has not been in active use for some time now.

Once this change is deployed we can remove the claims_claim_uploader_use_bd feature toggle.

## Related issue(s)

|[Jira ticket](https://jira.devops.va.gov/browse/API-48893)|
|-|
|<img width="1009" height="657" alt="Screenshot 2025-10-03 at 12 26 44" src="https://github.com/user-attachments/assets/4f327a74-8beb-4516-b222-03824d9271ed" />|

## Testing done

- [X] *New code is covered by unit tests*

## Screenshots
_Note: Optional_

## What areas of the site does it impact?

```
modules/claims_api/app/sidekiq/claims_api/claim_uploader.rb
modules/claims_api/spec/sidekiq/claim_uploader_spec.rb
```

## Acceptance criteria

- [X]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

## Requested Feedback

NA
